### PR TITLE
Explicitly call default constructor to silence a bogus warning

### DIFF
--- a/bundled/boost-1.56.0/include/boost/archive/iterators/istream_iterator.hpp
+++ b/bundled/boost-1.56.0/include/boost/archive/iterators/istream_iterator.hpp
@@ -84,13 +84,15 @@ class istream_iterator :
     Elem m_current_value;
 public:
     istream_iterator(istream_type & is) :
-        m_istream(& is)
+        m_istream(& is),
+        m_current_value()
     {
         //increment();
     }
 
     istream_iterator() :
-        m_istream(NULL)
+        m_istream(NULL),
+        m_current_value()
     {}
 
     istream_iterator(const istream_iterator<Elem> & rhs) :


### PR DESCRIPTION
This fixes a bogus warning emitted by gcc 4.8 and 4.9 about a possible
uninitialized member object.