### PR TITLE
Remove Assert in CellAccessor::face()

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3245,8 +3245,6 @@ typename DoFCellAccessor<DH,level_dof_access>::face_iterator
 DoFCellAccessor<DH,level_dof_access>::face (const unsigned int i) const
 {
   Assert (i<GeometryInfo<dim>::faces_per_cell, ExcIndexRange (i, 0, GeometryInfo<dim>::faces_per_cell));
-  Assert (static_cast<unsigned int>(this->level()) < this->dof_handler->levels.size(),
-          ExcMessage ("DoFHandler not initialized"));
 
   const unsigned int dim = DH::dimension;
   return dealii::internal::DoFCellAccessor::get_face (*this, i, dealii::internal::int2type<dim>());


### PR DESCRIPTION
The Assert checked that DoFs are distributed before allowing the use of
::face(), which is overly restrictive.

Also see https://groups.google.com/d/topic/dealii/G3Xp-Uv72_M/discussion
