### PR TITLE
Remove assertion without argument.

### DIFF
--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1637,7 +1637,7 @@ BlockMatrixBase<MatrixType>::set (const size_type i,
 {
   prepare_set_operation();
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   const std::pair<unsigned int,size_type>
   row_index = row_block_indices.global_to_local (i),
@@ -1823,7 +1823,7 @@ BlockMatrixBase<MatrixType>::add (const size_type  i,
                                   const value_type value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   prepare_add_operation();
 
@@ -2069,7 +2069,7 @@ void
 BlockMatrixBase<MatrixType>::add (const value_type                   factor,
                                   const BlockMatrixBase<MatrixType> &matrix)
 {
-  Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+  AssertIsFinite(factor);
 
   prepare_add_operation();
 

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -353,7 +353,7 @@ BlockSparseMatrixEZ<Number>::set (const size_type i,
                                   const Number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   const std::pair<size_type,size_type>
   row_index = row_indices.global_to_local (i),
@@ -373,7 +373,7 @@ BlockSparseMatrixEZ<Number>::add (const size_type i,
                                   const Number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   const std::pair<unsigned int,size_type>
   row_index = row_indices.global_to_local (i),

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -380,7 +380,7 @@ BlockVector<Number> &
 BlockVector<Number>::operator = (const value_type s)
 {
 
-  Assert (numbers::is_finite(s), ExcNumberNotFinite());
+  AssertIsFinite(s);
 
   BaseClass::operator = (s);
   return *this;

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1935,7 +1935,7 @@ BlockVectorBase<VectorType>::add (const size_type  n_indices,
 template <class VectorType>
 void BlockVectorBase<VectorType>::add (const value_type a)
 {
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   for (size_type i=0; i<n_blocks(); ++i)
     {
@@ -1964,7 +1964,7 @@ void BlockVectorBase<VectorType>::add (const value_type a,
                                        const BlockVectorBase<VectorType> &v)
 {
 
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -1984,8 +1984,8 @@ void BlockVectorBase<VectorType>::add (const value_type a,
                                        const BlockVectorBase<VectorType> &w)
 {
 
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
-  Assert (numbers::is_finite(b), ExcNumberNotFinite());
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2006,7 +2006,7 @@ void BlockVectorBase<VectorType>::sadd (const value_type x,
                                         const BlockVectorBase<VectorType> &v)
 {
 
-  Assert (numbers::is_finite(x), ExcNumberNotFinite());
+  AssertIsFinite(x);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2024,8 +2024,8 @@ void BlockVectorBase<VectorType>::sadd (const value_type x, const value_type a,
                                         const BlockVectorBase<VectorType> &v)
 {
 
-  Assert (numbers::is_finite(x), ExcNumberNotFinite());
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(x);
+  AssertIsFinite(a);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2045,9 +2045,9 @@ void BlockVectorBase<VectorType>::sadd (const value_type x, const value_type a,
                                         const BlockVectorBase<VectorType> &w)
 {
 
-  Assert (numbers::is_finite(x), ExcNumberNotFinite());
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
-  Assert (numbers::is_finite(b), ExcNumberNotFinite());
+  AssertIsFinite(x);
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2071,10 +2071,10 @@ void BlockVectorBase<VectorType>::sadd (const value_type x, const value_type a,
                                         const BlockVectorBase<VectorType> &y)
 {
 
-  Assert (numbers::is_finite(x), ExcNumberNotFinite());
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
-  Assert (numbers::is_finite(b), ExcNumberNotFinite());
-  Assert (numbers::is_finite(c), ExcNumberNotFinite());
+  AssertIsFinite(x);
+  AssertIsFinite(a);
+  AssertIsFinite(b);
+  AssertIsFinite(c);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2111,8 +2111,8 @@ void BlockVectorBase<VectorType>::equ (const value_type a,
                                        const BlockVectorBase<VectorType> &w)
 {
 
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
-  Assert (numbers::is_finite(b), ExcNumberNotFinite());
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2146,7 +2146,7 @@ void BlockVectorBase<VectorType>::equ (const value_type    a,
                                        const BlockVector2 &v)
 {
 
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   Assert (n_blocks() == v.n_blocks(),
           ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2171,7 +2171,7 @@ BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator = (const value_type s)
 {
 
-  Assert (numbers::is_finite(s), ExcNumberNotFinite());
+  AssertIsFinite(s);
 
   for (size_type i=0; i<n_blocks(); ++i)
     components[i] = s;
@@ -2249,7 +2249,7 @@ BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator *= (const value_type factor)
 {
 
-  Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+  AssertIsFinite(factor);
 
   for (size_type i=0; i<n_blocks(); ++i)
     components[i] *= factor;
@@ -2265,7 +2265,7 @@ BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator /= (const value_type factor)
 {
 
-  Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+  AssertIsFinite(factor);
   Assert (factor > 0., ExcDivideByZero() );
 
   for (size_type i=0; i<n_blocks(); ++i)

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -1419,7 +1419,7 @@ void ChunkSparseMatrix<number>::set (const size_type i,
                                      const number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   Assert (cols != 0, ExcNotInitialized());
   // it is allowed to set elements of the matrix that are not part of the
@@ -1442,7 +1442,7 @@ void ChunkSparseMatrix<number>::add (const size_type i,
                                      const number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   Assert (cols != 0, ExcNotInitialized());
 

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -843,7 +843,7 @@ ConstraintMatrix::distribute (VectorType &vec) const
               new_value += (static_cast<typename VectorType::value_type>
                             (ghosted_vector(it->entries[i].first)) *
                             it->entries[i].second);
-            Assert(numbers::is_finite(new_value), ExcNumberNotFinite());
+            AssertIsFinite(new_value);
             vec(it->line) = new_value;
           }
 
@@ -871,7 +871,7 @@ ConstraintMatrix::distribute (VectorType &vec) const
             new_value += (static_cast<typename VectorType::value_type>
                           (vec(next_constraint->entries[i].first)) *
                           next_constraint->entries[i].second);
-          Assert(numbers::is_finite(new_value), ExcNumberNotFinite());
+          AssertIsFinite(new_value);
           vec(next_constraint->line) = new_value;
         }
     }

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -835,7 +835,7 @@ FilteredMatrix<VECTOR>::apply_constraints (
   const const_index_value_iterator e = constraints.end();
   for (; i!=e; ++i)
     {
-      Assert(numbers::is_finite(i->second), ExcNumberNotFinite());
+      AssertIsFinite(i->second);
       (*tmp_vector)(i->first) = -i->second;
     }
 
@@ -847,7 +847,7 @@ FilteredMatrix<VECTOR>::apply_constraints (
   // entries themselves
   for (i=constraints.begin(); i!=e; ++i)
     {
-      Assert(numbers::is_finite(i->second), ExcNumberNotFinite());
+      AssertIsFinite(i->second);
       v(i->first) = i->second;
     }
 }
@@ -880,7 +880,7 @@ FilteredMatrix<VECTOR>::post_filter (const VECTOR &in,
   const const_index_value_iterator e = constraints.end();
   for (; i!=e; ++i)
     {
-      Assert(numbers::is_finite(in(i->first)), ExcNumberNotFinite());
+      AssertIsFinite(in(i->first));
       out(i->first) = in(i->first);
     }
 }

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -1360,7 +1360,7 @@ inline
 number
 FullMatrix<number>::Accessor::value() const
 {
-  Assert (numbers::is_finite( matrix->el(a_row, a_col) ), ExcNumberNotFinite());
+  AssertIsFinite(matrix->el(a_row, a_col));
   return matrix->el(a_row, a_col);
 }
 

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -150,7 +150,7 @@ FullMatrix<number> &
 FullMatrix<number>::operator *= (const number factor)
 {
 
-  Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+  AssertIsFinite(factor);
 
   number       *p = &(*this)(0,0);
   const number *e = &(*this)(0,0) + n()*m();
@@ -167,14 +167,14 @@ FullMatrix<number> &
 FullMatrix<number>::operator /= (const number factor)
 {
 
-  Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+  AssertIsFinite(factor);
 
   number       *p = &(*this)(0,0);
   const number *e = &(*this)(0,0) + n()*m();
 
   const number factor_inv = number(1.)/factor;
 
-  Assert (numbers::is_finite(factor_inv), ExcNumberNotFinite());
+  AssertIsFinite(factor_inv);
 
   while (p != e)
     *p++ *= factor_inv;
@@ -296,7 +296,7 @@ void FullMatrix<number>::forward (Vector<number2>       &dst,
       for (j=0; j<i; ++j)
         s -= number(dst(j)) * (*this)(i,j);
       dst(i) = s/(*this)(i,i);
-      Assert(numbers::is_finite(dst(i)), ExcNumberNotFinite());
+      AssertIsFinite(dst(i));
     }
 }
 
@@ -317,7 +317,7 @@ void FullMatrix<number>::backward (Vector<number2>       &dst,
       for (j=i+1; j<nu; ++j)
         s -= dst(j) * number2((*this)(i,j));
       dst(i) = s/number2((*this)(i,i));
-      Assert(numbers::is_finite(dst(i)), ExcNumberNotFinite());
+      AssertIsFinite(dst(i));
     }
 }
 

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -229,7 +229,7 @@ Householder<number>::least_squares (Vector<number2> &dst,
   number2 sum = 0.;
   for (size_type i=n ; i<m ; ++i)
     sum += (*aux)(i) * (*aux)(i);
-  Assert(numbers::is_finite(sum), ExcNumberNotFinite());
+  AssertIsFinite(sum);
 
   // Compute solution
   this->backward(dst, *aux);
@@ -274,7 +274,7 @@ Householder<number>::least_squares (BlockVector<number2> &dst,
   number2 sum = 0.;
   for (size_type i=n ; i<m ; ++i)
     sum += (*aux)(i) * (*aux)(i);
-  Assert(numbers::is_finite(sum), ExcNumberNotFinite());
+  AssertIsFinite(sum);
 
   //backward works for
   //Vectors only, so copy

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -582,7 +582,7 @@ namespace parallel
     BlockVector<Number>::operator = (const value_type s)
     {
 
-      Assert (numbers::is_finite(s), ExcNumberNotFinite());
+      AssertIsFinite(s);
 
       BaseClass::operator = (s);
       return *this;

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1159,7 +1159,7 @@ namespace PETScWrappers
                    const size_type   j,
                    const PetscScalar value)
   {
-    Assert (numbers::is_finite(value), ExcNumberNotFinite());
+    AssertIsFinite(value);
 
     set (i, 1, &j, &value, false);
   }
@@ -1258,7 +1258,7 @@ namespace PETScWrappers
         for (size_type j=0; j<n_cols; ++j)
           {
             const PetscScalar value = values[j];
-            Assert (numbers::is_finite(value), ExcNumberNotFinite());
+            AssertIsFinite(value);
             if (value != PetscScalar())
               {
                 column_indices[n_columns] = col_indices[j];
@@ -1287,7 +1287,7 @@ namespace PETScWrappers
                    const PetscScalar value)
   {
 
-    Assert (numbers::is_finite(value), ExcNumberNotFinite());
+    AssertIsFinite(value);
 
     if (value == PetscScalar())
       {
@@ -1404,7 +1404,7 @@ namespace PETScWrappers
         for (size_type j=0; j<n_cols; ++j)
           {
             const PetscScalar value = values[j];
-            Assert (numbers::is_finite(value), ExcNumberNotFinite());
+            AssertIsFinite(value);
             if (value != PetscScalar())
               {
                 column_indices[n_columns] = col_indices[j];

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -204,7 +204,7 @@ RelaxationBlock<MATRIX,inverse_type>::do_step (
 #ifdef DEBUG
           for (unsigned int i=0; i<x_cell.size(); ++i)
             {
-              Assert(numbers::is_finite(x_cell(i)), ExcNumberNotFinite());
+              AssertIsFinite(x_cell(i));
             }
 #endif
           // Store in result vector

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1646,7 +1646,7 @@ SparseMatrix<number>::set (const size_type i,
                            const size_type j,
                            const number       value)
 {
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   const size_type index = cols->operator()(i, j);
 
@@ -1730,7 +1730,7 @@ SparseMatrix<number>::add (const size_type i,
                            const size_type j,
                            const number    value)
 {
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   if (value == 0)
     return;

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -580,7 +580,7 @@ SparseMatrix<number>::add (const size_type  row,
   for (size_type j=0; j<n_cols; ++j)
     {
       const number value = values[j];
-      Assert (numbers::is_finite(value), ExcNumberNotFinite());
+      AssertIsFinite(value);
 
 #ifdef DEBUG
       if (elide_zero_values==true && value == 0)
@@ -641,7 +641,7 @@ SparseMatrix<number>::set (const size_type  row,
       for (size_type j=0; j<n_cols; ++j)
         {
           const number value = values[j];
-          Assert (numbers::is_finite(value), ExcNumberNotFinite());
+          AssertIsFinite(value);
 
           if (value == 0)
             continue;
@@ -677,7 +677,7 @@ set_value:
       for (size_type j=0; j<n_cols; ++j)
         {
           const number value = values[j];
-          Assert (numbers::is_finite(value), ExcNumberNotFinite());
+          AssertIsFinite(value);
 
           if (index != next_row_index && my_cols[index] == col_indices[j])
             goto set_value_checked;

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -1197,7 +1197,7 @@ void SparseMatrixEZ<number>::set (const size_type i,
                                   const number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   Assert (i<m(), ExcIndexRange(i,0,m()));
   Assert (j<n(), ExcIndexRange(j,0,n()));
@@ -1224,7 +1224,7 @@ void SparseMatrixEZ<number>::add (const size_type i,
                                   const number value)
 {
 
-  Assert (numbers::is_finite(value), ExcNumberNotFinite());
+  AssertIsFinite(value);
 
   Assert (i<m(), ExcIndexRange(i,0,m()));
   Assert (j<n(), ExcIndexRange(j,0,n()));

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2348,7 +2348,7 @@ namespace TrilinosWrappers
                      const TrilinosScalar value)
   {
 
-    Assert (numbers::is_finite(value), ExcNumberNotFinite());
+    AssertIsFinite(value);
 
     set (i, 1, &j, &value, false);
   }
@@ -2468,7 +2468,7 @@ namespace TrilinosWrappers
         for (size_type j=0; j<n_cols; ++j)
           {
             const double value = values[j];
-            Assert (numbers::is_finite(value), ExcNumberNotFinite());
+            AssertIsFinite(value);
             if (value != 0)
               {
                 col_index_ptr[n_columns] = col_indices[j];
@@ -2554,7 +2554,7 @@ namespace TrilinosWrappers
                      const size_type      j,
                      const TrilinosScalar value)
   {
-    Assert (numbers::is_finite(value), ExcNumberNotFinite());
+    AssertIsFinite(value);
 
     if (value == 0)
       {
@@ -2679,7 +2679,7 @@ namespace TrilinosWrappers
         n_columns = n_cols;
 #ifdef DEBUG
         for (size_type j=0; j<n_cols; ++j)
-          Assert (numbers::is_finite(values[j]), ExcNumberNotFinite());
+          AssertIsFinite(values[j]);
 #endif
       }
     else
@@ -2704,7 +2704,7 @@ namespace TrilinosWrappers
           {
             const double value = values[j];
 
-            Assert (numbers::is_finite(value), ExcNumberNotFinite());
+            AssertIsFinite(value);
             if (value != 0)
               {
                 col_index_ptr[n_columns] = col_indices[j];

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -1205,7 +1205,7 @@ namespace TrilinosWrappers
   VectorBase &
   VectorBase::operator = (const TrilinosScalar s)
   {
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     const int ierr = vector->PutScalar(s);
 
@@ -1564,7 +1564,7 @@ namespace TrilinosWrappers
   VectorBase &
   VectorBase::operator *= (const TrilinosScalar a)
   {
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const int ierr = vector->Scale(a);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
@@ -1578,11 +1578,11 @@ namespace TrilinosWrappers
   VectorBase &
   VectorBase::operator /= (const TrilinosScalar a)
   {
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const TrilinosScalar factor = 1./a;
 
-    Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+    AssertIsFinite(factor);
 
     const int ierr = vector->Scale(factor);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
@@ -1633,7 +1633,7 @@ namespace TrilinosWrappers
     // if we have ghost values, do not allow
     // writing to this vector at all.
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     size_type n_local = local_size();
     for (size_type i=0; i<n_local; i++)
@@ -1653,7 +1653,7 @@ namespace TrilinosWrappers
     Assert (local_size() == v.local_size(),
             ExcDimensionMismatch(local_size(), v.local_size()));
 
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const int ierr = vector->Update(a, *(v.vector), 1.);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
@@ -1676,8 +1676,8 @@ namespace TrilinosWrappers
     Assert (local_size() == w.local_size(),
             ExcDimensionMismatch(local_size(), w.local_size()));
 
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     const int ierr = vector->Update(a, *(v.vector), b, *(w.vector), 1.);
 
@@ -1697,7 +1697,7 @@ namespace TrilinosWrappers
     Assert (size() == v.size(),
             ExcDimensionMismatch (size(), v.size()));
 
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     // We assume that the vectors have the same Map
     // if the local size is the same and if the vectors are not ghosted
@@ -1728,8 +1728,8 @@ namespace TrilinosWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
     Assert (size() == v.size(),
             ExcDimensionMismatch (size(), v.size()));
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
 
     // We assume that the vectors have the same Map
     // if the local size is the same and if the vectors are not ghosted
@@ -1766,9 +1766,9 @@ namespace TrilinosWrappers
             ExcDimensionMismatch (size(), v.size()));
     Assert (size() == w.size(),
             ExcDimensionMismatch (size(), w.size()));
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     // We assume that the vectors have the same Map
     // if the local size is the same and if the vectors are not ghosted
@@ -1810,10 +1810,10 @@ namespace TrilinosWrappers
             ExcDimensionMismatch (size(), w.size()));
     Assert (size() == x.size(),
             ExcDimensionMismatch (size(), x.size()));
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
-    Assert (numbers::is_finite(c), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
+    AssertIsFinite(b);
+    AssertIsFinite(c);
 
     // We assume that the vectors have the same Map
     // if the local size is the same and if the vectors are not ghosted
@@ -1872,7 +1872,7 @@ namespace TrilinosWrappers
     // if we have ghost values, do not allow
     // writing to this vector at all.
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     // If we don't have the same map, copy.
     if (vector->Map().SameAs(v.vector->Map())==false)
@@ -1905,8 +1905,8 @@ namespace TrilinosWrappers
     Assert (v.local_size() == w.local_size(),
             ExcDimensionMismatch (v.local_size(), w.local_size()));
 
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     // If we don't have the same map, copy.
     if (vector->Map().SameAs(v.vector->Map())==false)

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1227,7 +1227,7 @@ inline
 Vector<Number> &
 Vector<Number>::operator /= (const Number factor)
 {
-  Assert (numbers::is_finite(factor),ExcNumberNotFinite());
+  AssertIsFinite(factor);
   Assert (factor != Number(0.), ExcZero() );
 
   this->operator *= (Number(1.)/factor);

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -729,7 +729,7 @@ template <typename Number>
 Vector<Number> &
 Vector<Number>::operator = (const Number s)
 {
-  Assert (numbers::is_finite(s), ExcNumberNotFinite());
+  AssertIsFinite(s);
   if (s != Number())
     Assert (vec_size!=0, ExcEmptyObject());
   if (vec_size>internal::Vector::minimum_parallel_grain_size)
@@ -751,7 +751,7 @@ template <>
 Vector<std::complex<float> > &
 Vector<std::complex<float> >::operator = (const std::complex<float> s)
 {
-  Assert (numbers::is_finite(s), ExcNumberNotFinite());
+  AssertIsFinite(s);
   if (s != std::complex<float>())
     Assert (vec_size!=0, ExcEmptyObject());
   if (vec_size!=0)
@@ -766,7 +766,7 @@ Vector<std::complex<float> >::operator = (const std::complex<float> s)
 template <typename Number>
 Vector<Number> &Vector<Number>::operator *= (const Number factor)
 {
-  Assert (numbers::is_finite(factor),ExcNumberNotFinite());
+  AssertIsFinite(factor);
 
   Assert (vec_size!=0, ExcEmptyObject());
 
@@ -786,7 +786,7 @@ void
 Vector<Number>::add (const Number a,
                      const Vector<Number> &v)
 {
-  Assert (numbers::is_finite(a),ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.vec_size, ExcDimensionMismatch(vec_size, v.vec_size));
@@ -806,8 +806,8 @@ Vector<Number>::sadd (const Number x,
                       const Number a,
                       const Vector<Number> &v)
 {
-  Assert (numbers::is_finite(x),ExcNumberNotFinite());
-  Assert (numbers::is_finite(a),ExcNumberNotFinite());
+  AssertIsFinite(x);
+  AssertIsFinite(a);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.vec_size, ExcDimensionMismatch(vec_size, v.vec_size));
@@ -1226,7 +1226,7 @@ Number Vector<Number>::operator * (const Vector<Number2> &v) const
   Number sum;
   internal::Vector::accumulate (internal::Vector::Dot<Number,Number2>(),
                                 val, v.val, Number(), vec_size, val, sum);
-  Assert(numbers::is_finite(sum), ExcNumberNotFinite());
+  AssertIsFinite(sum);
 
   return sum;
 }
@@ -1243,7 +1243,7 @@ Vector<Number>::norm_sqr () const
   internal::Vector::accumulate (internal::Vector::Norm2<Number,real_type>(),
                                 val, val, real_type(), vec_size, val, sum);
 
-  Assert(numbers::is_finite(sum), ExcNumberNotFinite());
+  AssertIsFinite(sum);
 
   return sum;
 }
@@ -1315,7 +1315,7 @@ Vector<Number>::l2_norm () const
                 sum += (abs_x/scale) * (abs_x/scale);
             }
         }
-      Assert(numbers::is_finite(scale*std::sqrt(sum)), ExcNumberNotFinite());
+      AssertIsFinite(scale*std::sqrt(sum));
       return scale * std::sqrt(sum);
     }
 }
@@ -1393,7 +1393,7 @@ Vector<Number>::add_and_dot (const Number          a,
   Number sum;
   internal::Vector::accumulate (internal::Vector::AddAndDot<Number>(),
                                 V.val, W.val, a, vec_size, val, sum);
-  Assert(numbers::is_finite(sum), ExcNumberNotFinite());
+  AssertIsFinite(sum);
 
   return sum;
 }
@@ -1458,8 +1458,8 @@ template <typename Number>
 void Vector<Number>::add (const Number a, const Vector<Number> &v,
                           const Number b, const Vector<Number> &w)
 {
-  Assert (numbers::is_finite(a),ExcNumberNotFinite());
-  Assert (numbers::is_finite(b),ExcNumberNotFinite());
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.vec_size, ExcDimensionMismatch(vec_size, v.vec_size));
@@ -1480,7 +1480,7 @@ template <typename Number>
 void Vector<Number>::sadd (const Number x,
                            const Vector<Number> &v)
 {
-  Assert (numbers::is_finite(x),ExcNumberNotFinite());
+  AssertIsFinite(x);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.vec_size, ExcDimensionMismatch(vec_size, v.vec_size));
@@ -1499,9 +1499,9 @@ void Vector<Number>::sadd (const Number x, const Number a,
                            const Vector<Number> &v, const Number b,
                            const Vector<Number> &w)
 {
-  Assert (numbers::is_finite(x),ExcNumberNotFinite());
-  Assert (numbers::is_finite(a),ExcNumberNotFinite());
-  Assert (numbers::is_finite(b),ExcNumberNotFinite());
+  AssertIsFinite(x);
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.vec_size, ExcDimensionMismatch(vec_size, v.vec_size));
@@ -1561,7 +1561,7 @@ template <typename Number>
 void Vector<Number>::equ (const Number a,
                           const Vector<Number> &u)
 {
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == u.vec_size, ExcDimensionMismatch(vec_size, u.vec_size));
@@ -1580,7 +1580,7 @@ template <typename Number2>
 void Vector<Number>::equ (const Number a,
                           const Vector<Number2> &u)
 {
-  Assert (numbers::is_finite(a), ExcNumberNotFinite());
+  AssertIsFinite(a);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == u.vec_size, ExcDimensionMismatch(vec_size, u.vec_size));
@@ -1601,8 +1601,8 @@ template <typename Number>
 void Vector<Number>::equ (const Number a, const Vector<Number> &u,
                           const Number b, const Vector<Number> &v)
 {
-  Assert (numbers::is_finite(a),ExcNumberNotFinite());
-  Assert (numbers::is_finite(b),ExcNumberNotFinite());
+  AssertIsFinite(a);
+  AssertIsFinite(b);
 
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == u.vec_size, ExcDimensionMismatch(vec_size, u.vec_size));

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2292,7 +2292,7 @@ namespace VectorTools
         if (dof_to_boundary_mapping[i] != DoFHandler<dim,spacedim>::invalid_dof_index
             && ! excluded_dofs[dof_to_boundary_mapping[i]])
           {
-            Assert(numbers::is_finite(boundary_projection(dof_to_boundary_mapping[i])), ExcNumberNotFinite());
+            AssertIsFinite(boundary_projection(dof_to_boundary_mapping[i]));
 
             // this dof is on one of the
             // interesting boundary parts
@@ -6294,7 +6294,7 @@ namespace VectorTools
         }
 
       // append result of this cell to the end of the vector
-      Assert (numbers::is_finite(diff), ExcNumberNotFinite());
+      AssertIsFinite(diff);
       return diff;
     }
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -213,7 +213,7 @@ namespace PETScWrappers
   VectorBase &
   VectorBase::operator = (const PetscScalar s)
   {
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     //TODO[TH]: assert(is_compressed())
 
@@ -774,7 +774,7 @@ namespace PETScWrappers
   VectorBase::operator *= (const PetscScalar a)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const int ierr = VecScale (vector, a);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -788,10 +788,10 @@ namespace PETScWrappers
   VectorBase::operator /= (const PetscScalar a)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const PetscScalar factor = 1./a;
-    Assert (numbers::is_finite(factor), ExcNumberNotFinite());
+    AssertIsFinite(factor);
 
     const int ierr = VecScale (vector, factor);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -829,7 +829,7 @@ namespace PETScWrappers
   VectorBase::add (const PetscScalar s)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     const int ierr = VecShift (vector, s);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -850,7 +850,7 @@ namespace PETScWrappers
                    const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     const int ierr = VecAXPY (vector, a, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -865,8 +865,8 @@ namespace PETScWrappers
                    const VectorBase &w)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     const PetscScalar weights[2] = {a,b};
     Vec               addends[2] = {v.vector, w.vector};
@@ -882,7 +882,7 @@ namespace PETScWrappers
                     const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
+    AssertIsFinite(s);
 
     const int ierr = VecAYPX (vector, s, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -896,8 +896,8 @@ namespace PETScWrappers
                     const VectorBase     &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
 
     // there is nothing like a AXPAY
     // operation in Petsc, so do it in two
@@ -916,9 +916,9 @@ namespace PETScWrappers
                     const VectorBase     &w)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     // there is no operation like MAXPAY, so
     // do it in two steps
@@ -943,10 +943,10 @@ namespace PETScWrappers
                     const VectorBase     &x)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(s), ExcNumberNotFinite());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
-    Assert (numbers::is_finite(c), ExcNumberNotFinite());
+    AssertIsFinite(s);
+    AssertIsFinite(a);
+    AssertIsFinite(b);
+    AssertIsFinite(c);
 
     // there is no operation like MAXPAY, so
     // do it in two steps
@@ -977,7 +977,7 @@ namespace PETScWrappers
                    const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
+    AssertIsFinite(a);
 
     Assert (size() == v.size(),
             ExcDimensionMismatch (size(), v.size()));
@@ -1000,8 +1000,8 @@ namespace PETScWrappers
                    const VectorBase &w)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (numbers::is_finite(a), ExcNumberNotFinite());
-    Assert (numbers::is_finite(b), ExcNumberNotFinite());
+    AssertIsFinite(a);
+    AssertIsFinite(b);
 
     Assert (size() == v.size(),
             ExcDimensionMismatch (size(), v.size()));

--- a/source/numerics/matrix_tools.cc
+++ b/source/numerics/matrix_tools.cc
@@ -1118,13 +1118,12 @@ namespace MatrixCreator
                         if (copy_data.dof_is_on_face[pos][j] &&
                             dof_to_boundary_mapping[copy_data.dofs[j]] != numbers::invalid_dof_index)
                           {
-                            Assert(numbers::is_finite(copy_data.cell_matrix[pos](i,j)),
-                                   ExcNumberNotFinite());
+                            AssertIsFinite(copy_data.cell_matrix[pos](i,j));
                             matrix.add(dof_to_boundary_mapping[copy_data.dofs[i]],
                                        dof_to_boundary_mapping[copy_data.dofs[j]],
                                        copy_data.cell_matrix[pos](i,j));
                           }
-                      Assert(numbers::is_finite(copy_data.cell_vector[pos](i)), ExcNumberNotFinite());
+                      AssertIsFinite(copy_data.cell_vector[pos](i));
                       rhs_vector(dof_to_boundary_mapping[copy_data.dofs[i]]) += copy_data.cell_vector[pos](i);
                     }
                 }


### PR DESCRIPTION
Specifically, replace ExcNumberNotFinite with a way to provide both this number and a (lengthy) explanation of what may possibly have caused this problem. I see my students struggle with this error.