### PR TITLE
Revert generic linear algebra typedef CompressedBlockSparsityPattern change

### DIFF
--- a/include/deal.II/lac/generic_linear_algebra.h
+++ b/include/deal.II/lac/generic_linear_algebra.h
@@ -91,7 +91,7 @@ namespace LinearAlgebraPETSc
      */
     typedef PETScWrappers::MPI::BlockSparseMatrix BlockSparseMatrix;
 
-    typedef dealii::BlockCompressedSimpleSparsityPattern BlockCompressedSparsityPattern;
+    typedef dealii::BlockCompressedSimpleSparsityPattern CompressedBlockSparsityPattern;
 
     /**
      * Typedef for the AMG preconditioner type.
@@ -172,7 +172,7 @@ namespace LinearAlgebraTrilinos
      */
     typedef TrilinosWrappers::BlockSparseMatrix BlockSparseMatrix;
 
-    typedef TrilinosWrappers::BlockSparsityPattern BlockCompressedSparsityPattern;
+    typedef TrilinosWrappers::BlockSparsityPattern CompressedBlockSparsityPattern;
 
     /**
      * Typedef for the AMG preconditioner type.


### PR DESCRIPTION
This reverts part of commit 365ebc60cdfdf73afd56d422b59457a7e2591317 that was
supposed to remove the deprecated CompressedBlockSparsityPattern but also
renamed a typedef in the generic linear algebra namespace breaking ASPECT
(using PETSc).