### PR TITLE
Do not allow instantiation of MultithreadInfo

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -334,6 +334,15 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+
+  <li> Changed: All members of MultithreadInfo are now static so it is no
+  longer necessary to use the global instance multithread_info (now
+  deprecated) or create your own instance (which does not work correctly
+  anyway).
+  <br>
+  (Timo Heister, 2015/02/13)
+  </li>
+
   <li> Changed: If you take the product of a Tensor and a scalar number,
   you previously got a Tensor back that stored its elements in the same
   data type as the original tensor. This leads to problems if you

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -780,7 +780,7 @@ namespace Step17
                                         local_error_per_cell,
                                         ComponentMask(),
                                         0,
-                                        multithread_info.n_threads(),
+                                        MultithreadInfo::n_threads(),
                                         this_mpi_process);
 
     // Now all processes have computed error indicators for their own cells

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1647,7 +1647,7 @@ namespace Step18
                                         error_per_cell,
                                         ComponentMask(),
                                         0,
-                                        multithread_info.n_threads(),
+                                        MultithreadInfo::n_threads(),
                                         this_mpi_process);
 
     // Then set up a global vector into which we merge the local indicators

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -48,8 +48,7 @@
 // programs. In the first one, the classes and functions are declared which we
 // need to do assembly in parallel (i.e. the
 // <code>WorkStream</code> namespace). The
-// second file has a class <code>MultithreadInfo</code> (and a global object
-// <code>multithread_info</code> of that type) which can be used to query the
+// second file has a class <code>MultithreadInfo</code> which can be used to query the
 // number of processors in your system, which is often useful when deciding
 // how many threads to start in parallel.
 #include <deal.II/base/work_stream.h>

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -49,29 +49,27 @@ class MultithreadInfo
 {
 public:
   /**
-   * The constructor determines the number of CPUs in the system. At the
-   * moment detection of CPUs is only implemented on Linux computers with the
-   * /proc filesystem and on Sun machines.  The number of CPUs present is set
-   * to one if detection failed or if detection is not supported.
-   */
-  MultithreadInfo ();
-
-  /**
-   * The number of CPUs in the system.  It is one if detection is not
-   * implemented or failed.
+   * The number of CPUs in the system. At the moment detection of CPUs is only
+   * implemented on Linux, FreeBSD, and Mac computers.  It is one if detection
+   * failed or is not implemented on your system.
    *
    * If it is one, although you are on a multi-processor machine, please refer
    * to the documentation in <tt>multithread_info.cc</tt> near to the
    * <tt>error</tt> directive.
    */
-  const unsigned int n_cpus;
+  static unsigned int n_cores ();
+
+  /**
+   * @deprecated Use n_cores() instead.
+   */
+  static const unsigned int n_cpus DEAL_II_DEPRECATED;
 
   /**
    * Returns the number of threads to use. This is initially set to the number
    * of cores the system has (n_cpus) but can be further restricted by
    * set_thread_limit().
    */
-  unsigned int n_threads() const;
+  static unsigned int n_threads ();
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -94,7 +92,7 @@ public:
    * method will have any effect. Use the parameter of the MPI_InitFinalize if
    * you have an MPI based code.
    */
-  void set_thread_limit(const unsigned int max_threads = numbers::invalid_unsigned_int);
+  static void set_thread_limit (const unsigned int max_threads = numbers::invalid_unsigned_int);
 
 
   /**
@@ -103,11 +101,18 @@ public:
    * is used in the PETScWrappers to avoid using the interface that is not
    * thread-safe.
    */
-  bool is_running_single_threaded();
+  static bool is_running_single_threaded ();
+
   /**
    * Exception
    */
   DeclException0(ExcProcNotPresent);
+
+  /**
+   * @deprecated All members are static, so there is no need to construct an
+   * instance.
+   */
+  MultithreadInfo () DEAL_II_DEPRECATED;
 
 private:
 
@@ -116,24 +121,24 @@ private:
    * Linux, OSF, SGI, and Sun machines; if no detection of the number of CPUs
    * is supported, or if detection fails, this function returns one.
    */
-  static unsigned int get_n_cpus();
+  static unsigned int get_n_cpus ();
 
   /**
-   * variable representing the maximum number of threads
+   * Variable representing the maximum number of threads.
    */
-  unsigned int n_max_threads;
+  static unsigned int n_max_threads;
 };
 
 
 
 /**
- * Global variable of type <tt>MultithreadInfo</tt> which you may ask for the
- * number of CPUs in your system, as well as for the default number of threads
- * that multithreaded functions shall use.
+ * Global variable of type <tt>MultithreadInfo</tt>.
+ *
+ * @deprecated Use the static member functions instead.
  *
  * @ingroup threads
  */
-extern MultithreadInfo multithread_info;
+extern MultithreadInfo multithread_info DEAL_II_DEPRECATED;
 
 
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -389,7 +389,7 @@ namespace Utilities
           // set maximum number of threads (also respecting the environment
           // variable that the called function evaluates) based on what
           // the user asked
-          multithread_info.set_thread_limit(max_num_threads);
+          MultithreadInfo::set_thread_limit(max_num_threads);
         }
       else
         // user wants automatic choice
@@ -437,20 +437,20 @@ namespace Utilities
           // if the number would be zero, round up to one since every
           // process needs to have at least one thread
           const unsigned int n_threads
-            = std::max(multithread_info.n_cpus / n_local_processes
+            = std::max(MultithreadInfo::n_cpus / n_local_processes
                        +
-                       (nth_process_on_host <= multithread_info.n_cpus % n_local_processes
+                       (nth_process_on_host <= MultithreadInfo::n_cpus % n_local_processes
                         ?
                         1
                         :
                         0),
                        1U);
 #else
-          const unsigned int n_threads = multithread_info.n_cpus;
+          const unsigned int n_threads = MultithreadInfo::n_cpus;
 #endif
 
           // finally set this number of threads
-          multithread_info.set_thread_limit(n_threads);
+          MultithreadInfo::set_thread_limit(n_threads);
         }
     }
 

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -98,6 +98,15 @@ unsigned int MultithreadInfo::get_n_cpus()
 
 #  endif
 
+const unsigned int MultithreadInfo::n_cpus = MultithreadInfo::get_n_cpus();
+unsigned int MultithreadInfo::n_max_threads = numbers::invalid_unsigned_int;
+
+unsigned int MultithreadInfo::n_cores()
+{
+  return MultithreadInfo::n_cpus;
+}
+
+
 void MultithreadInfo::set_thread_limit(const unsigned int max_threads)
 {
   Assert(n_max_threads==numbers::invalid_unsigned_int,
@@ -148,7 +157,7 @@ void MultithreadInfo::set_thread_limit(const unsigned int max_threads)
 }
 
 
-unsigned int MultithreadInfo::n_threads() const
+unsigned int MultithreadInfo::n_threads()
 {
   if (n_max_threads == numbers::invalid_unsigned_int)
     return tbb::task_scheduler_init::default_num_threads();
@@ -164,7 +173,7 @@ unsigned int MultithreadInfo::get_n_cpus()
   return 1;
 }
 
-unsigned int MultithreadInfo::n_threads() const
+unsigned int MultithreadInfo::n_threads()
 {
   return 1;
 }
@@ -183,9 +192,6 @@ bool MultithreadInfo::is_running_single_threaded()
 
 
 MultithreadInfo::MultithreadInfo ()
-  :
-  n_cpus (get_n_cpus()),
-  n_max_threads (numbers::invalid_unsigned_int)
 {}
 
 
@@ -199,8 +205,8 @@ MultithreadInfo::memory_consumption ()
 }
 
 
-
 // definition of the variable which is declared `extern' in the .h file
 MultithreadInfo multithread_info;
+
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3283,7 +3283,7 @@ FEValuesBase<dim,spacedim>::check_cell_similarity
   //
   // TODO: Is it reasonable to introduce a flag "unsafe" in the constructor of
   // FEValues to re-enable this feature?
-  if (multithread_info.n_threads() > 1)
+  if (MultithreadInfo::n_threads() > 1)
     {
       cell_similarity = CellSimilarity::none;
       return;

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -152,7 +152,7 @@ namespace PETScWrappers
     last_action (::dealii::VectorOperation::unknown),
     attained_ownership(true)
   {
-    Assert( multithread_info.is_running_single_threaded(),
+    Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
                        "the thread limit to 1 in MPI_InitFinalize()."));
   }
@@ -167,7 +167,7 @@ namespace PETScWrappers
     last_action (::dealii::VectorOperation::unknown),
     attained_ownership(true)
   {
-    Assert( multithread_info.is_running_single_threaded(),
+    Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
                        "the thread limit to 1 in MPI_InitFinalize()."));
 
@@ -188,7 +188,7 @@ namespace PETScWrappers
     last_action (::dealii::VectorOperation::unknown),
     attained_ownership(false)
   {
-    Assert( multithread_info.is_running_single_threaded(),
+    Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
                        "the thread limit to 1 in MPI_InitFinalize()."));
   }

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -460,7 +460,7 @@ void DataOut<dim,DH>::build_patches (const Mapping<DH::dimension,DH::space_dimen
                      // about 10% improvement) and the items in flight at any
                      // given time (another 5% on the testcase discussed in
                      // @ref workstream_paper, on 32 cores) and if
-                     8*multithread_info.n_threads(),
+                     8*MultithreadInfo::n_threads(),
                      64);
 }
 

--- a/tests/base/task_09.cc
+++ b/tests/base/task_09.cc
@@ -66,7 +66,7 @@ int main()
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  for (unsigned int i=0; i<multithread_info.n_cpus*2; ++i)
+  for (unsigned int i=0; i<MultithreadInfo::n_cpus*2; ++i)
     Threads::new_task (outer);
 
   deallog << "OK" << std::endl;

--- a/tests/bits/error_estimator_01.cc
+++ b/tests/bits/error_estimator_01.cc
@@ -170,7 +170,7 @@ check ()
       KellyErrorEstimator<dim>::estimate (mapping, dof, q_face, neumann_bc,
                                           v, this_error,
                                           std::vector<bool>(), 0,
-                                          multithread_info.n_threads(),
+                                          MultithreadInfo::n_threads(),
                                           subdomain);
       this_error *= scaling_factor;
 

--- a/tests/bits/error_estimator_02.cc
+++ b/tests/bits/error_estimator_02.cc
@@ -170,7 +170,7 @@ check ()
       KellyErrorEstimator<dim>::estimate (mapping, dof, q_face, neumann_bc,
                                           v, this_error,
                                           std::vector<bool>(), 0,
-                                          multithread_info.n_threads(),
+                                          MultithreadInfo::n_threads(),
                                           numbers::invalid_unsigned_int,
                                           material);
       this_error *= scaling_factor;

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -357,7 +357,7 @@ namespace LaplaceSolver
     typename DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -443,7 +443,7 @@ namespace LaplaceSolver
     typename DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),
@@ -1684,7 +1684,7 @@ namespace LaplaceSolver
     error_indicators.reinit (dual_solver.dof_handler
                              .get_tria().n_active_cells());
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     for (unsigned int i=0; i<n_threads; ++i)
       {
         estimate_some

--- a/tests/codim_one/error_estimator_01.cc
+++ b/tests/codim_one/error_estimator_01.cc
@@ -168,7 +168,7 @@ check ()
       KellyErrorEstimator<dim,spacedim>::estimate (mapping, dof, q_face, neumann_bc,
                                                    v, this_error,
                                                    std::vector<bool>(), 0,
-                                                   multithread_info.n_threads(),
+                                                   MultithreadInfo::n_threads(),
                                                    subdomain);
       this_error *= scaling_factor;
 

--- a/tests/deal.II/assemble_matrix_parallel_02.cc
+++ b/tests/deal.II/assemble_matrix_parallel_02.cc
@@ -400,7 +400,7 @@ void LaplaceProblem<dim>::assemble_test_1 ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe_collection, quadrature_collection),
          Assembly::Copy::Data (),
-         multithread_info.n_threads(),
+         MultithreadInfo::n_threads(),
          1);
 }
 
@@ -425,7 +425,7 @@ void LaplaceProblem<dim>::assemble_test_2 ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe_collection, quadrature_collection),
          Assembly::Copy::Data (true),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
 }
 

--- a/tests/deal.II/assemble_matrix_parallel_04.cc
+++ b/tests/deal.II/assemble_matrix_parallel_04.cc
@@ -428,7 +428,7 @@ void LaplaceProblem<dim>::assemble_test_1 ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe_collection, quadrature_collection),
          Assembly::Copy::Data (1),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)
     if (constraints.is_constrained(i))
@@ -459,7 +459,7 @@ void LaplaceProblem<dim>::assemble_test_2 ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe_collection, quadrature_collection),
          Assembly::Copy::Data (2),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)
     if (constraints.is_constrained(i))

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -443,7 +443,7 @@ namespace LaplaceSolver
     typename hp::DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),
@@ -1684,7 +1684,7 @@ namespace LaplaceSolver
     error_indicators.reinit (dual_solver.dof_handler
                              .get_tria().n_active_cells());
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     Threads::ThreadGroup<> threads;
     for (unsigned int i=0; i<n_threads; ++i)
       threads += Threads::new_thread (&WeightedResidual<dim>::estimate_some, *this,

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -357,7 +357,7 @@ namespace LaplaceSolver
     typename hp::DoFHandler<dim>::active_cell_iterator
     active_cell_iterator;
 
-    const unsigned int n_threads = multithread_info.n_threads();
+    const unsigned int n_threads = MultithreadInfo::n_threads();
     std::vector<std::pair<active_cell_iterator,active_cell_iterator> >
     thread_ranges
       = Threads::split_range<active_cell_iterator> (dof_handler.begin_active (),

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -152,7 +152,7 @@ void do_test (const DoFHandler<dim> &dof)
          &copy_data_local_to_global,
          Assembly::Scratch::Data<dim,fe_degree>(dof.get_fe()),
          dummy,
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   deallog << "OK" << std::endl;
 }

--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -60,8 +60,8 @@ int main ()
   if (!getaffinity(bits_set, mask))
     return 1;
 
-  unsigned int nprocs = dealii::multithread_info.n_cpus;
-  unsigned int tbbprocs = dealii::multithread_info.n_threads();
+  unsigned int nprocs = dealii::MultithreadInfo::n_cpus;
+  unsigned int tbbprocs = dealii::MultithreadInfo::n_threads();
   printf("aff_ncpus=%d, mask=%08X, nprocs=%d, tbb_threads=%d\n",
 	 bits_set, mask, nprocs, tbbprocs );
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -191,7 +191,7 @@ struct LimitConcurrency
 {
   LimitConcurrency ()
   {
-    multithread_info.set_thread_limit (5);
+    MultithreadInfo::set_thread_limit (5);
   }
 } limit_concurrency;
 #endif

--- a/tests/trilinos/assemble_matrix_parallel_01.cc
+++ b/tests/trilinos/assemble_matrix_parallel_01.cc
@@ -367,7 +367,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe_collection, quadrature_collection),
          Assembly::Copy::Data (),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
 
   test_matrix.add(-1, reference_matrix);

--- a/tests/trilinos/assemble_matrix_parallel_02.cc
+++ b/tests/trilinos/assemble_matrix_parallel_02.cc
@@ -377,7 +377,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_rhs.compress(VectorOperation::add);

--- a/tests/trilinos/assemble_matrix_parallel_03.cc
+++ b/tests/trilinos/assemble_matrix_parallel_03.cc
@@ -378,7 +378,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_rhs.compress(VectorOperation::add);

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -393,7 +393,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_rhs.compress(VectorOperation::add);

--- a/tests/trilinos/assemble_matrix_parallel_05.cc
+++ b/tests/trilinos/assemble_matrix_parallel_05.cc
@@ -379,7 +379,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_rhs.compress(VectorOperation::add);

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -394,7 +394,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_rhs.compress(VectorOperation::add);

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -386,7 +386,7 @@ void LaplaceProblem<dim>::assemble_test ()
                           std_cxx11::_1),
          Assembly::Scratch::Data<dim>(fe, quadrature),
          Assembly::Copy::Data (false),
-         2*multithread_info.n_threads(),
+         2*MultithreadInfo::n_threads(),
          1);
   test_matrix.compress(VectorOperation::add);
   test_matrix.compress(VectorOperation::add);


### PR DESCRIPTION
If the user creates her own instance of MultithreadInfo, the
functionality in set_thread_limit() won't work correctly. This patch
makes the constructor private, create a factory function get_instance()
and changes the global variable multithread_info into a reference.