### PR TITLE
add '*.vtu *.pvtu' to CLEAN_UP_FILES list in step-40.

### DIFF
--- a/examples/step-40/CMakeLists.txt
+++ b/examples/step-40/CMakeLists.txt
@@ -47,5 +47,6 @@ One or all of these are OFF in your installation but are required for this tutor
 ENDIF()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
+SET(CLEAN_UP_FILES *.log *.gmv *.gnuplot *.gpl *.eps *.pov *.vtk *.ucd *.d2 *.vtu *.pvtu)
 PROJECT(${TARGET})
 DEAL_II_INVOKE_AUTOPILOT()


### PR DESCRIPTION
The default CLEAN_UP_FILES does not cover *.vtu *.pvtu files generated by step-40.
Set the variable CLEAN_UP_FILES before calling macro DEAL_II_INVOKE_AUTOPILOT() to shield its default value. 