### PR TITLE
CMake: Bugfix: Use Trilinos third party header locations

### DIFF
--- a/cmake/modules/FindTRILINOS.cmake
+++ b/cmake/modules/FindTRILINOS.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -183,9 +183,9 @@ DEAL_II_PACKAGE_HANDLE(TRILINOS
     REQUIRED ${_libraries} Trilinos_TPL_LIBRARIES
     OPTIONAL MPI_CXX_LIBRARIES
   INCLUDE_DIRS
-    REQUIRED Trilinos_INCLUDE_DIRS
+    REQUIRED Trilinos_INCLUDE_DIRS Trilinos_TPL_INCLUDE_DIRS
   USER_INCLUDE_DIRS
-    REQUIRED Trilinos_INCLUDE_DIRS
+    REQUIRED Trilinos_INCLUDE_DIRS Trilinos_TPL_INCLUDE_DIRS
   CLEAR
     TRILINOS_CONFIG_DIR EPETRA_CONFIG_H SACADO_CMATH_HPP ${_libraries}
     TRILINOS_SUPPORTS_CPP11 TRILINOS_HAS_C99_TR1_WORKAROUND


### PR DESCRIPTION
Also append Trilinos_TPL_INCLUDE_DIRS to TRILINOS_INCLUDE_DIRS