### PR TITLE
[WIP] Disabled SIMD vector operations for certain types

### DIFF
--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -48,6 +48,28 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+/**
+ * Helper struct to tell us if we can use SIMD instructions for the given @p
+ * Number type.
+ */
+template <typename Number>
+struct EnableOpenMPSimdFor
+{
+  static const bool value = true;
+};
+
+#ifdef __INTEL_COMPILER
+// Disable long double SIMD instructions on ICC. This is to work around a bug
+// that generates wrong code at least up to intel 15 (see
+// tests/lac/vector-vector, tests/lac/intel-15-bug, and the discussion at
+// https://github.com/dealii/dealii/issues/598).
+template <>
+struct EnableOpenMPSimdFor<long double>
+{
+  static const bool value = false;
+};
+#endif
+
 
 namespace internal
 {
@@ -159,9 +181,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] *= factor;
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] *= factor;
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] *= factor;
+        }
     }
   };
 
@@ -180,9 +210,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] += factor*v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] += factor*v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] += factor*v_val[i];
+        }
     }
   };
 
@@ -202,9 +240,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = x*val[i] + a*v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + a*v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + a*v_val[i];
+        }
     }
   };
 
@@ -222,9 +268,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] -= v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] -= v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] -= v_val[i];
+        }
     }
   };
 
@@ -242,9 +296,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] += factor;
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] += factor;
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] += factor;
+        }
     }
   };
 
@@ -262,9 +324,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] += v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] += v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] += v_val[i];
+        }
     }
   };
 
@@ -285,9 +355,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = val[i] + a*v_val[i] + b*w_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = val[i] + a*v_val[i] + b*w_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = val[i] + a*v_val[i] + b*w_val[i];
+        }
     }
   };
 
@@ -306,9 +384,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = x*val[i] + v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + v_val[i];
+        }
     }
   };
 
@@ -330,9 +416,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = x*val[i] + a*v_val[i] + b*w_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + a*v_val[i] + b*w_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = x*val[i] + a*v_val[i] + b*w_val[i];
+        }
     }
   };
 
@@ -350,9 +444,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] *= v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] *= v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] *= v_val[i];
+        }
     }
   };
 
@@ -371,9 +473,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = a*u_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i];
+        }
     }
   };
 
@@ -394,9 +504,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = a*u_val[i] + b*v_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i] + b*v_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i] + b*v_val[i];
+        }
     }
   };
 
@@ -419,9 +537,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = a*u_val[i] + b*v_val[i] + c*w_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i] + b*v_val[i] + c*w_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a*u_val[i] + b*v_val[i] + c*w_val[i];
+        }
     }
   };
 
@@ -440,9 +566,17 @@ namespace internal
 
     void operator() (const size_type begin, const size_type end) const
     {
-      DEAL_II_OPENMP_SIMD_PRAGMA
-      for (size_type i=begin; i<end; ++i)
-        val[i] = a_val[i]/b_val[i];
+      if (EnableOpenMPSimdFor<Number>::value)
+        {
+          DEAL_II_OPENMP_SIMD_PRAGMA
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a_val[i]/b_val[i];
+        }
+      else
+        {
+          for (size_type i=begin; i<end; ++i)
+            val[i] = a_val[i]/b_val[i];
+        }
     }
   };
 


### PR DESCRIPTION
Disable long double SIMD instructions on ICC. This is to work around a bug that generates wrong code at least up to intel 15 (see tests/lac/vector-vector, tests/lac/intel-15-bug, and the discussion at https://github.com/dealii/dealii/issues/598).