### PR TITLE
Use and document VectorTools::ExcPointNotAvailableHere

### DIFF
--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -32,6 +32,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+namespace VectorTools
+{
+  class ExcPointNotAvailableHere;
+}
+
 namespace Functions
 {
 
@@ -116,7 +121,7 @@ namespace Functions
    * @ref GlossGhostCell).
    * If the cell is artificial, we have no access to the solution there and
    * functions that evaluate the solution at such a point will trigger an
-   * exception of type FEFieldFunction::ExcPointNotAvailableHere. The same
+   * exception of type VectorTools::ExcPointNotAvailableHere. The same
    * kind of exception will also be produced if the cell is a ghost cell: On
    * such cells, one could in principle evaluate the solution, but it becomes
    * easier if we do not allow to do so because then there is exactly one
@@ -139,7 +144,7 @@ namespace Functions
    *     {
    *       solution_at_origin = solution_function.value (origin);
    *     }
-   *   catch (const typename Functions::FEFieldFunction<dim,DoFHandler<dim>,TrilinosWrappers::MPI::Vector>::ExcPointNotAvailableHere &)
+   *   catch (const VectorTools::ExcPointNotAvailableHere &)
    *     {
    *       point_found = false;
    *     }
@@ -147,14 +152,6 @@ namespace Functions
    *   if (point_found == true)
    *     ...do something...;
    * @endcode
-   *
-   * @note To C++,
-   * <code>Functions::FEFieldFunction<dim>::ExcPointNotAvailableHere</code>
-   * and <code>Functions::FEFieldFunction<dim,DoFHandler<dim>,
-   * TrilinosWrappers::MPI::Vector>::ExcPointNotAvailableHere</code> are
-   * distinct types. You need to make sure that the type of the exception you
-   * catch matches the type of the object that throws it, as shown in the
-   * example above.
    *
    * @ingroup functions
    * @author Luca Heltai, 2006, Markus Buerg, 2012, Wolfgang Bangerth, 2013
@@ -414,9 +411,9 @@ namespace Functions
                             std::vector<std::vector<unsigned int> > &maps) const;
 
     /**
-     * Exception
+     * @deprecated Use VectorTools::ExcPointNotAvailableHere instead.
      */
-    DeclException0 (ExcPointNotAvailableHere);
+    typedef VectorTools::ExcPointNotAvailableHere ExcPointNotAvailableHere DEAL_II_DEPRECATED;
 
   private:
     /**

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -23,6 +23,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/numerics/fe_field_function.h>
+#include <deal.II/numerics/vector_tools.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -73,7 +74,7 @@ namespace Functions
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
           = GridTools::find_active_cell_around_point (mapping, *dh, p);
         AssertThrow (my_pair.first->is_locally_owned(),
-                     ExcPointNotAvailableHere());
+                     VectorTools::ExcPointNotAvailableHere());
 
         cell = my_pair.first;
         qp = my_pair.second;
@@ -124,7 +125,7 @@ namespace Functions
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
           = GridTools::find_active_cell_around_point (mapping, *dh, p);
         AssertThrow (my_pair.first->is_locally_owned(),
-                     ExcPointNotAvailableHere());
+                     VectorTools::ExcPointNotAvailableHere());
 
         cell = my_pair.first;
         qp = my_pair.second;
@@ -177,7 +178,7 @@ namespace Functions
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
           = GridTools::find_active_cell_around_point (mapping, *dh, p);
         AssertThrow (my_pair.first->is_locally_owned(),
-                     ExcPointNotAvailableHere());
+                     VectorTools::ExcPointNotAvailableHere());
 
         cell = my_pair.first;
         qp = my_pair.second;
@@ -445,7 +446,7 @@ namespace Functions
           my_pair  = GridTools::find_active_cell_around_point
                      (mapping, *dh, points[0]);
           AssertThrow (my_pair.first->is_locally_owned(),
-                       ExcPointNotAvailableHere());
+                       VectorTools::ExcPointNotAvailableHere());
 
           cell = my_pair.first;
           qp = my_pair.second;
@@ -509,7 +510,7 @@ namespace Functions
             const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
               = GridTools::find_active_cell_around_point (mapping, *dh, points[first_outside]);
             AssertThrow (my_pair.first->is_locally_owned(),
-                         ExcPointNotAvailableHere());
+                         VectorTools::ExcPointNotAvailableHere());
 
             cells.push_back(my_pair.first);
             qpoints.push_back(std::vector<Point<dim> >(1, my_pair.second));

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -2208,7 +2208,10 @@ namespace VectorTools
   /**
    * Exception
    */
-  DeclException0 (ExcPointNotAvailableHere);
+  DeclExceptionMsg (ExcPointNotAvailableHere,
+                    "The given point is inside a cell of a "
+                    "parallel::distributed::Triangulation that is not "
+                    "locally owned by this processor.");
 }
 
 

--- a/tests/mpi/fe_field_function_01.cc
+++ b/tests/mpi/fe_field_function_01.cc
@@ -101,7 +101,7 @@ void test()
           Assert (std::fabs(value - (p[0]+2)) < 1e-8* std::fabs(value + (p[0]+2)),
                   ExcInternalError());
         }
-      catch (typename Functions::FEFieldFunction<dim,DoFHandler<dim>,TrilinosWrappers::MPI::Vector>::ExcPointNotAvailableHere &)
+      catch (typename VectorTools::ExcPointNotAvailableHere &)
         {
           point_found = false;
         }


### PR DESCRIPTION
ExcPointNotAvailableHere is duplicated in VectorTools and
FEFieldFunction and is awkward to use in the latter because of the
template arguments.

- provide textual description of Exception
- deprecate the version in FEFieldFunction
- update documentation
- update test