### PR TITLE
Now also cached variables for cpack config have CPACK prefix.

### DIFF
--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -410,9 +410,9 @@ FOREACH(_var ${_res})
 ENDFOREACH()
 
 # CPack miscellaneous options
-SET(DEAL_II_EXTERNAL_LIBS_TREE "" CACHE PATH
+SET(DEAL_II_CPACK_EXTERNAL_LIBS_TREE "" CACHE PATH
     "Path to tree of external libraries that will be installed in bundle package."
   )
-MARK_AS_ADVANCED(DEAL_II_EXTERNAL_LIBS_TREE)
+MARK_AS_ADVANCED(DEAL_II_CPACK_EXTERNAL_LIBS_TREE)
 
 


### PR DESCRIPTION
I had left this in my previous patch. Nothing functional, except one had to know the variable name to use... I'm probably the only one using this, so nobody could notice... 

:)
