### PR TITLE
SparseMIC optimization

### DIFF
--- a/include/deal.II/lac/sparse_mic.templates.h
+++ b/include/deal.II/lac/sparse_mic.templates.h
@@ -143,7 +143,6 @@ void
 SparseMIC<number>::vmult (Vector<somenumber>       &dst,
                           const Vector<somenumber> &src) const
 {
-  SparseLUDecomposition<number>::vmult (dst, src);
   Assert (dst.size() == src.size(), ExcDimensionMismatch(dst.size(), src.size()));
   Assert (dst.size() == this->m(), ExcDimensionMismatch(dst.size(), this->m()));
 


### PR DESCRIPTION
It seems like we are computing a mat-vec just to overwrite it a couple
of lines later. Remove it.