### PR TITLE
Rename boundary_indicator() to boundary_id()

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -328,12 +328,12 @@
  *     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
  *       if (cell->face(f)->at_boundary())
  *         if (cell->face(f)->center()[0] == -1)
- *           cell->face(f)->set_boundary_indicator (42);
+ *           cell->face(f)->set_boundary_id (42);
  * @endcode
- * This calls functions TriaAccessor::set_boundary_indicator. In 3d, it may
- * also be appropriate to call TriaAccessor::set_all_boundary_indicators instead
+ * This calls functions TriaAccessor::set_boundary_id. In 3d, it may
+ * also be appropriate to call TriaAccessor::set_all_boundary_ids instead
  * on each of the selected faces. To query the boundary indicator of a particular
- * face or edge, use TriaAccessor::boundary_indicator.
+ * face or edge, use TriaAccessor::boundary_id.
  *
  * In older versions of the library (prior to 8.2), if you wanted also
  * to change the way the Triangulation class treated the boundary for

--- a/doc/doxygen/headers/iterators.h
+++ b/doc/doxygen/headers/iterators.h
@@ -225,7 +225,7 @@ iterator are
   line->child(0);
   hex->face(3);
   cell->at_boundary();
-  face->boundary_indicator();
+  face->boundary_id();
 @endcode
 
 Since dereferencing iterators yields accessor objects, these calls are to

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -352,6 +352,18 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Deprecated: The library uses functions such as CellAccessor::subdomain_id(),
+  TriaAccessor::manifold_id(), etc, but used the deviant spelling
+  TriaAccessor::boundary_indicator(), TriaAccessor::set_boundary_indicator(),
+  TriaAccessor::set_all_boundary_indicators(). These last three functions are now
+  deprecated and have been replaced by TriaAccessor::boundary_id(),
+  TriaAccessor::set_boundary_id(), and TriaAccessor::set_all_boundary_ids() for
+  consistency. Similar, Triangulation::get_boundary_indicators() has been
+  deprecated in favor of Triangulation::get_boundary_ids().
+  <br>
+  (Wolfgang Bangerth, 2015/04/11)
+  </li>
+
   <li> Changed: All example programs used to have calls to set_boundary() 
   methods to deal with curved boundaries. These have been replaced with 
   the corresponding set_manifold() equivalent. 

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -823,16 +823,16 @@ namespace Step18
             const Point<dim> face_center = cell->face(f)->center();
 
             if (face_center[2] == 0)
-              cell->face(f)->set_boundary_indicator (0);
+              cell->face(f)->set_boundary_id (0);
             else if (face_center[2] == 3)
-              cell->face(f)->set_boundary_indicator (1);
+              cell->face(f)->set_boundary_id (1);
             else if (std::sqrt(face_center[0]*face_center[0] +
                                face_center[1]*face_center[1])
                      <
                      (inner_radius + outer_radius) / 2)
-              cell->face(f)->set_boundary_indicator (2);
+              cell->face(f)->set_boundary_id (2);
             else
-              cell->face(f)->set_boundary_indicator (3);
+              cell->face(f)->set_boundary_id (3);
           }
 
     // In order to make sure that new vertices are placed correctly on

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -954,7 +954,7 @@ namespace Step22
          cell != triangulation.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->center()[dim-1] == 0)
-          cell->face(f)->set_all_boundary_indicators(1);
+          cell->face(f)->set_all_boundary_ids(1);
 
 
     // We then apply an initial refinement before solving for the first

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -494,7 +494,7 @@ namespace Step29
              ((cell->face(face)->center() - transducer).norm_square() < 0.01) )
           {
 
-            cell->face(face)->set_boundary_indicator (1);
+            cell->face(face)->set_boundary_id (1);
             cell->face(face)->set_manifold_id (1);
           }
     // For the circle part of the transducer lens, a hyper-ball object is used
@@ -709,7 +709,7 @@ namespace Step29
         // absorbing boundary conditions:
         for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           if (cell->face(face)->at_boundary() &&
-              (cell->face(face)->boundary_indicator() == 0) )
+              (cell->face(face)->boundary_id() == 0) )
             {
 
 

--- a/examples/step-3/doc/results.dox
+++ b/examples/step-3/doc/results.dox
@@ -102,7 +102,7 @@ suggestions:
   of the boundary different indicators. For example, try this
   immediately after calling <code>GridGenerator::hyper_cube</code>:
   @code
-  triangulation.begin_active()->face(0)->set_boundary_indicator(1);
+  triangulation.begin_active()->face(0)->set_boundary_id(1);
   @endcode
   What this does is it first asks the triangulation to
   return an iterator that points to the first active cell. Of course,

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1490,7 +1490,7 @@ namespace Step33
                                   dof_indices,
                                   std::vector<types::global_dof_index>(),
                                   true,
-                                  cell->face(face_no)->boundary_indicator(),
+                                  cell->face(face_no)->boundary_id(),
                                   cell->face(face_no)->diameter());
             }
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -412,7 +412,7 @@ namespace Step35
 
     EquationData::Velocity<dim>       vel_exact;
     std::map<types::global_dof_index, double>    boundary_values;
-    std::vector<types::boundary_id> boundary_indicators;
+    std::vector<types::boundary_id> boundary_ids;
 
     Triangulation<dim> triangulation;
 
@@ -709,7 +709,7 @@ namespace Step35
     std::cout << "Number of active cells: " << triangulation.n_active_cells()
               << std::endl;
 
-    boundary_indicators = triangulation.get_boundary_indicators();
+    boundary_ids = triangulation.get_boundary_ids();
 
     dof_handler_velocity.distribute_dofs (fe_velocity);
     DoFRenumbering::boost::Cuthill_McKee (dof_handler_velocity);
@@ -1022,8 +1022,8 @@ namespace Step35
         vel_exact.set_component(d);
         boundary_values.clear();
         for (std::vector<types::boundary_id>::const_iterator
-             boundaries = boundary_indicators.begin();
-             boundaries != boundary_indicators.end();
+             boundaries = boundary_ids.begin();
+             boundaries != boundary_ids.end();
              ++boundaries)
           {
             switch (*boundaries)

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -938,7 +938,7 @@ namespace Step42
 
         GridGenerator::hyper_rectangle(triangulation, p1, p2);
 
-        /* boundary_indicators:
+        /* boundary_ids:
 
          */
         Triangulation<3>::active_cell_iterator
@@ -949,14 +949,14 @@ namespace Step42
                ++face)
             {
               if (cell->face(face)->center()[2] == p2(2))
-                cell->face(face)->set_boundary_indicator(1);
+                cell->face(face)->set_boundary_id(1);
               if (cell->face(face)->center()[0] == p1(0)
                   || cell->face(face)->center()[0] == p2(0)
                   || cell->face(face)->center()[1] == p1(1)
                   || cell->face(face)->center()[1] == p2(1))
-                cell->face(face)->set_boundary_indicator(8);
+                cell->face(face)->set_boundary_id(8);
               if (cell->face(face)->center()[2] == p1(2))
-                cell->face(face)->set_boundary_indicator(6);
+                cell->face(face)->set_boundary_id(6);
             }
       }
 
@@ -1153,7 +1153,7 @@ namespace Step42
              ++face)
           if (cell->face(face)->at_boundary()
               &&
-              cell->face(face)->boundary_indicator() == 1)
+              cell->face(face)->boundary_id() == 1)
             {
               fe_values_face.reinit(cell, face);
               cell_matrix = 0;
@@ -1243,7 +1243,7 @@ namespace Step42
         for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           if (cell->face(face)->at_boundary()
               &&
-              cell->face(face)->boundary_indicator() == 1)
+              cell->face(face)->boundary_id() == 1)
             {
               fe_values_face.reinit(cell, face);
               cell->face(face)->get_dof_indices(dof_indices);
@@ -1422,7 +1422,7 @@ namespace Step42
           for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary()
                 &&
-                cell->face(face)->boundary_indicator() == 1)
+                cell->face(face)->boundary_id() == 1)
               {
                 fe_values_face.reinit(cell, face);
 
@@ -1554,7 +1554,7 @@ namespace Step42
 
           for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary()
-                && cell->face(face)->boundary_indicator() == 1)
+                && cell->face(face)->boundary_id() == 1)
               {
                 fe_values_face.reinit(cell, face);
 
@@ -2103,7 +2103,7 @@ namespace Step42
         for (unsigned int face = 0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           if (cell->face(face)->at_boundary()
               &&
-              cell->face(face)->boundary_indicator() == 1)
+              cell->face(face)->boundary_id() == 1)
             {
               fe_values_face.reinit(cell, face);
 

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1543,7 +1543,7 @@ namespace Step44
           if (cell->face(face)->center()[0] < 0.5 * parameters.scale
               &&
               cell->face(face)->center()[1] < 0.5 * parameters.scale)
-            cell->face(face)->set_boundary_indicator(6);
+            cell->face(face)->set_boundary_id(6);
   }
 
 
@@ -2372,7 +2372,7 @@ namespace Step44
     for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
          ++face)
       if (cell->face(face)->at_boundary() == true
-          && cell->face(face)->boundary_indicator() == 6)
+          && cell->face(face)->boundary_id() == 6)
         {
           scratch.fe_face_values_ref.reinit(cell, face);
 

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -150,8 +150,8 @@ namespace Step45
   void LaplaceProblem::make_grid_and_dofs ()
   {
     GridGenerator::hyper_cube (triangulation);
-    triangulation.begin_active ()->face (2)->set_boundary_indicator (1);
-    triangulation.begin_active ()->face (3)->set_boundary_indicator (1);
+    triangulation.begin_active ()->face (2)->set_boundary_id (1);
+    triangulation.begin_active ()->face (3)->set_boundary_id (1);
     triangulation.refine_global (5);
 
     // The next step is to distribute the degrees of freedom and produce a

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -321,7 +321,7 @@ namespace Step46
         if (cell->face(f)->at_boundary()
             &&
             (cell->face(f)->center()[dim-1] == 1))
-          cell->face(f)->set_all_boundary_indicators(1);
+          cell->face(f)->set_all_boundary_ids(1);
 
 
     for (typename Triangulation<dim>::active_cell_iterator

--- a/examples/step-49/doc/results.dox
+++ b/examples/step-49/doc/results.dox
@@ -276,12 +276,12 @@ describe this. A first attempt looks like this:
 	  {
 	    if ((face_center[2] <= 2.5 || face_center[2] >= 5) &&
 	        face_center[1] >= 3)
-	      cell->face(f)->set_boundary_indicator(8);
+	      cell->face(f)->set_boundary_id(8);
 
 	    if (face_center[2] >= 2.5 &&
 	        face_center[2] <= 5
 	        && face_center[1] >= 3)
-	      cell->face(f)->set_boundary_indicator(9);
+	      cell->face(f)->set_boundary_id(9);
 	  }
       }
 
@@ -325,8 +325,8 @@ mid-edge points are in the wrong place (you see this by comparing the
 picture with the one of the coarse mesh). What is happening is that we
 are only telling the triangulation to use these geometry objects for
 the <i>faces</i> but not for the adjacent <i>edges</i> as well. This is
-easily fixed by using the function TriaAccessor::set_all_boundary_indicators()
-instead of TriaAccessor::set_boundary_indicator() used above. With this change,
+easily fixed by using the function TriaAccessor::set_all_boundary_ids()
+instead of TriaAccessor::set_boundary_id() used above. With this change,
 the grid now looks like this:
 
 <img
@@ -374,11 +374,11 @@ code does the trick:
             {
               if ((face_center[2] < 2.5 || face_center[2] > 5)
                   && face_center[1] >= 3)
-                cell->face(f)->set_all_boundary_indicators(8);
+                cell->face(f)->set_all_boundary_ids(8);
 
               if (face_center[2] > 2.5 && face_center[2] < 5
                   && face_center[1] >= 3)
-                cell->face(f)->set_all_boundary_indicators(9);
+                cell->face(f)->set_all_boundary_ids(9);
             }
       }
 }

--- a/examples/step-49/step-49.cc
+++ b/examples/step-49/step-49.cc
@@ -80,7 +80,7 @@ void mesh_info(const Triangulation<dim> &tria,
         for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           {
             if (cell->face(face)->at_boundary())
-              boundary_count[cell->face(face)->boundary_indicator()]++;
+              boundary_count[cell->face(face)->boundary_id()]++;
           }
       }
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -882,7 +882,7 @@ namespace Step51
 
                 if (cell->face(face)->at_boundary()
                     &&
-                    (cell->face(face)->boundary_indicator() == 1))
+                    (cell->face(face)->boundary_id() == 1))
                   {
                     const double neumann_value =
                       - scratch.exact_solution.gradient (quadrature_point) * normal
@@ -1323,7 +1323,7 @@ namespace Step51
           if ((std::fabs(cell->face(face)->center()(0) - (-1)) < 1e-12)
               ||
               (std::fabs(cell->face(face)->center()(1) - (-1)) < 1e-12))
-            cell->face(face)->set_boundary_indicator (1);
+            cell->face(face)->set_boundary_id (1);
   }
 
   // @sect4{HDG::run}

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -614,9 +614,9 @@ namespace Step52
         if (cell->face(f)->at_boundary())
           {
             if ((cell->face(f)->center()[0]==0.) || (cell->face(f)->center()[0]==5.))
-              cell->face(f)->set_boundary_indicator(1);
+              cell->face(f)->set_boundary_id(1);
             else
-              cell->face(f)->set_boundary_indicator(0);
+              cell->face(f)->set_boundary_id(0);
           }
 
     // Next, we set up the linear systems and fill them with content so that

--- a/examples/step-53/step-53.cc
+++ b/examples/step-53/step-53.cc
@@ -413,7 +413,7 @@ namespace Step53
         for (Triangulation<3>::active_cell_iterator cell=triangulation.begin_active();
              cell!=triangulation.end(); ++cell)
           for (unsigned int f=0; f<GeometryInfo<3>::faces_per_cell; ++f)
-            if (cell->face(f)->boundary_indicator() == 5)
+            if (cell->face(f)->boundary_id() == 5)
               {
                 cell->set_refine_flag ();
                 break;

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -668,7 +668,7 @@ namespace Step7
         for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
           if (cell->face(face_number)->at_boundary()
               &&
-              (cell->face(face_number)->boundary_indicator() == 1))
+              (cell->face(face_number)->boundary_id() == 1))
             {
               // If we came into here, then we have found an external face
               // belonging to Gamma2. Next, we have to compute the values of
@@ -991,7 +991,7 @@ namespace Step7
                 if ((std::fabs(cell->face(face_number)->center()(0) - (-1)) < 1e-12)
                     ||
                     (std::fabs(cell->face(face_number)->center()(1) - (-1)) < 1e-12))
-                  cell->face(face_number)->set_boundary_indicator (1);
+                  cell->face(face_number)->set_boundary_id (1);
           }
         else
           refine_grid ();

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -242,7 +242,7 @@ namespace parallel
      *     #include <deal.II/base/std_cxx11/bind.h>
      *
      *     template <int dim>
-     *     void set_boundary_indicators (parallel::distributed::Triangulation<dim> &triangulation)
+     *     void set_boundary_ids (parallel::distributed::Triangulation<dim> &triangulation)
      *     {
      *       ... set boundary indicators on the triangulation object ...
      *     }
@@ -255,7 +255,7 @@ namespace parallel
      *       ... create the coarse mesh ...
      *
      *       coarse_grid.signals.post_refinement.connect
-     *         (std_cxx11::bind (&set_boundary_indicators<dim>,
+     *         (std_cxx11::bind (&set_boundary_ids<dim>,
      *                           std_cxx11::ref(coarse_grid)));
      *
      *     }
@@ -267,7 +267,7 @@ namespace parallel
      * argument but permanently fix this one argument to a reference to the
      * coarse grid triangulation. After each refinement step, the
      * triangulation will then call the object so created which will in turn
-     * call <code>set_boundary_indicators<dim></code> with the reference to
+     * call <code>set_boundary_ids<dim></code> with the reference to
      * the coarse grid as argument.
      *
      * This approach can be generalized. In the example above, we have used a
@@ -275,7 +275,7 @@ namespace parallel
      * that this function is in fact a member function of the class that
      * generates the mesh, for example because it needs to access run-time
      * parameters. This can be achieved as follows: assuming the
-     * <code>set_boundary_indicators()</code> function has been declared as a
+     * <code>set_boundary_ids()</code> function has been declared as a
      * (non-static, but possibly private) member function of the
      * <code>MyClass</code> class, then the following will work:
      * @code
@@ -284,7 +284,7 @@ namespace parallel
      *     template <int dim>
      *     void
      *     MyClass<dim>::
-     *     set_boundary_indicators (parallel::distributed::Triangulation<dim> &triangulation) const
+     *     set_boundary_ids (parallel::distributed::Triangulation<dim> &triangulation) const
      *     {
      *       ... set boundary indicators on the triangulation object ...
      *     }
@@ -297,21 +297,21 @@ namespace parallel
      *       ... create the coarse mesh ...
      *
      *       coarse_grid.signals.post_refinement.connect
-     *         (std_cxx11::bind (&MyGeometry<dim>::set_boundary_indicators,
+     *         (std_cxx11::bind (&MyGeometry<dim>::set_boundary_ids,
      *                           std_cxx11::cref(*this),
      *                           std_cxx11::ref(coarse_grid)));
      *     }
      * @endcode
      * Here, like any other member function,
-     * <code>set_boundary_indicators</code> implicitly takes a pointer or
+     * <code>set_boundary_ids</code> implicitly takes a pointer or
      * reference to the object it belongs to as first argument.
      * <code>std::bind</code> again creates an object that can be called like
      * a global function with no arguments, and this object in turn calls
-     * <code>set_boundary_indicators</code> with a pointer to the current
+     * <code>set_boundary_ids</code> with a pointer to the current
      * object and a reference to the triangulation to work on. Note that
      * because the <code>create_coarse_mesh</code> function is declared as
      * <code>const</code>, it is necessary that the
-     * <code>set_boundary_indicators</code> function is also declared
+     * <code>set_boundary_ids</code> function is also declared
      * <code>const</code>.
      *
      * <b>Note:</b>For reasons that have to do with the way the

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -706,14 +706,14 @@ public:
    * function.
    */
   types::global_dof_index
-  n_boundary_dofs (const FunctionMap &boundary_indicators) const;
+  n_boundary_dofs (const FunctionMap &boundary_ids) const;
 
   /**
    * Same function, but with different data type of the argument, which is
    * here simply a list of the boundary indicators under consideration.
    */
   types::global_dof_index
-  n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const;
+  n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const;
 
   /**
    * Access to an object informing of the block structure of the dof handler.

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -558,7 +558,7 @@ namespace DoFTools
   template <class DH, class SparsityPattern>
   void
   make_boundary_sparsity_pattern (const DH &dof,
-                                  const typename FunctionMap<DH::space_dimension>::type &boundary_indicators,
+                                  const typename FunctionMap<DH::space_dimension>::type &boundary_ids,
                                   const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
                                   SparsityPattern    &sparsity);
 
@@ -1027,7 +1027,7 @@ namespace DoFTools
    * @ref GlossFaceOrientation "standard orientation".
    *
    * Instead of defining a 'first' and 'second' boundary with the help of two
-   * boundary_indicators this function defines a 'left' boundary as all faces
+   * boundary_ids this function defines a 'left' boundary as all faces
    * with local face index <code>2*dimension</code> and boundary indicator @p
    * b_id and, similarly, a 'right' boundary consisting of all face with local
    * face index <code>2*dimension+1</code> and boundary indicator @p b_id.
@@ -1202,7 +1202,7 @@ namespace DoFTools
    * of freedom is at the boundary and belongs to one of the selected
    * components, and @p false otherwise. The function is used in step-15.
    *
-   * By specifying the @p boundary_indicator variable, you can select which
+   * By specifying the @p boundary_id variable, you can select which
    * boundary indicators the faces have to have on which the degrees of
    * freedom are located that shall be extracted. If it is an empty list, then
    * all boundary indicators are accepted.
@@ -1236,8 +1236,8 @@ namespace DoFTools
    * contain the indices of degrees of freedom that are located on the
    * boundary (and correspond to the selected vector components and boundary
    * indicators, depending on the values of the @p component_mask and @p
-   * boundary_indicators arguments).
-   * @param boundary_indicators If empty, this function extracts the indices
+   * boundary_ids arguments).
+   * @param boundary_ids If empty, this function extracts the indices
    * of the degrees of freedom for all parts of the boundary. If it is a non-
    * empty list, then the function only considers boundary faces with the
    * boundary indicators listed in this argument.
@@ -1250,7 +1250,7 @@ namespace DoFTools
   extract_boundary_dofs (const DH                   &dof_handler,
                          const ComponentMask        &component_mask,
                          std::vector<bool>          &selected_dofs,
-                         const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                         const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * This function does the same as the previous one but it returns its result
@@ -1273,8 +1273,8 @@ namespace DoFTools
    * contain the indices of degrees of freedom that are located on the
    * boundary (and correspond to the selected vector components and boundary
    * indicators, depending on the values of the @p component_mask and @p
-   * boundary_indicators arguments).
-   * @param boundary_indicators If empty, this function extracts the indices
+   * boundary_ids arguments).
+   * @param boundary_ids If empty, this function extracts the indices
    * of the degrees of freedom for all parts of the boundary. If it is a non-
    * empty list, then the function only considers boundary faces with the
    * boundary indicators listed in this argument.
@@ -1287,7 +1287,7 @@ namespace DoFTools
   extract_boundary_dofs (const DH                   &dof_handler,
                          const ComponentMask        &component_mask,
                          IndexSet                   &selected_dofs,
-                         const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                         const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * This function is similar to the extract_boundary_dofs() function but it
@@ -1310,7 +1310,7 @@ namespace DoFTools
   extract_dofs_with_support_on_boundary (const DH               &dof_handler,
                                          const ComponentMask    &component_mask,
                                          std::vector<bool>      &selected_dofs,
-                                         const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                                         const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * Extract a vector that represents the constant modes of the DoFHandler for
@@ -1906,7 +1906,7 @@ namespace DoFTools
   template <class DH>
   void
   map_dof_to_boundary_indices (const DH                      &dof_handler,
-                               const std::set<types::boundary_id> &boundary_indicators,
+                               const std::set<types::boundary_id> &boundary_ids,
                                std::vector<types::global_dof_index>     &mapping);
 
   /**
@@ -2031,7 +2031,7 @@ namespace DoFTools
    * A variant of this function with different arguments is used in step-36.
    *
    * @param dof The DoFHandler to work on.
-   * @param boundary_indicator The indicator of that part of the boundary for
+   * @param boundary_id The indicator of that part of the boundary for
    * which constraints should be computed. If this number equals
    * numbers::invalid_boundary_id then all boundaries of the domain will be
    * treated.
@@ -2064,7 +2064,7 @@ namespace DoFTools
   template <int dim, int spacedim, template <int, int> class DH>
   void
   make_zero_boundary_constraints (const DH<dim,spacedim> &dof,
-                                  const types::boundary_id boundary_indicator,
+                                  const types::boundary_id boundary_id,
                                   ConstraintMatrix       &zero_boundary_constraints,
                                   const ComponentMask    &component_mask = ComponentMask());
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -99,7 +99,7 @@ namespace GridGenerator
    * Create a coordinate-parallel brick from the two diagonally opposite
    * corner points @p p1 and @p p2.
    *
-   * If the @p colorize flag is set, the @p boundary_indicators of the
+   * If the @p colorize flag is set, the @p boundary_ids of the
    * surfaces are assigned, such that the lower one in @p x-direction is 0,
    * the upper one is 1. The indicators for the surfaces in @p y-direction are
    * 2 and 3, the ones for @p z are 4 and 5. Additionally, material ids are
@@ -127,7 +127,7 @@ namespace GridGenerator
    * a list of integers denoting the number of subdivisions in each coordinate
    * direction.
    *
-   * If the @p colorize flag is set, the @p boundary_indicators of the
+   * If the @p colorize flag is set, the @p boundary_ids of the
    * surfaces are assigned, such that the lower one in @p x-direction is 0,
    * the upper one is 1 (the left and the right vertical face). The indicators
    * for the surfaces in @p y-direction are 2 and 3, the ones for @p z are 4

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1115,7 +1115,7 @@ namespace GridTools
    * @ref GlossFaceOrientation "standard orientation".
    *
    * Instead of defining a 'first' and 'second' boundary with the help of two
-   * boundary_indicators this function defines a 'left' boundary as all faces
+   * boundary_ids this function defines a 'left' boundary as all faces
    * with local face index <code>2*dimension</code> and boundary indicator @p
    * b_id and, similarly, a 'right' boundary consisting of all face with local
    * face index <code>2*dimension+1</code> and boundary indicator @p b_id.

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -780,7 +780,7 @@ namespace internal
  * have boundary indicator zero while rightmost vertices have boundary
  * indicator one. In either case, the boundary indicator of a face can be
  * changed using a call of the kind
- * <code>cell-@>face(1)-@>set_boundary_indicator(42);</code>.
+ * <code>cell-@>face(1)-@>set_boundary_id(42);</code>.
  *
  * @see
  * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
@@ -1683,7 +1683,14 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  std::vector<types::boundary_id> get_boundary_indicators() const;
+  std::vector<types::boundary_id> get_boundary_ids() const;
+
+  /**
+   * Deprecated spelling of get_boundary_ids().
+   *
+   * @deprecated Use get_boundary_ids() instead.
+   */
+  std::vector<types::boundary_id> get_boundary_indicators() const DEAL_II_DEPRECATED;
 
   /**
    * Returns a vector containing all manifold indicators assigned to the
@@ -3112,7 +3119,7 @@ private:
    * fields of this class that can be modified by the TriaAccessor hierarchy
    * are pointers, and so these accessor classes store a const pointer to the
    * triangulation. We could no longer do so for TriaAccessor<0,1,spacedim> if
-   * this field (that can be modified by TriaAccessor::set_boundary_indicator)
+   * this field (that can be modified by TriaAccessor::set_boundary_id)
    * were not a pointer.
    */
   std::map<unsigned int, types::boundary_id> *vertex_to_boundary_id_map_1d;
@@ -3134,7 +3141,7 @@ private:
    * fields of this class that can be modified by the TriaAccessor hierarchy
    * are pointers, and so these accessor classes store a const pointer to the
    * triangulation. We could no longer do so for TriaAccessor<0,1,spacedim> if
-   * this field (that can be modified by TriaAccessor::set_boundary_indicator)
+   * this field (that can be modified by TriaAccessor::set_boundary_id)
    * were not a pointer.
    */
   std::map<unsigned int, types::manifold_id> *vertex_to_manifold_id_map_1d;

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -866,7 +866,7 @@ public:
    */
 
   /**
-   * Boundary indicator of this object.
+   * Return the boundary indicator of this object.
    *
    * If the return value is the special value
    * numbers::internal_face_boundary_id, then this object is in the interior
@@ -875,18 +875,26 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  types::boundary_id boundary_indicator () const;
+  types::boundary_id boundary_id () const;
 
   /**
-   * Set the boundary indicator. The same applies as for the
-   * <tt>boundary_indicator()</tt> function.
+   * Return the boundary indicator of this object.
    *
-   * Note that it only sets the boundary object of the current object itself,
+   * @deprecated This spelling of the function name is deprecated. Use
+   * boundary_id() instead.
+   */
+  types::boundary_id boundary_indicator () const DEAL_II_DEPRECATED;
+
+  /**
+   * Set the boundary indicator of the current object. The same applies as for the
+   * boundary_id() function.
+   *
+   * This function only sets the boundary object of the current object itself,
    * not the indicators of the ones that bound it. For example, in 3d, if this
    * function is called on a face, then the boundary indicator of the 4 edges
    * that bound the face remain unchanged. If you want to set the boundary
    * indicators of face and edges at the same time, use the
-   * set_all_boundary_indicators() function. You can see the result of not
+   * set_all_boundary_ids() function. You can see the result of not
    * using the correct function in the results section of step-49.
    *
    * @warning You should never set the boundary indicator of an interior face
@@ -906,18 +914,26 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  void set_boundary_indicator (const types::boundary_id) const;
+  void set_boundary_id (const types::boundary_id) const;
 
   /**
-   * Do as set_boundary_indicator() but also set the boundary indicators of
+   * Set the boundary indicator of this object.
+   *
+   * @deprecated This spelling of the function name is deprecated. Use
+   * set_boundary_id() instead.
+   */
+  void set_boundary_indicator (const types::boundary_id) const DEAL_II_DEPRECATED;
+
+  /**
+   * Do as set_boundary_id() but also set the boundary indicators of
    * the objects that bound the current object. For example, in 3d, if
-   * set_boundary_indicator() is called on a face, then the boundary indicator
+   * set_boundary_id() is called on a face, then the boundary indicator
    * of the 4 edges that bound the face remain unchanged. In contrast, if you
    * call the current function, the boundary indicators of face and edges are
    * all set to the given value.
    *
    * This function is useful if you set boundary indicators of faces in 3d (in
-   * 2d, the function does the same as set_boundary_indicator()) and you do so
+   * 2d, the function does the same as set_boundary_id()) and you do so
    * because you want a curved boundary object to represent the part of the
    * boundary that corresponds to the current face. In that case, the
    * Triangulation class needs to figure out where to put new vertices upon
@@ -938,7 +954,15 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  void set_all_boundary_indicators (const types::boundary_id) const;
+  void set_all_boundary_ids (const types::boundary_id) const;
+
+  /**
+   * Set the boundary indicator of this object and all that bound it.
+   *
+   * @deprecated This spelling of the function name is deprecated. Use
+   * set_all_boundary_ids() instead.
+   */
+  void set_all_boundary_indicators (const types::boundary_id) const DEAL_II_DEPRECATED;
 
   /**
    * Return whether this object is at the boundary. Obviously, the use of this
@@ -1698,7 +1722,15 @@ public:
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  types::boundary_id boundary_indicator () const;
+  types::boundary_id boundary_id () const;
+
+  /**
+   * Return the boundary indicator of this object.
+   *
+   * @deprecated This spelling of the function name is deprecated. Use
+   * boundary_id() instead.
+   */
+  types::boundary_id boundary_indicator () const DEAL_II_DEPRECATED;
 
   /**
    * Return the manifold indicator of this object.
@@ -1813,7 +1845,7 @@ public:
 
   /**
    * Set the boundary indicator. The same applies as for the
-   * <tt>boundary_indicator()</tt> function.
+   * <tt>boundary_id()</tt> function.
    *
    * @warning You should never set the boundary indicator of an interior face
    * (a face not at the boundary of the domain), or set set the boundary
@@ -1833,7 +1865,15 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void
-  set_boundary_indicator (const types::boundary_id);
+  set_boundary_id (const types::boundary_id);
+
+  /**
+   * Set the boundary indicator of this object.
+   *
+   * @deprecated This spelling of the function name is deprecated. Use
+   * set_boundary_id() instead.
+   */
+  void set_boundary_indicator (const types::boundary_id) DEAL_II_DEPRECATED;
 
   /**
    * Set the manifold indicator of this vertex. This does nothing so far since
@@ -1848,7 +1888,7 @@ public:
    * Set the boundary indicator of this object and all of its lower-
    * dimensional sub-objects.  Since this object only represents a single
    * vertex, there are no lower-dimensional obejct and this function is
-   * equivalent to calling set_boundary_indicator with the same argument.
+   * equivalent to calling set_boundary_id() with the same argument.
    *
    * @ingroup boundary
    *
@@ -1856,20 +1896,27 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void
-  set_all_boundary_indicators (const types::boundary_id);
+  set_all_boundary_ids (const types::boundary_id);
+
+  /**
+   * Set the boundary indicator of this object and all that bound it.
+   *
+   * @deprecated This spelling of the function name is deprecated. Use
+   * set_all_boundary_ids() instead.
+   */
+  void set_all_boundary_indicators (const types::boundary_id) DEAL_II_DEPRECATED;
 
   /**
    * Set the manifold indicator of this object and all of its lower-
    * dimensional sub-objects.  Since this object only represents a single
    * vertex, there are no lower-dimensional obejct and this function is
-   * equivalent to calling set_manifold_indicator with the same argument.
+   * equivalent to calling set_manifold_id() with the same argument.
    *
    * @ingroup manifold
    *
    * @see
    * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
    */
-
   void
   set_all_manifold_ids (const types::manifold_id);
   /**

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1826,7 +1826,7 @@ TriaAccessor<structdim, dim, spacedim>::number_of_children () const
 
 template <int structdim, int dim, int spacedim>
 types::boundary_id
-TriaAccessor<structdim, dim, spacedim>::boundary_indicator () const
+TriaAccessor<structdim, dim, spacedim>::boundary_id () const
 {
   Assert (structdim<dim, ExcImpossibleInDim(dim));
   Assert (this->used(), TriaAccessorExceptions::ExcCellNotUsed());
@@ -1837,9 +1837,19 @@ TriaAccessor<structdim, dim, spacedim>::boundary_indicator () const
 
 
 template <int structdim, int dim, int spacedim>
+types::boundary_id
+TriaAccessor<structdim, dim, spacedim>::boundary_indicator () const
+{
+  return boundary_id();
+}
+
+
+
+
+template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::
-set_boundary_indicator (const types::boundary_id boundary_ind) const
+set_boundary_id (const types::boundary_id boundary_ind) const
 {
   Assert (structdim<dim, ExcImpossibleInDim(dim));
   Assert (this->used(), TriaAccessorExceptions::ExcCellNotUsed());
@@ -1852,9 +1862,19 @@ set_boundary_indicator (const types::boundary_id boundary_ind) const
 template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::
-set_all_boundary_indicators (const types::boundary_id boundary_ind) const
+set_boundary_indicator (const types::boundary_id boundary_ind) const
 {
-  set_boundary_indicator (boundary_ind);
+  set_boundary_id (boundary_ind);
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+void
+TriaAccessor<structdim, dim, spacedim>::
+set_all_boundary_ids (const types::boundary_id boundary_ind) const
+{
+  set_boundary_id (boundary_ind);
 
   switch (structdim)
     {
@@ -1867,7 +1887,7 @@ set_all_boundary_indicators (const types::boundary_id boundary_ind) const
       // for boundary quads also set
       // boundary_id of bounding lines
       for (unsigned int i=0; i<4; ++i)
-        this->line(i)->set_boundary_indicator (boundary_ind);
+        this->line(i)->set_boundary_id (boundary_ind);
       break;
 
     default:
@@ -1878,12 +1898,22 @@ set_all_boundary_indicators (const types::boundary_id boundary_ind) const
 
 
 template <int structdim, int dim, int spacedim>
+void
+TriaAccessor<structdim, dim, spacedim>::
+set_all_boundary_indicators (const types::boundary_id boundary_ind) const
+{
+  set_all_boundary_ids (boundary_ind);
+}
+
+
+
+template <int structdim, int dim, int spacedim>
 bool
 TriaAccessor<structdim, dim, spacedim>::at_boundary () const
 {
   // error checking is done
-  // in boundary_indicator()
-  return (boundary_indicator() != numbers::internal_face_boundary_id);
+  // in boundary_id()
+  return (boundary_id() != numbers::internal_face_boundary_id);
 }
 
 
@@ -2318,7 +2348,7 @@ TriaAccessor<0, 1, spacedim>::at_boundary () const
 template <int spacedim>
 inline
 types::boundary_id
-TriaAccessor<0, 1, spacedim>::boundary_indicator () const
+TriaAccessor<0, 1, spacedim>::boundary_id () const
 {
   switch (vertex_kind)
     {
@@ -2335,8 +2365,19 @@ TriaAccessor<0, 1, spacedim>::boundary_indicator () const
     default:
       return numbers::internal_face_boundary_id;
     }
-
 }
+
+
+
+template <int spacedim>
+inline
+types::boundary_id
+TriaAccessor<0, 1, spacedim>::boundary_indicator () const
+{
+  return boundary_id();
+}
+
+
 
 template <int spacedim>
 inline
@@ -2463,10 +2504,11 @@ int TriaAccessor<0, 1, spacedim>::isotropic_child_index (const unsigned int)
 }
 
 
+
 template <int spacedim>
 inline
 void
-TriaAccessor<0, 1, spacedim>::set_boundary_indicator (const types::boundary_id b)
+TriaAccessor<0, 1, spacedim>::set_boundary_id (const types::boundary_id b)
 {
   Assert (tria->vertex_to_boundary_id_map_1d->find (this->vertex_index())
           != tria->vertex_to_boundary_id_map_1d->end(),
@@ -2474,6 +2516,18 @@ TriaAccessor<0, 1, spacedim>::set_boundary_indicator (const types::boundary_id b
 
   (*tria->vertex_to_boundary_id_map_1d)[this->vertex_index()] = b;
 }
+
+
+
+template <int spacedim>
+inline
+void
+TriaAccessor<0, 1, spacedim>::set_boundary_indicator (const types::boundary_id b)
+{
+  set_boundary_id (b);
+}
+
+
 
 
 template <int spacedim>
@@ -2488,9 +2542,18 @@ TriaAccessor<0, 1, spacedim>::set_manifold_id (const types::manifold_id b)
 
 template <int spacedim>
 inline
+void TriaAccessor<0, 1, spacedim>::set_all_boundary_ids (const types::boundary_id b)
+{
+  set_boundary_id (b);
+}
+
+
+
+template <int spacedim>
+inline
 void TriaAccessor<0, 1, spacedim>::set_all_boundary_indicators (const types::boundary_id b)
 {
-  set_boundary_indicator (b);
+  set_all_boundary_ids (b);
 }
 
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -527,14 +527,14 @@ namespace hp
      * function.
      */
     types::global_dof_index
-    n_boundary_dofs (const FunctionMap &boundary_indicators) const;
+    n_boundary_dofs (const FunctionMap &boundary_ids) const;
 
     /**
      * Same function, but with different data type of the argument, which is
      * here simply a list of the boundary indicators under consideration.
      */
     types::global_dof_index
-    n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const;
+    n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const;
 
     /**
      * Return the number of degrees of freedom that belong to this process.

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -653,7 +653,7 @@ namespace VectorTools
    *
    * The parameter @p function_map provides a list of boundary indicators to
    * be handled by this function and corresponding boundary value functions.
-   * The keys of this map correspond to the number @p boundary_indicator of
+   * The keys of this map correspond to the number @p boundary_id of
    * the face.  numbers::internal_face_boundary_id is an illegal value for
    * this key since it is reserved for interior faces.
    *
@@ -784,7 +784,7 @@ namespace VectorTools
    * @ref constraints.
    *
    * The parameter @p boundary_component corresponds to the number @p
-   * boundary_indicator of the face.
+   * boundary_id of the face.
    *
    * The flags in the last parameter, @p component_mask denote which
    * components of the finite element space shall be interpolated. If it is
@@ -1063,7 +1063,7 @@ namespace VectorTools
    * $z$-component.
    *
    * The parameter @p boundary_component corresponds to the number @p
-   * boundary_indicator of the face. numbers::internal_face_boundary_id is an
+   * boundary_id of the face. numbers::internal_face_boundary_id is an
    * illegal value, since it is reserved for interior faces.
    *
    * The last argument is denoted to compute the normal vector $\vec{n}$ at
@@ -1180,7 +1180,7 @@ namespace VectorTools
    * that are ordered in the same way as we usually order the coordinate directions,
    * i.e. $x$-, $y$-, and finally $z$-component.
    *
-   * The parameter @p boundary_component corresponds to the number @p boundary_indicator
+   * The parameter @p boundary_component corresponds to the number @p boundary_id
    * of the face. numbers::internal_face_boundary_id is an illegal value, since it is
    * reserved for interior faces.
    *
@@ -1245,7 +1245,7 @@ namespace VectorTools
    * $z$-component.
    *
    * The parameter @p boundary_component corresponds to the @p
-   * boundary_indicator of the faces where the boundary conditions are
+   * boundary_id of the faces where the boundary conditions are
    * applied. numbers::internal_face_boundary_id is an illegal value, since it
    * is reserved for interior faces. The @p mapping is used to compute the
    * normal vector $\vec{n}$ at the boundary points.
@@ -1719,7 +1719,7 @@ namespace VectorTools
                                         const Quadrature<dim-1> &q,
                                         const Function<spacedim,double>     &rhs,
                                         Vector<double>          &rhs_vector,
-                                        const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                                        const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * Calls the create_boundary_right_hand_side() function, see above, with
@@ -1733,7 +1733,7 @@ namespace VectorTools
                                         const Quadrature<dim-1> &q,
                                         const Function<spacedim,double>     &rhs,
                                         Vector<double>          &rhs_vector,
-                                        const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                                        const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * Same as the set of functions above, but for hp objects.
@@ -1747,7 +1747,7 @@ namespace VectorTools
                                         const hp::QCollection<dim-1> &q,
                                         const Function<spacedim,double>     &rhs,
                                         Vector<double>          &rhs_vector,
-                                        const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                                        const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
    * Calls the create_boundary_right_hand_side() function, see above, with a
@@ -1762,7 +1762,7 @@ namespace VectorTools
                                         const hp::QCollection<dim-1> &q,
                                         const Function<spacedim,double>     &rhs,
                                         Vector<double>          &rhs_vector,
-                                        const std::set<types::boundary_id> &boundary_indicators = std::set<types::boundary_id>());
+                                        const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   //@}
   /**

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -684,11 +684,11 @@ namespace VectorTools
             // function to hold on
             // all parts of the boundary
             const std::vector<types::boundary_id>
-            used_boundary_indicators = dof.get_tria().get_boundary_indicators();
+            used_boundary_ids = dof.get_tria().get_boundary_ids();
 
             typename FunctionMap<spacedim>::type boundary_functions;
-            for (unsigned int i=0; i<used_boundary_indicators.size(); ++i)
-              boundary_functions[used_boundary_indicators[i]] = &function;
+            for (unsigned int i=0; i<used_boundary_ids.size(); ++i)
+              boundary_functions[used_boundary_ids[i]] = &function;
             project_boundary_values (mapping, dof, boundary_functions, q_boundary,
                                      boundary_values);
           }
@@ -1336,7 +1336,7 @@ namespace VectorTools
                                    const Quadrature<dim-1> &quadrature,
                                    const Function<spacedim>     &rhs_function,
                                    Vector<double>          &rhs_vector,
-                                   const std::set<types::boundary_id> &boundary_indicators)
+                                   const std::set<types::boundary_id> &boundary_ids)
   {
     const FiniteElement<dim> &fe  = dof_handler.get_fe();
     Assert (fe.n_components() == rhs_function.n_components,
@@ -1368,10 +1368,10 @@ namespace VectorTools
         for (; cell!=endc; ++cell)
           for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary () &&
-                (boundary_indicators.empty() ||
-                 (boundary_indicators.find (cell->face(face)->boundary_indicator())
+                (boundary_ids.empty() ||
+                 (boundary_ids.find (cell->face(face)->boundary_id())
                   !=
-                  boundary_indicators.end())))
+                  boundary_ids.end())))
               {
                 fe_values.reinit(cell, face);
 
@@ -1398,10 +1398,10 @@ namespace VectorTools
         for (; cell!=endc; ++cell)
           for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary () &&
-                (boundary_indicators.empty() ||
-                 (boundary_indicators.find (cell->face(face)->boundary_indicator())
+                (boundary_ids.empty() ||
+                 (boundary_ids.find (cell->face(face)->boundary_id())
                   !=
-                  boundary_indicators.end())))
+                  boundary_ids.end())))
               {
                 fe_values.reinit(cell, face);
 
@@ -1458,12 +1458,12 @@ namespace VectorTools
                                    const Quadrature<dim-1> &quadrature,
                                    const Function<spacedim>     &rhs_function,
                                    Vector<double>          &rhs_vector,
-                                   const std::set<types::boundary_id> &boundary_indicators)
+                                   const std::set<types::boundary_id> &boundary_ids)
   {
     create_boundary_right_hand_side(StaticMappingQ1<dim>::mapping, dof_handler,
                                     quadrature,
                                     rhs_function, rhs_vector,
-                                    boundary_indicators);
+                                    boundary_ids);
   }
 
 
@@ -1475,7 +1475,7 @@ namespace VectorTools
                                    const hp::QCollection<dim-1>  &quadrature,
                                    const Function<spacedim>      &rhs_function,
                                    Vector<double>                &rhs_vector,
-                                   const std::set<types::boundary_id> &boundary_indicators)
+                                   const std::set<types::boundary_id> &boundary_ids)
   {
     const hp::FECollection<dim> &fe  = dof_handler.get_fe();
     Assert (fe.n_components() == rhs_function.n_components,
@@ -1506,10 +1506,10 @@ namespace VectorTools
         for (; cell!=endc; ++cell)
           for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary () &&
-                (boundary_indicators.empty() ||
-                 (boundary_indicators.find (cell->face(face)->boundary_indicator())
+                (boundary_ids.empty() ||
+                 (boundary_ids.find (cell->face(face)->boundary_id())
                   !=
-                  boundary_indicators.end())))
+                  boundary_ids.end())))
               {
                 x_fe_values.reinit(cell, face);
 
@@ -1543,10 +1543,10 @@ namespace VectorTools
         for (; cell!=endc; ++cell)
           for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
             if (cell->face(face)->at_boundary () &&
-                (boundary_indicators.empty() ||
-                 (boundary_indicators.find (cell->face(face)->boundary_indicator())
+                (boundary_ids.empty() ||
+                 (boundary_ids.find (cell->face(face)->boundary_id())
                   !=
-                  boundary_indicators.end())))
+                  boundary_ids.end())))
               {
                 x_fe_values.reinit(cell, face);
 
@@ -1609,12 +1609,12 @@ namespace VectorTools
                                    const hp::QCollection<dim-1>  &quadrature,
                                    const Function<spacedim>      &rhs_function,
                                    Vector<double>                &rhs_vector,
-                                   const std::set<types::boundary_id> &boundary_indicators)
+                                   const std::set<types::boundary_id> &boundary_ids)
   {
     create_boundary_right_hand_side(hp::StaticMappingQ1<dim>::mapping_collection,
                                     dof_handler, quadrature,
                                     rhs_function, rhs_vector,
-                                    boundary_indicators);
+                                    boundary_ids);
   }
 
 
@@ -1660,10 +1660,10 @@ namespace VectorTools
              direction<GeometryInfo<dim>::faces_per_cell; ++direction)
           if (cell->at_boundary(direction)
               &&
-              (function_map.find(cell->face(direction)->boundary_indicator()) != function_map.end()))
+              (function_map.find(cell->face(direction)->boundary_id()) != function_map.end()))
             {
               const Function<DH::space_dimension> &boundary_function
-                = *function_map.find(cell->face(direction)->boundary_indicator())->second;
+                = *function_map.find(cell->face(direction)->boundary_id())->second;
 
               // get the FE corresponding to this
               // cell
@@ -1848,7 +1848,7 @@ namespace VectorTools
                 }
 
               const typename DH::face_iterator face = cell->face(face_no);
-              const types::boundary_id boundary_component = face->boundary_indicator();
+              const types::boundary_id boundary_component = face->boundary_id();
 
               // see if this face is part of the boundaries for which we are
               // supposed to do something, and also see if the finite element
@@ -3451,7 +3451,7 @@ namespace VectorTools
         for (; cell != dof_handler.end (); ++cell)
           if (cell->at_boundary () && cell->is_locally_owned ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a
                   // FE_Nothing object
@@ -3535,7 +3535,7 @@ namespace VectorTools
         for (; cell != dof_handler.end (); ++cell)
           if (cell->at_boundary () && cell->is_locally_owned ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a
                   // FE_Nothing object
@@ -3656,7 +3656,7 @@ namespace VectorTools
         for (; cell != dof_handler.end (); ++cell)
           if (cell->at_boundary () && cell->is_locally_owned ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a FE_Nothing object there is no work to do
                   if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != 0)
@@ -3733,7 +3733,7 @@ namespace VectorTools
         for (; cell != dof_handler.end (); ++cell)
           if (cell->at_boundary () && cell->is_locally_owned ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a FE_Nothing object there is no work to do
                   if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != 0)
@@ -4501,7 +4501,7 @@ namespace VectorTools
                 {
                   for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
                     {
-                      if (cell->face (face)->boundary_indicator () == boundary_component)
+                      if (cell->face (face)->boundary_id () == boundary_component)
                         {
                           // If the FE is an FE_Nothing object there is no work to do
                           if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != 0)
@@ -4596,7 +4596,7 @@ namespace VectorTools
                 {
                   for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
                     {
-                      if (cell->face (face)->boundary_indicator () == boundary_component)
+                      if (cell->face (face)->boundary_id () == boundary_component)
                         {
                           // If the FE is an FE_Nothing object there is no work to do
                           if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != 0)
@@ -4946,7 +4946,7 @@ namespace VectorTools
              cell != dof_handler.end (); ++cell)
           if (cell->at_boundary ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a
                   // FE_Nothing object
@@ -5017,7 +5017,7 @@ namespace VectorTools
              cell != dof_handler.end (); ++cell)
           if (cell->at_boundary ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // This is only
                   // implemented, if the
@@ -5107,7 +5107,7 @@ namespace VectorTools
              cell != dof_handler.end (); ++cell)
           if (cell->at_boundary ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // This is only
                   // implemented, if the
@@ -5154,7 +5154,7 @@ namespace VectorTools
              cell != dof_handler.end (); ++cell)
           if (cell->at_boundary ())
             for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-              if (cell->face (face)->boundary_indicator () == boundary_component)
+              if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // This is only
                   // implemented, if the
@@ -5300,7 +5300,7 @@ namespace VectorTools
       if (!cell->is_artificial())
         for (unsigned int face_no=0; face_no < GeometryInfo<dim>::faces_per_cell;
              ++face_no)
-          if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_indicator()))
+          if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_id()))
               != boundary_ids.end())
             {
               const FiniteElement<dim> &fe = cell->get_fe ();
@@ -5872,7 +5872,7 @@ namespace VectorTools
       if (!cell->is_artificial())
         for (unsigned int face_no=0; face_no < GeometryInfo<dim>::faces_per_cell;
              ++face_no)
-          if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_indicator()))
+          if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_id()))
               != boundary_ids.end())
             {
               const FiniteElement<dim> &fe = cell->get_fe();

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -992,33 +992,33 @@ types::global_dof_index DoFHandler<1>::n_boundary_dofs () const
 
 
 template <>
-types::global_dof_index DoFHandler<1>::n_boundary_dofs (const FunctionMap &boundary_indicators) const
+types::global_dof_index DoFHandler<1>::n_boundary_dofs (const FunctionMap &boundary_ids) const
 {
   // check that only boundary
   // indicators 0 and 1 are allowed
   // in 1d
-  for (FunctionMap::const_iterator i=boundary_indicators.begin();
-       i!=boundary_indicators.end(); ++i)
+  for (FunctionMap::const_iterator i=boundary_ids.begin();
+       i!=boundary_ids.end(); ++i)
     Assert ((i->first == 0) || (i->first == 1),
             ExcInvalidBoundaryIndicator());
 
-  return boundary_indicators.size()*get_fe().dofs_per_vertex;
+  return boundary_ids.size()*get_fe().dofs_per_vertex;
 }
 
 
 
 template <>
-types::global_dof_index DoFHandler<1>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const
+types::global_dof_index DoFHandler<1>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const
 {
   // check that only boundary
   // indicators 0 and 1 are allowed
   // in 1d
-  for (std::set<types::boundary_id>::const_iterator i=boundary_indicators.begin();
-       i!=boundary_indicators.end(); ++i)
+  for (std::set<types::boundary_id>::const_iterator i=boundary_ids.begin();
+       i!=boundary_ids.end(); ++i)
     Assert ((*i == 0) || (*i == 1),
             ExcInvalidBoundaryIndicator());
 
-  return boundary_indicators.size()*get_fe().dofs_per_vertex;
+  return boundary_ids.size()*get_fe().dofs_per_vertex;
 }
 
 
@@ -1031,33 +1031,33 @@ types::global_dof_index DoFHandler<1,2>::n_boundary_dofs () const
 
 
 template <>
-types::global_dof_index DoFHandler<1,2>::n_boundary_dofs (const FunctionMap &boundary_indicators) const
+types::global_dof_index DoFHandler<1,2>::n_boundary_dofs (const FunctionMap &boundary_ids) const
 {
   // check that only boundary
   // indicators 0 and 1 are allowed
   // in 1d
-  for (FunctionMap::const_iterator i=boundary_indicators.begin();
-       i!=boundary_indicators.end(); ++i)
+  for (FunctionMap::const_iterator i=boundary_ids.begin();
+       i!=boundary_ids.end(); ++i)
     Assert ((i->first == 0) || (i->first == 1),
             ExcInvalidBoundaryIndicator());
 
-  return boundary_indicators.size()*get_fe().dofs_per_vertex;
+  return boundary_ids.size()*get_fe().dofs_per_vertex;
 }
 
 
 
 template <>
-types::global_dof_index DoFHandler<1,2>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const
+types::global_dof_index DoFHandler<1,2>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const
 {
   // check that only boundary
   // indicators 0 and 1 are allowed
   // in 1d
-  for (std::set<types::boundary_id>::const_iterator i=boundary_indicators.begin();
-       i!=boundary_indicators.end(); ++i)
+  for (std::set<types::boundary_id>::const_iterator i=boundary_ids.begin();
+       i!=boundary_ids.end(); ++i)
     Assert ((*i == 0) || (*i == 1),
             ExcInvalidBoundaryIndicator());
 
-  return boundary_indicators.size()*get_fe().dofs_per_vertex;
+  return boundary_ids.size()*get_fe().dofs_per_vertex;
 }
 
 
@@ -1102,9 +1102,9 @@ types::global_dof_index DoFHandler<dim,spacedim>::n_boundary_dofs () const
 
 template<int dim, int spacedim>
 types::global_dof_index
-DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_indicators) const
+DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_ids) const
 {
-  Assert (boundary_indicators.find(numbers::internal_face_boundary_id) == boundary_indicators.end(),
+  Assert (boundary_ids.find(numbers::internal_face_boundary_id) == boundary_ids.end(),
           ExcInvalidBoundaryIndicator());
 
   std::set<int> boundary_dofs;
@@ -1121,8 +1121,8 @@ DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_indicator
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (cell->at_boundary(f)
           &&
-          (boundary_indicators.find(cell->face(f)->boundary_indicator()) !=
-           boundary_indicators.end()))
+          (boundary_ids.find(cell->face(f)->boundary_id()) !=
+           boundary_ids.end()))
         {
           cell->face(f)->get_dof_indices (dofs_on_face);
           for (unsigned int i=0; i<dofs_per_face; ++i)
@@ -1136,9 +1136,9 @@ DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_indicator
 
 template<int dim, int spacedim>
 types::global_dof_index
-DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const
+DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const
 {
-  Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
+  Assert (boundary_ids.find (numbers::internal_face_boundary_id) == boundary_ids.end(),
           ExcInvalidBoundaryIndicator());
 
   std::set<int> boundary_dofs;
@@ -1155,10 +1155,10 @@ DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &b
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (cell->at_boundary(f)
           &&
-          (std::find (boundary_indicators.begin(),
-                      boundary_indicators.end(),
-                      cell->face(f)->boundary_indicator()) !=
-           boundary_indicators.end()))
+          (std::find (boundary_ids.begin(),
+                      boundary_ids.end(),
+                      cell->face(f)->boundary_id()) !=
+           boundary_ids.end()))
         {
           cell->face(f)->get_dof_indices (dofs_on_face);
           for (unsigned int i=0; i<dofs_per_face; ++i)

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -515,7 +515,7 @@ namespace DoFTools
   extract_boundary_dofs (const DH                      &dof_handler,
                          const ComponentMask           &component_mask,
                          std::vector<bool>             &selected_dofs,
-                         const std::set<types::boundary_id> &boundary_indicators)
+                         const std::set<types::boundary_id> &boundary_ids)
   {
     Assert ((dynamic_cast<const parallel::distributed::Triangulation<DH::dimension,DH::space_dimension>*>
              (&dof_handler.get_tria())
@@ -525,7 +525,7 @@ namespace DoFTools
 
     IndexSet indices;
     extract_boundary_dofs (dof_handler, component_mask,
-                           indices, boundary_indicators);
+                           indices, boundary_ids);
 
     // clear and reset array by default values
     selected_dofs.clear ();
@@ -541,11 +541,11 @@ namespace DoFTools
   extract_boundary_dofs (const DH                      &dof_handler,
                          const ComponentMask       &component_mask,
                          IndexSet             &selected_dofs,
-                         const std::set<types::boundary_id> &boundary_indicators)
+                         const std::set<types::boundary_id> &boundary_ids)
   {
     Assert (component_mask.represents_n_components(n_components(dof_handler)),
             ExcMessage ("Component mask has invalid size."));
-    Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find (numbers::internal_face_boundary_id) == boundary_ids.end(),
             ExcInvalidBoundaryIndicator());
     const unsigned int dim=DH::dimension;
 
@@ -555,7 +555,7 @@ namespace DoFTools
 
     // let's see whether we have to check for certain boundary indicators
     // or whether we can accept all
-    const bool check_boundary_indicator = (boundary_indicators.size() != 0);
+    const bool check_boundary_id = (boundary_ids.size() != 0);
 
     // also see whether we have to check whether a certain vector component
     // is selected, or all
@@ -583,9 +583,9 @@ namespace DoFTools
         for (unsigned int face=0;
              face<GeometryInfo<DH::dimension>::faces_per_cell; ++face)
           if (cell->at_boundary(face))
-            if (! check_boundary_indicator ||
-                (boundary_indicators.find (cell->face(face)->boundary_indicator())
-                 != boundary_indicators.end()))
+            if (! check_boundary_id ||
+                (boundary_ids.find (cell->face(face)->boundary_id())
+                 != boundary_ids.end()))
               {
                 const FiniteElement<DH::dimension, DH::space_dimension> &fe = cell->get_fe();
 
@@ -648,16 +648,16 @@ namespace DoFTools
   extract_dofs_with_support_on_boundary (const DH                      &dof_handler,
                                          const ComponentMask           &component_mask,
                                          std::vector<bool>             &selected_dofs,
-                                         const std::set<types::boundary_id> &boundary_indicators)
+                                         const std::set<types::boundary_id> &boundary_ids)
   {
     Assert (component_mask.represents_n_components (n_components(dof_handler)),
             ExcMessage ("This component mask has the wrong size."));
-    Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find (numbers::internal_face_boundary_id) == boundary_ids.end(),
             ExcInvalidBoundaryIndicator());
 
     // let's see whether we have to check for certain boundary indicators
     // or whether we can accept all
-    const bool check_boundary_indicator = (boundary_indicators.size() != 0);
+    const bool check_boundary_id = (boundary_ids.size() != 0);
 
     // also see whether we have to check whether a certain vector component
     // is selected, or all
@@ -681,9 +681,9 @@ namespace DoFTools
       for (unsigned int face=0;
            face<GeometryInfo<DH::dimension>::faces_per_cell; ++face)
         if (cell->at_boundary(face))
-          if (! check_boundary_indicator ||
-              (boundary_indicators.find (cell->face(face)->boundary_indicator())
-               != boundary_indicators.end()))
+          if (! check_boundary_id ||
+              (boundary_ids.find (cell->face(face)->boundary_id())
+               != boundary_ids.end()))
             {
               const FiniteElement<DH::dimension, DH::space_dimension> &fe = cell->get_fe();
 
@@ -1580,10 +1580,10 @@ namespace DoFTools
   template <class DH>
   void map_dof_to_boundary_indices (
     const DH                      &dof_handler,
-    const std::set<types::boundary_id> &boundary_indicators,
+    const std::set<types::boundary_id> &boundary_ids,
     std::vector<types::global_dof_index>     &mapping)
   {
-    Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find (numbers::internal_face_boundary_id) == boundary_ids.end(),
             ExcInvalidBoundaryIndicator());
 
     mapping.clear ();
@@ -1591,7 +1591,7 @@ namespace DoFTools
                     DH::invalid_dof_index);
 
     // return if there is nothing to do
-    if (boundary_indicators.size() == 0)
+    if (boundary_ids.size() == 0)
       return;
 
     std::vector<types::global_dof_index> dofs_on_face;
@@ -1602,8 +1602,8 @@ namespace DoFTools
                                       endc = dof_handler.end();
     for (; cell!=endc; ++cell)
       for (unsigned int f=0; f<GeometryInfo<DH::dimension>::faces_per_cell; ++f)
-        if (boundary_indicators.find (cell->face(f)->boundary_indicator()) !=
-            boundary_indicators.end())
+        if (boundary_ids.find (cell->face(f)->boundary_id()) !=
+            boundary_ids.end())
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
@@ -1614,7 +1614,7 @@ namespace DoFTools
           }
 
     AssertDimension (next_boundary_index,
-                     dof_handler.n_boundary_dofs (boundary_indicators));
+                     dof_handler.n_boundary_dofs (boundary_ids));
   }
 
   namespace internal

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2974,7 +2974,7 @@ namespace DoFTools
   template <int dim, int spacedim, template <int,int> class DH>
   void
   make_zero_boundary_constraints (const DH<dim, spacedim> &dof,
-                                  const types::boundary_id boundary_indicator,
+                                  const types::boundary_id boundary_id,
                                   ConstraintMatrix        &zero_boundary_constraints,
                                   const ComponentMask     &component_mask)
   {
@@ -3018,9 +3018,9 @@ namespace DoFTools
               // boundary id property
               if (face->at_boundary ()
                   &&
-                  ((boundary_indicator == numbers::invalid_boundary_id)
+                  ((boundary_id == numbers::invalid_boundary_id)
                    ||
-                   (face->boundary_indicator() == boundary_indicator)))
+                   (face->boundary_id() == boundary_id)))
                 {
                   // get indices and physical location on this face
                   face_dofs.resize (fe.dofs_per_face);

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -335,11 +335,11 @@ namespace DoFTools
       {
         // there are only 2 boundary indicators in 1d, so it is no
         // performance problem to call the other function
-        typename DH::FunctionMap boundary_indicators;
-        boundary_indicators[0] = 0;
-        boundary_indicators[1] = 0;
+        typename DH::FunctionMap boundary_ids;
+        boundary_ids[0] = 0;
+        boundary_ids[1] = 0;
         make_boundary_sparsity_pattern<DH, SparsityPattern> (dof,
-                                                             boundary_indicators,
+                                                             boundary_ids,
                                                              dof_to_boundary_mapping,
                                                              sparsity);
         return;
@@ -395,7 +395,7 @@ namespace DoFTools
   template <class DH, class SparsityPattern>
   void make_boundary_sparsity_pattern (
     const DH                                        &dof,
-    const typename FunctionMap<DH::space_dimension>::type &boundary_indicators,
+    const typename FunctionMap<DH::space_dimension>::type &boundary_ids,
     const std::vector<types::global_dof_index>                 &dof_to_boundary_mapping,
     SparsityPattern                                 &sparsity)
   {
@@ -405,8 +405,8 @@ namespace DoFTools
         for (unsigned int direction=0; direction<2; ++direction)
           {
             // if this boundary is not requested, then go on with next one
-            if (boundary_indicators.find(direction) ==
-                boundary_indicators.end())
+            if (boundary_ids.find(direction) ==
+                boundary_ids.end())
               continue;
 
             // find active cell at that boundary: first go to left/right,
@@ -436,12 +436,12 @@ namespace DoFTools
     const types::global_dof_index n_dofs = dof.n_dofs();
 
     AssertDimension (dof_to_boundary_mapping.size(), n_dofs);
-    Assert (boundary_indicators.find(numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find(numbers::internal_face_boundary_id) == boundary_ids.end(),
             typename DH::ExcInvalidBoundaryIndicator());
-    Assert (sparsity.n_rows() == dof.n_boundary_dofs (boundary_indicators),
-            ExcDimensionMismatch (sparsity.n_rows(), dof.n_boundary_dofs (boundary_indicators)));
-    Assert (sparsity.n_cols() == dof.n_boundary_dofs (boundary_indicators),
-            ExcDimensionMismatch (sparsity.n_cols(), dof.n_boundary_dofs (boundary_indicators)));
+    Assert (sparsity.n_rows() == dof.n_boundary_dofs (boundary_ids),
+            ExcDimensionMismatch (sparsity.n_rows(), dof.n_boundary_dofs (boundary_ids)));
+    Assert (sparsity.n_cols() == dof.n_boundary_dofs (boundary_ids),
+            ExcDimensionMismatch (sparsity.n_cols(), dof.n_boundary_dofs (boundary_ids)));
 #ifdef DEBUG
     if (sparsity.n_rows() != 0)
       {
@@ -461,8 +461,8 @@ namespace DoFTools
                                       endc = dof.end();
     for (; cell!=endc; ++cell)
       for (unsigned int f=0; f<GeometryInfo<DH::dimension>::faces_per_cell; ++f)
-        if (boundary_indicators.find(cell->face(f)->boundary_indicator()) !=
-            boundary_indicators.end())
+        if (boundary_ids.find(cell->face(f)->boundary_id()) !=
+            boundary_ids.end())
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
             dofs_on_this_face.resize (dofs_per_face);

--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -78,14 +78,14 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
     template void
     DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
     (const DoFHandler<deal_II_dimension>& dof,
-     const FunctionMap<deal_II_dimension>::type  &boundary_indicators,
+     const FunctionMap<deal_II_dimension>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
 
     template void
     DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
     (const hp::DoFHandler<deal_II_dimension>& dof,
-     const FunctionMap<deal_II_dimension>::type  &boundary_indicators,
+     const FunctionMap<deal_II_dimension>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
 
@@ -93,7 +93,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
     template void
     DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
     (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const FunctionMap<deal_II_dimension+1>::type  &boundary_indicators,
+     const FunctionMap<deal_II_dimension+1>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
  #endif
@@ -204,14 +204,14 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
     template void
     DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
     (const DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-     const FunctionMap<deal_II_dimension+1>::type  &boundary_indicators,
+     const FunctionMap<deal_II_dimension+1>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
 
     //template void
     //DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>,SP>
     //(const hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>& dof,
-    // const FunctionMap<deal_II_dimension+1>::type  &boundary_indicators,
+    // const FunctionMap<deal_II_dimension+1>::type  &boundary_ids,
     // const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
     // SP    &sparsity);
 
@@ -281,14 +281,14 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
     template void
     DoFTools::make_boundary_sparsity_pattern<DoFHandler<1,3>,SP>
     (const DoFHandler<1,3>& dof,
-     const FunctionMap<3>::type  &boundary_indicators,
+     const FunctionMap<3>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
 
     template void
     DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<1,3>,SP>
     (const hp::DoFHandler<1,3>& dof,
-     const FunctionMap<3>::type  &boundary_indicators,
+     const FunctionMap<3>::type  &boundary_ids,
      const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
      SP    &sparsity);
 

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -64,7 +64,7 @@ MappingC1<2>::add_line_support_points (const Triangulation<2>::cell_iterator &ce
           // first get the normal vectors at the two vertices of this line
           // from the boundary description
           const Boundary<dim> &boundary
-            = line->get_triangulation().get_boundary(line->boundary_indicator());
+            = line->get_triangulation().get_boundary(line->boundary_id());
 
           Boundary<dim>::FaceVertexNormals face_vertex_normals;
           boundary.get_normals_at_vertices (line, face_vertex_normals);

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -77,7 +77,7 @@ namespace GridGenerator
           const typename Triangulation<dim,spacedim>::cell_iterator
           cell = tria.begin();
           for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-            cell->face(f)->set_boundary_indicator (f);
+            cell->face(f)->set_boundary_id (f);
         }
     }
 
@@ -118,21 +118,21 @@ namespace GridGenerator
                                                  endface = tria.end_face();
       for (; face!=endface; ++face)
         {
-          if (face->boundary_indicator() == 0)
+          if (face->boundary_id() == 0)
             {
               const Point<dim> center (face->center());
               if (std::abs(center(0)-p1[0]) < epsilon)
-                face->set_boundary_indicator(0);
+                face->set_boundary_id(0);
               else if (std::abs(center(0) - p2[0]) < epsilon)
-                face->set_boundary_indicator(1);
+                face->set_boundary_id(1);
               else if (dim > 1 && std::abs(center(1) - p1[1]) < epsilon)
-                face->set_boundary_indicator(2);
+                face->set_boundary_id(2);
               else if (dim > 1 && std::abs(center(1) - p2[1]) < epsilon)
-                face->set_boundary_indicator(3);
+                face->set_boundary_id(3);
               else if (dim > 2 && std::abs(center(2) - p1[2]) < epsilon)
-                face->set_boundary_indicator(4);
+                face->set_boundary_id(4);
               else if (dim > 2 && std::abs(center(2) - p2[2]) < epsilon)
-                face->set_boundary_indicator(5);
+                face->set_boundary_id(5);
               else
                 // triangulation says it
                 // is on the boundary,
@@ -173,7 +173,7 @@ namespace GridGenerator
            cell != tria.end (); ++cell)
         {
           Assert(cell->face(2)->at_boundary(), ExcInternalError());
-          cell->face (2)->set_all_boundary_indicators (1);
+          cell->face (2)->set_all_boundary_ids (1);
         }
     }
 
@@ -197,27 +197,27 @@ namespace GridGenerator
           Triangulation<3>::cell_iterator cell = tria.begin();
 
           Assert (cell->face(4)->at_boundary(), ExcInternalError());
-          cell->face(4)->set_all_boundary_indicators(1);
+          cell->face(4)->set_all_boundary_ids(1);
 
           ++cell;
           Assert (cell->face(2)->at_boundary(), ExcInternalError());
-          cell->face(2)->set_all_boundary_indicators(1);
+          cell->face(2)->set_all_boundary_ids(1);
 
           ++cell;
           Assert (cell->face(2)->at_boundary(), ExcInternalError());
-          cell->face(2)->set_all_boundary_indicators(1);
+          cell->face(2)->set_all_boundary_ids(1);
 
           ++cell;
           Assert (cell->face(0)->at_boundary(), ExcInternalError());
-          cell->face(0)->set_all_boundary_indicators(1);
+          cell->face(0)->set_all_boundary_ids(1);
 
           ++cell;
           Assert (cell->face(2)->at_boundary(), ExcInternalError());
-          cell->face(2)->set_all_boundary_indicators(1);
+          cell->face(2)->set_all_boundary_ids(1);
 
           ++cell;
           Assert (cell->face(0)->at_boundary(), ExcInternalError());
-          cell->face(0)->set_all_boundary_indicators(1);
+          cell->face(0)->set_all_boundary_ids(1);
         }
       else if (tria.n_cells() == 12)
         {
@@ -227,7 +227,7 @@ namespace GridGenerator
                cell != tria.end(); ++cell)
             {
               Assert (cell->face(5)->at_boundary(), ExcInternalError());
-              cell->face(5)->set_all_boundary_indicators(1);
+              cell->face(5)->set_all_boundary_ids(1);
             }
         }
       else if (tria.n_cells() == 96)
@@ -248,7 +248,7 @@ namespace GridGenerator
                cell != tria.end(); ++cell)
             if (cell->face(5)->at_boundary())
               {
-                cell->face(5)->set_all_boundary_indicators(1);
+                cell->face(5)->set_all_boundary_ids(1);
                 ++count;
               }
           Assert (count == 48, ExcInternalError());
@@ -286,43 +286,43 @@ namespace GridGenerator
             double radius = cell->face(f)->center().norm() - center.norm();
             if (std::fabs(cell->face(f)->center()(0)) < eps ) // x = 0 set boundary 2
               {
-                cell->face(f)->set_boundary_indicator(2);
+                cell->face(f)->set_boundary_id(2);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   if (cell->face(f)->line(j)->at_boundary())
                     if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                      cell->face(f)->line(j)->set_boundary_indicator(2);
+                      cell->face(f)->line(j)->set_boundary_id(2);
               }
             else if (std::fabs(cell->face(f)->center()(1)) < eps) // y = 0 set boundary 3
               {
-                cell->face(f)->set_boundary_indicator(3);
+                cell->face(f)->set_boundary_id(3);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   if (cell->face(f)->line(j)->at_boundary())
                     if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                      cell->face(f)->line(j)->set_boundary_indicator(3);
+                      cell->face(f)->line(j)->set_boundary_id(3);
               }
             else if (std::fabs(cell->face(f)->center()(2)) < eps ) // z = 0 set boundary 4
               {
-                cell->face(f)->set_boundary_indicator(4);
+                cell->face(f)->set_boundary_id(4);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   if (cell->face(f)->line(j)->at_boundary())
                     if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                      cell->face(f)->line(j)->set_boundary_indicator(4);
+                      cell->face(f)->line(j)->set_boundary_id(4);
               }
             else if (radius < middle) // inner radius set boundary 0
               {
-                cell->face(f)->set_boundary_indicator(0);
+                cell->face(f)->set_boundary_id(0);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   if (cell->face(f)->line(j)->at_boundary())
                     if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) < eps)
-                      cell->face(f)->line(j)->set_boundary_indicator(0);
+                      cell->face(f)->line(j)->set_boundary_id(0);
               }
             else if (radius > middle) // outer radius set boundary 1
               {
-                cell->face(f)->set_boundary_indicator(1);
+                cell->face(f)->set_boundary_id(1);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   if (cell->face(f)->line(j)->at_boundary())
                     if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) < eps)
-                      cell->face(f)->line(j)->set_boundary_indicator(1);
+                      cell->face(f)->line(j)->set_boundary_id(1);
               }
             else
               AssertThrow (false, ExcInternalError());
@@ -1511,15 +1511,15 @@ namespace GridGenerator
           {
             Point<2> cell_center = cell->center();
             for (unsigned int f=0; f<GeometryInfo<2>::faces_per_cell; ++f)
-              if (cell->face(f)->boundary_indicator() == 0)
+              if (cell->face(f)->boundary_id() == 0)
                 {
                   Point<2> face_center = cell->face(f)->center();
                   for (unsigned int i=0; i<2; ++i)
                     {
                       if (face_center[i]<cell_center[i]-eps)
-                        cell->face(f)->set_boundary_indicator(i*2);
+                        cell->face(f)->set_boundary_id(i*2);
                       if (face_center[i]>cell_center[i]+eps)
-                        cell->face(f)->set_boundary_indicator(i*2+1);
+                        cell->face(f)->set_boundary_id(i*2+1);
                     }
                 }
           }
@@ -1625,15 +1625,15 @@ namespace GridGenerator
           {
             Point<dim> cell_center = cell->center();
             for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-              if (cell->face(f)->boundary_indicator() == 0)
+              if (cell->face(f)->boundary_id() == 0)
                 {
                   Point<dim> face_center = cell->face(f)->center();
                   for (unsigned int i=0; i<dim; ++i)
                     {
                       if (face_center[i]<cell_center[i]-eps)
-                        cell->face(f)->set_boundary_indicator(i*2);
+                        cell->face(f)->set_boundary_id(i*2);
                       if (face_center[i]>cell_center[i]+eps)
-                        cell->face(f)->set_boundary_indicator(i*2+1);
+                        cell->face(f)->set_boundary_id(i*2+1);
                     }
                 }
           }
@@ -1850,9 +1850,9 @@ namespace GridGenerator
     if (colorize)
       {
         Triangulation<2>::cell_iterator cell = tria.begin();
-        cell->face(1)->set_boundary_indicator(1);
+        cell->face(1)->set_boundary_id(1);
         ++cell;
-        cell->face(3)->set_boundary_indicator(2);
+        cell->face(3)->set_boundary_id(2);
       }
   }
 
@@ -1887,11 +1887,11 @@ namespace GridGenerator
 
     Triangulation<2>::cell_iterator cell = triangulation.begin ();
 
-    cell->face (0)->set_boundary_indicator (1);
-    cell->face (1)->set_boundary_indicator (2);
+    cell->face (0)->set_boundary_id (1);
+    cell->face (1)->set_boundary_id (2);
 
     for (unsigned int i = 2; i < 4; ++i)
-      cell->face (i)->set_boundary_indicator (0);
+      cell->face (i)->set_boundary_id (0);
   }
 
 
@@ -2061,16 +2061,16 @@ namespace GridGenerator
     Triangulation<2>::face_iterator end = tria.end_face();
     while (f != end)
       {
-        switch (f->boundary_indicator())
+        switch (f->boundary_id())
           {
           case 0:
-            f->set_boundary_indicator(1);
+            f->set_boundary_id(1);
             break;
           case 1:
-            f->set_boundary_indicator(2);
+            f->set_boundary_id(2);
             break;
           default:
-            f->set_boundary_indicator(0);
+            f->set_boundary_id(0);
             break;
           }
         ++f;
@@ -2140,12 +2140,12 @@ namespace GridGenerator
       {
         for (unsigned int i=0; i<GeometryInfo<2>::faces_per_cell; ++i)
           {
-            if (cell->face(i)->boundary_indicator() == numbers::internal_face_boundary_id)
+            if (cell->face(i)->boundary_id() == numbers::internal_face_boundary_id)
               continue;
 
             // If x is zero, then this is part of the plane
             if (cell->face(i)->center()(0) < p(0)+1.e-5)
-              cell->face(i)->set_boundary_indicator(1);
+              cell->face(i)->set_boundary_id(1);
           }
         ++cell;
       }
@@ -2227,11 +2227,11 @@ namespace GridGenerator
         Triangulation<2>::cell_iterator cell = tria.begin();
         for (; cell!=tria.end(); ++cell)
           {
-            cell->face(2)->set_boundary_indicator(1);
+            cell->face(2)->set_boundary_id(1);
           }
-        tria.begin()->face(0)->set_boundary_indicator(3);
+        tria.begin()->face(0)->set_boundary_id(3);
 
-        tria.last()->face(1)->set_boundary_indicator(2);
+        tria.last()->face(1)->set_boundary_id(2);
       }
   }
 
@@ -2307,11 +2307,11 @@ namespace GridGenerator
         Triangulation<2>::cell_iterator cell = tria.begin();
         for (; cell!=tria.end(); ++cell)
           {
-            cell->face(2)->set_boundary_indicator(1);
+            cell->face(2)->set_boundary_id(1);
           }
-        tria.begin()->face(0)->set_boundary_indicator(3);
+        tria.begin()->face(0)->set_boundary_id(3);
 
-        tria.last()->face(1)->set_boundary_indicator(2);
+        tria.last()->face(1)->set_boundary_id(2);
       }
   }
 
@@ -2371,9 +2371,9 @@ namespace GridGenerator
       {
         Assert(false, ExcNotImplemented());
         Triangulation<3>::cell_iterator cell = tria.begin();
-        cell->face(1)->set_boundary_indicator(1);
+        cell->face(1)->set_boundary_id(1);
         ++cell;
-        cell->face(3)->set_boundary_indicator(2);
+        cell->face(3)->set_boundary_id(2);
       }
   }
 
@@ -2504,22 +2504,22 @@ namespace GridGenerator
       {
         if (cell->vertex (0) (0) == -half_length)
           {
-            cell->face (4)->set_boundary_indicator (1);
+            cell->face (4)->set_boundary_id (1);
 
             for (unsigned int i = 0; i < 4; ++i)
-              cell->line (i)->set_boundary_indicator (0);
+              cell->line (i)->set_boundary_id (0);
           }
 
         if (cell->vertex (4) (0) == half_length)
           {
-            cell->face (5)->set_boundary_indicator (2);
+            cell->face (5)->set_boundary_id (2);
 
             for (unsigned int i = 4; i < 8; ++i)
-              cell->line (i)->set_boundary_indicator (0);
+              cell->line (i)->set_boundary_id (0);
           }
 
         for (unsigned int i = 0; i < 4; ++i)
-          cell->face (i)->set_boundary_indicator (0);
+          cell->face (i)->set_boundary_id (0);
       }
   }
 
@@ -2749,25 +2749,25 @@ namespace GridGenerator
           {
             if (cell->face(i)->center()(0) > half_length-1.e-5)
               {
-                cell->face(i)->set_boundary_indicator(2);
+                cell->face(i)->set_boundary_id(2);
 
                 for (unsigned int e=0; e<GeometryInfo<3>::lines_per_face; ++e)
                   if ((std::fabs(cell->face(i)->line(e)->vertex(0)[1]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(0)[2]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(1)[1]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(1)[2]) == a))
-                    cell->face(i)->line(e)->set_boundary_indicator(2);
+                    cell->face(i)->line(e)->set_boundary_id(2);
               }
             else if (cell->face(i)->center()(0) < -half_length+1.e-5)
               {
-                cell->face(i)->set_boundary_indicator(1);
+                cell->face(i)->set_boundary_id(1);
 
                 for (unsigned int e=0; e<GeometryInfo<3>::lines_per_face; ++e)
                   if ((std::fabs(cell->face(i)->line(e)->vertex(0)[1]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(0)[2]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(1)[1]) == a) ||
                       (std::fabs(cell->face(i)->line(e)->vertex(1)[2]) == a))
-                    cell->face(i)->line(e)->set_boundary_indicator(1);
+                    cell->face(i)->line(e)->set_boundary_id(1);
               }
           }
   }
@@ -2856,7 +2856,7 @@ namespace GridGenerator
             // bounding faces unless both vertices are on the perimeter
             if (cell->face(i)->center()(0) < center(0)+1.e-5*radius)
               {
-                cell->face(i)->set_boundary_indicator(1);
+                cell->face(i)->set_boundary_id(1);
                 for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
                   {
                     const Point<3> line_vertices[2]
@@ -2868,7 +2868,7 @@ namespace GridGenerator
                         ||
                         (std::fabs(line_vertices[1].distance(center)-radius) >
                          1e-5*radius))
-                      cell->face(i)->line(j)->set_boundary_indicator(1);
+                      cell->face(i)->line(j)->set_boundary_id(1);
                   }
               }
           }
@@ -3550,7 +3550,7 @@ namespace GridGenerator
         for (unsigned int f=0; f<4; ++f)
           if (cell->at_boundary(f))
             {
-              quad.boundary_id = cell->face(f)->boundary_indicator();
+              quad.boundary_id = cell->face(f)->boundary_id();
               bid = std::max(bid, quad.boundary_id);
               for (unsigned int slice=0; slice<n_slices-1; ++slice)
                 {
@@ -3665,23 +3665,23 @@ namespace GridGenerator
               if (colorize)
                 {
                   if (std::abs(dx + outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(0);
+                    cell->face(f)->set_boundary_id(0);
                   else if (std::abs(dx - outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(1);
+                    cell->face(f)->set_boundary_id(1);
                   else if (std::abs(dy + outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(2);
+                    cell->face(f)->set_boundary_id(2);
                   else if (std::abs(dy - outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(3);
+                    cell->face(f)->set_boundary_id(3);
                   else
-                    cell->face(f)->set_boundary_indicator(4);
+                    cell->face(f)->set_boundary_id(4);
                 }
               else
                 {
                   double d = (cell->face(f)->center() - center).norm();
                   if (d-inner_radius < 0)
-                    cell->face(f)->set_boundary_indicator(1);
+                    cell->face(f)->set_boundary_id(1);
                   else
-                    cell->face(f)->set_boundary_indicator(0);
+                    cell->face(f)->set_boundary_id(0);
                 }
             }
       }
@@ -3764,28 +3764,28 @@ namespace GridGenerator
               if (colorize)
                 {
                   if (std::abs(dx + outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(0);
+                    cell->face(f)->set_boundary_id(0);
 
                   else if (std::abs(dx - outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(1);
+                    cell->face(f)->set_boundary_id(1);
 
                   else if (std::abs(dy + outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(2);
+                    cell->face(f)->set_boundary_id(2);
 
                   else if (std::abs(dy - outer_radius) < eps)
-                    cell->face(f)->set_boundary_indicator(3);
+                    cell->face(f)->set_boundary_id(3);
 
                   else if (std::abs(dz) < eps)
-                    cell->face(f)->set_boundary_indicator(4);
+                    cell->face(f)->set_boundary_id(4);
 
                   else if (std::abs(dz - L) < eps)
-                    cell->face(f)->set_boundary_indicator(5);
+                    cell->face(f)->set_boundary_id(5);
 
                   else
                     {
-                      cell->face(f)->set_boundary_indicator(6);
+                      cell->face(f)->set_boundary_id(6);
                       for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_face; ++l)
-                        cell->face(f)->line(l)->set_boundary_indicator(6);
+                        cell->face(f)->line(l)->set_boundary_id(6);
                     }
 
                 }
@@ -3796,12 +3796,12 @@ namespace GridGenerator
                   double d = c.norm();
                   if (d-inner_radius < 0)
                     {
-                      cell->face(f)->set_boundary_indicator(1);
+                      cell->face(f)->set_boundary_id(1);
                       for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_face; ++l)
-                        cell->face(f)->line(l)->set_boundary_indicator(1);
+                        cell->face(f)->line(l)->set_boundary_id(1);
                     }
                   else
-                    cell->face(f)->set_boundary_indicator(0);
+                    cell->face(f)->set_boundary_id(0);
                 }
             }
       }
@@ -3860,7 +3860,7 @@ namespace GridGenerator
                 {
                   for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_face; ++i)
                     subcelldata.boundary_lines[f].vertices[i] = face->vertex_index(i);
-                  subcelldata.boundary_lines[f].boundary_id = face->boundary_indicator();
+                  subcelldata.boundary_lines[f].boundary_id = face->boundary_id();
                   subcelldata.boundary_lines[f].manifold_id = face->manifold_id();
                   ++f;
                 }
@@ -3875,7 +3875,7 @@ namespace GridGenerator
                 {
                   for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_face; ++i)
                     subcelldata.boundary_quads[f].vertices[i] = face->vertex_index(i);
-                  subcelldata.boundary_quads[f].boundary_id = face->boundary_indicator();
+                  subcelldata.boundary_quads[f].boundary_id = face->boundary_id();
                   subcelldata.boundary_quads[f].manifold_id = face->manifold_id();
                   ++f;
                 }
@@ -3991,7 +3991,7 @@ namespace GridGenerator
           if ( face->at_boundary()
                &&
                (boundary_ids.empty() ||
-                ( boundary_ids.find(face->boundary_indicator()) != boundary_ids.end())) )
+                ( boundary_ids.find(face->boundary_id()) != boundary_ids.end())) )
             {
               for (unsigned int j=0;
                    j<GeometryInfo<boundary_dim>::vertices_per_cell; ++j)
@@ -4006,7 +4006,7 @@ namespace GridGenerator
                     }
 
                   c_data.vertices[j] = map_vert_index[v_index];
-                  c_data.material_id = static_cast<types::material_id>(face->boundary_indicator());
+                  c_data.material_id = static_cast<types::material_id>(face->boundary_id());
                 }
 
               cells.push_back(c_data);

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -845,7 +845,7 @@ void GridOut::write_dx (const Triangulation<dim, spacedim> &tria,
           // Little trick to get -1
           // for the interior
           for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-            out << ' ' << (int)(signed char)cell->face(f)->boundary_indicator();
+            out << ' ' << (int)(signed char)cell->face(f)->boundary_id();
           out << '\n';
         }
       out << "attribute \"dep\" string \"connections\"" << '\n' << '\n';
@@ -1355,7 +1355,7 @@ void GridOut::write_xfig (
           {
             Triangulation<dim, spacedim>::face_iterator
             face = cell->face(face_reorder[f]);
-            const types::boundary_id bi = face->boundary_indicator();
+            const types::boundary_id bi = face->boundary_id();
             if (bi != numbers::internal_face_boundary_id)
               {
                 // Code for polyline
@@ -2550,7 +2550,7 @@ unsigned int GridOut::n_boundary_faces (const Triangulation<dim,spacedim> &tria)
   for (face=tria.begin_active_face(), endf=tria.end_face();
        face != endf; ++face)
     if ((face->at_boundary()) &&
-        (face->boundary_indicator() != 0))
+        (face->boundary_id() != 0))
       n_faces++;
 
   return n_faces;
@@ -2579,7 +2579,7 @@ unsigned int GridOut::n_boundary_lines (const Triangulation<dim, spacedim> &tria
     for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_cell; ++l)
       if (cell->line(l)->at_boundary()
           &&
-          (cell->line(l)->boundary_indicator() != 0)
+          (cell->line(l)->boundary_id() != 0)
           &&
           (cell->line(l)->user_flag_set() == false))
         {
@@ -2672,7 +2672,7 @@ void GridOut::write_msh_faces (const Triangulation<dim,spacedim> &tria,
   for (face=tria.begin_active_face(), endf=tria.end_face();
        face != endf; ++face)
     if (face->at_boundary() &&
-        (face->boundary_indicator() != 0))
+        (face->boundary_id() != 0))
       {
         out << index << ' ';
         switch (dim)
@@ -2686,9 +2686,9 @@ void GridOut::write_msh_faces (const Triangulation<dim,spacedim> &tria,
           default:
             Assert (false, ExcNotImplemented());
           }
-        out << static_cast<unsigned int>(face->boundary_indicator())
+        out << static_cast<unsigned int>(face->boundary_id())
             << ' '
-            << static_cast<unsigned int>(face->boundary_indicator())
+            << static_cast<unsigned int>(face->boundary_id())
             << ' ' << GeometryInfo<dim>::vertices_per_face;
         // note: vertex numbers are 1-base
         for (unsigned int vertex=0; vertex<GeometryInfo<dim>::vertices_per_face; ++vertex)
@@ -2724,14 +2724,14 @@ void GridOut::write_msh_lines (const Triangulation<dim, spacedim> &tria,
     for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_cell; ++l)
       if (cell->line(l)->at_boundary()
           &&
-          (cell->line(l)->boundary_indicator() != 0)
+          (cell->line(l)->boundary_id() != 0)
           &&
           (cell->line(l)->user_flag_set() == false))
         {
           out << index << " 1 ";
-          out << static_cast<unsigned int>(cell->line(l)->boundary_indicator())
+          out << static_cast<unsigned int>(cell->line(l)->boundary_id())
               << ' '
-              << static_cast<unsigned int>(cell->line(l)->boundary_indicator())
+              << static_cast<unsigned int>(cell->line(l)->boundary_id())
               << " 2 ";
           // note: vertex numbers are 1-base
           for (unsigned int vertex=0; vertex<2; ++vertex)
@@ -2826,10 +2826,10 @@ void GridOut::write_ucd_faces (const Triangulation<dim, spacedim> &tria,
   for (face=tria.begin_active_face(), endf=tria.end_face();
        face != endf; ++face)
     if (face->at_boundary() &&
-        (face->boundary_indicator() != 0))
+        (face->boundary_id() != 0))
       {
         out << index << "  "
-            << static_cast<unsigned int>(face->boundary_indicator())
+            << static_cast<unsigned int>(face->boundary_id())
             << "  ";
         switch (dim)
           {
@@ -2876,12 +2876,12 @@ void GridOut::write_ucd_lines (const Triangulation<dim, spacedim> &tria,
     for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_cell; ++l)
       if (cell->line(l)->at_boundary()
           &&
-          (cell->line(l)->boundary_indicator() != 0)
+          (cell->line(l)->boundary_id() != 0)
           &&
           (cell->line(l)->user_flag_set() == false))
         {
           out << index << "  "
-              << static_cast<unsigned int>(cell->line(l)->boundary_indicator())
+              << static_cast<unsigned int>(cell->line(l)->boundary_id())
               << "  line    ";
           // note: vertex numbers in ucd format are 1-base
           for (unsigned int vertex=0; vertex<2; ++vertex)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2810,14 +2810,14 @@ next_cell:
         for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
           {
             const typename CONTAINER::face_iterator face = cell->face(i);
-            if (face->at_boundary() && face->boundary_indicator() == b_id1)
+            if (face->at_boundary() && face->boundary_id() == b_id1)
               {
                 const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair1
                   = std::make_pair(cell, i);
                 pairs1.insert(pair1);
               }
 
-            if (face->at_boundary() && face->boundary_indicator() == b_id2)
+            if (face->at_boundary() && face->boundary_id() == b_id2)
               {
                 const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair2
                   = std::make_pair(cell, i);
@@ -2867,14 +2867,14 @@ next_cell:
         const typename CONTAINER::face_iterator face_1 = cell->face(2*direction);
         const typename CONTAINER::face_iterator face_2 = cell->face(2*direction+1);
 
-        if (face_1->at_boundary() && face_1->boundary_indicator() == b_id)
+        if (face_1->at_boundary() && face_1->boundary_id() == b_id)
           {
             const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair1
               = std::make_pair(cell, 2*direction);
             pairs1.insert(pair1);
           }
 
-        if (face_2->at_boundary() && face_2->boundary_indicator() == b_id)
+        if (face_2->at_boundary() && face_2->boundary_id() == b_id)
           {
             const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair2
               = std::make_pair(cell, 2*direction+1);
@@ -2920,9 +2920,9 @@ next_cell:
         if (cell->face(f)->at_boundary())
           {
             cell->face(f)->set_manifold_id
-            (static_cast<types::manifold_id>(cell->face(f)->boundary_indicator()));
+            (static_cast<types::manifold_id>(cell->face(f)->boundary_id()));
             if (reset_boundary_ids == true)
-              cell->face(f)->set_boundary_indicator(0);
+              cell->face(f)->set_boundary_id(0);
           }
   }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1877,10 +1877,10 @@ namespace internal
             // boundary indicator zero by
             // default
             if (n_adj_cells == 1)
-              line->set_boundary_indicator (0);
+              line->set_boundary_id (0);
             else
               // interior line -> numbers::internal_face_boundary_id
-              line->set_boundary_indicator (numbers::internal_face_boundary_id);
+              line->set_boundary_id (numbers::internal_face_boundary_id);
             line->set_manifold_id(numbers::flat_manifold_id);
           }
 
@@ -1914,19 +1914,19 @@ namespace internal
 
             // assert that we only set
             // boundary info once
-            AssertThrow (! (line->boundary_indicator() != 0 &&
-                            line->boundary_indicator() != numbers::internal_face_boundary_id),
+            AssertThrow (! (line->boundary_id() != 0 &&
+                            line->boundary_id() != numbers::internal_face_boundary_id),
                          ExcMultiplySetLineInfoOfLine(line_vertices.first,
                                                       line_vertices.second));
 
             // Assert that only exterior lines
             // are given a boundary indicator
-            AssertThrow (! (line->boundary_indicator() == numbers::internal_face_boundary_id),
+            AssertThrow (! (line->boundary_id() == numbers::internal_face_boundary_id),
                          ExcInteriorLineCantBeBoundary(line->vertex_index(0),
                                                        line->vertex_index(1),
                                                        boundary_line->boundary_id));
 
-            line->set_boundary_indicator (boundary_line->boundary_id);
+            line->set_boundary_id (boundary_line->boundary_id);
             line->set_manifold_id (boundary_line->manifold_id);
           }
 
@@ -2614,10 +2614,10 @@ namespace internal
             // boundary indicator zero by
             // default
             if (n_adj_cells == 1)
-              quad->set_boundary_indicator (0);
+              quad->set_boundary_id (0);
             else
               // interior quad -> numbers::internal_face_boundary_id
-              quad->set_boundary_indicator (numbers::internal_face_boundary_id);
+              quad->set_boundary_id (numbers::internal_face_boundary_id);
             // Manifold ids are set
             // independently of where
             // they are
@@ -2634,7 +2634,7 @@ namespace internal
         for (typename Triangulation<dim,spacedim>::line_iterator
              line=triangulation.begin_line(); line!=triangulation.end_line(); ++line)
           {
-            line->set_boundary_indicator (numbers::internal_face_boundary_id);
+            line->set_boundary_id (numbers::internal_face_boundary_id);
             line->set_manifold_id(numbers::flat_manifold_id);
           }
 
@@ -2660,7 +2660,7 @@ namespace internal
              quad=triangulation.begin_quad(); quad!=triangulation.end_quad(); ++quad)
           if (quad->at_boundary())
             for (unsigned int l=0; l<4; ++l)
-              quad->line(l)->set_boundary_indicator (0);
+              quad->line(l)->set_boundary_id (0);
 
         ///////////////////////////////////////
         // now set boundary indicators
@@ -2706,12 +2706,12 @@ namespace internal
             // boundary indicator to a
             // different than the
             // previously set value
-            if (line->boundary_indicator() != 0)
-              AssertThrow (line->boundary_indicator() == boundary_line->boundary_id,
+            if (line->boundary_id() != 0)
+              AssertThrow (line->boundary_id() == boundary_line->boundary_id,
                            ExcMessage ("Duplicate boundary lines are only allowed "
                                        "if they carry the same boundary indicator."));
 
-            line->set_boundary_indicator (boundary_line->boundary_id);
+            line->set_boundary_id (boundary_line->boundary_id);
             // Set manifold id if given
             line->set_manifold_id(boundary_line->manifold_id);
           }
@@ -2844,12 +2844,12 @@ namespace internal
             // boundary indicator to a
             // different than the
             // previously set value
-            if (quad->boundary_indicator() != 0)
-              AssertThrow (quad->boundary_indicator() == boundary_quad->boundary_id,
+            if (quad->boundary_id() != 0)
+              AssertThrow (quad->boundary_id() == boundary_quad->boundary_id,
                            ExcMessage ("Duplicate boundary quads are only allowed "
                                        "if they carry the same boundary indicator."));
 
-            quad->set_boundary_indicator (boundary_quad->boundary_id);
+            quad->set_boundary_id (boundary_quad->boundary_id);
             quad->set_manifold_id (boundary_quad->manifold_id);
           }
 
@@ -3473,7 +3473,7 @@ namespace internal
                             switch_1->line_orientation(2),
                             switch_1->line_orientation(3)
                           };
-                          const types::boundary_id switch_1_boundary_indicator=switch_1->boundary_indicator();
+                          const types::boundary_id switch_1_boundary_id=switch_1->boundary_id();
                           const unsigned int switch_1_user_index=switch_1->user_index();
                           const bool switch_1_user_flag=switch_1->user_flag_set();
 
@@ -3485,7 +3485,7 @@ namespace internal
                           switch_1->set_line_orientation(1, switch_2->line_orientation(1));
                           switch_1->set_line_orientation(2, switch_2->line_orientation(2));
                           switch_1->set_line_orientation(3, switch_2->line_orientation(3));
-                          switch_1->set_boundary_indicator(switch_2->boundary_indicator());
+                          switch_1->set_boundary_id(switch_2->boundary_id());
                           switch_1->set_manifold_id(switch_2->manifold_id());
                           switch_1->set_user_index(switch_2->user_index());
                           if (switch_2->user_flag_set())
@@ -3501,7 +3501,7 @@ namespace internal
                           switch_2->set_line_orientation(1, switch_1_line_orientations[1]);
                           switch_2->set_line_orientation(2, switch_1_line_orientations[2]);
                           switch_2->set_line_orientation(3, switch_1_line_orientations[3]);
-                          switch_2->set_boundary_indicator(switch_1_boundary_indicator);
+                          switch_2->set_boundary_id(switch_1_boundary_id);
                           switch_2->set_manifold_id(switch_1->manifold_id());
                           switch_2->set_user_index(switch_1_user_index);
                           if (switch_1_user_flag)
@@ -4003,7 +4003,7 @@ namespace internal
             new_lines[l]->clear_user_data();
             new_lines[l]->clear_children();
             // interior line
-            new_lines[l]->set_boundary_indicator(numbers::internal_face_boundary_id);
+            new_lines[l]->set_boundary_id(numbers::internal_face_boundary_id);
             new_lines[l]->set_manifold_id(cell->manifold_id());
           }
 
@@ -4503,7 +4503,7 @@ namespace internal
                               line->set_user_flag ();
 //TODO[WB]: we overwrite the user_index here because we later on need
 // to find out which boundary object we have to ask to refine this
-// line. we can't use the boundary_indicator field because that can
+// line. we can't use the boundary_id field because that can
 // only be used for lines at the boundary of the domain, but we also
 // need a domain description for interior lines in the codim-1 case
                               if (spacedim > dim)
@@ -4511,7 +4511,7 @@ namespace internal
                                   if (line->at_boundary())
                                     // if possible honor boundary
                                     // indicator
-                                    line->set_user_index(line->boundary_indicator());
+                                    line->set_user_index(line->boundary_id());
                                   else
                                     // otherwise take manifold
                                     // description from the adjacent
@@ -4675,8 +4675,8 @@ namespace internal
                   children[0]->clear_user_flag();
                   children[1]->clear_user_flag();
 
-                  children[0]->set_boundary_indicator (line->boundary_indicator());
-                  children[1]->set_boundary_indicator (line->boundary_indicator());
+                  children[0]->set_boundary_id (line->boundary_id());
+                  children[1]->set_boundary_id (line->boundary_id());
 
                   children[0]->set_manifold_id (line->manifold_id());
                   children[1]->set_manifold_id (line->manifold_id());
@@ -5112,8 +5112,8 @@ namespace internal
                   children[0]->clear_user_flag();
                   children[1]->clear_user_flag();
 
-                  children[0]->set_boundary_indicator (line->boundary_indicator());
-                  children[1]->set_boundary_indicator (line->boundary_indicator());
+                  children[0]->set_boundary_id (line->boundary_id());
+                  children[1]->set_boundary_id (line->boundary_id());
 
                   children[0]->set_manifold_id (line->manifold_id());
                   children[1]->set_manifold_id (line->manifold_id());
@@ -5227,7 +5227,7 @@ namespace internal
                     new_line->clear_user_flag();
                     new_line->clear_user_data();
                     new_line->clear_children();
-                    new_line->set_boundary_indicator(quad->boundary_indicator());
+                    new_line->set_boundary_id(quad->boundary_id());
                     new_line->set_manifold_id(quad->manifold_id());
 
                     // child 0 and 1 of a line are switched if the
@@ -5288,7 +5288,7 @@ namespace internal
                         new_quads[i]->clear_user_flag();
                         new_quads[i]->clear_user_data();
                         new_quads[i]->clear_children();
-                        new_quads[i]->set_boundary_indicator (quad->boundary_indicator());
+                        new_quads[i]->set_boundary_id (quad->boundary_id());
                         new_quads[i]->set_manifold_id (quad->manifold_id());
                         // set all line orientations to true, change
                         // this after the loop, as we have to consider
@@ -5389,7 +5389,7 @@ namespace internal
 
                                 new_child[i]->set(internal::Triangulation::TriaObject<1>(old_child[i]->vertex_index(0),
                                                                                          old_child[i]->vertex_index(1)));
-                                new_child[i]->set_boundary_indicator(old_child[i]->boundary_indicator());
+                                new_child[i]->set_boundary_id(old_child[i]->boundary_id());
                                 new_child[i]->set_manifold_id(old_child[i]->manifold_id());
                                 new_child[i]->set_user_index(old_child[i]->user_index());
                                 if (old_child[i]->user_flag_set())
@@ -5477,7 +5477,7 @@ namespace internal
                               switch_1->line_orientation(2),
                               switch_1->line_orientation(3)
                             };
-                            const types::boundary_id switch_1_boundary_indicator=switch_1->boundary_indicator();
+                            const types::boundary_id switch_1_boundary_id=switch_1->boundary_id();
                             const unsigned int switch_1_user_index=switch_1->user_index();
                             const bool switch_1_user_flag=switch_1->user_flag_set();
                             const RefinementCase<dim-1> switch_1_refinement_case=switch_1->refinement_case();
@@ -5492,7 +5492,7 @@ namespace internal
                             switch_1->set_line_orientation(1, switch_2->line_orientation(1));
                             switch_1->set_line_orientation(2, switch_2->line_orientation(2));
                             switch_1->set_line_orientation(3, switch_2->line_orientation(3));
-                            switch_1->set_boundary_indicator(switch_2->boundary_indicator());
+                            switch_1->set_boundary_id(switch_2->boundary_id());
                             switch_1->set_manifold_id(switch_2->manifold_id());
                             switch_1->set_user_index(switch_2->user_index());
                             if (switch_2->user_flag_set())
@@ -5515,7 +5515,7 @@ namespace internal
                             switch_2->set_line_orientation(1, switch_1_line_orientations[1]);
                             switch_2->set_line_orientation(2, switch_1_line_orientations[2]);
                             switch_2->set_line_orientation(3, switch_1_line_orientations[3]);
-                            switch_2->set_boundary_indicator(switch_1_boundary_indicator);
+                            switch_2->set_boundary_id(switch_1_boundary_id);
                             switch_2->set_manifold_id(switch_1->manifold_id());
                             switch_2->set_user_index(switch_1_user_index);
                             if (switch_1_user_flag)
@@ -5643,8 +5643,8 @@ namespace internal
                             children[0]->clear_user_flag();
                             children[1]->clear_user_flag();
 
-                            children[0]->set_boundary_indicator (middle_line->boundary_indicator());
-                            children[1]->set_boundary_indicator (middle_line->boundary_indicator());
+                            children[0]->set_boundary_id (middle_line->boundary_id());
+                            children[1]->set_boundary_id (middle_line->boundary_id());
 
                             children[0]->set_manifold_id (middle_line->manifold_id());
                             children[1]->set_manifold_id (middle_line->manifold_id());
@@ -5758,7 +5758,7 @@ namespace internal
                         new_lines[i]->clear_user_flag();
                         new_lines[i]->clear_user_data();
                         new_lines[i]->clear_children();
-                        new_lines[i]->set_boundary_indicator(quad->boundary_indicator());
+                        new_lines[i]->set_boundary_id(quad->boundary_id());
                         new_lines[i]->set_manifold_id(quad->manifold_id());
                       }
 
@@ -5858,7 +5858,7 @@ namespace internal
                         new_quads[i]->clear_user_flag();
                         new_quads[i]->clear_user_data();
                         new_quads[i]->clear_children();
-                        new_quads[i]->set_boundary_indicator (quad->boundary_indicator());
+                        new_quads[i]->set_boundary_id (quad->boundary_id());
                         new_quads[i]->set_manifold_id (quad->manifold_id());
                         // set all line orientations to true, change
                         // this after the loop, as we have to consider
@@ -5970,7 +5970,7 @@ namespace internal
                       new_lines[i]->clear_user_data();
                       new_lines[i]->clear_children();
                       // interior line
-                      new_lines[i]->set_boundary_indicator(numbers::internal_face_boundary_id);
+                      new_lines[i]->set_boundary_id(numbers::internal_face_boundary_id);
                       // they inherit geometry description of the hex they belong to
                       new_lines[i]->set_manifold_id(hex->manifold_id());
                     }
@@ -5990,7 +5990,7 @@ namespace internal
                       new_quads[i]->clear_user_data();
                       new_quads[i]->clear_children();
                       // interior quad
-                      new_quads[i]->set_boundary_indicator (numbers::internal_face_boundary_id);
+                      new_quads[i]->set_boundary_id (numbers::internal_face_boundary_id);
                       // they inherit geometry description of the hex they belong to
                       new_quads[i]->set_manifold_id (hex->manifold_id());
                       // set all line orientation flags to true by
@@ -8927,20 +8927,20 @@ Triangulation<dim, spacedim>::get_manifold (const types::manifold_id m_number) c
 
 template <int dim, int spacedim>
 std::vector<types::boundary_id>
-Triangulation<dim, spacedim>::get_boundary_indicators () const
+Triangulation<dim, spacedim>::get_boundary_ids () const
 {
   // in 1d, we store a map of all used boundary indicators. use it for
   // our purposes
   if (dim == 1)
     {
-      std::vector<types::boundary_id> boundary_indicators;
+      std::vector<types::boundary_id> boundary_ids;
       for (std::map<unsigned int, types::boundary_id>::const_iterator
            p = vertex_to_boundary_id_map_1d->begin();
            p !=  vertex_to_boundary_id_map_1d->end();
            ++p)
-        boundary_indicators.push_back (p->second);
+        boundary_ids.push_back (p->second);
 
-      return boundary_indicators;
+      return boundary_ids;
     }
   else
     {
@@ -8949,11 +8949,22 @@ Triangulation<dim, spacedim>::get_boundary_indicators () const
       for (; cell!=end(); ++cell)
         for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           if (cell->at_boundary(face))
-            b_ids.insert(cell->face(face)->boundary_indicator());
-      std::vector<types::boundary_id> boundary_indicators(b_ids.begin(), b_ids.end());
-      return boundary_indicators;
+            b_ids.insert(cell->face(face)->boundary_id());
+      std::vector<types::boundary_id> boundary_ids(b_ids.begin(), b_ids.end());
+      return boundary_ids;
     }
 }
+
+
+
+template <int dim, int spacedim>
+std::vector<types::boundary_id>
+Triangulation<dim, spacedim>::get_boundary_indicators () const
+{
+  return get_boundary_ids();
+}
+
+
 
 template <int dim, int spacedim>
 std::vector<types::manifold_id>

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1823,15 +1823,15 @@ namespace hp
 
 
   template <>
-  types::global_dof_index DoFHandler<1>::n_boundary_dofs (const FunctionMap &boundary_indicators) const
+  types::global_dof_index DoFHandler<1>::n_boundary_dofs (const FunctionMap &boundary_ids) const
   {
     Assert (finite_elements != 0, ExcNoFESelected());
 
     // check that only boundary
     // indicators 0 and 1 are allowed
     // in 1d
-    for (FunctionMap::const_iterator i=boundary_indicators.begin();
-         i!=boundary_indicators.end(); ++i)
+    for (FunctionMap::const_iterator i=boundary_ids.begin();
+         i!=boundary_ids.end(); ++i)
       Assert ((i->first == 0) || (i->first == 1),
               ExcInvalidBoundaryIndicator());
 
@@ -1839,7 +1839,7 @@ namespace hp
     types::global_dof_index n = 0;
 
     // search left-most cell
-    if (boundary_indicators.find (0) != boundary_indicators.end())
+    if (boundary_ids.find (0) != boundary_ids.end())
       {
         cell = this->begin_active();
         while (!cell->at_boundary(0))
@@ -1848,7 +1848,7 @@ namespace hp
       }
 
     // same with right-most cell
-    if (boundary_indicators.find (1) != boundary_indicators.end())
+    if (boundary_ids.find (1) != boundary_ids.end())
       {
         cell = this->begin_active();
         while (!cell->at_boundary(1))
@@ -1862,15 +1862,15 @@ namespace hp
 
 
   template <>
-  types::global_dof_index DoFHandler<1>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const
+  types::global_dof_index DoFHandler<1>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const
   {
     Assert (finite_elements != 0, ExcNoFESelected());
 
     // check that only boundary
     // indicators 0 and 1 are allowed
     // in 1d
-    for (std::set<types::boundary_id>::const_iterator i=boundary_indicators.begin();
-         i!=boundary_indicators.end(); ++i)
+    for (std::set<types::boundary_id>::const_iterator i=boundary_ids.begin();
+         i!=boundary_ids.end(); ++i)
       Assert ((*i == 0) || (*i == 1),
               ExcInvalidBoundaryIndicator());
 
@@ -1878,7 +1878,7 @@ namespace hp
     types::global_dof_index n = 0;
 
     // search left-most cell
-    if (boundary_indicators.find (0) != boundary_indicators.end())
+    if (boundary_ids.find (0) != boundary_ids.end())
       {
         cell = this->begin_active();
         while (!cell->at_boundary(0))
@@ -1887,7 +1887,7 @@ namespace hp
       }
 
     // same with right-most cell
-    if (boundary_indicators.find (1) != boundary_indicators.end())
+    if (boundary_ids.find (1) != boundary_ids.end())
       {
         cell = this->begin_active();
         while (!cell->at_boundary(1))
@@ -1984,10 +1984,10 @@ namespace hp
 
   template<int dim, int spacedim>
   types::global_dof_index
-  DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_indicators) const
+  DoFHandler<dim,spacedim>::n_boundary_dofs (const FunctionMap &boundary_ids) const
   {
     Assert (finite_elements != 0, ExcNoFESelected());
-    Assert (boundary_indicators.find(numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find(numbers::internal_face_boundary_id) == boundary_ids.end(),
             ExcInvalidBoundaryIndicator());
 
     // same as above, but with
@@ -2002,8 +2002,8 @@ namespace hp
     for (; cell!=endc; ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->at_boundary(f) &&
-            (boundary_indicators.find(cell->face(f)->boundary_indicator()) !=
-             boundary_indicators.end()))
+            (boundary_ids.find(cell->face(f)->boundary_id()) !=
+             boundary_ids.end()))
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
@@ -2020,10 +2020,10 @@ namespace hp
 
   template<int dim, int spacedim>
   types::global_dof_index
-  DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_indicators) const
+  DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &boundary_ids) const
   {
     Assert (finite_elements != 0, ExcNoFESelected());
-    Assert (boundary_indicators.find (numbers::internal_face_boundary_id) == boundary_indicators.end(),
+    Assert (boundary_ids.find (numbers::internal_face_boundary_id) == boundary_ids.end(),
             ExcInvalidBoundaryIndicator());
 
     // same as above, but with
@@ -2038,8 +2038,8 @@ namespace hp
     for (; cell!=endc; ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->at_boundary(f) &&
-            (boundary_indicators.find(cell->face(f)->boundary_indicator()) !=
-             boundary_indicators.end()))
+            (boundary_ids.find(cell->face(f)->boundary_id()) !=
+             boundary_ids.end()))
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1219,7 +1219,7 @@ namespace MGTools
                 {
                   const typename DoFHandler<dim,spacedim>::face_iterator
                   face = cell->face(face_no);
-                  const types::boundary_id bi = face->boundary_indicator();
+                  const types::boundary_id bi = face->boundary_id();
                   // Face is listed in
                   // boundary map
                   if (function_map.find(bi) != function_map.end())
@@ -1276,7 +1276,7 @@ namespace MGTools
                   }
 
                 typename DoFHandler<dim,spacedim>::face_iterator face = cell->face(face_no);
-                const types::boundary_id boundary_component = face->boundary_indicator();
+                const types::boundary_id boundary_component = face->boundary_id();
                 if (function_map.find(boundary_component) != function_map.end())
                   // face is of the right component
                   {

--- a/source/numerics/error_estimator.cc
+++ b/source/numerics/error_estimator.cc
@@ -409,16 +409,16 @@ namespace internal
         // neumann boundary face. compute difference between normal derivative
         // and boundary function
         {
-          const types::boundary_id boundary_indicator = face->boundary_indicator();
+          const types::boundary_id boundary_id = face->boundary_id();
 
-          Assert (parallel_data.neumann_bc->find(boundary_indicator) !=
+          Assert (parallel_data.neumann_bc->find(boundary_id) !=
                   parallel_data.neumann_bc->end(),
                   ExcInternalError ());
           // get the values of the boundary function at the quadrature points
           if (n_components == 1)
             {
               std::vector<double> g(n_q_points);
-              parallel_data.neumann_bc->find(boundary_indicator)->second
+              parallel_data.neumann_bc->find(boundary_id)->second
               ->value_list (fe_face_values_cell.get_present_fe_values()
                             .get_quadrature_points(), g);
 
@@ -430,7 +430,7 @@ namespace internal
             {
               std::vector<dealii::Vector<double> >
               g(n_q_points, dealii::Vector<double>(n_components));
-              parallel_data.neumann_bc->find(boundary_indicator)->second
+              parallel_data.neumann_bc->find(boundary_id)->second
               ->vector_value_list (fe_face_values_cell.get_present_fe_values()
                                    .get_quadrature_points(),
                                    g);
@@ -689,7 +689,7 @@ namespace internal
           // face into the list of faces with contribution zero.
           if (face->at_boundary()
               &&
-              (parallel_data.neumann_bc->find(face->boundary_indicator()) ==
+              (parallel_data.neumann_bc->find(face->boundary_id()) ==
                parallel_data.neumann_bc->end()))
             {
               local_face_integrals[face]

--- a/source/numerics/matrix_tools.cc
+++ b/source/numerics/matrix_tools.cc
@@ -925,7 +925,7 @@ namespace MatrixCreator
       for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
         // check if this face is on that part of
         // the boundary we are interested in
-        if (boundary_functions.find(cell->face(face)->boundary_indicator()) !=
+        if (boundary_functions.find(cell->face(face)->boundary_id()) !=
             boundary_functions.end())
           {
             copy_data.cell_matrix.push_back(FullMatrix<double> (copy_data.dofs_per_cell,
@@ -936,7 +936,7 @@ namespace MatrixCreator
             if (fe_is_system)
               // FE has several components
               {
-                boundary_functions.find(cell->face(face)->boundary_indicator())
+                boundary_functions.find(cell->face(face)->boundary_id())
                 ->second->vector_value_list (fe_values.get_quadrature_points(),
                                              rhs_values_system);
 
@@ -1029,7 +1029,7 @@ namespace MatrixCreator
             else
               // FE is a scalar one
               {
-                boundary_functions.find(cell->face(face)->boundary_indicator())
+                boundary_functions.find(cell->face(face)->boundary_id())
                 ->second->value_list (fe_values.get_quadrature_points(), rhs_values_scalar);
 
                 if (coefficient != 0)
@@ -1106,7 +1106,7 @@ namespace MatrixCreator
         {
           // check if this face is on that part of
           // the boundary we are interested in
-          if (boundary_functions.find(copy_data.cell->face(face)->boundary_indicator()) !=
+          if (boundary_functions.find(copy_data.cell->face(face)->boundary_id()) !=
               boundary_functions.end())
             {
               for (unsigned int i=0; i<copy_data.dofs_per_cell; ++i)
@@ -1283,7 +1283,7 @@ namespace MatrixCreator
       for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
         // check if this face is on that part of
         // the boundary we are interested in
-        if (boundary_functions.find(cell->face(face)->boundary_indicator()) !=
+        if (boundary_functions.find(cell->face(face)->boundary_id()) !=
             boundary_functions.end())
           {
             x_fe_values.reinit (cell, face);
@@ -1299,7 +1299,7 @@ namespace MatrixCreator
               {
                 rhs_values_system.resize (fe_values.n_quadrature_points,
                                           Vector<double>(n_function_components));
-                boundary_functions.find(cell->face(face)->boundary_indicator())
+                boundary_functions.find(cell->face(face)->boundary_id())
                 ->second->vector_value_list (fe_values.get_quadrature_points(),
                                              rhs_values_system);
 
@@ -1384,7 +1384,7 @@ namespace MatrixCreator
               // FE is a scalar one
               {
                 rhs_values_scalar.resize (fe_values.n_quadrature_points);
-                boundary_functions.find(cell->face(face)->boundary_indicator())
+                boundary_functions.find(cell->face(face)->boundary_id())
                 ->second->value_list (fe_values.get_quadrature_points(), rhs_values_scalar);
 
                 if (coefficient != 0)
@@ -1482,7 +1482,7 @@ namespace MatrixCreator
         {
           // check if this face is on that part of
           // the boundary we are interested in
-          if (boundary_functions.find(copy_data.cell->face(face)->boundary_indicator()) !=
+          if (boundary_functions.find(copy_data.cell->face(face)->boundary_id()) !=
               boundary_functions.end())
             {
 #ifdef DEBUG

--- a/tests/benchmarks/step-22/step-22.cc
+++ b/tests/benchmarks/step-22/step-22.cc
@@ -1287,7 +1287,7 @@ namespace Step22
          cell != triangulation.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->center()[dim-1] == 0)
-          cell->face(f)->set_all_boundary_indicators(1);
+          cell->face(f)->set_all_boundary_ids(1);
 
 
     // We then apply an initial refinement

--- a/tests/benchmarks/test_assembly/step-22.cc
+++ b/tests/benchmarks/test_assembly/step-22.cc
@@ -1266,7 +1266,7 @@ namespace Step22
          cell != triangulation.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->face(f)->center()[dim-1] == 0)
-          cell->face(f)->set_all_boundary_indicators(1);
+          cell->face(f)->set_all_boundary_ids(1);
 
 
     // We then apply an initial refinement

--- a/tests/bits/anna_4.cc
+++ b/tests/bits/anna_4.cc
@@ -190,15 +190,15 @@ void FindBug<dim>::dirichlet_conditions ()
 
 
   std::vector<bool> fixed_dofs (dof_handler.n_dofs());
-  std::set<types::boundary_id> boundary_indicators;
-  boundary_indicators.insert (0);
+  std::set<types::boundary_id> boundary_ids;
+  boundary_ids.insert (0);
 
   // get a list of those boundary DoFs which
   // we want to be fixed:
   DoFTools::extract_boundary_dofs (dof_handler,
                                    component_mask,
                                    fixed_dofs,
-                                   boundary_indicators);
+                                   boundary_ids);
 
   // (Primitive) Check if the DoFs
   // where adjusted correctly (note

--- a/tests/bits/anna_6.cc
+++ b/tests/bits/anna_6.cc
@@ -186,12 +186,12 @@ void ImposeBC<dim>::test_extract_boundary_DoFs ()
   bc_component_select[2] = false;
 
   std::vector<bool> ned_boundary_dofs (dof_handler.n_dofs());
-  std::set<types::boundary_id> boundary_indicators;
-  boundary_indicators.insert (0);
+  std::set<types::boundary_id> boundary_ids;
+  boundary_ids.insert (0);
   DoFTools::extract_boundary_dofs (dof_handler,
                                    bc_component_select,
                                    ned_boundary_dofs,
-                                   boundary_indicators);
+                                   boundary_ids);
 
 
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)
@@ -225,12 +225,12 @@ void ImposeBC<dim>::test_interpolate_BC ()
   // (the pressure is assumed to be set to 1
   // on the boundary)
   std::vector<bool> p_boundary_dofs (dof_handler.n_dofs());
-  std::set<types::boundary_id> boundary_indicators;
-  boundary_indicators.insert (0);
+  std::set<types::boundary_id> boundary_ids;
+  boundary_ids.insert (0);
   DoFTools::extract_boundary_dofs (dof_handler,
                                    bc_component_select,
                                    p_boundary_dofs,
-                                   boundary_indicators);
+                                   boundary_ids);
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)
     {
       // error: pressure boundary DoF

--- a/tests/bits/cylinder.cc
+++ b/tests/bits/cylinder.cc
@@ -53,7 +53,7 @@ int main ()
        face!=tria.end_face(); ++face)
     {
       deallog << face << "   "
-              << (int)face->boundary_indicator() << "  "
+              << (int)face->boundary_id() << "  "
               << '<' << face->vertex(0) << '>' << std::endl
               << "           <" << face->vertex(1) << '>' << std::endl
               << "           <" << face->vertex(2) << '>' << std::endl

--- a/tests/bits/distorted_cells_03.cc
+++ b/tests/bits/distorted_cells_03.cc
@@ -85,7 +85,7 @@ void check ()
   // set bottom face to use MyBoundary
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (coarse_grid.begin_active()->face(f)->center()[dim-1] == -1)
-      coarse_grid.begin_active()->face(f)->set_boundary_indicator (1);
+      coarse_grid.begin_active()->face(f)->set_boundary_id (1);
   coarse_grid.set_boundary (1, my_boundary);
 
   // now try to refine this one

--- a/tests/bits/distorted_cells_04.cc
+++ b/tests/bits/distorted_cells_04.cc
@@ -118,7 +118,7 @@ void check ()
   // set bottom face to use MyBoundary
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (coarse_grid.begin_active()->face(f)->center()[dim-1] == -1)
-      coarse_grid.begin_active()->face(f)->set_boundary_indicator (1);
+      coarse_grid.begin_active()->face(f)->set_boundary_id (1);
   coarse_grid.set_boundary (1, my_boundary);
 
   // now try to refine this one

--- a/tests/bits/distorted_cells_05.cc
+++ b/tests/bits/distorted_cells_05.cc
@@ -120,7 +120,7 @@ void check ()
   // set bottom face to use MyBoundary
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (coarse_grid.begin_active()->face(f)->center()[dim-1] == -1)
-      coarse_grid.begin_active()->face(f)->set_boundary_indicator (1);
+      coarse_grid.begin_active()->face(f)->set_boundary_id (1);
   coarse_grid.set_boundary (1, my_boundary);
 
   // now try to refine this one

--- a/tests/bits/distorted_cells_06.cc
+++ b/tests/bits/distorted_cells_06.cc
@@ -78,7 +78,7 @@ void check ()
       if (coarse_grid.begin_active()->face(f)->line(e)->center()[0] == 0)
         if (coarse_grid.begin_active()->face(f)->line(e)->center()[1] == 0.5)
           if (coarse_grid.begin_active()->face(f)->line(e)->center()[2] == 0)
-            coarse_grid.begin_active()->face(f)->line(e)->set_boundary_indicator (99);
+            coarse_grid.begin_active()->face(f)->line(e)->set_boundary_id (99);
   coarse_grid.set_boundary (99, my_boundary);
 
   // now try to refine this one

--- a/tests/bits/dof_tools_21_b.cc
+++ b/tests/bits/dof_tools_21_b.cc
@@ -107,8 +107,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   triangulation.refine_global(0);
 }
@@ -182,8 +182,8 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
       if (cell_2->face(j)->center()(2) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   triangulation.refine_global(0);
 }

--- a/tests/bits/dof_tools_21_b_x.cc
+++ b/tests/bits/dof_tools_21_b_x.cc
@@ -105,8 +105,8 @@ void generate_grid(Triangulation<2> &triangulation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 }
 
 

--- a/tests/bits/dof_tools_21_b_x_q3.cc
+++ b/tests/bits/dof_tools_21_b_x_q3.cc
@@ -139,8 +139,8 @@ void generate_grid(Triangulation<2> &triangulation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 }
 
 

--- a/tests/bits/dof_tools_21_b_y.cc
+++ b/tests/bits/dof_tools_21_b_y.cc
@@ -104,8 +104,8 @@ void generate_grid(Triangulation<2> &triangulation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 }
 
 

--- a/tests/bits/dof_tools_21_c.cc
+++ b/tests/bits/dof_tools_21_c.cc
@@ -110,8 +110,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   cell_2->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
@@ -186,8 +186,8 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
       if (cell_2->face(j)->center()(2) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   cell_2->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();

--- a/tests/bits/dof_tools_common.h
+++ b/tests/bits/dof_tools_common.h
@@ -62,7 +62,7 @@ void
 set_boundary_ids (Triangulation<dim> &tria)
 {
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-    tria.begin_active()->face(f)->set_boundary_indicator (f);
+    tria.begin_active()->face(f)->set_boundary_id (f);
 }
 
 

--- a/tests/bits/get_boundary_indicators_1d.cc
+++ b/tests/bits/get_boundary_indicators_1d.cc
@@ -19,7 +19,7 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 
-// Check if Triangulation<1>::get_boundary_indicators() works for 1d grids.
+// Check if Triangulation<1>::get_boundary_ids() works for 1d grids.
 
 
 int main ()
@@ -30,7 +30,7 @@ int main ()
 
   Triangulation<1>   triangulation;
   GridGenerator::hyper_cube (triangulation, -1, 1);
-  const std::vector<types::boundary_id> indicators = triangulation.get_boundary_indicators();
+  const std::vector<types::boundary_id> indicators = triangulation.get_boundary_ids();
   for (unsigned int i=0; i<indicators.size(); ++i)
     deallog << int (indicators[i]) << std::endl;
 

--- a/tests/bits/hyper_ball_3d.cc
+++ b/tests/bits/hyper_ball_3d.cc
@@ -57,7 +57,7 @@ int main ()
        face!=tria.end_face(); ++face)
     {
       deallog << face << "   "
-              << (int)face->boundary_indicator() << "  "
+              << (int)face->boundary_id() << "  "
               << face->vertex_index(0)
               << " <" << face->vertex(0) << '>'
               << std::endl

--- a/tests/bits/periodicity_05.cc
+++ b/tests/bits/periodicity_05.cc
@@ -133,10 +133,10 @@ void Deal2PeriodicBug::makeGrid()
   deallog<< "Constructing the grid..." <<std::endl;
   const Point<2> p1(0,0), p2(1,1);
   GridGenerator::hyper_rectangle(triangulation,p1,p2);
-  triangulation.begin_active()->face(2)->set_boundary_indicator(1);
-  triangulation.begin_active()->face(3)->set_boundary_indicator(1);
-  triangulation.begin_active()->face(0)->set_boundary_indicator(0);
-  triangulation.begin_active()->face(1)->set_boundary_indicator(2);
+  triangulation.begin_active()->face(2)->set_boundary_id(1);
+  triangulation.begin_active()->face(3)->set_boundary_id(1);
+  triangulation.begin_active()->face(0)->set_boundary_id(0);
+  triangulation.begin_active()->face(1)->set_boundary_id(2);
   triangulation.refine_global(1);
 
   Triangulation<2>::active_cell_iterator cell = triangulation.begin_active();

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -388,7 +388,7 @@ void HelmholtzProblem<dim>::assemble_system (const bool do_reconstruct)
       for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
         if (cell->face(face)->at_boundary()
             &&
-            (cell->face(face)->boundary_indicator() == 1))
+            (cell->face(face)->boundary_id() == 1))
           {
             x_fe_face_values.reinit (cell, face);
             const FEFaceValues<dim> &fe_face_values
@@ -627,7 +627,7 @@ void HelmholtzProblem<dim>::run ()
               if ((cell->face(face)->center()(0) == -1)
                   ||
                   (cell->face(face)->center()(1) == -1))
-                cell->face(face)->set_boundary_indicator (1);
+                cell->face(face)->set_boundary_id (1);
         }
       else
         refine_grid ();

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -691,7 +691,7 @@ namespace Step51
 
                 if (cell->face(face)->at_boundary()
                     &&
-                    (cell->face(face)->boundary_indicator() == 1))
+                    (cell->face(face)->boundary_id() == 1))
                   {
                     const double neumann_value =
                       - scratch.exact_solution.gradient (quadrature_point) * normal
@@ -931,7 +931,7 @@ namespace Step51
         if (cell->face(face)->at_boundary())
           for (unsigned int d=0; d<dim; ++d)
             if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))
-              cell->face(face)->set_boundary_indicator (1);
+              cell->face(face)->set_boundary_id (1);
   }
 
 

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -691,7 +691,7 @@ namespace Step51
 
                 if (cell->face(face)->at_boundary()
                     &&
-                    (cell->face(face)->boundary_indicator() == 1))
+                    (cell->face(face)->boundary_id() == 1))
                   {
                     const double neumann_value =
                       - scratch.exact_solution.gradient (quadrature_point) * normal
@@ -929,7 +929,7 @@ namespace Step51
         if (cell->face(face)->at_boundary())
           for (unsigned int d=0; d<dim; ++d)
             if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))
-              cell->face(face)->set_boundary_indicator (1);
+              cell->face(face)->set_boundary_id (1);
   }
 
 

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -328,7 +328,7 @@ void HelmholtzProblem<dim>::assemble_system ()
       for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
         if (cell->face(face)->at_boundary()
             &&
-            (cell->face(face)->boundary_indicator() == 1))
+            (cell->face(face)->boundary_id() == 1))
           {
             x_fe_face_values.reinit (cell, face);
             const FEFaceValues<dim> &fe_face_values
@@ -504,7 +504,7 @@ void HelmholtzProblem<dim>::run ()
               if ((cell->face(face)->center()(0) == -1)
                   ||
                   (cell->face(face)->center()(1) == -1))
-                cell->face(face)->set_boundary_indicator (1);
+                cell->face(face)->set_boundary_id (1);
         }
       else
         refine_grid ();

--- a/tests/codim_one/boundary_indicator_01.cc
+++ b/tests/codim_one/boundary_indicator_01.cc
@@ -17,11 +17,11 @@
 
 // for surfaces, we need some sort of mapping also for interior cells
 // and faces, but at the time of writing this, we can only set
-// boundary_indicators of faces and edges that are truly at the
+// boundary_ids of faces and edges that are truly at the
 // boundary of the domain. to work around this, we use the material_id
 // field that one can set on cells, and copy it also to the adjacent
 // faces. initially, however, we also copied the material_id to the
-// boundary_indicator of adjacent faces that truly were at the
+// boundary_id of adjacent faces that truly were at the
 // boundary of the domain, and which might have had something
 // purposefully set already
 //
@@ -74,7 +74,7 @@ int main ()
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f))
             {
-              cell->face(f)->set_boundary_indicator(1);
+              cell->face(f)->set_boundary_id(1);
               done = true;
               break;
             }
@@ -88,10 +88,10 @@ int main ()
 
     // now extract a mesh of the 5
     // surface faces
-    std::set<types::boundary_id> boundary_indicators;
-    boundary_indicators.insert (0);
+    std::set<types::boundary_id> boundary_ids;
+    boundary_ids.insert (0);
     GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh,
-                                      boundary_indicators);
+                                      boundary_ids);
     deallog << volume_mesh.n_active_cells () << std::endl;
     deallog << boundary_mesh.n_active_cells () << std::endl;
 
@@ -107,7 +107,7 @@ int main ()
          cell != boundary_mesh.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim-1>::faces_per_cell; ++f)
         if (cell->at_boundary(f))
-          cell->face(f)->set_boundary_indicator(1);
+          cell->face(f)->set_boundary_id(1);
 
     boundary_mesh.refine_global (2);
 

--- a/tests/codim_one/extract_boundary_mesh_00.cc
+++ b/tests/codim_one/extract_boundary_mesh_00.cc
@@ -104,7 +104,7 @@ int main ()
 
     Triangulation<dim> volume_mesh;
     GridGenerator::hyper_cube(volume_mesh);
-    volume_mesh.begin_active()->face(0)->set_boundary_indicator(1);
+    volume_mesh.begin_active()->face(0)->set_boundary_id(1);
     volume_mesh.refine_global (1);
 
     save_mesh(volume_mesh);
@@ -135,7 +135,7 @@ int main ()
 
     Triangulation<dim> volume_mesh;
     GridGenerator::hyper_cube(volume_mesh);
-    volume_mesh.begin_active()->face(0)->set_boundary_indicator(1);
+    volume_mesh.begin_active()->face(0)->set_boundary_id(1);
     volume_mesh.refine_global (1);
 
     save_mesh(volume_mesh);
@@ -168,7 +168,7 @@ int main ()
 
     Triangulation<dim> volume_mesh;
     GridGenerator::hyper_cube(volume_mesh);
-    volume_mesh.begin_active()->face(0)->set_boundary_indicator(1);
+    volume_mesh.begin_active()->face(0)->set_boundary_id(1);
     volume_mesh.refine_global (1);
 
     save_mesh(volume_mesh);

--- a/tests/codim_one/extract_boundary_mesh_03.cc
+++ b/tests/codim_one/extract_boundary_mesh_03.cc
@@ -111,7 +111,7 @@ int main ()
          cell != volume_mesh.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->at_boundary(f))
-          cell->face(f)->set_all_boundary_indicators (1);
+          cell->face(f)->set_all_boundary_ids (1);
     volume_mesh.set_boundary (1, boundary_description);
     volume_mesh.refine_global (1);
 

--- a/tests/codim_one/extract_boundary_mesh_04.cc
+++ b/tests/codim_one/extract_boundary_mesh_04.cc
@@ -111,7 +111,7 @@ int main ()
          cell != volume_mesh.end(); ++cell)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->at_boundary(f) && (cell->center()[dim-1]>0))
-          cell->face(f)->set_all_boundary_indicators (1);
+          cell->face(f)->set_all_boundary_ids (1);
 
     volume_mesh.set_boundary (1, boundary_description);
     volume_mesh.set_boundary (0, boundary_description);

--- a/tests/codim_one/hanging_nodes_01.cc
+++ b/tests/codim_one/hanging_nodes_01.cc
@@ -52,7 +52,7 @@ int main ()
     Triangulation<spacedim>::active_cell_iterator
     cell = volume_mesh.begin_active();
 
-    cell->face(0)->set_all_boundary_indicators (1);
+    cell->face(0)->set_all_boundary_ids (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
     GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);

--- a/tests/codim_one/hanging_nodes_02.cc
+++ b/tests/codim_one/hanging_nodes_02.cc
@@ -52,7 +52,7 @@ int main ()
     Triangulation<spacedim>::active_cell_iterator
     cell = volume_mesh.begin_active();
 
-    cell->face(0)->set_all_boundary_indicators (1);
+    cell->face(0)->set_all_boundary_ids (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
     GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);

--- a/tests/codim_one/hanging_nodes_03.cc
+++ b/tests/codim_one/hanging_nodes_03.cc
@@ -46,7 +46,7 @@ int main ()
     Triangulation<spacedim>::active_cell_iterator
     cell = volume_mesh.begin_active();
 
-    cell->face(0)->set_all_boundary_indicators (1);
+    cell->face(0)->set_all_boundary_ids (1);
     std::set<types::boundary_id> boundary_ids;
     boundary_ids.insert(0);
     GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh, boundary_ids);

--- a/tests/codim_one/interpolate_boundary_values_02.cc
+++ b/tests/codim_one/interpolate_boundary_values_02.cc
@@ -66,7 +66,7 @@ void test()
            cell = dof_handler.begin_active(); cell != dof_handler.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f) &&
-              (cell->face(f)->boundary_indicator() == boundary_id))
+              (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_face; ++v)
               for (unsigned int i=0; i<fe.dofs_per_vertex; ++i)
                 {

--- a/tests/codim_one/interpolate_boundary_values_02_vector_valued.cc
+++ b/tests/codim_one/interpolate_boundary_values_02_vector_valued.cc
@@ -80,7 +80,7 @@ void test()
            cell = dof_handler.begin_active(); cell != dof_handler.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f) &&
-              (cell->face(f)->boundary_indicator() == boundary_id))
+              (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_face; ++v)
               for (unsigned int i=0; i<fe.dofs_per_vertex; ++i)
                 {

--- a/tests/codim_one/interpolate_boundary_values_03.cc
+++ b/tests/codim_one/interpolate_boundary_values_03.cc
@@ -73,7 +73,7 @@ void test()
            cell = dof_handler.begin_active(); cell != dof_handler.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f) &&
-              (cell->face(f)->boundary_indicator() == boundary_id))
+              (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_face; ++v)
               for (unsigned int i=0; i<fe.dofs_per_vertex; ++i)
                 {

--- a/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
+++ b/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
@@ -81,7 +81,7 @@ void test()
            cell = dof_handler.begin_active(); cell != dof_handler.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f) &&
-              (cell->face(f)->boundary_indicator() == boundary_id))
+              (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_face; ++v)
               for (unsigned int i=0; i<fe.dofs_per_vertex; ++i)
                 {

--- a/tests/deal.II/constraints_local_to_global.cc
+++ b/tests/deal.II/constraints_local_to_global.cc
@@ -48,7 +48,7 @@ void test ()
 {
   Triangulation<dim> tria;
   GridGenerator::hyper_cube (tria);
-  tria.begin()->face(0)->set_boundary_indicator(1);
+  tria.begin()->face(0)->set_boundary_id(1);
   tria.refine_global(1);
   tria.begin_active()->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/deal.II/constraints_local_to_global_chunk.cc
+++ b/tests/deal.II/constraints_local_to_global_chunk.cc
@@ -50,7 +50,7 @@ void test (unsigned int chunk_size)
 {
   Triangulation<dim> tria;
   GridGenerator::hyper_cube (tria);
-  tria.begin()->face(0)->set_boundary_indicator(1);
+  tria.begin()->face(0)->set_boundary_id(1);
   tria.refine_global(1);
   tria.begin_active()->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/deal.II/dof_test.cc
+++ b/tests/deal.II/dof_test.cc
@@ -119,7 +119,7 @@ CurvedLine<dim>::get_new_point_on_line (const typename Triangulation<dim>::line_
         // id was invented after the above was
         // written, so we are not very strict
         // here with using these flags
-        && (line->boundary_indicator() == 1))
+        && (line->boundary_id() == 1))
       return middle;
 
 
@@ -265,8 +265,8 @@ void TestCases<dim>::run (const unsigned int test_case)
     {
       if (dim==3)
         {
-          tria->begin_active()->face(4)->set_boundary_indicator(1);
-          tria->begin_active()->face(5)->set_boundary_indicator(1);
+          tria->begin_active()->face(4)->set_boundary_id(1);
+          tria->begin_active()->face(5)->set_boundary_id(1);
         };
 
       // set the boundary function

--- a/tests/deal.II/grid_hyper_shell.cc
+++ b/tests/deal.II/grid_hyper_shell.cc
@@ -55,7 +55,7 @@ void check (double r1, double r2, unsigned int n)
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
 	if (c->face(f)->at_boundary())
 	  for (unsigned int e=0; e<GeometryInfo<dim>::lines_per_face; ++e)
-	    c->face(f)->line(e)->set_boundary_indicator(0);
+	    c->face(f)->line(e)->set_boundary_id(0);
   
   static const HyperShellBoundary<dim> boundary(center);
   tria.set_boundary(0, boundary);

--- a/tests/deal.II/grid_hyper_shell_05.cc
+++ b/tests/deal.II/grid_hyper_shell_05.cc
@@ -67,7 +67,7 @@ void check (const unsigned int n)
        cell != tria.end(); ++cell)
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (cell->at_boundary(f))
-        deallog << cell->face(f) << ' ' << (int)cell->face(f)->boundary_indicator()
+        deallog << cell->face(f) << ' ' << (int)cell->face(f)->boundary_id()
                 << ' ' << cell->face(f)->center().norm() << std::endl;
 }
 

--- a/tests/deal.II/grid_hyper_shell_06.cc
+++ b/tests/deal.II/grid_hyper_shell_06.cc
@@ -52,9 +52,9 @@ void check (double r1, double r2, unsigned int n)
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (cell->face(f)->at_boundary())
         for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_face; ++l)
-          AssertThrow (cell->face(f)->line(l)->boundary_indicator()
+          AssertThrow (cell->face(f)->line(l)->boundary_id()
                        ==
-                       cell->face(f)->boundary_indicator(),
+                       cell->face(f)->boundary_id(),
                        ExcInternalError());
 
   deallog << "OK" << std::endl;

--- a/tests/deal.II/grid_out_03.cc
+++ b/tests/deal.II/grid_out_03.cc
@@ -41,8 +41,8 @@ void test ()
 {
   Triangulation<dim> tria;
   GridGenerator::hyper_cube (tria);
-  tria.begin_active()->line(0)->set_boundary_indicator(1);
-  tria.begin_active()->face(2*dim-1)->set_boundary_indicator(2);
+  tria.begin_active()->line(0)->set_boundary_id(1);
+  tria.begin_active()->face(2*dim-1)->set_boundary_id(2);
 
   GridOut grid_out;
   GridOutFlags::Ucd flags;

--- a/tests/deal.II/grid_out_04.cc
+++ b/tests/deal.II/grid_out_04.cc
@@ -41,8 +41,8 @@ void test ()
 {
   Triangulation<dim> tria;
   GridGenerator::hyper_cube (tria);
-  tria.begin_active()->line(0)->set_boundary_indicator(1);
-  tria.begin_active()->face(2*dim-1)->set_boundary_indicator(2);
+  tria.begin_active()->line(0)->set_boundary_id(1);
+  tria.begin_active()->face(2*dim-1)->set_boundary_id(2);
 
   GridOut grid_out;
   GridOutFlags::Msh flags;

--- a/tests/deal.II/grid_out_05.cc
+++ b/tests/deal.II/grid_out_05.cc
@@ -41,8 +41,8 @@ void test ()
 {
   Triangulation<dim> tria;
   GridGenerator::hyper_cube (tria);
-  tria.begin_active()->line(0)->set_boundary_indicator(1);
-  tria.begin_active()->face(2*dim-1)->set_boundary_indicator(2);
+  tria.begin_active()->line(0)->set_boundary_id(1);
+  tria.begin_active()->face(2*dim-1)->set_boundary_id(2);
 
   GridOut grid_out;
   GridOutFlags::Ucd flags;

--- a/tests/deal.II/grid_test.cc
+++ b/tests/deal.II/grid_test.cc
@@ -112,7 +112,7 @@ CurvedLine<dim>::get_new_point_on_line (const typename Triangulation<dim>::line_
         // id was invented after the above was
         // written, so we are not very strict
         // here with using these flags
-        && (line->boundary_indicator() == 1))
+        && (line->boundary_id() == 1))
       return middle;
 
 
@@ -221,8 +221,8 @@ void test (const int test_case)
     {
       if (dim==3)
         {
-          tria.begin_active()->face(4)->set_boundary_indicator(1);
-          tria.begin_active()->face(5)->set_boundary_indicator(1);
+          tria.begin_active()->face(4)->set_boundary_id(1);
+          tria.begin_active()->face(5)->set_boundary_id(1);
         };
 
 

--- a/tests/deal.II/grid_tools_05.cc
+++ b/tests/deal.II/grid_tools_05.cc
@@ -88,8 +88,8 @@ void generate_grid(Triangulation<2> &triangulation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(42);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(42);
 
   triangulation.refine_global(1);
 }
@@ -152,8 +152,8 @@ void generate_grid(Triangulation<3> &triangulation)
       if (cell_2->face(j)->center()(2) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(42);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(42);
 
   triangulation.refine_global(1);
 }

--- a/tests/deal.II/grid_tools_06.cc
+++ b/tests/deal.II/grid_tools_06.cc
@@ -94,8 +94,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
       if (cell_2->face(j)->center()(1) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   triangulation.refine_global(1);
 }
@@ -169,8 +169,8 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
       if (cell_2->face(j)->center()(2) < -2.9)
         face_2 = cell_2->face(j);
     }
-  face_1->set_boundary_indicator(42);
-  face_2->set_boundary_indicator(43);
+  face_1->set_boundary_id(42);
+  face_2->set_boundary_id(43);
 
   triangulation.refine_global(1);
 }

--- a/tests/deal.II/grid_transform.cc
+++ b/tests/deal.II/grid_transform.cc
@@ -90,7 +90,7 @@ int main ()
                       // circle.
                       new_points.insert(std::pair<types::global_dof_index, Point<dim> > (
                                           face->vertex_index(vertex_no), n_radius/inner_radius*v+n_center));
-                      face->set_boundary_indicator(1);
+                      face->set_boundary_id(1);
                     }
                   else
                     Assert(false, ExcInternalError());

--- a/tests/deal.II/grid_transform_coefficient.cc
+++ b/tests/deal.II/grid_transform_coefficient.cc
@@ -100,7 +100,7 @@ int main ()
                       // circle.
                       new_points.insert(std::pair<types::global_dof_index, Point<dim> > (
                                           face->vertex_index(vertex_no), n_radius/inner_radius*v+n_center));
-                      face->set_boundary_indicator(1);
+                      face->set_boundary_id(1);
                     }
                   else
                     Assert(false, ExcInternalError());

--- a/tests/deal.II/interpolate_boundary_values_01.cc
+++ b/tests/deal.II/interpolate_boundary_values_01.cc
@@ -151,15 +151,15 @@ void FindBug<dim>::dirichlet_conditions ()
 
 
   std::vector<bool> fixed_dofs (dof_handler.n_dofs());
-  std::set<types::boundary_id> boundary_indicators;
-  boundary_indicators.insert (0);
+  std::set<types::boundary_id> boundary_ids;
+  boundary_ids.insert (0);
 
   // get a list of those boundary DoFs which
   // we want to be fixed:
   DoFTools::extract_boundary_dofs (dof_handler,
                                    component_mask,
                                    fixed_dofs,
-                                   boundary_indicators);
+                                   boundary_ids);
 
   // (Primitive) Check if the DoFs
   // where adjusted correctly (note

--- a/tests/deal.II/interpolate_boundary_values_02.cc
+++ b/tests/deal.II/interpolate_boundary_values_02.cc
@@ -51,8 +51,8 @@ void test ()
   DoFHandler<dim>      dof_handler(triangulation);
 
   GridGenerator::hyper_cube (triangulation, 0, 1);
-  triangulation.begin_active()->face(0)->set_boundary_indicator(10);
-  triangulation.begin_active()->face(1)->set_boundary_indicator(20);
+  triangulation.begin_active()->face(0)->set_boundary_id(10);
+  triangulation.begin_active()->face(1)->set_boundary_id(20);
   triangulation.refine_global (1);
 
   dof_handler.distribute_dofs (fe);

--- a/tests/deal.II/kelly_crash_02.cc
+++ b/tests/deal.II/kelly_crash_02.cc
@@ -215,7 +215,7 @@ void test ()
           (cell->face(f)->center()[2] != 7)
           &&
           (cell->face(f)->at_boundary()))
-        cell->face(f)->set_boundary_indicator (1);
+        cell->face(f)->set_boundary_id (1);
 
   triangulation.refine_global (1);
 

--- a/tests/deal.II/merge_triangulations_02.cc
+++ b/tests/deal.II/merge_triangulations_02.cc
@@ -56,7 +56,7 @@ void mesh_info(const Triangulation<dim> &tria)
         for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
           {
             if (cell->face(face)->at_boundary())
-              boundary_count[cell->face(face)->boundary_indicator()]++;
+              boundary_count[cell->face(face)->boundary_id()]++;
           }
       }
 

--- a/tests/deal.II/merge_triangulations_03.cc
+++ b/tests/deal.II/merge_triangulations_03.cc
@@ -103,7 +103,7 @@ void mesh_info(const Triangulation<dim> &tria,
 	     ++face)
 	  {
 	    if (cell->face(face)->at_boundary())
-	      boundary_count[cell->face(face)->boundary_indicator()]++;
+	      boundary_count[cell->face(face)->boundary_id()]++;
 	  }
       }
     deallog << " boundary indicators: ";

--- a/tests/deal.II/no_flux_01.cc
+++ b/tests/deal.II/no_flux_01.cc
@@ -67,7 +67,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/no_flux_02.cc
+++ b/tests/deal.II/no_flux_02.cc
@@ -69,7 +69,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/no_flux_10.cc
+++ b/tests/deal.II/no_flux_10.cc
@@ -67,51 +67,51 @@ colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
         double radius = cell->face(f)->center().norm() - center.norm();
         if (std::fabs(cell->face(f)->center()(2) - sqrt(3.)*cell->face(f)->center()(0)) < eps ) // z = sqrt(3)x set boundary 2
           {
-            cell->face(f)->set_boundary_indicator(2);
+            cell->face(f)->set_boundary_id(2);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(2);
+                  cell->face(f)->line(j)->set_boundary_id(2);
           }
         else if (std::fabs(cell->face(f)->center()(2) + sqrt(3.)*cell->face(f)->center()(0)) < eps) // z = -sqrt(3)x set boundary 3
           {
-            cell->face(f)->set_boundary_indicator(3);
+            cell->face(f)->set_boundary_id(3);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(3);
+                  cell->face(f)->line(j)->set_boundary_id(3);
           }
         else if (std::fabs(cell->face(f)->center()(2) - sqrt(3.)*cell->face(f)->center()(1)) < eps ) // z = sqrt(3)y set boundary 4
           {
-            cell->face(f)->set_boundary_indicator(4);
+            cell->face(f)->set_boundary_id(4);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(4);
+                  cell->face(f)->line(j)->set_boundary_id(4);
           }
         else if (std::fabs(cell->face(f)->center()(2) + sqrt(3.)*cell->face(f)->center()(1)) < eps ) // z = -sqrt(3)y set boundary 5
           {
-            cell->face(f)->set_boundary_indicator(5);
+            cell->face(f)->set_boundary_id(5);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) > eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(5);
+                  cell->face(f)->line(j)->set_boundary_id(5);
           }
         else if (radius < middle) // inner radius set boundary 0
           {
-            cell->face(f)->set_boundary_indicator(0);
+            cell->face(f)->set_boundary_id(0);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) < eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(0);
+                  cell->face(f)->line(j)->set_boundary_id(0);
           }
         else if (radius > middle) // outer radius set boundary 1
           {
-            cell->face(f)->set_boundary_indicator(1);
+            cell->face(f)->set_boundary_id(1);
             for (unsigned int j=0; j<GeometryInfo<3>::lines_per_face; ++j)
               if (cell->face(f)->line(j)->at_boundary())
                 if (std::fabs(cell->face(f)->line(j)->vertex(0).norm() - cell->face(f)->line(j)->vertex(1).norm()) < eps)
-                  cell->face(f)->line(j)->set_boundary_indicator(1);
+                  cell->face(f)->line(j)->set_boundary_id(1);
           }
         else
           AssertThrow (false, ExcInternalError());
@@ -189,7 +189,7 @@ void run()
 
   for (unsigned int f=0; f<6; ++f)
     deallog << "Face=" << f << ", boundary_id="
-            << (int)triangulation.begin_active()->face(f)->boundary_indicator() << std::endl;
+            << (int)triangulation.begin_active()->face(f)->boundary_id() << std::endl;
 
   std::set<unsigned char> no_normal_flux_boundaries;
   no_normal_flux_boundaries.insert (0);

--- a/tests/deal.II/no_flux_11.cc
+++ b/tests/deal.II/no_flux_11.cc
@@ -65,25 +65,25 @@ void run()
 		    if ( (std::fabs(cell->face(face)->center()(0)) < 0.1)
 			 && (std::fabs(cell->face(face)->center()(dim-1)) < 1e-12) )
 		      {  
-			cell->face(face)->set_boundary_indicator (1);
+			cell->face(face)->set_boundary_id (1);
 		      }
 
 		    if ( (std::fabs(cell->face(face)->center()(0)) < 1e-12)
 			 && (std::fabs(cell->face(face)->center()(dim-1)) < 0.1) )
 		      {
-			cell->face(face)->set_boundary_indicator (1);
+			cell->face(face)->set_boundary_id (1);
 		      }
 
 		    if ( (std::fabs(1.0-cell->face(face)->center()(0)) < 0.1)
 			 && (std::fabs(1.0-cell->face(face)->center()(dim-1)) < 1e-12) )
 		      {
-			cell->face(face)->set_boundary_indicator (2);
+			cell->face(face)->set_boundary_id (2);
 		      }
 
 		    if ( (std::fabs(1.0-cell->face(face)->center()(0)) < 1e-12)
 			 && (std::fabs(1.0-cell->face(face)->center()(dim-1)) < 0.1) )
 		      {
-			cell->face(face)->set_boundary_indicator (2);
+			cell->face(face)->set_boundary_id (2);
 		      }
 
 		    // no normal flux boundary
@@ -91,25 +91,25 @@ void run()
 		    if ( (std::fabs(cell->face(face)->center()(0)) >= 0.1 && std::fabs(cell->face(face)->center()(0)) <= 1.0)
 			 && (std::fabs(cell->face(face)->center()(dim-1)) < 1e-12) )
 		      {  
-			cell->face(face)->set_boundary_indicator (3);
+			cell->face(face)->set_boundary_id (3);
 		      }
 
 		    if ( (std::fabs(cell->face(face)->center()(0)) >= 0.0 && std::fabs(cell->face(face)->center()(0)) <= 0.9)
 			 && (std::fabs(1.0-cell->face(face)->center()(dim-1)) < 1e-12) )
 		      {  
-			cell->face(face)->set_boundary_indicator (5);
+			cell->face(face)->set_boundary_id (5);
 		      }
 
 		    if ( (std::fabs(1.0-cell->face(face)->center()(0)) < 1e-12)
 			 && (std::fabs(cell->face(face)->center()(dim-1)) >= 0.0 && std::fabs(cell->face(face)->center()(dim-1)) <= 0.9) )
 		      {
-			cell->face(face)->set_boundary_indicator (4);
+			cell->face(face)->set_boundary_id (4);
 		      }
 
 		    if ( (std::fabs(cell->face(face)->center()(0)) < 1e-12)
 			 && (std::fabs(cell->face(face)->center()(dim-1)) >= 0.1 && std::fabs(cell->face(face)->center()(dim-1)) <= 1.0) )
 		      {
-			cell->face(face)->set_boundary_indicator (6);
+			cell->face(face)->set_boundary_id (6);
 		      }
 		  }
 	      }

--- a/tests/deal.II/no_flux_13.cc
+++ b/tests/deal.II/no_flux_13.cc
@@ -36,7 +36,7 @@ void test()
 {
   Triangulation<dim> triangulation;
   GridGenerator::hyper_cube (triangulation,-1.0,1.0);
-  triangulation.begin_active()->face(1)->set_all_boundary_indicators(1);
+  triangulation.begin_active()->face(1)->set_all_boundary_ids(1);
 
   FE_Q<dim> fe(1);
   DoFHandler<dim> dof_handler(triangulation);

--- a/tests/deal.II/no_flux_hp_01.cc
+++ b/tests/deal.II/no_flux_hp_01.cc
@@ -63,7 +63,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/no_flux_hp_02.cc
+++ b/tests/deal.II/no_flux_hp_02.cc
@@ -65,7 +65,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/normal_flux_01.cc
+++ b/tests/deal.II/normal_flux_01.cc
@@ -67,7 +67,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/normal_flux_02.cc
+++ b/tests/deal.II/normal_flux_02.cc
@@ -69,7 +69,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/normal_flux_hp_01.cc
+++ b/tests/deal.II/normal_flux_hp_01.cc
@@ -66,7 +66,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/normal_flux_inhom_01.cc
+++ b/tests/deal.II/normal_flux_inhom_01.cc
@@ -103,7 +103,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/tangential_flux_inhom_01.cc
+++ b/tests/deal.II/tangential_flux_inhom_01.cc
@@ -102,7 +102,7 @@ void test_hyper_cube()
   GridGenerator::hyper_cube(tr);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
-    tr.begin_active()->face(i)->set_boundary_indicator (i);
+    tr.begin_active()->face(i)->set_boundary_id (i);
 
   tr.refine_global(2);
 

--- a/tests/deal.II/vertex_as_face_04.cc
+++ b/tests/deal.II/vertex_as_face_04.cc
@@ -34,8 +34,8 @@ void test ()
   GridGenerator::hyper_cube (tria);
 
   deallog << "Coarse mesh:" << std::endl;
-  deallog << "Left vertex=" << (int)tria.begin_active()->face(0)->boundary_indicator() << std::endl;
-  deallog << "Right vertex=" << (int)tria.begin_active()->face(1)->boundary_indicator() << std::endl;
+  deallog << "Left vertex=" << (int)tria.begin_active()->face(0)->boundary_id() << std::endl;
+  deallog << "Right vertex=" << (int)tria.begin_active()->face(1)->boundary_id() << std::endl;
 
   tria.refine_global (2);
 
@@ -44,8 +44,8 @@ void test ()
        cell != tria.end(); ++cell)
     {
       deallog << "Cell: " << cell << std::endl;
-      deallog << "Left vertex=" << (int)cell->face(0)->boundary_indicator() << std::endl;
-      deallog << "Right vertex=" << (int)cell->face(1)->boundary_indicator() << std::endl;
+      deallog << "Left vertex=" << (int)cell->face(0)->boundary_id() << std::endl;
+      deallog << "Right vertex=" << (int)cell->face(1)->boundary_id() << std::endl;
     }
 }
 

--- a/tests/deal.II/vertex_as_face_08.cc
+++ b/tests/deal.II/vertex_as_face_08.cc
@@ -15,7 +15,7 @@
 
 
 // verify that we can do things like cell->face() in 1d as well. here:
-// Triangulation::get_boundary_indicators()
+// Triangulation::get_boundary_ids()
 
 
 #include "../tests.h"
@@ -35,7 +35,7 @@ void test ()
   tria.refine_global (2);
 
   std::vector<types::boundary_id>
-  boundary_ids = tria.get_boundary_indicators ();
+  boundary_ids = tria.get_boundary_ids ();
 
   for (unsigned int i=0; i<boundary_ids.size(); ++i)
     deallog << (int)boundary_ids[i] << std::endl;

--- a/tests/deal.II/vertex_as_face_09.cc
+++ b/tests/deal.II/vertex_as_face_09.cc
@@ -15,7 +15,7 @@
 
 
 // verify that we can do things like cell->face() in 1d as well. here:
-// Triangulation::get_boundary_indicators() should return an empty vector when
+// Triangulation::get_boundary_ids() should return an empty vector when
 // called to create a mesh that is a loop
 
 
@@ -39,7 +39,7 @@ void test ()
   GridGenerator::extract_boundary_mesh (volume_mesh, tria);
 
   deallog << "n_cells = " << tria.n_active_cells() << std::endl;
-  deallog << "n_boundary_ids = " << tria.get_boundary_indicators ().size()
+  deallog << "n_boundary_ids = " << tria.get_boundary_ids ().size()
           << std::endl;
 }
 

--- a/tests/deal.II/vertex_as_face_10.cc
+++ b/tests/deal.II/vertex_as_face_10.cc
@@ -33,11 +33,11 @@ void test ()
   Triangulation<1,spacedim> tria;
   GridGenerator::hyper_cube (tria);
 
-  tria.begin_active()->face(0)->set_boundary_indicator(2);
-  tria.begin_active()->face(1)->set_boundary_indicator(4);
+  tria.begin_active()->face(0)->set_boundary_id(2);
+  tria.begin_active()->face(1)->set_boundary_id(4);
 
   std::vector<types::boundary_id>
-  boundary_ids = tria.get_boundary_indicators ();
+  boundary_ids = tria.get_boundary_ids ();
 
   for (unsigned int i=0; i<boundary_ids.size(); ++i)
     deallog << (int)boundary_ids[i] << std::endl;

--- a/tests/deal.II/vertex_as_face_11.cc
+++ b/tests/deal.II/vertex_as_face_11.cc
@@ -33,11 +33,11 @@ void test ()
   Triangulation<1,spacedim> tria;
   GridGenerator::hyper_cube (tria);
 
-  tria.begin_active()->face(0)->set_boundary_indicator(2);
-  tria.begin_active()->face(1)->set_boundary_indicator(4);
+  tria.begin_active()->face(0)->set_boundary_id(2);
+  tria.begin_active()->face(1)->set_boundary_id(4);
 
-  deallog << (int)tria.begin_active()->face(0)->boundary_indicator() << std::endl;
-  deallog << (int)tria.begin_active()->face(1)->boundary_indicator() << std::endl;
+  deallog << (int)tria.begin_active()->face(0)->boundary_id() << std::endl;
+  deallog << (int)tria.begin_active()->face(1)->boundary_id() << std::endl;
 }
 
 

--- a/tests/fail/circular_01.cc
+++ b/tests/fail/circular_01.cc
@@ -817,7 +817,7 @@ void LaplaceProblem<3>::create_coarse_grid ()
           (cell->face(f)->center()[2] != 7)
           &&
           (cell->face(f)->at_boundary()))
-        cell->face(f)->set_boundary_indicator (1);
+        cell->face(f)->set_boundary_id (1);
 
   triangulation.refine_global (1);
 }

--- a/tests/fe/cell_similarity_01.cc
+++ b/tests/fe/cell_similarity_01.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_02.cc
+++ b/tests/fe/cell_similarity_02.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_03.cc
+++ b/tests/fe/cell_similarity_03.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_04.cc
+++ b/tests/fe/cell_similarity_04.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_05.cc
+++ b/tests/fe/cell_similarity_05.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_06.cc
+++ b/tests/fe/cell_similarity_06.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_07.cc
+++ b/tests/fe/cell_similarity_07.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_08.cc
+++ b/tests/fe/cell_similarity_08.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_09.cc
+++ b/tests/fe/cell_similarity_09.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_10.cc
+++ b/tests/fe/cell_similarity_10.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_01.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_01.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_02.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_02.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_03.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_03.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_04.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_04.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_05.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_05.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_06.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_06.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_07.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_07.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_08.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_08.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_09.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_09.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_monomial_10.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_10.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_01.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_01.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_02.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_02.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_03.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_03.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_04.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_04.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_05.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_05.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_06.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_06.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_07.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_07.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_08.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_08.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_09.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_09.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/cell_similarity_dgp_nonparametric_10.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_10.cc
@@ -157,7 +157,7 @@ void test()
   // set boundary id on cell 1
   for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
     if (tr.begin_active()->at_boundary(f))
-      tr.begin_active()->face(f)->set_boundary_indicator (1);
+      tr.begin_active()->face(f)->set_boundary_id (1);
 
   test(tr);
 }

--- a/tests/fe/mapping.cc
+++ b/tests/fe/mapping.cc
@@ -307,8 +307,8 @@ void create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       v3(1) = 3.;
       tria->set_boundary(1,*boundary1);
       tria->set_boundary(2,*boundary2);
-      tria->begin_active()->face(1)->set_boundary_indicator(1);
-      tria->begin_active()->face(3)->set_boundary_indicator(2);
+      tria->begin_active()->face(1)->set_boundary_id(1);
+      tria->begin_active()->face(3)->set_boundary_id(2);
       double pi=std::acos(-1.);
       double alpha=2*std::atan(0.5);
       exact_areas.push_back(4+pi-2.5*(alpha-std::sin(alpha)));
@@ -346,7 +346,7 @@ void create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       v3(0) = 0.5;
       v3(1) = 1.5;
       tria->set_boundary(1,*boundary1);
-      tria->begin_active()->face(1)->set_boundary_indicator(1);
+      tria->begin_active()->face(1)->set_boundary_id(1);
       exact_areas.push_back(0.);
       for (unsigned int i=0; i<=4; ++i)
         show[4][i]=1;
@@ -401,7 +401,7 @@ void create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
       tria_ptr.push_back(tria);
       GridGenerator::hyper_cube(*tria, 1., 3.);
       tria->set_boundary(1,*boundary1);
-      tria->begin_active()->face(1)->set_boundary_indicator(1);
+      tria->begin_active()->face(1)->set_boundary_id(1);
       exact_areas.push_back(8.+pi/3*h*h*(3*r-h));
     }
 

--- a/tests/fe/mapping_fe_real_to_unit_q5_curved.cc
+++ b/tests/fe/mapping_fe_real_to_unit_q5_curved.cc
@@ -60,7 +60,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
  const unsigned int n_points = 5;

--- a/tests/fe/mapping_real_to_unit_q4_curved.cc
+++ b/tests/fe/mapping_real_to_unit_q4_curved.cc
@@ -50,7 +50,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
   const unsigned int n_points = 5;
   std::vector< Point<dim> > unit_points(Utilities::fixed_power<dim>(n_points));

--- a/tests/fe/mapping_real_to_unit_q4_curved_codim.cc
+++ b/tests/fe/mapping_real_to_unit_q4_curved_codim.cc
@@ -50,7 +50,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
   const unsigned int n_points = 5;
   std::vector< Point<dim> > unit_points(Utilities::fixed_power<dim>(n_points));

--- a/tests/fe/mapping_real_to_unit_q4_sphere.cc
+++ b/tests/fe/mapping_real_to_unit_q4_sphere.cc
@@ -79,7 +79,7 @@ void test_real_to_unit_cell()
   // one face and adjacent edges of
   // the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(5)->set_all_boundary_indicators (1);
+  triangulation.begin_active()->face(5)->set_all_boundary_ids (1);
 
   // now try to find the coordinates
   // of the following point in the

--- a/tests/fe/mapping_real_to_unit_q4_sphere_x.cc
+++ b/tests/fe/mapping_real_to_unit_q4_sphere_x.cc
@@ -69,7 +69,7 @@ void test_real_to_unit_cell()
   // one face and adjacent edges of
   // the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(5)->set_all_boundary_indicators (1);
+  triangulation.begin_active()->face(5)->set_all_boundary_ids (1);
 
   // now try to find the coordinates
   // of the following point in the

--- a/tests/fe/mapping_real_to_unit_q4_sphere_y.cc
+++ b/tests/fe/mapping_real_to_unit_q4_sphere_y.cc
@@ -69,7 +69,7 @@ void test_real_to_unit_cell()
   // one face and adjacent edges of
   // the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(5)->set_all_boundary_indicators (1);
+  triangulation.begin_active()->face(5)->set_all_boundary_ids (1);
 
   // now try to find the coordinates
   // of the following point in the

--- a/tests/fe/mapping_real_to_unit_q4_sphere_z.cc
+++ b/tests/fe/mapping_real_to_unit_q4_sphere_z.cc
@@ -69,7 +69,7 @@ void test_real_to_unit_cell()
   // one face and adjacent edges of
   // the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(5)->set_all_boundary_indicators (1);
+  triangulation.begin_active()->face(5)->set_all_boundary_ids (1);
 
   // now see if the point is inside
   // or outside

--- a/tests/hp/create_rhs_01.cc
+++ b/tests/hp/create_rhs_01.cc
@@ -76,7 +76,7 @@ void test ()
   Vector<double> rhs_vector2(hp_dof_handler2.n_dofs());
 
   types::boundary_id myints[1] = {0};
-  std::set<types::boundary_id> boundary_indicators  (myints,myints+1);
+  std::set<types::boundary_id> boundary_ids  (myints,myints+1);
   myints[0]=0;
   hp::QCollection<1>   quadrature;
   quadrature.push_back (QGauss<1>(1));
@@ -93,7 +93,7 @@ void test ()
                                                  quadrature,
                                                  rhs_function,
                                                  rhs_vector2,
-                                                 boundary_indicators);
+                                                 boundary_ids);
   Assert (std::fabs (std::accumulate (rhs_vector2.begin(),
                                       rhs_vector2.end(), 0.)
                      - 4) < 1e-12,
@@ -104,7 +104,7 @@ void test ()
                                                  quadrature,
                                                  rhs_function,
                                                  rhs_vector,
-                                                 boundary_indicators);
+                                                 boundary_ids);
   Assert (std::fabs (std::accumulate (rhs_vector.begin(),
                                       rhs_vector.end(), 0.)
                      - 4) < 1e-12,

--- a/tests/hp/fe_nothing_18.cc
+++ b/tests/hp/fe_nothing_18.cc
@@ -269,8 +269,8 @@ void ElasticProblem<dim>::make_grid ()
   triangulationR.begin_active()->set_material_id(id_of_lagrange_mult);
 
   for (unsigned int i=0;i<n_faces_per_cell;i++) {
-    triangulationL.begin_active()->face(i)->set_boundary_indicator(i);
-    triangulationR.begin_active()->face(i)->set_boundary_indicator(n_faces_per_cell+i);
+    triangulationL.begin_active()->face(i)->set_boundary_id(i);
+    triangulationR.begin_active()->face(i)->set_boundary_id(n_faces_per_cell+i);
   }
     
   GridGenerator::merge_triangulations (triangulationL, triangulationR, triangulation);

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -327,7 +327,7 @@ void HelmholtzProblem<dim>::assemble_system ()
       for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
         if (cell->face(face)->at_boundary()
             &&
-            (cell->face(face)->boundary_indicator() == 1))
+            (cell->face(face)->boundary_id() == 1))
           {
             x_fe_face_values.reinit (cell, face);
             const FEFaceValues<dim> &fe_face_values
@@ -503,7 +503,7 @@ void HelmholtzProblem<dim>::run ()
               if ((cell->face(face)->center()(0) == -1)
                   ||
                   (cell->face(face)->center()(1) == -1))
-                cell->face(face)->set_boundary_indicator (1);
+                cell->face(face)->set_boundary_id (1);
         }
       else
         refine_grid ();

--- a/tests/integrators/mesh_worker_1d_dg.cc
+++ b/tests/integrators/mesh_worker_1d_dg.cc
@@ -305,7 +305,7 @@ namespace Advection
   void AdvectionProblem<dim>::integrate_boundary_term (MeshWorker::DoFInfo<dim> &dinfo,
                                                        MeshWorker::IntegrationInfo<dim> &info)
   {
-    const unsigned int boundary_id = dinfo.face->boundary_indicator();
+    const unsigned int boundary_id = dinfo.face->boundary_id();
 
     // We only have a non-zero boundary contribution at the
     // x=0 boundary

--- a/tests/manifold/copy_boundary_to_manifold_id_01.cc
+++ b/tests/manifold/copy_boundary_to_manifold_id_01.cc
@@ -35,7 +35,7 @@ void print_info(Triangulation<dim,spacedim> &tria) {
 	if(cell->face(f)->at_boundary()) 
 	  deallog << "face: " << cell->face(f)
 		  << ", boundary_id: " 
-		  << (int)cell->face(f)->boundary_indicator()
+		  << (int)cell->face(f)->boundary_id()
 		  << ", manifold_id: " 
 		  << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/copy_material_to_manifold_id_01.cc
+++ b/tests/manifold/copy_material_to_manifold_id_01.cc
@@ -40,7 +40,7 @@ void print_info(Triangulation<dim,spacedim> &tria) {
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
 	  deallog << "face: " << cell->face(f)
 		  << ", boundary_id: " 
-		  << (int)cell->face(f)->boundary_indicator()
+		  << (int)cell->face(f)->boundary_id()
 		  << ", manifold_id: " 
 		  << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/set_all_manifold_ids_01.cc
+++ b/tests/manifold/set_all_manifold_ids_01.cc
@@ -38,7 +38,7 @@ void print_info(Triangulation<dim,spacedim> &tria) {
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
 	  deallog << "face: " << cell->face(f)
 		  << ", boundary_id: " 
-		  << (int)cell->face(f)->boundary_indicator()
+		  << (int)cell->face(f)->boundary_id()
 		  << ", manifold_id: " 
 		  << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/set_all_manifold_ids_02.cc
+++ b/tests/manifold/set_all_manifold_ids_02.cc
@@ -38,7 +38,7 @@ void print_info(Triangulation<dim,spacedim> &tria) {
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
 	  deallog << "face: " << cell->face(f)
 		  << ", boundary_id: " 
-		  << (int)cell->face(f)->boundary_indicator()
+		  << (int)cell->face(f)->boundary_id()
 		  << ", manifold_id: " 
 		  << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/serialization/dof_handler_01.cc
+++ b/tests/serialization/dof_handler_01.cc
@@ -55,8 +55,8 @@ namespace dealii
 
             if (c1->face(f)->at_boundary())
               {
-                if (c1->face(f)->boundary_indicator() !=
-                    c2->face(f)->boundary_indicator())
+                if (c1->face(f)->boundary_id() !=
+                    c2->face(f)->boundary_id())
                   return false;
               }
             else
@@ -136,7 +136,7 @@ void do_boundary (Triangulation<dim,spacedim> &t1)
   for (; c1 != t1.end(); ++c1)
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (c1->at_boundary(f))
-        c1->face(f)->set_boundary_indicator (42);
+        c1->face(f)->set_boundary_id (42);
 }
 
 

--- a/tests/serialization/triangulation_01.cc
+++ b/tests/serialization/triangulation_01.cc
@@ -62,8 +62,8 @@ namespace dealii
 
             if (c1->face(f)->at_boundary())
               {
-                if (c1->face(f)->boundary_indicator() !=
-                    c2->face(f)->boundary_indicator())
+                if (c1->face(f)->boundary_id() !=
+                    c2->face(f)->boundary_id())
                   return false;
               }
             else
@@ -121,7 +121,7 @@ void do_boundary (Triangulation<dim,spacedim> &t1)
   for (; c1 != t1.end(); ++c1)
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (c1->at_boundary(f)) {
-        c1->face(f)->set_boundary_indicator (42);
+        c1->face(f)->set_boundary_id (42);
 	//        c1->face(f)->set_manifold_id (43);
       }
 }

--- a/tests/serialization/triangulation_02.cc
+++ b/tests/serialization/triangulation_02.cc
@@ -64,8 +64,8 @@ namespace dealii
 
             if (c1->face(f)->at_boundary())
               {
-                if (c1->face(f)->boundary_indicator() !=
-                    c2->face(f)->boundary_indicator())
+                if (c1->face(f)->boundary_id() !=
+                    c2->face(f)->boundary_id())
                   return false;
               }
             else
@@ -123,7 +123,7 @@ void do_boundary (Triangulation<dim,spacedim> &t1)
   for (; c1 != t1.end(); ++c1)
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (c1->at_boundary(f))
-        c1->face(f)->set_boundary_indicator (42);
+        c1->face(f)->set_boundary_id (42);
 }
 
 


### PR DESCRIPTION
This closes #747 . The call `cell->boundary_indicator()` is out of the system, since all other functions are always of the form `cell->subdomain_id()`, etc. Thus, rename `boundary_indicator()` and friends to `boundary_id()`, but keep the old name in deprecated form.

The only commit of interest is the first one. The others simply mechanically rename the functions we call in all of the other places (in the sources, in the tests, and in the documentation).