### PR TITLE
Do not output CG messages in memory_consumption_01

### DIFF
--- a/tests/deal.II/memory_consumption_01.cc
+++ b/tests/deal.II/memory_consumption_01.cc
@@ -274,8 +274,19 @@ void Step6<dim>::solve ()
   PreconditionSSOR<> preconditioner;
   preconditioner.initialize(system_matrix, 1.2);
 
-  solver.solve (system_matrix, solution, system_rhs,
-                preconditioner);
+  try
+    {
+      deallog.depth_file(0);
+      solver.solve (system_matrix, solution, system_rhs,
+                    preconditioner);
+      deallog.depth_file(3);
+    }
+  catch (std::exception &e)
+    {
+      deallog.depth_file(3);
+      deallog << e.what() << std::endl;
+      abort ();
+    }
 
   hanging_node_constraints.distribute (solution);
 }

--- a/tests/deal.II/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/deal.II/memory_consumption_01.with_64bit_indices=off.output
@@ -3,8 +3,6 @@ DEAL::1d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       8
 DEAL::   Number of degrees of freedom: 17
-DEAL:cg::Starting value 0.261041
-DEAL:cg::Convergence step 13 value 0
 DEAL::Memory consumption -- Triangulation: 2934
 DEAL::Memory consumption -- DoFHandler:    976
 DEAL::Memory consumption -- FE:            1488
@@ -16,8 +14,6 @@ DEAL::Memory consumption -- Rhs:           224
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       11
 DEAL::   Number of degrees of freedom: 23
-DEAL:cg::Starting value 0.235472
-DEAL:cg::Convergence step 16 value 0
 DEAL::Memory consumption -- Triangulation: 3822
 DEAL::Memory consumption -- DoFHandler:    1164
 DEAL::Memory consumption -- FE:            1488
@@ -29,8 +25,6 @@ DEAL::Memory consumption -- Rhs:           272
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       15
 DEAL::   Number of degrees of freedom: 31
-DEAL:cg::Starting value 0.226008
-DEAL:cg::Convergence step 21 value 0
 DEAL::Memory consumption -- Triangulation: 4686
 DEAL::Memory consumption -- DoFHandler:    1356
 DEAL::Memory consumption -- FE:            1488
@@ -42,8 +36,6 @@ DEAL::Memory consumption -- Rhs:           336
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 41
-DEAL:cg::Starting value 0.204506
-DEAL:cg::Convergence step 27 value 0
 DEAL::Memory consumption -- Triangulation: 5766
 DEAL::Memory consumption -- DoFHandler:    1584
 DEAL::Memory consumption -- FE:            1488
@@ -57,8 +49,6 @@ DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 89
-DEAL:cg::Starting value 0.351647
-DEAL:cg::Convergence step 22 value 0
 DEAL::Memory consumption -- Triangulation: 5283
 DEAL::Memory consumption -- DoFHandler:    1936
 DEAL::Memory consumption -- FE:            3904
@@ -70,8 +60,6 @@ DEAL::Memory consumption -- Rhs:           800
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
-DEAL:cg::Starting value 0.271387
-DEAL:cg::Convergence step 30 value 0
 DEAL::Memory consumption -- Triangulation: 10915
 DEAL::Memory consumption -- DoFHandler:    3728
 DEAL::Memory consumption -- FE:            3904
@@ -83,8 +71,6 @@ DEAL::Memory consumption -- Rhs:           1760
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
-DEAL:cg::Starting value 0.203851
-DEAL:cg::Convergence step 51 value 0
 DEAL::Memory consumption -- Triangulation: 21347
 DEAL::Memory consumption -- DoFHandler:    7184
 DEAL::Memory consumption -- FE:            3904
@@ -96,8 +82,6 @@ DEAL::Memory consumption -- Rhs:           3680
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
-DEAL:cg::Starting value 0.151971
-DEAL:cg::Convergence step 71 value 0
 DEAL::Memory consumption -- Triangulation: 42899
 DEAL::Memory consumption -- DoFHandler:    14672
 DEAL::Memory consumption -- FE:            3904
@@ -111,8 +95,6 @@ DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
 DEAL::   Number of degrees of freedom: 517
-DEAL:cg::Starting value 0.206362
-DEAL:cg::Convergence step 29 value 0
 DEAL::Memory consumption -- Triangulation: 24743
 DEAL::Memory consumption -- DoFHandler:    9760
 DEAL::Memory consumption -- FE:            12280
@@ -124,8 +106,6 @@ DEAL::Memory consumption -- Rhs:           4224
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
-DEAL:cg::Starting value 0.116541
-DEAL:cg::Convergence step 31 value 0
 DEAL::Memory consumption -- Triangulation: 97477
 DEAL::Memory consumption -- DoFHandler:    37996
 DEAL::Memory consumption -- FE:            12280
@@ -137,8 +117,6 @@ DEAL::Memory consumption -- Rhs:           17824
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
-DEAL:cg::Starting value 0.0978429
-DEAL:cg::Convergence step 55 value 0
 DEAL::Memory consumption -- Triangulation: 390903
 DEAL::Memory consumption -- DoFHandler:    151280
 DEAL::Memory consumption -- FE:            12280
@@ -150,8 +128,6 @@ DEAL::Memory consumption -- Rhs:           75072
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
-DEAL:cg::Starting value 0.0425276
-DEAL:cg::Convergence step 82 value 0
 DEAL::Memory consumption -- Triangulation: 1375395
 DEAL::Memory consumption -- DoFHandler:    542008
 DEAL::Memory consumption -- FE:            12280

--- a/tests/deal.II/memory_consumption_01.with_64bit_indices=on.output
+++ b/tests/deal.II/memory_consumption_01.with_64bit_indices=on.output
@@ -3,8 +3,6 @@ DEAL::1d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       8
 DEAL::   Number of degrees of freedom: 17
-DEAL:cg::Starting value 0.261041
-DEAL:cg::Convergence step 13 value 0
 DEAL::Memory consumption -- Triangulation: 2934
 DEAL::Memory consumption -- DoFHandler:    1280
 DEAL::Memory consumption -- FE:            1488
@@ -16,8 +14,6 @@ DEAL::Memory consumption -- Rhs:           232
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       11
 DEAL::   Number of degrees of freedom: 23
-DEAL:cg::Starting value 0.235472
-DEAL:cg::Convergence step 16 value 0
 DEAL::Memory consumption -- Triangulation: 3822
 DEAL::Memory consumption -- DoFHandler:    1576
 DEAL::Memory consumption -- FE:            1488
@@ -29,8 +25,6 @@ DEAL::Memory consumption -- Rhs:           280
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       15
 DEAL::   Number of degrees of freedom: 31
-DEAL:cg::Starting value 0.226008
-DEAL:cg::Convergence step 21 value 0
 DEAL::Memory consumption -- Triangulation: 4686
 DEAL::Memory consumption -- DoFHandler:    1912
 DEAL::Memory consumption -- FE:            1488
@@ -42,8 +36,6 @@ DEAL::Memory consumption -- Rhs:           344
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 41
-DEAL:cg::Starting value 0.204506
-DEAL:cg::Convergence step 27 value 0
 DEAL::Memory consumption -- Triangulation: 5766
 DEAL::Memory consumption -- DoFHandler:    2320
 DEAL::Memory consumption -- FE:            1488
@@ -57,8 +49,6 @@ DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 89
-DEAL:cg::Starting value 0.351647
-DEAL:cg::Convergence step 22 value 0
 DEAL::Memory consumption -- Triangulation: 5283
 DEAL::Memory consumption -- DoFHandler:    3288
 DEAL::Memory consumption -- FE:            3904
@@ -70,8 +60,6 @@ DEAL::Memory consumption -- Rhs:           808
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
-DEAL:cg::Starting value 0.271387
-DEAL:cg::Convergence step 30 value 0
 DEAL::Memory consumption -- Triangulation: 10915
 DEAL::Memory consumption -- DoFHandler:    6808
 DEAL::Memory consumption -- FE:            3904
@@ -83,8 +71,6 @@ DEAL::Memory consumption -- Rhs:           1768
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
-DEAL:cg::Starting value 0.203851
-DEAL:cg::Convergence step 51 value 0
 DEAL::Memory consumption -- Triangulation: 21347
 DEAL::Memory consumption -- DoFHandler:    13672
 DEAL::Memory consumption -- FE:            3904
@@ -96,8 +82,6 @@ DEAL::Memory consumption -- Rhs:           3688
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
-DEAL:cg::Starting value 0.151971
-DEAL:cg::Convergence step 71 value 0
 DEAL::Memory consumption -- Triangulation: 42899
 DEAL::Memory consumption -- DoFHandler:    28648
 DEAL::Memory consumption -- FE:            3904
@@ -111,8 +95,6 @@ DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
 DEAL::   Number of degrees of freedom: 517
-DEAL:cg::Starting value 0.206362
-DEAL:cg::Convergence step 29 value 0
 DEAL::Memory consumption -- Triangulation: 24743
 DEAL::Memory consumption -- DoFHandler:    18912
 DEAL::Memory consumption -- FE:            12280
@@ -124,8 +106,6 @@ DEAL::Memory consumption -- Rhs:           4232
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
-DEAL:cg::Starting value 0.116541
-DEAL:cg::Convergence step 31 value 0
 DEAL::Memory consumption -- Triangulation: 97477
 DEAL::Memory consumption -- DoFHandler:    75320
 DEAL::Memory consumption -- FE:            12280
@@ -137,8 +117,6 @@ DEAL::Memory consumption -- Rhs:           17832
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
-DEAL:cg::Starting value 0.0978429
-DEAL:cg::Convergence step 55 value 0
 DEAL::Memory consumption -- Triangulation: 390903
 DEAL::Memory consumption -- DoFHandler:    301840
 DEAL::Memory consumption -- FE:            12280
@@ -150,8 +128,6 @@ DEAL::Memory consumption -- Rhs:           75080
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
-DEAL:cg::Starting value 0.0425276
-DEAL:cg::Convergence step 82 value 0
 DEAL::Memory consumption -- Triangulation: 1375395
 DEAL::Memory consumption -- DoFHandler:    1083216
 DEAL::Memory consumption -- FE:            12280


### PR DESCRIPTION
It turns out that the previous fix for memory_consumption_01 for icc
was not enough. For icc in release mode the final residual for the CG
iteration is not stable - just prevent it to be ever printed...
