### PR TITLE
Testsuite: Bugfix: Guard mesh_converter tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,9 +87,14 @@ ENDFOREACH()
 SET(_categories
   a-framework algorithms all-headers aniso arpack base bits build_tests
   codim_one deal.II distributed_grids fe gla grid hp integrators lac lapack
-  manifold matrix_free mesh_converter metis mpi multigrid opencascade petsc
-  serialization slepc trilinos umfpack
+  manifold matrix_free metis mpi multigrid opencascade petsc serialization
+  slepc trilinos umfpack
   )
+IF(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
+  # Only set up mesh_converter tests if the testsuite is set up as a
+  # dependent project:
+  LIST(APPEND _categories mesh_converter)
+ENDIF()
 
 #
 # Custom targets for the testsuite:


### PR DESCRIPTION
Only run mesh_converter tests if the testsuite is set up as a dependent
project of the deal.II. In case of an already installed deal.II library,
not all necessary files and configuration for the mesh_converter tests are
available.