### PR TITLE
Fix issues with multithreading off and remove deprecated usage

### DIFF
--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -960,7 +960,7 @@ namespace WorkStream
        Copier                                     copier,
        const ScratchData                         &sample_scratch_data,
        const CopyData                            &sample_copy_data,
-       const unsigned int queue_length = 2*multithread_info.n_threads(),
+       const unsigned int queue_length = 2*MultithreadInfo::n_threads(),
        const unsigned int                         chunk_size = 8);
 
 
@@ -1010,7 +1010,7 @@ namespace WorkStream
        Copier                                   copier,
        const ScratchData                       &sample_scratch_data,
        const CopyData                          &sample_copy_data,
-       const unsigned int queue_length = 2*multithread_info.n_threads(),
+       const unsigned int queue_length = 2*MultithreadInfo::n_threads(),
        const unsigned int                       chunk_size = 8)
   {
     Assert (queue_length > 0,
@@ -1029,7 +1029,7 @@ namespace WorkStream
     // we want to use TBB if we have support and if it is not disabled at
     // runtime:
 #ifdef DEAL_II_WITH_THREADS
-    if (multithread_info.n_threads()==1)
+    if (MultithreadInfo::n_threads()==1)
 #endif
       {
         // need to copy the sample since it is marked const
@@ -1135,7 +1135,7 @@ namespace WorkStream
     // we want to use TBB if we have support and if it is not disabled at
     // runtime:
 #ifdef DEAL_II_WITH_THREADS
-    if (multithread_info.n_threads()==1)
+    if (MultithreadInfo::n_threads()==1)
 #endif
       {
         // need to copy the sample since it is marked const
@@ -1236,7 +1236,7 @@ namespace WorkStream
        void (MainClass::*copier) (const CopyData &),
        const ScratchData                       &sample_scratch_data,
        const CopyData                          &sample_copy_data,
-       const unsigned int queue_length =        2*multithread_info.n_threads(),
+       const unsigned int queue_length =        2*MultithreadInfo::n_threads(),
        const unsigned int chunk_size =          8)
   {
     // forward to the other function

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -437,16 +437,16 @@ namespace Utilities
           // if the number would be zero, round up to one since every
           // process needs to have at least one thread
           const unsigned int n_threads
-            = std::max(MultithreadInfo::n_cpus / n_local_processes
+            = std::max(MultithreadInfo::n_cores() / n_local_processes
                        +
-                       (nth_process_on_host <= MultithreadInfo::n_cpus % n_local_processes
+                       (nth_process_on_host <= MultithreadInfo::n_cores() % n_local_processes
                         ?
                         1
                         :
                         0),
                        1U);
 #else
-          const unsigned int n_threads = MultithreadInfo::n_cpus;
+          const unsigned int n_threads = MultithreadInfo::n_cores();
 #endif
 
           // finally set this number of threads

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -173,6 +173,11 @@ unsigned int MultithreadInfo::get_n_cpus()
   return 1;
 }
 
+unsigned int MultithreadInfo::n_cores()
+{
+  return 1;
+}
+
 unsigned int MultithreadInfo::n_threads()
 {
   return 1;


### PR DESCRIPTION
The last change in MultithreadingInfo broke code that was compiled single threaded. Further, workstream.h had a lot of deprecation warnings.

Timo, can you please have a look at multithreading_info.h and see if this is what you intended?