### PR TITLE
CMake: Remove -Wno-deprecated

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -72,11 +72,9 @@ INSTALL(FILES ${_macros}
 STRIP_FLAG(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
 
 #
-# Strip -Wno-deprecated from DEAL_II_CXX_FLAGS so that deprecation warnings
-# are actually shown for user code:
+# Strip -Wno-deprecated-declarations from DEAL_II_CXX_FLAGS so that
+# deprecation warnings are actually shown for user code:
 #
-
-STRIP_FLAG(DEAL_II_CXX_FLAGS "-Wno-deprecated")
 STRIP_FLAG(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
 
 #

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -74,7 +74,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-long-long")
 #
 # Disable deprecation warnings
 #
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
 
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
-Wno-deprecated has nothing to do with -Wno-deprecated-declarations.
It warns about deprecated gcc features, or similar... Thus, remove it.