### PR TITLE
GridTools get all vertices at boundary

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -333,6 +333,14 @@ inconvenience this causes.
 
 <ol>
 
+  <li> New: A new funtion to get a map with all vertices at boundaries 
+  has been added in GridTools::get_all_vertices_at_boundary. 
+  This function will return a map wich can be used in functions 
+  like GridTools::Laplace_transform.
+  <br>
+  (Fernando Posada, 2015/03/31)
+  </li>
+
   <li> New: A new flag no_automatic_repartitioning in
   parallel::distributed::Triangulation will disable the automatic
   repartitioning when calling execute_coarsening_and_refinement() (or things

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -297,12 +297,13 @@ namespace GridTools
                           const Function<dim,double> *coefficient = 0);
 
   /**
+  * Returns a std::map with all vertices of faces located in the boundary
   *
-  *
+  * @param[in] tria The Triangulation object.
   */
-  template<int dim>
-  std::map<unsigned int,Point<dim> >
-  get_all_vertex_at_boundary (const Triangulation<dim> &tria);
+  template <int dim, int spacedim>
+  std::map<unsigned int,Point<spacedim> >
+  get_all_vertices_at_boundary (const Triangulation<dim, spacedim> &tria);
 
   /**
    * Scale the entire triangulation by the given factor. To preserve the

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -297,6 +297,14 @@ namespace GridTools
                           const Function<dim,double> *coefficient = 0);
 
   /**
+  *
+  *
+  */
+  template<int dim>
+  std::map<unsigned int,Point<dim> >
+  get_all_vertex_at_boundary (const Triangulation<dim> &tria);
+
+  /**
    * Scale the entire triangulation by the given factor. To preserve the
    * orientation of the triangulation, the factor must be positive.
    *

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -768,31 +768,30 @@ namespace GridTools
         }
   }
 
-
-  template<int dim>
-  std::map<unsigned int,Point<dim> >
-  get_all_vertex_at_boundary (const Triangulation<dim> &tria)
+  template <int dim, int spacedim>
+  std::map<unsigned int,Point<spacedim> >
+  get_all_vertices_at_boundary (const Triangulation<dim, spacedim> &tria)
   {
-    std::map<unsigned int, Point<dim> > vertex_map;   
-    typename Triangulation<dim>::active_cell_iterator
+    std::map<unsigned int, Point<spacedim> > vertex_map;
+    typename Triangulation<dim,spacedim>::active_cell_iterator
     cell = tria.begin_active(),
     endc = tria.end();
     for (; cell!=endc; ++cell)
-    { 
-      for (unsigned int i=0;i<GeometryInfo<dim>::faces_per_cell; ++i)
       {
-        const auto face = cell->face(i);
-        if (face->at_boundary())
-        {
-          for (unsigned j = 0; j < GeometryInfo<dim>::vertices_per_face; ++j)
+        for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
           {
-            const auto vertex = face->vertex(j);
-            const auto vertex_index = face->vertex_index(j);
-            vertex_map[vertex_index] = vertex / vertex.norm();
+            const auto face = cell->face(i);
+            if (face->at_boundary())
+              {
+                for (unsigned j = 0; j < GeometryInfo<dim>::vertices_per_face; ++j)
+                  {
+                    const auto vertex = face->vertex(j);
+                    const auto vertex_index = face->vertex_index(j);
+                    vertex_map[vertex_index] = vertex;
+                  }
+              }
           }
-        }
       }
-    }
     return vertex_map;
   }
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -769,6 +769,32 @@ namespace GridTools
   }
 
 
+  template<int dim>
+  std::map<unsigned int,Point<dim> >
+  get_all_vertex_at_boundary (const Triangulation<dim> &tria)
+  {
+    std::map<unsigned int, Point<dim> > vertex_map;   
+    typename Triangulation<dim>::active_cell_iterator
+    cell = tria.begin_active(),
+    endc = tria.end();
+    for (; cell!=endc; ++cell)
+    { 
+      for (unsigned int i=0;i<GeometryInfo<dim>::faces_per_cell; ++i)
+      {
+        const auto face = cell->face(i);
+        if (face->at_boundary())
+        {
+          for (unsigned j = 0; j < GeometryInfo<dim>::vertices_per_face; ++j)
+          {
+            const auto vertex = face->vertex(j);
+            const auto vertex_index = face->vertex_index(j);
+            vertex_map[vertex_index] = vertex / vertex.norm();
+          }
+        }
+      }
+    }
+    return vertex_map;
+  }
 
   /**
     * Distort a triangulation in
@@ -1560,7 +1586,6 @@ next_cell:
     // now compress the so-built connectivity pattern
     cell_connectivity.compress ();
   }
-
 
 
   template <int dim, int spacedim>

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -211,6 +211,11 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     laplace_transform (const std::map<unsigned int,Point<deal_II_dimension> > &new_points,
                        Triangulation<deal_II_dimension> &triangulation,
                        const Function<deal_II_dimension> *coefficient);
+
+    template
+    std::map<unsigned int,Point<deal_II_dimension> >
+    get_all_vertex_at_boundary (const Triangulation<deal_II_dimension> &tria);
+
 #  endif
 
     template

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -204,6 +204,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
       double
       maximal_cell_diameter (const Triangulation<deal_II_dimension, deal_II_space_dimension> &triangulation);
 
+    template
+    std::map<unsigned int,Point<deal_II_space_dimension> >
+    get_all_vertices_at_boundary (const Triangulation<deal_II_dimension,deal_II_space_dimension> &tria);
+
 #if deal_II_dimension == deal_II_space_dimension
 #  if deal_II_dimension > 1
     template
@@ -211,10 +215,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     laplace_transform (const std::map<unsigned int,Point<deal_II_dimension> > &new_points,
                        Triangulation<deal_II_dimension> &triangulation,
                        const Function<deal_II_dimension> *coefficient);
-
-    template
-    std::map<unsigned int,Point<deal_II_dimension> >
-    get_all_vertex_at_boundary (const Triangulation<deal_II_dimension> &tria);
 
 #  endif
 


### PR DESCRIPTION
A new funtion to get a map with all vertices at boundaries 
  has been added in GridTools::get_all_vertices_at_boundary. 
  This function will return a map wich can be used in functions 
  like GridTools::Laplace_transform.