### PR TITLE
Query git branch and commit during configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,14 +118,11 @@ ENDFOREACH()
 #
 # Finalize the configuration:
 #
+VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_cpack.cmake)
 VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_custom_targets.cmake)
 VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_finalize.cmake)
+VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_git.cmake)
 VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_write_config.cmake)
-
-#
-# CPack configuration
-#
-VERBOSE_INCLUDE(${CMAKE_SOURCE_DIR}/cmake/setup_cpack.cmake)
 
 ########################################################################
 #                                                                      #

--- a/cmake/setup_git.cmake
+++ b/cmake/setup_git.cmake
@@ -1,0 +1,86 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2014 - 2015 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# Query git commit and branch information. If git was found and the source
+# directory is under version control the following variables are populated:
+#
+#     DEAL_II_GIT_BRANCH
+#     DEAL_II_GIT_REVISION
+#     DEAL_II_GIT_SHORTREV
+#
+
+FIND_PACKAGE(Git)
+
+#
+# Only run the following if we have git and the source directory seems to
+# be under version control.
+#
+IF(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git/HEAD)
+  #
+  # Bogus configure_file calls to trigger a reconfigure, and thus an update
+  # of branch and commit information every time HEAD has changed.
+  #
+  CONFIGURE_FILE(
+    ${CMAKE_SOURCE_DIR}/.git/HEAD
+    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/HEAD
+    )
+  FILE(STRINGS ${CMAKE_SOURCE_DIR}/.git/HEAD _head_ref LIMIT_COUNT 1)
+  STRING(REPLACE "ref: " "" _head_ref ${_head_ref})
+  IF(EXISTS ${CMAKE_SOURCE_DIR}/.git/${_head_ref})
+    CONFIGURE_FILE(
+      ${CMAKE_SOURCE_DIR}/.git/${_head_ref}
+      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/HEAD_REF
+      )
+  ENDIF()
+
+  #
+  # Query for branch and commit information:
+  #
+  EXECUTE_PROCESS(
+     COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"%H %h"
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     OUTPUT_VARIABLE _info
+     RESULT_VARIABLE _result
+     OUTPUT_STRIP_TRAILING_WHITESPACE
+     )
+  IF(${_result} EQUAL 0)
+    STRING(REGEX REPLACE "^\"([^ ]+) ([^ ]+)\"$"
+      "\\1" DEAL_II_GIT_REVISION "${_info}")
+    STRING(REGEX REPLACE "^\"([^ ]+) ([^ ]+)\"$"
+      "\\2" DEAL_II_GIT_SHORTREV "${_info}")
+  ENDIF()
+
+  EXECUTE_PROCESS(
+     COMMAND ${GIT_EXECUTABLE} symbolic-ref HEAD
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     OUTPUT_VARIABLE _branch
+     RESULT_VARIABLE _result
+     OUTPUT_STRIP_TRAILING_WHITESPACE
+     )
+  IF(${_result} EQUAL 0)
+    STRING(REGEX REPLACE "refs/heads/" "" DEAL_II_GIT_BRANCH "${_branch}")
+  ENDIF()
+ENDIF()
+
+FILE(WRITE ${CMAKE_BINARY_DIR}/revision.log
+"###
+#
+#  Git information:
+#        Branch:   ${DEAL_II_GIT_BRANCH}
+#        Revision: ${DEAL_II_GIT_REVISION}
+#
+###"
+  )

--- a/cmake/setup_write_config.cmake
+++ b/cmake/setup_write_config.cmake
@@ -45,8 +45,16 @@ _both(
 #        CMAKE_BUILD_TYPE:       ${CMAKE_BUILD_TYPE}
 #        BUILD_SHARED_LIBS:      ${BUILD_SHARED_LIBS}
 #        CMAKE_INSTALL_PREFIX:   ${CMAKE_INSTALL_PREFIX}
-#        CMAKE_SOURCE_DIR:       ${CMAKE_SOURCE_DIR} (Version ${DEAL_II_PACKAGE_VERSION})
-#        CMAKE_BINARY_DIR:       ${CMAKE_BINARY_DIR}
+#        CMAKE_SOURCE_DIR:       ${CMAKE_SOURCE_DIR}
+"
+  )
+IF("${DEAL_II_GIT_SHORTREV}" STREQUAL "")
+  _both("#                                (version ${DEAL_II_PACKAGE_VERSION})\n")
+ELSE()
+  _both("#                                (version ${DEAL_II_PACKAGE_VERSION}, shortrev ${DEAL_II_GIT_SHORTREV})\n")
+ENDIF()
+_both(
+"#        CMAKE_BINARY_DIR:       ${CMAKE_BINARY_DIR}
 #        CMAKE_CXX_COMPILER:     ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} on platform ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}
 #                                ${CMAKE_CXX_COMPILER}
 "

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -56,6 +56,15 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: The build system now queries for git branch name and
+  revision sha1 (and automatically reconfigures if necessary). This
+  information is used to annotate summary.log and detailed.log with the
+  current revision sha1. Further, a header file <deal.II/base/revision.h>
+  is now available that exports the macros: DEAL_II_GIT_BRANCH,
+  DEAL_II_GIT_REVISION, DEAL_II_GIT_REVISION_SHORT.
+  <br>
+  (Matthias Maier, 2015/01/02)
+  </li>
 </ol>
 
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013, 2015 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -14,11 +14,15 @@
 ## ---------------------------------------------------------------------
 
 #
-# Configure config.h
+# Configure config.h and revision.h
 #
 CONFIGURE_FILE(
   ${CMAKE_CURRENT_SOURCE_DIR}/deal.II/base/config.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/deal.II/base/config.h
+  )
+CONFIGURE_FILE(
+  ${CMAKE_CURRENT_SOURCE_DIR}/deal.II/base/revision.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/deal.II/base/revision.h
   )
 
 #

--- a/include/deal.II/base/revision.h.in
+++ b/include/deal.II/base/revision.h.in
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef __deal2__revision_h
+#define __deal2__revision_h
+
+/**
+ * Name of the local git branch of the source directory.
+ */
+#define DEAL_II_GIT_BRANCH @DEAL_II_GIT_BRANCH@
+
+/**
+ * Full sha1 revision of the current git HEAD.
+ */
+#define DEAL_II_GIT_REVISION @DEAL_II_GIT_REVISION@
+
+/**
+ * Short sha1 revision of the current git HEAD.
+ */
+#define DEAL_II_GIT_SHORTREV @DEAL_II_GIT_SHORTREV@
+
+#endif

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013 - 2014 by the deal.II authors
+## Copyright (C) 2013 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -335,7 +335,7 @@ IF(NOT GIT_FOUND)
 ENDIF()
 
 EXECUTE_PROCESS(
-   COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"%H %h %ae"
+   COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"%h"
    WORKING_DIRECTORY ${CTEST_SOURCE_DIRECTORY}
    OUTPUT_VARIABLE _git_WC_INFO
    RESULT_VARIABLE _result
@@ -346,14 +346,8 @@ IF(NOT ${_result} EQUAL 0)
   MESSAGE(FATAL_ERROR "\nCould not retrieve git information. Bailing out.\n")
 ENDIF()
 
-STRING(REGEX REPLACE "^\"([^ ]+) ([^ ]+) ([^\"]+)\""
-         "\\1" _git_WC_REV "${_git_WC_INFO}")
-
-STRING(REGEX REPLACE "^\"([^ ]+) ([^ ]+) ([^\"]+)\""
-         "\\2" _git_WC_SHORTREV "${_git_WC_INFO}")
-
-STRING(REGEX REPLACE "^\"([^ ]+) ([^ ]+) ([^\"]+)\""
-         "\\3" _git_WC_AUTHOR "${_git_WC_INFO}")
+STRING(REGEX REPLACE "^\"([^ ]+)\""
+         "\\1" _git_WC_SHORTREV "${_git_WC_INFO}")
 
 EXECUTE_PROCESS(
    COMMAND ${GIT_EXECUTABLE} symbolic-ref HEAD
@@ -365,21 +359,6 @@ EXECUTE_PROCESS(
 
 STRING(REGEX REPLACE "refs/heads/" ""
   _git_WC_BRANCH "${_git_WC_BRANCH}")
-
-#
-# Write revision log:
-#
-
-FILE(WRITE ${CTEST_BINARY_DIRECTORY}/revision.log
-"###
-#
-#  Git information:
-#    Branch: ${_git_WC_BRANCH}
-#    Commit: ${_git_WC_REV}
-#    Author: ${_git_WC_AUTHOR}
-#
-###"
-  )
 
 IF(NOT "${_git_WC_BRANCH}" STREQUAL "")
   SET(CTEST_BUILD_NAME "${CTEST_BUILD_NAME}-${_git_WC_BRANCH}")


### PR DESCRIPTION
54d70f0 (Matthias Maier, 21 hours ago)
   Add a revision.h header file that exports git branch and revision for
   compile time usage in user projects

c1b4bb2 (Matthias Maier, 31 hours ago)
   Testsuite: Do not write revision.log, this is now done in setup_git.cmake

a811f0b (Matthias Maier, 31 hours ago)
   CMake: Print commit in summary.log and detailed.log

a34bddf (Matthias Maier, 31 hours ago)
   CMake: Query branch and commit during configure