### PR TITLE
Suppress clang warnings when compiling bundled boost 1.56

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -113,6 +113,11 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-private-field")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-variable")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unsupported-friend")
+
+  # suppress warnings in boost 1.56:
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-c++11-extensions")
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-c99-extensions")
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-variadic-macros")
 ENDIF()
 
 


### PR DESCRIPTION
Clang generates a bunch of warnings of the type:

```
bundled/boost-1.56.0/include/boost/preprocessor/tuple/eat.hpp:23:26: warning: variadic macros are a C99 feature [-Wvariadic-macros]
bundled/boost-1.56.0/include/boost/mpl/if.hpp:131:1: warning: empty macro arguments are a C99 feature [-Wc99-extensions]
```

This patch just disables those warnings. Also see https://code.google.com/p/dealii/issues/detail?id=252
