### PR TITLE
Improved comparison operators for TriaAccessorBase

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -121,8 +121,9 @@ inline
 bool
 TriaAccessorBase<structdim,dim,spacedim>::operator == (const TriaAccessorBase<structdim,dim,spacedim> &a) const
 {
-  return ((tria == a.tria) &&
-          (present_level == a.present_level) &&
+  Assert (tria == a.tria || tria == 0 || a.tria == 0,
+          TriaAccessorExceptions::ExcCantCompareIterators());
+  return ((present_level == a.present_level) &&
           (present_index == a.present_index));
 }
 
@@ -133,8 +134,9 @@ inline
 bool
 TriaAccessorBase<structdim,dim,spacedim>::operator != (const TriaAccessorBase<structdim,dim,spacedim> &a) const
 {
-  return ((tria != a.tria) ||
-          (present_level != a.present_level) ||
+  Assert (tria == a.tria || tria == 0 || a.tria == 0,
+          TriaAccessorExceptions::ExcCantCompareIterators());
+  return ((present_level != a.present_level) ||
           (present_index != a.present_index));
 }
 


### PR DESCRIPTION
The previous commit was a bit too aggressive because it is still useful to catch the case when comparing iterators to two different triangulations (leading to infinite loops).

Therefore, I now merely extended the assertion to not trigger when one of the two objects is default constructed, i.e., does contain a null pointer to tria. The comparison then does not need tria == a.tria because invalid iterators use invalid cell and level index, too (leading to !=).
