### PR TITLE
fix SparseMIC

### DIFF
--- a/include/deal.II/lac/sparse_mic.templates.h
+++ b/include/deal.II/lac/sparse_mic.templates.h
@@ -67,16 +67,15 @@ void SparseMIC<number>::initialize (const SparseMatrix<somenumber> &matrix,
                                     const AdditionalData &data)
 {
   Assert (matrix.m()==matrix.n(), ExcNotQuadratic ());
-  Assert (this->m()==this->n(),   ExcNotQuadratic ());
-  Assert (matrix.m()==this->m(),  ExcDimensionMismatch(matrix.m(), this->m()));
-
   Assert (data.strengthen_diagonal>=0, ExcInvalidStrengthening (data.strengthen_diagonal));
 
   SparseLUDecomposition<number>::initialize(matrix, data);
-
   this->strengthen_diagonal = data.strengthen_diagonal;
   this->prebuild_lower_bound ();
   this->copy_from (matrix);
+
+  Assert (this->m()==this->n(),   ExcNotQuadratic ());
+  Assert (matrix.m()==this->m(),  ExcDimensionMismatch(matrix.m(), this->m()));
 
   if (data.strengthen_diagonal > 0)
     this->strengthen_diagonal_impl ();


### PR DESCRIPTION
We need to initialize the decomposition before we can look at this->m()
and this->n(). Bug got introduced in 27b50d8.