### PR TITLE
Elide default initialization.

### DIFF
--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -49,7 +49,6 @@ namespace SLEPcWrappers
     :
     solver_control (cn),
     mpi_communicator (mpi_communicator),
-    target_eigenvalue (NULL),
     set_which (EPS_LARGEST_MAGNITUDE),
     set_problem (EPS_GNHEP),
     opA (NULL),


### PR DESCRIPTION
Apparently, the initialization of a std::shared_ptr with NULL is not
allowed with the Intel compiler. It is also not necessary (that's what
the default constructor does anyway), so just remove the line.
