### PR TITLE
Silence bogus unused-parameters|variables warnings

### DIFF
--- a/include/deal.II/lac/swappable_vector.templates.h
+++ b/include/deal.II/lac/swappable_vector.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -183,6 +183,8 @@ void SwappableVector<number>::alert ()
 template <typename number>
 void SwappableVector<number>::reload_vector (const bool set_flag)
 {
+  (void)set_flag;
+
   Assert (filename != "", ExcInvalidFilename (filename));
   Assert (this->size() == 0, ExcSizeNonzero());
 
@@ -191,9 +193,7 @@ void SwappableVector<number>::reload_vector (const bool set_flag)
   tmp_in.close ();
 
 #ifdef DEAL_II_WITH_THREADS
-  // release the lock that was
-  // acquired by the calling
-  // functions
+  // release the lock that was acquired by the calling functions
 
   // set the flag if so required
   if (set_flag)

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1186,6 +1186,8 @@ namespace internal
                      ResultType        &result,
                      const int          depth = -1)
     {
+      (void)depth;
+
       if (vec_size <= 4096)
         {
           // the vector is short enough so we perform the summation. first

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,6 +24,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+#ifdef DEBUG
 namespace
 {
 // create a lock that might be used to control subscription to and
@@ -37,6 +38,7 @@ namespace
 // <subscriptor.h> file).
   Threads::Mutex subscription_lock;
 }
+#endif
 
 
 static const char *unknown_subscriber = "unknown subscriber";

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -153,6 +153,7 @@ namespace Threads
                               const char *,
                               void *)
   {
+    (void)count;
     Assert (count == 1, ExcBarrierSizeNotUseful(count));
   }
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -2401,6 +2401,9 @@ namespace internal
       renumber_dofs (const std::vector<dealii::types::global_dof_index> &new_numbers,
                      dealii::DoFHandler<dim,spacedim> &dof_handler) const
       {
+        (void)new_numbers;
+        (void)dof_handler;
+
         Assert (new_numbers.size() == dof_handler.locally_owned_dofs().n_elements(),
                 ExcInternalError());
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1407,6 +1407,7 @@ namespace DoFTools
       = *std::max_element (target_component.begin(),
                            target_component.end());
     const unsigned int n_target_components = max_component + 1;
+    (void)n_target_components; // silence possible warning about unused variable
 
     AssertDimension (dofs_per_component.size(), n_target_components);
 
@@ -1499,6 +1500,8 @@ namespace DoFTools
           = *std::max_element (target_block.begin(),
                                target_block.end());
         const unsigned int n_target_blocks = max_block + 1;
+        (void)n_target_blocks; // silence possible warning about unused variable
+
         const unsigned int n_blocks = fe.n_blocks();
 
         AssertDimension (dofs_per_block.size(), n_target_blocks);


### PR DESCRIPTION
This is a small follow-up for the patches by @drwells. It brings down the warnings for the "minimal_bundled" configuration to around 2-4.