### PR TITLE
Fix an oversight in the previous patch in which we did not put stuff into the correct namespace.

### DIFF
--- a/include/deal.II/base/std_cxx1x/array.h
+++ b/include/deal.II/base/std_cxx1x/array.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/array.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/bind.h
+++ b/include/deal.II/base/std_cxx1x/bind.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/bind.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/condition_variable.h
+++ b/include/deal.II/base/std_cxx1x/condition_variable.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/condition_variable.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/function.h
+++ b/include/deal.II/base/std_cxx1x/function.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/function.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/mutex.h
+++ b/include/deal.II/base/std_cxx1x/mutex.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/mutex.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/shared_ptr.h
+++ b/include/deal.II/base/std_cxx1x/shared_ptr.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/shared_ptr.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/thread.h
+++ b/include/deal.II/base/std_cxx1x/thread.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/thread.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/tuple.h
+++ b/include/deal.II/base/std_cxx1x/tuple.h
@@ -18,4 +18,6 @@
 #include "../std_cxx11/tuple.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
+DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx1x/type_traits.h
+++ b/include/deal.II/base/std_cxx1x/type_traits.h
@@ -18,5 +18,6 @@
 #include "../std_cxx11/type_traits.h"
 
 // then allow using the old namespace name instead of the new one
+DEAL_II_NAMESPACE_OPEN
 namespace std_cxx1x = std_cxx11;
-
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
It didn't show when compiling deal.II or the testsuite, but this is an emergency fix for all programs that still include the old std_cxx1x header files since they are currently broken.
