### PR TITLE
Consistently label 'block_sizes' as such.

### DIFF
--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -65,9 +65,10 @@ public:
 
   /**
    * Constructor. Initialize the number of entries in each block @p i as
-   * <tt>n[i]</tt>. The number of blocks will be the size of the vector
+   * <tt>block_sizes[i]</tt>. The number of blocks will be the size of @p
+   * block_sizes.
    */
-  BlockIndices (const std::vector<size_type> &n);
+  BlockIndices (const std::vector<size_type> &block_sizes);
 
   /**
    * Specialized constructor for a structure with blocks of equal size.
@@ -83,10 +84,11 @@ public:
 
   /**
    * Reinitialize the number of indices within each block from the given
-   * argument. The number of blocks will be adjusted to the size of @p n and
-   * the size of block @p i is set to <tt>n[i]</tt>.
+   * argument. The number of blocks will be adjusted to the size of
+   * <tt>block_sizes</tt> and the size of block @p i is set to
+   * <tt>block_sizes[i]</tt>.
    */
-  void reinit (const std::vector<size_type> &n);
+  void reinit (const std::vector<size_type> &block_sizes);
 
   /**
    * Add another block of given size to the end of the block structure.
@@ -306,16 +308,16 @@ BlockIndices::reinit (const unsigned int nb,
 
 inline
 void
-BlockIndices::reinit (const std::vector<size_type> &n)
+BlockIndices::reinit (const std::vector<size_type> &block_sizes)
 {
-  if (start_indices.size() != n.size()+1)
+  if (start_indices.size() != block_sizes.size()+1)
     {
-      n_blocks = static_cast<unsigned int>(n.size());
+      n_blocks = static_cast<unsigned int>(block_sizes.size());
       start_indices.resize(n_blocks+1);
     }
   start_indices[0] = 0;
   for (size_type i=1; i<=n_blocks; ++i)
-    start_indices[i] = start_indices[i-1] + n[i-1];
+    start_indices[i] = start_indices[i-1] + block_sizes[i-1];
 }
 
 
@@ -343,12 +345,12 @@ BlockIndices::BlockIndices (
 
 
 inline
-BlockIndices::BlockIndices (const std::vector<size_type> &n)
+BlockIndices::BlockIndices (const std::vector<size_type> &block_sizes)
   :
-  n_blocks(static_cast<unsigned int>(n.size())),
-  start_indices(n.size()+1)
+  n_blocks(static_cast<unsigned int>(block_sizes.size())),
+  start_indices(block_sizes.size()+1)
 {
-  reinit (n);
+  reinit (block_sizes);
 }
 
 

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -89,14 +89,14 @@ public:
   /**
    * Constructor. There are three ways to use this constructor. First, without
    * any arguments, it generates an object with no blocks. Given one argument,
-   * it initializes <tt>num_blocks</tt> blocks, but these blocks have size
+   * it initializes <tt>n_blocks</tt> blocks, but these blocks have size
    * zero. The third variant finally initializes all blocks to the same size
    * <tt>block_size</tt>.
    *
    * Confer the other constructor further down if you intend to use blocks of
    * different sizes.
    */
-  explicit BlockVector (const unsigned int num_blocks = 0,
+  explicit BlockVector (const unsigned int n_blocks = 0,
                         const size_type block_size = 0);
 
   /**
@@ -213,8 +213,8 @@ public:
   operator= (const TrilinosWrappers::BlockVector &V);
 #endif
   /**
-   * Reinitialize the BlockVector to contain <tt>num_blocks</tt> blocks of
-   * size <tt>block_size</tt> each.
+   * Reinitialize the BlockVector to contain <tt>n_blocks</tt> blocks of size
+   * <tt>block_size</tt> each.
    *
    * If the second argument is left at its default value, then the block
    * vector allocates the specified number of blocks but leaves them at zero
@@ -224,7 +224,7 @@ public:
    *
    * If <tt>fast==false</tt>, the vector is filled with zeros.
    */
-  void reinit (const unsigned int num_blocks,
+  void reinit (const unsigned int n_blocks,
                const size_type block_size = 0,
                const bool fast = false);
 

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -146,15 +146,16 @@ public:
   BlockVector (const BlockIndices &block_indices);
 
   /**
-   * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
-   * the vector with the elements pointed to by the range of iterators given
-   * as second and third argument. Apart from the first argument, this
-   * constructor is in complete analogy to the respective constructor of the
-   * <tt>std::vector</tt> class, but the first argument is needed in order to
-   * know how to subdivide the block vector into different blocks.
+   * Constructor. Set the number of blocks to <tt>block_sizes.size()</tt>.
+   * Initialize the vector with the elements pointed to by the range of
+   * iterators given as second and third argument. Apart from the first
+   * argument, this constructor is in complete analogy to the respective
+   * constructor of the <tt>std::vector</tt> class, but the first argument is
+   * needed in order to know how to subdivide the block vector into different
+   * blocks.
    */
   template <typename InputIterator>
-  BlockVector (const std::vector<size_type>    &n,
+  BlockVector (const std::vector<size_type>    &block_sizes,
                const InputIterator              first,
                const InputIterator              end);
 
@@ -243,7 +244,7 @@ public:
    * reinit() on one of the blocks, then subsequent actions on this object may
    * yield unpredictable results since they may be routed to the wrong block.
    */
-  void reinit (const std::vector<size_type> &N,
+  void reinit (const std::vector<size_type> &block_sizes,
                const bool                    fast=false);
 
   /**
@@ -353,7 +354,7 @@ public:
 
 template <typename Number>
 template <typename InputIterator>
-BlockVector<Number>::BlockVector (const std::vector<size_type>    &n,
+BlockVector<Number>::BlockVector (const std::vector<size_type>    &block_sizes,
                                   const InputIterator              first,
                                   const InputIterator              end)
 {
@@ -361,12 +362,12 @@ BlockVector<Number>::BlockVector (const std::vector<size_type>    &n,
   // don't initialize them as we will
   // copy elements soon
   (void)end;
-  reinit (n, true);
+  reinit (block_sizes, true);
   InputIterator start = first;
-  for (size_type b=0; b<n.size(); ++b)
+  for (size_type b=0; b<block_sizes.size(); ++b)
     {
       InputIterator end = start;
-      std::advance (end, static_cast<signed int>(n[b]));
+      std::advance (end, static_cast<signed int>(block_sizes[b]));
       std::copy (start, end, this->block(b).begin());
       start = end;
     };

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -92,11 +92,11 @@ BlockVector<Number>::BlockVector (const TrilinosWrappers::BlockVector &v)
 
 
 template <typename Number>
-void BlockVector<Number>::reinit (const unsigned int n_bl,
-                                  const size_type    bl_sz,
+void BlockVector<Number>::reinit (const unsigned int n_blocks,
+                                  const size_type    block_size,
                                   const bool         fast)
 {
-  std::vector<size_type> block_sizes(n_bl, bl_sz);
+  std::vector<size_type> block_sizes(n_blocks, block_size);
   reinit(block_sizes, fast);
 }
 

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -35,9 +35,9 @@ BlockVector<Number>::BlockVector (const unsigned int n_blocks,
 
 
 template <typename Number>
-BlockVector<Number>::BlockVector (const std::vector<size_type> &n)
+BlockVector<Number>::BlockVector (const std::vector<size_type> &block_sizes)
 {
-  reinit (n, false);
+  reinit (block_sizes, false);
 }
 
 
@@ -96,21 +96,21 @@ void BlockVector<Number>::reinit (const unsigned int n_bl,
                                   const size_type    bl_sz,
                                   const bool         fast)
 {
-  std::vector<size_type> n(n_bl, bl_sz);
-  reinit(n, fast);
+  std::vector<size_type> block_sizes(n_bl, bl_sz);
+  reinit(block_sizes, fast);
 }
 
 
 template <typename Number>
-void BlockVector<Number>::reinit (const std::vector<size_type> &n,
+void BlockVector<Number>::reinit (const std::vector<size_type> &block_sizes,
                                   const bool                    fast)
 {
-  this->block_indices.reinit (n);
+  this->block_indices.reinit (block_sizes);
   if (this->components.size() != this->n_blocks())
     this->components.resize(this->n_blocks());
 
   for (size_type i=0; i<this->n_blocks(); ++i)
-    this->components[i].reinit(n[i], fast);
+    this->components[i].reinit(block_sizes[i], fast);
 }
 
 


### PR DESCRIPTION
There were a few places were the documentation did not quite match the sources.

I also caught a usage of `num_` instead of `n_`.