### PR TITLE
Use pragmas to control diagnostics

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -82,7 +82,7 @@ CHECK_CXX_COMPILER_BUG(
 
 #
 # Check for existence of the __builtin_expect facility of newer
-# gcc compilers. This can be used to hint the compiler's branch
+# GCC compilers. This can be used to hint the compiler's branch
 # prediction unit in some cases. We use it in the AssertThrow
 # macros.
 #
@@ -97,7 +97,7 @@ CHECK_CXX_SOURCE_COMPILES(
 
 
 #
-# Newer versions of gcc have a very nice feature: you can set
+# Newer versions of GCC have a very nice feature: you can set
 # a verbose terminate handler, that not only aborts a program
 # when an exception is thrown and not caught somewhere, but
 # before aborting it prints that an exception has been thrown,
@@ -204,7 +204,7 @@ CHECK_CXX_SOURCE_COMPILES(
 
 
 #
-# Gcc and some other compilers have __PRETTY_FUNCTION__, showing
+# GCC and some other compilers have __PRETTY_FUNCTION__, showing
 # an unmangled version of the function we are presently in,
 # while __FUNCTION__ (or __func__ in ISO C99) simply give the
 # function name which would not include the arguments of that
@@ -252,7 +252,7 @@ ENDIF()
 
 
 #
-# Newer versions of gcc can pass a flag to the assembler to
+# Newer versions of GCC can pass a flag to the assembler to
 # compress debug sections. At the time of writing this test,
 # this can save around 230 MB of disk space on the object
 # files we produce (810MB down to 570MB for the debug versions
@@ -281,7 +281,7 @@ ENDIF()
 
 
 #
-# Gcc and some other compilers have an attribute of the form
+# GCC and some other compilers have an attribute of the form
 # __attribute__((deprecated)) that can be used to make the
 # compiler warn whenever a deprecated function is used. See
 # if this attribute is available.
@@ -312,4 +312,24 @@ IF(DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED)
 ELSE()
   SET(DEAL_II_DEPRECATED " ")
 ENDIF()
+
+
+#
+# GCC and Clang allow fine grained control of diagnostics via the "GCC
+# diagnostic" pragma. Check whether the compiler supports the "push" and
+# "pop" mechanism and the "ignored" toggle. Further, test for the
+# alternative "_Pragma(...)" variant (and that it does not emit a warning).
+#
+# - Matthias Maier, 2015
+#
+PUSH_CMAKE_REQUIRED("-Werror")
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  _Pragma(\"GCC diagnostic push\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  int main() { return 0; }
+  _Pragma(\"GCC diagnostic pop\")
+  "
+  DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA)
+RESET_CMAKE_REQUIRED()
 

--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -118,12 +118,13 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
     ENDIF()
 
     #
-    # Trilinos has to be configured with 32bit indices if deal.II uses unsigned int.
+    # Trilinos has to be configured with 32bit indices if deal.II uses
+    # unsigned int.
     #
     IF(TRILINOS_WITH_NO_32BIT_INDICES AND NOT DEAL_II_WITH_64BIT_INDICES)
       MESSAGE(STATUS "deal.II was configured to use 32bit global indices but "
         "Trilinos was not."
-        ) 
+        )
       SET(TRILINOS_ADDITIONAL_ERROR_STRING
         ${TRILINOS_ADDITIONAL_ERROR_STRING}
         "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
@@ -136,8 +137,8 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
     ENDIF()
 
     #
-    # Trilinos has to be configured with 64bit indices if deal.II uses unsigned long
-    # long int.
+    # Trilinos has to be configured with 64bit indices if deal.II uses
+    # unsigned long long int.
     #
     IF(TRILINOS_WITH_NO_64BIT_INDICES AND DEAL_II_WITH_64BIT_INDICES)
       MESSAGE(STATUS "deal.II was configured to use 64bit global indices but "
@@ -191,19 +192,6 @@ MACRO(FEATURE_TRILINOS_CONFIGURE_EXTERNAL)
   SET(DEAL_II_EXPAND_TRILINOS_BLOCK_SPARSITY_PATTERN "TrilinosWrappers::BlockSparsityPattern")
   SET(DEAL_II_EXPAND_TRILINOS_MPI_BLOCKVECTOR "TrilinosWrappers::MPI::BlockVector")
   SET(DEAL_II_EXPAND_TRILINOS_MPI_VECTOR "TrilinosWrappers::MPI::Vector")
-
-  ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-unused-function")
-  ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-unused-parameter")
-  ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-unused-variable")
-
-  #
-  # Disable a bunch of warnings caused by Trilinos headers in older versions:
-  #
-  IF(TRILINOS_VERSION VERSION_LESS "11.12")
-    ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-extra")
-    ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-overloaded-virtual")
-    ENABLE_IF_SUPPORTED(TRILINOS_CXX_FLAGS "-Wno-unused")
-  ENDIF()
 ENDMACRO()
 
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -18,15 +18,6 @@
 
 
 /***********************************************************************
- * Two macro names that we put at the top and bottom of all deal.II files
- * and that will be expanded to "namespace dealii {" and "}".
- */
-
-#define DEAL_II_NAMESPACE_OPEN namespace dealii {
-#define DEAL_II_NAMESPACE_CLOSE }
-
-
-/***********************************************************************
  * Information about deal.II:
  */
 
@@ -93,6 +84,7 @@
 #cmakedefine DEAL_II_HAVE_LIBSTDCXX_DEMANGLER
 #cmakedefine __PRETTY_FUNCTION__ @__PRETTY_FUNCTION__@
 #cmakedefine DEAL_II_DEPRECATED @DEAL_II_DEPRECATED@
+#cmakedefine DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
 
 
 /***********************************************************************
@@ -184,6 +176,9 @@
 
 /***********************************************************************
  * Various macros for version number query and comparison:
+ *
+ * These macros are defined to make testing for specific versions within
+ * the deal.II main code as simple as possible.
  */
 
 /*
@@ -241,18 +236,6 @@
  *  PETSC_USE_COMPLEX
  */
 
-/*
- * These macros are defined to make testing for PETSc versions within
- * the deal.II main code as simple as possible. In brief they are used
- * like this: (i) DEAL_II_PETSC_VERSION_LT is used to advance the
- * PETScWrappers to newer versions of PETSc while preserving backward
- * compatibility; and (ii) DEAL_II_PETSC_VERSION_GTE is used to add
- * functionality to the PETScWrappers that does not exist in previous
- * versions of PETSc.  Examples of usage can be found in
- * lac/source/petsc_matrix_base.h.  Note: SLEPcWrappers do not need
- * their own analogical macros, since SLEPc and PETSc must have
- * identical version numbers anyways.
- */
 #define DEAL_II_PETSC_VERSION_LT(major,minor,subminor) \
   ((PETSC_VERSION_MAJOR * 10000 + \
     PETSC_VERSION_MINOR * 100 + \
@@ -282,6 +265,44 @@
       DEAL_II_TRILINOS_VERSION_SUBMINOR) \
     >=  \
     (major)*10000 + (minor)*100 + (subminor))
+#endif
+
+
+/***********************************************************************
+ * Two macro names that we put at the top and bottom of all deal.II files
+ * and that will be expanded to "namespace dealii {" and "}".
+ */
+
+#define DEAL_II_NAMESPACE_OPEN namespace dealii {
+#define DEAL_II_NAMESPACE_CLOSE }
+
+
+/***********************************************************************
+ * Two macros to guard external header includes.
+ *
+ * Selectively disable diagnostics set by "-Wextra" (and similar flags) for
+ * GCC and compiler accepting GCC dialects (such as clang).
+ * "diagnostic push" is supported since gcc-4.6 and clang-3.3.
+ */
+
+#ifdef DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
+
+#  define DEAL_II_DISABLE_EXTRA_DIAGNOSTICS                \
+_Pragma("GCC diagnostic push")                             \
+_Pragma("GCC diagnostic ignored \"-Wextra\"")              \
+_Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"") \
+_Pragma("GCC diagnostic ignored \"-Wunused-function\"")    \
+_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")   \
+_Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
+
+#  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                 \
+_Pragma("GCC diagnostic pop")
+
+#else
+
+#  define DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #endif
 
 

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -27,6 +27,7 @@
 #  include <deal.II/lac/trilinos_vector_base.h>
 #  include <deal.II/lac/parallel_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  ifdef DEAL_II_WITH_MPI
 #    include <Epetra_MpiComm.h>
 #  else
@@ -42,6 +43,7 @@
 #  include <MueLu.hpp>
 #  include <Teuchos_RCP.hpp>
 #  endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 // forward declarations
 class Ifpack_Preconditioner;

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -27,10 +27,13 @@
 #  include <deal.II/lac/vector.h>
 #  include <deal.II/lac/parallel_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_LinearProblem.h>
 #  include <AztecOO.h>
 #  include <Epetra_Operator.h>
 #  include <Amesos.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -34,6 +34,8 @@
 #  include <memory>
 
 #  define TrilinosScalar double
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_FECrsMatrix.h>
 #  include <Epetra_Map.h>
 #  include <Epetra_CrsGraph.h>
@@ -44,6 +46,7 @@
 #  else
 #    include "Epetra_SerialComm.h"
 #  endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 class Epetra_Export;
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -31,6 +31,7 @@
 
 #  include <deal.II/base/std_cxx11/shared_ptr.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_FECrsGraph.h>
 #  include <Epetra_Map.h>
 #  ifdef DEAL_II_WITH_MPI
@@ -39,6 +40,8 @@
 #  else
 #    include "Epetra_SerialComm.h"
 #  endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -29,8 +29,10 @@
 #  include <deal.II/lac/vector.h>
 #  include <deal.II/lac/trilinos_vector_base.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include "Epetra_Map.h"
 #  include "Epetra_LocalMap.h"
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -31,6 +31,7 @@
 #  include <utility>
 #  include <memory>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  define TrilinosScalar double
 #  include "Epetra_ConfigDefs.h"
 #  ifdef DEAL_II_WITH_MPI // only if MPI is installed
@@ -40,6 +41,7 @@
 #    include "Epetra_SerialComm.h"
 #  endif
 #  include "Epetra_FEVector.h"
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,6 +21,7 @@
 #  include <deal.II/lac/sparse_matrix.h>
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Ifpack.h>
 #  include <Ifpack_Chebyshev.h>
 #  include <Teuchos_ParameterList.hpp>
@@ -32,6 +33,7 @@
 #include <MueLu_EpetraOperator.hpp>
 #include <MueLu_MLParameterListInterpreter.hpp>
 #endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -24,10 +24,12 @@
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
 #  include <deal.II/lac/sparsity_tools.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Export.h>
 #  include <ml_epetra_utils.h>
 #  include <ml_struct.h>
 #  include <Teuchos_RCP.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,7 +21,9 @@
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Export.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -19,8 +19,11 @@
 
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_block_vector.h>
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Import.h>
 #  include <Epetra_Vector.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <cmath>
 

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -19,8 +19,11 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <cmath>
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Import.h>
 #  include <Epetra_Export.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -12,13 +12,7 @@
 #include <iostream>
 #include <set>
 
-// Selectively disable -Werror switch for GCC and compiler accepting GCC
-// dialects (such as clang). "diagnostic push" is supported since gcc-4.6
-// and clang-3.3.
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wextra"
-#endif
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 #include <IGESControl_Controller.hxx>
 #include <IGESControl_Reader.hxx>
@@ -66,9 +60,7 @@
 #include <GCPnts_AbscissaPoint.hxx>
 #include <ShapeAnalysis_Surface.hxx>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
OK. Let's do this "GCC diagnostic" pragma stuff properly.

This pull-request first checks for support of the corresponding pragma mechanism in <code>check_01_compiler_features.cmake</code> and sets up <code>DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA</code>. In <code>config.h</code> two new macros are defined two guard external header files is necessary:
```
DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
#include <...>
// ...
DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
```

This has the advantage that our code can _always_ be compiled with <code>-pedantic -Wall -Wextra -Wno-long-long</code>, regardless of the configuration.