### PR TITLE
Silence a warning.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1474,9 +1474,11 @@ namespace DataOutBase
    * parameters which determine the direction of sight, the mode of
    * colorization, the scaling of the height axis, etc. (Of course,
    * all these parameters have reasonable default values, which you
-   * may want to change from time to time.) At present, this format
-   * only supports output for two-dimensional data, with values in the
-   * third direction taken from a data vector.
+   * may want to change.)
+   *
+   * This function only supports output for two-dimensional
+   * domains (i.e., with dim==2), with values in the vertical
+   * direction taken from a data vector.
    *
    * Basically, output consists of the mesh and the cells in between
    * them. You can draw either of these, or both, or none if you are
@@ -1509,6 +1511,19 @@ namespace DataOutBase
    * documentation of the <tt>EpsFlags</tt> member class of this
    * class. See there for more and detailed information.
    */
+  template <int spacedim>
+  void write_eps (const std::vector<Patch<2,spacedim> > &patches,
+                  const std::vector<std::string>          &data_names,
+                  const std::vector<std_cxx1x::tuple<unsigned int, unsigned int, std::string> > &vector_data_ranges,
+                  const EpsFlags                          &flags,
+                  std::ostream                            &out);
+
+  /**
+   * This is the same function as above except for domains that are
+   * not two-dimensional. This function is not implemented (and will
+   * throw an error if called) but is declared to allow for
+   * dimension-independent programs.
+   */
   template <int dim, int spacedim>
   void write_eps (const std::vector<Patch<dim,spacedim> > &patches,
                   const std::vector<std::string>          &data_names,
@@ -1516,6 +1531,7 @@ namespace DataOutBase
                   const EpsFlags                          &flags,
                   std::ostream                            &out);
 
+  
   /**
    * Write the given list of patches to the output stream in
    * GMV format.

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -3952,6 +3952,18 @@ namespace DataOutBase
                   const EpsFlags                          &flags,
                   std::ostream                            &out)
   {
+    // not implemented, see the documentation of the function
+    AssertThrow (dim==2, ExcNotImplemented());
+  }
+
+  
+  template <int spacedim>
+  void write_eps (const std::vector<Patch<2,spacedim> > &patches,
+                  const std::vector<std::string>          &/*data_names*/,
+                  const std::vector<std_cxx1x::tuple<unsigned int, unsigned int, std::string> > &,
+                  const EpsFlags                          &flags,
+                  std::ostream                            &out)
+  {
     Assert (out, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
@@ -3973,9 +3985,6 @@ namespace DataOutBase
     if (patches.size() == 0)
       return;
 #endif
-
-    // Do not allow volume rendering
-    AssertThrow (dim==2, ExcNotImplemented());
 
     const unsigned int old_precision = out.precision();
 
@@ -4011,7 +4020,7 @@ namespace DataOutBase
     // note that since dim==2, we
     // have exactly four vertices per
     // patch and per cell
-    for (typename std::vector<Patch<dim,spacedim> >::const_iterator patch=patches.begin();
+    for (typename std::vector<Patch<2,spacedim> >::const_iterator patch=patches.begin();
          patch!=patches.end(); ++patch)
       {
         const unsigned int n_subdivisions = patch->n_subdivisions;


### PR DESCRIPTION
Some newer compilers kept warning about an out-of-bounds array access
in Point<1>::operator() but didn't indicate where exactly it came
from. This turned out to be in DataOutBase::write_eps(), a function
that is implemented only for dim==2 but was compiled also for dim==1
and dim==3 and contained this statement: 'points[vertex](1)'. The patch
reorganizes the code so that the function is only compiled for dim==2
and a more general specialization that does nothing but abort is used
for all other dimensions.
