### PR TITLE
Also ensure that we have ML as part of Trilinos.

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -42,7 +42,7 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       )
 
     FOREACH(_module
-      Amesos Epetra Ifpack AztecOO Sacado Teuchos
+      Amesos Epetra Ifpack AztecOO Sacado Teuchos ML
       )
       ITEM_MATCHES(_module_found ${_module} ${Trilinos_PACKAGE_LIST})
       IF(_module_found)


### PR DESCRIPTION
I verified that it finds the ML package on my system. I guess people just follow our installation instructions and made sure that they do have ML, or someone would have reported compiler errors when compiling against a version of Trilinos that doesn't have ML installed.
