### PR TITLE
This series of commits resolve a bunch of issues with CMake 3.1 along with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,19 @@
 #
 # General configuration for cmake:
 #
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
-
 MESSAGE(STATUS "This is CMake ${CMAKE_VERSION}")
 MESSAGE(STATUS "")
 
-IF(POLICY CMP0026)
-  # enable target LOCATION property
-  CMAKE_POLICY(SET CMP0026 OLD)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
+
+#
+# We support all policy changes up to version 3.1.0. Thus, explicitly set
+# all policies CMP0001 - CMP0054 to new for version 3.1 (and later) to
+# avoid some unnecessary warnings.
+#
+IF( "${CMAKE_VERSION}" VERSION_EQUAL "3.1" OR
+    "${CMAKE_VERSION}" VERSION_GREATER "3.1" )
+  CMAKE_POLICY(VERSION 3.1.0)
 ENDIF()
 
 IF(POLICY CMP0037)

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -94,10 +94,17 @@ FOREACH(_build ${DEAL_II_BUILD_TYPES})
   ENDIF()
 
   #
-  # Get library name directly from the target:
+  # Build up library name depending on link type:
   #
-  GET_TARGET_PROPERTY(_lib ${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX} LOCATION)
-  GET_FILENAME_COMPONENT(CONFIG_LIBRARY_${_build} "${_lib}" NAME)
+  IF(BUILD_SHARED_LIBS)
+    SET(CONFIG_LIBRARY_${_build}
+      "${CMAKE_SHARED_LIBRARY_PREFIX}${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      )
+  ELSE()
+    SET(CONFIG_LIBRARY_${_build}
+      "${CMAKE_STATIC_LIBRARY_PREFIX}${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      )
+  ENDIF()
 
   IF(CMAKE_SYSTEM_NAME MATCHES "CYGWIN" OR CMAKE_SYSTEM_NAME MATCHES "Windows")
     SET(CONFIG_LIBRARIES_${_build}

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -44,9 +44,8 @@ MACRO(DEAL_II_ADD_LIBRARY _library)
       LINKER_LANGUAGE "CXX"
       )
 
-    FILE(APPEND
-      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${_build_lowercase}
-      "$<TARGET_OBJECTS:${_library}.${_build_lowercase}>\n"
+    SET_PROPERTY(GLOBAL APPEND PROPERTY DEAL_II_OBJECTS_${_build}
+      "$<TARGET_OBJECTS:${_library}.${_build_lowercase}>"
       )
   ENDFOREACH()
 

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -40,7 +40,7 @@ ENDFOREACH()
 # used during the configuration stage:
 #
 FOREACH(_flag ${DEAL_II_REMOVED_FLAGS})
-  IF(NOT "${_flag}" STREQUAL "")
+  IF(NOT "${${_flag}}" STREQUAL "")
     MESSAGE(FATAL_ERROR
       "\nInternal configuration error: The variable ${_flag} was set to a "
       "non empty value during the configuration! (The corresponding "

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -78,7 +78,7 @@ FOREACH(_suffix ${DEAL_II_LIST_SUFFIXES})
 ENDFOREACH()
 
 #
-# Cleanup deal.IITargets.cmake in the build directory:
+# Clean up deal.IITargets.cmake in the build directory:
 #
 FILE(REMOVE
   ${CMAKE_BINARY_DIR}/${DEAL_II_PROJECT_CONFIG_RELDIR}/${DEAL_II_PROJECT_CONFIG_NAME}Targets.cmake

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -78,19 +78,6 @@ FOREACH(_suffix ${DEAL_II_LIST_SUFFIXES})
 ENDFOREACH()
 
 #
-# Cleanup some files used for storing the names of all object targets that
-# will be bundled to the deal.II library.
-# (Right now, i.e. cmake 2.8.8, this is the only reliable way to get
-# information into a global scope...)
-#
-FOREACH(_build ${DEAL_II_BUILD_TYPES})
-  STRING(TOLOWER "${_build}" _build_lowercase)
-  FILE(REMOVE
-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${_build_lowercase}
-    )
-ENDFOREACH()
-
-#
 # Cleanup deal.IITargets.cmake in the build directory:
 #
 FILE(REMOVE

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -74,6 +74,11 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Ported: The build system now supports CMake up to version 3.1.
+  <br>
+  (Matthias Maier, 2015/01/06)
+  </li>
+
   <li> Fixed: CMake now also handles and exports the subminor version
   number correctly ("pre" and "rc?" are replaced by "0").
   <br>

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -55,13 +55,11 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   #
   # Combine all ${build} OBJECT targets to a ${build} library:
   #
-  FILE(STRINGS
-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${build_lowercase}
-    deal_ii_objects_${build_lowercase}
-    )
+
+  GET_PROPERTY(_objects GLOBAL PROPERTY DEAL_II_OBJECTS_${build})
   ADD_LIBRARY(${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX}
     dummy.cc # Workaround for a bug in the Xcode generator
-    ${deal_ii_objects_${build_lowercase}}
+    ${_objects}
     )
   ADD_DEPENDENCIES(library ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX})
 


### PR DESCRIPTION
some code cleanup.

533131d (Matthias Maier, 16 seconds ago)
   Add an entry to changes.h

e9a6cbb (Matthias Maier, 30 minutes ago)
   CMake: Build up library name directly

   The LOCATION property is deprecated starting with CMake 3.0. Further it
   leads to an astonishing bug if used in CMake 3.1 [1]. Thus, we have to
   build up the library name by hand.

   [1] http://public.kitware.com/Bug/view.php?id=15338

2cdbeca (Matthias Maier, 9 hours ago)
   CMake: Use a global property to store object targets

af0ccfa (Matthias Maier, 9 hours ago)
   CMake: Explicitly set all policies to new behavior

   We support all CMake policies up to version 3.1.0 . Thus, set them to new
   behavior.