### PR TITLE
Remove deprecated functions SparsityPattern::get_rowstart_indices and SparsityPattern::get_column_numbers.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -171,6 +171,8 @@ inconvenience this causes.
   - SparsityPattern and ChunkSparsityPattern functions that take an
     <code>optimize_diagonal</code> argument.
   - SparsityPattern::partition.
+  - SparsityPattern::get_rowstart_indices and
+    SparsityPattern::get_column_numbers.
   - The typedef CompressedBlockSparsityPattern.
   - The deprecated constructors of SparsityPattern iterator classes.
   - The deprecated variants of DoFTools::make_periodicity_constraints.

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -986,45 +986,6 @@ public:
    */
   row_iterator row_end (const size_type r) const DEAL_II_DEPRECATED;
 
-  /**
-   * @deprecated This is kind of an expert mode. Get access to the rowstart
-   * array, but read-only.
-   *
-   * Use of this function is highly deprecated. Use @p row_length and @p
-   * column_number instead. Also, using iterators may get you most of the
-   * information you may want.
-   *
-   * Though the return value is declared <tt>const</tt>, you should be aware
-   * that it may change if you call any nonconstant function of objects which
-   * operate on it.
-   *
-   * You should use this interface very carefully and only if you are
-   * absolutely sure to know what you do. You should also note that the
-   * structure of these arrays may change over time.  If you change the layout
-   * yourself, you should also rename this function to avoid programs relying
-   * on outdated information!
-   */
-  const std::size_t *get_rowstart_indices () const DEAL_II_DEPRECATED;
-
-  /**
-   * @deprecated. Use @p row_length and @p column_number instead. Also, using
-   * iterators may get you most of the information you may want.
-   *
-   * This is kind of an expert mode: get access to the colnums array, but
-   * readonly.
-   *
-   * Though the return value is declared <tt>const</tt>, you should be aware
-   * that it may change if you call any nonconstant function of objects which
-   * operate on it.
-   *
-   * You should use this interface very carefully and only if you are
-   * absolutely sure to know what you do. You should also note that the
-   * structure of these arrays may change over time. If you change the layout
-   * yourself, you should also rename this function to avoid programs relying
-   * on outdated information!
-   */
-  const size_type *get_column_numbers () const DEAL_II_DEPRECATED;
-
 // @}
 
   BOOST_SERIALIZATION_SPLIT_MEMBER()
@@ -1459,22 +1420,6 @@ bool
 SparsityPattern::stores_only_added_elements () const
 {
   return (store_diagonal_first_in_row == false);
-}
-
-
-inline
-const std::size_t *
-SparsityPattern::get_rowstart_indices () const
-{
-  return rowstart;
-}
-
-
-inline
-const SparsityPattern::size_type *
-SparsityPattern::get_column_numbers () const
-{
-  return colnums;
 }
 
 

--- a/tests/bits/dof_tools_01a.cc
+++ b/tests/bits/dof_tools_01a.cc
@@ -57,9 +57,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_01a_constraints_false.cc
+++ b/tests/bits/dof_tools_01a_constraints_false.cc
@@ -63,9 +63,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_01a_constraints_true.cc
+++ b/tests/bits/dof_tools_01a_constraints_true.cc
@@ -63,9 +63,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_01a_subdomain.cc
+++ b/tests/bits/dof_tools_01a_subdomain.cc
@@ -64,9 +64,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_02a.cc
+++ b/tests/bits/dof_tools_02a.cc
@@ -67,9 +67,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_02a_constraints_false.cc
+++ b/tests/bits/dof_tools_02a_constraints_false.cc
@@ -73,9 +73,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_02a_constraints_true.cc
+++ b/tests/bits/dof_tools_02a_constraints_true.cc
@@ -73,9 +73,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_02a_subdomain.cc
+++ b/tests/bits/dof_tools_02a_subdomain.cc
@@ -75,9 +75,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_15a.cc
+++ b/tests/bits/dof_tools_15a.cc
@@ -66,9 +66,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_16a.cc
+++ b/tests/bits/dof_tools_16a.cc
@@ -72,9 +72,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_17a.cc
+++ b/tests/bits/dof_tools_17a.cc
@@ -57,9 +57,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/bits/dof_tools_18a.cc
+++ b/tests/bits/dof_tools_18a.cc
@@ -83,10 +83,8 @@ my_check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }
 

--- a/tests/bits/dof_tools_18a_1d.cc
+++ b/tests/bits/dof_tools_18a_1d.cc
@@ -84,10 +84,8 @@ check_this (const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l=0; l<sp.n_rows(); ++l)
     hash += l*(sp.row_length(l) +
-               sp.get_rowstart_indices()[l] +
-               sp.get_column_numbers()[sp.get_rowstart_indices()[l]
-                                       +
-                                       (sp.row_length(l)>1 ? 1 : 0)]);
+               (sp.begin(l)-sp.begin()) +
+               (sp.row_length(l)>1 ? ++sp.begin(l) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }
 

--- a/tests/lac/sparsity_pattern.cc
+++ b/tests/lac/sparsity_pattern.cc
@@ -86,9 +86,8 @@ main ()
   for (unsigned int row=0; row<sp3.n_rows(); ++row)
     {
       sparsity.push_back (std::set<unsigned int,std::greater<unsigned int> >());
-      for (const types::global_dof_index *p=sp3.get_column_numbers()+sp3.get_rowstart_indices()[row];
-           p != sp3.get_column_numbers()+sp3.get_rowstart_indices()[row+1]; ++p)
-        sparsity.back().insert (*p);
+      for (SparsityPattern::const_iterator p=sp3.begin(row); p!=sp3.end(row); ++p)
+        sparsity.back().insert (p->column());
     };
   SparsityPattern sp4;
   sp4.copy_from ((N-1)*(N-1), (N-1)*(N-1),
@@ -97,14 +96,9 @@ main ()
   // now check for equivalence of sp3 and sp4
   for (unsigned int row=0; row<sp3.n_rows(); ++row)
     {
-      const types::global_dof_index
-      *sp3_p=sp3.get_column_numbers()+sp3.get_rowstart_indices()[row];
-      const types::global_dof_index
-      *sp4_p=sp4.get_column_numbers()+sp4.get_rowstart_indices()[row];
-      for (; sp3_p != (sp3.get_column_numbers() +
-                       sp3.get_rowstart_indices()[row+1]);
-           ++sp3_p, ++sp4_p)
-        Assert (*sp3_p == *sp4_p, ExcInternalError());
+      SparsityPattern::const_iterator p3=sp3.begin(row), p4=sp4.begin(row);
+      for (; p3!=sp3.end(row); ++p3, ++p4)
+        Assert (p3->column() == p4->column(), ExcInternalError());
     };
 
 
@@ -159,15 +153,10 @@ main ()
 
   for (unsigned int row=0; row<sp3.n_rows(); ++row)
     {
-      const types::global_dof_index
-      *sp3_p=sp3.get_column_numbers()+sp3.get_rowstart_indices()[row];
-      const types::global_dof_index
-      *sp5_p=sp5.get_column_numbers()+sp5.get_rowstart_indices()[row];
-      for (; sp3_p != (sp3.get_column_numbers() +
-                       sp3.get_rowstart_indices()[row+1]);
-           ++sp3_p, ++sp5_p)
-        Assert (*sp3_p == *sp5_p, ExcInternalError());
-    };
+      SparsityPattern::const_iterator p3=sp3.begin(row), p5=sp5.begin(row);
+      for (; p3!=sp3.end(row); ++p3, ++p5)
+        Assert (p3->column() == p5->column(), ExcInternalError());
+    }
 }
 
 


### PR DESCRIPTION
These functions have also been deprecated for more than a decade as they leak the storage format of SparsityPattern to the outside.