### PR TITLE
Disable nonlocal graph in Trilinos sparsity pattern

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -469,11 +469,14 @@ namespace TrilinosWrappers
    *   TrilinosWrappers::SparsityPattern object that in turn has been
    *   initialized with the reinit function specifying three index sets, one
    *   for the rows, one for the columns and for the larger set of @p
-   *   writeable_rows, and the operation is an addition. If Trilinos version
-   *   11.10 and greater is used, initializing from a
+   *   writeable_rows, and the operation is an addition. At some point in the
+   *   future, Trilinos support might be complete enough such that initializing
+   *   from a
    *   TrilinosWrappers::SparsityPattern that has been filled by a function
    *   similar to DoFTools::make_sparsity_pattern always results in a matrix
-   *   that allows several processes to write into the same matrix row.
+   *   that allows several processes to write into the same matrix row. However,
+   *   Trilinos until version at least 11.12 does not correctly support this
+   *   feature.
    * </ul>
    *
    * Note that all other reinit methods and constructors of

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -363,9 +363,13 @@ namespace TrilinosWrappers
     if (input_row_map.Comm().NumProc() > 1)
       graph.reset (new Epetra_FECrsGraph(Copy, input_row_map,
                                          n_entries_per_row, false
-#if DEAL_II_TRILINOS_VERSION_GTE(11,9,0)
-                                         , true
-#endif
+                                         // TODO: Check which new Trilinos
+                                         // version supports this... Remember
+                                         // to change tests/trilinos/assemble_matrix_parallel_07
+                                         // too.
+                                         //#if DEAL_II_TRILINOS_VERSION_GTE(11,14,0)
+                                         //, true
+                                         //#endif
                                         ));
     else
       graph.reset (new Epetra_FECrsGraph(Copy, input_row_map, input_col_map,

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -265,14 +265,15 @@ void LaplaceProblem<dim>::setup_system ()
     TrilinosWrappers::SparsityPattern csp;
     IndexSet relevant_set;
     DoFTools::extract_locally_relevant_dofs (dof_handler, relevant_set);
-#if DEAL_II_TRILINOS_VERSION_GTE(11,9,0)
+    // TODO: currently no Trilinos version is capable of doing this...
+    //#if DEAL_II_TRILINOS_VERSION_GTE(11,14,0)
     // Cannot pre-build sparsity pattern, Trilinos must provide it...
-    csp.reinit(locally_owned, locally_owned, MPI_COMM_WORLD);
-#else
+    //csp.reinit(locally_owned, locally_owned, MPI_COMM_WORLD);
+    //#else
     // OK, Trilinos not new enough - use exactly the same as
     // assemble_matrix_parallel_02.cc
     csp.reinit(locally_owned, locally_owned, relevant_set, MPI_COMM_WORLD);
-#endif
+    //#endif
     DoFTools::make_sparsity_pattern (dof_handler, csp,
                                      constraints, false);
     csp.compress();


### PR DESCRIPTION
There is still a bug left in the Trilinos sparse matrix that prevents us from enabling non-local graphs (and thread-safe writing into off-processor matrix rows). Bump version to 11.13 (might need to adjust that later).
