### PR TITLE
Workaround for IBM compiler in data_out_base.cc

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7953,7 +7953,7 @@ merge (const DataOutReader<dim,spacedim> &source)
   // adjust patch neighbors
   for (unsigned int i=old_n_patches; i<patches.size(); ++i)
     for (unsigned int n=0; n<GeometryInfo<dim>::faces_per_cell; ++n)
-      if (patches[i].neighbors[n] != Patch::no_neighbor)
+      if (patches[i].neighbors[n] != dealii::DataOutBase::Patch<dim,spacedim>::no_neighbor)
         patches[i].neighbors[n] += old_n_patches;
 }
 


### PR DESCRIPTION
This is a workaround for the IBM XL compiler as suggested by Kevin
Drzycimski on the mailing list.

Compiles with gcc-4.7.3. Should be fine with all other compilers, too.
