### PR TITLE
Silence a false positive "-Wunneeded-internal-declaration"

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -700,6 +700,7 @@ namespace VectorTools
      * Return whether the boundary values try to constrain a degree of freedom
      * that is already constrained to something else
      */
+    inline
     bool constraints_and_b_v_are_compatible (const ConstraintMatrix   &constraints,
                                              std::map<types::global_dof_index,double> &boundary_values)
     {


### PR DESCRIPTION
Clang inlines ```constraints_and_b_v_are_compatible``` into
```do_project``` and after that emits a wrong warning about the former not
being used. Explicitly annotating ```constraints_and_b_v_are_compatible```
with inline helps.