### PR TITLE
Remove deprecated functions 6

### DIFF
--- a/doc/doxygen/headers/multithreading.h
+++ b/doc/doxygen/headers/multithreading.h
@@ -1232,8 +1232,11 @@
  * that there are no other libraries starting threads.
  *
  * Note that a small number of places inside deal.II also uses thread-based
- * parallelism controlled by MultithreadInfo::n_default_threads
- * generally. Under some circumstances, deal.II also calls the BLAS library
+ * parallelism explicitly, for example for running background tasks that have
+ * to wait for input or output to happen and consequently do not consume
+ * much CPU time. Such threads do not run under the control of the TBB
+ * task scheduler and, therefore, are not affected by the procedure above.
+ * Under some circumstances, deal.II also calls the BLAS library
  * which may sometimes also start threads of its own. You will have to consult
  * the documentation of your BLAS installation to determine how to set the
  * number of threads for these operations.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -140,6 +140,7 @@ inconvenience this causes.
   - The MPI support functions in namespace Utilities and Utilities::System.
   - Deprecated members of namespace types.
   - Namespace deal_II_numbers.
+  - MultithreadInfo::n_default_threads.
 
   <br>
   <em>With headers in <code>deal.II/lac/</code>:</em>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -124,70 +124,37 @@ inconvenience this causes.
   you tried to use them). In almost all cases, there is a function with same
   name but different argument list that should be used instead.
   Specifically, the removed functions and classes are:
-  - TimeDependent::end_sweep (with an argument).
-  - PointValueHistory::mark_locations.
-  - The DataPostprocessor::compute_derived_quantities_scalar and
-    DataPostprocessor::compute_derived_quantities_vector functions without
-    evaluation points. If you have
-    data postprocessor classes implemented in your program that overload these
-    functions, you will have to change it in a way that they overload the
-    functions of same name but with the evaluation point argument instead.
-  - The constructors of classes MGSmoother, MGSmootherRelaxation and
-    MGSmootherPrecondition that take a VectorMemory object.
-  - Deprecated variants of MeshWorker::loop and MeshWorker::integration_loop.
+  <br>
+  <em>With headers in <code>deal.II/base/</code>:</em>
   - ThreadManagement::spawn.
   - Threads::ThreadCondition and Threads::ThreadMutex.
-  - GridGenerator::laplace_transformation.
-  - The version of GridGenerator::parallelogram where the corners are given
-    as a rank-2 tensor rather than as an array of points.
   - DataOutBase::create_xdmf_entry with 3 arguments.
   - DataOutBase::write_hdf5_parallel with 2 arguments.
-  - Algorithms::ThetaTimestepping::operator().
-  - Algorithms::ThetaTimestepping::initialize.
-  - Algorithms::Newton::initialize.
-  - MGLevelObject::get_minlevel and MGLevelObject::get_maxlevel.
   - The versions of FunctionParser::initialize that took a
     <code>use_degrees</code> or <code>constants</code> argument.
     The implementation as it is now no longer supports either of
     these two concepts (since we switched from the FunctionParser
     library to the muparser library after the deal.II 8.1 release).
-  - DoFRenumbering::downstream_dg.
-  - DoFTools::count_dofs_per_component.
-  - DoFTools::make_sparsity_pattern with a vector-of-vector mask.
   - GridOutFlags::XFig::level_color.
   - class BlockList.
-  - MGConstrainedDoFs::non_refinement_edge_index
-  - MGConstrainedDoFs::at_refinement_edge_boundary
-  - The refinement listener concept of the Triangulation class. This
-    approach to getting notified about what happens to triangulations
-    has been superseded by the signals defined by the triangulation
-    class.
   - The MPI support functions in namespace Utilities and Utilities::System.
   - Deprecated members of namespace types.
   - Namespace deal_II_numbers.
-  - Triangulation::distort_random.
-  - Triangulation::clear_user_pointers.
+
+  <br>
+  <em>With headers in <code>deal.II/lac/</code>:</em>
   - The deprecated constructor of SparseILU.
   - SparseILU::apply_decomposition.
   - The deprecated constructor of SparseMIC.
   - The compress() functions without argument in the various vector
     classes. You should use the versions with a VectorOperation
     argument instead.
-  - In FEValues and related classes, the functions that contain the
-    term <code>2nd_derivatives</code> were removed in favor of those
-    with names containing <code>hessian</code>. Similarly, functions
-    with names including <code>function_grads</code> were removed in
-    favor of those called <code>function_gradients</code>. Finally,
-    the <code>cell_normal_vector</code> functions were replaced by
-    <code>normal_vector</code> ones. In all cases, the new functions
-    have been around for a while.
   - Vector::scale.
   - TrilinosWrappers::*Vector*::compress with an Epetra_CombineMode
     argument.
   - SparsityPattern and ChunkSparsityPattern functions that take an
     <code>optimize_diagonal</code> argument.
   - SparsityPattern::partition.
-  - Mapping::transform_covariant and Mapping::transform_contravariant.
   - The typedef CompressedBlockSparsityPattern.
   - The deprecated constructors of SparsityPattern iterator classes.
   - The deprecated variants of DoFTools::make_periodicity_constraints.
@@ -200,19 +167,78 @@ inconvenience this causes.
     parallel::distributed::Vector::scale,
     parallel::distributed::BlockVector::scale
     function that takes a scalar as argument.
+  - PreconditionBlock::size.
+  - Classes PreconditionedMatrix and PreconditionLACSolver.
+  - PETScVectors::MPI::Vector constructors and reinit() variants.
+  - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
+    constructors.
+
+  <br>
+  <em>With headers in <code>deal.II/deal.II/</code>:</em>
+  - GridGenerator::laplace_transformation.
+  - The version of GridGenerator::parallelogram where the corners are given
+    as a rank-2 tensor rather than as an array of points.
   - GridTools::create_union_triangulation.
   - GridTools::extract_boundary_mesh.
-  - PreconditionBlock::size.
+  - Triangulation::distort_random.
+  - Triangulation::clear_user_pointers.
+  - The refinement listener concept of the Triangulation class. This
+    approach to getting notified about what happens to triangulations
+    has been superseded by the signals defined by the triangulation
+    class.
+
+  <br>
+  <em>With headers in <code>deal.II/fe/</code>:</em>
+  - In FEValues and related classes, the functions that contain the
+    term <code>2nd_derivatives</code> were removed in favor of those
+    with names containing <code>hessian</code>. Similarly, functions
+    with names including <code>function_grads</code> were removed in
+    favor of those called <code>function_gradients</code>. Finally,
+    the <code>cell_normal_vector</code> functions were replaced by
+    <code>normal_vector</code> ones. In all cases, the new functions
+    have been around for a while.
+  - Mapping::transform_covariant and Mapping::transform_contravariant.
+  - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
+
+  <br>
+  <em>With headers in <code>deal.II/dofs/</code>:</em>
+  - DoFRenumbering::downstream_dg.
+  - DoFTools::count_dofs_per_component.
+  - DoFTools::make_sparsity_pattern with a vector-of-vector mask.
+
+  <br>
+  <em>With headers in <code>deal.II/multigrid/</code>:</em>
+  - The constructors of classes MGSmoother, MGSmootherRelaxation and
+    MGSmootherPrecondition that take a VectorMemory object.
+  - MGLevelObject::get_minlevel and MGLevelObject::get_maxlevel.
+  - MGConstrainedDoFs::non_refinement_edge_index
+  - MGConstrainedDoFs::at_refinement_edge_boundary
   - MGTools::count_dofs_per_component.
   - MGTools::apply_boundary_values.
   - MGTools::extract_inner_interface_dofs.
   - Class MGMatrix.
   - Multigrid::vmult and friends.
-  - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
-  - Classes PreconditionedMatrix and PreconditionLACSolver.
-  - PETScVectors::MPI::Vector constructors and reinit() variants.
-  - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
-    constructors.
+
+  <br>
+  <em>With headers in <code>deal.II/mesh_worker/</code>:</em>
+  - Deprecated variants of MeshWorker::loop and MeshWorker::integration_loop.
+
+  <br>
+  <em>With headers in <code>deal.II/algorithm/</code>:</em>
+  - Algorithms::ThetaTimestepping::operator().
+  - Algorithms::ThetaTimestepping::initialize.
+  - Algorithms::Newton::initialize.
+
+  <br>
+  <em>With headers in <code>deal.II/numerics/</code>:</em>
+  - TimeDependent::end_sweep (with an argument).
+  - PointValueHistory::mark_locations.
+  - The DataPostprocessor::compute_derived_quantities_scalar and
+    DataPostprocessor::compute_derived_quantities_vector functions without
+    evaluation points. If you have
+    data postprocessor classes implemented in your program that overload these
+    functions, you will have to change it in a way that they overload the
+    functions of same name but with the evaluation point argument instead.
   <br>
   This release also removes the deprecated class MGDoFHandler. The
   functionality of this class had previously been incorporated into

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -202,7 +202,6 @@ inconvenience this causes.
     <code>normal_vector</code> ones. In all cases, the new functions
     have been around for a while.
   - Mapping::transform_covariant and Mapping::transform_contravariant.
-  - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
 
   <br>
   <em>With headers in <code>deal.II/dofs/</code>:</em>
@@ -222,6 +221,10 @@ inconvenience this causes.
   - MGTools::extract_inner_interface_dofs.
   - Class MGMatrix.
   - Multigrid::vmult and friends.
+
+  <br>
+  <em>With headers in <code>deal.II/matrix_free/</code>:</em>
+  - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
 
   <br>
   <em>With headers in <code>deal.II/mesh_worker/</code>:</em>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -211,6 +211,8 @@ inconvenience this causes.
   - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
   - Classes PreconditionedMatrix and PreconditionLACSolver.
   - PETScVectors::MPI::Vector constructors and reinit() variants.
+  - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
+    constructors.
   <br>
   This release also removes the deprecated class MGDoFHandler. The
   functionality of this class had previously been incorporated into

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -173,6 +173,7 @@ inconvenience this causes.
   - PETScVectors::MPI::Vector constructors and reinit() variants.
   - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
     constructors.
+  - SparseMatrix::raw_entry.
 
   <br>
   <em>With headers in <code>deal.II/deal.II/</code>:</em>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -141,6 +141,7 @@ inconvenience this causes.
   - Deprecated members of namespace types.
   - Namespace deal_II_numbers.
   - MultithreadInfo::n_default_threads.
+  - Table::data.
 
   <br>
   <em>With headers in <code>deal.II/lac/</code>:</em>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -210,6 +210,7 @@ inconvenience this causes.
   - Multigrid::vmult and friends.
   - Classes FEEvaluationDGP, FEEvaluationGeneral and FEEvaluationGL.
   - Classes PreconditionedMatrix and PreconditionLACSolver.
+  - PETScVectors::MPI::Vector constructors and reinit() variants.
   <br>
   This release also removes the deprecated class MGDoFHandler. The
   functionality of this class had previously been incorporated into

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -170,7 +170,8 @@ inconvenience this causes.
     function that takes a scalar as argument.
   - PreconditionBlock::size.
   - Classes PreconditionedMatrix and PreconditionLACSolver.
-  - PETScVectors::MPI::Vector constructors and reinit() variants.
+  - PETScWrappers::VectorBase::update_ghost_values.
+  - PETScWrappers::MPI::Vector constructors and reinit variants.
   - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
     constructors.
   - SparseMatrix::raw_entry.

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -67,28 +67,6 @@ public:
   const unsigned int n_cpus;
 
   /**
-   * The number of threads to use as a default value for all functions that
-   * support multithreading.  At start time this is <tt>n_cpus</tt> or one, if
-   * detection of the number of CPUs is not possible.
-   *
-   * This variable used to be the mechanism by which many parts of the library
-   * determined how many threads to use, for example when assembling matrices
-   * in MatrixCreator or generating output in DataOut. To this end,
-   * n_default_threads is set to n_cpus at the start of the program, but used
-   * programs could set it to a different value in their main() function.
-   * However, since almost all of deal.II has now been converted to a task-
-   * based parallelism model, this variable is no longer used in the library.
-   * Instead, the task scheduling methods use the n_threads() function as a
-   * guide to how many threads to use, and the current variable is now
-   * deprecated.
-   *
-   * @deprecated: Use n_threads() to query the number of threads to use (if
-   * you wanted to read this variable), and set_thread_limit() to limit it (if
-   * you wanted to write to it).
-   */
-  unsigned int n_default_threads DEAL_II_DEPRECATED;
-
-  /**
    * Returns the number of threads to use. This is initially set to the number
    * of cores the system has (n_cpus) but can be further restricted by
    * set_thread_limit().

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2002 - 2014 by the deal.II authors
+// Copyright (C) 2002 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -614,14 +614,6 @@ protected:
    * don't know here whether copying is expensive or not.
    */
   typename AlignedVector<T>::const_reference el (const TableIndices<N> &indices) const;
-
-  /**
-   * @deprecated This function accesses data directly and should not be used!
-   *
-   * Direct read-only access to data field. Used by <tt>FullMatrix</tt> of the
-   * LAC sublibrary (there even with a cast from const), otherwise, keep away!
-   */
-  typename AlignedVector<T>::const_pointer data () const DEAL_II_DEPRECATED;
 
 protected:
   /**
@@ -2069,20 +2061,6 @@ TableBase<N,T>::el (const TableIndices<N> &indices)
           ExcIndexRange (position(indices), 0, values.size()));
   return values[position(indices)];
 }
-
-
-
-template <int N, typename T>
-inline
-typename AlignedVector<T>::const_pointer
-TableBase<N,T>::data () const
-{
-  if (values.size() == 0)
-    return typename AlignedVector<T>::const_pointer();
-  else
-    return &values[0];
-}
-
 
 
 

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -979,7 +979,7 @@ namespace internal
                                        PETScWrappers::MPI::Vector       &output,
                                        const internal::bool2type<false>  /*is_block_vector*/)
     {
-      output.reinit (vec.get_mpi_communicator(), locally_owned_elements, needed_elements);
+      output.reinit (locally_owned_elements, needed_elements, vec.get_mpi_communicator());
       output = vec;
     }
 #endif

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -235,30 +235,6 @@ namespace PETScWrappers
                        const VectorBase   &v,
                        const size_type     local_size);
 
-
-      /**
-       * Constructs a new parallel ghosted PETSc vector from an Indexset. Note
-       * that @p local must be contiguous and the global size of the vector is
-       * determined by local.size(). The global indices in @p ghost are
-       * supplied as ghost indices that can also be read locally.
-       *
-       * Note that the @p ghost IndexSet may be empty and that any indices
-       * already contained in @p local are ignored during construction. That
-       * way, the ghost parameter can equal the set of locally relevant
-       * degrees of freedom, see step-32.
-       *
-       * @deprecated Use Vector::Vector(const IndexSet &,const IndexSet
-       * &,const MPI_Comm &) instead.
-       *
-       * @note This operation always creates a ghosted vector.
-       *
-       * @see
-       * @ref GlossGhostedVector "vectors with ghost elements"
-       */
-      explicit Vector (const MPI_Comm     &communicator,
-                       const IndexSet   &local,
-                       const IndexSet &ghost) DEAL_II_DEPRECATED;
-
       /**
        * Constructs a new parallel ghosted PETSc vector from an Indexset. Note
        * that @p local must be contiguous and the global size of the vector is
@@ -278,16 +254,6 @@ namespace PETScWrappers
       Vector (const IndexSet &local,
               const IndexSet &ghost,
               const MPI_Comm &communicator);
-
-      /**
-       * Constructs a new parallel PETSc vector from an IndexSet. This creates
-       * a non ghosted vector.
-       *
-       * @deprecated Use Vector::Vector(const IndexSet &,const MPI_Comm &)
-       * instead.
-       */
-      explicit Vector (const MPI_Comm &communicator,
-                       const IndexSet &local) DEAL_II_DEPRECATED;
 
       /**
        * Constructs a new parallel PETSc vector from an IndexSet. This creates
@@ -373,19 +339,6 @@ namespace PETScWrappers
                    const bool    fast = false);
 
       /**
-       * Reinit as a ghosted vector. See constructor with same signature for
-       * more details.
-       *
-       * @deprecated Use Vector::reinit(const IndexSet &, const IndexSet &,
-       * const MPI_Comm &) instead.
-       *
-       * @see
-       * @ref GlossGhostedVector "vectors with ghost elements"
-       */
-      void reinit (const MPI_Comm     &communicator,
-                   const IndexSet   &local,
-                   const IndexSet &ghost) DEAL_II_DEPRECATED;
-      /**
        * Reinit as a vector without ghost elements. See the constructor with
        * same signature for more details.
        *
@@ -395,16 +348,6 @@ namespace PETScWrappers
       void reinit (const IndexSet &local,
                    const IndexSet &ghost,
                    const MPI_Comm &communicator);
-
-      /**
-       * Reinit as a vector without ghost elements. See constructor with same
-       * signature for more details.
-       *
-       * @deprecated Use Vector::reinit(const IndexSet &, const MPI_Comm &)
-       * instead.
-       */
-      void reinit (const MPI_Comm     &communicator,
-                   const IndexSet   &local) DEAL_II_DEPRECATED;
 
       /**
        * Reinit as a vector without ghost elements. See constructor with same

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -661,16 +661,6 @@ namespace PETScWrappers
                 const VectorBase &b);
 
     /**
-     * Updates the ghost values of this vector. As ghosted vectors are now
-     * read-only and assignments from a non-ghosted vector update the ghost
-     * values automatically, this method does not need to be called in user
-     * code.
-     * @deprecated: calling this method is no longer necessary.
-     */
-    void update_ghost_values() const DEAL_II_DEPRECATED;
-
-
-    /**
      * Prints the PETSc vector object values using PETSc internal vector
      * viewer function <tt>VecView</tt>. The default format prints the
      * vector's contents, including indices of vector elements. For other

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -998,17 +998,6 @@ public:
   number &diag_element (const size_type i);
 
   /**
-   * Access to values in internal mode.  Returns the value of the
-   * <tt>index</tt>th entry in <tt>row</tt>. Here, <tt>index</tt> refers to
-   * the internal representation of the matrix, not the column. Be sure to
-   * understand what you are doing here.
-   *
-   * @deprecated Use iterator or const_iterator instead!
-   */
-  number raw_entry (const size_type row,
-                    const size_type index) const DEAL_II_DEPRECATED;
-
-  /**
    * This is for hackers. Get access to the <i>i</i>th element of this matrix.
    * The elements are stored in a consecutive way, refer to the
    * SparsityPattern class for more details.
@@ -1939,22 +1928,6 @@ number &SparseMatrix<number>::diag_element (const size_type i)
   // Use that the first element in each row of a quadratic matrix is the main
   // diagonal
   return val[cols->rowstart[i]];
-}
-
-
-
-template <typename number>
-inline
-number
-SparseMatrix<number>::raw_entry (const size_type row,
-                                 const size_type index) const
-{
-  Assert(row<cols->rows, ExcIndexRange(row,0,cols->rows));
-  Assert(index<cols->row_length(row),
-         ExcIndexRange(index,0,cols->row_length(row)));
-
-  // this function will soon go away.
-  return val[cols->rowstart[row]+index];
 }
 
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -110,16 +110,6 @@ namespace SparseMatrixIterators
 
     /**
      * Constructor.
-     *
-     * @deprecated This constructor is deprecated. Use the other constructor
-     * with a global index instead.
-     */
-    Accessor (MatrixType     *matrix,
-              const size_type row,
-              const size_type index) DEAL_II_DEPRECATED;
-
-    /**
-     * Constructor.
      */
     Accessor (MatrixType         *matrix,
               const std::size_t   index_within_matrix);
@@ -256,13 +246,6 @@ namespace SparseMatrixIterators
     /**
      * Constructor.
      */
-    Accessor (MatrixType     *matrix,
-              const size_type row,
-              const size_type index);
-
-    /**
-     * Constructor.
-     */
     Accessor (MatrixType         *matrix,
               const std::size_t   index);
 
@@ -354,17 +337,6 @@ namespace SparseMatrixIterators
      */
     typedef
     const Accessor<number,Constness> &value_type;
-
-    /**
-     * Constructor. Create an iterator into the matrix @p matrix for the given
-     * row and the index within it.
-     *
-     * @deprecated This constructor is deprecated. Use the other constructor
-     * with a global index instead.
-     */
-    Iterator (MatrixType     *matrix,
-              const size_type row,
-              const size_type index) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Create an iterator into the matrix @p matrix for the given
@@ -2044,20 +2016,6 @@ namespace SparseMatrixIterators
   template <typename number>
   inline
   Accessor<number,true>::
-  Accessor (const MatrixType *matrix,
-            const size_type   row,
-            const size_type   index)
-    :
-    SparsityPatternIterators::Accessor (&matrix->get_sparsity_pattern(),
-                                        row, index),
-    matrix (matrix)
-  {}
-
-
-
-  template <typename number>
-  inline
-  Accessor<number,true>::
   Accessor (const MatrixType   *matrix,
             const std::size_t   index_within_matrix)
     :
@@ -2194,20 +2152,6 @@ namespace SparseMatrixIterators
   template <typename number>
   inline
   Accessor<number,false>::
-  Accessor (MatrixType      *matrix,
-            const size_type  row,
-            const size_type  index)
-    :
-    SparsityPatternIterators::Accessor (&matrix->get_sparsity_pattern(),
-                                        row, index),
-    matrix (matrix)
-  {}
-
-
-
-  template <typename number>
-  inline
-  Accessor<number,false>::
   Accessor (MatrixType         *matrix,
             const std::size_t   index)
     :
@@ -2247,18 +2191,6 @@ namespace SparseMatrixIterators
   {
     return *matrix;
   }
-
-
-
-  template <typename number, bool Constness>
-  inline
-  Iterator<number, Constness>::
-  Iterator (MatrixType      *matrix,
-            const size_type  r,
-            const size_type  i)
-    :
-    accessor(matrix, r, i)
-  {}
 
 
 

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -157,7 +157,6 @@ bool MultithreadInfo::is_running_single_threaded()
 MultithreadInfo::MultithreadInfo ()
   :
   n_cpus (get_n_cpus()),
-  n_default_threads (n_cpus),
   n_max_threads (numbers::invalid_unsigned_int)
 {}
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -237,7 +237,12 @@ namespace PETScWrappers
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       if (has_ghost_elements())
-        update_ghost_values();
+        {
+          ierr = VecGhostUpdateBegin(vector, INSERT_VALUES, SCATTER_FORWARD);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
+          ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
+        }
       return *this;
     }
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -67,20 +67,6 @@ namespace PETScWrappers
 
 
 
-    Vector::Vector (const MPI_Comm     &communicator,
-                    const IndexSet   &local,
-                    const IndexSet &ghost)
-      :
-      communicator (communicator)
-    {
-      Assert(local.is_contiguous(), ExcNotImplemented());
-
-      IndexSet ghost_set = ghost;
-      ghost_set.subtract_set(local);
-
-      Vector::create_vector(local.size(), local.n_elements(), ghost_set);
-    }
-
     Vector::Vector (const IndexSet   &local,
                     const IndexSet &ghost,
                     const MPI_Comm     &communicator)
@@ -105,15 +91,6 @@ namespace PETScWrappers
       Vector::create_vector(local.size(), local.n_elements());
     }
 
-
-    Vector::Vector (const MPI_Comm     &communicator,
-                    const IndexSet   &local)
-      :
-      communicator (communicator)
-    {
-      Assert(local.is_contiguous(), ExcNotImplemented());
-      Vector::create_vector(local.size(), local.n_elements());
-    }
 
     void
     Vector::reinit (const MPI_Comm  &comm,
@@ -181,14 +158,6 @@ namespace PETScWrappers
 
 
     void
-    Vector::reinit (const MPI_Comm     &comm,
-                    const IndexSet   &local,
-                    const IndexSet &ghost)
-    {
-      reinit(local, ghost, comm);
-    }
-
-    void
     Vector::reinit (const IndexSet   &local,
                     const IndexSet &ghost,
                     const MPI_Comm     &comm)
@@ -209,13 +178,6 @@ namespace PETScWrappers
       ghost_set.subtract_set(local);
 
       create_vector(local.size(), local.n_elements(), ghost_set);
-    }
-
-    void
-    Vector::reinit (const MPI_Comm     &comm,
-                    const IndexSet   &local)
-    {
-      reinit(local, comm);
     }
 
     void

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -1152,25 +1152,6 @@ namespace PETScWrappers
     last_action = action;
   }
 
-
-  void
-  VectorBase::update_ghost_values() const
-  {
-    // generate an error for not ghosted
-    // vectors
-    if (!ghosted)
-      AssertThrow (false, ExcInternalError());
-
-    int ierr;
-
-    ierr = VecGhostUpdateBegin(vector, INSERT_VALUES, SCATTER_FORWARD);
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
-    ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
-  }
-
-
-
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -357,7 +357,7 @@ namespace LaplaceSolver
     typename DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -443,7 +443,7 @@ namespace LaplaceSolver
     typename DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),
@@ -1684,7 +1684,7 @@ namespace LaplaceSolver
     error_indicators.reinit (dual_solver.dof_handler
                              .get_tria().n_active_cells());
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     for (unsigned int i=0; i<n_threads; ++i)
       {
         estimate_some

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -443,7 +443,7 @@ namespace LaplaceSolver
     typename hp::DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),
@@ -1684,7 +1684,7 @@ namespace LaplaceSolver
     error_indicators.reinit (dual_solver.dof_handler
                              .get_tria().n_active_cells());
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     Threads::ThreadGroup<> threads;
     for (unsigned int i=0; i<n_threads; ++i)
       threads += Threads::new_thread (&WeightedResidual<dim>::estimate_some, *this,

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -357,7 +357,7 @@ namespace LaplaceSolver
     typename hp::DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_default_threads;
+    const unsigned int n_threads = multithread_info.n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),

--- a/tests/mpi/ghost_01.cc
+++ b/tests/mpi/ghost_01.cc
@@ -52,7 +52,6 @@ void test ()
   vb.compress(VectorOperation::insert);
   vb*=2.0;
   v=vb;
-  //v.update_ghost_values();
 
   Assert(!vb.has_ghost_elements(), ExcInternalError());
   Assert(v.has_ghost_elements(), ExcInternalError());

--- a/tests/petsc/copy_to_dealvec.cc
+++ b/tests/petsc/copy_to_dealvec.cc
@@ -55,7 +55,6 @@ void test ()
   vb.compress(VectorOperation::insert);
   vb*=2.0;
   v=vb;
-  //v.update_ghost_values();
 
   Assert(!vb.has_ghost_elements(), ExcInternalError());
   Assert(v.has_ghost_elements(), ExcInternalError());


### PR DESCRIPTION
This removes the remainder of the "easy" deprecated functions. What's left is used in a number of other contexts that make removal much harder. Some also fall outside my area of expertise.

I've taken the opportunity to sort the list of deprecated functions and classes in one of the commits to make it easier to read.