### PR TITLE
Changed order of arguments in constructor of MappingFEField

### DIFF
--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -64,7 +64,7 @@ DEAL_II_NAMESPACE_OPEN
  *    Vector<double> eulerq(dhq.n_dofs());
  *    // Fills the euler vector with information from the Triangulation
  *    VectorTools::get_position_vector(dhq, eulerq, mask);
- *    MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ *    MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
  * @endcode
  *
  * @author Luca Heltai, Marco Tezzele 2013, 2015
@@ -110,8 +110,8 @@ public:
    *
    * If an incompatible mask is passed, an exception is thrown.
    */
-  MappingFEField (const VECTOR  &euler_vector,
-                  const DH      &euler_dof_handler,
+  MappingFEField (const DH      &euler_dof_handler,
+                  const VECTOR  &euler_vector,
                   const ComponentMask mask=ComponentMask());
 
   /**

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -63,8 +63,8 @@ MappingFEField<dim,spacedim,VECTOR,DH>::InternalData::memory_consumption () cons
 
 
 template<int dim, int spacedim, class VECTOR, class DH>
-MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const VECTOR  &euler_vector,
-                                                        const DH      &euler_dof_handler,
+MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const DH      &euler_dof_handler,
+                                                        const VECTOR  &euler_vector,
                                                         const ComponentMask mask)
   :
   euler_vector(&euler_vector),

--- a/tests/fe/mapping_fe_field_real_to_unit_b1.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b1.cc
@@ -83,7 +83,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
 
 
  typename Triangulation<dim, spacedim >::active_cell_iterator

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
@@ -101,7 +101,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
  
 
  typename Triangulation<dim, spacedim >::active_cell_iterator

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
@@ -100,7 +100,7 @@ void test_real_to_unit_cell()
  mask.set(0, false);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
@@ -101,7 +101,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
  
 
  typename Triangulation<dim, spacedim >::active_cell_iterator

--- a/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
@@ -101,7 +101,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
@@ -101,7 +101,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhb, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhb, mask);
+ MappingFEField<dim,spacedim> map(dhb, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q1.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q1.cc
@@ -82,7 +82,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
@@ -103,7 +103,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q2_mask.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q2_mask.cc
@@ -85,7 +85,7 @@ void test_real_to_unit_cell()
  mask.set(0, false);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
@@ -103,7 +103,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
@@ -100,7 +100,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();

--- a/tests/fe/mapping_fe_field_real_to_unit_q5_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q5_curved.cc
@@ -100,7 +100,7 @@ void test_real_to_unit_cell()
  const ComponentMask mask(spacedim, true);
 
  VectorTools::get_position_vector(dhq, eulerq, mask);
- MappingFEField<dim,spacedim> map(eulerq, dhq, mask);
+ MappingFEField<dim,spacedim> map(dhq, eulerq, mask);
 
  typename Triangulation<dim, spacedim >::active_cell_iterator
  cell = triangulation.begin_active();


### PR DESCRIPTION
This is a fix for my last rebase. I had accidentally removed the last commit from @mtezzele, which contained the switch of the arguments. 

This should be safe to merge. 