### PR TITLE
Make compile in 64bit mode.

### DIFF
--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -565,7 +565,7 @@ private:
 
   mutable std::vector<double> local_dofs;
 
-  mutable std::vector<unsigned int> dof_indices;
+  mutable std::vector<types::global_dof_index> dof_indices;
 
   /**
    * Mutex to protect local_dofs.

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1327,7 +1327,7 @@ void MappingFE<dim,spacedim,DH,VECTOR>::update_euler_vector_using_triangulation
 
       MappingQ<dim,spacedim> map_q(fe->degree);
       FEValues<dim,spacedim> fe_v(map_q, *fe, quad, update_quadrature_points);
-      std::vector<unsigned int> dofs(fe->dofs_per_cell);
+      std::vector<types::global_dof_index> dofs(fe->dofs_per_cell);
 
       AssertDimension(fe->dofs_per_cell, support_points.size());
       Assert(fe->is_primitive(), ExcMessage("FE is not Primitive! This won't work."));


### PR DESCRIPTION
MappingFE does not currently compile in 64bit mode due to wrong data types in two places.