### PR TITLE
Remove "register" storage location specifier from bundled tbb

### DIFF
--- a/bundled/tbb41_20130401oss/src/tbb/tools_api/ittnotify_static.c
+++ b/bundled/tbb41_20130401oss/src/tbb/tools_api/ittnotify_static.c
@@ -769,7 +769,7 @@ static const char* __itt_get_lib_name(void)
 
 static __itt_group_id __itt_get_groups(void)
 {
-    register int i;
+    int i;
     __itt_group_id res = __itt_group_none;
     const char* var_name  = "INTEL_ITTNOTIFY_GROUPS";
     const char* group_str = __itt_get_env_var(var_name);
@@ -828,7 +828,7 @@ static int __itt_lib_version(lib_t lib)
 /* It's not used right now! Comment it out to avoid warnings.
 static void __itt_reinit_all_pointers(void)
 {
-    register int i;
+    int i;
     // Fill all pointers with initial stubs
     for (i = 0; __itt_ittapi_global.api_list_ptr[i].name != NULL; i++)
         *__itt_ittapi_global.api_list_ptr[i].func_ptr = __itt_ittapi_global.api_list_ptr[i].init_func;
@@ -837,7 +837,7 @@ static void __itt_reinit_all_pointers(void)
 
 static void __itt_nullify_all_pointers(void)
 {
-    register int i;
+    int i;
     /* Nulify all pointers except domain_create and string_handle_create */
     for (i = 0; __itt_ittapi_global.api_list_ptr[i].name != NULL; i++)
         *__itt_ittapi_global.api_list_ptr[i].func_ptr = __itt_ittapi_global.api_list_ptr[i].null_func;
@@ -883,7 +883,7 @@ ITT_EXTERN_C void _N_(fini_ittlib)(void)
 
 ITT_EXTERN_C int _N_(init_ittlib)(const char* lib_name, __itt_group_id init_groups)
 {
-    register int i;
+    int i;
     __itt_group_id groups;
 #ifdef ITT_COMPLETE_GROUP
     __itt_group_id zero_group = __itt_group_none;


### PR DESCRIPTION
In c++98, "register" is a mild hint for the compiler that it might be
beneficial to store the variable in a CPU register. This keyword is
deprecated in C++11. Remove it and trust the compiler to figure this out
for itself.

This fixes -Wdeprecated-register warnings generated by clang