### PR TITLE
Override all interpolate() variants in FE_Q_Hierarchical

### DIFF
--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -693,14 +693,28 @@ public:
   get_constant_modes () const;
 
   /**
-   * A function to interpolate scalar values, computed at the
-   * support points to the FE_Q_Hierarchical.
-   *
    * This function is not implemented and throws an exception if called.
    */
   virtual
   void interpolate(std::vector<double>       &local_dofs,
                    const std::vector<double> &values) const;
+
+  /**
+   * This function is not implemented and throws an exception if called.
+   */
+  virtual
+  void
+  interpolate(std::vector<double>                &local_dofs,
+              const std::vector<Vector<double> > &values,
+              unsigned int offset = 0) const;
+
+  /**
+   * This function is not implemented and throws an exception if called.
+   */
+  virtual
+  void
+  interpolate(std::vector<double> &local_dofs,
+              const VectorSlice<const std::vector<std::vector<double> > > &values) const;
 
 
 protected:

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -165,10 +165,9 @@ FE_BDM<dim>::interpolate(
           ExcDimensionMismatch(values.size(), this->generalized_support_points.size()));
   Assert (local_dofs.size() == this->dofs_per_cell,
           ExcDimensionMismatch(local_dofs.size(),this->dofs_per_cell));
-  // First do interpolation on
-  // faces. There, the component
-  // evaluated depends on the face
-  // direction and orientation.
+
+  // First do interpolation on faces. There, the component evaluated
+  // depends on the face direction and orientation.
   unsigned int fbase = 0;
   unsigned int f=0;
   for (; f<GeometryInfo<dim>::faces_per_cell;

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -122,22 +122,39 @@ FE_Q_Hierarchical<dim>::get_name () const
   return namebuf.str();
 }
 
+
 template <int dim>
 void
 FE_Q_Hierarchical<dim>::interpolate(
-  std::vector<double>       &/*local_dofs*/,
-  const std::vector<double> &/*values*/) const
+  std::vector<double> &,
+  const std::vector<double> &) const
 {
-  // The default implementation
-  // assumes that the FE has a delta property,
-  // i.e. values at the support points equal
-  // the corresponding DoFs.
-  // This is obviously not the case here.
-  Assert (false,
-          ExcNotImplemented());
+  // The default implementation assumes that the FE has a delta property,
+  // i.e., values at the support points equal the corresponding DoFs. This
+  // is obviously not the case here.
+  Assert (false, ExcNotImplemented());
 }
 
 
+template <int dim>
+void
+FE_Q_Hierarchical<dim>::interpolate(
+  std::vector<double> &,
+  const std::vector<Vector<double> > &,
+  unsigned int) const
+{
+  Assert (false, ExcNotImplemented());
+}
+
+
+template <int dim>
+void
+FE_Q_Hierarchical<dim>::interpolate(
+  std::vector<double> &local_dofs,
+  const VectorSlice<const std::vector<std::vector<double> > > &values) const
+{
+  Assert (false, ExcNotImplemented());
+}
 
 
 template <int dim>


### PR DESCRIPTION
This fixes a bunch of warnings by icc