### PR TITLE
Added set_all_manifold_ids* functions to tria.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -145,6 +145,15 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> New: Triangulation::set_all_manifold_ids() and 
+  Triangulation::set_all_manifold_ids_on_boundaries()
+  set all manifold ids on every object or on every 
+  boundary object respectively.
+  <br>
+  (Luca Heltai, 2015/01/12)
+  </li>
+
+
   <li> New: GridTools::copy_boundary_to_manifold_id() and 
   GridTools::copy_material_to_manifold_id() copy
   boundary_ids and material_ids to manifold_ids for 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1628,6 +1628,29 @@ public:
   void set_manifold (const types::manifold_id number);
 
   /**
+   * Set the manifold_id of all of cells and faces to the given
+   * argument.
+   *
+   * @ingroup manifold
+   *
+   * @see
+   * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
+   */
+  void set_all_manifold_ids (const types::manifold_id &number);
+
+  /**
+   * Set the manifold_id of all of boundary faces to the given
+   * argument.
+   *
+   * @ingroup manifold
+   *
+   * @see
+   * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
+   */
+  void set_all_manifold_ids_on_boundary (const types::manifold_id &number);
+
+
+  /**
    * Return a constant reference to a boundary object used for this
    * triangulation.  Number is the same as in @p set_boundary
    *

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1628,26 +1628,24 @@ public:
   void set_manifold (const types::manifold_id number);
 
   /**
-   * Set the manifold_id of all of cells and faces to the given
-   * argument.
+   * Set the manifold_id of all cells and faces to the given argument.
    *
    * @ingroup manifold
    *
    * @see
    * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
    */
-  void set_all_manifold_ids (const types::manifold_id &number);
+  void set_all_manifold_ids (const types::manifold_id number);
 
   /**
-   * Set the manifold_id of all of boundary faces to the given
-   * argument.
+   * Set the manifold_id of all boundary faces to the given argument.
    *
    * @ingroup manifold
    *
    * @see
    * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
    */
-  void set_all_manifold_ids_on_boundary (const types::manifold_id &number);
+  void set_all_manifold_ids_on_boundary (const types::manifold_id number);
 
 
   /**

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -8772,7 +8772,7 @@ Triangulation<dim, spacedim>::set_manifold (const types::manifold_id m_number)
 
 template <int dim, int spacedim>
 void
-Triangulation<dim, spacedim>::set_all_manifold_ids (const types::manifold_id &m_number)
+Triangulation<dim, spacedim>::set_all_manifold_ids (const types::manifold_id m_number)
 {
   typename Triangulation<dim,spacedim>::active_cell_iterator
   cell=this->begin_active(), endc=this->end();
@@ -8784,7 +8784,7 @@ Triangulation<dim, spacedim>::set_all_manifold_ids (const types::manifold_id &m_
 
 template <int dim, int spacedim>
 void
-Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary (const types::manifold_id &m_number)
+Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary (const types::manifold_id m_number)
 {
   typename Triangulation<dim,spacedim>::active_cell_iterator
   cell=this->begin_active(), endc=this->end();

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -8770,6 +8770,30 @@ Triangulation<dim, spacedim>::set_manifold (const types::manifold_id m_number)
   manifold.erase(m_number);
 }
 
+template <int dim, int spacedim>
+void
+Triangulation<dim, spacedim>::set_all_manifold_ids (const types::manifold_id &m_number)
+{
+  typename Triangulation<dim,spacedim>::active_cell_iterator
+  cell=this->begin_active(), endc=this->end();
+
+  for (; cell != endc; ++cell)
+    cell->set_all_manifold_ids(m_number);
+}
+
+
+template <int dim, int spacedim>
+void
+Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary (const types::manifold_id &m_number)
+{
+  typename Triangulation<dim,spacedim>::active_cell_iterator
+  cell=this->begin_active(), endc=this->end();
+
+  for (; cell != endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->face(f)->at_boundary())
+        cell->face(f)->set_all_manifold_ids(m_number);
+}
 
 
 template <int dim, int spacedim>

--- a/tests/manifold/set_all_manifold_ids_01.cc
+++ b/tests/manifold/set_all_manifold_ids_01.cc
@@ -1,0 +1,77 @@
+//------------------------------------------------------------
+//    Copyright (C) 2015, the deal.II authors
+//
+//    This file is subject to LGPL and may not be  distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <fstream>
+#include <base/logstream.h>
+
+
+// all include files you need here
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_out.h>
+
+template<int dim, int spacedim>
+void print_info(Triangulation<dim,spacedim> &tria) {
+  typename Triangulation<dim,spacedim>::active_cell_iterator cell;
+
+  for (cell = tria.begin_active(); cell != tria.end(); ++cell)
+    {
+      deallog << "cell: " << cell 
+	      << ", material_id: " 
+	      << (int)cell->material_id()
+	      << ", manifold_id: " 
+	      << (int)cell->manifold_id() << std::endl;
+
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+	  deallog << "face: " << cell->face(f)
+		  << ", boundary_id: " 
+		  << (int)cell->face(f)->boundary_indicator()
+		  << ", manifold_id: " 
+		  << (int)cell->face(f)->manifold_id() << std::endl;
+    }
+}
+
+
+// Helper function
+template <int dim, int spacedim>
+void test()
+{
+  deallog << "Testing dim=" << dim
+          << ", spacedim="<< spacedim << std::endl;
+
+  Triangulation<dim,spacedim> tria;
+  GridGenerator::hyper_cube (tria, 0., 1.);
+
+  deallog << "Original mesh ==============================" << std::endl;
+  print_info(tria);
+  tria.set_all_manifold_ids(1);
+  deallog << "Modified mesh ==============================" << std::endl;
+  print_info(tria);
+}
+
+int main ()
+{
+  initlog(true);
+  
+  test<1,1>();
+  test<1,2>();
+  test<2,2>();
+  test<2,3>();
+  test<3,3>();
+
+  return 0;
+}
+

--- a/tests/manifold/set_all_manifold_ids_01.output
+++ b/tests/manifold/set_all_manifold_ids_01.output
@@ -1,0 +1,62 @@
+
+DEAL::Testing dim=1, spacedim=1
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 1, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 1, manifold_id: 1
+DEAL::Testing dim=1, spacedim=2
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 1, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 1, manifold_id: 1
+DEAL::Testing dim=2, spacedim=2
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::Testing dim=2, spacedim=3
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::Testing dim=3, spacedim=3
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 4, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 5, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: 1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 4, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 5, boundary_id: 0, manifold_id: 1

--- a/tests/manifold/set_all_manifold_ids_02.cc
+++ b/tests/manifold/set_all_manifold_ids_02.cc
@@ -1,0 +1,77 @@
+//------------------------------------------------------------
+//    Copyright (C) 2015, the deal.II authors
+//
+//    This file is subject to LGPL and may not be  distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <fstream>
+#include <base/logstream.h>
+
+
+// all include files you need here
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_out.h>
+
+template<int dim, int spacedim>
+void print_info(Triangulation<dim,spacedim> &tria) {
+  typename Triangulation<dim,spacedim>::active_cell_iterator cell;
+
+  for (cell = tria.begin_active(); cell != tria.end(); ++cell)
+    {
+      deallog << "cell: " << cell 
+	      << ", material_id: " 
+	      << (int)cell->material_id()
+	      << ", manifold_id: " 
+	      << (int)cell->manifold_id() << std::endl;
+
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+	  deallog << "face: " << cell->face(f)
+		  << ", boundary_id: " 
+		  << (int)cell->face(f)->boundary_indicator()
+		  << ", manifold_id: " 
+		  << (int)cell->face(f)->manifold_id() << std::endl;
+    }
+}
+
+
+// Helper function
+template <int dim, int spacedim>
+void test()
+{
+  deallog << "Testing dim=" << dim
+          << ", spacedim="<< spacedim << std::endl;
+
+  Triangulation<dim,spacedim> tria;
+  GridGenerator::hyper_cube (tria, 0., 1.);
+
+  deallog << "Original mesh ==============================" << std::endl;
+  print_info(tria);
+  tria.set_all_manifold_ids_on_boundary(1);
+  deallog << "Modified mesh ==============================" << std::endl;
+  print_info(tria);
+}
+
+int main ()
+{
+  initlog(true);
+  
+  test<1,1>();
+  test<1,2>();
+  test<2,2>();
+  test<2,3>();
+  test<3,3>();
+
+  return 0;
+}
+

--- a/tests/manifold/set_all_manifold_ids_02.output
+++ b/tests/manifold/set_all_manifold_ids_02.output
@@ -1,0 +1,62 @@
+
+DEAL::Testing dim=1, spacedim=1
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 1, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 1, manifold_id: 1
+DEAL::Testing dim=1, spacedim=2
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 1, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 1, manifold_id: 1
+DEAL::Testing dim=2, spacedim=2
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::Testing dim=2, spacedim=3
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::Testing dim=3, spacedim=3
+DEAL::Original mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: -1
+DEAL::face: 3, boundary_id: 0, manifold_id: -1
+DEAL::face: 0, boundary_id: 0, manifold_id: -1
+DEAL::face: 4, boundary_id: 0, manifold_id: -1
+DEAL::face: 1, boundary_id: 0, manifold_id: -1
+DEAL::face: 5, boundary_id: 0, manifold_id: -1
+DEAL::Modified mesh ==============================
+DEAL::cell: 0.0, material_id: 0, manifold_id: -1
+DEAL::face: 2, boundary_id: 0, manifold_id: 1
+DEAL::face: 3, boundary_id: 0, manifold_id: 1
+DEAL::face: 0, boundary_id: 0, manifold_id: 1
+DEAL::face: 4, boundary_id: 0, manifold_id: 1
+DEAL::face: 1, boundary_id: 0, manifold_id: 1
+DEAL::face: 5, boundary_id: 0, manifold_id: 1


### PR DESCRIPTION
This allows one to set all manifold_ids of cells and faces, or only of boundary faces, by calling one of 

~~~ C++
tria.set_all_manifold_ids(number);
tria.set_all_manifold_ids_on_boundary(number);
~~~