### PR TITLE
Small cleanup in two matrix interfaces, documentation

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,11 +38,23 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li>Removed: The generic, templated vmult, Tvmult, etc. -interfaces of
+  LAPACKFullMatrix - they were never implemented.
+  <br>
+  (Matthias Maier, 2015/04/10)
+  </li>
+
+  <li>Removed: SparseDirectUMFPACK::vmult_add and
+  SparseDirectUMFPACK::Tvmult_add - they were never implemented.
+  <br>
+  (Matthias Maier, 2015/04/10)
+  </li>
+
   <li>Removed: The class NamedData has been removed after it had been
   superceded by AnyData a while ago. This affects the use of classes
   in Algorithms and MeshWorker
   <br>
-  (Guido KAnschat, 2015/04/02)
+  (Guido Kanschat, 2015/04/02)
   </li>
 
   <li> Removed: The CMake configuration does not use the variable

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -22,6 +22,7 @@
 // file and in each case pick the more accurate data type for intermediate
 // results. currently, the choice is pretty much random. this may also allow
 // us some operations where one operand is complex and the other is not
+// -> use ProductType<T,U> type trait for the results
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -17,7 +17,11 @@
 #define __deal2__full_matrix_templates_h
 
 
-//TODO: this file has a lot of operations between matrices and matrices or matrices and vectors of different precision. we should go through the file and in each case pick the more accurate data type for intermediate results. currently, the choice is pretty much random. this may also allow us some operations where one operand is complex and the other is not
+// TODO: this file has a lot of operations between matrices and matrices or
+// matrices and vectors of different precision. we should go through the
+// file and in each case pick the more accurate data type for intermediate
+// results. currently, the choice is pretty much random. this may also allow
+// us some operations where one operand is complex and the other is not
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -208,13 +208,16 @@ public:
    * @note The template with @tref number2 only exists for compile-time
    * compatibility with FullMatrix. Only the case @tref number2 = @tref
    * number is implemented due to limitations in the underlying LAPACK
-   * interface
+   * interface. All other variants throw an error upon invocation.
    */
   template <typename number2>
   void vmult (Vector<number2>       &w,
               const Vector<number2> &v,
               const bool             adding = false) const;
 
+  /**
+   * Specialization of above function for compatbile Vector::value_type.
+   */
   void vmult (Vector<number>       &w,
               const Vector<number> &v,
               const bool            adding = false) const;
@@ -228,6 +231,9 @@ public:
   void vmult_add (Vector<number2>       &w,
                   const Vector<number2> &v) const;
 
+  /**
+   * Specialization of above function for compatbile Vector::value_type.
+   */
   void vmult_add (Vector<number>       &w,
                   const Vector<number> &v) const;
 
@@ -248,6 +254,9 @@ public:
                const Vector<number2> &v,
                const bool             adding=false) const;
 
+  /**
+   * Specialization of above function for compatbile Vector::value_type.
+   */
   void Tvmult (Vector<number>       &w,
                const Vector<number> &v,
                const bool            adding=false) const;
@@ -262,6 +271,9 @@ public:
   void Tvmult_add (Vector<number2>       &w,
                    const Vector<number2> &v) const;
 
+  /**
+   * Specialization of above function for compatbile Vector::value_type.
+   */
   void Tvmult_add (Vector<number>       &w,
                    const Vector<number> &v) const;
 

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -146,14 +146,14 @@ public:
                const size_type cols);
 
   /**
-   * Return the dimension of the range space.
+   * Return the dimension of the codomain (or range) space.
    *
    * @note The matrix is of dimension $m \times n$.
    */
   unsigned int m () const;
 
   /**
-   * Return the number of the range space.
+   * Return the dimension of the domain space.
    *
    * @note The matrix is of dimension $m \times n$.
    */
@@ -193,7 +193,7 @@ public:
    * <li> If #state is LAPACKSupport::svd or LAPACKSupport::inverse_svd, this
    * function first multiplies with the right transformation matrix, then with
    * the diagonal matrix of singular values or their reciprocal values, and
-   * finally with the left trandformation matrix.
+   * finally with the left transformation matrix.
    * </ul>
    *
    * The optional parameter <tt>adding</tt> determines, whether the result is
@@ -205,20 +205,31 @@ public:
    *
    * @note Source and destination must not be the same vector.
    *
-   * @note This template only exists for compile-time compatibility with
-   * FullMatrix. Implementation is only available for
-   * <tt>VECTOR=Vector&lt;number&gt;</tt>
+   * @note The template with @tref number2 only exists for compile-time
+   * compatibility with FullMatrix. Only the case @tref number2 = @tref
+   * number is implemented due to limitations in the underlying LAPACK
+   * interface
    */
-  template <class VECTOR>
-  void vmult(VECTOR &dst, const VECTOR &src, const bool adding = false) const;
+  template <typename number2>
+  void vmult (Vector<number2>       &w,
+              const Vector<number2> &v,
+              const bool             adding = false) const;
+
+  void vmult (Vector<number>       &w,
+              const Vector<number> &v,
+              const bool            adding = false) const;
 
   /**
    * Adding Matrix-vector-multiplication.  <i>w += A*v</i>
    *
    * See the documentation of vmult() for details on the implementation.
    */
-  template <class VECTOR>
-  void vmult_add (VECTOR &w, const VECTOR &v) const;
+  template <typename number2>
+  void vmult_add (Vector<number2>       &w,
+                  const Vector<number2> &v) const;
+
+  void vmult_add (Vector<number>       &w,
+                  const Vector<number> &v) const;
 
   /**
    * Transpose matrix-vector-multiplication.
@@ -232,27 +243,25 @@ public:
    *
    * See the documentation of vmult() for details on the implementation.
    */
-  template <class VECTOR>
-  void Tvmult (VECTOR &w, const VECTOR &v,
-               const bool            adding=false) const;
+  template <typename number2>
+  void Tvmult (Vector<number2>       &w,
+               const Vector<number2> &v,
+               const bool             adding=false) const;
 
-  /**
-   * Adding transpose matrix-vector-multiplication.  <i>w +=
-   * A<sup>T</sup>*v</i>
-   *
-   * See the documentation of vmult() for details on the implementation.
-   */
-  template <class VECTOR>
-  void Tvmult_add (VECTOR &w, const VECTOR &v) const;
-
-  void vmult (Vector<number>   &w,
-              const Vector<number> &v,
-              const bool            adding=false) const;
-  void vmult_add (Vector<number>       &w,
-                  const Vector<number> &v) const;
   void Tvmult (Vector<number>       &w,
                const Vector<number> &v,
                const bool            adding=false) const;
+
+  /**
+   * Adding transpose matrix-vector-multiplication.
+   * <i>w += A<sup>T</sup>*v</i>
+   *
+   * See the documentation of vmult() for details on the implementation.
+   */
+  template <typename number2>
+  void Tvmult_add (Vector<number2>       &w,
+                   const Vector<number2> &v) const;
+
   void Tvmult_add (Vector<number>       &w,
                    const Vector<number> &v) const;
 
@@ -738,38 +747,52 @@ LAPACKFullMatrix<number>::fill (
 
 
 template <typename number>
-template <class VECTOR>
-inline void
-LAPACKFullMatrix<number>::vmult(VECTOR &, const VECTOR &, bool) const
+template <typename number2>
+void
+LAPACKFullMatrix<number>::vmult (Vector<number2> &,
+                                 const Vector<number2> &,
+                                 const bool) const
 {
-  Assert(false, ExcNotImplemented());
+  Assert(false,
+         ExcMessage("LAPACKFullMatrix<number>::vmult must be called with a "
+                    "matching Vector<double> vector type."));
 }
 
 
 template <typename number>
-template <class VECTOR>
-inline void
-LAPACKFullMatrix<number>::vmult_add(VECTOR &, const VECTOR &) const
+template <typename number2>
+void
+LAPACKFullMatrix<number>::vmult_add (Vector<number2> &,
+                                     const Vector<number2> &) const
 {
-  Assert(false, ExcNotImplemented());
+  Assert(false,
+         ExcMessage("LAPACKFullMatrix<number>::vmult_add must be called with a "
+                    "matching Vector<double> vector type."));
 }
 
 
 template <typename number>
-template <class VECTOR>
-inline void
-LAPACKFullMatrix<number>::Tvmult(VECTOR &, const VECTOR &, bool) const
+template <typename number2>
+void
+LAPACKFullMatrix<number>::Tvmult (Vector<number2> &,
+                                  const Vector<number2> &,
+                                  const bool) const
 {
-  Assert(false, ExcNotImplemented());
+  Assert(false,
+         ExcMessage("LAPACKFullMatrix<number>::Tvmult must be called with a "
+                    "matching Vector<double> vector type."));
 }
 
 
 template <typename number>
-template <class VECTOR>
-inline void
-LAPACKFullMatrix<number>::Tvmult_add(VECTOR &, const VECTOR &) const
+template <typename number2>
+void
+LAPACKFullMatrix<number>::Tvmult_add (Vector<number2> &,
+                                      const Vector<number2> &) const
 {
-  Assert(false, ExcNotImplemented());
+  Assert(false,
+         ExcMessage("LAPACKFullMatrix<number>::Tvmult_add must be called with a "
+                    "matching Vector<double> vector type."));
 }
 
 

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -186,20 +186,6 @@ public:
                const BlockVector<double> &src) const;
 
   /**
-   * Same as vmult(), but adding to the result to @p dst instead of
-   * overwriting the previous contents of the vector.
-   */
-  void vmult_add (Vector<double> &dst,
-                  const Vector<double> &src) const;
-
-  /**
-   * Same as before, but uses the transpose of the matrix, i.e. this function
-   * multiplies with $A^{-T}$.
-   */
-  void Tvmult_add (Vector<double> &dst,
-                   const Vector<double> &src) const;
-
-  /**
    * @}
    */
 

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -186,8 +186,8 @@ public:
                const BlockVector<double> &src) const;
 
   /**
-   * Same as vmult(), but adding to the previous solution. Not implemented yet
-   * but necessary for compiling certain other classes.
+   * Same as vmult(), but adding to the result to @p dst instead of
+   * overwriting the previous contents of the vector.
    */
   void vmult_add (Vector<double> &dst,
                   const Vector<double> &src) const;

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -46,7 +46,7 @@ template <typename number> class SparseBlockVanka;
  * matrices the application of Jacobi or Gauss-Seidel methods is impossible,
  * because some diagonal elements are zero in the rows of the Lagrange
  * multiplier. The approach of Vanka is to solve a small (usually indefinite)
- * system of equations for each Langrange multiplie variable (we will also
+ * system of equations for each Langrange multiplier variable (we will also
  * call the pressure in Stokes' equation a Langrange multiplier since it can
  * be interpreted as such).
  *
@@ -91,23 +91,21 @@ template <typename number> class SparseBlockVanka;
  * parameter optimization. The Lagrange multiplier is the third component of
  * the finite element used. The system is solved by the GMRES method.
  * @code
- *                        // tag the Lagrange multiplier variable
+ *    // tag the Lagrange multiplier variable
  *    vector<bool> signature(3);
  *    signature[0] = signature[1] = false;
  *    signature[2] = true;
  *
- *                        // tag all dofs belonging to the
- *                        // Lagrange multiplier
+ *    // tag all dofs belonging to the Lagrange multiplier
  *    vector<bool> selected_dofs (dof.n_dofs(), false);
  *    DoFTools::extract_dofs(dof, signature, p_select);
- *                        // create the Vanka object
+ *    // create the Vanka object
  *    SparseVanka<double> vanka (global_matrix, selected_dofs);
  *
- *                        // create the solver
- *    SolverGMRES<PreconditionedSparseMatrix<double>,
- *                Vector<double> >    gmres(control,memory,504);
+ *    // create the solver
+ *    SolverGMRES<> gmres(control,memory,504);
  *
- *                        // solve
+ *    // solve
  *    gmres.solve (global_matrix, solution, right_hand_side,
  *                 vanka);
  * @endcode

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -955,7 +955,7 @@ protected:
   /**
    * LAPACK matrices need access to the data.
    */
-  friend class LAPACKFullMatrix<Number>;
+  template <typename Number2> friend class LAPACKFullMatrix;
 
   /**
    * VectorView will access the pointer.

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -244,6 +244,24 @@ LAPACKFullMatrix<number>::Tvmult (
     default:
       Assert (false, ExcState(state));
     }
+}
+
+
+template <typename number>
+void
+LAPACKFullMatrix<number>::vmult_add (Vector<number>       &w,
+                                     const Vector<number> &v) const
+{
+  vmult(w, v, true);
+}
+
+
+template <typename number>
+void
+LAPACKFullMatrix<number>::Tvmult_add (Vector<number>       &w,
+                                      const Vector<number> &v) const
+{
+  Tvmult(w, v, true);
 }
 
 
@@ -955,31 +973,6 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
         }
     }
   state = LAPACKSupport::State(eigenvalues | unusable);
-}
-
-
-// template <typename number>
-// LAPACKFullMatrix<number>::()
-// {}
-
-
-template <typename number>
-void
-LAPACKFullMatrix<number>::vmult_add (
-  Vector<number>       &w,
-  const Vector<number> &v) const
-{
-  vmult(w, v, true);
-}
-
-
-template <typename number>
-void
-LAPACKFullMatrix<number>::Tvmult_add (
-  Vector<number>       &w,
-  const Vector<number> &v) const
-{
-  Tvmult(w, v, true);
 }
 
 

--- a/source/lac/lapack_full_matrix.inst.in
+++ b/source/lac/lapack_full_matrix.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014 by the deal.II authors
+// Copyright (C) 2013 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -469,25 +469,6 @@ SparseDirectUMFPACK::Tvmult (
 }
 
 
-void
-SparseDirectUMFPACK::vmult_add (
-  Vector<double> &,
-  const Vector<double> &) const
-{
-  Assert(false, ExcNotImplemented());
-}
-
-
-void
-SparseDirectUMFPACK::Tvmult_add (
-  Vector<double> &,
-  const Vector<double> &) const
-{
-  Assert(false, ExcNotImplemented());
-}
-
-
-
 // explicit instantiations for SparseMatrixUMFPACK
 #define InstantiateUMFPACK(MATRIX)                        \
   template                                                \


### PR DESCRIPTION
Changes:

f271071 (Matthias Maier, 43 minutes ago)
   Specialize LAPACKFullMatrix::vmult (etc.) interface

2dd6e8c (Matthias Maier, 7 hours ago)
   Remove vmult_add and Tvmult_add from SparseDirectUMFPACK

28a2cfa (Matthias Maier, 8 hours ago)
   Small documentation update

b1a8e52 (Matthias Maier, 8 hours ago)
   Documentation fixes