### PR TITLE
Fix a test.

### DIFF
--- a/tests/mpi/ghost_03.cc
+++ b/tests/mpi/ghost_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2013 by the deal.II authors
+// Copyright (C) 2004 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -67,14 +67,6 @@ void test ()
   try
     {
       v(0)*=2.0;
-    }
-  catch (ExceptionBase &e)
-    {
-      deallog << e.get_exc_name() << std::endl;
-    }
-  try
-    {
-      v=0.0;
     }
   catch (ExceptionBase &e)
     {

--- a/tests/mpi/ghost_03.with_petsc=true.mpirun=10.debug.output
+++ b/tests/mpi/ghost_03.with_petsc=true.mpirun=10.debug.output
@@ -3,5 +3,4 @@ DEAL:0::numproc=10
 DEAL:0::ExcGhostsPresent()
 DEAL:0::ExcGhostsPresent()
 DEAL:0::ExcGhostsPresent()
-DEAL:0::ExcGhostsPresent()
 DEAL:0::OK

--- a/tests/mpi/ghost_03.with_petsc=true.mpirun=4.debug.output
+++ b/tests/mpi/ghost_03.with_petsc=true.mpirun=4.debug.output
@@ -3,5 +3,4 @@ DEAL:0::numproc=4
 DEAL:0::ExcGhostsPresent()
 DEAL:0::ExcGhostsPresent()
 DEAL:0::ExcGhostsPresent()
-DEAL:0::ExcGhostsPresent()
 DEAL:0::OK


### PR DESCRIPTION
We have recently allowed that one can set a vector to zero, even if it has
ghost elements. But this test verified that we throw an exception in this
case. Remove this one test.
