### PR TITLE
step-34: fixes a runtime error in step-34

### DIFF
--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -1010,8 +1010,10 @@ namespace Step34
     DataOut<dim-1, DoFHandler<dim-1, dim> > dataout;
 
     dataout.attach_dof_handler(dh);
-    dataout.add_data_vector(phi, "phi");
-    dataout.add_data_vector(alpha, "alpha");
+    dataout.add_data_vector(phi, "phi",
+                            DataOut<dim-1, DoFHandler<dim-1, dim> >::type_dof_data);
+    dataout.add_data_vector(alpha, "alpha",
+                            DataOut<dim-1, DoFHandler<dim-1, dim> >::type_dof_data);
     dataout.build_patches(mapping,
                           mapping.get_degree(),
                           DataOut<dim-1, DoFHandler<dim-1, dim> >::curved_inner_cells);


### PR DESCRIPTION
In the function output_results, around line 1017, two vectors (phi and alpha)
are added to a DataOut object.
A runtime error is occuring, because the type of the vector can here not
determined automatically.
This bug fix adds the DoFHandler in front of the added vectors.
Afterwards, the program runs without runtime errors.

Additional information: this could also be fixed by setting the DataVectorType
as third input argument; e.g. dataout.add_data_vector(phi, "phi, DATAVECTORTYPE).

On branch dataout-issue-step-34
Changes to be committed:
	modified:   examples/step-34/step-34.cc