### PR TITLE
Allow comparison == and != of TriaAccessorBase with different tria

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -121,8 +121,8 @@ inline
 bool
 TriaAccessorBase<structdim,dim,spacedim>::operator == (const TriaAccessorBase<structdim,dim,spacedim> &a) const
 {
-  Assert (tria == a.tria, TriaAccessorExceptions::ExcCantCompareIterators());
-  return ((present_level == a.present_level) &&
+  return ((tria == a.tria) &&
+          (present_level == a.present_level) &&
           (present_index == a.present_index));
 }
 
@@ -133,8 +133,8 @@ inline
 bool
 TriaAccessorBase<structdim,dim,spacedim>::operator != (const TriaAccessorBase<structdim,dim,spacedim> &a) const
 {
-  Assert (tria == a.tria, TriaAccessorExceptions::ExcCantCompareIterators());
-  return ((present_level != a.present_level) ||
+  return ((tria != a.tria) ||
+          (present_level != a.present_level) ||
           (present_index != a.present_index));
 }
 


### PR DESCRIPTION
It is well-defined to check for equality and inequality of TriaAccessorBase (cell_iterator types) that belong to different triangulations. Those are simply unequal. This is necessary e.g. for comparing with a default constructed cell_iterator variable. Of course, operator < is still undefined.
