### PR TITLE
Bugfix: step-53 requires enabled DEAL_II_WITH_ZLIB

### DIFF
--- a/examples/step-53/CMakeLists.txt
+++ b/examples/step-53/CMakeLists.txt
@@ -34,6 +34,17 @@ IF(NOT ${deal.II_FOUND})
     )
 ENDIF()
 
+#
+# Are all dependencies fullfilled?
+#
+IF(NOT DEAL_II_WITH_ZLIB)
+  MESSAGE(FATAL_ERROR "
+Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+  DEAL_II_WITH_ZLIB = ON
+One or all of these are OFF in your installation but are required for this tutorial step."
+    )
+ENDIF()
+
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT(${TARGET})
 DEAL_II_INVOKE_AUTOPILOT()


### PR DESCRIPTION
step-53 uses boost's <iostreams/filter/gzip.hpp> in order to unpack the
file topography.txt.gz.

If the internal boost variant is used this requires external linkage to
zlib. This commit adds a corresponding configuration toggle to the
CMakeLists.txt file of step-53.
