### PR TITLE
Add a missing call to distribute() to step-26 after SolutionTransfer.

### DIFF
--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2013 - 2014 by the deal.II authors
+ * Copyright (C) 2013 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -402,14 +402,20 @@ namespace Step26
     triangulation.prepare_coarsening_and_refinement();
     solution_trans.prepare_for_coarsening_and_refinement(previous_solution);
 
-    // Now everything is ready, so do the refinement and recreate the dof
-    // structure on the new grid, and initialize the matrix structures and the
-    // new vectors in the <code>setup_system</code> function. Next, we actually
-    // perform the interpolation of the solution from old to new grid.
+    // Now everything is ready, so do the refinement and recreate the DoF
+    // structure on the new grid, and finally initialize the matrix structures
+    // and the new vectors in the <code>setup_system</code> function. Next, we
+    // actually perform the interpolation of the solution from old to new
+    // grid. The final step is to apply the hanging node constraints to the
+    // solution vector, i.e., to make sure that the values of degrees of
+    // freedom located on hanging nodes are so that the solution is
+    // continuous. This is necessary since SolutionTransfer only operates on
+    // cells locally, without regard to the neighborhoof.
     triangulation.execute_coarsening_and_refinement ();
     setup_system ();
 
     solution_trans.interpolate(previous_solution, solution);
+    constraints.distribute (solution);
   }
 
 

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -35,9 +35,9 @@ DEAL_II_NAMESPACE_OPEN
  * solution vector) from one mesh to another that is obtained from the first
  * by a single refinement and/or coarsening step. During interpolation the
  * vector is reinitialized to the new size and filled with the interpolated
- * values. This class is used in the step-15, step-31, and step-33 tutorial
- * programs. A version of this class that works on parallel triangulations is
- * available as parallel::distributed::SolutionTransfer.
+ * values. This class is used in the step-15, step-26, step-31, and step-33
+ * tutorial programs. A version of this class that works on parallel
+ * triangulations is available as parallel::distributed::SolutionTransfer.
  *
  * <h3>Usage</h3>
  *
@@ -110,8 +110,8 @@ DEAL_II_NAMESPACE_OPEN
  * soltrans.interpolate(solution, interpolated_solution);
  * @endcode
  *
- * Multiple calls to the function <tt>interpolate (const Vector<number> &in,
- * Vector<number> &out)</tt> are NOT allowed. Interpolating several functions
+ * Multiple calls to the function <code>interpolate (const Vector<number> &in,
+ * Vector<number> &out)</code> are NOT allowed. Interpolating several functions
  * can be performed in one step by using <tt>void interpolate (const
  * vector<Vector<number> >&all_in, vector<Vector<number> >&all_out)
  * const</tt>, and using the respective @p
@@ -125,6 +125,21 @@ DEAL_II_NAMESPACE_OPEN
  *
  * The template argument @p number denotes the data type of the vectors you
  * want to transfer.
+ *
+ *
+ * <h3>Interpolating in the presence of hanging nodes and boundary values</h3>
+ *
+ * The interpolation onto the new mesh is a local operation, i.e., it
+ * interpolates onto the new mesh only. If that new mesh has hanging nodes,
+ * you will therefore get a solution that does not satisfy hanging node
+ * constraints. The same is true with boundary values: the interpolated
+ * solution will just be the interpolation of the old solution at the
+ * boundary, and this may or may not satisfy boundary values at newly
+ * introduced boundary nodes.
+ *
+ * Consequently, you may have to apply hanging node or boundary value
+ * constraints after interpolation. step-15 and step-26 have examples of
+ * dealing with this.
  *
  *
  * <h3>Implementation</h3>


### PR DESCRIPTION
This was pointed out in #757 but it only addresses part of the problem: I believe a similar call is also missing steps 31, 32, 33, 42, 43. It is there in step-15.