### PR TITLE
Updated documentation

### DIFF
--- a/examples/step-20/doc/intro.dox
+++ b/examples/step-20/doc/intro.dox
@@ -439,14 +439,14 @@ class SchurComplement
 {
   public:
     SchurComplement (const BlockSparseMatrix<double> &A,
-                     const InverseMatrix             &Minv);
+                     const IterativeInverse<Vector<double> > &Minv);
 
     void vmult (Vector<double>       &dst,
                 const Vector<double> &src) const;
 
   private:
     const SmartPointer<const BlockSparseMatrix<double> > system_matrix;
-    const SmartPointer<const InverseMatrix>              m_inverse;
+    const SmartPointer<const IterativeInverse<Vector<double> > > m_inverse;
 
     mutable Vector<double> tmp1, tmp2;
 };

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -34,7 +34,7 @@ DEAL_II_NAMESPACE_OPEN
  * order to approximate the action of the inverse matrix.
  *
  * Krylov space methods like SolverCG or SolverBicgstab
- * become inefficient if soution down to machine accuracy is
+ * become inefficient if solution down to machine accuracy is
  * needed. This is due to the fact, that round-off errors spoil the
  * orthogonality of the vector sequences. Therefore, a nested
  * iteration of two methods is proposed: The outer method is


### PR DESCRIPTION
Updated documentation for step-20 Introduction section and a typo in the documentation for iterative_inverse.h.
Detailed: In the introduction of the step-20 tutorial, "Sec. Solving using the Schur complement", the IterativeInverse class is introduced and then in the following code section not used. Now the InverseMatrix is changed to IterativeInverse< .. > to match with the code of the tutorial, as used below.
