### PR TITLE
Move create_union_triangulation() and extract_boundary_mesh().

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -277,6 +277,16 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Changed: The functions GridTools::extract_boundary_mesh() and
+  GridTools::create_union_triangulation() have been moved to
+  GridGenerator::extract_boundary_mesh() and
+  GridGenerator::create_union_triangulation() since, conceptually, they
+  generate meshes. The old functions have been retained but are now
+  deprecated.
+  <br>
+  (Wolfgang Bangerth, 2014/08/19)
+  </li>
+
   <li> New: TriaAccessor::measure() is now also implemented for faces of
   3d cells as long as the face is planar.
   <br>

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -861,59 +861,13 @@ namespace GridTools
                          const Container &mesh_2);
 
   /**
-   * Given the two triangulations
-   * specified as the first two
-   * arguments, create the
-   * triangulation that contains
-   * the finest cells of both
-   * triangulation and store it in
-   * the third parameter. Previous
-   * content of @p result will be
-   * deleted.
-   *
-   * @note This function is intended
-   * to create an adaptively refined
-   * triangulation that contains the
-   * <i>most refined cells</i> from
-   * two input triangulations that
-   * were derived from the <i>same</i>
-   * coarse grid by adaptive refinement.
-   * This is an operation sometimes
-   * needed when one solves for two
-   * variables of a coupled problem
-   * on separately refined meshes on
-   * the same domain (for example
-   * because these variables have
-   * boundary layers in different places)
-   * but then needs to compute something
-   * that involves both variables or
-   * wants to output the result into a
-   * single file. In both cases, in
-   * order not to lose information,
-   * the two solutions can not be
-   * interpolated onto the respectively
-   * other mesh because that may be
-   * coarser than the ones on which
-   * the variable was computed. Rather,
-   * one needs to have a mesh for the
-   * domain that is at least as fine
-   * as each of the two initial meshes.
-   * This function computes such a mesh.
-   *
-   * @note If you want to create
-   * a mesh that is the merger of
-   * two other coarse meshes, for
-   * example in order to compose a mesh
-   * for a complicated geometry from
-   * meshes for simpler geometries,
-   * then this is not the function for you. Instead, consider
-   * GridGenerator::merge_triangulations().
+   * @deprecated Use GridGenerator::create_union_triangulation().
    */
   template <int dim, int spacedim>
   void
   create_union_triangulation (const Triangulation<dim, spacedim> &triangulation_1,
                               const Triangulation<dim, spacedim> &triangulation_2,
-                              Triangulation<dim, spacedim>       &result);
+                              Triangulation<dim, spacedim>       &result)  DEAL_II_DEPRECATED;
 
   /*@}*/
   /**
@@ -1027,85 +981,7 @@ namespace GridTools
 #endif
 
   /**
-   * This function implements a boundary
-   * subgrid extraction.  Given a
-   * <dim,spacedim>-Triangulation (the
-   * "volume mesh") the function extracts a
-   * subset of its boundary (the "surface
-   * mesh").  The boundary to be extracted
-   * is specified by a list of
-   * boundary_ids.  If none is specified
-   * the whole boundary will be
-   * extracted. The function is used in
-   * step-38.
-   *
-   * The function also builds a mapping linking the
-   * cells on the surface mesh to the
-   * corresponding faces on the volume
-   * one. This mapping is the return value
-   * of the function.
-   *
-   * @note The function builds the surface
-   * mesh by creating a coarse mesh from
-   * the selected faces of the coarse cells
-   * of the volume mesh. It copies the
-   * boundary indicators of these faces to
-   * the cells of the coarse surface
-   * mesh. The surface mesh is then refined
-   * in the same way as the faces of the
-   * volume mesh are. In order to ensure
-   * that the surface mesh has the same
-   * vertices as the volume mesh, it is
-   * therefore important that you assign
-   * appropriate boundary objects through
-   * Triangulation::set_boundary to the
-   * surface mesh object before calling
-   * this function. If you don't, the
-   * refinement will happen under the
-   * assumption that all faces are straight
-   * (i.e using the StraightBoundary class)
-   * rather than any curved boundary object
-   * you may want to use to determine the
-   * location of new vertices.
-   *
-   *
-   * @tparam Container A type that satisfies the
-   * requirements of a mesh container (see @ref GlossMeshAsAContainer).
-   * The map that is returned will
-   * be between cell
-   * iterators pointing into the container describing the surface mesh
-   * and face
-   * iterators of the volume
-   * mesh container. If the Container argument is
-   * DoFHandler of hp::DoFHandler, then
-   * the function will
-   * re-build the triangulation
-   * underlying the second argument
-   * and return a map between
-   * appropriate iterators into the Container arguments. However,
-   * the function will not actually
-   * distribute degrees of freedom
-   * on this newly created surface
-   * mesh.
-   *
-   * @note The algorithm outlined
-   * above assumes that all faces
-   * on higher refinement levels
-   * always have exactly the same
-   * boundary indicator as their
-   * parent face. Consequently, we
-   * can start with coarse level
-   * faces and build the surface
-   * mesh based on that. It would
-   * not be very difficult to
-   * extend the function to also
-   * copy boundary indicators from
-   * finer level faces to their
-   * corresponding surface mesh
-   * cells, for example to
-   * accommodate different geometry
-   * descriptions in the case of
-   * curved boundaries.
+   * @deprecated Use GridGenerator::extract_boundary_mesh() instead.
    */
   template <template <int,int> class Container, int dim, int spacedim>
 #ifndef _MSC_VER
@@ -1117,7 +993,7 @@ namespace GridTools
       extract_boundary_mesh (const Container<dim,spacedim> &volume_mesh,
                              Container<dim-1,spacedim>     &surface_mesh,
                              const std::set<types::boundary_id> &boundary_ids
-                             = std::set<types::boundary_id>());
+                             = std::set<types::boundary_id>()) DEAL_II_DEPRECATED;
 
   /*@}*/
   /**

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -31,6 +31,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/intergrid_map.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>
@@ -3426,6 +3427,56 @@ namespace GridGenerator
   }
 
 
+  template <int dim, int spacedim>
+  void
+  create_union_triangulation (const Triangulation<dim, spacedim> &triangulation_1,
+                              const Triangulation<dim, spacedim> &triangulation_2,
+                              Triangulation<dim, spacedim>       &result)
+  {
+    Assert (GridTools::have_same_coarse_mesh (triangulation_1, triangulation_2),
+            ExcMessage ("The two input triangulations are not derived from "
+                        "the same coarse mesh as required."));
+
+    // first copy triangulation_1, and
+    // then do as many iterations as
+    // there are levels in
+    // triangulation_2 to refine
+    // additional cells. since this is
+    // the maximum number of
+    // refinements to get from the
+    // coarse grid to triangulation_2,
+    // it is clear that this is also
+    // the maximum number of
+    // refinements to get from any cell
+    // on triangulation_1 to
+    // triangulation_2
+    result.clear ();
+    result.copy_triangulation (triangulation_1);
+    for (unsigned int iteration=0; iteration<triangulation_2.n_levels();
+         ++iteration)
+      {
+        InterGridMap<Triangulation<dim, spacedim> > intergrid_map;
+        intergrid_map.make_mapping (result, triangulation_2);
+
+        bool any_cell_flagged = false;
+        for (typename Triangulation<dim, spacedim>::active_cell_iterator
+             result_cell = result.begin_active();
+             result_cell != result.end(); ++result_cell)
+          if (intergrid_map[result_cell]->has_children())
+            {
+              any_cell_flagged = true;
+              result_cell->set_refine_flag ();
+            }
+
+        if (any_cell_flagged == false)
+          break;
+        else
+          result.execute_coarsening_and_refinement();
+      }
+  }
+
+
+
   void
   extrude_triangulation(const Triangulation<2, 2> &input,
                         const unsigned int n_slices,
@@ -3947,6 +3998,174 @@ namespace GridGenerator
       }
     }
     out_tria.create_triangulation(v, cells, subcelldata);
+  }
+
+
+
+  // This anonymous namespace contains utility functions to extract the
+  // triangulation from any container such as DoFHandler
+  // and the like
+    namespace
+    {
+      template<int dim, int spacedim>
+      const Triangulation<dim, spacedim> &
+      get_tria(const Triangulation<dim, spacedim> &tria)
+      {
+        return tria;
+      }
+
+      template<int dim, int spacedim>
+      const Triangulation<dim, spacedim> &
+      get_tria(const parallel::distributed::Triangulation<dim, spacedim> &tria)
+      {
+        return tria;
+      }
+
+      template<int dim, template<int, int> class Container, int spacedim>
+      const Triangulation<dim,spacedim> &
+      get_tria(const Container<dim,spacedim> &container)
+      {
+        return container.get_tria();
+      }
+
+
+      template<int dim, int spacedim>
+      Triangulation<dim, spacedim> &
+      get_tria(Triangulation<dim, spacedim> &tria)
+      {
+        return tria;
+      }
+
+      template<int dim, int spacedim>
+      Triangulation<dim, spacedim> &
+      get_tria(parallel::distributed::Triangulation<dim, spacedim> &tria)
+      {
+        return tria;
+      }
+
+      template<int dim, template<int, int> class Container, int spacedim>
+      const Triangulation<dim,spacedim> &
+      get_tria(Container<dim,spacedim> &container)
+      {
+        return container.get_tria();
+      }
+    }
+
+
+
+  template <template <int,int> class Container, int dim, int spacedim>
+#ifndef _MSC_VER
+  std::map<typename Container<dim-1,spacedim>::cell_iterator,
+      typename Container<dim,spacedim>::face_iterator>
+#else
+  typename ExtractBoundaryMesh<Container,dim,spacedim>::return_type
+#endif
+      extract_boundary_mesh (const Container<dim,spacedim> &volume_mesh,
+                             Container<dim-1,spacedim>     &surface_mesh,
+                             const std::set<types::boundary_id> &boundary_ids)
+  {
+// This function works using the following assumption:
+//    Triangulation::create_triangulation(...) will create cells that preserve
+//    the order of cells passed in using the CellData argument; also,
+//    that it will not reorder the vertices.
+
+    std::map<typename Container<dim-1,spacedim>::cell_iterator,
+        typename Container<dim,spacedim>::face_iterator>
+        surface_to_volume_mapping;
+
+    const unsigned int boundary_dim = dim-1; //dimension of the boundary mesh
+
+    // First create surface mesh and mapping
+    // from only level(0) cells of volume_mesh
+    std::vector<typename Container<dim,spacedim>::face_iterator>
+    mapping;  // temporary map for level==0
+
+
+    std::vector< bool > touched (get_tria(volume_mesh).n_vertices(), false);
+    std::vector< CellData< boundary_dim > > cells;
+    std::vector< Point<spacedim> >      vertices;
+
+    std::map<unsigned int,unsigned int> map_vert_index; //volume vertex indices to surf ones
+
+    unsigned int v_index;
+    CellData< boundary_dim > c_data;
+
+    for (typename Container<dim,spacedim>::cell_iterator
+         cell = volume_mesh.begin(0);
+         cell != volume_mesh.end(0);
+         ++cell)
+      for (unsigned int i=0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+        {
+          const typename Container<dim,spacedim>::face_iterator
+          face = cell->face(i);
+
+          if ( face->at_boundary()
+               &&
+               (boundary_ids.empty() ||
+                ( boundary_ids.find(face->boundary_indicator()) != boundary_ids.end())) )
+            {
+              for (unsigned int j=0;
+                   j<GeometryInfo<boundary_dim>::vertices_per_cell; ++j)
+                {
+                  v_index = face->vertex_index(j);
+
+                  if ( !touched[v_index] )
+                    {
+                      vertices.push_back(face->vertex(j));
+                      map_vert_index[v_index] = vertices.size() - 1;
+                      touched[v_index] = true;
+                    }
+
+                  c_data.vertices[j] = map_vert_index[v_index];
+                  c_data.material_id = static_cast<types::material_id>(face->boundary_indicator());
+                }
+
+              cells.push_back(c_data);
+              mapping.push_back(face);
+            }
+        }
+
+    // create level 0 surface triangulation
+    Assert (cells.size() > 0, ExcMessage ("No boundary faces selected"));
+    const_cast<Triangulation<dim-1,spacedim>&>(get_tria(surface_mesh))
+    .create_triangulation (vertices, cells, SubCellData());
+
+    // Make the actual mapping
+    for (typename Container<dim-1,spacedim>::active_cell_iterator
+         cell = surface_mesh.begin(0);
+         cell!=surface_mesh.end(0); ++cell)
+      surface_to_volume_mapping[cell] = mapping.at(cell->index());
+
+    do
+      {
+        bool changed = false;
+
+        for (typename Container<dim-1,spacedim>::active_cell_iterator
+            cell = surface_mesh.begin_active(); cell!=surface_mesh.end(); ++cell)
+          if (surface_to_volume_mapping[cell]->has_children() == true )
+            {
+              cell->set_refine_flag ();
+              changed = true;
+            }
+
+        if (changed)
+          {
+            const_cast<Triangulation<dim-1,spacedim>&>(get_tria(surface_mesh))
+            .execute_coarsening_and_refinement();
+
+            for (typename Container<dim-1,spacedim>::cell_iterator
+                surface_cell = surface_mesh.begin(); surface_cell!=surface_mesh.end(); ++surface_cell)
+              for (unsigned int c=0; c<surface_cell->n_children(); c++)
+                if (surface_to_volume_mapping.find(surface_cell->child(c)) == surface_to_volume_mapping.end())
+                  surface_to_volume_mapping[surface_cell->child(c)]
+                    = surface_to_volume_mapping[surface_cell]->child(c);
+          }
+        else
+          break;
+      }
+    while (true);
+
+    return surface_to_volume_mapping;
   }
 
 }

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -37,8 +37,38 @@ namespace GridGenerator
        const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation_2,
        Triangulation<deal_II_dimension,deal_II_space_dimension>       &result);
       
+    template
+      void
+      create_union_triangulation
+      (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_1,
+       const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_2,
+       Triangulation<deal_II_dimension, deal_II_space_dimension>       &result);
+      
 #endif
 \}  
+  }
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; Container : TRIANGULATION_AND_DOFHANDLER_TEMPLATES)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    namespace GridGenerator \{
+
+#if deal_II_dimension != 1
+      template
+#ifndef _MSC_VER
+      std::map<Container<deal_II_dimension-1,deal_II_space_dimension>::cell_iterator,
+                   Container<deal_II_dimension,deal_II_space_dimension>::face_iterator>
+#else
+      ExtractBoundaryMesh<Container,deal_II_dimension,deal_II_space_dimension>::return_type
+#endif
+      extract_boundary_mesh (const Container<deal_II_dimension, deal_II_space_dimension> &mesh,
+                             Container<deal_II_dimension-1,deal_II_space_dimension>  &boundary_mesh,
+                             const std::set<types::boundary_id> &boundary_ids);
+#endif
+      \}
+#endif
+
   }
 
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -234,6 +234,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 	const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_1,
 	const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation_2,
 	Triangulation<deal_II_dimension, deal_II_space_dimension>       &result);
+
 #if deal_II_dimension == deal_II_space_dimension
     template
     void

--- a/tests/codim_one/boundary_indicator_01.cc
+++ b/tests/codim_one/boundary_indicator_01.cc
@@ -91,7 +91,7 @@ int main ()
     // surface faces
     std::set<types::boundary_id> boundary_indicators;
     boundary_indicators.insert (0);
-    GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh,
+    GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh,
                                       boundary_indicators);
     deallog << volume_mesh.n_active_cells () << std::endl;
     deallog << boundary_mesh.n_active_cells () << std::endl;

--- a/tests/codim_one/data_out_03.cc
+++ b/tests/codim_one/data_out_03.cc
@@ -94,7 +94,7 @@ int main ()
   std::set<types::boundary_id> boundary_ids;
   boundary_ids.insert(0);
 
-  GridTools::extract_boundary_mesh (volume_mesh, tria,
+  GridGenerator::extract_boundary_mesh (volume_mesh, tria,
                                     boundary_ids);
 
   // test for the position

--- a/tests/codim_one/direction_flag_01.cc
+++ b/tests/codim_one/direction_flag_01.cc
@@ -36,7 +36,7 @@ void test ()
   Triangulation<dim,spacedim> boundary_mesh;
   Triangulation<spacedim> volume_mesh;
   GridGenerator::hyper_cube(volume_mesh);
-  GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+  GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
   for (Triangulation<dim,spacedim>::active_cell_iterator
        cell = boundary_mesh.begin_active();
        cell != boundary_mesh.end(); ++cell)

--- a/tests/codim_one/direction_flag_02.cc
+++ b/tests/codim_one/direction_flag_02.cc
@@ -36,7 +36,7 @@ void test ()
   Triangulation<dim,spacedim> boundary_mesh;
   Triangulation<spacedim> volume_mesh;
   GridGenerator::hyper_cube(volume_mesh);
-  GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+  GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
   for (Triangulation<dim,spacedim>::active_cell_iterator
        cell = boundary_mesh.begin_active();
        cell != boundary_mesh.end(); ++cell)

--- a/tests/codim_one/extract_boundary_mesh_00.cc
+++ b/tests/codim_one/extract_boundary_mesh_00.cc
@@ -17,7 +17,7 @@
 
 /*
  Code for testing the function
- GridTools::extract_boundary_mesh (...).
+ GridGenerator::extract_boundary_mesh (...).
  We test that the order of cells and the orientation
  of the vertices is consistent between the two meshes.
 
@@ -113,7 +113,7 @@ int main ()
     Triangulation<dim-1,dim> boundary_mesh;
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
     if (test_vertices_orientation(boundary_mesh, surface_to_volume_mapping))
       deallog << "Passed.";
@@ -144,7 +144,7 @@ int main ()
     Triangulation<dim-1,dim> boundary_mesh;
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
     if (test_vertices_orientation(boundary_mesh, surface_to_volume_mapping))
       deallog << "Passed.";
@@ -179,7 +179,7 @@ int main ()
     boundary_ids.insert(0);
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh,
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh,
                                           boundary_ids);
 
     if (test_vertices_orientation(boundary_mesh, surface_to_volume_mapping))

--- a/tests/codim_one/extract_boundary_mesh_01.cc
+++ b/tests/codim_one/extract_boundary_mesh_01.cc
@@ -17,7 +17,7 @@
 
 /*
  Code for testing the function
- GridTools::extract_boundary_mesh (...).
+ GridGenerator::extract_boundary_mesh (...).
  We test that the order of cells and the orientation
  of the vertices is consistent between the two meshes.
 
@@ -117,7 +117,7 @@ int main ()
     Triangulation<dim-1,dim> boundary_mesh;
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
     if (!test_vertices_orientation(boundary_mesh, surface_to_volume_mapping,2))
       Assert (false, ExcInternalError());

--- a/tests/codim_one/extract_boundary_mesh_02.cc
+++ b/tests/codim_one/extract_boundary_mesh_02.cc
@@ -17,7 +17,7 @@
 
 /*
  Code for testing the function
- GridTools::extract_boundary_mesh (...).
+ GridGenerator::extract_boundary_mesh (...).
  We test that the order of cells and the orientation
  of the vertices is consistent between the two meshes.
 
@@ -107,7 +107,7 @@ int main ()
     boundary_mesh.set_boundary (0, surface_description);
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
     deallog << volume_mesh.n_active_cells () << std::endl;
     deallog << boundary_mesh.n_active_cells () << std::endl;
     save_mesh(boundary_mesh);

--- a/tests/codim_one/extract_boundary_mesh_03.cc
+++ b/tests/codim_one/extract_boundary_mesh_03.cc
@@ -17,7 +17,7 @@
 
 /*
  Code for testing the function
- GridTools::extract_boundary_mesh (...).
+ GridGenerator::extract_boundary_mesh (...).
  We test that the order of cells and the orientation
  of the vertices is consistent between the two meshes.
 
@@ -121,7 +121,7 @@ int main ()
     boundary_mesh.set_boundary (1, surface_description);
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
     deallog << volume_mesh.n_active_cells () << std::endl;
     deallog << boundary_mesh.n_active_cells () << std::endl;
     save_mesh(boundary_mesh);

--- a/tests/codim_one/extract_boundary_mesh_04.cc
+++ b/tests/codim_one/extract_boundary_mesh_04.cc
@@ -17,7 +17,7 @@
 
 /*
  Code for testing the function
- GridTools::extract_boundary_mesh (...).
+ GridGenerator::extract_boundary_mesh (...).
  We test that the order of cells and the orientation
  of the vertices is consistent between the two meshes.
 
@@ -127,7 +127,7 @@ int main ()
     boundary_ids.insert(1);
 
     surface_to_volume_mapping
-      = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh,
+      = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh,
                                           boundary_ids);
 
     deallog << volume_mesh.n_active_cells () << std::endl;

--- a/tests/codim_one/extract_boundary_mesh_05.cc
+++ b/tests/codim_one/extract_boundary_mesh_05.cc
@@ -43,7 +43,7 @@ void test ()
   GridGenerator::hyper_cube(volume_mesh);
 
   surface_to_volume_mapping
-    = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+    = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
   FE_Q <dim-1,dim>  boundary_fe (1);
   DoFHandler<dim-1,dim> boundary_dh(boundary_mesh);

--- a/tests/codim_one/extract_boundary_mesh_06.cc
+++ b/tests/codim_one/extract_boundary_mesh_06.cc
@@ -44,7 +44,7 @@ void test ()
   GridGenerator::hyper_cube(volume_mesh);
   volume_mesh.refine_global(1);
   surface_to_volume_mapping
-    = GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+    = GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
   boundary_mesh.refine_global(1);
 
   for (Triangulation<dim,spacedim>::active_cell_iterator

--- a/tests/codim_one/extract_boundary_mesh_07.cc
+++ b/tests/codim_one/extract_boundary_mesh_07.cc
@@ -89,7 +89,7 @@ namespace Step38
     std::map<typename DoFHandler<boundary_dim, spacedim>::cell_iterator,
         typename DoFHandler<spacedim>::face_iterator>
         element_assignment =
-          GridTools::extract_boundary_mesh(space_dof_handler,
+          GridGenerator::extract_boundary_mesh(space_dof_handler,
                                            contact_dof_handler,
                                            boundary_ids);
 

--- a/tests/codim_one/hanging_nodes_01.cc
+++ b/tests/codim_one/hanging_nodes_01.cc
@@ -56,7 +56,7 @@ int main ()
     cell->face(0)->set_all_boundary_indicators (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
-    GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
+    GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
   }
   boundary_mesh.begin_active()->set_refine_flag ();
   boundary_mesh.execute_coarsening_and_refinement ();

--- a/tests/codim_one/hanging_nodes_02.cc
+++ b/tests/codim_one/hanging_nodes_02.cc
@@ -56,7 +56,7 @@ int main ()
     cell->face(0)->set_all_boundary_indicators (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
-    GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
+    GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
   }
   boundary_mesh.begin_active()->set_refine_flag ();
   boundary_mesh.execute_coarsening_and_refinement ();

--- a/tests/codim_one/hanging_nodes_03.cc
+++ b/tests/codim_one/hanging_nodes_03.cc
@@ -50,7 +50,7 @@ int main ()
     cell->face(0)->set_all_boundary_indicators (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
-    GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
+    GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);
   }
 
   Triangulation<dim,spacedim>::active_cell_iterator

--- a/tests/codim_one/interpolate_boundary_values_03.cc
+++ b/tests/codim_one/interpolate_boundary_values_03.cc
@@ -45,7 +45,7 @@ void test()
   std::set<types::boundary_id> boundary_ids;
   boundary_ids.insert(0);
 
-  GridTools::extract_boundary_mesh (volume_mesh, tria,boundary_ids);
+  GridGenerator::extract_boundary_mesh (volume_mesh, tria,boundary_ids);
 
   deallog << tria.n_active_cells() << " active cells" << std::endl;
 

--- a/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
+++ b/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
@@ -55,7 +55,7 @@ void test()
   GridGenerator::hyper_cube(volume_mesh);
 
   surface_to_volume_mapping
-    = GridTools::extract_boundary_mesh (volume_mesh, tria);
+    = GridGenerator::extract_boundary_mesh (volume_mesh, tria);
 
   FE_Q<dim,spacedim> fe(2);
   DoFHandler<dim,spacedim> dof_handler (tria);

--- a/tests/codim_one/mapping_01.cc
+++ b/tests/codim_one/mapping_01.cc
@@ -48,7 +48,7 @@ void test ()
   Triangulation<dim-1,dim> boundary_mesh;
   boundary_mesh.set_boundary (0, surface_description);
 
-  GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+  GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
   QGauss<dim-1> quadrature(2);
   MappingQ1<dim-1,dim> mapping;

--- a/tests/codim_one/mapping_02.cc
+++ b/tests/codim_one/mapping_02.cc
@@ -45,7 +45,7 @@ void test ()
   Triangulation<dim-1,dim> boundary_mesh;
   boundary_mesh.set_boundary (0, surface_description);
 
-  GridTools::extract_boundary_mesh (volume_mesh, boundary_mesh);
+  GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
   QGauss<dim-1> quadrature(dim == 2 ? 3 : 2);
   MappingQ<dim-1,dim> mapping(2);

--- a/tests/codim_one/normal_vectors_01.cc
+++ b/tests/codim_one/normal_vectors_01.cc
@@ -41,7 +41,7 @@ void test ()
   GridGenerator::hyper_cube(volume_mesh);
 
   Triangulation<dim-1,dim> tria;
-  GridTools::extract_boundary_mesh (volume_mesh, tria);
+  GridGenerator::extract_boundary_mesh (volume_mesh, tria);
 
   FE_Q<dim-1,dim> fe (1);
   DoFHandler<dim-1,dim> dh(tria);

--- a/tests/codim_one/transform_01.cc
+++ b/tests/codim_one/transform_01.cc
@@ -75,7 +75,7 @@ int main ()
   std::set<types::boundary_id> boundary_ids;
   boundary_ids.insert(0);
 
-  GridTools::extract_boundary_mesh (volume_mesh, triangulation,
+  GridGenerator::extract_boundary_mesh (volume_mesh, triangulation,
                                     boundary_ids);
   triangulation.set_boundary (1);
   triangulation.set_boundary (0);

--- a/tests/deal.II/union_triangulation.cc
+++ b/tests/deal.II/union_triangulation.cc
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------
 // $Id$
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,7 +61,7 @@ void test ()
   (++tria_2.begin_active())->set_refine_flag();
   tria_2.execute_coarsening_and_refinement ();
 
-  GridTools::create_union_triangulation (tria_1, tria_2, tria_3);
+  GridGenerator::create_union_triangulation (tria_1, tria_2, tria_3);
 
   GridOut().write_gnuplot (tria_3, logfile);
 

--- a/tests/deal.II/vertex_as_face_09.cc
+++ b/tests/deal.II/vertex_as_face_09.cc
@@ -37,7 +37,7 @@ void test ()
 
   Triangulation<1,2> tria;
 
-  GridTools::extract_boundary_mesh (volume_mesh, tria);
+  GridGenerator::extract_boundary_mesh (volume_mesh, tria);
 
   deallog << "n_cells = " << tria.n_active_cells() << std::endl;
   deallog << "n_boundary_ids = " << tria.get_boundary_indicators ().size()

--- a/tests/manifold/spherical_manifold_04.cc
+++ b/tests/manifold/spherical_manifold_04.cc
@@ -36,7 +36,7 @@ void test(unsigned int ref=1)
   Triangulation<spacedim, spacedim> volume_tria;
   Triangulation<dim, spacedim> tria;
   GridGenerator::hyper_ball (volume_tria);
-  GridTools::extract_boundary_mesh(volume_tria, tria);
+  GridGenerator::extract_boundary_mesh(volume_tria, tria);
 
   typename Triangulation<dim,spacedim>::active_cell_iterator cell;
   


### PR DESCRIPTION
These functions were previously in GridTools, but conceptually they create
meshes and so should be in GridGenerator. Move them there but leave the
old functions in GridTools with a note that they are now deprecated.

Also structure the documentation of the functions in GridGenerator better.
