### PR TITLE
[RFC] Reenable deprecation warnings

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -70,14 +70,6 @@ INSTALL(FILES ${_macros}
 STRIP_FLAG(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
 
 #
-# Strip -Wno-deprecated from DEAL_II_CXX_FLAGS so that deprecation warnings
-# are actually shown for user code:
-#
-
-STRIP_FLAG(DEAL_II_CXX_FLAGS "-Wno-deprecated")
-STRIP_FLAG(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
-
-#
 # Populate a bunch of CONFIG_* variables with useful information:
 #
 

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -77,12 +77,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-local-typedefs")
 # with disabled C++11 support:
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-long-long")
-
-#
-# Disable deprecation warnings
-#
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated")
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
 
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   #

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -93,7 +93,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-w2")
 #   -w981   operands are evaluated in unspecified order
 #   -w1418  external function definition with no prior declaration
 #           (happens in boost)
-#   -w1478  deprecation warning
 #   -w1572  floating-point equality and inequality comparisons are unreliable
 #   -w2259  non-pointer conversion from "double" to "float" may
 #           lose significant bits
@@ -112,7 +111,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd327")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd383")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd981")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd1418")
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd1478")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd1572")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd2259")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-wd21")


### PR DESCRIPTION
Currently, we do not build the library with deprecation warnings due the
(former) inflationary amount of internal use...
But thanks to Wolfgang's work on removing deprecated stuff we're down to
around 100 warnings due to deprecated functions (for a single build type).

I'd say once we get this number down a bit more, this pull request can be
merged.