### PR TITLE
Add missing includes to step-17 and step-18

### DIFF
--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -24,6 +24,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/multithread_info.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/constraint_matrix.h>

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -25,6 +25,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/multithread_info.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/lac/vector.h>


### PR DESCRIPTION
This commit fixes up a regression introduced with commit
  06a70bad3cbbcbb6abc51e12f29e3b5dfffb928a
that removed unnecessary includes of base/multithread_info.h. Both steps
need them for multithread_info.n_threads()
