### PR TITLE
Check in DoFHandler::renumber_dofs() that DoFs are distributed

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -372,8 +372,11 @@ public:
   virtual void distribute_dofs (const FiniteElement<dim,spacedim> &fe);
 
   /**
-   * Distribute multigrid degrees of freedom similar
-   * to distribute_dofs() but on each level.
+   * Distribute level degrees of freedom on each level for geometric
+   * multigrid. The active DoFs need to be distributed using distribute_dofs()
+   * before calling this function and the @p fe needs to be identical to the
+   * finite element passed to distribute_dofs().
+   *
    * This replaces the functionality of the old MGDoFHandler.
    */
   virtual void distribute_mg_dofs (const FiniteElement<dim, spacedim> &fe);

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1239,9 +1239,10 @@ void DoFHandler<dim,spacedim>::distribute_dofs (const FiniteElement<dim,spacedim
 template<int dim, int spacedim>
 void DoFHandler<dim, spacedim>::distribute_mg_dofs (const FiniteElement<dim, spacedim> &fe)
 {
+  Assert(levels.size()>0, ExcMessage("Distribute active DoFs using distribute_dofs() before calling distribute_mg_dofs()."));
+
   const FiniteElement<dim, spacedim> *old_fe = selected_fe;
-  Assert((old_fe==NULL) || (old_fe == &fe), ExcMessage("you are required to use the same FE for level and active DoFs!") );
-  selected_fe = &fe;
+  Assert(old_fe == &fe, ExcMessage("You are required to use the same FE for level and active DoFs!") );
 
   clear_mg_space();
 
@@ -1311,6 +1312,8 @@ template <int dim, int spacedim>
 void
 DoFHandler<dim,spacedim>::renumber_dofs (const std::vector<types::global_dof_index> &new_numbers)
 {
+  Assert(levels.size()>0, ExcMessage("You need to distribute DoFs before you can renumber them."));
+
   Assert (new_numbers.size() == n_locally_owned_dofs(),
           ExcRenumberingIncomplete());
 
@@ -1356,6 +1359,8 @@ template<>
 void DoFHandler<1>::renumber_dofs (const unsigned int level,
                                    const std::vector<types::global_dof_index> &new_numbers)
 {
+  Assert(mg_levels.size()>0 && levels.size()>0,
+         ExcMessage("You need to distribute active and level DoFs before you can renumber level DoFs."));
   Assert (new_numbers.size() == n_dofs(level), DoFHandler<1>::ExcRenumberingIncomplete());
 
   // note that we can not use cell iterators
@@ -1390,6 +1395,8 @@ template<>
 void DoFHandler<2>::renumber_dofs (const unsigned int  level,
                                    const std::vector<types::global_dof_index>  &new_numbers)
 {
+  Assert(mg_levels.size()>0 && levels.size()>0,
+         ExcMessage("You need to distribute active and level DoFs before you can renumber level DoFs."));
   Assert (new_numbers.size() == n_dofs(level),
           DoFHandler<2>::ExcRenumberingIncomplete());
 
@@ -1447,6 +1454,8 @@ template<>
 void DoFHandler<3>::renumber_dofs (const unsigned int  level,
                                    const std::vector<types::global_dof_index>  &new_numbers)
 {
+  Assert(mg_levels.size()>0 && levels.size()>0,
+         ExcMessage("You need to distribute active and level DoFs before you can renumber level DoFs."));
   Assert (new_numbers.size() == n_dofs(level),
           DoFHandler<3>::ExcRenumberingIncomplete());
 


### PR DESCRIPTION
This adds several Asserts to check that DoFs are distributed
before calling renumber_dofs() for active or level DoFs. Note
that we now also require that you call distribute_dofs() before
distribute_mg_dofs().

Let's wait until we complete the discussion in https://groups.google.com/d/topic/dealii/G3Xp-Uv72_M/discussion
