### PR TITLE
Fixup for the get_all_vertices_at_boundary merge

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -333,14 +333,6 @@ inconvenience this causes.
 
 <ol>
 
-  <li> New: A new funtion to get a map with all vertices at boundaries 
-  has been added in GridTools::get_all_vertices_at_boundary. 
-  This function will return a map wich can be used in functions 
-  like GridTools::Laplace_transform.
-  <br>
-  (Fernando Posada, 2015/03/31)
-  </li>
-
   <li> New: A new flag no_automatic_repartitioning in
   parallel::distributed::Triangulation will disable the automatic
   repartitioning when calling execute_coarsening_and_refinement() (or things
@@ -410,6 +402,14 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> New: A new funtion to get a map with all vertices at boundaries
+  has been added in GridTools::get_all_vertices_at_boundary.
+  This function will return a map wich can be used in functions
+  like GridTools::Laplace_transform.
+  <br>
+  (Fernando Posada, 2015/03/31)
+  </li>
+
   <li> Fixed: TrilinosWrappers::SparseMatrix::local_range() erroneously
   threw an exception in 64-bit mode. This is now fixed.
   <br>

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -769,7 +769,7 @@ namespace GridTools
   }
 
   template <int dim, int spacedim>
-  std::map<unsigned int,Point<spacedim> >
+  std::map<unsigned int, Point<spacedim> >
   get_all_vertices_at_boundary (const Triangulation<dim, spacedim> &tria)
   {
     std::map<unsigned int, Point<spacedim> > vertex_map;
@@ -780,13 +780,14 @@ namespace GridTools
       {
         for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
           {
-            const auto face = cell->face(i);
+            const typename Triangulation<dim, spacedim>::face_iterator &face
+              = cell->face(i);
             if (face->at_boundary())
               {
                 for (unsigned j = 0; j < GeometryInfo<dim>::vertices_per_face; ++j)
                   {
-                    const auto vertex = face->vertex(j);
-                    const auto vertex_index = face->vertex_index(j);
+                    const Point<spacedim> &vertex = face->vertex(j);
+                    const unsigned int vertex_index = face->vertex_index(j);
                     vertex_map[vertex_index] = vertex;
                   }
               }


### PR DESCRIPTION
Changes:

c17a12b (Matthias Maier, 23 seconds ago)
   Move entry in changes.h to appropriate place

663a8e5 (Matthias Maier, 3 minutes ago)
   Bugfix: Do not use c++11 features in get_all_vertices_at_boundary