### PR TITLE
Fix undefined symbols on Mac.

### DIFF
--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -31,5 +31,14 @@ for (deal_II_dimension : DIMENSIONS)
 
   template struct internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,double>;
   template struct internal::MatrixFreeFunctions::MappingInfo<deal_II_dimension,float>;
+
+#ifndef DEAL_II_MSVC
+  template void internal::MatrixFreeFunctions::ShapeInfo<double>::reinit
+  <deal_II_dimension>(const Quadrature<1> &, const FiniteElement
+                      <deal_II_dimension,deal_II_dimension> &, const unsigned int);
+  template void internal::MatrixFreeFunctions::ShapeInfo<float>::reinit
+  <deal_II_dimension>(const Quadrature<1> &, const FiniteElement
+                      <deal_II_dimension,deal_II_dimension> &, const unsigned int);
+#endif
 }
 


### PR DESCRIPTION
Deactivate ShapeInfo::reinit on MSVC target as proposed in c2021e2.
