### PR TITLE
Require BOOST 1.48 or later when looking for an external installation.

### DIFF
--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -43,7 +43,7 @@ IF(NOT BUILD_SHARED_LIBS)
 ENDIF()
 
 LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-FIND_PACKAGE(Boost 1.44 COMPONENTS iostreams serialization system thread)
+FIND_PACKAGE(Boost 1.48 COMPONENTS iostreams serialization system thread)
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 
 #
@@ -51,7 +51,7 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 #
 IF(NOT Boost_FOUND AND Boost_USE_STATIC_LIBS)
   SET(Boost_USE_STATIC_LIBS FALSE)
-  FIND_PACKAGE(Boost 1.44 COMPONENTS iostreams serialization system thread)
+  FIND_PACKAGE(Boost 1.48 COMPONENTS iostreams serialization system thread)
 ENDIF()
 
 IF(Boost_FOUND)

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -97,6 +97,15 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: Newer versions of GCC (e.g. 4.9.x) are no longer compatible
+  with BOOST 1.46. Consequently, the CMake scripts now require at least
+  BOOST 1.48 in order to use a BOOST version found on the system. If no
+  installed BOOST library is found, or if the version is older than 1.48,
+  CMake will simply take the one that comes bundled with deal.II
+  <br>
+  (Wolfgang Bangerth, 2014/08/19)
+  </li>
+
   <li> New: There is now a documentation module that describes
   deal.II's support for and interaction with the
   @ref CPP11 "C++11 standard".


### PR DESCRIPTION
This addresses issue 246.
