### PR TITLE
improve SolutionTransfer exception

### DIFF
--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -47,7 +47,13 @@ namespace parallel
     SolutionTransfer<dim, VECTOR, DH>::SolutionTransfer(const DH &dof)
       :
       dof_handler(&dof, typeid(*this).name())
-    {}
+    {
+      parallel::distributed::Triangulation<dim> *tria
+        = (dynamic_cast<parallel::distributed::Triangulation<dim>*>
+           (const_cast<dealii::Triangulation<dim>*>
+            (&dof_handler->get_tria())));
+      Assert (tria != 0, ExcMessage("parallel::distributed::SolutionTransfer requires a parallel::distributed::Triangulation object."));
+    }
 
 
 


### PR DESCRIPTION
parallel::distributed::SolutionTransfer only works with parallel::distributed::Triangulation. This is now checked in the constructor.
