### PR TITLE
Fix a compiler warning with gcc-4.9

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -104,8 +104,6 @@ SphericalManifold<dim,spacedim>::pull_back(const Point<spacedim> &space_point) c
 {
   const Point<spacedim> R = space_point-center;
   const double rho = R.norm();
-  const double x = R[0];
-  const double y = R[1];
 
   Point<spacedim> p;
   p[0] = rho;
@@ -113,17 +111,17 @@ SphericalManifold<dim,spacedim>::pull_back(const Point<spacedim> &space_point) c
   switch (spacedim)
     {
     case 2:
-      p[1] = atan2(y,x);
+      p[1] = atan2(R[1],R[0]);
       if (p[1] < 0)
         p[1] += 2*numbers::PI;
       break;
     case 3:
     {
       const double z = R[2];
-      p[2] = atan2(y,x); // phi
+      p[2] = atan2(R[1],R[0]); // phi
       if (p[2] < 0)
         p[2] += 2*numbers::PI; // phi is periodic
-      p[1] = atan2(sqrt(x*x+y*y),z);  // theta
+      p[1] = atan2(sqrt(R[0]*R[0]+R[1]*R[1]),z);  // theta
     }
     break;
     default:


### PR DESCRIPTION
gcc-4.9 seems to be able to see that accessing R[1] in 1D is out of bound
for spacedim == 1 but it can omit the warning if accessed inside a switch
statement. Fix this warning (even though we won't use SphericalManifold
for spacedim == 1).
