### PR TITLE
Fix instantiation issue with FlatManifold properly

### DIFF
--- a/source/grid/manifold.inst.in
+++ b/source/grid/manifold.inst.in
@@ -18,12 +18,14 @@
 
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
   {
+#if deal_II_dimension <= deal_II_space_dimension
     template class Manifold<deal_II_dimension, deal_II_space_dimension>;
     template class FlatManifold<deal_II_dimension, deal_II_space_dimension>;
 
     template class ManifoldChart<deal_II_dimension, deal_II_space_dimension, 1>;
     template class ManifoldChart<deal_II_dimension, deal_II_space_dimension, 2>;
     template class ManifoldChart<deal_II_dimension, deal_II_space_dimension, 3>;
+#endif
   }
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13292,22 +13292,31 @@ Triangulation<dim, spacedim>::remove_refinement_listener (RefinementListener &li
 template <>
 const Manifold<2,1> & Triangulation<2, 1>::get_manifold(const types::manifold_id) const {
   Assert(false, ExcImpossibleInDim(1));
-  static FlatManifold<2,1> flat;
-  return flat;
+  // We cannot simply create a temporary Manifold<2,1> because it is not
+  // instantiated and would lead to unresolved symbols. Given the fact that
+  // this function should be unreachable anyaway, just dereference a
+  // nullptr:
+  return *static_cast<FlatManifold<2,1>*>(0);
 }
 
 template <>
 const Manifold<3,1> & Triangulation<3, 1>::get_manifold(const types::manifold_id) const {
   Assert(false, ExcImpossibleInDim(1));
-  static FlatManifold<3,1> flat;
-  return flat;
+  // We cannot simply create a temporary Manifold<2,1> because it is not
+  // instantiated and would lead to unresolved symbols. Given the fact that
+  // this function should be unreachable anyaway, just dereference a
+  // nullptr:
+  return *static_cast<FlatManifold<3,1>*>(0);
 }
 
 template <>
 const Manifold<3,2> & Triangulation<3, 2>::get_manifold(const types::manifold_id) const {
   Assert(false, ExcImpossibleInDim(2));
-  static FlatManifold<3,2> flat;
-  return flat;
+  // We cannot simply create a temporary Manifold<2,1> because it is not
+  // instantiated and would lead to unresolved symbols. Given the fact that
+  // this function should be unreachable anyaway, just dereference a
+  // nullptr:
+  return *static_cast<FlatManifold<3,2>*>(0);
 }
 
 // explicit instantiations


### PR DESCRIPTION
This commit reverts the quick fix in commit 982b0683.

The issue why we encountered unresolved references to
dealii::FlatManifold<3, 2>::FlatManifold(dealii::Point<2, double>, double)
etc. was due to boilerplate instantiations of Triangulation::get_manifold
for cases with spacedim < dim (in order to make TriaAccessor happy).

This commit fixes the issue by using a nullptr-dereference in order to
return an invalid object - the specific code throws an error message before
that and should actually not be reachable at all.
