### PR TITLE
Add workaround to be able to use SLEPc >= 3.5.0 with deal.II. 

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -250,6 +250,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Fixed: Support SLEPc 3.5 by disabling SDFOLD spectrum transformation type
+  that has been removed from SLEPc. Therefore, TransformationSpectrumFolding 
+  cannot be used with newer SLEPc versions. 
+  <br>
+  (Alexander Grayver, 2014/08/15)
+  </li>
+
   <li> New: To better support applications that want to use C++11's
   <a href="http://en.wikipedia.org/wiki/C%2B%2B11#Range-based_for_loop">range-based
   for loops</a>, there are now functions Triangulation::cell_iterators(),

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -232,7 +232,8 @@ namespace SLEPcWrappers
 
   /**
    * An implementation of the transformation interface using the SLEPc
-   * Spectrum Folding.
+   * Spectrum Folding. This transformation type has been removed in
+   * SLEPc 3.5.0 and thus cannot be used in the newer versions.
    *
    * @ingroup SLEPcWrappers
    * @author Toby D. Young 2009

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -122,12 +122,19 @@ namespace SLEPcWrappers
   void
   TransformationSpectrumFolding::set_transformation_type (ST &st) const
   {
+#if DEAL_II_PETSC_VERSION_LT(3,5,0)
     int ierr;
     ierr = STSetType (st, const_cast<char *>(STFOLD));
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
     ierr = STSetShift (st, additional_data.shift_parameter);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
+#else
+    // PETSc/SLEPc version must be < 3.5.0.
+    Assert ((false),
+            ExcMessage ("Folding transformation has been removed in SLEPc 3.5.0 and newer."
+                        "You cannot use this transformation anymore."));
+#endif
   }
 
   /* ------------------- TransformationCayley --------------------- */


### PR DESCRIPTION
This requires disabling support for STFOLD spectrum transformation type since it was removed in SLEPc 3.5.0 and newer.
