### PR TITLE
Only test indentation on pull requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 #  These tests run ok, but they might be out of policy...
   - CI_TEST_SUITE=build CI_BUILD_TYPE=Debug
+  - CI_TEST_SUITE=indent
 #  - CI_TEST_SUITE=build CI_BUILD_TYPE=Release
 
 # These tests only compile and run "make tests"

--- a/contrib/utilities/run_travis.sh
+++ b/contrib/utilities/run_travis.sh
@@ -1,21 +1,30 @@
 #!/bin/sh
 case $1 in
-#mini)
-#    echo "Building and running mini tests in $2 mode."
-#    mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=$2 ../ && make -j4 && make tests
-#    ;;
 build)
-    echo "Running build tests."
-    mkdir build_test 
-    cd build_test
-    ctest -DCMAKE_BUILD_TYPE=$2 -V -j4 -S ../tests/run_buildtest.cmake
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then 
+	echo "Running build tests."
+	mkdir build_test 
+	cd build_test
+	ctest -DCMAKE_BUILD_TYPE=$2 -V -j4 -S ../tests/run_buildtest.cmake
+    else 
+	echo "Build test is only run when merging to master branch. Exiting."
+    fi
     ;;
-#tests)
-#    echo "Running full testsuite."
-#    mkdir full_tests
-#    cd full_tests
-#    ctest -DCMAKE_BUILD_TYPE=$2 -V -j4 -S ../tests/run_testsuite.cmake
-#    ;;
+indent)
+     if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then 
+	echo "Running indentation test on master merge."
+     else 
+        echo "Running indentation test on Pull Request #${TRAVIS_PULL_REQUEST}"
+     fi
+     wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.04/astyle_2.04_linux.tar.gz > /dev/null
+     tar xvfz astyle_2.04_linux.tar.gz > /dev/null
+     pushd astyle/build/gcc
+     make -j4 > /dev/null
+     popd
+     export PATH=`pwd`/astyle/build/gcc/bin:$PATH
+     ./contrib/utilities/indent
+     git diff-files --quiet || (git diff && failing_missing_command)	
+     ;;
 *)
     echo "Unrecognized test type! [$1]"
     exit 1


### PR DESCRIPTION
This closes issue #89, where we discussed about possibly testing with Travis CI the indentation of the pull request. 

Since most of the pull requests are failing anyway on Travis (time limit for a pull request is 25 minutes, and we hit it pretty regularly), this pull request configures Travis CI to only check indentation in pull requests, and do the full build only when the pull request is merged on master. 
