### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install: ./contrib/utilities/setup_travis.sh
 
 os:
 - linux
-- mac
+#  - mac
 
-compiler: 
-- clang
+compiler:
 - gcc
+#  - clang
 
 script: ./contrib/utilities/run_travis.sh $CI_TEST_SUITE $CI_BUILD_TYPE
 
@@ -17,13 +17,8 @@ branches:
     - master
 
 env:
-#  This is way too long. We should find a way to do this in little pieces...
-#  - CI_TEST_SUITE=tests 
-
-#  These tests run ok, but they might be out of policy...
   - CI_TEST_SUITE=build CI_BUILD_TYPE=Debug
-  - CI_TEST_SUITE=build CI_BUILD_TYPE=Release
 
-# These tests only compile and run "make tests"
-#  - CI_TEST_SUITE=mini CI_BUILD_TYPE=Debug
-#  - CI_TEST_SUITE=mini CI_BUILD_TYPE=Release
+# Other possiblities:
+#  * CI_TEST_SUITE=tests - full testsuite
+#  * CI_TEST_SUITE=mini  - only quicktests

--- a/contrib/utilities/run_travis.sh
+++ b/contrib/utilities/run_travis.sh
@@ -6,7 +6,7 @@ case $1 in
 #    ;;
 build)
     echo "Running build tests."
-    mkdir build_test 
+    mkdir build_test
     cd build_test
     ctest -DCMAKE_BUILD_TYPE=$2 -V -j4 -S ../tests/run_buildtest.cmake
     ;;

--- a/contrib/utilities/setup_travis.sh
+++ b/contrib/utilities/setup_travis.sh
@@ -1,7 +1,7 @@
 #/bin/sh -f
- 
+
 # things to do for travis-ci in the before_install section
- 
+
 if ( test "`uname -s`" = "Darwin" )
 then
   #cmake v2.8.12 is installed on the Mac workers now


### PR DESCRIPTION
Only run build tests in debug configuration.

Furthermore reduce configuration to linux and gcc only.
