### PR TITLE
Fix references to publications.html.

### DIFF
--- a/doc/documentation.html
+++ b/doc/documentation.html
@@ -33,7 +33,7 @@
           <li><a href="doxygen/deal.II/index.html" target="_top">Manual</a></li>
           <li><a href="http://www.math.tamu.edu/~bangerth/videos.html" target="_top">Wolfgang's lectures</a></li>
           <li><a href="reports/index.html" target="body">Technical reports</a></li>
-          <li><a href="http://www.dealii.org/publications.html" target="body">Publications</a></li>
+          <li><a href="http://www.dealii.org/publications.html" target="_top">Publications</a></li>
         </ol>
       </div>
     </div>

--- a/doc/navbar.html
+++ b/doc/navbar.html
@@ -50,7 +50,7 @@
     <b><small>Resources</small></b>
     <p>
       <a href="reports/index.html" target="body">Reports</a><br />
-      <a href="http://www.dealii.org/publications.html" target="body">Publications</a><br />
+      <a href="http://www.dealii.org/publications.html" target="_top">Publications</a><br />
       <a href="http://www.dealii.org/authors.html" target="_top">Authors</a> <br />
       <a href="license.html" target="body">License</a> <br />
       <a href="mail.html" target="body">Contact</a>


### PR DESCRIPTION
References should now go to the entire window, not the 'body' frame.
