### PR TITLE
Avoid a warning with recently enabled -Wxxx flags.

### DIFF
--- a/bundled/tbb41_20130401oss/src/tbb/governor.cpp
+++ b/bundled/tbb41_20130401oss/src/tbb/governor.cpp
@@ -60,7 +60,12 @@ static __cilk_tbb_retcode (*watch_stack_handler)(struct __cilk_tbb_unwatch_thunk
 
 //! Table describing how to link the handlers.
 static const dynamic_link_descriptor CilkLinkTable[] = {
-    { "__cilkrts_watch_stack", (pointer_to_handler*)(void*)(&watch_stack_handler) }
+    { "__cilkrts_watch_stack", (pointer_to_handler*)(void*)(&watch_stack_handler)
+#if __TBB_WEAK_SYMBOLS_PRESENT
+    ,
+    NULL
+#endif
+    }
 };
 
 static atomic<do_once_state> cilkrts_load_state;


### PR DESCRIPTION
Specifically, we get the following warning:

/home/bangerth/p/deal.II/1/dealii/bundled/tbb41_20130401oss/src/tbb/governor.cpp:64:1: warning: missing initializer for member 'tbb::internal::dynamic_link_descriptor::ptr' [-Wmissing-field-initializers]