### PR TITLE
Fix two mistakes with MPI initialization.

### DIFF
--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -2239,8 +2239,11 @@ start_time_iteration:
 
 // @sect3{The <code>main()</code> function}
 //
-// The main function looks almost the same as in all other programs:
-int main ()
+// The main function looks almost the same as in all other programs. The need
+// to initialize the MPI subsystem for a program that uses Trilinos -- even
+// for programs that do not actually run in parallel -- is explained in
+// step-31.
+int main (int argc, char *argv[])
 {
   try
     {
@@ -2248,6 +2251,8 @@ int main ()
       using namespace Step43;
 
       deallog.depth_console (0);
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv);
 
       TwoPhaseFlowProblem<2> two_phase_flow_problem(1);
       two_phase_flow_problem.run ();

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2010 - 2013 by the deal.II authors and
+ * Copyright (C) 2010 - 2013, 2015 by the deal.II authors and
  *                              & Jean-Paul Pelteret and Andrew McBride
  *
  * This file is part of the deal.II library.
@@ -3166,13 +3166,10 @@ namespace Step44
 // @sect3{Main function}
 // Lastly we provide the main driver function which appears
 // no different to the other tutorials.
-int main (int argc, char *argv[])
+int main ()
 {
   using namespace dealii;
   using namespace Step44;
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv,
-                                                       dealii::numbers::invalid_unsigned_int);
 
   try
     {


### PR DESCRIPTION
In one case, we unnecessarily initialize MPI. The second case undoes a recent
invalid patch that removed the initialization, but it turns out that we
actually need it because we use Trilinos (see the main function of step-31
for an explanation).