### PR TITLE
Improve error messages.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -694,13 +694,10 @@ public:
   bool restriction_is_additive (const unsigned int index) const;
 
   /**
-   * Return a read only reference to the matrix which describes the
+   * Return a read only reference to the matrix that describes the
    * constraints at the interface between a refined and an unrefined cell.
    *
-   * The matrix is obviously empty in only one dimension, since there are no
-   * constraints then.
-   *
-   * Note that some finite elements do not (yet) implement hanging node
+   * Some finite elements do not (yet) implement hanging node
    * constraints. If this is the case, then this function will generate an
    * exception, since no useful return value can be generated. If you should
    * have a way to live with this, then you might want to use the
@@ -1628,7 +1625,7 @@ public:
   DeclException0 (ExcUnitShapeValuesDoNotExist);
 
   /**
-   * Attempt to access support points of a finite element which is not
+   * Attempt to access support points of a finite element that is not
    * Lagrangian.
    *
    * @ingroup Exceptions
@@ -1636,7 +1633,7 @@ public:
   DeclException0 (ExcFEHasNoSupportPoints);
 
   /**
-   * Attempt to access embedding matrices of a finite element which did not
+   * Attempt to access embedding matrices of a finite element that did not
    * implement these matrices.
    *
    * @ingroup Exceptions
@@ -1644,22 +1641,13 @@ public:
   DeclException0 (ExcEmbeddingVoid);
 
   /**
-   * Attempt to access restriction matrices of a finite element which did not
+   * Attempt to access restriction matrices of a finite element that did not
    * implement these matrices.
    *
    * Exception
    * @ingroup Exceptions
    */
   DeclException0 (ExcProjectionVoid);
-
-  /**
-   * Attempt to access constraint matrices of a finite element which did not
-   * implement these matrices.
-   *
-   * Exception
-   * @ingroup Exceptions
-   */
-  DeclException0 (ExcConstraintsVoid);
 
   /**
    * Exception

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -821,9 +821,16 @@ template <int dim, int spacedim>
 const FullMatrix<double> &
 FiniteElement<dim,spacedim>::constraints (const internal::SubfaceCase<dim> &subface_case) const
 {
-  Assert (subface_case==internal::SubfaceCase<dim>::case_isotropic, ExcConstraintsVoid());
+  Assert (subface_case==internal::SubfaceCase<dim>::case_isotropic,
+          ExcMessage("Constraints for this element are only implemented "
+                     "for the case that faces are refined isotropically "
+                     "(which is always the case in 2d, and in 3d requires "
+                     "that the neighboring cell of a coarse cell presents "
+                     "exactly four children on the common face)."));
   Assert ((this->dofs_per_face  == 0) || (interface_constraints.m() != 0),
-          ExcConstraintsVoid());
+          ExcMessage ("The finite element for which you try to obtain "
+                      "hanging node constraints does not appear to "
+                      "implement them."));
 
   if (dim==1)
     Assert ((interface_constraints.m()==0) && (interface_constraints.n()==0),


### PR DESCRIPTION
Using bare exceptions without any explanatory text in so many places was a bad idea right from the beginning, though nobody seems to have noticed for a long time. This replaces a bare exception with an ExcMessage in a couple of places.