### PR TITLE
Remove explicit instantiations.

### DIFF
--- a/source/grid/tria_objects.inst.in
+++ b/source/grid/tria_objects.inst.in
@@ -16,23 +16,7 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-#if deal_II_dimension >= 2
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<1>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<1> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<1>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<1> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<2>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<2> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<2>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<2> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
-#endif
-
 #if deal_II_dimension >= 3
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<3>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<3> >::next_free_single_object (const dealii::Triangulation<deal_II_dimension> &tria);
-    template dealii::TriaRawIterator<dealii::TriaAccessor<TriaObject<3>::dimension,deal_II_dimension,deal_II_dimension> >
-    TriaObjects<TriaObject<3> >::next_free_pair_object (const dealii::Triangulation<deal_II_dimension> &tria);
-
     template dealii::Triangulation<deal_II_dimension>::raw_hex_iterator
     TriaObjects<TriaObject<3> >::next_free_hex(const dealii::Triangulation<deal_II_dimension> &, const unsigned int);
 #endif


### PR DESCRIPTION
Since these functions were moved to the header file, we no longer
need to explicitly instantiate them since every .cc file that uses
them will generate an instantiation where necessary.
