### PR TITLE
Point vs tensor cleanups

### DIFF
--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2000 - 2014 by the deal.II authors
+ * Copyright (C) 2000 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -210,15 +210,15 @@ namespace Step8
     // If now the point <code>p</code> is in a circle (sphere) of radius 0.2
     // around one of these points, then set the force in x-direction to one,
     // otherwise to zero:
-    if (((p-point_1).square() < 0.2*0.2) ||
-        ((p-point_2).square() < 0.2*0.2))
+    if (((p-point_1).norm_square() < 0.2*0.2) ||
+        ((p-point_2).norm_square() < 0.2*0.2))
       values(0) = 1;
     else
       values(0) = 0;
 
     // Likewise, if <code>p</code> is in the vicinity of the origin, then set
     // the y-force to 1, otherwise to zero:
-    if (p.square() < 0.2*0.2)
+    if (p.norm_square() < 0.2*0.2)
       values(1) = 1;
     else
       values(1) = 0;

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2000 - 2014 by the deal.II authors
+ * Copyright (C) 2000 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -329,7 +329,7 @@ namespace Step9
   {
     Assert (component == 0, ExcIndexRange (component, 0, 1));
     const double diameter = 0.1;
-    return ( (p-center_point).square() < diameter*diameter ?
+    return ( (p-center_point).norm_square() < diameter*diameter ?
              .1/std::pow(diameter,dim) :
              0);
   }
@@ -376,8 +376,8 @@ namespace Step9
   {
     Assert (component == 0, ExcIndexRange (component, 0, 1));
 
-    const double sine_term = std::sin(16*numbers::PI*std::sqrt(p.square()));
-    const double weight    = std::exp(-5*p.square()) / std::exp(-5.);
+    const double sine_term = std::sin(16*numbers::PI*std::sqrt(p.norm_square()));
+    const double weight    = std::exp(-5*p.norm_square()) / std::exp(-5.);
     return sine_term * weight;
   }
 
@@ -1254,8 +1254,8 @@ namespace Step9
         // two cells. Note that as opposed to the introduction, we denote
         // by <code>y</code> the normalized difference vector, as this is
         // the quantity used everywhere in the computations.
-        Point<dim>   y        = neighbor_center - this_center;
-        const double distance = std::sqrt(y.square());
+        Tensor<1,dim> y        = neighbor_center - this_center;
+        const double  distance = y.norm();
         y /= distance;
 
         // Then add up the contribution of this cell to the Y matrix...
@@ -1300,7 +1300,7 @@ namespace Step9
     // using this quantity and the right powers of the mesh width:
     const Tensor<2,dim> Y_inverse = invert(Y);
 
-    Point<dim> gradient;
+    Tensor<1,dim> gradient;
     contract (gradient, Y_inverse, projected_gradient);
 
     // The last part of this function is the one where we
@@ -1311,7 +1311,7 @@ namespace Step9
     // difficult:
     *(std_cxx11::get<1>(cell.iterators)) = (std::pow(std_cxx11::get<0>(cell.iterators)->diameter(),
                                                      1+1.0*dim/2) *
-                                            std::sqrt(gradient.square()));
+                                            std::sqrt(gradient.norm_square()));
 
   }
 }

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -132,7 +132,7 @@ private:
   /**
    * Helper object. Contains the increment vector for the formula.
    */
-  std::vector<Point<dim> > incr;
+  std::vector<Tensor<1,dim> > incr;
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -635,7 +635,7 @@ namespace Functions
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
      */
-    FourierCosineFunction (const Point<dim> &fourier_coefficients);
+    FourierCosineFunction (const Tensor<1,dim> &fourier_coefficients);
 
     /**
      * Return the value of the function at the given point. Unless there is
@@ -662,7 +662,7 @@ namespace Functions
     /**
      * Stored Fourier coefficients.
      */
-    const Point<dim> fourier_coefficients;
+    const Tensor<1,dim> fourier_coefficients;
   };
 
 
@@ -687,7 +687,7 @@ namespace Functions
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
      */
-    FourierSineFunction (const Point<dim> &fourier_coefficients);
+    FourierSineFunction (const Tensor<1,dim> &fourier_coefficients);
 
     /**
      * Return the value of the function at the given point. Unless there is
@@ -714,7 +714,7 @@ namespace Functions
     /**
      * Stored Fourier coefficients.
      */
-    const Point<dim> fourier_coefficients;
+    const Tensor<1,dim> fourier_coefficients;
   };
 
 

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -406,7 +406,7 @@ namespace DoFRenumbering
   };
 
 
-  
+
   /**
    * A namespace for the implementation of some renumbering algorithms based
    * on algorithms implemented in the Boost Graph Library (BGL) by Jeremy Siek

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -350,7 +350,7 @@ namespace DoFRenumbering
     /**
      * Constructor.
      */
-    CompareDownstream (const Point<dim> &dir)
+    CompareDownstream (const Tensor<1,dim> &dir)
       :
       dir(dir)
     {}
@@ -359,7 +359,7 @@ namespace DoFRenumbering
      */
     bool operator () (const Iterator &c1, const Iterator &c2) const
     {
-      const Point<dim> diff = c2->center() - c1->center();
+      const Tensor<1,dim> diff = c2->center() - c1->center();
       return (diff*dir > 0);
     }
 
@@ -367,7 +367,7 @@ namespace DoFRenumbering
     /**
      * Flow direction.
      */
-    const Point<dim> dir;
+    const Tensor<1,dim> dir;
   };
 
 
@@ -384,7 +384,7 @@ namespace DoFRenumbering
     /**
      * Constructor.
      */
-    ComparePointwiseDownstream (const Point<dim> &dir)
+    ComparePointwiseDownstream (const Tensor<1,dim> &dir)
       :
       dir(dir)
     {}
@@ -394,7 +394,7 @@ namespace DoFRenumbering
     bool operator () (const std::pair<Point<dim>,types::global_dof_index> &c1,
                       const std::pair<Point<dim>,types::global_dof_index> &c2) const
     {
-      const Point<dim> diff = c2.first-c1.first;
+      const Tensor<1,dim> diff = c2.first-c1.first;
       return (diff*dir > 0 || (diff*dir==0 && c1.second<c2.second));
     }
 
@@ -402,9 +402,11 @@ namespace DoFRenumbering
     /**
      * Flow direction.
      */
-    const Point<dim> dir;
+    const Tensor<1,dim> dir;
   };
 
+
+  
   /**
    * A namespace for the implementation of some renumbering algorithms based
    * on algorithms implemented in the Boost Graph Library (BGL) by Jeremy Siek

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1998,15 +1998,15 @@ TriaAccessor<structdim, dim, spacedim>::diameter () const
   switch (structdim)
     {
     case 1:
-      return std::sqrt((this->vertex(1)-this->vertex(0)).square());
+      return (this->vertex(1)-this->vertex(0)).norm();
     case 2:
-      return std::sqrt(std::max((this->vertex(3)-this->vertex(0)).square(),
-                                (this->vertex(2)-this->vertex(1)).square()));
+      return std::max((this->vertex(3)-this->vertex(0)).norm(),
+                      (this->vertex(2)-this->vertex(1)).norm());
     case 3:
-      return std::sqrt(std::max( std::max((this->vertex(7)-this->vertex(0)).square(),
-                                          (this->vertex(6)-this->vertex(1)).square()),
-                                 std::max((this->vertex(2)-this->vertex(5)).square(),
-                                          (this->vertex(3)-this->vertex(4)).square()) ));
+      return std::max( std::max((this->vertex(7)-this->vertex(0)).norm(),
+                                (this->vertex(6)-this->vertex(1)).norm()),
+                       std::max((this->vertex(2)-this->vertex(5)).norm(),
+                                (this->vertex(3)-this->vertex(4)).norm()) );
     default:
       Assert (false, ExcNotImplemented());
       return -1e10;
@@ -2022,14 +2022,14 @@ TriaAccessor<structdim, dim, spacedim>::minimum_vertex_distance () const
   switch (structdim)
     {
     case 1:
-      return std::sqrt((this->vertex(1)-this->vertex(0)).square());
+      return (this->vertex(1)-this->vertex(0)).norm();
     case 2:
     case 3:
     {
       double min = std::numeric_limits<double>::max();
       for (unsigned int i=0; i<GeometryInfo<structdim>::vertices_per_cell; ++i)
         for (unsigned int j=i+1; j<GeometryInfo<structdim>::vertices_per_cell; ++j)
-          min = std::min(min, (this->vertex(i)-this->vertex(j)).square());
+          min = std::min(min, (this->vertex(i)-this->vertex(j)) * (this->vertex(i)-this->vertex(j)));
       return std::sqrt(min);
     }
     default:

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2977,15 +2977,15 @@ namespace VectorTools
                 || ((dynamic_cast<const FE_Nedelec<dim>*> (&fe) != 0) && (line * fe.degree <= i)
                     && (i < (line + 1) * fe.degree)))
               {
-		const double tangential_solution_component
-		  = (values[q_point] (first_vector_component) * tangentials[q_point][0]
-		     + values[q_point] (first_vector_component + 1) * tangentials[q_point][1]
-		     + values[q_point] (first_vector_component + 2) * tangentials[q_point][2]);
+                const double tangential_solution_component
+                  = (values[q_point] (first_vector_component) * tangentials[q_point][0]
+                     + values[q_point] (first_vector_component + 1) * tangentials[q_point][1]
+                     + values[q_point] (first_vector_component + 2) * tangentials[q_point][2]);
                 dof_values[i]
                 += (fe_values.JxW (q_point)
                     * tangential_solution_component
                     * (fe_values[vec].value (fe.face_to_cell_index (i, face), q_point) *
-		       tangentials[q_point])
+                       tangentials[q_point])
                     / std::sqrt (jacobians[q_point][0][edge_coordinate_direction[face][line]]
                                  * jacobians[q_point][0][edge_coordinate_direction[face][line]]
                                  + jacobians[q_point][1][edge_coordinate_direction[face][line]]
@@ -3122,7 +3122,7 @@ namespace VectorTools
                                                  shifted_reference_point_2))
                   / tol;
               tangentials[q_point] /= tangentials[q_point].norm();
-	      
+
               // Compute the degrees
               // of freedom.
               for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
@@ -4473,7 +4473,7 @@ namespace VectorTools
                     Tensor<1,dim> normal_vector
                       = (cell->face(face_no)->get_boundary().normal_vector
                          (cell->face(face_no),
-			  fe_values.quadrature_point(i)));
+                          fe_values.quadrature_point(i)));
                     if (normal_vector * static_cast<Tensor<1,dim> >(fe_values.normal_vector(i)) < 0)
                       normal_vector *= -1;
                     Assert (std::fabs(normal_vector.norm() - 1) < 1e-14,

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -131,7 +131,7 @@ namespace Functions
             ExcDimensionMismatch(gradients.size(), points.size()));
 
     for (unsigned int i=0; i<points.size(); ++i)
-      gradients[i] = points[i]*2;
+      gradients[i] = static_cast<Tensor<1,dim> >(points[i])*2;
   }
 
 
@@ -1839,7 +1839,7 @@ namespace Functions
 
   template <int dim>
   FourierCosineFunction<dim>::
-  FourierCosineFunction (const Point<dim> &fourier_coefficients)
+  FourierCosineFunction (const Tensor<1,dim> &fourier_coefficients)
     :
     Function<dim> (1),
     fourier_coefficients (fourier_coefficients)
@@ -1875,7 +1875,7 @@ namespace Functions
                                          const unsigned int  component) const
   {
     Assert (component==0, ExcIndexRange(component,0,1));
-    return fourier_coefficients.square() * (-std::cos(fourier_coefficients * p));
+    return (fourier_coefficients * fourier_coefficients) * (-std::cos(fourier_coefficients * p));
   }
 
 
@@ -1887,7 +1887,7 @@ namespace Functions
 
   template <int dim>
   FourierSineFunction<dim>::
-  FourierSineFunction (const Point<dim> &fourier_coefficients)
+  FourierSineFunction (const Tensor<1,dim> &fourier_coefficients)
     :
     Function<dim> (1),
     fourier_coefficients (fourier_coefficients)
@@ -1923,7 +1923,7 @@ namespace Functions
                                        const unsigned int  component) const
   {
     Assert (component==0, ExcIndexRange(component,0,1));
-    return fourier_coefficients.square() * (-std::sin(fourier_coefficients * p));
+    return (fourier_coefficients * fourier_coefficients) * (-std::sin(fourier_coefficients * p));
   }
 
 
@@ -1994,7 +1994,7 @@ namespace Functions
     const unsigned int n = weights.size();
     double sum = 0;
     for (unsigned int s=0; s<n; ++s)
-      sum -= fourier_coefficients[s].square() * std::sin(fourier_coefficients[s] * p);
+      sum -= (fourier_coefficients[s] * fourier_coefficients[s]) * std::sin(fourier_coefficients[s] * p);
 
     return sum;
   }
@@ -2066,7 +2066,7 @@ namespace Functions
     const unsigned int n = weights.size();
     double sum = 0;
     for (unsigned int s=0; s<n; ++s)
-      sum -= fourier_coefficients[s].square() * std::cos(fourier_coefficients[s] * p);
+      sum -= (fourier_coefficients[s] * fourier_coefficients[s]) * std::cos(fourier_coefficients[s] * p);
 
     return sum;
   }

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -786,7 +786,7 @@ unsigned int QGaussOneOverR<2>::quad_size(const Point<2> singularity,
     if ( ( std::abs(singularity[i]  ) < eps ) ||
          ( std::abs(singularity[i]-1) < eps ) )
       on_edge = true;
-  if (on_edge && (std::abs( (singularity-Point<2>(.5, .5)).square()-.5)
+  if (on_edge && (std::abs( (singularity-Point<2>(.5, .5)).norm_square()-.5)
                   < eps) )
     on_vertex = true;
   if (on_vertex) return (2*n*n);

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1938,8 +1938,8 @@ transform_real_to_unit_cell_internal_codim1
 
   Point<spacedim1> p_minus_F;
 
-  Point<spacedim1>  DF[dim1];
-  Point<spacedim1>  D2F[dim1][dim1];
+  Tensor<1,spacedim1>  DF[dim1];
+  Tensor<1,spacedim1>  D2F[dim1][dim1];
 
   Point<dim1> p_unit = initial_p_unit;
   Point<dim1> f;

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -767,7 +767,7 @@ namespace GridGenerator
                 ExcMessage ("Invalid distance between corner points of parallelepiped."));
 
     // Create a list of points
-    Point<dim> (delta) [dim];
+    Point<dim> delta[dim];
 
     for (unsigned int i=0; i<dim; ++i)
       delta[i] = corners[i]/n_subdivisions[i];

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -3581,19 +3581,19 @@ namespace internal
           // in this plane. we chose the first one
           // to be the projection of the z-axis
           // to this plane
-          const Point<dim> vector1
+          const Tensor<1,dim> vector1
             = Point<dim>(0,0,1) - ((Point<dim>(0,0,1) * view_direction) * view_direction);
-          const Point<dim> unit_vector1 = vector1 / std::sqrt(vector1.square());
+          const Tensor<1,dim> unit_vector1 = vector1 / vector1.norm();
 
           // now the third vector is fixed. we
           // chose the projection of a more or
           // less arbitrary vector to the plane
           // perpendicular to the first one
-          const Point<dim> vector2
+          const Tensor<1,dim> vector2
             = (Point<dim>(1,0,0)
                - ((Point<dim>(1,0,0) * view_direction) * view_direction)
                - ((Point<dim>(1,0,0) * unit_vector1)   * unit_vector1));
-          const Point<dim> unit_vector2 = vector2 / std::sqrt(vector2.square());
+          const Tensor<1,dim> unit_vector2 = vector2 / vector2.norm();
 
 
           for (; cell!=endc; ++cell)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -170,8 +170,8 @@ namespace GridTools
         std::vector<bool>::const_iterator pj = pi+1;
         for (unsigned int j=i+1; j<N; ++j, ++pj)
           if ((*pi==true) && (*pj==true) &&
-              ((vertices[i]-vertices[j]).square() > max_distance_sqr))
-            max_distance_sqr = (vertices[i]-vertices[j]).square();
+              ((vertices[i]-vertices[j]).norm_square() > max_distance_sqr))
+            max_distance_sqr = (vertices[i]-vertices[j]).norm_square();
       };
 
     return std::sqrt(max_distance_sqr);
@@ -1020,14 +1020,14 @@ namespace GridTools
     Assert(first != used.end(), ExcInternalError());
 
     unsigned int best_vertex = std::distance(used.begin(), first);
-    double       best_dist   = (p - vertices[best_vertex]).square();
+    double       best_dist   = (p - vertices[best_vertex]).norm_square();
 
     // For all remaining vertices, test
     // whether they are any closer
     for (unsigned int j = best_vertex+1; j < vertices.size(); j++)
       if (used[j])
         {
-          double dist = (p - vertices[j]).square();
+          double dist = (p - vertices[j]).norm_square();
           if (dist < best_dist)
             {
               best_vertex = j;

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2163,14 +2163,14 @@ next_cell:
               {
                 const double eps = step_length/10;
 
-                Point<spacedim> h;
+                Tensor<1,spacedim> h;
                 h[d] = eps/2;
 
                 if (respect_manifold == false)
                   gradient[d]
                     = ((objective_function (object, object_mid_point + h)
                         -
-                        objective_function (object, object_mid_point + (-h)))
+                        objective_function (object, object_mid_point - h))
                        /
                        eps);
                 else
@@ -2181,7 +2181,7 @@ next_cell:
                         -
                         objective_function (object,
                                             manifold->project_to_surface(object,
-                                                                         object_mid_point + (-h))))
+                                                                         object_mid_point - h)))
                        /
                        eps);
               }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2170,7 +2170,7 @@ next_cell:
                   gradient[d]
                     = ((objective_function (object, object_mid_point + h)
                         -
-                        objective_function (object, object_mid_point - h))
+                        objective_function (object, object_mid_point + (-h)))
                        /
                        eps);
                 else
@@ -2181,7 +2181,7 @@ next_cell:
                         -
                         objective_function (object,
                                             manifold->project_to_surface(object,
-                                                                         object_mid_point - h)))
+                                                                         object_mid_point + (-h))))
                        /
                        eps);
               }

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014 by the deal.II authors
+// Copyright (C) 2013 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -172,7 +172,7 @@ get_new_point (const Quadrature<spacedim> &quad) const
   Point<spacedim> middle = flat_manifold.get_new_point(quad);
 
   double radius = 0;
-  Point<spacedim> on_plane;
+  Tensor<1,spacedim> on_plane;
 
   for (unsigned int i=0; i<surrounding_points.size(); ++i)
     {
@@ -184,8 +184,8 @@ get_new_point (const Quadrature<spacedim> &quad) const
   // we then have to project this point out to the given radius from
   // the axis. to this end, we have to take into account the offset
   // point_on_axis and the direction of the axis
-  const Point<spacedim> vector_from_axis = (middle-point_on_axis) -
-                                           ((middle-point_on_axis) * direction) * direction;
+  const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
+					      ((middle-point_on_axis) * direction) * direction;
 
   // scale it to the desired length and put everything back together,
   // unless we have a point on the axis

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -185,7 +185,7 @@ get_new_point (const Quadrature<spacedim> &quad) const
   // the axis. to this end, we have to take into account the offset
   // point_on_axis and the direction of the axis
   const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
-					      ((middle-point_on_axis) * direction) * direction;
+                                              ((middle-point_on_axis) * direction) * direction;
 
   // scale it to the desired length and put everything back together,
   // unless we have a point on the axis

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -903,7 +903,7 @@ namespace
   {
     // remember that we use (dim-)linear
     // mappings
-    return std::sqrt((accessor.vertex(1)-accessor.vertex(0)).square());
+    return (accessor.vertex(1)-accessor.vertex(0)).norm();
   }
 
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -978,13 +978,13 @@ namespace
     // v_03, should be in the plane P_012 of vertices 0, 1 and 2.  Get
     // the normal vector of P_012 and test if v_03 is orthogonal to
     // that. If so, the face is planar and computing its area is simple.
-    const Point<3> v01 = accessor.vertex(1) - accessor.vertex(0);
-    const Point<3> v02 = accessor.vertex(2) - accessor.vertex(0);
+    const Tensor<1,3> v01 = accessor.vertex(1) - accessor.vertex(0);
+    const Tensor<1,3> v02 = accessor.vertex(2) - accessor.vertex(0);
 
-    Point<3> normal;
+    Tensor<1,3> normal;
     cross_product(normal, v01, v02);
 
-    const Point<3> v03 = accessor.vertex(3) - accessor.vertex(0);
+    const Tensor<1,3> v03 = accessor.vertex(3) - accessor.vertex(0);
 
     // check whether v03 does not lie in the plane of v01 and v02
     // (i.e., whether the face is not planar). we do so by checking
@@ -992,7 +992,7 @@ namespace
     // volume relative to |v01|*|v02|*|v03|. the test checks the
     // squares of these to avoid taking norms/square roots:
     if (std::abs((v03 * normal) * (v03 * normal) /
-                 (v03.square() * v01.square() * v02.square()))
+                 ((v03 * v03) * (v01 * v01) * (v02 * v02)))
         >=
         1e-24)
       {
@@ -1283,12 +1283,12 @@ bool CellAccessor<2>::point_inside (const Point<2> &p) const
     {
       // vector from the first vertex
       // of the line to the point
-      const Point<2> to_p = p-this->vertex(
-                              GeometryInfo<2>::face_to_cell_vertices(f,0));
+      const Tensor<1,2> to_p = p-this->vertex(
+	                         GeometryInfo<2>::face_to_cell_vertices(f,0));
       // vector describing the line
-      const Point<2> face = direction[f]*(
-                              this->vertex(GeometryInfo<2>::face_to_cell_vertices(f,1)) -
-                              this->vertex(GeometryInfo<2>::face_to_cell_vertices(f,0)));
+      const Tensor<1,2> face = direction[f]*(
+                                 this->vertex(GeometryInfo<2>::face_to_cell_vertices(f,1)) -
+                                 this->vertex(GeometryInfo<2>::face_to_cell_vertices(f,0)));
 
       // if we rotate the face vector
       // by 90 degrees to the left
@@ -1302,7 +1302,7 @@ bool CellAccessor<2>::point_inside (const Point<2> &p) const
       // is not the case, we can be
       // sure that the point is
       // outside
-      if ((-face(1)*to_p(0)+face(0)*to_p(1))<0)
+      if ((-face[1]*to_p[0]+face[0]*to_p[1])<0)
         return false;
     };
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1284,7 +1284,7 @@ bool CellAccessor<2>::point_inside (const Point<2> &p) const
       // vector from the first vertex
       // of the line to the point
       const Tensor<1,2> to_p = p-this->vertex(
-	                         GeometryInfo<2>::face_to_cell_vertices(f,0));
+                                 GeometryInfo<2>::face_to_cell_vertices(f,0));
       // vector describing the line
       const Tensor<1,2> face = direction[f]*(
                                  this->vertex(GeometryInfo<2>::face_to_cell_vertices(f,1)) -

--- a/source/grid/tria_boundary_lib.cc
+++ b/source/grid/tria_boundary_lib.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -74,8 +74,8 @@ get_new_point_on_line (const typename Triangulation<dim,spacedim>::line_iterator
   // have to take into account the
   // offset point_on_axis and the
   // direction of the axis
-  const Point<spacedim> vector_from_axis = (middle-point_on_axis) -
-                                           ((middle-point_on_axis) * direction) * direction;
+  const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
+                                              ((middle-point_on_axis) * direction) * direction;
   // scale it to the desired length
   // and put everything back
   // together, unless we have a point
@@ -100,8 +100,8 @@ get_new_point_on_quad (const Triangulation<3>::quad_iterator &quad) const
   // same algorithm as above
   const unsigned int spacedim = 3;
 
-  const Point<spacedim> vector_from_axis = (middle-point_on_axis) -
-                                           ((middle-point_on_axis) * direction) * direction;
+  const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
+                                              ((middle-point_on_axis) * direction) * direction;
   if (vector_from_axis.norm() <= 1e-10 * middle.norm())
     return middle;
   else
@@ -119,8 +119,8 @@ get_new_point_on_quad (const Triangulation<2,3>::quad_iterator &quad) const
 
   // same algorithm as above
   const unsigned int spacedim = 3;
-  const Point<spacedim> vector_from_axis = (middle-point_on_axis) -
-                                           ((middle-point_on_axis) * direction) * direction;
+  const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
+                                              ((middle-point_on_axis) * direction) * direction;
   if (vector_from_axis.norm() <= 1e-10 * middle.norm())
     return middle;
   else

--- a/source/grid/tria_boundary_lib.cc
+++ b/source/grid/tria_boundary_lib.cc
@@ -594,7 +594,7 @@ HyperBallBoundary<dim,spacedim>::get_intermediate_points_between_points (
   Assert(n>0, ExcInternalError());
 
   const Tensor<1,spacedim> v0=p0-center,
-			   v1=p1-center;
+                           v1=p1-center;
   const double length=(v1-v0).norm();
 
   double eps=1e-12;

--- a/source/grid/tria_boundary_lib.cc
+++ b/source/grid/tria_boundary_lib.cc
@@ -173,8 +173,8 @@ CylinderBoundary<dim,spacedim>::get_intermediate_points_between_points (
       const double x = line_points[i+1][0];
       const Point<spacedim> middle = (1-x)*v0 + x*v1;
 
-      const Point<spacedim> vector_from_axis = (middle-point_on_axis) -
-                                               ((middle-point_on_axis) * direction) * direction;
+      const Tensor<1,spacedim> vector_from_axis = (middle-point_on_axis) -
+                                                  ((middle-point_on_axis) * direction) * direction;
       if (vector_from_axis.norm() <= 1e-10 * middle.norm())
         points[i] = middle;
       else
@@ -252,8 +252,8 @@ get_normals_at_vertices (const typename Triangulation<dim,spacedim>::face_iterat
     {
       const Point<spacedim> vertex = face->vertex(v);
 
-      const Point<spacedim> vector_from_axis = (vertex-point_on_axis) -
-                                               ((vertex-point_on_axis) * direction) * direction;
+      const Tensor<1,spacedim> vector_from_axis = (vertex-point_on_axis) -
+                                                  ((vertex-point_on_axis) * direction) * direction;
 
       face_vertex_normals[v] = (vector_from_axis / vector_from_axis.norm());
     }
@@ -305,7 +305,7 @@ get_intermediate_points_between_points (const Point<dim> &p0,
                                         std::vector<Point<dim> > &points) const
 {
   const unsigned int n = points.size ();
-  const Point<dim> axis = x_1 - x_0;
+  const Tensor<1,dim> axis = x_1 - x_0;
 
   Assert (n > 0, ExcInternalError ());
 
@@ -319,7 +319,7 @@ get_intermediate_points_between_points (const Point<dim> &p0,
       const Point<dim> x_i = (1-x)*p0 + x*p1;
       // To project this point on the boundary of the cone we first compute
       // the orthogonal projection of this point onto the axis of the cone.
-      const double c = (x_i - x_0) * axis / axis.square ();
+      const double c = (x_i - x_0) * axis / (axis*axis);
       const Point<dim> x_ip = x_0 + c * axis;
       // Compute the projection of the middle point on the boundary of the
       // cone.
@@ -332,12 +332,12 @@ Point<dim>
 ConeBoundary<dim>::
 get_new_point_on_line (const typename Triangulation<dim>::line_iterator &line) const
 {
-  const Point<dim> axis = x_1 - x_0;
+  const Tensor<1,dim> axis = x_1 - x_0;
   // Compute the middle point of the line.
   const Point<dim> middle = StraightBoundary<dim>::get_new_point_on_line (line);
   // To project it on the boundary of the cone we first compute the orthogonal
   // projection of the middle point onto the axis of the cone.
-  const double c = (middle - x_0) * axis / axis.square ();
+  const double c = (middle - x_0) * axis / (axis*axis);
   const Point<dim> middle_p = x_0 + c * axis;
   // Compute the projection of the middle point on the boundary of the cone.
   return middle_p + get_radius (middle_p) * (middle - middle_p) / (middle - middle_p).norm ();
@@ -352,13 +352,13 @@ get_new_point_on_quad (const Triangulation<3>::quad_iterator &quad) const
 {
   const int dim = 3;
 
-  const Point<dim> axis = x_1 - x_0;
+  const Tensor<1,dim> axis = x_1 - x_0;
   // Compute the middle point of the quad.
   const Point<dim> middle = StraightBoundary<3,3>::get_new_point_on_quad (quad);
   // Same algorithm as above: To project it on the boundary of the cone we
   // first compute the orthogonal projection of the middle point onto the axis
   // of the cone.
-  const double c = (middle - x_0) * axis / axis.square ();
+  const double c = (middle - x_0) * axis / (axis*axis);
   const Point<dim> middle_p = x_0 + c * axis;
   // Compute the projection of the middle point on the boundary of the cone.
   return middle_p + get_radius (middle_p) * (middle - middle_p) / (middle - middle_p).norm ();
@@ -458,13 +458,13 @@ ConeBoundary<dim>::
 get_normals_at_vertices (const typename Triangulation<dim>::face_iterator &face,
                          typename Boundary<dim>::FaceVertexNormals &face_vertex_normals) const
 {
-  const Point<dim> axis = x_1 - x_0;
+  const Tensor<1,dim> axis = x_1 - x_0;
 
   for (unsigned int vertex = 0; vertex < GeometryInfo<dim>::vertices_per_cell; ++vertex)
     {
       // Compute the orthogonal projection of the vertex onto the axis of the
       // cone.
-      const double c = (face->vertex (vertex) - x_0) * axis / axis.square ();
+      const double c = (face->vertex (vertex) - x_0) * axis / (axis*axis);
       const Point<dim> vertex_p = x_0 + c * axis;
       // Then compute the vector pointing from the point <tt>vertex_p</tt> on
       // the axis to the vertex.
@@ -593,9 +593,9 @@ HyperBallBoundary<dim,spacedim>::get_intermediate_points_between_points (
   const unsigned int n=points.size();
   Assert(n>0, ExcInternalError());
 
-  const Point<spacedim> v0=p0-center,
-                        v1=p1-center;
-  const double length=std::sqrt((v1-v0).square());
+  const Tensor<1,spacedim> v0=p0-center,
+			   v1=p1-center;
+  const double length=(v1-v0).norm();
 
   double eps=1e-12;
   double r=0;
@@ -609,10 +609,10 @@ HyperBallBoundary<dim,spacedim>::get_intermediate_points_between_points (
 
 
   const double r2=r*r;
-  Assert(std::fabs(v0.square()-r2)<eps*r2, ExcInternalError());
-  Assert(std::fabs(v1.square()-r2)<eps*r2, ExcInternalError());
+  Assert(std::fabs(v0*v0-r2)<eps*r2, ExcInternalError());
+  Assert(std::fabs(v1*v1-r2)<eps*r2, ExcInternalError());
 
-  const double alpha=std::acos((v0*v1)/std::sqrt(v0.square()*v1.square()));
+  const double alpha=std::acos((v0*v1)/std::sqrt((v0*v0)*(v1*v1)));
   const Point<spacedim> pm=0.5*(v0+v1);
 
   const double h=std::sqrt(pm.square());

--- a/tests/aniso/mesh_3d_21.cc
+++ b/tests/aniso/mesh_3d_21.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -77,7 +77,7 @@ void check_this (Triangulation<3> &tria)
             for (unsigned int q=0; q<quadrature.size(); ++q)
               {
                 Assert ((fe_face_values1.quadrature_point(q)-
-                         fe_face_values2.quadrature_point(q)).square()
+                         fe_face_values2.quadrature_point(q)).norm_square()
                         < 1e-20,
                         ExcInternalError());
 

--- a/tests/base/geometry_info_1.cc
+++ b/tests/base/geometry_info_1.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -77,7 +77,7 @@ void test ()
 
               deallog << "    " << c << " [" << q << "] [" << pp << ']'
                       << std::endl;
-              Assert ((p-pp).square() < 1e-15*1e-15, ExcInternalError());
+              Assert ((p-pp).norm_square() < 1e-15*1e-15, ExcInternalError());
               Assert (GeometryInfo<dim>::is_inside_unit_cell (p) ==
                       GeometryInfo<dim>::is_inside_unit_cell (pp),
                       ExcInternalError());

--- a/tests/bits/q_points.cc
+++ b/tests/bits/q_points.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -115,7 +115,7 @@ void check (Triangulation<3> &tria)
               deallog << "  " << fe_face_values1.quadrature_point(q)
                       << std::endl;
               Assert ((fe_face_values1.quadrature_point(q)-
-                       fe_face_values2.quadrature_point(q)).square()
+                       fe_face_values2.quadrature_point(q)).norm_square()
                       < 1e-20,
                       ExcInternalError());
             }

--- a/tests/bits/step-8.cc
+++ b/tests/bits/step-8.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -122,13 +122,13 @@ void RightHandSide<dim>::vector_value (const Point<dim> &p,
   point_1(0) = 0.5;
   point_2(0) = -0.5;
 
-  if (((p-point_1).square() < 0.2*0.2) ||
-      ((p-point_2).square() < 0.2*0.2))
+  if (((p-point_1).norm_square() < 0.2*0.2) ||
+      ((p-point_2).norm_square() < 0.2*0.2))
     values(0) = 1;
   else
     values(0) = 0;
 
-  if (p.square() < 0.2*0.2)
+  if (p.norm_square() < 0.2*0.2)
     values(1) = 1;
   else
     values(1) = 0;

--- a/tests/fe/mapping.cc
+++ b/tests/fe/mapping.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -391,7 +391,7 @@ void create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
     {
       Point<3> m(2,2,2);
       Point<3> v(3,3,3);
-      double r=std::sqrt((m-v).square()),
+      double r=std::sqrt((m-v).norm_square()),
              h=r-1.5,
              pi=std::acos(-1.);
       Boundary<3> *boundary1=new HyperBallBoundary<3>(m, r);

--- a/tests/fe/mapping_c1.cc
+++ b/tests/fe/mapping_c1.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -124,7 +124,7 @@ int main ()
               Point<2> radius = c1_values.quadrature_point(i);
               radius /= std::sqrt(radius.square());
 
-              Assert ((radius-c1_values.normal_vector(i)).square() < 1e-14,
+              Assert ((radius-c1_values.normal_vector(i)).norm_square() < 1e-14,
                       ExcInternalError());
             };
         };

--- a/tests/grid/mesh_3d_14.cc
+++ b/tests/grid/mesh_3d_14.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -78,7 +78,7 @@ void check_this (Triangulation<3> &tria)
             for (unsigned int q=0; q<quadrature.size(); ++q)
               {
                 Assert ((fe_face_values1.quadrature_point(q)-
-                         fe_face_values2.quadrature_point(q)).square()
+                         fe_face_values2.quadrature_point(q)).norm_square()
                         < 1e-20,
                         ExcInternalError());
 
@@ -86,7 +86,7 @@ void check_this (Triangulation<3> &tria)
                                   fe_face_values2.JxW(q)) < 1e-15,
                         ExcInternalError());
                 Assert ((fe_face_values1.normal_vector(q) +
-                         fe_face_values2.normal_vector(q)).square()
+                         fe_face_values2.normal_vector(q)).norm_square()
                         < 1e-20,
                         ExcInternalError());
               }

--- a/tests/grid/mesh_3d_20.cc
+++ b/tests/grid/mesh_3d_20.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -85,7 +85,7 @@ void check_this (Triangulation<3> &tria)
                         << std::endl;
 
               Assert ((fe_face_values1.quadrature_point(q)-
-                       fe_face_values2.quadrature_point(q)).square()
+                       fe_face_values2.quadrature_point(q)).norm_square()
                       < 1e-20,
                       ExcInternalError());
 

--- a/tests/grid/mesh_3d_7.cc
+++ b/tests/grid/mesh_3d_7.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -84,7 +84,7 @@ void check_this (Triangulation<3> &tria)
                         << std::endl;
 
               Assert ((fe_face_values1.quadrature_point(q)-
-                       fe_face_values2.quadrature_point(q)).square()
+                       fe_face_values2.quadrature_point(q)).norm_square()
                       < 1e-20,
                       ExcInternalError());
 

--- a/tests/hp/step-8.cc
+++ b/tests/hp/step-8.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -121,13 +121,13 @@ void RightHandSide<dim>::vector_value (const Point<dim> &p,
   point_1(0) = 0.5;
   point_2(0) = -0.5;
 
-  if (((p-point_1).square() < 0.2*0.2) ||
-      ((p-point_2).square() < 0.2*0.2))
+  if (((p-point_1).norm_square() < 0.2*0.2) ||
+      ((p-point_2).norm_square() < 0.2*0.2))
     values(0) = 1;
   else
     values(0) = 0;
 
-  if (p.square() < 0.2*0.2)
+  if (p.norm_square() < 0.2*0.2)
     values(1) = 1;
   else
     values(1) = 0;


### PR DESCRIPTION
This is the uncontroversial part of a patch that will come next. It simply changes a lot of places where we currently use `Point` to represent differences between `Point` objects or directions to `Tensor`. I would like us to move to a convention where a `Point` is really a point in space, i.e., a vector anchored at the origin, whereas `Tensor<1,dim>` is a vector anchored somewhere else (e.g., a direction, a normal vector, etc). The difference between two points is then a `Tensor<1,dim>`, not a `Point<dim>`.

Many of the places just deal with the fact that we have `Point::square()` but for tensors we need to use `Tensor::norm_square()` instead.