### PR TITLE
Fix copyright years in doc/users/doxygen.html

### DIFF
--- a/doc/users/doxygen.html
+++ b/doc/users/doxygen.html
@@ -6,7 +6,7 @@
   <title>deal.II Doxygen documentation</title>
   <link href="../screen.css" rel="StyleSheet">
   <meta name="author" content="the deal.II authors">
-  <meta name="copyright" content="Copyright (C) 2012 - 2014, 2013 by the deal.II authors">
+  <meta name="copyright" content="Copyright (C) 2012 - 2014 by the deal.II authors">
   <meta name="date" content="$Date$">
   <meta name="keywords" content="deal dealii finite elements fem triangulation">
   <meta http-equiv="content-language" content="en">


### PR DESCRIPTION
The year 2013 is already included in the range 2012 - 2014.
