### PR TITLE
Fix SparsityTools::reorder_hierarchical with 64 bit integers

### DIFF
--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -371,12 +371,12 @@ namespace SparsityTools
           // Find cell with the minimal number of neighbors (typically a corner
           // node when based on FEM meshes). If no cell is left, we are done.
           std::pair<types::global_dof_index,types::global_dof_index> min_neighbors
-          (numbers::invalid_unsigned_int, numbers::invalid_unsigned_int);
+          (numbers::invalid_dof_index, numbers::invalid_dof_index);
           for (types::global_dof_index i=0; i<touched_nodes.size(); ++i)
-            if (touched_nodes[i] == numbers::invalid_unsigned_int)
+            if (touched_nodes[i] == numbers::invalid_dof_index)
               if (connectivity.row_length(i) < min_neighbors.second)
                 min_neighbors = std::make_pair(i, connectivity.row_length(i));
-          if (min_neighbors.first == numbers::invalid_unsigned_int)
+          if (min_neighbors.first == numbers::invalid_dof_index)
             break;
 
           current_neighbors.clear();
@@ -385,18 +385,18 @@ namespace SparsityTools
             {
               // Find cell with minimum number of untouched neighbors among the
               // next set of possible neighbors
-              min_neighbors = std::make_pair (numbers::invalid_unsigned_int,
-                                              numbers::invalid_unsigned_int);
+              min_neighbors = std::make_pair (numbers::invalid_dof_index,
+                                              numbers::invalid_dof_index);
               for (std::set<types::global_dof_index>::iterator it=current_neighbors.begin();
                    it != current_neighbors.end(); ++it)
                 {
-                  AssertThrow(touched_nodes[*it] == numbers::invalid_unsigned_int,
+                  AssertThrow(touched_nodes[*it] == numbers::invalid_dof_index,
                               ExcInternalError());
                   types::global_dof_index active_row_length = 0;
                   for (CompressedSimpleSparsityPattern::row_iterator rowit
                        = connectivity.row_begin(*it);
                        rowit != connectivity.row_end(*it); ++rowit)
-                    if (touched_nodes[*rowit] == numbers::invalid_unsigned_int)
+                    if (touched_nodes[*rowit] == numbers::invalid_dof_index)
                       ++active_row_length;
                   if (active_row_length < min_neighbors.second)
                     min_neighbors = std::make_pair(*it, active_row_length);
@@ -412,7 +412,7 @@ namespace SparsityTools
                   for (CompressedSimpleSparsityPattern::row_iterator rowit
                        = connectivity.row_begin(*it);
                        rowit != connectivity.row_end(*it); ++rowit)
-                    if (touched_nodes[*rowit] == numbers::invalid_unsigned_int)
+                    if (touched_nodes[*rowit] == numbers::invalid_dof_index)
                       ++active_row_length;
                   if (active_row_length == best_row_length)
                     if (connectivity.row_length(*it) > min_neighbors.second)
@@ -431,7 +431,7 @@ namespace SparsityTools
                    = connectivity.row_begin(min_neighbors.first);
                    it != connectivity.row_end(min_neighbors.first); ++it)
                 {
-                  if (touched_nodes[*it] == numbers::invalid_unsigned_int)
+                  if (touched_nodes[*it] == numbers::invalid_dof_index)
                     {
                       new_entries.push_back(*it);
                       touched_nodes[*it] = groups.size()-1;
@@ -446,7 +446,7 @@ namespace SparsityTools
                   for (CompressedSimpleSparsityPattern::row_iterator it
                        = connectivity.row_begin(new_entries[i]);
                        it != connectivity.row_end(new_entries[i]); ++it)
-                    if (touched_nodes[*it] == numbers::invalid_unsigned_int)
+                    if (touched_nodes[*it] == numbers::invalid_dof_index)
                       current_neighbors.insert(*it);
                   current_neighbors.erase(new_entries[i]);
                 }


### PR DESCRIPTION
It turns out that my new implementation was partly using 64 bit integers, leading to strange comparisons `invalid_unsigned_int == invalid_dof_index` which can only lead to trouble when `global_dof_index != unsigned int`. Be consistent with the data types.