### PR TITLE
Fix links to doc/reports/index.html.

### DIFF
--- a/doc/documentation.html
+++ b/doc/documentation.html
@@ -32,7 +32,7 @@
           <li><a href="doxygen/deal.II/Tutorial.html" target="_top">Tutorial</a></li>
           <li><a href="doxygen/deal.II/index.html" target="_top">Manual</a></li>
           <li><a href="http://www.math.tamu.edu/~bangerth/videos.html" target="_top">Wolfgang's lectures</a></li>
-          <li><a href="reports/index.html" target="body">Technical reports</a></li>
+          <li><a href="http://www.dealii.org/reports.html" target="body">Technical reports</a></li>
           <li><a href="http://www.dealii.org/publications.html" target="_top">Publications</a></li>
         </ol>
       </div>

--- a/doc/navbar.html
+++ b/doc/navbar.html
@@ -49,7 +49,7 @@
 
     <b><small>Resources</small></b>
     <p>
-      <a href="reports/index.html" target="body">Reports</a><br />
+      <a href="http://www.dealii.org/reports.html" target="body">Reports</a><br />
       <a href="http://www.dealii.org/publications.html" target="_top">Publications</a><br />
       <a href="http://www.dealii.org/authors.html" target="_top">Authors</a> <br />
       <a href="license.html" target="body">License</a> <br />


### PR DESCRIPTION
This file (lost in the conversion from svn to git) was moved to http://www.dealii.org/reports.html since the actual reports are already there. This patch redirects the links there as well.
