### PR TITLE
Make explicit instantiations match the way we declare the function in the header file.

### DIFF
--- a/source/grid/tria_objects.inst.in
+++ b/source/grid/tria_objects.inst.in
@@ -17,20 +17,20 @@
 for (deal_II_dimension : DIMENSIONS)
   {
 #if deal_II_dimension >= 2
-    template dealii::TriaRawIterator<dealii::TriaAccessor<1,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<1>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<1> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<1,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<1>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<1> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<2,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<2>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<2> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<2,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<2>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<2> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
 #endif
 
 #if deal_II_dimension >= 3
-    template dealii::TriaRawIterator<dealii::TriaAccessor<3,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<3>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<3> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<3,deal_II_dimension,deal_II_dimension> >
+    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<3>::dimension,deal_II_dimension,deal_II_dimension> >
     TriaObjects<TriaObject<3> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
 
     template dealii::Triangulation<deal_II_dimension>::raw_hex_iterator


### PR DESCRIPTION
This is in response to a problem currently reported on the mailing list. I don't know whether it helps the problem, but it at least makes the way we write the instantiation match the way we write the declaration in the header file.
