### PR TITLE
Fix an oversight that prevented code from compiling.

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -587,7 +587,7 @@ namespace PETScWrappers
      * natively supported and thus the cost is completely equivalent as
      * calling the two methods separately.
      */
-    PetscScalar add_and_dot (const Number      a,
+    PetscScalar add_and_dot (const PetscScalar a,
                              const VectorBase &V,
                              const VectorBase &W);
 


### PR DESCRIPTION
The add-and-dot patch did not compile with PETSc enabled because of a mismatched declaration. I don't have access to a sufficiently fast machine to verify that the patch proposed here actually works, but am reasonably confident that it does (which usually means that it won't, of course).
