### PR TITLE
Add an assertion.

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -305,7 +305,7 @@ public:
    * The last argument only plays a role if the communicator is a parallel
    * one, distributing computations across multiple processors. In that case,
    * if the last argument is false, then it is assumed that the index sets
-   * this function is called on on all processors are mutually exclusive but
+   * this function is called with on all processors are mutually exclusive but
    * together enumerate each index exactly once. In other words, if you call
    * this function on two processors, then the index sets this function is
    * called with must together have all possible indices from zero to

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -432,6 +432,30 @@ IndexSet::make_trilinos_map (const MPI_Comm &communicator,
 {
   compress ();
 
+#ifdef DEBUG
+  if (!overlapping)
+    {
+      const unsigned int n_global_elements
+        = Utilities::MPI::sum (n_elements(), communicator);
+      Assert (n_global_elements == size(),
+              ExcMessage ("You are trying to create an Epetra_Map object "
+                          "that partitions elements of an index set "
+                          "between processors. However, the union of the "
+                          "index sets on different processors does not "
+                          "contain all indices exactly once: the sum of "
+                          "the number of entries the various processors "
+                          "want to store locally is "
+                          + Utilities::int_to_string (n_global_elements) +
+                          " whereas the total size of the object to be "
+                          "allocated is "
+                          + Utilities::int_to_string (size()) +
+                          ". In other words, there are "
+                          "either indices that are not spoken for "
+                          "by any processor, or there are indices that are "
+                          "claimed by multiple processors."));
+    }
+#endif
+
   if ((is_contiguous() == true) && (!overlapping))
     return Epetra_Map (TrilinosWrappers::types::int_type(size()),
                        TrilinosWrappers::types::int_type(n_elements()),


### PR DESCRIPTION
Spencer Patty ran into this today: if you try to create a
Trilinos SparsityPattern class where the IndexSets do not
exactly add up, Trilinos somewhere deep down throws an
exception of a type that we do not catch in typical
main() functions (because it is not derived from std::exception).
This leads to impossible to debug problems if you don't happen
to still have the Trilinos sources around and know how to set
breakpoints on all 'throw' statements. Better catch stuff like
this ourselves.