### PR TITLE
[RFC] Reorganize config.h.in, remove obsolete definitions

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,25 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Removed: The following compatibility definitions were removed from
+  <code>include/deal.II/base/config.h.in</code> (replacement in brackets):
+  - DEAL_II_CAN_USE_CXX11 (new: DEAL_II_WITH_CXX11)
+  - DEAL_II_CAN_USE_CXX1X (new: DEAL_II_WITH_CXX11)
+  - DEAL_II_COMPILER_SUPPORTS_MPI (new: DEAL_II_WITH_MPI)
+  - DEAL_II_MAJOR (new: DEAL_II_VERSION_MAJOR)
+  - DEAL_II_MINOR (new: DEAL_II_VERSION_MINOR)
+  - DEAL_II_USE_ARPACK (new: DEAL_II_WITH_ARPACK)
+  - DEAL_II_USE_CXX11 (new: DEAL_II_WITH_CXX11)
+  - DEAL_II_USE_METIS (new: DEAL_II_WITH_METIS)
+  - DEAL_II_USE_MT (new: DEAL_II_WITH_THREADS)
+  - DEAL_II_USE_P4EST (new: DEAL_II_WITH_P4EST)
+  - DEAL_II_USE_PETSC (new: DEAL_II_WITH_PETSC)
+  - DEAL_II_USE_SLEPC (new: DEAL_II_WITH_SLEPC)
+  - DEAL_II_USE_TRILINOS (new: DEAL_II_WITH_TRILINOS)
+  <br>
+  (Matthias Maier, 2015/01/12)
+  </li>
+
   <li> Removed: The direct Mumps interface through
   <code>SparseDirectMUMPS</code> has been removed. The MUMPS solver is
   still available through the Trilinos or PETSc interfaces. Alternatively,

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -17,178 +17,129 @@
 #define __deal2__config_h
 
 
-/**
+/***********************************************************************
  * Two macro names that we put at the top and bottom of all deal.II files
  * and that will be expanded to "namespace dealii {" and "}".
  */
+
 #define DEAL_II_NAMESPACE_OPEN namespace dealii {
 #define DEAL_II_NAMESPACE_CLOSE }
 
 
-/***********************************************
- * Configured in setup_cached_variables.cmake: *
- ***********************************************/
+/***********************************************************************
+ * Information about deal.II:
+ */
 
-#cmakedefine DEAL_II_WITH_64BIT_INDICES
-
-
-/**************************************
- * Configured in setup_deal_ii.cmake: *
- **************************************/
-
-/** Defined to the full name of this package. */
 #define DEAL_II_PACKAGE_NAME "@DEAL_II_PACKAGE_NAME@"
 
-/** Defined to the version of this package. */
 #define DEAL_II_PACKAGE_VERSION "@DEAL_II_PACKAGE_VERSION@"
 
-/** Major version number of deal.II */
 #define DEAL_II_VERSION_MAJOR @DEAL_II_VERSION_MAJOR@
-#define DEAL_II_MAJOR @DEAL_II_VERSION_MAJOR@
-
-/** Minor version number of deal.II */
 #define DEAL_II_VERSION_MINOR @DEAL_II_VERSION_MINOR@
-#define DEAL_II_MINOR @DEAL_II_VERSION_MINOR@
-
-/** Subminor version number of deal.II */
 #define DEAL_II_VERSION_SUBMINOR @DEAL_II_VERSION_SUBMINOR@
 
-#define DEAL_II_VERSION_GTE(major,minor,subminor) \
- ((DEAL_II_VERSION_MAJOR * 10000 + \
-    DEAL_II_VERSION_MINOR * 100 + \
-     DEAL_II_VERSION_SUBMINOR) \
-    >=  \
-    (major)*10000 + (minor)*100 + (subminor))
+
+/***********************************************************************
+ * Configured deal.II features:
+ */
+
+#cmakedefine DEAL_II_WITH_64BIT_INDICES
+#cmakedefine DEAL_II_WITH_ARPACK
+#cmakedefine DEAL_II_WITH_BZIP2
+#cmakedefine DEAL_II_WITH_CXX11
+#cmakedefine DEAL_II_WITH_HDF5
+#cmakedefine DEAL_II_WITH_LAPACK
+#cmakedefine DEAL_II_WITH_METIS
+#cmakedefine DEAL_II_WITH_MPI
+#cmakedefine DEAL_II_WITH_MUPARSER
+#cmakedefine DEAL_II_WITH_NETCDF
+#cmakedefine DEAL_II_WITH_OPENCASCADE
+#cmakedefine DEAL_II_WITH_P4EST
+#cmakedefine DEAL_II_WITH_PETSC
+#cmakedefine DEAL_II_WITH_SLEPC
+#cmakedefine DEAL_II_WITH_THREADS
+#cmakedefine DEAL_II_WITH_TRILINOS
+#cmakedefine DEAL_II_WITH_UMFPACK
+#cmakedefine DEAL_II_WITH_ZLIB
 
 
-/********************************************
- * Configured in check_1_compiler_features: *
- ********************************************/
+/***********************************************************************
+ * Compiler bugs:
+ *
+ * For documentation see cmake/checks/check_03_compiler_bugs.cmake
+ */
 
-/** Defined if the compiler can use arithmetic operations on vectorized data types */
+#cmakedefine DEAL_II_TEMPL_SPEC_FRIEND_BUG
+#cmakedefine DEAL_II_MEMBER_ARRAY_SPECIALIZATION_BUG
+#cmakedefine DEAL_II_MEMBER_VAR_SPECIALIZATION_BUG
+#cmakedefine DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
+#cmakedefine DEAL_II_CONST_MEMBER_DEDUCTION_BUG
+#cmakedefine DEAL_II_BOOST_BIND_COMPILER_BUG
+#cmakedefine DEAL_II_BIND_NO_CONST_OP_PARENTHESES
+#cmakedefine DEAL_II_CONSTEXPR_BUG
+
+
+/***********************************************************************
+ * Compiler features:
+ *
+ * For documentation see cmake/checks/check_01_compiler_features.cmake
+ */
+
 #cmakedefine DEAL_II_COMPILER_USE_VECTOR_ARITHMETICS
-
-/** Defined if vector iterators are just plain pointers */
 #cmakedefine DEAL_II_VECTOR_ITERATOR_IS_POINTER
-
-/** Define if the compiler provides __builtin_expect */
 #cmakedefine DEAL_II_HAVE_BUILTIN_EXPECT
-
-/** Define if the compiler provides __verbose_terminate_handler */
 #cmakedefine DEAL_II_HAVE_VERBOSE_TERMINATE
-
-/** Define if deal.II is linked against a libc that provides stacktrace
- * debug information that can be printed out in the exception class
- * */
 #cmakedefine DEAL_II_HAVE_GLIBC_STACKTRACE
-
-/** Defined if the std c++ library provides a demangler conforming to the
- * GCC libstdc++ interface.
- */
 #cmakedefine DEAL_II_HAVE_LIBSTDCXX_DEMANGLER
-
-/** If already available, do not define at all. Otherwise, define to
- * __func__ if that is available. In all other cases, indicate that no
- * information about the present function is available for this compiler.
- */
 #cmakedefine __PRETTY_FUNCTION__ @__PRETTY_FUNCTION__@
-
-/** If the compiler supports it, then this variable is defined to a string
- * that when written after a function name makes the compiler emit a warning
- * whenever this function is used somewhere that its use is deprecated.
- */
 #cmakedefine DEAL_II_DEPRECATED @DEAL_II_DEPRECATED@
 
 
-/***************************************
- * Configured in check_1_cpu_features: *
- ***************************************/
+/***********************************************************************
+ * CPU features:
+ *
+ * For documentation see cmake/checks/check_01_cpu_features.cmake
+ */
 
-/** Defined if the system stores words with the most significant byte first */
 #cmakedefine DEAL_II_WORDS_BIGENDIAN
-
-/** Equal to 0 in the generic case, equal to 1 if CPU compiled for supports
- * SSE2, equal to 2 if CPU compiled for supports AVX, equal to 3 if AVX512
- * support is available
- */
 #define DEAL_II_COMPILER_VECTORIZATION_LEVEL @DEAL_II_COMPILER_VECTORIZATION_LEVEL@
-
-/** If openmp simd support is available this string contains the
- * corresponding pragma directive
- */
 #define DEAL_II_OPENMP_SIMD_PRAGMA @DEAL_II_OPENMP_SIMD_PRAGMA@
 
 
-/***************************************
- * Configured in check_1_cxx_features: *
- ***************************************/
-
-/** Defined if the compiler we use supports the C++2011 standard well enough
- * to allow using the standard library classes instead of the corresponding
- * BOOST classes.
+/***********************************************************************
+ * Language features:
+ *
+ * For documentation see cmake/checks/check_01_cxx_features.cmake
  */
-#cmakedefine DEAL_II_WITH_CXX11
-#ifdef DEAL_II_WITH_CXX11
-/** Compatibility definition (with naming from deal.II 8.0): */
-# define DEAL_II_USE_CXX11
-/** Compatibility definition (with naming from deal.II < 8.0): */
-# define DEAL_II_CAN_USE_CXX11
-# define DEAL_II_CAN_USE_CXX1X
-#endif
 
-/** Defined if C++11 is enabled and the standard library supports
- * template<typename T> std::is_trivially_copyable<T>
- */
 #cmakedefine DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE
-
-/** Defined if isnan is available */
 #cmakedefine DEAL_II_HAVE_ISNAN
-
-/** Defined if _isnan is available */
 #cmakedefine DEAL_II_HAVE_UNDERSCORE_ISNAN
-
-/** Defined if std::isfinite is available */
 #cmakedefine DEAL_II_HAVE_ISFINITE
 
 
-/******************************************
- * Configured in check_1_system_features: *
- ******************************************/
+/***********************************************************************
+ * System features:
+ *
+ * For documentation see cmake/checks/check_02_system_features.cmake
+ */
 
-/** Defined if you have the <sys/resource.h> header file */
 #cmakedefine DEAL_II_HAVE_SYS_RESOURCE_H
-
-/** Defined if you have the <sys/time.h> header file. */
 #cmakedefine DEAL_II_HAVE_SYS_TIME_H
-
-/** Defined if you have the <sys/times.h> header file. */
 #cmakedefine DEAL_II_HAVE_SYS_TIMES_H
-
-/** Defined if you have the <sys/types.h> header file. */
 #cmakedefine DEAL_II_HAVE_SYS_TYPES_H
-
-/** Defined if you have the <unistd.h> header file. */
 #cmakedefine DEAL_II_HAVE_UNISTD_H
-
-/** Defined if you have the "gethostname" function. */
 #cmakedefine DEAL_II_HAVE_GETHOSTNAME
-
-/** Defined if you have the "getpid' function. */
 #cmakedefine DEAL_II_HAVE_GETPID
-
-/** Defined if you have the "rand_r" function */
 #cmakedefine DEAL_II_HAVE_RAND_R
-
-/** Defined if you have the "times" function. */
 #cmakedefine DEAL_II_HAVE_TIMES
-
-/** Defined if you have the "jn" function. */
 #cmakedefine DEAL_II_HAVE_JN
 
-/** Defined if deal.II was configured on a native Windows platform. */
 #cmakedefine DEAL_II_MSVC
 
-/** Disable a bunch of warnings for Microsoft Visual C++. */
+/*
+ * Disable a bunch of warnings for Microsoft Visual C++.
+ */
 #ifdef _MSC_VER
 #  pragma warning( disable : 4244 ) /* implied downcasting from double to float */
 #  pragma warning( disable : 4267 ) /* implied downcasting from size_t to unsigned int */
@@ -202,135 +153,55 @@
 #  pragma warning( disable : 4700 ) /* uninitialized local variable */
 #  pragma warning( disable : 4789 ) /* destination of memory copy is too small */
 #  pragma warning( disable : 4808 ) /* case 'value' is not a valid value for switch condition of type 'bool */
-
-/** Also make sure we don't let MS Windows headers define min/max as
-   macros, see http://support.microsoft.com/kb/143208 */
+/*
+ * Also make sure we don't let MS Windows headers define min/max as
+ * macros, see http://support.microsoft.com/kb/143208
+ */
 #  define NOMINMAX
 #endif /*_MSC_VER*/
 
 
-/****************************************
- * Configured in check_3_compiler_bugs: *
- ****************************************/
-
-/** Defined if we have to work around a bug with some compilers that will not
- * allow us to specify a fully specialized class of a template as a friend.
- * See the aclocal.m4 file in the top-level directory for a description of
- * this bug.
- * */
-#cmakedefine DEAL_II_TEMPL_SPEC_FRIEND_BUG
-
-/** Defined if the compiler refuses to allow the explicit specialization of
- * static member arrays. For the exact failure mode, look at aclocal.m4 in the
- * top-level directory.
+/***********************************************************************
+ * Thread support
+ *
+ * For documentation see cmake/configure/configure_1_threads.cmake
  */
-#cmakedefine DEAL_II_MEMBER_ARRAY_SPECIALIZATION_BUG
 
-/** Defined if the compiler refuses to allow the explicit specialization of
- * static member variables.
+#cmakedefine DEAL_II_USE_MT_POSIX
+#cmakedefine DEAL_II_USE_MT_POSIX_NO_BARRIERS
+
+/*
+ * Depending on the use of threads, we will have to make some variables
+ * volatile. We do this here in a very old-fashioned C-style, but still
+ * convenient way.
  */
-#cmakedefine DEAL_II_MEMBER_VAR_SPECIALIZATION_BUG
-
-/** Defined if the compiler does not honor the explicit keyword on template
- * constructors.
- */
-#cmakedefine DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
-
-/** Defined if the compiler has a bug in deducing the type of pointers to const
- * member functions.
- */
-#cmakedefine DEAL_II_CONST_MEMBER_DEDUCTION_BUG
-
-/** Defined if the compiler gets an internal error compiling some code that
- * involves boost::bind
- */
-#cmakedefine DEAL_II_BOOST_BIND_COMPILER_BUG
-
-/**
- * Defined if there is no const operator() in the class type returned
- * by std::bind.
- */
-#cmakedefine DEAL_II_BIND_NO_CONST_OP_PARENTHESES
-
-/** Defined if the compiler incorrectly deduces a constexpr as not being a
- * constant integral expression under certain optimization (notably
- * gcc-4.8.1 on Windows and Mac)
- */
-#cmakedefine DEAL_II_CONSTEXPR_BUG
-
-
-/*****************************************
- * Configured in configure_arpack.cmake: *
- *****************************************/
-
-#cmakedefine DEAL_II_WITH_ARPACK
-#ifdef DEAL_II_WITH_ARPACK
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_ARPACK
+#ifdef DEAL_II_WITH_THREADS
+#  define DEAL_VOLATILE volatile
+#else
+#  define DEAL_VOLATILE
 #endif
 
 
+/***********************************************************************
+ * Various macros for version number query and comparison:
+ */
 
-/***************************************
- * Configured in configure_hdf5.cmake: *
- ***************************************/
+/*
+ * deal.II:
+ */
 
-#cmakedefine DEAL_II_WITH_HDF5
+#define DEAL_II_VERSION_GTE(major,minor,subminor) \
+ ((DEAL_II_VERSION_MAJOR * 10000 + \
+    DEAL_II_VERSION_MINOR * 100 + \
+     DEAL_II_VERSION_SUBMINOR) \
+    >=  \
+    (major)*10000 + (minor)*100 + (subminor))
 
+/*
+ * p4est:
+ */
 
-
-/*****************************************
- * Configured in configure_lapack.cmake: *
- *****************************************/
-
-#cmakedefine DEAL_II_WITH_LAPACK
-
-
-/****************************************
- * Configured in configure_metis.cmake: *
- ****************************************/
-
-#cmakedefine DEAL_II_WITH_METIS
-#ifdef DEAL_II_WITH_METIS
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_METIS
-#endif
-
-
-/**************************************
- * Configured in configure_mpi.cmake: *
- **************************************/
-
-#cmakedefine DEAL_II_WITH_MPI
-#ifdef DEAL_II_WITH_MPI
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_COMPILER_SUPPORTS_MPI
-#endif
-
-
-/*************************************************
- * Configured in configure_functionparser.cmake: *
- *************************************************/
-
-#cmakedefine DEAL_II_WITH_MUPARSER
-
-
-/*****************************************
- * Configured in configure_netcdf.cmake: *
- *****************************************/
-
-#cmakedefine DEAL_II_WITH_NETCDF
-
-
-/****************************************
- * Configured in configure_p4est.cmake: *
- ****************************************/
-
-#cmakedefine DEAL_II_WITH_P4EST
 #ifdef DEAL_II_WITH_P4EST
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_P4EST
-
 #  define DEAL_II_P4EST_VERSION_MAJOR @P4EST_VERSION_MAJOR@
 #  define DEAL_II_P4EST_VERSION_MINOR @P4EST_VERSION_MINOR@
 #  define DEAL_II_P4EST_VERSION_SUBMINOR @P4EST_VERSION_SUBMINOR@
@@ -354,22 +225,11 @@
     0) \
     >=  \
     (major)*1000000 + (minor)*10000 + (subminor)*100 + (patch))
-
 #endif
-
-
-/****************************************
- * Configured in configure_petsc.cmake: *
- ****************************************/
-
-#cmakedefine DEAL_II_WITH_PETSC
-#ifdef DEAL_II_WITH_PETSC
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_PETSC
-#endif
-
 
 /*
+ * PETSc:
+ *
  * Note: The following definitions will be set in petscconf.h and
  *       petscversion.h, so we don't repeat them here.
  *
@@ -381,7 +241,7 @@
  *  PETSC_USE_COMPLEX
  */
 
-/**
+/*
  * These macros are defined to make testing for PETSc versions within
  * the deal.II main code as simple as possible. In brief they are used
  * like this: (i) DEAL_II_PETSC_VERSION_LT is used to advance the
@@ -407,73 +267,11 @@
     >=  \
     (major)*10000 + (minor)*100 + (subminor))
 
-/****************************************
- * Configured in configure_slepc.cmake: *
- ****************************************/
-
-#cmakedefine DEAL_II_WITH_SLEPC
-#ifdef DEAL_II_WITH_SLEPC
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_SLEPC
-#endif
-
-
-/******************************************
- * Configured in configure_1_bzip2.cmake: *
- ******************************************/
-
-#cmakedefine DEAL_II_WITH_BZIP2
-
-
-/********************************************
- * Configured in configure_1_threads.cmake: *
- ********************************************/
-
-#cmakedefine DEAL_II_WITH_THREADS
-#ifdef DEAL_II_WITH_THREADS
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_MT
-#endif
-
-/**
- * Defined if multi-threading is to be achieved by using the POSIX functions
+/*
+ * Trilinos:
  */
-#cmakedefine DEAL_II_USE_MT_POSIX
 
-/** Defined if POSIX is supported but not the newer POSIX barrier functions.
- * Barriers will then not work in the library, but the other threading
- * functionality is available.
- */
-#cmakedefine DEAL_II_USE_MT_POSIX_NO_BARRIERS
-
-/**
- * Depending on the use of threads, we will have to make some variables
- * volatile. We do this here in a very old-fashioned C-style, but still
- * convenient way.
- */
-#ifdef DEAL_II_WITH_THREADS
-#  define DEAL_VOLATILE volatile
-#else
-#  define DEAL_VOLATILE
-#endif
-
-
-/*****************************************
- * Configured in configure_1_zlib.cmake: *
- *****************************************/
-
-#cmakedefine DEAL_II_WITH_ZLIB
-
-
-/*******************************************
- * Configured in configure_trilinos.cmake: *
- *******************************************/
-
-#cmakedefine DEAL_II_WITH_TRILINOS
 #ifdef DEAL_II_WITH_TRILINOS
-/** Compatibility definition (with naming from deal.II < 8.0): */
-#  define DEAL_II_USE_TRILINOS
-
 #  define DEAL_II_TRILINOS_VERSION_MAJOR @TRILINOS_VERSION_MAJOR@
 #  define DEAL_II_TRILINOS_VERSION_MINOR @TRILINOS_VERSION_MINOR@
 #  define DEAL_II_TRILINOS_VERSION_SUBMINOR @TRILINOS_VERSION_SUBMINOR@
@@ -487,26 +285,17 @@
 #endif
 
 
-/******************************************
- * Configured in configure_umfpack.cmake: *
- ******************************************/
+/***********************************************************************
+ * Final inclusions:
+ */
 
-#cmakedefine DEAL_II_WITH_UMFPACK
-
-
-/**********************************************
- * Configured in configure_opencascade.cmake: *
- **********************************************/
-
-#cmakedefine DEAL_II_WITH_OPENCASCADE
-
-
-// Some systems require including mpi.h before stdio.h which happens in
-// types.h
+/*
+ * Some systems require including mpi.h before stdio.h which happens in
+ * types.h
+ */
 #if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
 #  include <mpi.h>
 #endif
-
 
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/types.h>

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -895,7 +895,7 @@ namespace GridTools
                 }
             }
 
-#ifdef DEAL_II_USE_P4EST
+#ifdef DEAL_II_WITH_P4EST
         distributed_triangulation
         ->communicate_locally_moved_vertices(locally_owned_vertices);
 #else


### PR DESCRIPTION
I think along with the big deprecated functions cleanup it is also a good
idea to decruft config.h.in.

The following patchset thus removes all old definitions from changes.h.in.

Further, the documentation is radically shortened and just points to the
correct cmake configuration file (where every configure check is explained
in detail). This should ease the maintenance burden to keep everything in
sync a bit.