### PR TITLE
Do not repeat template default arguments

### DIFF
--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -1144,9 +1144,7 @@ namespace
  *
  * @ingroup LAOperators
  */
-template <typename Range = Vector<double>,
-          typename Domain = Range,
-          typename Matrix>
+template <typename Range, typename Domain, typename Matrix>
 LinearOperator<Range, Domain> linear_operator(const Matrix &matrix)
 {
   // implement with the more generic variant below...
@@ -1171,13 +1169,12 @@ LinearOperator<Range, Domain> linear_operator(const Matrix &matrix)
  *
  * @ingroup LAOperators
  */
-template <typename Range = Vector<double>,
-          typename Domain = Range,
+template <typename Range,
+          typename Domain,
           typename OperatorExemplar,
           typename Matrix>
 LinearOperator<Range, Domain>
-linear_operator(const OperatorExemplar &operator_exemplar,
-                const Matrix &matrix)
+linear_operator(const OperatorExemplar &operator_exemplar, const Matrix &matrix)
 {
   LinearOperator<Range, Domain> return_op;
 


### PR DESCRIPTION
This is indeed not valid C++11 and clang is unhappy about that.

Further, it works around a regression in gcc up to 4.7 that ejects a bogus
error in the lambda definitions in case of partial template default
arguments [1]

Closes #842

[1] https://github.com/dealii/dealii/pull/843