### PR TITLE
Fix opencascade warnings

### DIFF
--- a/cmake/configure/configure_opencascade.cmake
+++ b/cmake/configure/configure_opencascade.cmake
@@ -17,12 +17,4 @@
 # Configuration for the OpenCASCADE library:
 #
 
-MACRO(FEATURE_OPENCASCADE_CONFIGURE_EXTERNAL)
-  #
-  # Disable a bunch of warnings caused by OpenCascade headers:
-  #
-  ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-extra")
-ENDMACRO()
-
-
 CONFIGURE_FEATURE(OPENCASCADE)

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -8,10 +8,17 @@
 
 #include <boost/bind.hpp>
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
 #include <iostream>
 #include <set>
+
+// Selectively disable -Werror switch for GCC and compiler accepting GCC
+// dialects (such as clang). "diagnostic push" is supported since gcc-4.6
+// and clang-3.3.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wextra"
+#endif
 
 #include <IGESControl_Controller.hxx>
 #include <IGESControl_Reader.hxx>
@@ -58,6 +65,10 @@
 
 #include <GCPnts_AbscissaPoint.hxx>
 #include <ShapeAnalysis_Surface.hxx>
+
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
The big problem with the opencascade warnings we hit is the fact that those
are only toggled by "-Wextra" - which is highly annoying.

There is a nice feature supported by GCC and Clang that allows to
selectively disable warnings via "#pragma" GCC diagnostic.

What about using this?

We could also convert the global switches for Trilinos and PETSc into such
"#pragma" statements. This would have the advantage that we do not lose the
"-Wextra" diagnostics on our source code.