### PR TITLE
Suppress a warning inside boost.

### DIFF
--- a/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp
+++ b/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp
@@ -19,6 +19,17 @@
 
 namespace boost { namespace property_tree { namespace json_parser
 {
+  inline bool is_ascii (char) 
+  {
+    return true;
+  }
+
+  template <class Ch>
+  inline bool is_ascii (Ch b)
+  {
+    return b <= 0xFF;
+  }
+  
 
     // Create necessary escape sequences from illegal characters
     template<class Ch>
@@ -33,7 +44,7 @@ namespace boost { namespace property_tree { namespace json_parser
             // We escape everything outside ASCII, because this code can't
             // handle high unicode characters.
             if (*b == 0x20 || *b == 0x21 || (*b >= 0x23 && *b <= 0x2E) ||
-                (*b >= 0x30 && *b <= 0x5B) || (*b >= 0x5D && *b <= 0xFF))
+                (*b >= 0x30 && *b <= 0x5B) || (*b >= 0x5D && is_ascii(*b)))
                 result += *b;
             else if (*b == Ch('\b')) result += Ch('\\'), result += Ch('b');
             else if (*b == Ch('\f')) result += Ch('\\'), result += Ch('f');


### PR DESCRIPTION
Specifically, suppress the following warning:

In file included from /u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/json_parser.hpp:15:0,
                 from /u/bangerth/p/deal.II/1/dealii/source/base/parameter_handler.cc:25:
/u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp: In function �std::basic_string<_CharT> boost::property_tree::json_parser::create_escapes(const std::basic_string<_CharT>&) [with Ch = char]�
:/u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp:79:67:   instantiated from �void boost::property_tree::json_parser::write_json_helper(std::basic_ostream<typename Ptree::key_type::value_type>&, const Ptree&, int, bool) [with Ptree = boost::property_tree::basic_ptree<std::basic_string<char>, std::basic_string<char> >, typename Ptree::key_type::value_type = char]
�/u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp:159:9:   instantiated from �void boost::property_tree::json_parser::write_json_internal(std::basic_ostream<typename Ptree::key_type::value_type>&, const Ptree&, const string&, bool) [with Ptree = boost::property_tree::basic_ptree<std::basic_string<char>, std::basic_string<char> >, typename Ptree::key_type::value_type = char, std::string = std::basic_string<char>]
�/u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/json_parser.hpp:98:9:   instantiated from �void boost::property_tree::json_parser::write_json(std::basic_ostream<typename Ptree::key_type::value_type>&, const Ptree&, bool) [with Ptree = boost::property_tree::basic_ptree<std::basic_string<char>, std::basic_string<char> >, typename Ptree::key_type::value_type = char]
�/u/bangerth/p/deal.II/1/dealii/source/base/parameter_handler.cc:1921:32:   instantiated from here
/u/bangerth/p/deal.II/1/dealii/bundled/boost-1.56.0/include/boost/property_tree/detail/json_parser_write.hpp:35:13: warning: comparison is always true due to limited range of data type [-Wtype-limits]