### PR TITLE
Fix linkage for bundled boost

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -23,6 +23,16 @@ SET(DEAL_II_WITH_BOOST ON # Always true. We need it :-]
 
 
 MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
+
+  #
+  # Add rt to the link interface as well, boost/chrono needs it.
+  #
+  FIND_SYSTEM_LIBRARY(rt_LIBRARY NAMES rt)
+  MARK_AS_ADVANCED(rt_LIBRARY)
+  IF(NOT rt_LIBRARY MATCHES "-NOTFOUND")
+    SET(BOOST_LIBRARIES ${rt_LIBRARY})
+  ENDIF()
+
   SET(BOOST_BUNDLED_INCLUDE_DIRS ${BOOST_FOLDER}/include)
 ENDMACRO()
 

--- a/cmake/macros/macro_find_system_library.cmake
+++ b/cmake/macros/macro_find_system_library.cmake
@@ -42,7 +42,7 @@ MACRO(FIND_SYSTEM_LIBRARY)
       ENDIF()
     ENDFOREACH()
 
-    IF(NOT _variable)
+    IF(NOT ${_variable})
       SET(${_variable} "${_variable}-NOTFOUND")
     ENDIF()
   ENDIF()

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -280,6 +280,12 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Bugfix: deal.II now correctly links against librt in case of bundled
+  boost being used.
+  <br>
+  (Matthias Maier, 2015/01/27)
+  </li>
+
   <li> New: A new macro <code>DEAL_II_QUERY_GIT_INFORMATION</code> is
   provided to query user projects for git repository information simmilarly
   to those exported by deal.II.


### PR DESCRIPTION
It turns out that boost::chrono nowadays need -lrt on Linux targets.

Changes:

024d3fe (Matthias Maier, 14 minutes ago)
   add a changelog entry

cb08b77 (Matthias Maier, 16 minutes ago)
   CMake: Bugfix: Add -lrt to the link interface in case of bundled boost

9c97fa1 (Matthias Maier, 5 minutes ago)
   CMake: Fix FIND_SYSTEM_LIBRARY macro