### PR TITLE
CMake: Also handle subminor version number

### DIFF
--- a/cmake/config/Config.cmake.in
+++ b/cmake/config/Config.cmake.in
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -32,6 +32,7 @@ SET(DEAL_II_PACKAGE_DESCRIPTION "@DEAL_II_PACKAGE_DESCRIPTION@")
 
 SET(DEAL_II_VERSION_MAJOR "@DEAL_II_VERSION_MAJOR@")
 SET(DEAL_II_VERSION_MINOR "@DEAL_II_VERSION_MINOR@")
+SET(DEAL_II_VERSION_SUBMINOR "@DEAL_II_VERSION_SUBMINOR@")
 SET(DEAL_II_VERSION "@DEAL_II_VERSION@")
 
 SET(DEAL_II_PROJECT_CONFIG_NAME "@DEAL_II_PROJECT_CONFIG_NAME@")

--- a/cmake/config/Make.global_options.in
+++ b/cmake/config/Make.global_options.in
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -46,6 +46,7 @@ enable-parser        = @MAKEFILE_enableparser@
 DEAL_II_VERSION      = @DEAL_II_PACKAGE_VERSION@
 DEAL_II_MAJOR        = @DEAL_II_VERSION_MAJOR@
 DEAL_II_MINOR        = @DEAL_II_VERSION_MINOR@
+DEAL_II_SUBMINOR     = @DEAL_II_VERSION_SUBMINOR@
 
 PERL                 = perl
 

--- a/cmake/setup_deal_ii.cmake
+++ b/cmake/setup_deal_ii.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -32,6 +32,7 @@
 #     DEAL_II_PACKAGE_DESCRIPTION     *)
 #     DEAL_II_VERSION_MAJOR
 #     DEAL_II_VERSION_MINOR
+#     DEAL_II_VERSION_SUBMINOR
 #     DEAL_II_VERSION
 #
 # Information about paths, install locations and names:
@@ -65,24 +66,40 @@
 
 SET_IF_EMPTY(DEAL_II_PACKAGE_NAME "deal.II")
 
-FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
-SET_IF_EMPTY(DEAL_II_PACKAGE_VERSION "${_version}")
-
 SET_IF_EMPTY(DEAL_II_PACKAGE_VENDOR
   "The deal.II Authors <http://www.dealii.org/>"
   )
-
 SET_IF_EMPTY(DEAL_II_PACKAGE_DESCRIPTION
   "Library for solving partial differential equations with the finite element method"
   )
 
-STRING(REGEX REPLACE
-  "^([0-9]+)\\..*" "\\1" DEAL_II_VERSION_MAJOR "${DEAL_II_PACKAGE_VERSION}"
+FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
+SET_IF_EMPTY(DEAL_II_PACKAGE_VERSION "${_version}")
+
+#
+# We expect a version number of the form "X.Y.Z", where X and Y are always
+# numbers and Z is either a third number (for a release version) or a short
+# string.
+#
+STRING(REGEX REPLACE "^([0-9]+)\\..*" "\\1"
+  DEAL_II_VERSION_MAJOR "${DEAL_II_PACKAGE_VERSION}"
   )
-STRING(REGEX REPLACE
-  "^[0-9]+\\.([0-9]+).*" "\\1" DEAL_II_VERSION_MINOR "${DEAL_II_PACKAGE_VERSION}"
+STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
+  DEAL_II_VERSION_MINOR "${DEAL_II_PACKAGE_VERSION}"
   )
-SET(DEAL_II_VERSION ${DEAL_II_VERSION_MAJOR}.${DEAL_II_VERSION_MINOR})
+
+#
+# If Z is not a number, replace it with "0", otherwise extract version
+# number:
+#
+IF(DEAL_II_PACKAGE_VERSION MATCHES "^[0-9]+\\.[0-9]+.*\\.[0-9]+.*")
+  STRING(REGEX REPLACE "^[0-9]+\\.[0-9]+.*\\.([0-9]+).*" "\\1"
+    DEAL_II_VERSION_SUBMINOR "${DEAL_II_PACKAGE_VERSION}"
+    )
+ELSE()
+  SET(DEAL_II_VERSION_SUBMINOR "0")
+ENDIF()
+SET(DEAL_II_VERSION ${DEAL_II_VERSION_MAJOR}.${DEAL_II_VERSION_MINOR}.${DEAL_II_VERSION_SUBMINOR})
 
 
 ########################################################################

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -65,6 +65,12 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Fixed: CMake now also handles and exports the subminor version
+  number correctly ("pre" and "rc?" are replaced by "0").
+  <br>
+  (Matthias Maier, 2015/01/02)
+  </li>
+
   <li> Fixed: VectorTools::interpolate_to_different_mesh() was accidentally
   only instantiated for dealii::Vector arguments, rather than all vector
   classes. This is now fixed.

--- a/doc/users/cmakelists.html
+++ b/doc/users/cmakelists.html
@@ -713,9 +713,11 @@ DEAL_II_PACKAGE_VERSION     - the full package version string, e.g. "8.1.pre"
 DEAL_II_PACKAGE_VENDOR
 DEAL_II_PACKAGE_DESCRIPTION
 
-DEAL_II_VERSION             - version string without suffix, e.g. "8.1"
+DEAL_II_VERSION             - numerical version number (with "pre" and "rc?"
+                              replaced by "0"), e.g. "8.2.0"
 DEAL_II_VERSION_MAJOR       - the major number, e.g. "8"
-DEAL_II_VERSION_MINOR       - the minor version number, e.g. "1"
+DEAL_II_VERSION_MINOR       - the minor version number, e.g. "2"
+DEAL_II_VERSION_SUBMINOR    - the minor version number, e.g. "0"
 
 DEAL_II_BUILD_TYPE          - the configured build type, e.g. "DebugRelease"
 DEAL_II_BUILD_TYPES         - an all caps list of available configurations,

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2014 by the deal.II authors
+// Copyright (C) 2012 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -49,6 +49,9 @@
 /** Minor version number of deal.II */
 #define DEAL_II_VERSION_MINOR @DEAL_II_VERSION_MINOR@
 #define DEAL_II_MINOR @DEAL_II_VERSION_MINOR@
+
+/** Subminor version number of deal.II */
+#define DEAL_II_VERSION_SUBMINOR @DEAL_II_VERSION_SUBMINOR@
 
 #define DEAL_II_VERSION_GTE(major,minor,subminor) \
  ((DEAL_II_VERSION_MAJOR * 10000 + \


### PR DESCRIPTION
CMake now correctly queries the DEAL_II_PACKAGE_VERSION string for a
subminor version replacing "pre" and "rc?" by "0". The subminor version
number is also exported in the project configuration and the config.h
header file.