### PR TITLE
CMake: Simplify clang configuration

### DIFF
--- a/cmake/configure/configure_boost.cmake
+++ b/cmake/configure/configure_boost.cmake
@@ -22,28 +22,6 @@ SET(DEAL_II_WITH_BOOST ON # Always true. We need it :-]
   )
 
 
-MACRO(SET_UP_BOOST_FLAGS)
-  #
-  # Newer versions of gcc have a flag -Wunused-local-typedefs that, though in
-  # principle a good idea, triggers a lot in BOOST in various places.
-  # Unfortunately, this warning is included in -W/-Wall, so disable it if the
-  # compiler supports it.
-  #
-  ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-local-typedefs")
-
-  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # not harmless but needed for boost <1.50.0
-    ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-delete-non-virtual-dtor")
-
-    # suppress warnings in boost 1.56:
-    ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-c++11-extensions")
-    ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-c99-extensions")
-    ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-parameter")
-    ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-variadic-macros")
-  ENDIF()
-ENDMACRO()
-
-
 MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
   #
   # Add rt to the link interface as well, boost/chrono needs it.
@@ -54,14 +32,14 @@ MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
     SET(BOOST_LIBRARIES ${rt_LIBRARY})
   ENDIF()
 
-  SET_UP_BOOST_FLAGS()
+  ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-local-typedefs")
 
   SET(BOOST_BUNDLED_INCLUDE_DIRS ${BOOST_FOLDER}/include)
 ENDMACRO()
 
 
 MACRO(FEATURE_BOOST_CONFIGURE_EXTERNAL)
-  SET_UP_BOOST_FLAGS()
+  ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-local-typedefs")
 ENDMACRO()
 
 

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -78,7 +78,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
 
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-
   #
   # Silence Clang warnings about unused compiler parameters (works around a
   # regression in the clang driver frontend of certain versions):
@@ -86,18 +85,21 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Qunused-arguments")
 
   #
-  # *Boy*, clang seems to be the very definition of "pedantic" in
-  # "-pedantic" mode, so disable a bunch of harmless warnings
-  # (that are mainly triggered in third party headers so that we cannot
-  # easily fix them...)
+  # Clang verbosely warns about not supporting all our friend declarations
+  # (and consequently removing access control alltogether)
   #
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-dangling-else")
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-long-long")
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-newline-eof")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unsupported-friend")
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-function")
-  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-private-field")
+
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-parameter")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-variable")
+
+  IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.6")
+    #
+    # Clang versions prior to 3.6 emit a lot of false positives wrt
+    # "-Wunused-function".
+    #
+    ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-unused-function")
+  ENDIF()
 ENDIF()
 
 


### PR DESCRIPTION
It turns out that clang went a long way since 2011/2012. Remove unneeded -Wno-* switches.