### PR TITLE
try to get the arpack test a bit more stable

### DIFF
--- a/tests/arpack/step-36_ar.cc
+++ b/tests/arpack/step-36_ar.cc
@@ -114,8 +114,7 @@ namespace Step36
     stiffness_matrix.reinit (sparsity_pattern);
     mass_matrix.reinit (sparsity_pattern);
 
-    eigenfunctions
-    .resize (5);
+    eigenfunctions.resize (8);
     for (unsigned int i=0; i<eigenfunctions.size (); ++i)
       eigenfunctions[i].reinit (dof_handler.n_dofs ());
 
@@ -281,7 +280,7 @@ namespace Step36
 
     std::sort(eigenvalues.begin(), eigenvalues.end(), my_compare);
 
-    for (unsigned int i=0; i<eigenvalues.size(); ++i)
+    for (unsigned int i = 0; i < 5 && i < eigenvalues.size(); ++i)
       deallog << "      Eigenvalue " << i
               << " : " << eigenvalues[i]
               << std::endl;
@@ -301,14 +300,10 @@ int main (int argc, char **argv)
       deallog.depth_console(0);
       deallog.threshold_double(1.e-10);
 
+      deallog.depth_console (0);
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-      {
-        deallog.depth_console (0);
-
-        EigenvalueProblem<2> problem ("");
-        problem.run ();
-      }
+      EigenvalueProblem<2> problem ("");
+      problem.run ();
     }
 
   catch (std::exception &exc)

--- a/tests/arpack/step-36_ar.output
+++ b/tests/arpack/step-36_ar.output
@@ -1,6 +1,6 @@
 
 DEAL::      Eigenvalue 0 : (4.93877,0.00000)
 DEAL::      Eigenvalue 1 : (12.3707,0.00000)
-DEAL::      Eigenvalue 2 : (19.8027,0.00000)
-DEAL::      Eigenvalue 3 : (24.8370,0.00000)
+DEAL::      Eigenvalue 2 : (12.3707,0.00000)
+DEAL::      Eigenvalue 3 : (19.8027,0.00000)
 DEAL::      Eigenvalue 4 : (24.8370,0.00000)


### PR DESCRIPTION
Well, it turns out that depending on arpack version and CPU the result for
the first 5 eigenvalues differs. Try to make this a bit more stable by
computing 8 eigenvalues and only print the first 5.
