### PR TITLE
more multithread_info fixes

### DIFF
--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -37,10 +37,9 @@ DEAL_II_NAMESPACE_OPEN
  * @ref threads
  * for more information on this.  Thread-based parallel methods need to
  * explicitly created threads and may want to use a number of threads that is
- * related to the number of CPUs in your system. This can be queried using the
- * variable <code> multithread_info.n_cpus; </code> of a global variable
- * <code>multithread_info</code> of this class that, or using <code>
- * multithread_info.n_threads(); </code>
+ * related to the number of CPUs in your system. The recommended number of threads
+ * can be queried using MultithreadInfo::n_threads(), while the number of cores
+ * in the system is returned by MultithreadInfo::n_cores().
  *
  * @ingroup threads
  * @author Thomas Richter, Wolfgang Bangerth, 2000
@@ -66,7 +65,7 @@ public:
 
   /**
    * Returns the number of threads to use. This is initially set to the number
-   * of cores the system has (n_cpus) but can be further restricted by
+   * of cores the system has (see n_cores()) but can be further restricted by
    * set_thread_limit().
    */
   static unsigned int n_threads ();

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -165,7 +165,7 @@ public:
   SparseVanka(const SparseMatrix<number> &M,
               const std::vector<bool>    &selected,
               const bool                  conserve_memory = false,
-              const unsigned int          n_threads       = multithread_info.n_threads());
+              const unsigned int          n_threads       = MultithreadInfo::n_threads());
 
   /**
    * Destructor. Delete all allocated matrices.
@@ -441,7 +441,7 @@ public:
                     const unsigned int          n_blocks,
                     const BlockingStrategy      blocking_strategy,
                     const bool                  conserve_memory = false,
-                    const unsigned int          n_threads       = multithread_info.n_threads());
+                    const unsigned int          n_threads       = MultithreadInfo::n_threads());
 
   /**
    * Apply the preconditioner.

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -1150,7 +1150,7 @@ namespace internal
           result = outer_results[0];
         }
 #ifdef DEAL_II_WITH_THREADS
-      else if (multithread_info.n_threads() > 1 &&
+      else if (MultithreadInfo::n_threads() > 1 &&
                vec_size > 4 * internal::Vector::minimum_parallel_grain_size &&
                depth != 0)
         {
@@ -1161,10 +1161,10 @@ namespace internal
 
           // find out how many recursions we should make (avoid too deep
           // hierarchies of tasks on large vectors), max use 8 *
-          // multithread_info.n_threads()
+          // MultithreadInfo::n_threads()
           int next_depth = depth;
           if (depth == -1)
-            next_depth = 8 * multithread_info.n_threads();
+            next_depth = 8 * MultithreadInfo::n_threads();
           next_depth /= 4;
 
           Threads::TaskGroup<> task_group;

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -795,7 +795,7 @@ no_constraint:
           // we would like to have enough work to do, so as first guess, try
           // to get 50 times as many chunks as we have threads on the system.
           task_info.block_size =
-            size_info.n_macro_cells / (multithread_info.n_threads() * 50);
+            size_info.n_macro_cells / (MultithreadInfo::n_threads() * 50);
 
           // if there are too few degrees of freedom per cell, need to
           // increase the block size

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -203,7 +203,7 @@ public:
     /**
      * Sets the number of so-called macro cells that should form one
      * partition. If zero size is given, the class tries to find a good size
-     * for the blocks based on multithread_info.n_threads() and the number of
+     * for the blocks based on MultithreadInfo::n_threads() and the number of
      * cells present. Otherwise, the given number is used. If the given number
      * is larger than one third of the number of total cells, this means no
      * parallelism. Note that in the case vectorization is used, a macro cell

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -157,7 +157,7 @@ internal_reinit(const Mapping<dim>                          &mapping,
       // passed to the DoFInfo structure
 #ifdef DEAL_II_WITH_THREADS
       if (additional_data.tasks_parallel_scheme != AdditionalData::none &&
-          multithread_info.n_threads() > 1)
+          MultithreadInfo::n_threads() > 1)
         {
           task_info.use_multithreading = true;
           task_info.block_size = additional_data.tasks_block_size;
@@ -287,7 +287,7 @@ internal_reinit(const Mapping<dim>                            &mapping,
       // passed to the DoFInfo structure
 #ifdef DEAL_II_WITH_THREADS
       if (additional_data.tasks_parallel_scheme != AdditionalData::none &&
-          multithread_info.n_threads() > 1)
+          MultithreadInfo::n_threads() > 1)
         {
           task_info.use_multithreading = true;
           task_info.block_size = additional_data.tasks_block_size;

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -98,9 +98,6 @@ unsigned int MultithreadInfo::get_n_cpus()
 
 #  endif
 
-const unsigned int MultithreadInfo::n_cpus = MultithreadInfo::get_n_cpus();
-unsigned int MultithreadInfo::n_max_threads = numbers::invalid_unsigned_int;
-
 unsigned int MultithreadInfo::n_cores()
 {
   return MultithreadInfo::n_cpus;
@@ -209,6 +206,9 @@ MultithreadInfo::memory_consumption ()
   return sizeof (MultithreadInfo);
 }
 
+
+const unsigned int MultithreadInfo::n_cpus = MultithreadInfo::get_n_cpus();
+unsigned int MultithreadInfo::n_max_threads = numbers::invalid_unsigned_int;
 
 // definition of the variable which is declared `extern' in the .h file
 MultithreadInfo multithread_info;

--- a/tests/base/task_09.cc
+++ b/tests/base/task_09.cc
@@ -66,7 +66,7 @@ int main()
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  for (unsigned int i=0; i<MultithreadInfo::n_cpus*2; ++i)
+  for (unsigned int i=0; i<MultithreadInfo::n_cores()*2; ++i)
     Threads::new_task (outer);
 
   deallog << "OK" << std::endl;

--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -60,7 +60,7 @@ int main ()
   if (!getaffinity(bits_set, mask))
     return 1;
 
-  unsigned int nprocs = dealii::MultithreadInfo::n_cpus;
+  unsigned int nprocs = dealii::MultithreadInfo::n_cores();
   unsigned int tbbprocs = dealii::MultithreadInfo::n_threads();
   printf("aff_ncpus=%d, mask=%08X, nprocs=%d, tbb_threads=%d\n",
 	 bits_set, mask, nprocs, tbbprocs );


### PR DESCRIPTION
- initialize static members correctly when THREADS=OFF
- update documentation
- do not use deprecated multithread_info instance
- use n_cores() instead of n_cpus