### PR TITLE
Fix typos.

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -40,7 +40,7 @@ DEAL_II_NAMESPACE_OPEN
  * that make up geometric objects. As such, they have a small number of
  * additional operations over general tensors of rank 1 for which we use the
  * <tt>Tensor<1,dim></tt> class. In particular, there is a distance() function
- * to compute the Euclidian distance between two points in space.
+ * to compute the Euclidean distance between two points in space.
  *
  * The <tt>Point</tt> class is really only used where the coordinates of an
  * object can be thought to possess the dimension of a length. For all other
@@ -165,7 +165,7 @@ public:
   Number              square () const;
 
   /**
-   * Returns the Euclidian distance of <tt>this</tt> point to the point
+   * Returns the Euclidean distance of <tt>this</tt> point to the point
    * <tt>p</tt>, i.e. the <tt>l_2</tt> norm of the difference between the
    * vectors representing the two points.
    */

--- a/include/deal.II/base/tensor_base.h
+++ b/include/deal.II/base/tensor_base.h
@@ -278,7 +278,7 @@ private:
  * points that make up geometric objects. As such, they have a small number of
  * additional operations over general tensors of rank 1 for which we use the
  * <tt>Tensor<1,dim,Number></tt> class. In particular, there is a distance()
- * function to compute the Euclidian distance between two points in space.
+ * function to compute the Euclidean distance between two points in space.
  *
  * However, the <tt>Point</tt> class is really only used where the coordinates
  * of an object can be thought to possess the dimension of a length. For all

--- a/include/deal.II/numerics/derivative_approximation.h
+++ b/include/deal.II/numerics/derivative_approximation.h
@@ -166,7 +166,7 @@ namespace DerivativeApproximation
   /**
    * This function is used to obtain an approximation of the gradient. Pass it
    * the DoF handler object that describes the finite element field, a nodal
-   * value vector, and receive the cell-wise Euclidian norm of the
+   * value vector, and receive the cell-wise Euclidean norm of the
    * approximated gradient.
    *
    * The last parameter denotes the solution component, for which the gradient

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -103,7 +103,7 @@ namespace DerivativeApproximation
 
       /**
        * Return the norm of the derivative object. Here, for the gradient, we
-       * choose the Euclidian norm of the gradient vector.
+       * choose the Euclidean norm of the gradient vector.
        */
       static double derivative_norm (const Derivative &d);
 


### PR DESCRIPTION
The proper spelling of the word is 'Euclidean', not 'Euclidian'.