### PR TITLE
Fix definition of syev method. Correct ifdef guard.

### DIFF
--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -546,7 +546,7 @@ void FullMatrix<number>::mmult (FullMatrix<number2>       &dst,
   // see if we can use BLAS algorithms for this and if the type for 'number'
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
-#if DEAL_II_WITH_LAPACK
+#ifdef DEAL_II_WITH_LAPACK
   if ((types_are_equal<number,double>::value
        ||
        types_are_equal<number,float>::value)
@@ -616,7 +616,7 @@ void FullMatrix<number>::Tmmult (FullMatrix<number2>       &dst,
   // see if we can use BLAS algorithms for this and if the type for 'number'
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
-#if DEAL_II_WITH_LAPACK
+#ifdef DEAL_II_WITH_LAPACK
   if ((types_are_equal<number,double>::value
        ||
        types_are_equal<number,float>::value)
@@ -706,7 +706,7 @@ void FullMatrix<number>::mTmult (FullMatrix<number2>       &dst,
   // see if we can use BLAS algorithms for this and if the type for 'number'
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
-#if DEAL_II_WITH_LAPACK
+#ifdef DEAL_II_WITH_LAPACK
   if ((types_are_equal<number,double>::value
        ||
        types_are_equal<number,float>::value)
@@ -794,7 +794,7 @@ void FullMatrix<number>::TmTmult (FullMatrix<number2>       &dst,
   // see if we can use BLAS algorithms for this and if the type for 'number'
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
-#if DEAL_II_WITH_LAPACK
+#ifdef DEAL_II_WITH_LAPACK
   if ((types_are_equal<number,double>::value
        ||
        types_are_equal<number,float>::value)
@@ -1713,7 +1713,7 @@ FullMatrix<number>::gauss_jordan ()
   // works for us (it is usually not
   // efficient to use Lapack for very small
   // matrices):
-#if DEAL_II_WITH_LAPACK
+#ifdef DEAL_II_WITH_LAPACK
   if (types_are_equal<number,double>::value
       ||
       types_are_equal<number,float>::value)

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -719,7 +719,7 @@ syev (const char *, const char *, const int *, number1 *, const int *, number2 *
 inline void
 syev (const char *jobz, const char *uplo, const int *n, double *A, const int *lda, double *w, double *work, const int *lwork, int *info)
 {
-  dsyev_ (char *jobz,char *uplo,int *n,double*A,int *lda,double*w,double*work,int *lwork,int *info);
+  dsyev_ (jobz,uplo,n,A,lda,w,work,lwork,info);
 }
 #else
 inline void
@@ -734,7 +734,7 @@ syev (const char *, const char *, const int *, double *, const int *, double *, 
 inline void
 syev (const char *jobz, const char *uplo, const int *n, float *A, const int *lda, float *w, float *work, const int *lwork, int *info)
 {
-  ssyev_ (char *jobz,char *uplo,int *n,double*A,int *lda,double*w,double*work,int *lwork,int *info);
+  ssyev_ (jobz,uplo,n,A,lda,w,work,lwork,info);
 }
 #else
 inline void


### PR DESCRIPTION
This avoids compiler errors with clang 3.5.