### PR TITLE
Fix: BlockIndices in BlockDynamicSP

### DIFF
--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -532,6 +532,14 @@ public:
   BlockDynamicSparsityPattern (const std::vector<IndexSet> &partitioning);
 
   /**
+   * Initialize the pattern with two BlockIndices for the block structures of
+   * matrix rows and columns.
+   */
+  BlockDynamicSparsityPattern (const BlockIndices &row_indices,
+                               const BlockIndices &col_indices);
+
+
+  /**
    * Resize the pattern to a tensor product of matrices with dimensions
    * defined by the arguments.
    *
@@ -547,6 +555,13 @@ public:
    * IndexSet. See the constructor taking a vector of IndexSets for details.
    */
   void reinit(const std::vector<IndexSet> &partitioning);
+
+  /**
+   * Resize the matrix to a tensor product of matrices with dimensions defined
+   * by the arguments. The two BlockIndices objects must be initialized and
+   * the sparsity pattern will have the same block structure afterwards.
+   */
+  void reinit (const BlockIndices &row_indices, const BlockIndices &col_indices);
 
   /**
    * Access to column number field. Return the column number of the @p index

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -482,6 +482,13 @@ BlockDynamicSparsityPattern (const std::vector<IndexSet> &partitioning)
 }
 
 
+BlockDynamicSparsityPattern::
+BlockDynamicSparsityPattern (const BlockIndices &row_indices,
+                             const BlockIndices &col_indices)
+{
+  reinit(row_indices, col_indices);
+}
+
 
 void
 BlockDynamicSparsityPattern::reinit (
@@ -507,6 +514,20 @@ BlockDynamicSparsityPattern::reinit (
       this->block(i,j).reinit(partitioning[i].size(),
                               partitioning[j].size(),
                               partitioning[i]);
+  this->collect_sizes();
+}
+
+void
+BlockDynamicSparsityPattern::reinit (
+  const BlockIndices &row_indices,
+  const BlockIndices &col_indices)
+{
+  BlockSparsityPatternBase<DynamicSparsityPattern>::reinit(row_indices.size(),
+                                                           col_indices.size());
+  for (size_type i=0; i<row_indices.size(); ++i)
+    for (size_type j=0; j<col_indices.size(); ++j)
+      this->block(i,j).reinit(row_indices.block_size(i),
+                              col_indices.block_size(j));
   this->collect_sizes();
 }
 


### PR DESCRIPTION
Implement constructor and reinit with BlockIndices for
BlockDynamicSparsityPattern. This existed for BlockCompressedSP but not
for BlockCompressedSimpleSP, but BlockCompressedSP is now a typedef to
BlockDynamicSP (see 3b9a4bc2).

This should fix the test integrators/cochain_01.cc

resolves #683 