### PR TITLE
Add a local typedef IndexSet::value_type.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -350,6 +350,11 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> New: IndexSet now has a local typedef IndexSet::value_type/
+  <br>
+  (Wolfgang Bangerth, 2015/02/22)
+  </li>
+
   <li> Fixed: MappingQEulerian would previously not move interior points
   in 1D for higher order mappings. This has been fixed by removing a few
   specializations of MappingQ for 1D that are no longer necessary.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -350,7 +350,7 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
-  <li> New: IndexSet now has a local typedef IndexSet::value_type/
+  <li> New: IndexSet now has a local typedef IndexSet::value_type.
   <br>
   (Wolfgang Bangerth, 2015/02/22)
   </li>

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -60,6 +60,27 @@ class IndexSet
 {
 public:
   /**
+   * One can see an IndexSet as a container of size size(), where the
+   * elements of the containers are bool values that are either false
+   * or true, depending on whether a particular index is an element of
+   * the IndexSet or not. In other words, an IndexSet is a bit like a
+   * vector in which the elements we store are booleans. In this view,
+   * the correct local typedef indicating the type of the elements of
+   * the vector would then be @p bool.
+   *
+   * On the other hand, @p bool has the disadvantage that it is not a
+   * numerical type that, for example, allows multiplication with a @p
+   * double. In other words, one can not easily use a vector of
+   * booleans in a place where other vectors are
+   * allowed. Consequently, we declare the type of the elements of
+   * such a vector as a signed integer. This uses the fact that in the
+   * C++ language, booleans are implicitly convertible to integers. In
+   * other words, declaring the type of the elements of the vector as
+   * a signed integer is only a small lie, but it is a useful one.
+   */
+  typedef signed int value_type;
+
+  /**
    * Default constructor.
    */
   IndexSet ();


### PR DESCRIPTION
We'll need this for making FEValues::get_function_values work for arbitrary scalar types.