### PR TITLE
Include mpi.h in base/config.h to avoid Intel compile error

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -574,6 +574,11 @@
 #cmakedefine DEAL_II_WITH_OPENCASCADE
 
 
+// Some systems require including mpi.h before stdio.h which happens in
+// types.h
+#if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
+#  include <mpi.h>
+#endif
 
 
 #include <deal.II/base/numbers.h>

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -20,9 +20,9 @@
 #include <vector>
 
 #if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
-#  include <mpi.h>
-// Check whether <mpi.h> is a suitable
-// include for us (if MPI_SEEK_SET is not
+// mpi.h included through deal.II/base/config.h
+
+// Check whether <mpi.h> is a suitable include for us (if MPI_SEEK_SET is not
 // defined, we'll die anyway):
 #  ifndef MPI_SEEK_SET
 #    error "The buildsystem included an insufficient mpi.h header that does not export MPI_SEEK_SET"


### PR DESCRIPTION
On my system with Intel compiler, I used to get the following error:
In file included from /lrz/sys/intel/mpi_41_3_048/intel64/include/mpi.h(1279),
                 from [...]/deal.II/include/deal.II/base/mpi.h(23),
                 from [...]/deal.II/include/deal.II/base/utilities.h(21),
                 from [...]/deal.II/include/deal.II/base/index_set.h(20),
                 from [...]/deal.II/include/deal.II/lac/vector.h(24),
                 from [...]/deal.II/source/numerics/data_out_faces.cc(18):
/lrz/sys/intel/mpi_41_3_048/intel64/include/mpicxx.h(99): error: #error directive: "SEEK_CUR is #defined but must not be for the C++ binding of MPI. Include mpi.h before stdio.h"
  #error "SEEK_CUR is #defined but must not be for the C++ binding of MPI. Include mpi.h before stdio.h"
   ^

This is Intel compiler 15.0 with Intel MPI. The solution to this problem is to include mpi.h early enough, which for us means to include it in base/config.h before we include types.h.
