### PR TITLE
CMake: Correctly detect -Wno-... support for gcc

### DIFF
--- a/cmake/macros/macro_enable_if_supported.cmake
+++ b/cmake/macros/macro_enable_if_supported.cmake
@@ -34,6 +34,19 @@ MACRO(ENABLE_IF_SUPPORTED _variable _flag)
   ENDIF()
 
   STRING(STRIP "${_flag}" _flag_stripped)
+  SET(_flag_stripped_orig "${_flag_stripped}")
+
+  #
+  # Gcc does not emit a warning if testing -Wno-... flags which leads to
+  # false positive detection. Unfortunately it later warns that an unknown
+  # warning option is used if another warning is emited in the same
+  # compilation unit.
+  # Therefore we invert the test for -Wno-... flags:
+  #
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    STRING(REPLACE "-Wno-" "-W" _flag_stripped "${_flag_stripped}")
+  ENDIF()
+
   IF(NOT "${_flag_stripped}" STREQUAL "")
     STRING(REGEX REPLACE "^-" "" _flag_name "${_flag_stripped}")
     STRING(REPLACE "," "" _flag_name "${_flag_name}")
@@ -44,7 +57,7 @@ MACRO(ENABLE_IF_SUPPORTED _variable _flag)
       DEAL_II_HAVE_FLAG_${_flag_name}
       )
     IF(DEAL_II_HAVE_FLAG_${_flag_name})
-      SET(${_variable} "${${_variable}} ${_flag_stripped}")
+      SET(${_variable} "${${_variable}} ${_flag_stripped_orig}")
       STRING(STRIP "${${_variable}}" ${_variable})
     ENDIF()
   ENDIF()

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -340,6 +340,11 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li>Fixed: CMake now correctly detects -Wno-... support for gcc.
+  <br>
+  (Matthias Maier, 2014/12/11)
+  </li>
+
   <li> New: The FE_Q and FE_Q_Hierarchical classes now include pictures
   of their 2d shape functions in the class documentation.
   <br>


### PR DESCRIPTION
gcc does not emit a warning if an unknown -Wno-... flag is specified on the
command line, thus the ENABLE_IF_SUPPORTED macro unconditionally enabled
-Wno-... flags for gcc. Unfortunately, gcc _does_ emit a warning for the
unrecognized compiler option if another warning is emitted in the same
compilation unit. This is now fixed by always querying for the non-negated
version, i.e. -Wfoo instead of -Wno-foo.

Closes [Unfortunately, no github issue :-( Now, I can't close on the
command line :'-(]
