### PR TITLE
Add a missing set of include files.

### DIFF
--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -27,6 +27,8 @@
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/number_cache.h>
 #include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/dof_faces.h>
+#include <deal.II/hp/dof_level.h>
 
 #include <vector>
 #include <map>
@@ -39,8 +41,6 @@ namespace internal
   namespace hp
   {
     class DoFLevel;
-    template <int> class DoFIndicesOnFaces;
-    template <int> class DoFIndicesOnFacesOrEdges;
 
     namespace DoFHandler
     {


### PR DESCRIPTION
This fixes a recent regression in one of our tests (bits/serialize_hp_dof_handler) that tries
to serialize an object but that requires to know the actual type of one of the members to
be serialized to compile without error.