### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests/* export-ignore
+/tests/quick_tests -export-ignore
+/tests/CMakeLists.txt -export-ignore
+/tests/run_test.cmake -export-ignore
+.gitattributes export-ignore
+.travis.yml export-ignore


### PR DESCRIPTION
we ignore the testsuite and some other files when creating a tarball
with git archive. This is also used by github for 'releases'.
