### PR TITLE
Final fix of tests for hierarchical cell numbering.

### DIFF
--- a/tests/mpi/periodicity_01.with_petsc=true.mpirun=3.output
+++ b/tests/mpi/periodicity_01.with_petsc=true.mpirun=3.output
@@ -60,7 +60,7 @@ DEAL::Convergence step 7 value 0
 0.750000 0.00000 0.750000	-8.82296e-05
 
 Cycle 2:
-DEAL::Starting value 0.0249162
+DEAL::Starting value 0.0250422
 DEAL::Convergence step 7 value 0
    Solved in 7 iterations.
 0.125000 0.125000 0.00000	0.000714896

--- a/tests/mpi/periodicity_01.with_petsc=true.mpirun=5.output
+++ b/tests/mpi/periodicity_01.with_petsc=true.mpirun=5.output
@@ -37,7 +37,7 @@ DEAL::Convergence step 7 value 0
 0.500000 0.00000 0.500000	0.000542250
 
 Cycle 1:
-DEAL::Starting value 0.0136233
+DEAL::Starting value 0.0137083
 DEAL::Convergence step 7 value 0
    Solved in 7 iterations.
 0.250000 0.250000 0.00000	-7.02574e-05
@@ -60,7 +60,7 @@ DEAL::Convergence step 7 value 0
 0.750000 0.00000 0.750000	-8.82296e-05
 
 Cycle 2:
-DEAL::Starting value 0.0247852
+DEAL::Starting value 0.0248658
 DEAL::Convergence step 8 value 0
    Solved in 8 iterations.
 0.125000 0.125000 0.00000	0.000714896

--- a/tests/mpi/periodicity_01.with_petsc=true.mpirun=7.output
+++ b/tests/mpi/periodicity_01.with_petsc=true.mpirun=7.output
@@ -37,9 +37,9 @@ DEAL::Convergence step 7 value 0
 0.500000 0.00000 0.500000	0.000542250
 
 Cycle 1:
-DEAL::Starting value 0.0136343
-DEAL::Convergence step 8 value 0
-   Solved in 8 iterations.
+DEAL::Starting value 0.0135106
+DEAL::Convergence step 7 value 0
+   Solved in 7 iterations.
 0.250000 0.250000 0.00000	-7.02574e-05
 0.250000 0.00000 0.250000	-8.84955e-05
 0.250000 0.500000 0.00000	2.30224e-05
@@ -60,7 +60,7 @@ DEAL::Convergence step 8 value 0
 0.750000 0.00000 0.750000	-8.82296e-05
 
 Cycle 2:
-DEAL::Starting value 0.0248010
+DEAL::Starting value 0.0248824
 DEAL::Convergence step 8 value 0
    Solved in 8 iterations.
 0.125000 0.125000 0.00000	0.000714896


### PR DESCRIPTION
That one took me a bit longer to verify because I had to check the slightly different output more closely. The problem was that I believed the rhs norm changed on a deterministic function (starting value of convergence check). However, it turned out that the rhs norm remained the same but BoomerAMG is slightly different and a different 'starting value' for the log stream in the PETSc solver is displayed with that value which is perfectly fine.