### PR TITLE
fix compilation against opencascade on linux targets

### DIFF
--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -25,8 +25,19 @@
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/grid/tria_boundary.h>
 
+// We have to clean up certain name clashes prior to any opencascade header
+// inclusion. Unfortunately, this is clumsy and should be resolved by
+// renaming our very own includes someday...
+// --Maier, 2014
+#define HAVE_CONFIG_H
+#undef HAVE_SYS_TYPES_H
+#undef HAVE_SYS_TIMES_H
+#undef HAVE_SYS_TIME_H
+#undef HAVE_UNISTD_H
+#undef HAVE_GETHOSTNAME
 #include <BRepAdaptor_Curve.hxx>
 #include <Adaptor3d_Curve.hxx>
+#undef HAVE_CONFIG_H
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -23,8 +23,20 @@
 #ifdef DEAL_II_WITH_OPENCASCADE
 
 #include <deal.II/grid/tria.h>
+#include <deal.II/base/point.h>
 
 #include <string>
+
+// We have to clean up certain name clashes prior to any opencascade header
+// inclusion. Unfortunately, this is clumsy and should be resolved by
+// renaming our very own includes someday...
+// --Maier, 2014
+#define HAVE_CONFIG_H
+#undef HAVE_SYS_TYPES_H
+#undef HAVE_SYS_TIMES_H
+#undef HAVE_SYS_TIME_H
+#undef HAVE_UNISTD_H
+#undef HAVE_GETHOSTNAME
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Edge.hxx>
@@ -36,8 +48,8 @@
 #include <TopoDS_Wire.hxx>
 #include <IFSelect_ReturnStatus.hxx>
 #include <gp_Pnt.hxx>
+#undef HAVE_CONFIG_H
 
-#include <deal.II/base/point.h>
 
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
It turns out that I need some define magic in order to compile against
opencascade 6.7.1 on a Linux target:

@luca-heltai: Prior to inclusion can you please verify that with this
changes, opencascade still compiles and works fine on your setup? Ideally
before 12:00 (UTC+1) :-]
