### PR TITLE
Fixed an issue with Utilities::int_to_string.

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/exceptions.h>
 
 #include <boost/math/special_functions/erf.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <algorithm>
 #include <cerrno>
@@ -70,55 +71,18 @@ namespace Utilities
                   << " to the desired type");
 
   std::string
-  int_to_string (const unsigned int i,
-                 const unsigned int digits)
+  int_to_string (const unsigned int value, const unsigned int digits)
   {
-    // if second argument is invalid, then do
-    // not pad the resulting string at all
+    std::string lc_string = boost::lexical_cast<std::string>(value);
+
     if (digits == numbers::invalid_unsigned_int)
-      return int_to_string (i, needed_digits(i));
-
-
-    AssertThrow ( ! ((digits==1 && i>=10)   ||
-                     (digits==2 && i>=100)  ||
-                     (digits==3 && i>=1000) ||
-                     (digits==4 && i>=10000)||
-                     (digits==5 && i>=100000)||
-                     (digits==6 && i>=1000000)||
-                     (digits==7 && i>=10000000)||
-                     (digits==8 && i>=100000000)||
-                     (digits==9 && i>=1000000000)||
-                     (i>=1000000000)),
-                  ExcInvalidNumber2StringConversersion(i, digits));
-
-    std::string s;
-    switch (digits)
+      return lc_string;
+    else if (lc_string.size() < digits)
       {
-      case 10:
-        s += '0' + i/1000000000;
-      case 9:
-        s += '0' + i/100000000;
-      case 8:
-        s += '0' + i/10000000;
-      case 7:
-        s += '0' + i/1000000;
-      case 6:
-        s += '0' + i/100000;
-      case 5:
-        s += '0' + (i%100000)/10000;
-      case 4:
-        s += '0' + (i%10000)/1000;
-      case 3:
-        s += '0' + (i%1000)/100;
-      case 2:
-        s += '0' + (i%100)/10;
-      case 1:
-        s += '0' + i%10;
-        break;
-      default:
-        s += "invalid digits information";
-      };
-    return s;
+        std::string padding(digits - lc_string.size(), '0');
+        lc_string.insert(0, padding);
+      }
+    return lc_string;
   }
 
 


### PR DESCRIPTION
`Utilities::int_to_string` does not like numbers with more than ten digits. I know this is a niche issue but I ran into it this morning. In case anyone is interested, I can demonstrate the issue with

```cpp
#include <iostream>
#include <string>

#include <deal.II/base/utilities.h>
#include <deal.II/bundled/boost/lexical_cast.hpp>

using namespace dealii;
// This is the new version I include in the pull request.
std::string
int_to_string (const unsigned int value, const unsigned int digits)
{
  std::string lc_string = boost::lexical_cast<std::string>(value);

  if (digits == numbers::invalid_unsigned_int)
    return lc_string;
  else if (lc_string.size() < digits)
    {
      std::string padding(digits - lc_string.size(), '0');
      lc_string.insert(0, padding);
    }
  return lc_string;
}

int main ()
{
  unsigned int value = 9999999;
  unsigned int string_length = 10;
  std::string dealii_string = Utilities::int_to_string (value, string_length);
  std::string lc_string = int_to_string (value, string_length);

  std::cout << "deal.II version: '" << dealii_string << "'" << std::endl;
  std::cout << "boost version: '" << lc_string << "'" << std::endl;
}
```

which produces
```
deal.II version: 'invalid digits information'
boost version: '000000009999999'
```