### PR TITLE
Remove deprecated function SparseMatrix::global_entry()

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -175,7 +175,7 @@ inconvenience this causes.
   - PETScWrappers::MPI::Vector constructors and reinit variants.
   - SparseMatrixIterators::Accessor and SparseMatrixIterators::Iterator
     constructors.
-  - SparseMatrix::raw_entry.
+  - SparseMatrix::raw_entry and SparseMatrix::global_entry.
 
   <br>
   <em>With headers in <code>deal.II/deal.II/</code>:</em>

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -997,28 +997,6 @@ public:
    */
   number &diag_element (const size_type i);
 
-  /**
-   * This is for hackers. Get access to the <i>i</i>th element of this matrix.
-   * The elements are stored in a consecutive way, refer to the
-   * SparsityPattern class for more details.
-   *
-   * You should use this interface very carefully and only if you are
-   * absolutely sure to know what you do. You should also note that the
-   * structure of these arrays may change over time.  If you change the layout
-   * yourself, you should also rename this function to avoid programs relying
-   * on outdated information!
-   *
-   * @deprecated Use iterator or const_iterator instead!
-   */
-  number global_entry (const size_type i) const DEAL_II_DEPRECATED;
-
-  /**
-   * Same as above, but with write access.  You certainly know what you do?
-   *
-   * @deprecated Use iterator or const_iterator instead!
-   */
-  number &global_entry (const size_type i) DEAL_II_DEPRECATED;
-
 //@}
   /**
    * @name Multiplications
@@ -1928,32 +1906,6 @@ number &SparseMatrix<number>::diag_element (const size_type i)
   // Use that the first element in each row of a quadratic matrix is the main
   // diagonal
   return val[cols->rowstart[i]];
-}
-
-
-
-template <typename number>
-inline
-number SparseMatrix<number>::global_entry (const size_type j) const
-{
-  Assert (cols != 0, ExcNotInitialized());
-  Assert (j < cols->n_nonzero_elements(),
-          ExcIndexRange (j, 0, cols->n_nonzero_elements()));
-
-  return val[j];
-}
-
-
-
-template <typename number>
-inline
-number &SparseMatrix<number>::global_entry (const size_type j)
-{
-  Assert (cols != 0, ExcNotInitialized());
-  Assert (j < cols->n_nonzero_elements(),
-          ExcIndexRange (j, 0, cols->n_nonzero_elements()));
-
-  return val[j];
 }
 
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -1060,7 +1060,7 @@ namespace TrilinosWrappers
      * <li> If the matrix was initialized without a sparsity pattern, elements
      * have been added manually using the set() command. When this process is
      * completed, a call to compress() reorganizes the internal data
-     * structures (aparsity pattern) so that a fast access to data is possible
+     * structures (sparsity pattern) so that a fast access to data is possible
      * in matrix-vector products.
      * <li> If the matrix structure has already been fixed (either by
      * initialization with a sparsity pattern or by calling compress() during

--- a/tests/deal.II/create_laplace_matrix_01.cc
+++ b/tests/deal.II/create_laplace_matrix_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -110,8 +110,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_laplace_matrix_01b.cc
+++ b/tests/deal.II/create_laplace_matrix_01b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -106,8 +106,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_laplace_matrix_02.cc
+++ b/tests/deal.II/create_laplace_matrix_02.cc
@@ -113,8 +113,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_laplace_matrix_02b.cc
+++ b/tests/deal.II/create_laplace_matrix_02b.cc
@@ -109,8 +109,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_laplace_matrix_03.cc
+++ b/tests/deal.II/create_laplace_matrix_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -110,8 +110,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_laplace_matrix_03b.cc
+++ b/tests/deal.II/create_laplace_matrix_03b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -108,8 +108,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_laplace_matrix_04.cc
+++ b/tests/deal.II/create_laplace_matrix_04.cc
@@ -113,8 +113,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_laplace_matrix_04b.cc
+++ b/tests/deal.II/create_laplace_matrix_04b.cc
@@ -111,8 +111,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_mass_matrix_01.cc
+++ b/tests/deal.II/create_mass_matrix_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -110,8 +110,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_mass_matrix_01b.cc
+++ b/tests/deal.II/create_mass_matrix_01b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -106,8 +106,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_mass_matrix_02.cc
+++ b/tests/deal.II/create_mass_matrix_02.cc
@@ -113,8 +113,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_mass_matrix_02b.cc
+++ b/tests/deal.II/create_mass_matrix_02b.cc
@@ -109,8 +109,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_mass_matrix_03.cc
+++ b/tests/deal.II/create_mass_matrix_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -110,8 +110,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_mass_matrix_03b.cc
+++ b/tests/deal.II/create_mass_matrix_03b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -108,8 +108,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_mass_matrix_04.cc
+++ b/tests/deal.II/create_mass_matrix_04.cc
@@ -113,8 +113,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/deal.II/create_mass_matrix_04b.cc
+++ b/tests/deal.II/create_mass_matrix_04b.cc
@@ -111,8 +111,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/create_mass_matrix_05.cc
+++ b/tests/deal.II/create_mass_matrix_05.cc
@@ -107,8 +107,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/deal.II/matrices.cc
+++ b/tests/deal.II/matrices.cc
@@ -104,8 +104,7 @@ check_boundary (const DoFHandler<dim> &dof,
   // range of 1 or below,
   // multiply matrix by 100 to
   // make test more sensitive
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    matrix.global_entry(i) *= 100;
+  matrix *= 100;
 
   // finally write out matrix
   matrix.print (deallog.get_file_stream());
@@ -197,9 +196,10 @@ check ()
       // range of 1 or below,
       // multiply matrix by 100 to
       // make test more sensitive
-      for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-        deallog.get_file_stream() << matrix.global_entry(i) * 100
-                                  << std::endl;
+      for (SparseMatrix<double>::const_iterator p=matrix.begin();
+	   p!=matrix.end(); ++p)
+	deallog.get_file_stream() << p->value() * 100
+				  << std::endl;
     };
 
   if (dim > 1)

--- a/tests/fe/non_primitive_1.cc
+++ b/tests/fe/non_primitive_1.cc
@@ -318,13 +318,16 @@ test ()
   // reduce the amount of data
   // written out a little bit, only
   // write every so-many-th element
-  for (unsigned int i=0; i<A1.n_nonzero_elements(); ++i)
+  SparseMatrix<double>::const_iterator p1 = A1.begin(),
+				       p2 = A2.begin(),
+				       p3 = A3.begin();
+  for (unsigned int i=0; i<A1.n_nonzero_elements(); ++i, ++p1, ++p2, ++p3)
     {
       if (i % (dim*dim*dim) == 0)
-        deallog << i << ' ' << A1.global_entry(i) << std::endl;
-      Assert (A1.global_entry(i) == A2.global_entry(i),
+        deallog << i << ' ' << p1->value() << std::endl;
+      Assert (p1->value() == p2->value(),
               ExcInternalError());
-      Assert (A1.global_entry(i) == A3.global_entry(i),
+      Assert (p1->value() == p3->value(),
               ExcInternalError());
     };
 }

--- a/tests/fe/non_primitive_2.cc
+++ b/tests/fe/non_primitive_2.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -243,11 +243,13 @@ test (const unsigned int p)
   // reduce the amount of data
   // written out a little bit, only
   // write every so-many-th element
-  for (unsigned int i=0; i<A2.n_nonzero_elements(); ++i)
+  SparseMatrix<double>::const_iterator p2 = A2.begin(),
+				       p3 = A3.begin();
+  for (unsigned int i=0; i<A2.n_nonzero_elements(); ++i, ++p2, ++p3)
     {
       if (i % (dim*dim*dim) == 0)
-        deallog << i << ' ' << A2.global_entry(i) << std::endl;
-      Assert (A3.global_entry(i) == A2.global_entry(i),
+        deallog << i << ' ' << p2->value() << std::endl;
+      Assert (p3->value() == p2->value(),
               ExcInternalError());
     };
 }

--- a/tests/hp/create_laplace_matrix_01.cc
+++ b/tests/hp/create_laplace_matrix_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,8 +121,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_laplace_matrix_01b.cc
+++ b/tests/hp/create_laplace_matrix_01b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,8 +117,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_laplace_matrix_02.cc
+++ b/tests/hp/create_laplace_matrix_02.cc
@@ -126,8 +126,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_laplace_matrix_02b.cc
+++ b/tests/hp/create_laplace_matrix_02b.cc
@@ -122,8 +122,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_laplace_matrix_03.cc
+++ b/tests/hp/create_laplace_matrix_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,8 +121,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_laplace_matrix_03b.cc
+++ b/tests/hp/create_laplace_matrix_03b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -119,8 +119,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_laplace_matrix_04.cc
+++ b/tests/hp/create_laplace_matrix_04.cc
@@ -126,8 +126,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_laplace_matrix_04b.cc
+++ b/tests/hp/create_laplace_matrix_04b.cc
@@ -124,8 +124,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_mass_matrix_01.cc
+++ b/tests/hp/create_mass_matrix_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,8 +121,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_mass_matrix_01b.cc
+++ b/tests/hp/create_mass_matrix_01b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,8 +117,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_mass_matrix_02.cc
+++ b/tests/hp/create_mass_matrix_02.cc
@@ -126,8 +126,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_mass_matrix_02b.cc
+++ b/tests/hp/create_mass_matrix_02b.cc
@@ -122,8 +122,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_mass_matrix_03.cc
+++ b/tests/hp/create_mass_matrix_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,8 +121,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_mass_matrix_03b.cc
+++ b/tests/hp/create_mass_matrix_03b.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,8 +121,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_mass_matrix_04.cc
+++ b/tests/hp/create_mass_matrix_04.cc
@@ -126,8 +126,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 
   deallog << "RHS vector: " << std::endl;

--- a/tests/hp/create_mass_matrix_04b.cc
+++ b/tests/hp/create_mass_matrix_04b.cc
@@ -124,8 +124,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/create_mass_matrix_05.cc
+++ b/tests/hp/create_mass_matrix_05.cc
@@ -122,8 +122,9 @@ check ()
   // multiply matrix by 100 to
   // make test more sensitive
   deallog << "Matrix: " << std::endl;
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    deallog << matrix.global_entry(i) * 100
+  for (SparseMatrix<double>::const_iterator p=matrix.begin();
+       p!=matrix.end(); ++p)
+    deallog << p->value() * 100
             << std::endl;
 }
 

--- a/tests/hp/matrices.cc
+++ b/tests/hp/matrices.cc
@@ -109,8 +109,7 @@ check_boundary (const hp::DoFHandler<dim> &dof,
   // range of 1 or below,
   // multiply matrix by 100 to
   // make test more sensitive
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    matrix.global_entry(i) *= 100;
+  matrix *= 100;
 
   // finally write out matrix
   matrix.print (deallog.get_file_stream());
@@ -206,9 +205,10 @@ check ()
       // range of 1 or below,
       // multiply matrix by 100 to
       // make test more sensitive
-      for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-        deallog.get_file_stream() << matrix.global_entry(i) * 100
-                                  << std::endl;
+      for (SparseMatrix<double>::const_iterator p=matrix.begin();
+	   p!=matrix.end(); ++p)
+	deallog.get_file_stream() << p->value() * 100
+				  << std::endl;
     };
 
   if (dim > 1)

--- a/tests/hp/matrices_hp.cc
+++ b/tests/hp/matrices_hp.cc
@@ -108,8 +108,7 @@ check_boundary (const hp::DoFHandler<dim> &dof,
   // range of 1 or below,
   // multiply matrix by 100 to
   // make test more sensitive
-  for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-    matrix.global_entry(i) *= 100;
+  matrix *= 100;
 
   // finally write out matrix
   matrix.print (deallog.get_file_stream());
@@ -212,9 +211,10 @@ check ()
       // range of 1 or below,
       // multiply matrix by 100 to
       // make test more sensitive
-      for (unsigned int i=0; i<matrix.n_nonzero_elements(); ++i)
-        deallog.get_file_stream() << matrix.global_entry(i) * 100
-                                  << std::endl;
+      for (SparseMatrix<double>::const_iterator p=matrix.begin();
+	   p!=matrix.end(); ++p)
+	deallog.get_file_stream() << p->value() * 100
+				  << std::endl;
     };
 
   if (dim > 1)

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -394,9 +394,11 @@ int main()
 
   std::remove ("sparse_matrices.tmp");
 
-  for (unsigned int i=0; i<A.n_nonzero_elements(); ++i)
-    if (std::fabs(A.global_entry(i) - A_tmp.global_entry(i)) <=
-        std::fabs(1e-14*A.global_entry(i)))
+  SparseMatrix<double>::const_iterator p    =A.begin(),
+				       p_tmp=A_tmp.begin();
+  for (; p!=A.end(); ++p, ++p_tmp)
+    if (std::fabs(p->value() - p_tmp->value()) <=
+        std::fabs(1e-14*p->value()))
       deallog << "write/read-error at global position "
-              << i << std::endl;
+              << (p-A.begin()) << std::endl;
 }


### PR DESCRIPTION
Pretty straightforward stuff other than the fact that the function was used all over the place in the test suite.