### PR TITLE
Further point vs tensor cleanups

### DIFF
--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2013 - 2014 by the deal.II authors
+ * Copyright (C) 2013 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -154,8 +154,8 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
-        return_value += std::exp(-x_minus_xi.square() /
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+        return_value += std::exp(-x_minus_xi.norm_square() /
                                  (this->width * this->width));
       }
 
@@ -173,10 +173,10 @@ namespace Step51
 
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value += (-2 / (this->width * this->width) *
-                         std::exp(-x_minus_xi.square() /
+                         std::exp(-x_minus_xi.norm_square() /
                                   (this->width * this->width)) *
                          x_minus_xi);
       }
@@ -285,13 +285,13 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value +=
-          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.square()/
+          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.norm_square()/
             (this->width * this->width)) /
            (this->width * this->width) *
-           std::exp(-x_minus_xi.square() /
+           std::exp(-x_minus_xi.norm_square() /
                     (this->width * this->width)));
       }
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2000 - 2014 by the deal.II authors
+ * Copyright (C) 2000 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -210,8 +210,8 @@ namespace Step7
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
-        return_value += std::exp(-x_minus_xi.square() /
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+        return_value += std::exp(-x_minus_xi.norm_square() /
                                  (this->width * this->width));
       }
 
@@ -251,13 +251,13 @@ namespace Step7
 
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         // For the gradient, note that its direction is along (x-x_i), so we
         // add up multiples of this distance vector, where the factor is given
         // by the exponentials.
         return_value += (-2 / (this->width * this->width) *
-                         std::exp(-x_minus_xi.square() /
+                         std::exp(-x_minus_xi.norm_square() /
                                   (this->width * this->width)) *
                          x_minus_xi);
       }
@@ -295,16 +295,16 @@ namespace Step7
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         // The first contribution is the Laplacian:
-        return_value += ((2*dim - 4*x_minus_xi.square()/
+        return_value += ((2*dim - 4*x_minus_xi.norm_square()/
                           (this->width * this->width)) /
                          (this->width * this->width) *
-                         std::exp(-x_minus_xi.square() /
+                         std::exp(-x_minus_xi.norm_square() /
                                   (this->width * this->width)));
         // And the second is the solution itself:
-        return_value += std::exp(-x_minus_xi.square() /
+        return_value += std::exp(-x_minus_xi.norm_square() /
                                  (this->width * this->width));
       }
 

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2315,7 +2315,7 @@ GeometryInfo<1>::cell_to_child_coordinates (const Point<1>         &p,
           ExcInternalError());
   (void)refine_case; // removes -Wunused-parameter warning in optimized mode
 
-  return p*2.0-unit_cell_vertex(child_index);
+  return Point<1>(p*2.0-unit_cell_vertex(child_index));
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2060,11 +2060,11 @@ is_translation_of (const TriaIterator<TriaAccessor<structdim,dim,spacedim> > &o)
   // times the distance between the zeroth
   // vertices here.
   bool is_translation = true;
-  const Point<spacedim> dist = o->vertex(0) - this->vertex(0);
+  const Tensor<1,spacedim> dist = o->vertex(0) - this->vertex(0);
   const double tol_square = 1e-24 * dist.norm_square();
   for (unsigned int i=1; i<GeometryInfo<structdim>::vertices_per_cell; ++i)
     {
-      const Point<spacedim> dist_new = (o->vertex(i) - this->vertex(i)) - dist;
+      const Tensor<1,spacedim> dist_new = (o->vertex(i) - this->vertex(i)) - dist;
       if (dist_new.norm_square() > tol_square)
         {
           is_translation = false;

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -825,7 +825,7 @@ QGaussOneOverR<2>::QGaussOneOverR(const unsigned int n,
   double eps = 1e-8;
   unsigned int q_id = 0; // Current quad point index.
   double area = 0;
-  Point<2> dist;
+  Tensor<1,2> dist;
 
   for (unsigned int box=0; box<4; ++box)
     {

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1743,10 +1743,10 @@ namespace DoFRenumbering
                     const DHCellIterator &c2,
                     dealii::internal::int2type<xdim>) const
       {
-        const Point<dim> v1 = c1->center() - center;
-        const Point<dim> v2 = c2->center() - center;
-        const double s1 = std::atan2(v1(0), v1(1));
-        const double s2 = std::atan2(v2(0), v2(1));
+        const Tensor<1,dim> v1 = c1->center() - center;
+        const Tensor<1,dim> v2 = c2->center() - center;
+        const double s1 = std::atan2(v1[0], v1[1]);
+        const double s2 = std::atan2(v2[0], v2[1]);
         return ( counter ? (s1>s2) : (s2>s1));
       }
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -64,8 +64,8 @@ InternalDataBase::initialize_2nd (const FiniteElement<dim,spacedim> *element,
   differences.resize(2*dim);
   for (unsigned int d=0; d<dim; ++d)
     {
-      Point<dim> shift;
-      shift (d) = fd_step_length;
+      Tensor<1,dim> shift;
+      shift[d] = fd_step_length;
 
       // generate points and FEValues
       // objects shifted in

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1039,7 +1039,7 @@ namespace internal
                   }
 
                 if (update_flags & update_normal_vectors)
-                  normal_vectors[i] = boundary_forms[i] / boundary_forms[i].norm();
+                  normal_vectors[i] = Point<spacedim>(boundary_forms[i] / boundary_forms[i].norm());
               }
 
           if (update_flags & update_jacobians)
@@ -1720,10 +1720,10 @@ transform_real_to_unit_cell_internal
 
   compute_shapes(std::vector<Point<dim> > (1, p_unit), mdata);
   Point<spacedim> p_real = transform_unit_to_real_cell_internal(mdata);
-  Point<spacedim> f = p_real-p;
+  Tensor<1,spacedim> f = p_real-p;
 
   // early out if we already have our point
-  if (f.square() < 1e-24 * cell->diameter() * cell->diameter())
+  if (f.norm_square() < 1e-24 * cell->diameter() * cell->diameter())
     return p_unit;
 
   // we need to compare the position of the computed p(x) against the given
@@ -1809,7 +1809,7 @@ transform_real_to_unit_cell_internal
 
           // f(x)
           Point<spacedim> p_real_trial = transform_unit_to_real_cell_internal(mdata);
-          const Point<spacedim> f_trial = p_real_trial-p;
+          const Tensor<1,spacedim> f_trial = p_real_trial-p;
 
 #ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
           std::cout << "     step_length=" << step_length << std::endl

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3071,7 +3071,7 @@ namespace GridGenerator
                 // one. move it to halfway
                 // between inner and outer
                 // sphere
-                const Point<3> old_distance = cell->vertex(v) - p;
+                const Tensor<1,3> old_distance = cell->vertex(v) - p;
                 const double old_radius = cell->vertex(v).distance(p);
                 cell->vertex(v) = p + old_distance * (middle_radius / old_radius);
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -57,7 +57,7 @@ SphericalManifold<dim,spacedim>::get_new_point(const Quadrature<spacedim> &quad)
           mid_point += quad.weight(i)*quad.point(i);
         }
       // Project the mid_pont back to the right location
-      Point<spacedim> R = mid_point-center;
+      Tensor<1,spacedim> R = mid_point-center;
       // Scale it to have radius rho_average
       R *= rho_average/R.norm();
       // And return it.
@@ -102,7 +102,7 @@ template <int dim, int spacedim>
 Point<spacedim>
 SphericalManifold<dim,spacedim>::pull_back(const Point<spacedim> &space_point) const
 {
-  const Point<spacedim> R = space_point-center;
+  const Tensor<1,spacedim> R = space_point-center;
   const double rho = R.norm();
 
   Point<spacedim> p;
@@ -193,9 +193,9 @@ get_new_point (const Quadrature<spacedim> &quad) const
     return middle;
 
   else
-    return (vector_from_axis / vector_from_axis.norm() * radius +
-            ((middle-point_on_axis) * direction) * direction +
-            point_on_axis);
+    return Point<spacedim>((vector_from_axis / vector_from_axis.norm() * radius +
+                            ((middle-point_on_axis) * direction) * direction +
+                            point_on_axis));
 }
 
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1003,8 +1003,8 @@ namespace
 
     // the face is planar. then its area is 1/2 of the norm of the
     // cross product of the two diagonals
-    const Point<3> v12 = accessor.vertex(2) - accessor.vertex(1);
-    Point<3> twice_area;
+    const Tensor<1,3> v12 = accessor.vertex(2) - accessor.vertex(1);
+    Tensor<1,3> twice_area;
     cross_product(twice_area, v03, v12);
     return 0.5 * twice_area.norm();
   }

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -628,7 +628,7 @@ normal_vector (const typename Triangulation<dim,spacedim>::face_iterator &face,
           for (unsigned int k=0; k<spacedim; ++k)
             H[i][j] += grad_F[i][k] * grad_F[j][k];
 
-      const Point<facedim> delta_xi = -invert(H) * J;
+      const Tensor<1,facedim> delta_xi = -invert(H) * J;
       xi += delta_xi;
 
       if (delta_xi.norm() < eps)
@@ -847,7 +847,7 @@ namespace internal
               H_k += (object->vertex(i) * object->vertex(j)) * tmp;
             }
 
-        const Point<dim> delta_xi = - invert(H_k) * F_k;
+        const Tensor<1,dim> delta_xi = - invert(H_k) * F_k;
         xi += delta_xi;
 
         x_k = Point<spacedim>();

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -863,8 +863,8 @@ namespace DerivativeApproximation
           // direction between
           // the centers of two
           // cells
-          Point<dim>   y        = neighbor_center - this_center;
-          const double distance = std::sqrt(y.square());
+          Tensor<1,dim> y        = neighbor_center - this_center;
+          const double  distance = y.norm();
           // normalize y
           y /= distance;
           // *** note that unlike in

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -122,8 +122,8 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
-        return_value += std::exp(-x_minus_xi.square() /
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+        return_value += std::exp(-x_minus_xi.norm_square() /
                                  (this->width * this->width));
       }
 
@@ -141,10 +141,10 @@ namespace Step51
 
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value += (-2 / (this->width * this->width) *
-                         std::exp(-x_minus_xi.square() /
+                         std::exp(-x_minus_xi.norm_square() /
                                   (this->width * this->width)) *
                          x_minus_xi);
       }
@@ -241,13 +241,13 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value +=
-          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.square()/
+          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.norm_square()/
             (this->width * this->width)) /
            (this->width * this->width) *
-           std::exp(-x_minus_xi.square() /
+           std::exp(-x_minus_xi.norm_square() /
                     (this->width * this->width)));
       }
 

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -122,8 +122,8 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
-        return_value += std::exp(-x_minus_xi.square() /
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+        return_value += std::exp(-x_minus_xi.norm_square() /
                                  (this->width * this->width));
       }
 
@@ -141,10 +141,10 @@ namespace Step51
 
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value += (-2 / (this->width * this->width) *
-                         std::exp(-x_minus_xi.square() /
+                         std::exp(-x_minus_xi.norm_square() /
                                   (this->width * this->width)) *
                          x_minus_xi);
       }
@@ -241,13 +241,13 @@ namespace Step51
     double return_value = 0;
     for (unsigned int i=0; i<this->n_source_centers; ++i)
       {
-        const Point<dim> x_minus_xi = p - this->source_centers[i];
+        const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
         return_value +=
-          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.square()/
+          ((2*dim - 2*convection*x_minus_xi - 4*x_minus_xi.norm_square()/
             (this->width * this->width)) /
            (this->width * this->width) *
-           std::exp(-x_minus_xi.square() /
+           std::exp(-x_minus_xi.norm_square() /
                     (this->width * this->width)));
       }
 

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -113,8 +113,8 @@ double Solution<dim>::value (const Point<dim>   &p,
   double return_value = 0;
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
-      return_value += std::exp(-x_minus_xi.square() /
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+      return_value += std::exp(-x_minus_xi.norm_square() /
                                (this->width * this->width));
     }
 
@@ -130,10 +130,10 @@ Tensor<1,dim> Solution<dim>::gradient (const Point<dim>   &p,
 
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
       return_value += (-2 / (this->width * this->width) *
-                       std::exp(-x_minus_xi.square() /
+                       std::exp(-x_minus_xi.norm_square() /
                                 (this->width * this->width)) *
                        x_minus_xi);
     }
@@ -162,14 +162,14 @@ double RightHandSide<dim>::value (const Point<dim>   &p,
   double return_value = 0;
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
-      return_value += ((2*dim - 4*x_minus_xi.square()/
+      return_value += ((2*dim - 4*x_minus_xi.norm_square()/
                         (this->width * this->width)) /
                        (this->width * this->width) *
-                       std::exp(-x_minus_xi.square() /
+                       std::exp(-x_minus_xi.norm_square() /
                                 (this->width * this->width)));
-      return_value += std::exp(-x_minus_xi.square() /
+      return_value += std::exp(-x_minus_xi.norm_square() /
                                (this->width * this->width));
     }
 

--- a/tests/codim_one/bem_integration.cc
+++ b/tests/codim_one/bem_integration.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -73,15 +73,15 @@ public:
                                    const Point<dim+1> &point);
 
 private:
-  double term_S(const Point<3> &r,
-                const Point<3> &a1,
-                const Point<3> &a2,
+  double term_S(const Tensor<1,3> &r,
+                const Tensor<1,3> &a1,
+                const Tensor<1,3> &a2,
                 const Point<3> &n,
                 const double &rn_c);
 
-  double term_D(const Point<3> &r,
-                const Point<3> &a1,
-                const Point<3> &a2);
+  double term_D(const Tensor<1,3> &r,
+                const Tensor<1,3> &a1,
+                const Tensor<1,3> &a2);
 
   SmartPointer<FEValues<dim,dim+1> > fe_values;
 };
@@ -125,8 +125,8 @@ LaplaceKernelIntegration<2>::compute_SD_integral_on_cell(vector<double> &dst,
   vector<DerivativeForm<1,2,3> > jacobians = fe_values->get_jacobians();
   vector<Point<3> > normals = fe_values->get_normal_vectors();
 
-  Point<3> r,a1,a2,n,r_c,n_c;
-  r_c = point-cell->center();
+  Point<3> n,n_c;
+  Tensor<1,3> r_c = point-cell->center();
   n_c = normals[4];
 
   double rn_c = r_c*n_c;
@@ -134,9 +134,9 @@ LaplaceKernelIntegration<2>::compute_SD_integral_on_cell(vector<double> &dst,
   vector<double> i_D(4);
   for (unsigned int q_point=0; q_point < 4; ++q_point)
     {
-      r = point-cell->vertex(q_point);
-      a1 = transpose(jacobians[q_point])[0];
-      a2 = transpose(jacobians[q_point])[1];
+      const Tensor<1,3> r = point-cell->vertex(q_point);
+      const Tensor<1,3> a1 = transpose(jacobians[q_point])[0];
+      const Tensor<1,3> a2 = transpose(jacobians[q_point])[1];
       n =  normals[q_point];
       i_S[q_point]=term_S(r,a1,a2,n,rn_c);
       i_D[q_point]=term_D(r,a1,a2);
@@ -148,9 +148,9 @@ LaplaceKernelIntegration<2>::compute_SD_integral_on_cell(vector<double> &dst,
 
 template <int dim>
 double
-LaplaceKernelIntegration<dim>::term_S (const Point<3> &r,
-                                       const Point<3> &a1,
-                                       const Point<3> &a2,
+LaplaceKernelIntegration<dim>::term_S (const Tensor<1,3> &r,
+                                       const Tensor<1,3> &a1,
+                                       const Tensor<1,3> &a2,
                                        const Point<3> &n,
                                        const double &rn_c)
 {
@@ -174,9 +174,9 @@ LaplaceKernelIntegration<dim>::term_S (const Point<3> &r,
 
 template <int dim>
 double
-LaplaceKernelIntegration<dim>::term_D (const Point<3> &r,
-                                       const Point<3> &a1,
-                                       const Point<3> &a2)
+LaplaceKernelIntegration<dim>::term_D (const Tensor<1,3> &r,
+                                       const Tensor<1,3> &a1,
+                                       const Tensor<1,3> &a2)
 {
   Point<3> ra1, ra2, a12;
 

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -112,8 +112,8 @@ double Solution<dim>::value (const Point<dim>   &p,
   double return_value = 0;
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
-      return_value += std::exp(-x_minus_xi.square() /
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
+      return_value += std::exp(-x_minus_xi.norm_square() /
                                (this->width * this->width));
     }
 
@@ -129,10 +129,10 @@ Tensor<1,dim> Solution<dim>::gradient (const Point<dim>   &p,
 
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
       return_value += (-2 / (this->width * this->width) *
-                       std::exp(-x_minus_xi.square() /
+                       std::exp(-x_minus_xi.norm_square() /
                                 (this->width * this->width)) *
                        x_minus_xi);
     }
@@ -161,14 +161,14 @@ double RightHandSide<dim>::value (const Point<dim>   &p,
   double return_value = 0;
   for (unsigned int i=0; i<this->n_source_centers; ++i)
     {
-      const Point<dim> x_minus_xi = p - this->source_centers[i];
+      const Tensor<1,dim> x_minus_xi = p - this->source_centers[i];
 
-      return_value += ((2*dim - 4*x_minus_xi.square()/
+      return_value += ((2*dim - 4*x_minus_xi.norm_square()/
                         (this->width * this->width)) /
                        (this->width * this->width) *
-                       std::exp(-x_minus_xi.square() /
+                       std::exp(-x_minus_xi.norm_square() /
                                 (this->width * this->width)));
-      return_value += std::exp(-x_minus_xi.square() /
+      return_value += std::exp(-x_minus_xi.norm_square() /
                                (this->width * this->width));
     }
 


### PR DESCRIPTION
This is another set of (independent, non-controversial) patches that eliminate confusion about where to use Tensors and where to use Points. In particular, it eliminates implicit casts from Tensor to Point.