### PR TITLE
Fix bug in energy source term according to Praveen C's report.

### DIFF
--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -314,9 +314,7 @@ namespace Step33
             forcing[c] = gravity * W[density_component];
             break;
           case energy_component:
-            forcing[c] = gravity *
-                         W[density_component] *
-                         W[first_momentum_component+dim-1];
+            forcing[c] = gravity * W[first_momentum_component+dim-1];
             break;
           default:
             forcing[c] = 0;


### PR DESCRIPTION
    The energy source term due to gravity should be rho*g*v=g*momentum.