### PR TITLE
fixed a bug in set_matrix_mode.

### DIFF
--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -128,6 +128,8 @@ namespace SLEPcWrappers
     };
 
     std_cxx11::shared_ptr<TransformationData> transformation_data;
+
+    std_cxx11::shared_ptr<STMatMode> mat_mode;
   };
 
   /**

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -50,12 +50,19 @@ namespace SLEPcWrappers
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
     set_transformation_type(transformation_data->st);
+
+    // if mat_mode has been set,
+    // pass it to ST object
+    if (mat_mode.get() != 0)
+      {
+        int ierr = STSetMatMode(transformation_data->st,*(mat_mode.get()) );
+        AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
+      }
   }
 
   void TransformationBase::set_matrix_mode(const STMatMode mode)
   {
-    int ierr = STSetMatMode(transformation_data->st,mode);
-    AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
+    mat_mode.reset (new STMatMode(mode));
   }
 
   /* ------------------- TransformationShift --------------------- */


### PR DESCRIPTION
STSetMatMode shall be called only after transformation_data->st
is initialised. Thus, we need to store the desired STMatMode
untill set_context is called from the solver object.
