### PR TITLE
Introduce active cell index 2

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6376,9 +6376,8 @@ namespace VectorTools
       IDScratchData<dim,spacedim> data(mapping, fe_collection, q, update_flags);
 
       // loop over all cells
-      typename DH::active_cell_iterator cell = dof.begin_active(),
-                                        endc = dof.end();
-      for (unsigned int index=0; cell != endc; ++cell, ++index)
+      for (typename DH::active_cell_iterator cell = dof.begin_active();
+           cell != dof.end(); ++cell)
         if (cell->is_locally_owned())
           {
             // initialize for this cell
@@ -6393,7 +6392,7 @@ namespace VectorTools
             if (update_flags & update_gradients)
               fe_values.get_function_gradients (fe_function, data.function_grads);
 
-            difference(index) =
+            difference(cell->active_cell_index()) =
               integrate_difference_inner (exact_solution, norm, weight,
                                           update_flags, exponent,
                                           n_components, data);
@@ -6401,7 +6400,7 @@ namespace VectorTools
         else
           // the cell is a ghost cell or is artificial. write a zero into the
           // corresponding value of the returned vector
-          difference(index) = 0;
+          difference(cell->active_cell_index()) = 0;
     }
 
   } // namespace internal

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -158,20 +158,17 @@ namespace
     Assert (locally_owned_indicators.size() == tria.n_locally_owned_active_cells(),
             ExcInternalError());
 
-    unsigned int active_index = 0;
     unsigned int owned_index = 0;
     for (typename Triangulation<dim,spacedim>::active_cell_iterator
          cell = tria.begin_active();
-         cell != tria.end(); ++cell, ++active_index)
+         cell != tria.end(); ++cell)
       if (cell->subdomain_id() == tria.locally_owned_subdomain())
         {
           locally_owned_indicators(owned_index)
-            = criteria(active_index);
+            = criteria(cell->active_cell_index());
           ++owned_index;
         }
     Assert (owned_index == tria.n_locally_owned_active_cells(),
-            ExcInternalError());
-    Assert ((active_index == tria.Triangulation<dim,spacedim>::n_active_cells()),
             ExcInternalError());
   }
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1069,8 +1069,8 @@ namespace DoFTools
     typename DH::active_cell_iterator
     cell = dof_handler.begin_active(),
     endc = dof_handler.end();
-    for (unsigned int index=0; cell!=endc; ++cell, ++index)
-      active_fe_indices[index] = cell->active_fe_index();
+    for (; cell!=endc; ++cell)
+      active_fe_indices[cell->active_cell_index()] = cell->active_fe_index();
   }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2993,14 +2993,13 @@ namespace GridGenerator
         // now copy the resulting level 1 cells
         // into the new triangulation,
         cells.resize(tmp.n_active_cells(), CellData<3>());
-
-        unsigned int index = 0;
         for (Triangulation<3>::active_cell_iterator cell = tmp.begin_active();
-             cell != tmp.end(); ++cell, ++index)
+             cell != tmp.end(); ++cell)
           {
+            const unsigned int cell_index = cell->active_cell_index();
             for (unsigned int v=0; v<GeometryInfo<3>::vertices_per_cell; ++v)
-              cells[index].vertices[v] = cell->vertex_index(v);
-            cells[index].material_id = 0;
+              cells[cell_index].vertices[v] = cell->vertex_index(v);
+            cells[cell_index].material_id = 0;
           }
 
         tria.create_triangulation (tmp.get_vertices(), cells, SubCellData());

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1047,11 +1047,9 @@ void GridOut::write_msh (const Triangulation<dim, spacedim> &tria,
 
   // write cells. Enumerate cells
   // consecutively, starting with 1
-  unsigned int cell_index=1;
-  for (cell=tria.begin_active();
-       cell!=endc; ++cell, ++cell_index)
+  for (cell=tria.begin_active(); cell!=endc; ++cell)
     {
-      out << cell_index << ' ' << elm_type << ' '
+      out << cell->active_cell_index()+1 << ' ' << elm_type << ' '
           << static_cast<unsigned int>(cell->material_id()) << ' '
           << cell->subdomain_id() << ' '
           << GeometryInfo<dim>::vertices_per_cell << ' ';
@@ -1066,10 +1064,11 @@ void GridOut::write_msh (const Triangulation<dim, spacedim> &tria,
 
   // write faces and lines with
   // non-zero boundary indicator
+  unsigned int next_index = tria.n_active_cells()+1;
   if (msh_flags.write_faces)
-    write_msh_faces (tria, cell_index, out);
+    write_msh_faces (tria, next_index, out);
   if (msh_flags.write_lines)
-    write_msh_lines (tria, cell_index, out);
+    write_msh_lines (tria, next_index, out);
 
   out << "$ENDELM" << std::endl;
 
@@ -1146,11 +1145,9 @@ void GridOut::write_ucd (const Triangulation<dim,spacedim> &tria,
 
   // write cells. Enumerate cells
   // consecutively, starting with 1
-  unsigned int cell_index=1;
-  for (cell=tria.begin_active();
-       cell!=endc; ++cell, ++cell_index)
+  for (cell=tria.begin_active();  cell!=endc; ++cell)
     {
-      out << cell_index << ' '
+      out << cell->active_cell_index()+1 << ' '
           << static_cast<unsigned int>(cell->material_id())
           << ' ';
       switch (dim)
@@ -1191,10 +1188,11 @@ void GridOut::write_ucd (const Triangulation<dim,spacedim> &tria,
 
   // write faces and lines with
   // non-zero boundary indicator
+  unsigned int next_index = tria.n_active_cells()+1;
   if (ucd_flags.write_faces)
-    write_ucd_faces (tria, cell_index, out);
+    write_ucd_faces (tria, next_index, out);
   if (ucd_flags.write_lines)
-    write_ucd_lines (tria, cell_index, out);
+    write_ucd_lines (tria, next_index, out);
 
   // make sure everything now gets to
   // disk
@@ -2376,9 +2374,7 @@ void GridOut::write_mathgl (const Triangulation<dim, spacedim> &tria,
   endc=tria.end ();
 
   // No global indices in deal.II, so we make one up here.
-  unsigned int cell_global_index = 0;
-
-  for (; cell!=endc; ++cell, ++cell_global_index)
+  for (; cell!=endc; ++cell)
     {
       for (unsigned int i=0; i<dim; ++i)
         {
@@ -2387,7 +2383,7 @@ void GridOut::write_mathgl (const Triangulation<dim, spacedim> &tria,
           // else
           //   out << "\nfalse";
 
-          out << "\nlist " << axes[i] << cell_global_index << " ";
+          out << "\nlist " << axes[i] << cell->active_cell_index() << " ";
           for (unsigned int j=0; j<GeometryInfo<dim>::vertices_per_cell; ++j)
             out << cell->vertex(j)[i] << " ";
         }

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -225,7 +225,6 @@ void GridRefinement::refine (Triangulation<dim,spacedim> &tria,
   if (criteria.all_zero())
     return;
 
-  typename Triangulation<dim,spacedim>::active_cell_iterator cell = tria.begin_active();
   const unsigned int n_cells = criteria.size();
 
 //TODO: This is undocumented, looks fishy and seems unnecessary
@@ -244,8 +243,9 @@ void GridRefinement::refine (Triangulation<dim,spacedim> &tria,
     }
 
   unsigned int marked=0;
-  for (unsigned int index=0; index<n_cells; ++cell, ++index)
-    if (std::fabs(criteria(index)) >= new_threshold)
+  for (typename Triangulation<dim,spacedim>::active_cell_iterator cell = tria.begin_active();
+       cell != tria.end(); ++cell)
+    if (std::fabs(criteria(cell->active_cell_index())) >= new_threshold)
       {
         if (max_to_mark!=numbers::invalid_unsigned_int && marked>=max_to_mark)
           break;
@@ -265,11 +265,9 @@ void GridRefinement::coarsen (Triangulation<dim,spacedim> &tria,
           ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));
   Assert (criteria.is_non_negative (), ExcNegativeCriteria());
 
-  typename Triangulation<dim,spacedim>::active_cell_iterator cell = tria.begin_active();
-  const unsigned int n_cells = criteria.size();
-
-  for (unsigned int index=0; index<n_cells; ++cell, ++index)
-    if (std::fabs(criteria(index)) <= threshold)
+  for (typename Triangulation<dim,spacedim>::active_cell_iterator cell = tria.begin_active();
+       cell != tria.end(); ++cell)
+    if (std::fabs(criteria(cell->active_cell_index())) <= threshold)
       if (!cell->refine_flag_set())
         cell->set_coarsen_flag();
 }

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -330,9 +330,9 @@ estimate (const Mapping<1,spacedim>                    &mapping,
   // loop over all cells and do something on the cells which we're told to
   // work on. note that the error indicator is only a sum over the two
   // contributions from the two vertices of each cell.
-  typename DH::active_cell_iterator cell = dof_handler.begin_active();
-  for (unsigned int cell_index=0; cell != dof_handler.end();
-       ++cell, ++cell_index)
+  for (typename DH::active_cell_iterator cell = dof_handler.begin_active();
+       cell != dof_handler.end();
+       ++cell)
     if (((subdomain_id == numbers::invalid_subdomain_id)
          ||
          (cell->subdomain_id() == subdomain_id))
@@ -342,7 +342,7 @@ estimate (const Mapping<1,spacedim>                    &mapping,
          (cell->material_id() == material_id)))
       {
         for (unsigned int n=0; n<n_solution_vectors; ++n)
-          (*errors[n])(cell_index) = 0;
+          (*errors[n])(cell->active_cell_index()) = 0;
 
         // loop over the two points bounding this line. n==0 is left point,
         // n==1 is right point
@@ -429,12 +429,12 @@ estimate (const Mapping<1,spacedim>                    &mapping,
 
                     const double jump = ((grad_here - grad_neighbor[s](component)) *
                                          coefficient_values(component));
-                    (*errors[s])(cell_index) += jump*jump * cell->diameter();
+                    (*errors[s])(cell->active_cell_index()) += jump*jump * cell->diameter();
                   }
           }
 
         for (unsigned int s=0; s<n_solution_vectors; ++s)
-          (*errors[s])(cell_index) = std::sqrt((*errors[s])(cell_index));
+          (*errors[s])(cell->active_cell_index()) = std::sqrt((*errors[s])(cell->active_cell_index()));
       }
 }
 


### PR DESCRIPTION
This is the first part of the promised follow-up to #765 (active_cell_index) that tries to address #761 . These are some mechanical changes that remove the double indexing loops over cells and indices.

I've excluded the interesting places in DataOut and KellyErrorEstimator where I think that the active cell index will lead to significant code cleanups, and to the steps. Rather, this PR only contains the controversial pieces in that (i) they are in the library where clarity is good but not the overriding principle, (ii) it will lead to some slowdown, (iii) the cleanups are minor.

I think that in all cases treated here, the slowdown will be relatively minor (accessing active_cell_index is relatively cheap compared with most of the surrounding code in most cases). I've kept things in separate commits to make it simple to drop any one people don't like.

In summary, I think these cases lead to small cleanups but I'm otherwise not wedded to them. Please discuss!