### PR TITLE
wrapcomments paren handling

### DIFF
--- a/contrib/utilities/wrapcomments.py
+++ b/contrib/utilities/wrapcomments.py
@@ -117,7 +117,7 @@ def format_block(lines, infostr=""):
                 out.extend(wrap_block(remove_junk(curlines), start))
                 curlines=[]
             thisline = remove_junk([lines[idx]])[0]
-            if not thisline.startswith("@ref"):
+            if not thisline.startswith("@ref") and not thisline.startswith("(@ref"):
                 print ("%s warning %s not at start of line"%(infostr, "@ref"), file=sys.stderr)
 
             # format:

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -37,8 +37,8 @@ template <typename number> class SparseMatrix;
  * triangulations for some basic geometries.
  *
  * Some of these functions receive a flag @p colorize. If this is set, parts
- * of the boundary receive different boundary indicators (
- * @ref GlossBoundaryIndicator),
+ * of the boundary receive different boundary indicators
+ * (@ref GlossBoundaryIndicator),
  * allowing them to be distinguished for the purpose of attaching geometry
  * objects and evaluating different boundary conditions.
  *


### PR DESCRIPTION
Correctly handle an opening parenthesis directly in front of @ref and
fix the one place we use it. This addresses #393.
