### PR TITLE
empty string in split_string_list fix

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -219,7 +219,7 @@ namespace Utilities
                (name[0] == ' '))
           name.erase (0,1);
 
-        while (name[name.length()-1] == ' ')
+        while (name[name.length()-1] == ' ' && name.length() != 0)
           name.erase (name.length()-1, 1);
 
         split_list.push_back (name);

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -219,7 +219,7 @@ namespace Utilities
                (name[0] == ' '))
           name.erase (0,1);
 
-        while (name[name.length()-1] == ' ' && name.length() != 0)
+        while (name.length() != 0 && name[name.length()-1] == ' ')
           name.erase (name.length()-1, 1);
 
         split_list.push_back (name);


### PR DESCRIPTION
When an empty string or a string with only spaces is given to this function, the split_string_list function will ask in line 222 for name[-1], which will result in unpredictable behaviour. I propose to prevent this by adding a condition that the length of the string may not be 0.