### PR TITLE
Silence a warning from gcc 4.9.1.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -78,6 +78,7 @@ namespace
 
 namespace
 {
+#ifdef DEAL_II_WITH_ZLIB
   // the functions in this namespace are
   // taken from the libb64 project, see
   // http://sourceforge.net/projects/libb64
@@ -219,7 +220,7 @@ namespace
 
     return encoded_data;
   }
-
+#endif
 
 
 #ifdef DEAL_II_WITH_ZLIB


### PR DESCRIPTION
The warning pertained to the fact that we define a function in an anonymous
namespace that is only called from a function inside an #ifdef ... #endif
block. The solution is to move the function into #ifdef ... #endif as well.

This addresses this test result: http://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=11683
