### PR TITLE
Fix compiler warnings with clang 3.6.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1549,7 +1549,6 @@ DoFAccessor<structdim, DH,level_dof_access>::mg_vertex_dof_index (const int leve
     const unsigned int fe_index) const
 {
   Assert (this->dof_handler != 0, ExcInvalidObject ());
-  Assert (&this->dof_handler->get_fe () != 0, ExcInvalidObject ());
   Assert (vertex < GeometryInfo<structdim>::vertices_per_cell, ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
   Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex, ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
   return this->dof_handler->mg_vertex_dofs[this->vertex_index (vertex)].get_index (level, i);
@@ -1583,7 +1582,6 @@ DoFAccessor<structdim, DH,level_dof_access>::set_mg_vertex_dof_index (const int 
     const unsigned int fe_index) const
 {
   Assert (this->dof_handler != 0, ExcInvalidObject ());
-  Assert (&this->dof_handler->get_fe () != 0, ExcInvalidObject ());
   Assert (vertex < GeometryInfo<structdim>::vertices_per_cell, ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
   Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex, ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
   this->dof_handler->mg_vertex_dofs[this->vertex_index (vertex)].set_index (level, i, index);
@@ -1851,7 +1849,6 @@ DoFAccessor<structdim,DH,level_dof_access>::get_dof_indices (std::vector<types::
     const unsigned int         fe_index) const
 {
   Assert (this->dof_handler != 0, ExcNotInitialized());
-  Assert (&this->dof_handler->get_fe() != 0, ExcMessage ("DoFHandler not initialized"));
   Assert (static_cast<unsigned int>(this->level()) < this->dof_handler->levels.size(),
           ExcMessage ("DoFHandler not initialized"));
 
@@ -1914,7 +1911,6 @@ void DoFAccessor<structdim, DH,level_dof_access>::get_mg_dof_indices (const int 
     const unsigned int fe_index) const
 {
   Assert (this->dof_handler != 0, ExcInvalidObject ());
-  Assert (&this->dof_handler->get_fe () != 0, ExcInvalidObject ());
 
   switch (structdim)
     {
@@ -1966,7 +1962,6 @@ void DoFAccessor<structdim, DH,level_dof_access>::set_mg_dof_indices (const int 
     const unsigned int fe_index)
 {
   Assert (this->dof_handler != 0, ExcInvalidObject ());
-  Assert (&this->dof_handler->get_fe () != 0, ExcInvalidObject ());
 
   switch (structdim)
     {

--- a/include/deal.II/hp/dof_faces.h
+++ b/include/deal.II/hp/dof_faces.h
@@ -371,11 +371,6 @@ namespace internal
       Assert ((fe_index != dealii::hp::DoFHandler<dim,spacedim>::default_fe_index),
               ExcMessage ("You need to specify a FE index when working "
                           "with hp DoFHandlers"));
-      Assert (&dof_handler != 0,
-              ExcMessage ("No DoFHandler is specified for this iterator"));
-      Assert (&dof_handler.get_fe() != 0,
-              ExcMessage ("No finite element collection is associated with "
-                          "this DoFHandler"));
       Assert (fe_index < dof_handler.get_fe().size(),
               ExcIndexRange (fe_index, 0, dof_handler.get_fe().size()));
       Assert (local_index <
@@ -433,11 +428,6 @@ namespace internal
       Assert ((fe_index != dealii::hp::DoFHandler<dim,spacedim>::default_fe_index),
               ExcMessage ("You need to specify a FE index when working "
                           "with hp DoFHandlers"));
-      Assert (&dof_handler != 0,
-              ExcMessage ("No DoFHandler is specified for this iterator"));
-      Assert (&dof_handler.get_fe() != 0,
-              ExcMessage ("No finite element collection is associated with "
-                          "this DoFHandler"));
       Assert (fe_index < dof_handler.get_fe().size(),
               ExcIndexRange (fe_index, 0, dof_handler.get_fe().size()));
       Assert (local_index <
@@ -490,11 +480,6 @@ namespace internal
     n_active_fe_indices (const dealii::hp::DoFHandler<dim,spacedim> &dof_handler,
                          const unsigned int                obj_index) const
     {
-      Assert (&dof_handler != 0,
-              ExcMessage ("No DoFHandler is specified for this iterator"));
-      Assert (&dof_handler.get_fe() != 0,
-              ExcMessage ("No finite element collection is associated with "
-                          "this DoFHandler"));
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, dof_offsets.size()));
 
@@ -540,11 +525,6 @@ namespace internal
                          const unsigned int                obj_index,
                          const unsigned int                n) const
     {
-      Assert (&dof_handler != 0,
-              ExcMessage ("No DoFHandler is specified for this iterator"));
-      Assert (&dof_handler.get_fe() != 0,
-              ExcMessage ("No finite element collection is associated with "
-                          "this DoFHandler"));
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, dof_offsets.size()));
 
@@ -601,11 +581,6 @@ namespace internal
                         const unsigned int                fe_index,
                         const unsigned int                obj_level) const
     {
-      Assert (&dof_handler != 0,
-              ExcMessage ("No DoFHandler is specified for this iterator"));
-      Assert (&dof_handler.get_fe() != 0,
-              ExcMessage ("No finite element collection is associated with "
-                          "this DoFHandler"));
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, static_cast<unsigned int>(dof_offsets.size())));
       Assert ((fe_index != dealii::hp::DoFHandler<dim,spacedim>::default_fe_index),

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -49,7 +49,6 @@ DoFCellAccessor<DH,lda>::update_cell_dof_indices_cache () const
           ExcMessage ("DoFHandler not initialized"));
 
   Assert (this->dof_handler != 0, typename BaseClass::ExcInvalidObject());
-  Assert (&this->get_fe() != 0, typename BaseClass::ExcInvalidObject());
 
   internal::DoFCellAccessor::Implementation::
   update_cell_dof_indices_cache (*this);
@@ -65,7 +64,6 @@ DoFCellAccessor<DH,lda>::set_dof_indices (const std::vector<types::global_dof_in
           ExcMessage ("DoFHandler not initialized"));
 
   Assert (this->dof_handler != 0, typename BaseClass::ExcInvalidObject());
-  Assert (&this->get_fe() != 0, typename BaseClass::ExcInvalidObject());
 
   internal::DoFCellAccessor::Implementation::
   set_dof_indices (*this, local_dof_indices);

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -103,8 +103,6 @@ get_interpolated_dof_values (const InputVector &values,
 
       Assert (this->dof_handler != 0,
               typename BaseClass::ExcInvalidObject());
-      Assert (&fe != 0,
-              typename BaseClass::ExcInvalidObject());
       Assert (interpolated_values.size() == dofs_per_cell,
               typename BaseClass::ExcVectorDoesNotMatch());
       Assert (values.size() == this->dof_handler->n_dofs(),

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -100,8 +100,6 @@ set_dof_values_by_interpolation (const Vector<number> &local_values,
 
       Assert (this->dof_handler != 0,
               typename BaseClass::ExcInvalidObject());
-      Assert (&this->get_dof_handler().get_fe() != 0,
-              typename BaseClass::ExcInvalidObject());
       Assert (local_values.size() == dofs_per_cell,
               typename BaseClass::ExcVectorDoesNotMatch());
       Assert (values.size() == this->dof_handler->n_dofs(),

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1545,8 +1545,6 @@ namespace DoFTools
   map_dof_to_boundary_indices (const DH                  &dof_handler,
                                std::vector<types::global_dof_index> &mapping)
   {
-    Assert (&dof_handler.get_fe() != 0, ExcNoFESelected());
-
     mapping.clear ();
     mapping.insert (mapping.end(), dof_handler.n_dofs(),
                     DH::invalid_dof_index);
@@ -1587,7 +1585,6 @@ namespace DoFTools
     const std::set<types::boundary_id> &boundary_indicators,
     std::vector<types::global_dof_index>     &mapping)
   {
-    Assert (&dof_handler.get_fe() != 0, ExcNoFESelected());
     Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
             ExcInvalidBoundaryIndicator());
 


### PR DESCRIPTION
Comparing the address of a reference to an object with the zero pointer like in
  &dof_handler.get_fe() != 0
will always evaluate to true. Thus, these assertions do not make sense and clang rightfully complains.