### PR TITLE
Testsuite: Bugfix: Use DIFF_EXECUTABLE in mesh_converter tests

### DIFF
--- a/tests/mesh_converter/CMakeLists.txt
+++ b/tests/mesh_converter/CMakeLists.txt
@@ -75,7 +75,7 @@ FOREACH(_full_file ${_meshes})
       COMMAND rm -f ${_test_directory}/failing_diff
       COMMAND touch ${_test_directory}/diff
       COMMAND
-        ${TEST_DIFF} ${_comparison_file} ${_test_directory}/output > ${_test_directory}/diff
+        ${DIFF_EXECUTABLE} ${_comparison_file} ${_test_directory}/output > ${_test_directory}/diff
         || (mv ${_test_directory}/diff
                ${_test_directory}/failing_diff
             && echo "${_test_full}: RUN successful."

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -87,7 +87,8 @@
 # Furthermore, the following variables controlling the testsuite can be set
 # and will be automatically handed down to cmake:
 #
-#   TEST_DIFF
+#   NUMDIFF_DIR
+#   DIFF_DIR
 #   TEST_TIME_LIMIT
 #   TEST_PICKUP_REGEX
 #


### PR DESCRIPTION
... again *sigh*