### PR TITLE
Fix previous commit 1d327fd1dcd34023a3d5bb2c0ee7524593d44015.

### DIFF
--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2014 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -975,7 +975,8 @@ namespace internal
           else
             next_free_single=pos+1;
         }
-      else
+
+      if (reverse_order_next_free_single)
         {
           // second sweep, use all slots, even
           // in pairs


### PR DESCRIPTION
Commit 1d327fd1dcd34023a3d5bb2c0ee7524593d44015 moved a function from the .cc
file into the .h file and made it inline. Subtly, it also snuck in a small
change in the code: it changed
  if (!something)
   {
     ...
   }

  if (something)
into
  if (!something)
    {
      ...
    }
  else

The problem is that the first code block in rare circumstances changed the
value of the variable something. It is remarkable that this only triggered
in a single test in the testsuite -- an indication that the testsuite is
after all reasonably good at finding even obscure problems, but also an
indication that the anisotropic refinement stuff is not particularly well
tested.
