### PR TITLE
Fix number usage in functions

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -49,11 +49,11 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * object represents. Access to function objects therefore is through the
  * following methods:
  * @code
- *                 // access to one component at one point
+ *   // access to one component at one point
  *   double value        (const Point<dim>   &p,
  *                        const unsigned int  component = 0) const;
  *
- *                 // return all components at one point
+ *   // return all components at one point
  *   void   vector_value (const Point<dim>   &p,
  *                        Vector<double>     &value) const;
  * @endcode
@@ -61,12 +61,12 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * For more efficiency, there are other functions returning one or all
  * components at a list of points at once:
  * @code
- *                 // access to one component at several points
+ *   // access to one component at several points
  *   void   value_list (const std::vector<Point<dim> >  &point_list,
  *                      std::vector<double>             &value_list,
  *                      const unsigned int  component = 0) const;
  *
- *                 // return all components at several points
+ *   // return all components at several points
  *   void   vector_value_list (const std::vector<Point<dim> >    &point_list,
  *                             std::vector<Vector<double> >      &value_list) const;
  * @endcode
@@ -80,9 +80,9 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * vector_value(), and gradient analogs), while those ones will throw an
  * exception when called but not overloaded.
  *
- * Note however, that conversely the functions returning all components of the
- * function at one or several points (i.e. vector_value(),
- * vector_value_list()), will not call the function returning one component at
+ * Conversely, the functions returning all components of the function at
+ * one or several points (i.e. vector_value(), vector_value_list()),
+ * will <em>not</em> call the function returning one component at
  * one point repeatedly, once for each point and component. The reason is
  * efficiency: this would amount to too many virtual function calls. If you
  * have vector-valued functions, you should therefore also provide overloads
@@ -93,16 +93,38 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * returning a whole array), since the cost of evaluation of a point value is
  * often less than the virtual function call itself.
  *
- *
  * Support for time dependent functions can be found in the base class
  * FunctionTime.
  *
- * @note If the functions you are dealing with have sizes which are a priori
- * known (for example, <tt>dim</tt> elements), you might consider using the
- * TensorFunction class instead. On the other hand, functions like
- * VectorTools::interpolate or VectorTools::interpolate_boundary_values
- * definitely only want objects of the current type. You can use the
- * VectorFunctionFromTensorFunction class to convert the former to the latter.
+ *
+ * <h3>Functions that return tensors</h3>
+ *
+ * If the functions you are dealing with have a number of
+ * components that are a priori known (for example, <tt>dim</tt>
+ * elements), you might consider using the TensorFunction class
+ * instead. This is, in particular, true if the objects you return
+ * have the properties of a tensor, i.e., they are for example
+ * dim-dimensional vectors or dim-by-dim matrices. On the other hand,
+ * functions like VectorTools::interpolate or
+ * VectorTools::interpolate_boundary_values definitely only want
+ * objects of the current type. You can use the
+ * VectorFunctionFromTensorFunction class to convert the former to the
+ * latter.
+ *
+ *
+ * <h3>Functions that return different fields</h3>
+ *
+ * Most of the time, your functions will have the form
+ * $f : \Omega \rightarrow {\mathbb R}^{n_\text{components}}$. However,
+ * there are occasions where you want the function to return vectors (or
+ * scalars) over a different number field, for example functions that
+ * return complex numbers or vectors of complex numbers:
+ * $f : \Omega \rightarrow {\mathbb C}^{n_\text{components}}$. In such
+ * cases, you can use the second template argument of this class: it
+ * describes the scalar type to be used for each component of your return
+ * values. It defaults to @p double, but in the example above, it could
+ * be set to <code>std::complex@<double@></code>.
+ *
  *
  * @ingroup functions
  * @author Wolfgang Bangerth, 1998, 1999, Luca Heltai 2014

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -50,11 +50,11 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * following methods:
  * @code
  *                 // access to one component at one point
- *   double value        (const Point<dim, Number>   &p,
+ *   double value        (const Point<dim>   &p,
  *                        const unsigned int  component = 0) const;
  *
  *                 // return all components at one point
- *   void   vector_value (const Point<dim, Number>   &p,
+ *   void   vector_value (const Point<dim>   &p,
  *                        Vector<double>     &value) const;
  * @endcode
  *
@@ -62,12 +62,12 @@ template <int rank, int dim, typename Number> class TensorFunction;
  * components at a list of points at once:
  * @code
  *                 // access to one component at several points
- *   void   value_list (const std::vector<Point<dim, Number> >  &point_list,
+ *   void   value_list (const std::vector<Point<dim> >  &point_list,
  *                      std::vector<double>             &value_list,
  *                      const unsigned int  component = 0) const;
  *
  *                 // return all components at several points
- *   void   vector_value_list (const std::vector<Point<dim, Number> >    &point_list,
+ *   void   vector_value_list (const std::vector<Point<dim> >    &point_list,
  *                             std::vector<Vector<double> >      &value_list) const;
  * @endcode
  *
@@ -168,7 +168,7 @@ public:
    * component you want to have evaluated; it defaults to zero, i.e. the first
    * component.
    */
-  virtual Number value (const Point<dim, Number>   &p,
+  virtual Number value (const Point<dim>   &p,
                         const unsigned int  component = 0) const;
 
   /**
@@ -178,7 +178,7 @@ public:
    *
    * The default implementation will call value() for each component.
    */
-  virtual void vector_value (const Point<dim, Number>   &p,
+  virtual void vector_value (const Point<dim>   &p,
                              Vector<Number>     &values) const;
 
   /**
@@ -190,7 +190,7 @@ public:
    * By default, this function repeatedly calls value() for each point
    * separately, to fill the output array.
    */
-  virtual void value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<Number>            &values,
                            const unsigned int              component = 0) const;
 
@@ -204,7 +204,7 @@ public:
    * By default, this function repeatedly calls vector_value() for each point
    * separately, to fill the output array.
    */
-  virtual void vector_value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_value_list (const std::vector<Point<dim> > &points,
                                   std::vector<Vector<Number> >   &values) const;
 
   /**
@@ -215,20 +215,20 @@ public:
    * value_list() for each component. In order to improve performance, this
    * can be reimplemented in derived classes to speed up performance.
    */
-  virtual void vector_values (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_values (const std::vector<Point<dim> > &points,
                               std::vector<std::vector<Number> > &values) const;
 
   /**
    * Return the gradient of the specified component of the function at the
    * given point.
    */
-  virtual Tensor<1,dim, Number> gradient (const Point<dim, Number>   &p,
+  virtual Tensor<1,dim, Number> gradient (const Point<dim>   &p,
                                           const unsigned int  component = 0) const;
 
   /**
    * Return the gradient of all components of the function at the given point.
    */
-  virtual void vector_gradient (const Point<dim, Number>            &p,
+  virtual void vector_gradient (const Point<dim>            &p,
                                 std::vector<Tensor<1,dim, Number> > &gradients) const;
 
   /**
@@ -237,7 +237,7 @@ public:
    * already has the right size, i.e.  the same size as the <tt>points</tt>
    * array.
    */
-  virtual void gradient_list (const std::vector<Point<dim, Number> > &points,
+  virtual void gradient_list (const std::vector<Point<dim> > &points,
                               std::vector<Tensor<1,dim, Number> >    &gradients,
                               const unsigned int              component = 0) const;
 
@@ -249,7 +249,7 @@ public:
    * value_list() for each component. In order to improve performance, this
    * can be reimplemented in derived classes to speed up performance.
    */
-  virtual void vector_gradients (const std::vector<Point<dim, Number> >            &points,
+  virtual void vector_gradients (const std::vector<Point<dim> >            &points,
                                  std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
 
   /**
@@ -261,33 +261,33 @@ public:
    * The outer loop over <tt>gradients</tt> is over the points in the list,
    * the inner loop over the different components of the function.
    */
-  virtual void vector_gradient_list (const std::vector<Point<dim, Number> >            &points,
+  virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
                                      std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
 
   /**
    * Compute the Laplacian of a given component at point <tt>p</tt>.
    */
-  virtual Number laplacian (const Point<dim, Number>   &p,
+  virtual Number laplacian (const Point<dim>   &p,
                             const unsigned int  component = 0) const;
 
   /**
    * Compute the Laplacian of all components at point <tt>p</tt> and store
    * them in <tt>values</tt>.
    */
-  virtual void vector_laplacian (const Point<dim, Number>   &p,
+  virtual void vector_laplacian (const Point<dim>   &p,
                                  Vector<Number>     &values) const;
 
   /**
    * Compute the Laplacian of one component at a set of points.
    */
-  virtual void laplacian_list (const std::vector<Point<dim, Number> > &points,
+  virtual void laplacian_list (const std::vector<Point<dim> > &points,
                                std::vector<Number>            &values,
                                const unsigned int              component = 0) const;
 
   /**
    * Compute the Laplacians of all components at a set of points.
    */
-  virtual void vector_laplacian_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_laplacian_list (const std::vector<Point<dim> > &points,
                                       std::vector<Vector<Number> >   &values) const;
 
   /**
@@ -329,30 +329,30 @@ public:
    */
   virtual ~ZeroFunction ();
 
-  virtual Number value (const Point<dim, Number>   &p,
+  virtual Number value (const Point<dim>   &p,
                         const unsigned int  component) const;
 
-  virtual void vector_value (const Point<dim, Number> &p,
+  virtual void vector_value (const Point<dim> &p,
                              Vector<Number>   &return_value) const;
 
-  virtual void value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<Number>            &values,
                            const unsigned int              component = 0) const;
 
-  virtual void vector_value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_value_list (const std::vector<Point<dim> > &points,
                                   std::vector<Vector<Number> >   &values) const;
 
-  virtual Tensor<1,dim, Number> gradient (const Point<dim, Number> &p,
+  virtual Tensor<1,dim, Number> gradient (const Point<dim> &p,
                                           const unsigned int component = 0) const;
 
-  virtual void vector_gradient (const Point<dim, Number>            &p,
+  virtual void vector_gradient (const Point<dim>            &p,
                                 std::vector<Tensor<1,dim, Number> > &gradients) const;
 
-  virtual void gradient_list (const std::vector<Point<dim, Number> > &points,
+  virtual void gradient_list (const std::vector<Point<dim> > &points,
                               std::vector<Tensor<1,dim, Number> >    &gradients,
                               const unsigned int              component = 0) const;
 
-  virtual void vector_gradient_list (const std::vector<Point<dim, Number> >            &points,
+  virtual void vector_gradient_list (const std::vector<Point<dim> >            &points,
                                      std::vector<std::vector<Tensor<1,dim, Number> > > &gradients) const;
 };
 
@@ -397,17 +397,17 @@ public:
    */
   virtual ~ConstantFunction ();
 
-  virtual Number value (const Point<dim, Number>   &p,
+  virtual Number value (const Point<dim>   &p,
                         const unsigned int  component) const;
 
-  virtual void   vector_value (const Point<dim, Number> &p,
+  virtual void   vector_value (const Point<dim> &p,
                                Vector<Number>   &return_value) const;
 
-  virtual void value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<Number>            &values,
                            const unsigned int              component = 0) const;
 
-  virtual void vector_value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_value_list (const std::vector<Point<dim> > &points,
                                   std::vector<Vector<Number> >   &values) const;
 
   std::size_t memory_consumption () const;
@@ -468,7 +468,7 @@ public:
   /**
    * Return the value of the function at the given point for all components.
    */
-  virtual void   vector_value (const Point<dim, Number> &p,
+  virtual void   vector_value (const Point<dim> &p,
                                Vector<Number>   &return_value) const;
 
   /**
@@ -477,7 +477,7 @@ public:
    * already has the right size, i.e. the same size as the <tt>points</tt>
    * array.
    */
-  virtual void vector_value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_value_list (const std::vector<Point<dim> > &points,
                                   std::vector<Vector<Number> >   &values) const;
 
   /**
@@ -501,7 +501,7 @@ protected:
 /**
  * This class provides a way to convert a scalar function of the kind
  * @code
- *   Number foo (const Point<dim, Number> &);
+ *   Number foo (const Point<dim> &);
  * @endcode
  * into an object of type Function@<dim@>. Since the argument returns a
  * scalar, the result is clearly a Function object for which
@@ -530,7 +530,7 @@ protected:
  *   template <int dim, typename Number>
  *   class Norm : public Function<dim, Number> {
  *     public:
- *       virtual Number value (const Point<dim, Number> &p,
+ *       virtual Number value (const Point<dim> &p,
  *                             const unsigned int component) const {
  *         Assert (component == 0, ExcMessage ("This object is scalar!"));
  *         return p.norm();
@@ -542,7 +542,7 @@ protected:
  * and then pass the <code>my_norm_object</code> around, or you could write it
  * like so:
  * @code
- *   ScalarFunctionFromFunctionObject<dim, Number> my_norm_object (&Point<dim, Number>::norm);
+ *   ScalarFunctionFromFunctionObject<dim, Number> my_norm_object (&Point<dim>::norm);
  * @endcode
  *
  * Similarly, to generate an object that computes the distance to a point
@@ -551,14 +551,14 @@ protected:
  *   template <int dim, typename Number>
  *   class DistanceTo : public Function<dim, Number> {
  *     public:
- *       DistanceTo (const Point<dim, Number> &q) : q(q) {}
- *       virtual Number value (const Point<dim, Number> &p,
+ *       DistanceTo (const Point<dim> &q) : q(q) {}
+ *       virtual Number value (const Point<dim> &p,
  *                             const unsigned int component) const {
  *         Assert (component == 0, ExcMessage ("This object is scalar!"));
  *         return q.distance(p);
  *       }
  *     private:
- *       const Point<dim, Number> q;
+ *       const Point<dim> q;
  *    };
  *
  *    Point<2> q (2,3);
@@ -567,7 +567,7 @@ protected:
  * or we could write it like so:
  * @code
  *    ScalarFunctionFromFunctionObject<dim, Number>
- *      my_distance_object (std_cxx11::bind (&Point<dim, Number>::distance,
+ *      my_distance_object (std_cxx11::bind (&Point<dim>::distance,
  *                                           q,
  *                                           std_cxx11::_1));
  * @endcode
@@ -584,13 +584,13 @@ public:
    * convert this into an object that matches the Function<dim, Number>
    * interface.
    */
-  ScalarFunctionFromFunctionObject (const std_cxx11::function<Number (const Point<dim, Number> &)> &function_object);
+  ScalarFunctionFromFunctionObject (const std_cxx11::function<Number (const Point<dim> &)> &function_object);
 
   /**
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
    */
-  virtual Number value (const Point<dim, Number>   &p,
+  virtual Number value (const Point<dim>   &p,
                         const unsigned int  component = 0) const;
 
 private:
@@ -598,7 +598,7 @@ private:
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std_cxx11::function<Number (const Point<dim, Number> &)> function_object;
+  const std_cxx11::function<Number (const Point<dim> &)> function_object;
 };
 
 
@@ -651,7 +651,7 @@ public:
    * @param selected_component The single component that should be filled by
    * the first argument.
    */
-  VectorFunctionFromScalarFunctionObject (const std_cxx11::function<Number (const Point<dim, Number> &)> &function_object,
+  VectorFunctionFromScalarFunctionObject (const std_cxx11::function<Number (const Point<dim> &)> &function_object,
                                           const unsigned int selected_component,
                                           const unsigned int n_components);
 
@@ -659,7 +659,7 @@ public:
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
    */
-  virtual Number value (const Point<dim, Number>   &p,
+  virtual Number value (const Point<dim>   &p,
                         const unsigned int  component = 0) const;
 
   /**
@@ -667,7 +667,7 @@ public:
    *
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
-  virtual void vector_value (const Point<dim, Number>   &p,
+  virtual void vector_value (const Point<dim>   &p,
                              Vector<Number>     &values) const;
 
 private:
@@ -675,7 +675,7 @@ private:
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std_cxx11::function<Number (const Point<dim, Number> &)> function_object;
+  const std_cxx11::function<Number (const Point<dim> &)> function_object;
 
   /**
    * The vector component whose value is to be filled by the given scalar
@@ -752,7 +752,7 @@ public:
   /**
    * Return a single component of a vector-valued function at a given point.
    */
-  virtual Number value (const Point<dim, Number> &p,
+  virtual Number value (const Point<dim> &p,
                         const unsigned int component = 0) const;
 
   /**
@@ -760,7 +760,7 @@ public:
    *
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
-  virtual void vector_value (const Point<dim, Number> &p,
+  virtual void vector_value (const Point<dim> &p,
                              Vector<Number>   &values) const;
 
   /**
@@ -770,7 +770,7 @@ public:
    * element of the vector will be passed to vector_value() to evaluate the
    * function
    */
-  virtual void vector_value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void vector_value_list (const std::vector<Point<dim> > &points,
                                   std::vector<Vector<Number> >   &value_list) const;
 
 private:

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -80,27 +80,27 @@ public:
   /**
    * Return the value of the function at the given point.
    */
-  virtual value_type value (const Point<dim, Number> &p) const;
+  virtual value_type value (const Point<dim> &p) const;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
    * <tt>points</tt>.  It is assumed that <tt>values</tt> already has the
    * right size, i.e.  the same size as the <tt>points</tt> array.
    */
-  virtual void value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<value_type> &values) const;
 
   /**
    * Return the gradient of the function at the given point.
    */
-  virtual gradient_type gradient (const Point<dim, Number> &p) const;
+  virtual gradient_type gradient (const Point<dim> &p) const;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the function at the
    * <tt>points</tt>.  It is assumed that <tt>values</tt> already has the
    * right size, i.e.  the same size as the <tt>points</tt> array.
    */
-  virtual void gradient_list (const std::vector<Point<dim, Number> >   &points,
+  virtual void gradient_list (const std::vector<Point<dim> >   &points,
                               std::vector<gradient_type> &gradients) const;
 
   /**
@@ -142,14 +142,14 @@ public:
 
   virtual ~ConstantTensorFunction ();
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::value_type value (const Point<dim, Number> &p) const;
+  virtual typename dealii::TensorFunction<rank, dim, Number>::value_type value (const Point<dim> &p) const;
 
-  virtual void value_list (const std::vector<Point<dim, Number> > &points,
+  virtual void value_list (const std::vector<Point<dim> > &points,
                            std::vector<typename dealii::TensorFunction<rank, dim, Number>::value_type> &values) const;
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::gradient_type gradient (const Point<dim, Number> &p) const;
+  virtual typename dealii::TensorFunction<rank, dim, Number>::gradient_type gradient (const Point<dim> &p) const;
 
-  virtual void gradient_list (const std::vector<Point<dim, Number> > &points,
+  virtual void gradient_list (const std::vector<Point<dim> > &points,
                               std::vector<typename dealii::TensorFunction<rank, dim, Number>::gradient_type> &gradients) const;
 
 private:

--- a/source/base/function.cc
+++ b/source/base/function.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -59,7 +59,7 @@ Function<dim, Number> &Function<dim, Number>::operator= (const Function &f)
 
 
 template <int dim, typename Number>
-Number Function<dim, Number>::value (const Point<dim, Number> &,
+Number Function<dim, Number>::value (const Point<dim> &,
                                      const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
@@ -68,7 +68,7 @@ Number Function<dim, Number>::value (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::vector_value (const Point<dim, Number> &p,
+void Function<dim, Number>::vector_value (const Point<dim> &p,
                                           Vector<Number> &v) const
 {
   AssertDimension(v.size(), this->n_components);
@@ -78,7 +78,7 @@ void Function<dim, Number>::vector_value (const Point<dim, Number> &p,
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::value_list (const std::vector<Point<dim, Number> > &points,
+void Function<dim, Number>::value_list (const std::vector<Point<dim> > &points,
                                         std::vector<Number>                     &values,
                                         const unsigned int                       component) const
 {
@@ -94,7 +94,7 @@ void Function<dim, Number>::value_list (const std::vector<Point<dim, Number> > &
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::vector_value_list (const std::vector<Point<dim, Number> > &points,
+void Function<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
                                                std::vector<Vector<Number> >   &values) const
 {
   // check whether component is in
@@ -110,7 +110,7 @@ void Function<dim, Number>::vector_value_list (const std::vector<Point<dim, Numb
 
 template <int dim, typename Number>
 void Function<dim, Number>::vector_values (
-  const std::vector<Point<dim, Number> > &points,
+  const std::vector<Point<dim> > &points,
   std::vector<std::vector<Number> > &values) const
 {
   const unsigned int n = this->n_components;
@@ -121,17 +121,17 @@ void Function<dim, Number>::vector_values (
 
 
 template <int dim, typename Number>
-Tensor<1,dim,Number> Function<dim, Number>::gradient (const Point<dim, Number> &,
+Tensor<1,dim,Number> Function<dim, Number>::gradient (const Point<dim> &,
                                                       const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
-  return Point<dim, Number>();
+  return Point<dim>();
 }
 
 
 template <int dim, typename Number>
 void Function<dim, Number>::vector_gradient (
-  const Point<dim, Number> &p,
+  const Point<dim> &p,
   std::vector<Tensor<1,dim,Number> > &v) const
 {
   AssertDimension(v.size(), this->n_components);
@@ -141,7 +141,7 @@ void Function<dim, Number>::vector_gradient (
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::gradient_list (const std::vector<Point<dim, Number> > &points,
+void Function<dim, Number>::gradient_list (const std::vector<Point<dim> > &points,
                                            std::vector<Tensor<1,dim,Number> >    &gradients,
                                            const unsigned int              component) const
 {
@@ -154,7 +154,7 @@ void Function<dim, Number>::gradient_list (const std::vector<Point<dim, Number> 
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::vector_gradient_list (const std::vector<Point<dim, Number> >            &points,
+void Function<dim, Number>::vector_gradient_list (const std::vector<Point<dim> >            &points,
                                                   std::vector<std::vector<Tensor<1,dim,Number> > > &gradients) const
 {
   Assert (gradients.size() == points.size(),
@@ -171,7 +171,7 @@ void Function<dim, Number>::vector_gradient_list (const std::vector<Point<dim, N
 
 template <int dim, typename Number>
 void Function<dim, Number>::vector_gradients (
-  const std::vector<Point<dim, Number> > &points,
+  const std::vector<Point<dim> > &points,
   std::vector<std::vector<Tensor<1,dim,Number> > > &values) const
 {
   const unsigned int n = this->n_components;
@@ -183,7 +183,7 @@ void Function<dim, Number>::vector_gradients (
 
 
 template <int dim, typename Number>
-Number Function<dim, Number>::laplacian (const Point<dim, Number> &,
+Number Function<dim, Number>::laplacian (const Point<dim> &,
                                          const unsigned int) const
 {
   Assert (false, ExcPureFunctionCalled());
@@ -192,7 +192,7 @@ Number Function<dim, Number>::laplacian (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::vector_laplacian (const Point<dim, Number> &,
+void Function<dim, Number>::vector_laplacian (const Point<dim> &,
                                               Vector<Number> &) const
 {
   Assert (false, ExcPureFunctionCalled());
@@ -201,7 +201,7 @@ void Function<dim, Number>::vector_laplacian (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::laplacian_list (const std::vector<Point<dim, Number> > &points,
+void Function<dim, Number>::laplacian_list (const std::vector<Point<dim> > &points,
                                             std::vector<Number>            &laplacians,
                                             const unsigned int              component) const
 {
@@ -217,7 +217,7 @@ void Function<dim, Number>::laplacian_list (const std::vector<Point<dim, Number>
 
 
 template <int dim, typename Number>
-void Function<dim, Number>::vector_laplacian_list (const std::vector<Point<dim, Number> > &points,
+void Function<dim, Number>::vector_laplacian_list (const std::vector<Point<dim> > &points,
                                                    std::vector<Vector<Number> >   &laplacians) const
 {
   // check whether component is in
@@ -257,7 +257,7 @@ ZeroFunction<dim, Number>::~ZeroFunction ()
 
 
 template <int dim, typename Number>
-Number ZeroFunction<dim, Number>::value (const Point<dim, Number> &,
+Number ZeroFunction<dim, Number>::value (const Point<dim> &,
                                          const unsigned int) const
 {
   return 0.;
@@ -265,7 +265,7 @@ Number ZeroFunction<dim, Number>::value (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::vector_value (const Point<dim, Number> &,
+void ZeroFunction<dim, Number>::vector_value (const Point<dim> &,
                                               Vector<Number>   &return_value) const
 {
   Assert (return_value.size() == this->n_components,
@@ -276,7 +276,7 @@ void ZeroFunction<dim, Number>::vector_value (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::value_list (const std::vector<Point<dim, Number> > &points,
+void ZeroFunction<dim, Number>::value_list (const std::vector<Point<dim> > &points,
                                             std::vector<Number>            &values,
                                             const unsigned int         /*component*/) const
 {
@@ -288,7 +288,7 @@ void ZeroFunction<dim, Number>::value_list (const std::vector<Point<dim, Number>
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::vector_value_list (const std::vector<Point<dim, Number> > &points,
+void ZeroFunction<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
                                                    std::vector<Vector<Number> >   &values) const
 {
   Assert (values.size() == points.size(),
@@ -304,7 +304,7 @@ void ZeroFunction<dim, Number>::vector_value_list (const std::vector<Point<dim, 
 
 
 template <int dim, typename Number>
-Tensor<1,dim,Number> ZeroFunction<dim, Number>::gradient (const Point<dim, Number> &,
+Tensor<1,dim,Number> ZeroFunction<dim, Number>::gradient (const Point<dim> &,
                                                           const unsigned int) const
 {
   return Tensor<1,dim,Number>();
@@ -312,7 +312,7 @@ Tensor<1,dim,Number> ZeroFunction<dim, Number>::gradient (const Point<dim, Numbe
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::vector_gradient (const Point<dim, Number> &,
+void ZeroFunction<dim, Number>::vector_gradient (const Point<dim> &,
                                                  std::vector<Tensor<1,dim,Number> > &gradients) const
 {
   Assert (gradients.size() == this->n_components,
@@ -324,7 +324,7 @@ void ZeroFunction<dim, Number>::vector_gradient (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::gradient_list (const std::vector<Point<dim, Number> > &points,
+void ZeroFunction<dim, Number>::gradient_list (const std::vector<Point<dim> > &points,
                                                std::vector<Tensor<1,dim,Number> >    &gradients,
                                                const unsigned int              /*component*/) const
 {
@@ -337,7 +337,7 @@ void ZeroFunction<dim, Number>::gradient_list (const std::vector<Point<dim, Numb
 
 
 template <int dim, typename Number>
-void ZeroFunction<dim, Number>::vector_gradient_list (const std::vector<Point<dim, Number> >            &points,
+void ZeroFunction<dim, Number>::vector_gradient_list (const std::vector<Point<dim> >            &points,
                                                       std::vector<std::vector<Tensor<1,dim,Number> > > &gradients) const
 {
   Assert (gradients.size() == points.size(),
@@ -370,7 +370,7 @@ ConstantFunction<dim, Number>::~ConstantFunction () {}
 
 
 template <int dim, typename Number>
-Number ConstantFunction<dim, Number>::value (const Point<dim, Number> &,
+Number ConstantFunction<dim, Number>::value (const Point<dim> &,
                                              const unsigned int component) const
 {
   Assert (component < this->n_components,
@@ -381,7 +381,7 @@ Number ConstantFunction<dim, Number>::value (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void ConstantFunction<dim, Number>::vector_value (const Point<dim, Number> &,
+void ConstantFunction<dim, Number>::vector_value (const Point<dim> &,
                                                   Vector<Number>   &return_value) const
 {
   Assert (return_value.size() == this->n_components,
@@ -393,7 +393,7 @@ void ConstantFunction<dim, Number>::vector_value (const Point<dim, Number> &,
 
 
 template <int dim, typename Number>
-void ConstantFunction<dim, Number>::value_list (const std::vector<Point<dim, Number> > &points,
+void ConstantFunction<dim, Number>::value_list (const std::vector<Point<dim> > &points,
                                                 std::vector<Number>            &values,
                                                 const unsigned int              component) const
 {
@@ -408,7 +408,7 @@ void ConstantFunction<dim, Number>::value_list (const std::vector<Point<dim, Num
 
 
 template <int dim, typename Number>
-void ConstantFunction<dim, Number>::vector_value_list (const std::vector<Point<dim, Number> > &points,
+void ConstantFunction<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
                                                        std::vector<Vector<Number> >   &values) const
 {
   Assert (values.size() == points.size(),
@@ -480,7 +480,7 @@ ComponentSelectFunction (const std::pair<unsigned int,unsigned int> &selected,
 
 
 template <int dim, typename Number>
-void ComponentSelectFunction<dim, Number>::vector_value (const Point<dim, Number> &,
+void ComponentSelectFunction<dim, Number>::vector_value (const Point<dim> &,
                                                          Vector<Number>   &return_value) const
 {
   Assert (return_value.size() == this->n_components,
@@ -495,7 +495,7 @@ void ComponentSelectFunction<dim, Number>::vector_value (const Point<dim, Number
 
 
 template <int dim, typename Number>
-void ComponentSelectFunction<dim, Number>::vector_value_list (const std::vector<Point<dim, Number> > &points,
+void ComponentSelectFunction<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
     std::vector<Vector<Number> >   &values) const
 {
   Assert (values.size() == points.size(),
@@ -520,7 +520,7 @@ ComponentSelectFunction<dim, Number>::memory_consumption () const
 
 template <int dim, typename Number>
 ScalarFunctionFromFunctionObject<dim, Number>::
-ScalarFunctionFromFunctionObject (const std_cxx11::function<Number (const Point<dim, Number> &)> &function_object)
+ScalarFunctionFromFunctionObject (const std_cxx11::function<Number (const Point<dim> &)> &function_object)
   :
   Function<dim, Number>(1),
   function_object (function_object)
@@ -530,7 +530,7 @@ ScalarFunctionFromFunctionObject (const std_cxx11::function<Number (const Point<
 
 template <int dim, typename Number>
 Number
-ScalarFunctionFromFunctionObject<dim, Number>::value (const Point<dim, Number> &p,
+ScalarFunctionFromFunctionObject<dim, Number>::value (const Point<dim> &p,
                                                       const unsigned int component) const
 {
   Assert (component == 0,
@@ -542,7 +542,7 @@ ScalarFunctionFromFunctionObject<dim, Number>::value (const Point<dim, Number> &
 
 template <int dim, typename Number>
 VectorFunctionFromScalarFunctionObject<dim, Number>::
-VectorFunctionFromScalarFunctionObject (const std_cxx11::function<Number (const Point<dim, Number> &)> &function_object,
+VectorFunctionFromScalarFunctionObject (const std_cxx11::function<Number (const Point<dim> &)> &function_object,
                                         const unsigned int selected_component,
                                         const unsigned int n_components)
   :
@@ -558,7 +558,7 @@ VectorFunctionFromScalarFunctionObject (const std_cxx11::function<Number (const 
 
 template <int dim, typename Number>
 Number
-VectorFunctionFromScalarFunctionObject<dim, Number>::value (const Point<dim, Number> &p,
+VectorFunctionFromScalarFunctionObject<dim, Number>::value (const Point<dim> &p,
                                                             const unsigned int component) const
 {
   Assert (component < this->n_components,
@@ -575,7 +575,7 @@ VectorFunctionFromScalarFunctionObject<dim, Number>::value (const Point<dim, Num
 template <int dim, typename Number>
 void
 VectorFunctionFromScalarFunctionObject<dim, Number>::
-vector_value (const Point<dim, Number>   &p,
+vector_value (const Point<dim>   &p,
               Vector<Number>     &values) const
 {
   AssertDimension(values.size(), this->n_components);
@@ -615,7 +615,7 @@ VectorFunctionFromTensorFunction<dim, Number>::~VectorFunctionFromTensorFunction
 
 template <int dim, typename Number>
 inline
-Number VectorFunctionFromTensorFunction<dim, Number>::value (const Point<dim, Number> &p,
+Number VectorFunctionFromTensorFunction<dim, Number>::value (const Point<dim> &p,
     const unsigned int component) const
 {
   Assert (component<this->n_components,
@@ -639,7 +639,7 @@ Number VectorFunctionFromTensorFunction<dim, Number>::value (const Point<dim, Nu
 
 template <int dim, typename Number>
 inline
-void VectorFunctionFromTensorFunction<dim, Number>::vector_value (const Point<dim, Number> &p,
+void VectorFunctionFromTensorFunction<dim, Number>::vector_value (const Point<dim> &p,
     Vector<Number>   &values) const
 {
   Assert(values.size() == this->n_components,
@@ -660,12 +660,12 @@ void VectorFunctionFromTensorFunction<dim, Number>::vector_value (const Point<di
 
 
 /** Member function <tt>vector_value_list </tt> is the interface for giving a list of
- * points (<code>vector<Point<dim, Number> ></code>) of which to evaluate using the <tt>vector_value</tt>
+ * points (<code>vector<Point<dim> ></code>) of which to evaluate using the <tt>vector_value</tt>
  * member function.  Again, this function is written so as to not replicate the function definition
  * but passes each point on to <tt>vector_value</tt> to be evaluated.
  */
 template <int dim, typename Number>
-void VectorFunctionFromTensorFunction<dim, Number>::vector_value_list (const std::vector<Point<dim, Number> > &points,
+void VectorFunctionFromTensorFunction<dim, Number>::vector_value_list (const std::vector<Point<dim> > &points,
     std::vector<Vector<Number> > &value_list) const
 {
   Assert (value_list.size() == points.size(),

--- a/source/base/tensor_function.cc
+++ b/source/base/tensor_function.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -42,7 +42,7 @@ TensorFunction<rank, dim, Number>::~TensorFunction ()
 
 template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::value_type
-TensorFunction<rank, dim, Number>::value (const Point<dim,Number> &) const
+TensorFunction<rank, dim, Number>::value (const Point<dim> &) const
 {
   Assert (false, ExcPureFunctionCalled());
   return Tensor<rank,dim>();
@@ -51,7 +51,7 @@ TensorFunction<rank, dim, Number>::value (const Point<dim,Number> &) const
 
 template <int rank, int dim, typename Number>
 void
-TensorFunction<rank, dim, Number>::value_list (const std::vector<Point<dim,Number> > &points,
+TensorFunction<rank, dim, Number>::value_list (const std::vector<Point<dim> > &points,
                                                std::vector<value_type>        &values) const
 {
   Assert (values.size() == points.size(),
@@ -64,7 +64,7 @@ TensorFunction<rank, dim, Number>::value_list (const std::vector<Point<dim,Numbe
 
 template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::gradient_type
-TensorFunction<rank, dim, Number>::gradient (const Point<dim,Number> &) const
+TensorFunction<rank, dim, Number>::gradient (const Point<dim> &) const
 {
   Assert (false, ExcPureFunctionCalled());
   return Tensor<rank+1,dim>();
@@ -73,7 +73,7 @@ TensorFunction<rank, dim, Number>::gradient (const Point<dim,Number> &) const
 
 template <int rank, int dim, typename Number>
 void
-TensorFunction<rank, dim, Number>::gradient_list (const std::vector<Point<dim,Number> >   &points,
+TensorFunction<rank, dim, Number>::gradient_list (const std::vector<Point<dim> >   &points,
                                                   std::vector<gradient_type> &gradients) const
 {
   Assert (gradients.size() == points.size(),
@@ -106,7 +106,7 @@ ConstantTensorFunction<rank, dim, Number>::~ConstantTensorFunction ()
 
 template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::value_type
-ConstantTensorFunction<rank, dim, Number>::value (const Point<dim,Number> &/*point*/) const
+ConstantTensorFunction<rank, dim, Number>::value (const Point<dim> &/*point*/) const
 {
   return _value;
 }
@@ -114,7 +114,7 @@ ConstantTensorFunction<rank, dim, Number>::value (const Point<dim,Number> &/*poi
 
 template <int rank, int dim, typename Number>
 void
-ConstantTensorFunction<rank, dim, Number>::value_list (const std::vector<Point<dim,Number> > &points,
+ConstantTensorFunction<rank, dim, Number>::value_list (const std::vector<Point<dim> > &points,
                                                        std::vector<typename TensorFunction<rank, dim, Number>::value_type> &values) const
 {
   Assert (values.size() == points.size(),
@@ -127,7 +127,7 @@ ConstantTensorFunction<rank, dim, Number>::value_list (const std::vector<Point<d
 
 template <int rank, int dim, typename Number>
 typename TensorFunction<rank, dim, Number>::gradient_type
-ConstantTensorFunction<rank, dim, Number>::gradient (const Point<dim,Number> &) const
+ConstantTensorFunction<rank, dim, Number>::gradient (const Point<dim> &) const
 {
   static const Tensor<rank+1,dim> zero;
 
@@ -137,7 +137,7 @@ ConstantTensorFunction<rank, dim, Number>::gradient (const Point<dim,Number> &) 
 
 template <int rank, int dim, typename Number>
 void
-ConstantTensorFunction<rank, dim, Number>::gradient_list (const std::vector<Point<dim,Number> >   &points,
+ConstantTensorFunction<rank, dim, Number>::gradient_list (const std::vector<Point<dim> >   &points,
                                                           std::vector<typename TensorFunction<rank, dim, Number>::gradient_type> &gradients) const
 {
   Assert (gradients.size() == points.size(),


### PR DESCRIPTION
This removes the second template argument on `Point<dim,Number>` when used as an argument in `Function` objects.

This addresses one part of #526 