### PR TITLE
Cherry-pick commits to the release branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -30,12 +30,18 @@
 #
 # General configuration for cmake:
 #
+MESSAGE(STATUS "This is CMake ${CMAKE_VERSION}")
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 
-IF(POLICY CMP0026)
-  # enable target LOCATION property
-  CMAKE_POLICY(SET CMP0026 OLD)
+#
+# We support all policy changes up to version 3.1.0. Thus, explicitly set
+# all policies CMP0001 - CMP0054 to new for version 3.1 (and later) to
+# avoid some unnecessary warnings.
+#
+IF( "${CMAKE_VERSION}" VERSION_EQUAL "3.1" OR
+    "${CMAKE_VERSION}" VERSION_GREATER "3.1" )
+  CMAKE_POLICY(VERSION 3.1.0)
 ENDIF()
 
 IF(POLICY CMP0037)
@@ -43,7 +49,6 @@ IF(POLICY CMP0037)
   CMAKE_POLICY(SET CMP0037 OLD)
 ENDIF()
 
-MESSAGE(STATUS "This is CMake ${CMAKE_VERSION}")
 
 LIST(APPEND CMAKE_MODULE_PATH
   ${CMAKE_SOURCE_DIR}/cmake/

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -94,10 +94,17 @@ FOREACH(_build ${DEAL_II_BUILD_TYPES})
   ENDIF()
 
   #
-  # Get library name directly from the target:
+  # Build up library name depending on link type:
   #
-  GET_TARGET_PROPERTY(_lib ${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX} LOCATION)
-  GET_FILENAME_COMPONENT(CONFIG_LIBRARY_${_build} "${_lib}" NAME)
+  IF(BUILD_SHARED_LIBS)
+    SET(CONFIG_LIBRARY_${_build}
+      "${CMAKE_SHARED_LIBRARY_PREFIX}${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      )
+  ELSE()
+    SET(CONFIG_LIBRARY_${_build}
+      "${CMAKE_STATIC_LIBRARY_PREFIX}${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      )
+  ENDIF()
 
   IF(CMAKE_SYSTEM_NAME MATCHES "CYGWIN" OR CMAKE_SYSTEM_NAME MATCHES "Windows")
     SET(CONFIG_LIBRARIES_${_build}

--- a/cmake/config/Config.cmake.in
+++ b/cmake/config/Config.cmake.in
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -32,6 +32,7 @@ SET(DEAL_II_PACKAGE_DESCRIPTION "@DEAL_II_PACKAGE_DESCRIPTION@")
 
 SET(DEAL_II_VERSION_MAJOR "@DEAL_II_VERSION_MAJOR@")
 SET(DEAL_II_VERSION_MINOR "@DEAL_II_VERSION_MINOR@")
+SET(DEAL_II_VERSION_SUBMINOR "@DEAL_II_VERSION_SUBMINOR@")
 SET(DEAL_II_VERSION "@DEAL_II_VERSION@")
 
 SET(DEAL_II_PROJECT_CONFIG_NAME "@DEAL_II_PROJECT_CONFIG_NAME@")

--- a/cmake/config/Make.global_options.in
+++ b/cmake/config/Make.global_options.in
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -46,6 +46,7 @@ enable-parser        = @MAKEFILE_enableparser@
 DEAL_II_VERSION      = @DEAL_II_PACKAGE_VERSION@
 DEAL_II_MAJOR        = @DEAL_II_VERSION_MAJOR@
 DEAL_II_MINOR        = @DEAL_II_VERSION_MINOR@
+DEAL_II_SUBMINOR     = @DEAL_II_VERSION_SUBMINOR@
 
 PERL                 = perl
 

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -44,9 +44,8 @@ MACRO(DEAL_II_ADD_LIBRARY _library)
       LINKER_LANGUAGE "CXX"
       )
 
-    FILE(APPEND
-      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${_build_lowercase}
-      "$<TARGET_OBJECTS:${_library}.${_build_lowercase}>\n"
+    SET_PROPERTY(GLOBAL APPEND PROPERTY DEAL_II_OBJECTS_${_build}
+      "$<TARGET_OBJECTS:${_library}.${_build_lowercase}>"
       )
   ENDFOREACH()
 

--- a/cmake/setup_deal_ii.cmake
+++ b/cmake/setup_deal_ii.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -32,6 +32,7 @@
 #     DEAL_II_PACKAGE_DESCRIPTION     *)
 #     DEAL_II_VERSION_MAJOR
 #     DEAL_II_VERSION_MINOR
+#     DEAL_II_VERSION_SUBMINOR
 #     DEAL_II_VERSION
 #
 # Information about paths, install locations and names:
@@ -65,24 +66,40 @@
 
 SET_IF_EMPTY(DEAL_II_PACKAGE_NAME "deal.II")
 
-FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
-SET_IF_EMPTY(DEAL_II_PACKAGE_VERSION "${_version}")
-
 SET_IF_EMPTY(DEAL_II_PACKAGE_VENDOR
   "The deal.II Authors <http://www.dealii.org/>"
   )
-
 SET_IF_EMPTY(DEAL_II_PACKAGE_DESCRIPTION
   "Library for solving partial differential equations with the finite element method"
   )
 
-STRING(REGEX REPLACE
-  "^([0-9]+)\\..*" "\\1" DEAL_II_VERSION_MAJOR "${DEAL_II_PACKAGE_VERSION}"
+FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" _version LIMIT_COUNT 1)
+SET_IF_EMPTY(DEAL_II_PACKAGE_VERSION "${_version}")
+
+#
+# We expect a version number of the form "X.Y.Z", where X and Y are always
+# numbers and Z is either a third number (for a release version) or a short
+# string.
+#
+STRING(REGEX REPLACE "^([0-9]+)\\..*" "\\1"
+  DEAL_II_VERSION_MAJOR "${DEAL_II_PACKAGE_VERSION}"
   )
-STRING(REGEX REPLACE
-  "^[0-9]+\\.([0-9]+).*" "\\1" DEAL_II_VERSION_MINOR "${DEAL_II_PACKAGE_VERSION}"
+STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
+  DEAL_II_VERSION_MINOR "${DEAL_II_PACKAGE_VERSION}"
   )
-SET(DEAL_II_VERSION ${DEAL_II_VERSION_MAJOR}.${DEAL_II_VERSION_MINOR})
+
+#
+# If Z is not a number, replace it with "0", otherwise extract version
+# number:
+#
+IF(DEAL_II_PACKAGE_VERSION MATCHES "^[0-9]+\\.[0-9]+.*\\.[0-9]+.*")
+  STRING(REGEX REPLACE "^[0-9]+\\.[0-9]+.*\\.([0-9]+).*" "\\1"
+    DEAL_II_VERSION_SUBMINOR "${DEAL_II_PACKAGE_VERSION}"
+    )
+ELSE()
+  SET(DEAL_II_VERSION_SUBMINOR "0")
+ENDIF()
+SET(DEAL_II_VERSION ${DEAL_II_VERSION_MAJOR}.${DEAL_II_VERSION_MINOR}.${DEAL_II_VERSION_SUBMINOR})
 
 
 ########################################################################

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -40,7 +40,7 @@ ENDFOREACH()
 # used during the configuration stage:
 #
 FOREACH(_flag ${DEAL_II_REMOVED_FLAGS})
-  IF(NOT "${_flag}" STREQUAL "")
+  IF(NOT "${${_flag}}" STREQUAL "")
     MESSAGE(FATAL_ERROR
       "\nInternal configuration error: The variable ${_flag} was set to a "
       "non empty value during the configuration! (The corresponding "

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -78,7 +78,7 @@ FOREACH(_suffix ${DEAL_II_LIST_SUFFIXES})
 ENDFOREACH()
 
 #
-# Cleanup deal.IITargets.cmake in the build directory:
+# Clean up deal.IITargets.cmake in the build directory:
 #
 FILE(REMOVE
   ${CMAKE_BINARY_DIR}/${DEAL_II_PROJECT_CONFIG_RELDIR}/${DEAL_II_PROJECT_CONFIG_NAME}Targets.cmake

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -78,19 +78,6 @@ FOREACH(_suffix ${DEAL_II_LIST_SUFFIXES})
 ENDFOREACH()
 
 #
-# Cleanup some files used for storing the names of all object targets that
-# will be bundled to the deal.II library.
-# (Right now, i.e. cmake 2.8.8, this is the only reliable way to get
-# information into a global scope...)
-#
-FOREACH(_build ${DEAL_II_BUILD_TYPES})
-  STRING(TOLOWER "${_build}" _build_lowercase)
-  FILE(REMOVE
-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${_build_lowercase}
-    )
-ENDFOREACH()
-
-#
 # Cleanup deal.IITargets.cmake in the build directory:
 #
 FILE(REMOVE

--- a/doc/news/8.2.0-vs-8.2.1.h
+++ b/doc/news/8.2.0-vs-8.2.1.h
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+/**
+@page changes_between_8_2_0_and_8_2_1 Changes between Version 8.2.0 and 8.2.1
+
+<p>
+This is the list of changes made between the release of deal.II version
+8.2.0 and that of 8.2.1. All entries are signed with the names of the
+authors.
+</p>
+
+<!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
+
+<a name="specific"></a>
+<h3>Specific improvements</h3>
+
+<ol>
+  <li> Ported: The build system now supports CMake up to version 3.1.
+  <br>
+  (Matthias Maier, 2015/01/06)
+  </li>
+
+  <li> Fixed: CMake now also handles and exports the subminor version
+  number correctly ("pre" and "rc?" are replaced by "0").
+  <br>
+  (Matthias Maier, 2015/01/02)
+  </li>
+</ol>
+
+*/

--- a/doc/users/cmakelists.html
+++ b/doc/users/cmakelists.html
@@ -713,9 +713,11 @@ DEAL_II_PACKAGE_VERSION     - the full package version string, e.g. "8.1.pre"
 DEAL_II_PACKAGE_VENDOR
 DEAL_II_PACKAGE_DESCRIPTION
 
-DEAL_II_VERSION             - version string without suffix, e.g. "8.1"
+DEAL_II_VERSION             - numerical version number (with "pre" and "rc?"
+                              replaced by "0"), e.g. "8.2.0"
 DEAL_II_VERSION_MAJOR       - the major number, e.g. "8"
-DEAL_II_VERSION_MINOR       - the minor version number, e.g. "1"
+DEAL_II_VERSION_MINOR       - the minor version number, e.g. "2"
+DEAL_II_VERSION_SUBMINOR    - the minor version number, e.g. "0"
 
 DEAL_II_BUILD_TYPE          - the configured build type, e.g. "DebugRelease"
 DEAL_II_BUILD_TYPES         - an all caps list of available configurations,

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2014 by the deal.II authors
+// Copyright (C) 2012 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -49,6 +49,9 @@
 /** Minor version number of deal.II */
 #define DEAL_II_VERSION_MINOR @DEAL_II_VERSION_MINOR@
 #define DEAL_II_MINOR @DEAL_II_VERSION_MINOR@
+
+/** Subminor version number of deal.II */
+#define DEAL_II_VERSION_SUBMINOR @DEAL_II_VERSION_SUBMINOR@
 
 #define DEAL_II_VERSION_GTE(major,minor,subminor) \
  ((DEAL_II_VERSION_MAJOR * 10000 + \

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2013 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -55,13 +55,11 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   #
   # Combine all ${build} OBJECT targets to a ${build} library:
   #
-  FILE(STRINGS
-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/deal_ii_objects_${build_lowercase}
-    deal_ii_objects_${build_lowercase}
-    )
+
+  GET_PROPERTY(_objects GLOBAL PROPERTY DEAL_II_OBJECTS_${build})
   ADD_LIBRARY(${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX}
     dummy.cc # Workaround for a bug in the Xcode generator
-    ${deal_ii_objects_${build_lowercase}}
+    ${_objects}
     )
   ADD_DEPENDENCIES(library ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX})
 


### PR DESCRIPTION
This pull-request consists of two changes for version dealii-8.2.1 that ports
the build system to CMake-3.1:

53d2e2b (Matthias Maier, 10 minutes ago)
   Provide a 8.2.0-vs-8.2.1.h changelog

53a2985 (Matthias Maier, 6 days ago)
   CMake: Build up library name directly

   The LOCATION property is deprecated starting with CMake 3.0. Further it
   leads to an astonishing bug if used in CMake 3.1 [1]. Thus, we have to
   build up the library name by hand.

   [1] http://public.kitware.com/Bug/view.php?id=15338

c29cf73 (Matthias Maier, 7 days ago)
   CMake: Use a global property to store object targets

0c21e72 (Matthias Maier, 7 days ago)
   CMake: Explicitly set all policies to new behavior

   We support all CMake policies up to version 3.1.0 . Thus, set them to new
   behavior.

   Conflicts:
   CMakeLists.txt

96b8c20 (Matthias Maier, 10 days ago)
   CMake: Also handle subminor version number

   CMake now correctly queries the DEAL_II_PACKAGE_VERSION string for a
   subminor version replacing "pre" and "rc?" by "0". The subminor version
   number is also exported in the project configuration and the config.h
   header file.

   Conflicts:
   doc/news/changes.h