### PR TITLE
Write the steps in lowercase.

### DIFF
--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -600,20 +600,6 @@
  *     <td>step-30</td>
  *   </tr>
  *
- *   <tr>
- *     <td> Multilevel preconditioners
- *     </td>
- *     <td>
- *       step-16,
- *       step-31,
- *       step-32,
- *       step-39,
- *       step-41,
- *       step-42,
- *       step-43
- *     </td>
- *   </tr>
- *
  *   <tr valign="top">
  *     <td> Computing Jacobians from residuals, automatic differentiation
  *     </td>


### PR DESCRIPTION
This way, the filter script can replace them automatically with references to
the corresponding pages for each of the tutorial programs. This does not
currently work on http://dealii.org/developer/doxygen/deal.II/Tutorial.html .
