### PR TITLE
PETSc mat compress

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -270,7 +270,7 @@ namespace PETScWrappers
      * @ref GlossCompress "Compressing distributed objects"
      * for more information.
      */
-    void compress (::dealii::VectorOperation::values operation);
+    void compress (const VectorOperation::values operation);
 
     /**
      * Set all components of the vector to the given number @p s. Simply pass
@@ -741,7 +741,7 @@ namespace PETScWrappers
      * variable is @p mutable so that the accessor classes can write to it,
      * even though the vector object they refer to is constant.
      */
-    mutable ::dealii::VectorOperation::values last_action;
+    mutable VectorOperation::values last_action;
 
     /**
      * Make the reference class a friend.

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -567,6 +567,8 @@ namespace PETScWrappers
                                     local_columns_per_process.size()));
       Assert (this_process < local_rows_per_process.size(),
               ExcInternalError());
+      assert_is_compressed ();
+
       // for each row that we own locally, we
       // have to count how many of the
       // entries in the sparsity pattern lie
@@ -753,13 +755,12 @@ namespace PETScWrappers
               }
           }
 
-          compress ();
+          compress (VectorOperation::insert);
 
           // set the dummy entries set above
           // back to zero
           *this = 0;
 #endif // version <=2.3.3
-          compress ();
 
 
           // Tell PETSc that we are not

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -262,7 +262,7 @@ namespace PETScWrappers
                           row_lengths[i], &row_entries[0],
                           &row_values[0], INSERT_VALUES);
           }
-        compress ();
+        compress (VectorOperation::insert);
 
 
         // Tell PETSc that we are not

--- a/source/numerics/matrix_tools.cc
+++ b/source/numerics/matrix_tools.cc
@@ -2410,7 +2410,6 @@ namespace MatrixTools
           }
 
         // clean up
-        matrix.compress ();
         solution.compress (VectorOperation::insert);
         right_hand_side.compress (VectorOperation::insert);
       }
@@ -2445,9 +2444,6 @@ namespace MatrixTools
     // used for both petsc matrix types
     internal::PETScWrappers::apply_boundary_values (boundary_values, matrix, solution,
                                                     right_hand_side, eliminate_columns);
-
-    // compress the matrix once we're done
-    matrix.compress ();
   }
 
 

--- a/tests/mpi/petsc_distribute_01_block.cc
+++ b/tests/mpi/petsc_distribute_01_block.cc
@@ -52,7 +52,7 @@ void test()
     vec.block(0)(i) = i;
   for (unsigned int i=vec.block(1).local_range().first; i<vec.block(1).local_range().second; ++i)
     vec.block(1)(i) = i;
-  vec.compress(VectorOperation::add);
+  vec.compress(VectorOperation::insert);
 
   // verify correctness so far
   {

--- a/tests/petsc/01.cc
+++ b/tests/petsc/01.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then make sure we retrieve the same ones
   for (unsigned int i=0; i<m.m(); ++i)

--- a/tests/petsc/05.cc
+++ b/tests/petsc/05.cc
@@ -37,7 +37,7 @@ void test (PETScWrappers::SparseMatrix &m)
           ++counter;
         }
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   deallog << m.n_nonzero_elements() << std::endl;
   Assert (m.n_nonzero_elements() == counter,

--- a/tests/petsc/06.cc
+++ b/tests/petsc/06.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // compare against the exact value of the
   // l1-norm (max col-sum)

--- a/tests/petsc/07.cc
+++ b/tests/petsc/07.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // compare against the exact value of the
   // linfty-norm (max row-sum)

--- a/tests/petsc/08.cc
+++ b/tests/petsc/08.cc
@@ -37,7 +37,7 @@ void test (PETScWrappers::SparseMatrix &m)
         }
   norm = std::sqrt(norm);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // compare against the exact value of the
   // l2-norm (max row-sum)

--- a/tests/petsc/09.cc
+++ b/tests/petsc/09.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then multiply everything by 1.25 and
   // make sure we retrieve the values we

--- a/tests/petsc/10.cc
+++ b/tests/petsc/10.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then divide everything by 4/3 and
   // make sure we retrieve the values we

--- a/tests/petsc/11.cc
+++ b/tests/petsc/11.cc
@@ -29,7 +29,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); i+=1+i)
     v(i) = i;
 
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   Assert (v.size() == 100, ExcInternalError());
 

--- a/tests/petsc/12.cc
+++ b/tests/petsc/12.cc
@@ -36,7 +36,7 @@ void test (PETScWrappers::Vector &v)
       pattern[i] = true;
     }
 
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // check that they are ok, and this time
   // all of them

--- a/tests/petsc/17.cc
+++ b/tests/petsc/17.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       norm += std::fabs(1.*i);
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then check the norm
   Assert (v.l1_norm() == norm, ExcInternalError());

--- a/tests/petsc/19.cc
+++ b/tests/petsc/19.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       norm = std::max(norm,fabs(i));
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then check the norm
   Assert (v.linfty_norm() == norm, ExcInternalError());

--- a/tests/petsc/20.cc
+++ b/tests/petsc/20.cc
@@ -35,7 +35,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       pattern[i] = true;
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // multiply v with 5/4
   v *= 5./4.;

--- a/tests/petsc/21.cc
+++ b/tests/petsc/21.cc
@@ -35,7 +35,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       pattern[i] = true;
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // multiply v with 3/4
   v /= 4./3.;

--- a/tests/petsc/22.cc
+++ b/tests/petsc/22.cc
@@ -35,8 +35,8 @@ void test (PETScWrappers::Vector &v,
       v(i) = i;
     else
       w(i) = i;
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // make sure the scalar product is zero
   Assert (v*w == 0, ExcInternalError());

--- a/tests/petsc/23.cc
+++ b/tests/petsc/23.cc
@@ -42,8 +42,8 @@ void test (PETScWrappers::Vector &v,
         }
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // make sure the scalar product is zero
   Assert (v*w == product, ExcInternalError());

--- a/tests/petsc/24.cc
+++ b/tests/petsc/24.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then clear it again and make sure the
   // vector is really empty

--- a/tests/petsc/25.cc
+++ b/tests/petsc/25.cc
@@ -30,7 +30,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then clear it again and make sure the
   // vector is really empty

--- a/tests/petsc/26.cc
+++ b/tests/petsc/26.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   const unsigned int sz = v.size();
   v = 2;

--- a/tests/petsc/27.cc
+++ b/tests/petsc/27.cc
@@ -30,7 +30,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then copy it
   PETScWrappers::Vector w (v.size());

--- a/tests/petsc/28.cc
+++ b/tests/petsc/28.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then copy it to a vector of different
   // size

--- a/tests/petsc/31.cc
+++ b/tests/petsc/31.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       norm += std::fabs(1.*i)*std::fabs(1.*i);
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then check the norm
   const double eps=typeid(PetscScalar)==typeid(double) ? 1e-14 : 1e-5;

--- a/tests/petsc/32.cc
+++ b/tests/petsc/32.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       sum += i;
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then check the norm
   const double eps=typeid(PetscScalar)==typeid(double) ? 1e-14 : 1e-5;

--- a/tests/petsc/33.cc
+++ b/tests/petsc/33.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       sum += i*i*i;
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then check the norm
   const double eps=typeid(PetscScalar)==typeid(double) ? 1e-14 : 1e-5;

--- a/tests/petsc/34.cc
+++ b/tests/petsc/34.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::Vector &v)
       v(i) = i;
       sum += i*i*i;
     }
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // set them to zero again
   v = 0;

--- a/tests/petsc/35.cc
+++ b/tests/petsc/35.cc
@@ -36,8 +36,8 @@ void test (PETScWrappers::Vector &v,
         w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v += w;
 

--- a/tests/petsc/36.cc
+++ b/tests/petsc/36.cc
@@ -36,8 +36,8 @@ void test (PETScWrappers::Vector &v,
         w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v -= w;
 

--- a/tests/petsc/37.cc
+++ b/tests/petsc/37.cc
@@ -29,7 +29,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   v.add (1.);
 

--- a/tests/petsc/38.cc
+++ b/tests/petsc/38.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.add (w);
 

--- a/tests/petsc/39.cc
+++ b/tests/petsc/39.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.add (2, w);
 

--- a/tests/petsc/40.cc
+++ b/tests/petsc/40.cc
@@ -35,9 +35,9 @@ void test (PETScWrappers::Vector &v,
       x(i) = i+2.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
-  x.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
+  x.compress (VectorOperation::insert);
 
   v.add (2, w, 3, x);
 

--- a/tests/petsc/41.cc
+++ b/tests/petsc/41.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.sadd (2, w);
 

--- a/tests/petsc/42.cc
+++ b/tests/petsc/42.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.sadd (3, 2, w);
 

--- a/tests/petsc/43.cc
+++ b/tests/petsc/43.cc
@@ -35,9 +35,9 @@ void test (PETScWrappers::Vector &v,
       x(i) = i+2.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
-  x.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
+  x.compress (VectorOperation::insert);
 
   v.sadd (1.5, 2, w, 3, x);
 

--- a/tests/petsc/45.cc
+++ b/tests/petsc/45.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.scale (w);
 

--- a/tests/petsc/46.cc
+++ b/tests/petsc/46.cc
@@ -33,8 +33,8 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   v.equ (2, w);
 

--- a/tests/petsc/47.cc
+++ b/tests/petsc/47.cc
@@ -35,9 +35,9 @@ void test (PETScWrappers::Vector &v,
       x(i) = i+2.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
-  x.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
+  x.compress (VectorOperation::insert);
 
   v.equ (2, w, 3, x);
 

--- a/tests/petsc/48.cc
+++ b/tests/petsc/48.cc
@@ -35,9 +35,9 @@ void test (PETScWrappers::Vector &v,
       x(i) = i+2.;
     }
 
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
-  x.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
+  x.compress (VectorOperation::insert);
 
   v.ratio (w, x);
 

--- a/tests/petsc/51.cc
+++ b/tests/petsc/51.cc
@@ -30,11 +30,10 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     if (i%3 == 0)
       v(i) = i+1.;
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // then copy it
   PETScWrappers::Vector w (v);
-  w.compress (VectorOperation::add);
 
   // make sure they're equal
   deallog << v *w << ' ' << v.l2_norm() * w.l2_norm()

--- a/tests/petsc/52.cc
+++ b/tests/petsc/52.cc
@@ -33,7 +33,7 @@ void test (PETScWrappers::SparseMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then make sure we retrieve the same ones
   for (unsigned int i=0; i<m.m(); ++i)

--- a/tests/petsc/55.cc
+++ b/tests/petsc/55.cc
@@ -38,7 +38,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); i+=1+i)
     v(i) *= 2;
 
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // check that they are ok, and this time
   // all of them

--- a/tests/petsc/56.cc
+++ b/tests/petsc/56.cc
@@ -38,7 +38,7 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); i+=1+i)
     v(i) /= 2;
 
-  v.compress (VectorOperation::add);
+  v.compress (VectorOperation::insert);
 
   // check that they are ok, and this time
   // all of them

--- a/tests/petsc/64.cc
+++ b/tests/petsc/64.cc
@@ -34,8 +34,8 @@ template<typename MatrixType>
 void test (MatrixType &m)
 {
   m.add(0,0,1);
+  m.compress(VectorOperation::add);
   m = 0;
-  m.compress();
 
   Assert(fabs(m.frobenius_norm())<1e-15, ExcInternalError());
 

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -83,13 +83,11 @@ int main(int argc, char **argv)
     FDMatrix testproblem(size, size);
     PETScWrappers::SparseMatrix  A(dim, dim, 5);
     testproblem.five_point(A);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
 
     GrowingVectorMemory<PETScWrappers::Vector> mem;
     SolverCG<PETScWrappers::Vector> solver(control,mem);

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -84,13 +84,11 @@ int main(int argc, char **argv)
     FDMatrix testproblem(size, size);
     PETScWrappers::SparseMatrix  A(dim, dim, 5);
     testproblem.five_point(A);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
 
     GrowingVectorMemory<PETScWrappers::Vector> mem;
     SolverBicgstab<PETScWrappers::Vector> solver(control,mem);

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -89,9 +89,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     GrowingVectorMemory<PETScWrappers::Vector> mem;
     SolverGMRES<PETScWrappers::Vector> solver(control,mem);

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -88,9 +88,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     GrowingVectorMemory<PETScWrappers::Vector> mem;
     SolverMinRes<PETScWrappers::Vector> solver(control,mem);

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -87,9 +87,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     GrowingVectorMemory<PETScWrappers::Vector> mem;
     SolverQMRS<PETScWrappers::Vector> solver(control,mem);

--- a/tests/petsc/full_matrix_00.cc
+++ b/tests/petsc/full_matrix_00.cc
@@ -34,7 +34,7 @@ void test (PETScWrappers::FullMatrix &m)
     for (unsigned int j=0; j<m.n(); ++j)
       m.set (i, j, i+2*j);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // things we know
   Assert (m.m() == 3, ExcInternalError());
@@ -57,7 +57,7 @@ void test (PETScWrappers::FullMatrix &m)
   for (unsigned int i=0; i<m.m(); ++i)
     for (unsigned int j=0; j<m.n(); ++j)
       m.set (i, j, j+2*i);
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
   
   // things we know
   Assert (m.m() == 5, ExcInternalError());

--- a/tests/petsc/full_matrix_01.cc
+++ b/tests/petsc/full_matrix_01.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::FullMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then make sure we retrieve the same ones
   for (unsigned int i=0; i<m.m(); ++i)

--- a/tests/petsc/full_matrix_05.cc
+++ b/tests/petsc/full_matrix_05.cc
@@ -37,7 +37,7 @@ void test (PETScWrappers::FullMatrix &m)
           ++counter;
         }
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // check n_nonzero_elements then
   // output a dummy number.

--- a/tests/petsc/full_matrix_06.cc
+++ b/tests/petsc/full_matrix_06.cc
@@ -32,7 +32,7 @@ void test (PETScWrappers::FullMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // compare against the exact value of the
   // l1-norm (max col-sum)

--- a/tests/petsc/full_matrix_08.cc
+++ b/tests/petsc/full_matrix_08.cc
@@ -37,7 +37,7 @@ void test (PETScWrappers::FullMatrix &m)
         }
   norm = std::sqrt(norm);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // compare against the exact value of the
   // l2-norm (max row-sum)

--- a/tests/petsc/full_matrix_09.cc
+++ b/tests/petsc/full_matrix_09.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::FullMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then multiply everything by 1.25 and
   // make sure we retrieve the values we

--- a/tests/petsc/full_matrix_10.cc
+++ b/tests/petsc/full_matrix_10.cc
@@ -31,7 +31,7 @@ void test (PETScWrappers::FullMatrix &m)
       if ((i+2*j+1) % 3 == 0)
         m.set (i,j, i*j*.5+.5);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   // then divide everything by 4/3 and
   // make sure we retrieve the values we

--- a/tests/petsc/full_matrix_iterator_01.cc
+++ b/tests/petsc/full_matrix_iterator_01.cc
@@ -29,7 +29,7 @@ void test ()
   m.set (0,0,1);
   m.set (1,1,2);
   m.set (1,2,3);
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
   PETScWrappers::FullMatrix::const_iterator i = m.begin();
   deallog << i->row() << ' ' << i->column() << ' ' << i->value() << std::endl;
   ++i;

--- a/tests/petsc/full_matrix_vector_01.cc
+++ b/tests/petsc/full_matrix_vector_01.cc
@@ -36,9 +36,8 @@ void test (PETScWrappers::Vector &v,
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // w:=Mv
   m.vmult (w,v);

--- a/tests/petsc/full_matrix_vector_02.cc
+++ b/tests/petsc/full_matrix_vector_02.cc
@@ -36,9 +36,8 @@ void test (PETScWrappers::Vector &v,
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // w:=Mv
   m.Tvmult (w,v);

--- a/tests/petsc/full_matrix_vector_03.cc
+++ b/tests/petsc/full_matrix_vector_03.cc
@@ -39,9 +39,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // w:=Mv
   m.vmult_add (w,v);

--- a/tests/petsc/full_matrix_vector_05.cc
+++ b/tests/petsc/full_matrix_vector_05.cc
@@ -39,9 +39,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // <w,Mv>
   const PetscScalar s = m.matrix_scalar_product (w,v);

--- a/tests/petsc/full_matrix_vector_06.cc
+++ b/tests/petsc/full_matrix_vector_06.cc
@@ -35,8 +35,8 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // <w,Mv>
   const PetscScalar s = m.matrix_norm_square (v);

--- a/tests/petsc/full_matrix_vector_07.cc
+++ b/tests/petsc/full_matrix_vector_07.cc
@@ -40,9 +40,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // x=w-Mv
   const double s = m.residual (x, v, w);

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -81,9 +81,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverRichardson solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -84,9 +84,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverChebychev solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -80,9 +80,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionNone preconditioner(A);

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -83,9 +83,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionBoomerAMG preconditioner(A);

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -84,9 +84,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionBoomerAMG preconditioner(A, true);

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionEisenstat preconditioner(A);

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionICC preconditioner(A);

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -89,9 +89,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionLU preconditioner(A);

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionParaSails preconditioner(A);

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionSOR preconditioner(A);

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCG solver(control);
     PETScWrappers::PreconditionSSOR preconditioner(A);

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverBiCG solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverGMRES solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -85,9 +85,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverBicgstab solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCGS solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverTFQMR solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -86,9 +86,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverTCQMR solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -82,9 +82,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverCR solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -86,9 +86,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverLSQR solver(control);
     PETScWrappers::PreconditionJacobi preconditioner(A);

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -75,9 +75,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  f(dim);
     PETScWrappers::Vector  u(dim);
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     PETScWrappers::SolverPreOnly solver(control);
 

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -73,9 +73,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  u(dim);
     u = 0.;
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
     PETScWrappers::Vector t=u;
 
     PETScWrappers::SolverPreOnly solver(control);

--- a/tests/petsc/sparse_direct_mumps.cc
+++ b/tests/petsc/sparse_direct_mumps.cc
@@ -57,9 +57,7 @@ int main(int argc, char **argv)
     PETScWrappers::Vector  u(dim);
     u = 0.;
     f = 1.;
-    A.compress (VectorOperation::add);
-    f.compress (VectorOperation::add);
-    u.compress (VectorOperation::add);
+    A.compress (VectorOperation::insert);
 
     SolverControl cn;
     PETScWrappers::SparseDirectMUMPS solver(cn);

--- a/tests/petsc/sparse_matrix_01.cc
+++ b/tests/petsc/sparse_matrix_01.cc
@@ -33,13 +33,13 @@ void test ()
     for (unsigned int j=0; j<=i; ++j)
       m.set (i,j, i+2*j);
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   PETScWrappers::SparseMatrix m2(s,s,s);
   m2.set(0,1,5.0);
   for (unsigned int i=0; i<m2.m(); ++i)
     m2.set(i,i,1.0+ i);
-  m2.compress (VectorOperation::add);
+  m2.compress (VectorOperation::insert);
 
   // we now print the matrix m,
   // print after adding m2, and then subtract m2 again

--- a/tests/petsc/sparse_matrix_02.cc
+++ b/tests/petsc/sparse_matrix_02.cc
@@ -34,7 +34,7 @@ void test ()
       m.set (i,j, i+2*j);
 
 
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
 
   {
 

--- a/tests/petsc/sparse_matrix_iterator_01.cc
+++ b/tests/petsc/sparse_matrix_iterator_01.cc
@@ -29,7 +29,7 @@ void test ()
   m.set (0,0,1);
   m.set (1,1,2);
   m.set (1,2,3);
-  m.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
   PETScWrappers::SparseMatrix::const_iterator i = m.begin();
   deallog << i->row() << ' ' << i->column() << ' ' << i->value() << std::endl;
   ++i;

--- a/tests/petsc/sparse_matrix_vector_01.cc
+++ b/tests/petsc/sparse_matrix_vector_01.cc
@@ -36,9 +36,8 @@ void test (PETScWrappers::Vector &v,
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // w:=Mv
   m.vmult (w,v);

--- a/tests/petsc/sparse_matrix_vector_02.cc
+++ b/tests/petsc/sparse_matrix_vector_02.cc
@@ -36,9 +36,8 @@ void test (PETScWrappers::Vector &v,
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // w:=Mv
   m.Tvmult (w,v);

--- a/tests/petsc/sparse_matrix_vector_03.cc
+++ b/tests/petsc/sparse_matrix_vector_03.cc
@@ -39,9 +39,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // w:=Mv
   m.vmult_add (w,v);

--- a/tests/petsc/sparse_matrix_vector_04.cc
+++ b/tests/petsc/sparse_matrix_vector_04.cc
@@ -39,9 +39,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // w:=Mv
   m.Tvmult_add (w,v);

--- a/tests/petsc/sparse_matrix_vector_05.cc
+++ b/tests/petsc/sparse_matrix_vector_05.cc
@@ -39,9 +39,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // <w,Mv>
   const PetscScalar s = m.matrix_scalar_product (w,v);

--- a/tests/petsc/sparse_matrix_vector_06.cc
+++ b/tests/petsc/sparse_matrix_vector_06.cc
@@ -35,8 +35,8 @@ void test (PETScWrappers::Vector &v)
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = i;
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
 
   // <w,Mv>
   const PetscScalar s = m.matrix_norm_square (v);

--- a/tests/petsc/sparse_matrix_vector_07.cc
+++ b/tests/petsc/sparse_matrix_vector_07.cc
@@ -40,9 +40,9 @@ void test (PETScWrappers::Vector &v,
       w(i) = i+1;
     }
 
-  m.compress (VectorOperation::add);
-  v.compress (VectorOperation::add);
-  w.compress (VectorOperation::add);
+  m.compress (VectorOperation::insert);
+  v.compress (VectorOperation::insert);
+  w.compress (VectorOperation::insert);
 
   // x=w-Mv
   const double s = m.residual (x, v, w);


### PR DESCRIPTION
- remove deprecated compress() in PETSc matrices
- add additional compress() checks
- cleanup
- fix tests
