### PR TITLE
Third attempt to fix uninitialized variable in MPI::MinMaxAvg

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -216,8 +216,8 @@ namespace Utilities
      */
     struct MinMaxAvg
     {
-      MinMaxAvg();
-
+      // Note: We assume a POD property of this struct in the MPI calls in
+      // min_max_avg
       double sum;
       double min;
       double max;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -230,7 +230,11 @@ namespace Utilities
     min_max_avg(const double my_value,
                 const MPI_Comm &mpi_communicator)
     {
-      MinMaxAvg result;
+      // To avoid uninitialized values on some MPI implementations, provide
+      // result with a default value already...
+      MinMaxAvg result = { 0., std::numeric_limits<double>::max(),
+                           -std::numeric_limits<double>::max(), 0, 0, 0.
+                         };
 
       const unsigned int my_id
         = dealii::Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -307,18 +311,6 @@ namespace Utilities
     }
 
 #endif
-
-
-
-    MinMaxAvg::MinMaxAvg ()
-      :
-      sum (0.),
-      min (std::numeric_limits<double>::max()),
-      max (-min),
-      min_index (0),
-      max_index (0),
-      avg (0)
-    {}
 
 
 


### PR DESCRIPTION
It turned out (see cdash) that my recent commit destroyed the POD property of MinMaxAvg. Instead of changing the code that uses this property, this commit reverts 97bd7e and f402371 and instead makes sure to use initialized variables by setting the result variable first. Sorry for the initially bad solution.
