### PR TITLE
Fix issue #642

### DIFF
--- a/tests/deal.II/nedelec_non_rect_face.cc
+++ b/tests/deal.II/nedelec_non_rect_face.cc
@@ -463,7 +463,7 @@ int main ()
   deallog.attach(logfile);
   deallog.depth_console(0);
   
-  for (unsigned int p=0; p<4; ++p)
+  for (unsigned int p=0; p<3; ++p)
     {
       MaxwellProblem<3> (p).run();
     }

--- a/tests/deal.II/nedelec_non_rect_face.output
+++ b/tests/deal.II/nedelec_non_rect_face.output
@@ -14,8 +14,3 @@ cycle cells dofs  L2 Error  H(curl) Error
 0     1     144  6.0548e-16 1.2581e-15    
 1     8     882  4.7208e-15 5.6992e-15    
 2     64    6084 3.7516e-14 4.1547e-14    
-DEAL::p = 3
-cycle cells dofs   L2 Error  H(curl) Error 
-0     1     300   9.4037e-16 1.8758e-15    
-1     8     1944  1.5731e-14 1.6809e-14    
-2     64    13872 8.7253e-14 9.1275e-14    


### PR DESCRIPTION
Removed p=3 case as it takes far too long to run (issue #642). Test is still valid as the solution should be exact at p=2