### PR TITLE
Minor vector cleanups

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1050,9 +1050,8 @@ void Vector<Number>::reinit (const size_type n, const bool fast)
   if (n>max_vec_size)
     {
       if (val) deallocate();
-      allocate(n);
-      Assert (val != 0, ExcOutOfMemory());
       max_vec_size = n;
+      allocate(max_vec_size);
     };
   vec_size = n;
   if (fast == false)

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -965,9 +965,10 @@ protected:
 private:
 
   /**
-   * Allocate and align @p v along 64-byte boundaries.
+   * Allocate and align @p val along 64-byte boundaries. The size
+   * of the allocated memory is determined by @p max_vec_size .
    */
-  void allocate(const size_type n);
+  void allocate();
 
   /**
    * Deallocate @p val.
@@ -1051,7 +1052,7 @@ void Vector<Number>::reinit (const size_type n, const bool fast)
     {
       if (val) deallocate();
       max_vec_size = n;
-      allocate(max_vec_size);
+      allocate();
     };
   vec_size = n;
   if (fast == false)

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1347,12 +1347,14 @@ inline
 void
 Vector<Number>::load (Archive &ar, const unsigned int)
 {
-  // forward to serialization function in the base class.
-  ar   &static_cast<Subscriptor &>(*this);
+  // get rid of previous content
+  deallocate();
 
+  // the load stuff again from the archive
+  ar &static_cast<Subscriptor &>(*this);
   ar &vec_size &max_vec_size ;
 
-  allocate(max_vec_size);
+  allocate();
   ar &boost::serialization::make_array(val, max_vec_size);
 }
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -575,7 +575,6 @@ Vector<Number>::Vector (const Vector<Number> &v)
   if (vec_size != 0)
     {
       allocate(max_vec_size);
-      Assert (val != 0, ExcOutOfMemory());
       *this = v;
     }
 }
@@ -595,7 +594,6 @@ Vector<Number>::Vector (const Vector<OtherNumber> &v)
   if (vec_size != 0)
     {
       allocate(max_vec_size);
-      Assert (val != 0, ExcOutOfMemory());
       std::copy (v.begin(), v.end(), begin());
     }
 }
@@ -616,7 +614,6 @@ Vector<Number>::Vector (const PETScWrappers::Vector &v)
   if (vec_size != 0)
     {
       allocate(max_vec_size);
-      Assert (val != 0, ExcOutOfMemory());
 
       // get a representation of the vector
       // and copy it
@@ -668,7 +665,6 @@ Vector<Number>::Vector (const TrilinosWrappers::MPI::Vector &v)
   if (vec_size != 0)
     {
       allocate(max_vec_size);
-      Assert (val != 0, ExcOutOfMemory());
 
       // Copy the distributed vector to
       // a local one at all
@@ -702,7 +698,6 @@ Vector<Number>::Vector (const TrilinosWrappers::Vector &v)
   if (vec_size != 0)
     {
       allocate(max_vec_size);
-      Assert (val != 0, ExcOutOfMemory());
 
       // get a representation of the vector
       // and copy it
@@ -2051,6 +2046,7 @@ void
 Vector<Number>::allocate(const size_type size)
 {
   val = static_cast<Number *>(_mm_malloc (sizeof(Number)*size, 64));
+  Assert (val != 0, ExcOutOfMemory());
 }
 
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -574,7 +574,7 @@ Vector<Number>::Vector (const Vector<Number> &v)
 {
   if (vec_size != 0)
     {
-      allocate(max_vec_size);
+      allocate();
       *this = v;
     }
 }
@@ -593,7 +593,7 @@ Vector<Number>::Vector (const Vector<OtherNumber> &v)
 {
   if (vec_size != 0)
     {
-      allocate(max_vec_size);
+      allocate();
       std::copy (v.begin(), v.end(), begin());
     }
 }
@@ -613,7 +613,7 @@ Vector<Number>::Vector (const PETScWrappers::Vector &v)
 {
   if (vec_size != 0)
     {
-      allocate(max_vec_size);
+      allocate();
 
       // get a representation of the vector
       // and copy it
@@ -664,7 +664,7 @@ Vector<Number>::Vector (const TrilinosWrappers::MPI::Vector &v)
 {
   if (vec_size != 0)
     {
-      allocate(max_vec_size);
+      allocate();
 
       // Copy the distributed vector to
       // a local one at all
@@ -697,7 +697,7 @@ Vector<Number>::Vector (const TrilinosWrappers::Vector &v)
 {
   if (vec_size != 0)
     {
-      allocate(max_vec_size);
+      allocate();
 
       // get a representation of the vector
       // and copy it
@@ -2043,9 +2043,9 @@ Vector<Number>::memory_consumption () const
 
 template <typename Number>
 void
-Vector<Number>::allocate(const size_type size)
+Vector<Number>::allocate()
 {
-  val = static_cast<Number *>(_mm_malloc (sizeof(Number)*size, 64));
+  val = static_cast<Number *>(_mm_malloc (sizeof(Number)*max_vec_size, 64));
   Assert (val != 0, ExcOutOfMemory());
 }
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -2045,6 +2045,8 @@ template <typename Number>
 void
 Vector<Number>::allocate()
 {
+  // make sure that we don't create a memory leak
+  Assert (val == 0, ExcInternalError());
   val = static_cast<Number *>(_mm_malloc (sizeof(Number)*max_vec_size, 64));
   Assert (val != 0, ExcOutOfMemory());
 }
@@ -2056,6 +2058,7 @@ void
 Vector<Number>::deallocate()
 {
   _mm_free(val);
+  val = 0;
 }
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Simplify code by placing the assertion that we got enough memory right next to the place where we actually allocate it. Also check that we don't create a memory leak -- which promptly triggered in the serialization function.