### PR TITLE
Bugfix: Do not forget to use the 'RELATIVE' keyword

### DIFF
--- a/tests/all-headers/CMakeLists.txt
+++ b/tests/all-headers/CMakeLists.txt
@@ -33,7 +33,7 @@ SET(_category all-headers)
 # Glob together all header files and strip SOURCE_DIR/include/deal.II to
 # get a correct relative path:
 #
-FILE(GLOB_RECURSE _headers ${DEAL_II_SOURCE_DIR}/include/deal.II/
+FILE(GLOB_RECURSE _headers RELATIVE ${DEAL_II_SOURCE_DIR}/include/deal.II
   ${DEAL_II_SOURCE_DIR}/include/deal.II/*.h
   )
 


### PR DESCRIPTION
Well, I forgot the 'RELATIVE' clause in the new globbing expression (and
miraculously it worked on my machine...).
