### PR TITLE
Bux fix for transform_real_to_unit_cell_internal in mapping_q1.cc

### DIFF
--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1687,6 +1687,7 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
     }
 }
 
+
 template<int dim, int spacedim>
 Point<dim>
 MappingQ1<dim,spacedim>::
@@ -1705,169 +1706,157 @@ transform_real_to_unit_cell_internal
 
   /*
   Newton iteration to solve
-  
-      p(x) = p 
-      
-  or, equivalently, 
-  
-      p(x) - p = 0    
-      
-  where we are looking for 'x' and p(x) is the mapping 
-  
-  (1)   x -> p(x)  
-     
-  i.e., the mapping 'transform_unit_to_real_cell'.  We find the (approximate) 
+
+      p(x) = p
+
+  or, equivalently,
+
+      p(x) - p = 0
+
+  where we are looking for 'x' and p(x) is the mapping
+
+  (1)   x -> p(x)
+
+  i.e., the mapping 'transform_unit_to_real_cell'.  We find the (approximate)
   solution using Newton's method:
-  
+
      x_{n+1} = x_n - J(x_n)^{-1} * [p(x_n) - p]
-     
+
   where J(x_n) is the Jacobian of the mapping x -> p(x) in (1) evaluated at the
   point x_n in the unit cell.
-   
+
   To compute the initial guess, the cell is approximated by a rectangle or,
   equivalently, the mapping (1) is approximated by an affine mapping
-  
+
     (2) x -> Ax + b
-  
-  The initial guess x_0 = initial_p_unit is then easily found: 
-  
-  (3) A*x_0 + b = p => x_0 = A^{-1}(p - b). 
-  
+
+  The initial guess x_0 = initial_p_unit is then easily found:
+
+  (3) A*x_0 + b = p => x_0 = A^{-1}(p - b).
+
   (cf. the documentation for transform_real_to_unit_cell_initial_guess function
   for further description of the algorithm for computing A and b).
    */
- 
- const double eps = 1.e-11;
- const unsigned int newton_iteration_limit = 20;
-  
- Point<dim> x_unit_n;
- Point<spacedim> p_real_n; 
- 
- Tensor<1,spacedim> delta_x_unit;
+
+  const double eps = 1.e-11;
+  const unsigned int newton_iteration_limit = 20;
+
+  Point<dim> x_unit_n;
+  Point<spacedim> p_real_n;
+
+  Tensor<1,spacedim> delta_x_unit;
 
   x_unit_n = initial_p_unit;
-  
-/*
-  We need to compare the position of the computed p(x_n) against the given
-  point 'p'. We will terminate the computation after the n-th iteration and 
-  return 'x_n' if they are less than eps apart. The question is: in which 
-  norm do we want 'p' and 'p(x)' to be eps apart.
-  
-  This question is non-trivial since we may have to deal with very elongated
-  cells where we may achieve eps for the distance of these two points in the
-  'long' direction, but achieving this tolerance in the 'short' direction of
-  the cell may not be possible.
-  
-  In other words, the algorithm must take into account the metric anisotropy 
-  of the cell. This means that the error in a measurement depends on the
-  direction in which the measurement is taken. For example, if a cell is very 
-  thin and elongated, a measurement of its length along the "long" direction 
-  has smaller relative error than along the "short" direction, given that the
-  absolute errors in both cases are equal. The converse is also true: if the 
-  relative errors are equal, then the absolute error in the "long" direction 
-  is greater than in the "short" direction.
-  
-  In addition, there is dimensional inconsistency: the real (physical) cell has
-  dimensions of length, whereas the unit (index) cell is dimensionless.
-       
-  Since the Euclidean norm (|| ||_2-norm) does not take anisotropy and 
-  dimensionality into account, we must use another norm: the 'A_norm'.
-  
-  NOTE: The matrix A in the A_norm is not the same matrix A as in the equations (2) and (3)!
-  
-  Thus, the computation must terminate after n-th iteration if 
-    
-    ||p(x_n) - p||_A < eps, where 
-  
-  || ||_A is the A-norm, which is defined as 
-    
-    ||p||_A = sqrt(<A p,p>), 
-	
-  where <,> is the standard inner product in Euclidean space.
-    
-  Thus, if 
-  
-    A = B^T * B,
-	
-  then 
-  
-    <A p,p> = (A p)^T (p) = (B^T B p)^T p = p^T B^T B p = (B p)^T (B p) = <B p, B p>
-    
-  In other words,
 
-    ||p||_A = || p ||_(B^T B) = ||B p||_2
-    
-  Hence,
-  
-    ||p(x_n) - p||_A = ||p(x_n) - p||_(B^T * B) = ||B (p(x_n) - p) ||_2 
-  
-  It is natural to suggest that B should be equal to J(x_n)^(-1). In this case,
-  the distance between p and p(x) is measured in the unit cell, which takes care
-  of both the anisotropy and dimensionality.
-  
-  Thus,
-  
-    B = J(x_n)^(-1) => A
-	
-	  = J(x_n)^(-T) * J(x_n)^(-1), 
-	  
-  and
-        ||p(x_n) - p||_A = ||J(x_n)^(-1) * (p(x_n) - p)||_2 
-    
-  However, recall from the definition of Newton's method that 
-    
-    x_{n+1} = x_n - J(x_n)^{-1} * [p(x_n) - p].
-    
-  Hence,
-    
-    ||x_{n+1} - x_n||_2 = ||J(x_n)^{-1} (p - p(x_n))||_2
-	
-	                    = ||p(x_n) - p||_A
-    
-  Therefore, a condition that is equivalent to 
-  
-    ||p(x_n) - p||_A < eps 
-	
-  for terminating the computation after the n-th iteration is
+  /*
+    We need to compare the position of the computed p(x_n) against the given
+    point 'p'. We will terminate the computation after the n-th iteration and
+    return 'x_n' if they are less than eps apart. The question is: in which
+    norm do we want 'p' and 'p(x)' to be eps apart.
 
-    ||x_{n+1} - x_n||_2 < eps 
-    
-  Thus, if we let
-  
-    delta_x_unit := x_{n+1} - x_n, 
+    This question is non-trivial since we may have to deal with very elongated
+    cells where we may achieve eps for the distance of these two points in the
+    'long' direction, but achieving this tolerance in the 'short' direction of
+    the cell may not be possible.
 
-  then the condition implemented in the following algorithm is 
-      
-      ||delta_x_unit||_2 < eps
-    
-  */
+    In other words, the algorithm must take into account the metric anisotropy
+    of the cell. This means that the error in a measurement depends on the
+    direction in which the measurement is taken. For example, if a cell is very
+    thin and elongated, a measurement of its length along the "long" direction
+    has smaller relative error than along the "short" direction, given that the
+    absolute errors in both cases are equal. The converse is also true: if the
+    relative errors are equal, then the absolute error in the "long" direction
+    is greater than in the "short" direction.
 
-  for(unsigned int newton_iteration = 0; newton_iteration < newton_iteration_limit; newton_iteration++) 
+    In addition, there is dimensional inconsistency: the real (physical) cell has
+    dimensions of length, whereas the unit (index) cell is dimensionless.
+
+    Since the Euclidean norm (|| ||_2-norm) does not take anisotropy and
+    dimensionality into account, we must use another norm: the 'A_norm'.
+
+    NOTE: The matrix A in the A_norm is not the same matrix A as in the equations (2) and (3)!
+
+    Thus, the computation must terminate after n-th iteration if
+
+      ||p(x_n) - p||_A < eps, where
+
+    || ||_A is the A-norm, which is defined as
+
+      ||p||_A = sqrt(<A p,p>),
+
+    where <,> is the standard inner product in Euclidean space.
+
+    Thus, if
+
+      A = B^T * B,
+
+    then
+
+      <A p,p> = (A p)^T (p) = (B^T B p)^T p = p^T B^T B p = (B p)^T (B p) = <B p, B p>
+
+    In other words,
+
+      ||p||_A = || p ||_(B^T B) = ||B p||_2
+
+    Hence,
+
+      ||p(x_n) - p||_A = ||p(x_n) - p||_(B^T * B) = ||B (p(x_n) - p) ||_2
+
+    It is natural to suggest that B should be equal to J(x_n)^(-1). In this case,
+    the distance between p and p(x) is measured in the unit cell, which takes care
+    of both the anisotropy and dimensionality.
+
+    Thus,
+
+      B = J(x_n)^(-1) => A
+
+      = J(x_n)^(-T) * J(x_n)^(-1),
+
+    and
+          ||p(x_n) - p||_A = ||J(x_n)^(-1) * (p(x_n) - p)||_2
+
+    However, recall from the definition of Newton's method that
+
+      x_{n+1} = x_n - J(x_n)^{-1} * [p(x_n) - p].
+
+    Hence,
+
+      ||x_{n+1} - x_n||_2 = ||J(x_n)^{-1} (p - p(x_n))||_2
+
+                        = ||p(x_n) - p||_A
+
+    Therefore, a condition that is equivalent to
+
+      ||p(x_n) - p||_A < eps
+
+    for terminating the computation after the n-th iteration is
+
+      ||x_{n+1} - x_n||_2 < eps
+
+    Thus, if we let
+
+      delta_x_unit := x_{n+1} - x_n,
+
+    then the condition implemented in the following algorithm is
+
+        ||delta_x_unit||_2 < eps
+
+    */
+
+  for (unsigned int newton_iteration = 0; newton_iteration < newton_iteration_limit; newton_iteration++)
     {
-  
-  // shape values and derivatives at x_unit_n
-  compute_shapes(std::vector<Point<dim> > (1, x_unit_n), mdata);
-  
-  // p(x_unit_n)    
-  p_real_n= transform_unit_to_real_cell_internal(mdata);
-      
-      // Initialize the Jacobian
-      Tensor<2, spacedim> J;
-      
-/*     
-  TODO: Would this be more efficient/cheaper?
-  
-   for (unsigned int i=0; i<spacedim; ++i)
-            for (unsigned int j=0; j<dim; ++j)
-              J[i][j]=0;
-	    
-	    or, perhaps
-	    
-    J.clear();
 
-*/
+      // shape values and derivatives at x_unit_n
+      compute_shapes(std::vector<Point<dim> > (1, x_unit_n), mdata);
+
+      // p(x_unit_n)
+      p_real_n= transform_unit_to_real_cell_internal(mdata);
+
+      // Initialize the Jacobian with a null matrix
+      Tensor<2, spacedim> J;
+
       // Now compute the Jacobian, J(x_unit_n)
-      
+
       for (unsigned int k=0; k<mdata.n_shape_functions; ++k)
         {
           const Tensor<1,dim> &grad_transform=mdata.derivative(0,k);
@@ -1877,54 +1866,53 @@ transform_real_to_unit_cell_internal
             for (unsigned int j=0; j<dim; ++j)
               J[i][j]+=point[i]*grad_transform[j];
         }
-    
-    /*
-      Compute the correction for x_unit_n: 
-	 	delta_x_unit = x_{n+1} - x_n = - J(x_unit_n)^(-1) * (p(x_unit_n) - p)
+
+      /*
+        Compute the correction for x_unit_n:
+      delta_x_unit = x_{n+1} - x_n = - J(x_unit_n)^(-1) * (p(x_unit_n) - p)
+
       Equivalently, avoiding the minus sign for clarity,
-	 	delta_x_unit = x_{n+1} - x_n = J(x_unit_n)^(-1) * (p - p(x_unit_n))
-	 	*/
+      delta_x_unit = x_{n+1} - x_n = J(x_unit_n)^(-1) * (p - p(x_unit_n))
+      */
 
       contract (delta_x_unit, invert(J), static_cast<const Tensor<1,spacedim>&>(p-p_real_n));
 
       /*
       Return x_unit_n if the norm of the correction is less than eps,
-      i.e. if further correction of x_unit_n is smaller than the tolerance value. 
+      i.e. if further correction of x_unit_n is smaller than the tolerance value.
       */
 
 #ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
-  std::cout << "Iteration = " << newton_iteration << std::endl
-            << "\tNorm: ||p_real_n - p|| = " << (p_real_n-p).norm() << std::endl 
-            << "\tNorm of the correction: ||delta_x_unit|| = ||x_" << newton_iteration + 1 << " - x_" << newton_iteration << "|| = " << delta_x_unit.norm() << std::endl
-	    << "\t||delta|| / eps = " << delta_x_unit.norm()/eps << ", where eps = " << eps << std::endl;     
-#endif 
-      
-      if (delta_x_unit.norm() < eps) 
-      return x_unit_n; 
-      
-/*      
-    Otherwise, correct x_unit_n with delta_x_unit and do another iteration.
-	  The spacedim-th component of transformed point is simply ignored 
-	  in the codimension one case. When this component is not zero, then we 
-	  are projecting the point to the surface or curve identified by the cell.*/
+      std::cout << "Iteration = " << newton_iteration << std::endl
+                << "\tNorm: ||p_real_n - p|| = " << (p_real_n-p).norm() << std::endl
+                << "\tNorm of the correction: ||delta_x_unit|| = ||x_" << newton_iteration + 1 << " - x_" << newton_iteration << "|| = " << delta_x_unit.norm() << std::endl
+                << "\t||delta|| / eps = " << delta_x_unit.norm()/eps << ", where eps = " << eps << std::endl;
+#endif
 
-	  for (unsigned int i=0; i<dim; ++i)
-		x_unit_n[i] += delta_x_unit[i];
-	  
+      if (delta_x_unit.norm() < eps)
+        return x_unit_n;
+
+      /*
+          Otherwise, correct x_unit_n with delta_x_unit and do another iteration.
+          The spacedim-th component of transformed point is simply ignored
+          in the codimension one case. When this component is not zero, then we
+          are projecting the point to the surface or curve identified by the cell.*/
+
+      x_unit_n += delta_x_unit;
+
     }
-    
- /* 
- Throw an exception if the number of iterations exceedes newton_iteration_limit,
- i.e., indicate that the numerical process failed to converge within the given constraints.
- */   
-    
- AssertThrow (false, 
-	      (typename Mapping<dim,spacedim>::ExcTransformationFailed())); 
- 
- return x_unit_n;
-  
-}
 
+  /*
+  Throw an exception if the number of iterations exceedes newton_iteration_limit,
+  i.e., indicate that the numerical process failed to converge within the given constraints.
+  */
+
+  AssertThrow (false,
+               (typename Mapping<dim,spacedim>::ExcTransformationFailed()));
+
+  return x_unit_n;
+
+}
 
 /*
   This function becomes a little tricky in dimension <2,3>.

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1687,8 +1687,6 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
     }
 }
 
-
-
 template<int dim, int spacedim>
 Point<dim>
 MappingQ1<dim,spacedim>::
@@ -1705,73 +1703,171 @@ transform_real_to_unit_cell_internal
   std::vector<Point<spacedim> > &points=mdata.mapping_support_points;
   AssertDimension (points.size(), n_shapes);
 
+  /*
+  Newton iteration to solve
+  
+      p(x) = p 
+      
+  or, equivalently, 
+  
+      p(x) - p = 0    
+      
+  where we are looking for 'x' and p(x) is the mapping 
+  
+  (1)   x -> p(x)  
+     
+  i.e., the mapping 'transform_unit_to_real_cell'.  We find the (approximate) 
+  solution using Newton's method:
+  
+     x_{n+1} = x_n - J(x_n)^{-1} * [p(x_n) - p]
+     
+  where J(x_n) is the Jacobian of the mapping x -> p(x) in (1) evaluated at the
+  point x_n in the unit cell.
+   
+  To compute the initial guess, the cell is approximated by a rectangle or,
+  equivalently, the mapping (1) is approximated by an affine mapping
+  
+    (2) x -> Ax + b
+  
+  The initial guess x_0 = initial_p_unit is then easily found: 
+  
+  (3) A*x_0 + b = p => x_0 = A^{-1}(p - b). 
+  
+  (cf. the documentation for transform_real_to_unit_cell_initial_guess function
+  for further description of the algorithm for computing A and b).
+   */
+ 
+ const double eps = 1.e-11;
+ const unsigned int newton_iteration_limit = 20;
+  
+ Point<dim> x_unit_n;
+ Point<spacedim> p_real_n; 
+ 
+ Tensor<1,spacedim> delta_x_unit;
 
-  // Newton iteration to solve
-  //    f(x)=p(x)-p=0
-  // where we are looking for 'x' and p(x) is the forward transformation
-  // from unit to real cell. We solve this using a Newton iteration
-  //    x_{n+1}=x_n-[f'(x)]^{-1}f(x)
-  // The start value is set to be the linear approximation to the cell
+  x_unit_n = initial_p_unit;
+  
+/*
+  We need to compare the position of the computed p(x_n) against the given
+  point 'p'. We will terminate the computation after the n-th iteration and 
+  return 'x_n' if they are less than eps apart. The question is: in which 
+  norm do we want 'p' and 'p(x)' to be eps apart.
+  
+  This question is non-trivial since we may have to deal with very elongated
+  cells where we may achieve eps for the distance of these two points in the
+  'long' direction, but achieving this tolerance in the 'short' direction of
+  the cell may not be possible.
+  
+  In other words, the algorithm must take into account the metric anisotropy 
+  of the cell. This means that the error in a measurement depends on the
+  direction in which the measurement is taken. For example, if a cell is very 
+  thin and elongated, a measurement of its length along the "long" direction 
+  has smaller relative error than along the "short" direction, given that the
+  absolute errors in both cases are equal. The converse is also true: if the 
+  relative errors are equal, then the absolute error in the "long" direction 
+  is greater than in the "short" direction.
+  
+  In addition, there is dimensional inconsistency: the real (physical) cell has
+  dimensions of length, whereas the unit (index) cell is dimensionless.
+       
+  Since the Euclidean norm (|| ||_2-norm) does not take anisotropy and 
+  dimensionality into account, we must use another norm: the 'A_norm'.
+  
+  NOTE: The matrix A in the A_norm is not the same matrix A as in the equations (2) and (3)!
+  
+  Thus, the computation must terminate after n-th iteration if 
+    
+    ||p(x_n) - p||_A < eps, where 
+  
+  || ||_A is the A-norm, which is defined as 
+    
+    ||p||_A = sqrt(<A p,p>), 
+	
+  where <,> is the standard inner product in Euclidean space.
+    
+  Thus, if 
+  
+    A = B^T * B,
+	
+  then 
+  
+    <A p,p> = (A p)^T (p) = (B^T B p)^T p = p^T B^T B p = (B p)^T (B p) = <B p, B p>
+    
+  In other words,
 
-  // The shape values and derivatives of the mapping at this point are
-  // previously computed.
+    ||p||_A = || p ||_(B^T B) = ||B p||_2
+    
+  Hence,
+  
+    ||p(x_n) - p||_A = ||p(x_n) - p||_(B^T * B) = ||B (p(x_n) - p) ||_2 
+  
+  It is natural to suggest that B should be equal to J(x_n)^(-1). In this case,
+  the distance between p and p(x) is measured in the unit cell, which takes care
+  of both the anisotropy and dimensionality.
+  
+  Thus,
+  
+    B = J(x_n)^(-1) => A
+	
+	  = J(x_n)^(-T) * J(x_n)^(-1), 
+	  
+  and
+        ||p(x_n) - p||_A = ||J(x_n)^(-1) * (p(x_n) - p)||_2 
+    
+  However, recall from the definition of Newton's method that 
+    
+    x_{n+1} = x_n - J(x_n)^{-1} * [p(x_n) - p].
+    
+  Hence,
+    
+    ||x_{n+1} - x_n||_2 = ||J(x_n)^{-1} (p - p(x_n))||_2
+	
+	                    = ||p(x_n) - p||_A
+    
+  Therefore, a condition that is equivalent to 
+  
+    ||p(x_n) - p||_A < eps 
+	
+  for terminating the computation after the n-th iteration is
 
-  Point<dim> p_unit = initial_p_unit;
+    ||x_{n+1} - x_n||_2 < eps 
+    
+  Thus, if we let
+  
+    delta_x_unit := x_{n+1} - x_n, 
 
-  compute_shapes(std::vector<Point<dim> > (1, p_unit), mdata);
-  Point<spacedim> p_real = transform_unit_to_real_cell_internal(mdata);
-  Tensor<1,spacedim> f = p_real-p;
+  then the condition implemented in the following algorithm is 
+      
+      ||delta_x_unit||_2 < eps
+    
+  */
 
-  // early out if we already have our point
-  if (f.norm_square() < 1e-24 * cell->diameter() * cell->diameter())
-    return p_unit;
-
-  // we need to compare the position of the computed p(x) against the given
-  // point 'p'. We will terminate the iteration and return 'x' if they are
-  // less than eps apart. The question is how to choose eps -- or, put maybe
-  // more generally: in which norm we want these 'p' and 'p(x)' to be eps
-  // apart.
-  //
-  // the question is difficult since we may have to deal with very elongated
-  // cells where we may achieve 1e-12*h for the distance of these two points
-  // in the 'long' direction, but achieving this tolerance in the 'short'
-  // direction of the cell may not be possible
-  //
-  // what we do instead is then to terminate iterations if
-  //    \| p(x) - p \|_A < eps
-  // where the A-norm is somehow induced by the transformation of the cell.
-  // in particular, we want to measure distances relative to the sizes of
-  // the cell in its principal directions.
-  //
-  // to define what exactly A should be, note that to first order we have
-  // the following (assuming that x* is the solution of the problem, i.e.,
-  // p(x*)=p):
-  //    p(x) - p = p(x) - p(x*)
-  //             = -grad p(x) * (x*-x) + higher order terms
-  // This suggest to measure with a norm that corresponds to
-  //    A = {[grad p(x]^T [grad p(x)]}^{-1}
-  // because then
-  //    \| p(x) - p \|_A  \approx  \| x - x* \|
-  // Consequently, we will try to enforce that
-  //    \| p(x) - p \|_A  =  \| f \|  <=  eps
-  //
-  // Note that using this norm is a bit dangerous since the norm changes
-  // in every iteration (A isn't fixed by depends on xk). However, if the
-  // cell is not too deformed (it may be stretched, but not twisted) then
-  // the mapping is almost linear and A is indeed constant or nearly so.
-  const double eps = 1.e-11;
-  const unsigned int newton_iteration_limit = 20;
-
-  unsigned int newton_iteration = 0;
-  double last_f_weighted_norm;
-  do
+  for(unsigned int newton_iteration = 0; newton_iteration < newton_iteration_limit; newton_iteration++) 
     {
-#ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
-      std::cout << "Newton iteration " << newton_iteration << std::endl;
-#endif
+  
+  // shape values and derivatives at x_unit_n
+  compute_shapes(std::vector<Point<dim> > (1, x_unit_n), mdata);
+  
+  // p(x_unit_n)    
+  p_real_n= transform_unit_to_real_cell_internal(mdata);
+      
+      // Initialize the Jacobian
+      Tensor<2, spacedim> J;
+      
+/*     
+  TODO: Would this be more efficient/cheaper?
+  
+   for (unsigned int i=0; i<spacedim; ++i)
+            for (unsigned int j=0; j<dim; ++j)
+              J[i][j]=0;
+	    
+	    or, perhaps
+	    
+    J.clear();
 
-      // f'(x)
-      Tensor<2,spacedim> df;
+*/
+      // Now compute the Jacobian, J(x_unit_n)
+      
       for (unsigned int k=0; k<mdata.n_shape_functions; ++k)
         {
           const Tensor<1,dim> &grad_transform=mdata.derivative(0,k);
@@ -1779,86 +1875,62 @@ transform_real_to_unit_cell_internal
 
           for (unsigned int i=0; i<spacedim; ++i)
             for (unsigned int j=0; j<dim; ++j)
-              df[i][j]+=point[i]*grad_transform[j];
+              J[i][j]+=point[i]*grad_transform[j];
         }
+    
+    /*
+      Compute the correction for x_unit_n: 
+	 	delta_x_unit = x_{n+1} - x_n = - J(x_unit_n)^(-1) * (p(x_unit_n) - p)
+      Equivalently, avoiding the minus sign for clarity,
+	 	delta_x_unit = x_{n+1} - x_n = J(x_unit_n)^(-1) * (p - p(x_unit_n))
+	 	*/
 
-      // Solve  [f'(x)]d=f(x)
-      Tensor<1,spacedim> delta;
-      Tensor<2,spacedim> df_inverse = invert(df);
-      contract (delta, df_inverse, static_cast<const Tensor<1,spacedim>&>(f));
+      contract (delta_x_unit, invert(J), static_cast<const Tensor<1,spacedim>&>(p-p_real_n));
+
+      /*
+      Return x_unit_n if the norm of the correction is less than eps,
+      i.e. if further correction of x_unit_n is smaller than the tolerance value. 
+      */
 
 #ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
-      std::cout << "   delta=" << delta  << std::endl;
-#endif
+  std::cout << "Iteration = " << newton_iteration << std::endl
+            << "\tNorm: ||p_real_n - p|| = " << (p_real_n-p).norm() << std::endl 
+            << "\tNorm of the correction: ||delta_x_unit|| = ||x_" << newton_iteration + 1 << " - x_" << newton_iteration << "|| = " << delta_x_unit.norm() << std::endl
+	    << "\t||delta|| / eps = " << delta_x_unit.norm()/eps << ", where eps = " << eps << std::endl;     
+#endif 
+      
+      if (delta_x_unit.norm() < eps) 
+      return x_unit_n; 
+      
+/*      
+    Otherwise, correct x_unit_n with delta_x_unit and do another iteration.
+	  The spacedim-th component of transformed point is simply ignored 
+	  in the codimension one case. When this component is not zero, then we 
+	  are projecting the point to the surface or curve identified by the cell.*/
 
-      // do a line search
-      double step_length = 1;
-      do
-        {
-          // update of p_unit. The spacedim-th component of transformed point
-          // is simply ignored in codimension one case. When this component is
-          // not zero, then we are projecting the point to the surface or
-          // curve identified by the cell.
-          Point<dim> p_unit_trial = p_unit;
-          for (unsigned int i=0; i<dim; ++i)
-            p_unit_trial[i] -= step_length * delta[i];
-
-          // shape values and derivatives
-          // at new p_unit point
-          compute_shapes(std::vector<Point<dim> > (1, p_unit_trial), mdata);
-
-          // f(x)
-          Point<spacedim> p_real_trial = transform_unit_to_real_cell_internal(mdata);
-          const Tensor<1,spacedim> f_trial = p_real_trial-p;
-
-#ifdef DEBUG_TRANSFORM_REAL_TO_UNIT_CELL
-          std::cout << "     step_length=" << step_length << std::endl
-                    << "       ||f ||   =" << f.norm() << std::endl
-                    << "       ||f*||   =" << f_trial.norm() << std::endl
-                    << "       ||f*||_A =" << (df_inverse * f_trial).norm() << std::endl;
-#endif
-
-          // see if we are making progress with the current step length
-          // and if not, reduce it by a factor of two and try again
-          //
-          // strictly speaking, we should probably use the same norm as we use
-          // for the outer algorithm. in practice, line search is just a
-          // crutch to find a "reasonable" step length, and so using the l2
-          // norm is probably just fine
-          if (f_trial.norm() < f.norm())
-            {
-              p_real = p_real_trial;
-              p_unit = p_unit_trial;
-              f = f_trial;
-              break;
-            }
-          else if (step_length > 0.05)
-            step_length /= 2;
-          else
-            AssertThrow (false,
-                         (typename Mapping<dim,spacedim>::ExcTransformationFailed()));
-        }
-      while (true);
-
-      ++newton_iteration;
-      if (newton_iteration > newton_iteration_limit)
-        AssertThrow (false,
-                     (typename Mapping<dim,spacedim>::ExcTransformationFailed()));
-      last_f_weighted_norm = (df_inverse * f).norm();
+	  for (unsigned int i=0; i<dim; ++i)
+		x_unit_n[i] += delta_x_unit[i];
+	  
     }
-  while (last_f_weighted_norm > eps);
-
-  return p_unit;
+    
+ /* 
+ Throw an exception if the number of iterations exceedes newton_iteration_limit,
+ i.e., indicate that the numerical process failed to converge within the given constraints.
+ */   
+    
+ AssertThrow (false, 
+	      (typename Mapping<dim,spacedim>::ExcTransformationFailed())); 
+ 
+ return x_unit_n;
+  
 }
-
 
 
 /*
   This function becomes a little tricky in dimension <2,3>.
   There is a surface embedded in R^3 and we pass a point p in R^3, that
   is most likely not lying on the surface.
-  We then ask,
-  what point in R^2 (hopefully in the unit cell) satisfies that
+  We then ask, what point in R^2 (hopefully in the unit cell) satisfies that
   map(x) = p.
 
   An appropriate modification of this question is:


### PR DESCRIPTION
Rewrite of transform_real_to_unit_cell_internal in mapping_q1.cc in order to fix the bug noted in Giorgos Kourako's post 'transform_real_to_unit_cell instability?' on 5/8/2014 in the dealii user group by Professor E. G. Puckett's CIG REU Group.