### PR TITLE
Do not allow for implicit casts from Tensor to Point.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,19 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Changed: Implicit conversion from Tensor@<1,dim@> to Point@<dim@> was
+  previously possible. This has now been prohibited (but you can still
+  do the conversion with an explicit cast) as such conversions are
+  likely incorrect uses of class Point (which should represent only
+  points in space, i.e., vectors anchored at the origin) whereas Tensor
+  should be used for vectors anchored elsewhere (such as normal vectors,
+  directions, differences between points, etc). The difference in
+  usage between Point and Tensor have now been clarified in the documentation
+  of class Point.
+  <br>
+  (Wolfgang Bangerth, 2015/01/12)
+  </li>
+
   <li> Changed: The project configuration no longer exports
   <code>[...]/include/deal.II</code>. Thus it is now mandatory to prefix
   all includes of deal.II headers with <code>deal.II/</code>, i.e.

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -90,7 +90,7 @@ public:
   /**
    * Convert a tensor to a point.
    */
-  Point (const Tensor<1,dim,Number> &);
+  explicit Point (const Tensor<1,dim,Number> &);
 
   /**
    * Constructor for one dimensional points. This function is only implemented
@@ -324,7 +324,9 @@ inline
 Point<dim,Number>
 Point<dim,Number>::operator + (const Tensor<1,dim,Number> &p) const
 {
-  return (Point<dim,Number>(*this) += p);
+  Point<dim,Number> tmp = *this;
+  tmp += p;
+  return tmp;
 }
 
 
@@ -344,7 +346,9 @@ inline
 Point<dim,Number>
 Point<dim,Number>::operator - (const Tensor<1,dim,Number> &p) const
 {
-  return (Point<dim,Number>(*this) -= p);
+  Point<dim,Number> tmp = *this;
+  tmp -= p;
+  return tmp;
 }
 
 
@@ -367,7 +371,9 @@ inline
 Point<dim,Number>
 Point<dim,Number>::operator * (const Number factor) const
 {
-  return (Point<dim,Number>(*this) *= factor);
+  Point<dim,Number> tmp = *this;
+  tmp *= factor;
+  return tmp;
 }
 
 
@@ -416,7 +422,9 @@ template <int dim, typename Number>
 inline
 Point<dim,Number> Point<dim,Number>::operator / (const Number factor) const
 {
-  return (Point<dim,Number>(*this) /= factor);
+  Point<dim,Number> tmp = *this;
+  tmp /= factor;
+  return tmp;
 }
 
 


### PR DESCRIPTION
These are likely invalid uses of class Point and should use Tensor instead.
At the same time, still allow for explicit casts.