### PR TITLE
Added set_matrix_mode to the SLEPcWrappers::TransformationBase class.

### DIFF
--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -86,8 +86,12 @@ namespace SLEPcWrappers
      * Set a flag to indicate how the
      * transformed matrices are being stored in
      * the spectral transformations.
+     *
+     * The possible values are given by the
+     * enumerator STMatMode in the SLEPc library
+     * http://www.grycap.upv.es/slepc/documentation/current/docs/manualpages/ST/STMatMode.html
      */
-    void set_matrix_mode(STMatMode mode);
+    void set_matrix_mode(const STMatMode mode);
 
   protected:
 

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -52,7 +52,7 @@ namespace SLEPcWrappers
     set_transformation_type(transformation_data->st);
   }
 
-  void TransformationBase::set_matrix_mode(STMatMode mode)
+  void TransformationBase::set_matrix_mode(const STMatMode mode)
   {
     int ierr = STSetMatMode(transformation_data->st,mode);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));


### PR DESCRIPTION
this is handy when one needs to specify how the transformed matrices are being stored in the spectral transformations. In particular for a MatrixFree class, the (non-default) ST_MATMODE_SHELL is the simplest way to go.
