### PR TITLE
Fix a 64-bit issue in TrilinosWrappers::SparseMatrix::local_range().

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -395,6 +395,12 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Fixed: TrilinosWrappers::SparseMatrix::local_range() erroneously
+  threw an exception in 64-bit mode. This is now fixed.
+  <br>
+  (Wolfgang Bangerth, 2015/03/24)
+  </li>
+
   <li> New: The GridOut::write_gnuplot() function produced output
   for 1d meshes embedded in higher dimensional spaces that was
   invalid in that the lines showing individual cells were connected.

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2352,8 +2352,8 @@ namespace TrilinosWrappers
     begin = matrix->RowMap().MinMyGID();
     end = matrix->RowMap().MaxMyGID()+1;
 #else
-    begin = matrix->RowMap().MinMyGID();
-    end = matrix->RowMap().MaxMyGID()+1;
+    begin = matrix->RowMap().MinMyGID64();
+    end = matrix->RowMap().MaxMyGID64()+1;
 #endif
 
     return ((index >= static_cast<size_type>(begin)) &&


### PR DESCRIPTION
This tripped up all of the Trilinos sparse matrix iterators in 64 bit
mode after one of my recent changes.