### PR TITLE
fix FindOPENCASCADE for OCC

### DIFF
--- a/cmake/modules/FindOPENCASCADE.cmake
+++ b/cmake/modules/FindOPENCASCADE.cmake
@@ -61,7 +61,7 @@ FOREACH(_library ${_opencascade_libraries})
   DEAL_II_FIND_LIBRARY(OPENCASCADE_${_library}
     NAMES ${_library}
     HINTS ${OPENCASCADE_DIR}
-    PATH_SUFFIXES lib${LIB_SUFFIX} lib64 lib
+    PATH_SUFFIXES lib${LIB_SUFFIX} lib64 lib mac64/clang/lib mac32/clang/lib lin64/gcc/lib lin32/gcc/lib
     )
 ENDFOREACH()
 


### PR DESCRIPTION
added mac[64,32]/clang/lib and lin[64,32]/gcc/lib to path_suffixes.