### PR TITLE
Use an explicit cast when need a bool from optional<...>. 

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1275,7 +1275,7 @@ ParameterHandler::demangle (const std::string &s)
 bool
 ParameterHandler::is_parameter_node (const boost::property_tree::ptree &p)
 {
-  return (p.get_optional<std::string>("value"));
+  return static_cast<bool>(p.get_optional<std::string>("value"));
 }
 
 


### PR DESCRIPTION
The implicit cast was previously allowed, but newer versions of BOOST together with C++11 mark
the cast as 'explicit', and it fails in the current context.
