### PR TITLE
Removed release builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 #  These tests run ok, but they might be out of policy...
   - CI_TEST_SUITE=build CI_BUILD_TYPE=Debug
-  - CI_TEST_SUITE=build CI_BUILD_TYPE=Release
+#  - CI_TEST_SUITE=build CI_BUILD_TYPE=Release
 
 # These tests only compile and run "make tests"
 #  - CI_TEST_SUITE=mini CI_BUILD_TYPE=Debug


### PR DESCRIPTION
This closes #71

The Release runs time out on Travis.org almost 80% of the times...

This fix removes Release builds from Travis CI.
