### PR TITLE
Fix include statements in testsuite

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,13 +38,21 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Changed: The project configuration no longer exports
+  <code>[...]/include/deal.II</code>. Thus it is now mandatory to prefix
+  all includes of deal.II headers with <code>deal.II/</code>, i.e.
+  <code>#include &lt;deal.II/[...]&gt;</code>.
+  <br>
+  (Matthias Maier, 2015/01/19)
+  </li>
+
   <li> Changed: ParameterHandler::leave_subsection() no longer returns a bool
   indicating if there was a subsection to leave. This never worked in the
   first place, because an exception was thrown.
   <br>
   (Timo Heister, 2015/01/19)
   </li>
-  
+
   <li> Changed: Make.global_options was completely redesigned. It still
   contains Makefile sourcable information, but they now closely mimic the
   declarative style of deal.IIConfig.cmake. Thus, projects that still use

--- a/tests/base/threads_02.cc
+++ b/tests/base/threads_02.cc
@@ -14,8 +14,8 @@
 // ---------------------------------------------------------------------
 
 #include "../tests.h"
-#include <base/thread_management.h>
-#include <base/logstream.h>
+#include <deal.II/base/thread_management.h>
+#include <deal.II/base/logstream.h>
 #include <fstream>
 #include <iostream>
 template <int> struct X {};

--- a/tests/bits/find_cell_10.cc
+++ b/tests/bits/find_cell_10.cc
@@ -48,19 +48,19 @@
 #include <stdio.h>
 #include <cstdlib>
 
-#include <base/quadrature_lib.h>
-#include <fe/mapping_q.h>
-#include <base/function.h>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_accessor.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_tools.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_q.h>
-#include <fe/fe_values.h>
-#include <grid/grid_in.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/grid/grid_in.h>
 
 
 #include <iostream>

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -26,19 +26,19 @@
 #include <stdio.h>
 #include <cstdlib>
 
-#include <base/quadrature_lib.h>
-#include <fe/mapping_q.h>
-#include <base/function.h>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_accessor.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_tools.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_q.h>
-#include <fe/fe_values.h>
-#include <grid/grid_in.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/grid/grid_in.h>
 
 
 #include <iostream>

--- a/tests/bits/find_cell_11.cc
+++ b/tests/bits/find_cell_11.cc
@@ -23,19 +23,19 @@
 #include <stdio.h>
 #include <cstdlib>
 
-#include <base/quadrature_lib.h>
-#include <fe/mapping_q.h>
-#include <base/function.h>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_accessor.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_tools.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_q.h>
-#include <fe/fe_values.h>
-#include <grid/grid_in.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/grid/grid_in.h>
 
 
 #include <iostream>

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -23,19 +23,19 @@
 #include <stdio.h>
 #include <cstdlib>
 
-#include <base/quadrature_lib.h>
-#include <fe/mapping_q.h>
-#include <base/function.h>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_accessor.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_tools.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_q.h>
-#include <fe/fe_values.h>
-#include <grid/grid_in.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/grid/grid_in.h>
 
 
 #include <iostream>

--- a/tests/codim_one/mesh_bug.cc
+++ b/tests/codim_one/mesh_bug.cc
@@ -19,18 +19,18 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 // all include files you need here
 
 
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/grid_in.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 
 int main ()

--- a/tests/deal.II/block_list.h
+++ b/tests/deal.II/block_list.h
@@ -18,7 +18,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/dofs/dof_accessor.h>
-#include <dofs/dof_tools.h>
+#include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_raviart_thomas.h>

--- a/tests/deal.II/constraints_block_01.cc
+++ b/tests/deal.II/constraints_block_01.cc
@@ -23,43 +23,43 @@
 // testcase by Jason Sheldon
 
 #include "../tests.h"
-#include <base/logstream.h>
-#include <base/utilities.h>
-#include <base/quadrature_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/quadrature_lib.h>
 
-#include <numerics/vector_tools.h>
-#include <numerics/matrix_tools.h>
-#include <numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/data_out.h>
 
-#include <lac/vector.h>
-#include <lac/sparse_direct.h>
-#include <lac/full_matrix.h>
-#include <lac/compressed_sparsity_pattern.h>
-#include <lac/sparse_matrix.h>
-#include <lac/constraint_matrix.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/compressed_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/constraint_matrix.h>
 
-#include <dofs/dof_accessor.h>
-#include <lac/constraint_matrix.h>
-#include <dofs/dof_renumbering.h>
-#include <dofs/dof_handler.h>
-#include <dofs/dof_tools.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
 
-#include <hp/dof_handler.h>
-#include <hp/q_collection.h>
-#include <hp/fe_collection.h>
-#include <hp/fe_values.h>
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/hp/q_collection.h>
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/fe_values.h>
 
-#include <fe/fe.h>
-#include <fe/fe_tools.h>
-#include <fe/fe_q.h>
-#include <fe/fe_nothing.h>
-#include <fe/fe_system.h>
-#include <fe/fe_values.h>
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
 
-#include <grid/grid_generator.h>
-#include <grid/tria_iterator.h>
-#include <grid/tria_boundary_lib.h>
-#include <grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/tria.h>
 
 #include <fstream>
 #include <cmath>

--- a/tests/deal.II/fe_values_view_tensor_01.cc
+++ b/tests/deal.II/fe_values_view_tensor_01.cc
@@ -18,28 +18,28 @@
 // a complete testcase by Denis Davydov for FEValuesExtractors::Tensor
 
 #include "../tests.h"
-#include <base/quadrature_lib.h>
-#include <base/logstream.h>
-#include <base/function.h>
-#include <lac/block_vector.h>
-#include <lac/full_matrix.h>
-#include <lac/block_sparse_matrix.h>
-#include <lac/solver_cg.h>
-#include <lac/precondition.h>
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_accessor.h>
-#include <grid/tria_iterator.h>
-#include <dofs/dof_handler.h>
-#include <dofs/dof_renumbering.h>
-#include <dofs/dof_accessor.h>
-#include <dofs/dof_tools.h>
-#include <fe/fe_system.h>
-#include <fe/fe_values.h>
-#include <numerics/vector_tools.h>
-#include <numerics/matrix_tools.h>
-#include <numerics/data_out.h>
-#include <fe/fe_q.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/function.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/fe/fe_q.h>
 
 #include <fstream>
 

--- a/tests/deal.II/no_flux_10.cc
+++ b/tests/deal.II/no_flux_10.cc
@@ -31,17 +31,17 @@
 
 #include "../tests.h"
 
-#include <grid/tria.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
-#include <grid/grid_out.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_system.h>
-#include <fe/mapping_q.h>
-#include <numerics/vector_tools.h>
-#include <numerics/data_out.h>
-#include <base/exceptions.h>
-#include <base/function.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 
 
 void

--- a/tests/deal.II/no_flux_11.cc
+++ b/tests/deal.II/no_flux_11.cc
@@ -22,17 +22,17 @@
 
 #include "../tests.h"
 
-#include <grid/tria.h>
-#include <grid/grid_in.h>
-#include <grid/tria_boundary_lib.h>
-#include <grid/grid_out.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_system.h>
-#include <fe/mapping_q.h>
-#include <numerics/vector_tools.h>
-#include <numerics/data_out.h>
-#include <base/exceptions.h>
-#include <base/function.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 
 
 

--- a/tests/deal.II/no_flux_12.cc
+++ b/tests/deal.II/no_flux_12.cc
@@ -53,17 +53,17 @@
 
 #include "../tests.h"
 
-#include <grid/tria.h>
-#include <grid/tria_boundary_lib.h>
-#include <grid/grid_out.h>
-#include <grid/grid_generator.h>
-#include <dofs/dof_handler.h>
-#include <fe/fe_system.h>
-#include <fe/mapping_q.h>
-#include <numerics/vector_tools.h>
-#include <numerics/data_out.h>
-#include <base/exceptions.h>
-#include <base/function.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 
 
 template <int dim>

--- a/tests/integrators/assembler_simple_matrix_04.cc
+++ b/tests/integrators/assembler_simple_matrix_04.cc
@@ -22,7 +22,7 @@
 #include "../tests.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/full_matrix.h>
-#include <lac/sparse_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>

--- a/tests/manifold/copy_boundary_to_manifold_id_01.cc
+++ b/tests/manifold/copy_boundary_to_manifold_id_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/copy_material_to_manifold_id_01.cc
+++ b/tests/manifold/copy_material_to_manifold_id_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/cylindrical_manifold_01.cc
+++ b/tests/manifold/cylindrical_manifold_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/cylindrical_manifold_02.cc
+++ b/tests/manifold/cylindrical_manifold_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/flat_manifold_01.cc
+++ b/tests/manifold/flat_manifold_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/flat_manifold_02.cc
+++ b/tests/manifold/flat_manifold_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/flat_manifold_03.cc
+++ b/tests/manifold/flat_manifold_03.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/flat_manifold_04.cc
+++ b/tests/manifold/flat_manifold_04.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/manifold/function_manifold_01.cc
+++ b/tests/manifold/function_manifold_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/function_manifold_02.cc
+++ b/tests/manifold/function_manifold_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_01.cc
+++ b/tests/manifold/manifold_id_01.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_02.cc
+++ b/tests/manifold/manifold_id_02.cc
@@ -15,7 +15,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_03.cc
+++ b/tests/manifold/manifold_id_03.cc
@@ -17,7 +17,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_04.cc
+++ b/tests/manifold/manifold_id_04.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_05.cc
+++ b/tests/manifold/manifold_id_05.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_06.cc
+++ b/tests/manifold/manifold_id_06.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/manifold_id_07.cc
+++ b/tests/manifold/manifold_id_07.cc
@@ -16,7 +16,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/set_all_manifold_ids_01.cc
+++ b/tests/manifold/set_all_manifold_ids_01.cc
@@ -11,7 +11,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/set_all_manifold_ids_02.cc
+++ b/tests/manifold/set_all_manifold_ids_02.cc
@@ -11,7 +11,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/spherical_manifold_01.cc
+++ b/tests/manifold/spherical_manifold_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/spherical_manifold_02.cc
+++ b/tests/manifold/spherical_manifold_02.cc
@@ -14,7 +14,7 @@
 #include "../tests.h"
 
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/spherical_manifold_03.cc
+++ b/tests/manifold/spherical_manifold_03.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/spherical_manifold_04.cc
+++ b/tests/manifold/spherical_manifold_04.cc
@@ -14,7 +14,7 @@
 #include "../tests.h"
 
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/spherical_manifold_05.cc
+++ b/tests/manifold/spherical_manifold_05.cc
@@ -14,7 +14,7 @@
 #include "../tests.h"
 
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/tria_accessor_point_01.cc
+++ b/tests/manifold/tria_accessor_point_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/tria_accessor_point_02.cc
+++ b/tests/manifold/tria_accessor_point_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/manifold/tria_accessor_point_03.cc
+++ b/tests/manifold/tria_accessor_point_03.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 
 // all include files you need here

--- a/tests/opencascade/arclength_boundary_01.cc
+++ b/tests/opencascade/arclength_boundary_01.cc
@@ -11,7 +11,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/opencascade/boundary_lib.h>

--- a/tests/opencascade/arclength_boundary_02.cc
+++ b/tests/opencascade/arclength_boundary_02.cc
@@ -17,13 +17,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/axis_boundary_02.cc
+++ b/tests/opencascade/axis_boundary_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/opencascade/boundary_lib.h>

--- a/tests/opencascade/circle_normal_projection.cc
+++ b/tests/opencascade/circle_normal_projection.cc
@@ -17,13 +17,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/closest_point_to_shape.cc
+++ b/tests/opencascade/closest_point_to_shape.cc
@@ -16,13 +16,13 @@
 
 #include <deal.II/opencascade/utilities.h>
 
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/create_tria_00.cc
+++ b/tests/opencascade/create_tria_00.cc
@@ -17,13 +17,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/create_tria_01.cc
+++ b/tests/opencascade/create_tria_01.cc
@@ -18,13 +18,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/directional_boundary_01.cc
+++ b/tests/opencascade/directional_boundary_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/opencascade/boundary_lib.h>

--- a/tests/opencascade/iges_create.cc
+++ b/tests/opencascade/iges_create.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/iges_describe.cc
+++ b/tests/opencascade/iges_describe.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/iges_describe_02.cc
+++ b/tests/opencascade/iges_describe_02.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/iges_write.cc
+++ b/tests/opencascade/iges_write.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/interpolation_curve_boundary.cc
+++ b/tests/opencascade/interpolation_curve_boundary.cc
@@ -17,13 +17,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/normal_projection_01.cc
+++ b/tests/opencascade/normal_projection_01.cc
@@ -17,13 +17,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/normal_to_mesh_projection_01.cc
+++ b/tests/opencascade/normal_to_mesh_projection_01.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/opencascade/boundary_lib.h>

--- a/tests/opencascade/normal_to_mesh_projection_02.cc
+++ b/tests/opencascade/normal_to_mesh_projection_02.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <deal.II/opencascade/boundary_lib.h>

--- a/tests/opencascade/plane_intersection_01.cc
+++ b/tests/opencascade/plane_intersection_01.cc
@@ -18,13 +18,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/project_center_cell_01.cc
+++ b/tests/opencascade/project_center_cell_01.cc
@@ -18,13 +18,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/project_center_cell_02.cc
+++ b/tests/opencascade/project_center_cell_02.cc
@@ -18,13 +18,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/project_center_cell_03.cc
+++ b/tests/opencascade/project_center_cell_03.cc
@@ -18,13 +18,13 @@
 #include <deal.II/opencascade/boundary_lib.h>
 
 #include <fstream>
-#include <base/logstream.h>
-#include <grid/tria.h>
-#include <grid/tria_accessor.h>
-#include <grid/grid_out.h>
-#include <grid/tria_iterator.h>
-#include <grid/grid_generator.h>
-#include <grid/tria_boundary_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
 
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>

--- a/tests/opencascade/step_create.cc
+++ b/tests/opencascade/step_create.cc
@@ -13,7 +13,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/step_describe.cc
+++ b/tests/opencascade/step_describe.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/step_describe_02.cc
+++ b/tests/opencascade/step_describe_02.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>

--- a/tests/opencascade/step_write.cc
+++ b/tests/opencascade/step_write.cc
@@ -14,7 +14,7 @@
 
 #include "../tests.h"
 #include <fstream>
-#include <base/logstream.h>
+#include <deal.II/base/logstream.h>
 
 #include <deal.II/opencascade/utilities.h>
 #include <TopTools.hxx>


### PR DESCRIPTION
Changes:

95eee0e (Matthias Maier, 19 seconds ago)
   add a forgotten changelog entry

b32994e (Matthias Maier, 5 minutes ago)
   Testsuite: Fix includes

   One of the previous changes removed [...]/deal.II from the list of include
   directories. Consequently, it is now mandatory to prefix all deal.II
   includes with deal.II/