### PR TITLE
Remove STL references

### DIFF
--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2013 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -124,7 +124,7 @@ style guidelines outlined in this page.</p>
   use lowercase letters and underscores to separate words.
   The only exception are the iterator typedefs in Triangulation
   and DoFHandler (named cell_iterator, active_line_iterator, etc)
-  to make the connection to the STL classes clear.</li>
+  to make the connection to the standard library container classes clear.</li>
 
 <li> For classes with multiple template arguments, the dimension is usually
   put before the data type specifier, i.e., we use Point<dim,number> and not

--- a/doc/doxygen/headers/memory.h
+++ b/doc/doxygen/headers/memory.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/doc/doxygen/headers/memory.h
+++ b/doc/doxygen/headers/memory.h
@@ -30,9 +30,9 @@
  *
  * In contrast to this, the MemoryConsumption namespace provides
  * functions that can be used to determine the memory consumption of
- * objects. For some simple classes, like the STL containers, it
- * directly determines how much memory they need (or at least gives an
- * estimate). For deal.II classes, it uses the
+ * objects. For some simple classes, like the standard library
+ * containers, it directly determines how much memory they need (or at
+ * least gives an estimate). For deal.II classes, it uses the
  * <code>memory_consumption</code> member function that most classes
  * have.
  *

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -1441,8 +1441,8 @@ namespace Step14
       const unsigned int
       n_vertices = sizeof(vertices_1) / sizeof(vertices_1[0]);
 
-      // From this static list of vertices, we generate an STL vector of the
-      // vertices, as this is the data type the library wants to see.
+      // From this static list of vertices, we generate a <tt>std::vector</tt>
+      // of the vertices, as this is the data type the library wants to see.
       const std::vector<Point<dim> > vertices (&vertices_1[0],
                                                &vertices_1[n_vertices]);
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -162,23 +162,22 @@ namespace Step48
   // The nonlinear function that we have to evaluate for the time stepping
   // routine includes the value of the function at the present time @p current
   // as well as the value at the previous time step @p old. Both values are
-  // passed to the operator in the collection of source vectors @p src, which
-  // is simply an STL vector of pointers to the actual solution vectors. This
-  // construct of collecting several source vectors into one is necessary as
-  // the cell loop in @p MatrixFree takes exactly one source and one
-  // destination vector, even if we happen to use many vectors like the two in
-  // this case. Note that the cell loop accepts any valid class for input and
-  // output, which does not only include vectors but general data
-  // types. However, only in case it encounters a
-  // parallel::distributed::Vector<Number> or an STL vector collecting these
-  // vectors, it calls functions that exchange data at the beginning and the
-  // end of the loop. In the loop over the cells, we first have to read in the
-  // values in the vectors related to the local values. Then, we evaluate the
-  // value and the gradient of the current solution vector and the values of
-  // the old vector at the quadrature points. Then, we combine the terms in
-  // the scheme in the loop over the quadrature points. Finally, we integrate
-  // the result against the test function and accumulate the result to the
-  // global solution vector @p dst.
+  // passed to the operator in the collection of source vectors @p src, which is
+  // simply a <tt>std::vector</tt> of pointers to the actual solution
+  // vectors. This construct of collecting several source vectors into one is
+  // necessary as the cell loop in @p MatrixFree takes exactly one source and
+  // one destination vector, even if we happen to use many vectors like the two
+  // in this case. Note that the cell loop accepts any valid class for input and
+  // output, which does not only include vectors but general data types.
+  // However, only in case it encounters a parallel::distributed::Vector<Number>
+  // or a <tt>std::vector</tt> collecting these vectors, it calls functions that
+  // exchange data at the beginning and the end of the loop. In the loop over
+  // the cells, we first have to read in the values in the vectors related to
+  // the local values. Then, we evaluate the value and the gradient of the
+  // current solution vector and the values of the old vector at the quadrature
+  // points. Then, we combine the terms in the scheme in the loop over the
+  // quadrature points. Finally, we integrate the result against the test
+  // function and accumulate the result to the global solution vector @p dst.
   template <int dim, int fe_degree>
   void SineGordonOperation<dim, fe_degree>::
   local_apply (const MatrixFree<dim>                      &data,
@@ -541,8 +540,8 @@ namespace Step48
     // artificial time.
 
     // We create an output of the initial value. Then we also need to collect
-    // the two starting solutions in an STL vector of pointers field and to
-    // set up an instance of the <code> SineGordonOperation class </code>
+    // the two starting solutions in a <tt>std::vector</tt> of pointers field
+    // and to set up an instance of the <code> SineGordonOperation class </code>
     // based on the finite element degree specified at the top of this file.
     VectorTools::interpolate (dof_handler,
                               ExactSolution<dim> (1, time),

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -323,11 +323,9 @@ namespace DataOutBase
     bool operator == (const Patch &patch) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
 
@@ -451,11 +449,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm);
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -497,11 +493,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -558,11 +552,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm);
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -805,11 +797,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm);
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -851,11 +841,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -904,11 +892,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -983,11 +969,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -1046,11 +1030,9 @@ namespace DataOutBase
              const bool draw_colorbar = true);
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -1101,11 +1083,9 @@ namespace DataOutBase
     void parse_parameters (const ParameterHandler &prm) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
   };
@@ -2505,11 +2485,9 @@ public:
   void parse_parameters (ParameterHandler &prm);
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -310,11 +310,9 @@ public:
                                       std::vector<Vector<Number> >   &values) const;
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   std::size_t memory_consumption () const;
 };
@@ -500,11 +498,9 @@ public:
                                   std::vector<Vector<Number> >   &values) const;
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -95,11 +95,9 @@ public:
                            const unsigned int              component = 0) const;
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -578,11 +578,9 @@ namespace Functions
                                  const unsigned int              component = 0) const;
 
     /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object. Since sometimes the size of objects can not be determined
-     * exactly (for example: what is the memory consumption of an STL
-     * <tt>std::map</tt> type with a certain number of elements?), this is
-     * only an estimate. however often quite close to the true value.
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
      */
     std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -390,11 +390,9 @@ public:
 
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   std::size_t memory_consumption () const;
 

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -35,9 +35,8 @@ template <typename T> class VectorizedArray;
 /**
  * This namespace provides functions helping to determine the amount of memory
  * used by objects. The goal is not necessarily to give the amount of memory
- * used up to the last bit (what is the memory used by an STL
- * <tt>std::map<></tt> object?), but rather to aid in the search for memory
- * bottlenecks.
+ * used up to the last bit (what is the memory used by a <tt>std::map</tt>
+ * object?), but rather to aid in the search for memory bottlenecks.
  *
  * This namespace has a single member function memory_consumption() and a lot
  * of specializations. Depending on the argument type of the function, there
@@ -228,7 +227,7 @@ namespace MemoryConsumption
   /**
    * Estimate the amount of memory (in bytes) occupied by a C-style array.
    * Since in this library we do not usually store simple data elements like
-   * <tt>double</tt>s in such arrays (but rather use STL <tt>std::vector</tt>s
+   * <tt>double</tt>s in such arrays (but rather use <tt>std::vector</tt>s
    * or deal.II <tt>Vector</tt> objects), we do not provide specializations
    * like for the <tt>std::vector</tt> arrays, but always use the loop over
    * all elements.

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -71,11 +71,9 @@ public:
   static unsigned int n_threads ();
 
   /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object. Since sometimes the size of objects can not be determined exactly
-   * (for example: what is the memory consumption of an STL <tt>std::map</tt>
-   * type with a certain number of elements?), this is only an estimate.
-   * however often quite close to the true value.
+   * Return an estimate for the memory consumption, in bytes, of this
+   * object. This is not exact (but will usually be close) because calculating
+   * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
    */
   static std::size_t memory_consumption ();
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -752,14 +752,14 @@ public:
   /**
    * Reset all values to zero.
    *
-   * Note that this is partly inconsistent with the semantics of the @p
-   * clear() member functions of the STL and of several other classes within
-   * deal.II which not only reset the values of stored elements to zero, but
-   * release all memory and return the object into a virginial state. However,
-   * since the size of objects of the present type is determined by its
-   * template parameters, resizing is not an option, and indeed the state
-   * where all elements have a zero value is the state right after
-   * construction of such an object.
+   * Note that this is partly inconsistent with the semantics of the @p clear()
+   * member functions of the standard library containers and of several other
+   * classes within deal.II, which not only reset the values of stored elements
+   * to zero, but release all memory and return the object into a virginial
+   * state. However, since the size of objects of the present type is determined
+   * by its template parameters, resizing is not an option, and indeed the state
+   * where all elements have a zero value is the state right after construction
+   * of such an object.
    */
   void clear ();
 

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -526,7 +526,7 @@ protected:
   struct Column
   {
     /**
-     * Constructor needed by STL maps.
+     * Constructor needed by <tt>std::map</tt>.
      */
     Column ();
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -274,14 +274,14 @@ public:
   /**
    * Reset all values to zero.
    *
-   * Note that this is partly inconsistent with the semantics of the @p
-   * clear() member functions of the STL and of several other classes within
-   * deal.II which not only reset the values of stored elements to zero, but
-   * release all memory and return the object into a virginial state. However,
-   * since the size of objects of the present type is determined by its
-   * template parameters, resizing is not an option, and indeed the state
-   * where all elements have a zero value is the state right after
-   * construction of such an object.
+   * Note that this is partly inconsistent with the semantics of the @p clear()
+   * member functions of the standard library containers and of several other
+   * classes within deal.II, which not only reset the values of stored elements
+   * to zero, but release all memory and return the object into a virginial
+   * state. However, since the size of objects of the present type is determined
+   * by its template parameters, resizing is not an option, and indeed the state
+   * where all elements have a zero value is the state right after construction
+   * of such an object.
    */
   void clear ();
 

--- a/include/deal.II/base/tensor_base.h
+++ b/include/deal.II/base/tensor_base.h
@@ -244,14 +244,14 @@ public:
   /**
    * Reset all values to zero.
    *
-   * Note that this is partly inconsistent with the semantics of the @p
-   * clear() member functions of the STL and of several other classes within
-   * deal.II which not only reset the values of stored elements to zero, but
-   * release all memory and return the object into a virginial state. However,
-   * since the size of objects of the present type is determined by its
-   * template parameters, resizing is not an option, and indeed the state
-   * where all elements have a zero value is the state right after
-   * construction of such an object.
+   * Note that this is partly inconsistent with the semantics of the @p clear()
+   * member functions of the standard library containers and of several other
+   * classes within deal.II, which not only reset the values of stored elements
+   * to zero, but release all memory and return the object into a virginial
+   * state. However, since the size of objects of the present type is determined
+   * by its template parameters, resizing is not an option, and indeed the state
+   * where all elements have a zero value is the state right after construction
+   * of such an object.
    */
   void clear ();
 
@@ -512,14 +512,14 @@ public:
   /**
    * Reset all values to zero.
    *
-   * Note that this is partly inconsistent with the semantics of the @p
-   * clear() member functions of the STL and of several other classes within
-   * deal.II which not only reset the values of stored elements to zero, but
-   * release all memory and return the object into a virginial state. However,
-   * since the size of objects of the present type is determined by its
-   * template parameters, resizing is not an option, and indeed the state
-   * where all elements have a zero value is the state right after
-   * construction of such an object.
+   * Note that this is partly inconsistent with the semantics of the @p clear()
+   * member functions of the standard library containers and of several other
+   * classes within deal.II, which not only reset the values of stored elements
+   * to zero, but release all memory and return the object into a virginial
+   * state. However, since the size of objects of the present type is determined
+   * by its template parameters, resizing is not an option, and indeed the state
+   * where all elements have a zero value is the state right after construction
+   * of such an object.
    */
   void clear ();
 
@@ -1550,5 +1550,3 @@ operator * (const std::complex<double>  factor,
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-
-

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2014 by the deal.II authors
+// Copyright (C) 2004 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -82,22 +82,22 @@ public:
   typename VECTOR::const_reference operator[] (unsigned int i) const;
 
   /**
-   * STL conforming iterator function.
+   * Standard-conforming iterator function.
    */
   typename VECTOR::iterator begin();
 
   /**
-   * STL conforming iterator function.
+   * Standard-conforming iterator function.
    */
   typename VECTOR::const_iterator begin() const;
 
   /**
-   * STL conforming iterator function.
+   * Standard-conforming iterator function.
    */
   typename VECTOR::iterator end();
 
   /**
-   * STL conforming iterator function.
+   * Standard-conforming iterator function.
    */
   typename VECTOR::const_iterator end() const;
 

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/dofs/function_map.h
+++ b/include/deal.II/dofs/function_map.h
@@ -69,7 +69,7 @@ struct FunctionMap
   /**
    * Declare the type as discussed above. Since we can't name it FunctionMap
    * (as that would ambiguate a possible constructor of this class), name it
-   * in the fashion of the STL local typedefs.
+   * in the fashion of the standard container local typedefs.
    */
   typedef std::map<types::boundary_id, const Function<dim,Number>*> type;
 };

--- a/include/deal.II/grid/grid_reordering_internal.h
+++ b/include/deal.II/grid/grid_reordering_internal.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/grid/grid_reordering_internal.h
+++ b/include/deal.II/grid/grid_reordering_internal.h
@@ -371,7 +371,7 @@ namespace internal
                  const unsigned int n1);
 
       /**
-       * Need a partial ordering for the STL
+       * Need a partial ordering for sorting algorithms
        */
       bool operator< (const CheapEdge &e2) const;
     };

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -435,15 +435,14 @@ namespace internal
  * quite inconvenient if one attempted to operate on it directly, since data
  * is spread over quite a lot of arrays and other places. However, there are
  * ways powerful enough to work on these data structures without knowing their
- * exact relations. This is done through the concept of iterators (see the STL
- * documentation and TriaIterator). In order to make things as easy and
- * dimension independent as possible, use of class local typedefs is made, see
- * below.
+ * exact relations. deal.II uses class local typedefs (see below) to make things
+ * as easy and dimension independent as possible.
  *
- * The Triangulation class provides iterator which enable looping over all
- * cells without knowing the exact representation used to describe them. Their
- * names are typedefs imported from the Iterators class (thus making them
- * local types to this class) and are as follows:
+ * The Triangulation class provides iterators which enable looping over all
+ * cells without knowing the exact representation used to describe them. For
+ * more information see the documentation of <tt>TriaIterator</tt>. Their names
+ * are typedefs imported from the Iterators class (thus making them local types
+ * to this class) and are as follows:
  *
  * <ul>
  * <li> <tt>cell_iterator</tt>: loop over all cells used in the Triangulation
@@ -475,10 +474,11 @@ namespace internal
  * functions returning iterators. Take a look at the class doc to get an
  * overview.
  *
- * Usage of these iterators works mostly like with the STL iterators. Some
- * examples taken from the Triangulation source code follow (notice that in
- * the last two examples the template parameter @p spacedim has been omitted,
- * so it takes the default value <code>dim</code>).
+ * Usage of these iterators is similar to usage of standard container
+ * iterators. Some examples taken from the Triangulation source code follow
+ * (notice that in the last two examples the template parameter @p spacedim has
+ * been omitted, so it takes the default value <code>dim</code>).
+ *
  * <ul>
  * <li> <em>Counting the number of cells on a specific level</em>
  *    @code
@@ -492,7 +492,7 @@ namespace internal
  *        return n;
  *      };
  *    @endcode
- * Another way which uses the STL @p distance function would be to write
+ * Another way, which uses <tt>std::distance</tt>, would be to write
  *    @code
  *      template <int dim>
  *      int Triangulation<dim>::n_cells (const int level) const {

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -49,13 +49,12 @@ template <typename> class TriaActiveIterator;
 
 
 /**
- * This class implements an iterator, analogous to those of the standard
- * template library (STL). It fulfills the requirements of a bidirectional
- * iterator.  See the C++ documentation for further details of iterator
- * specification and usage.
+ * This class implements an iterator, analogous to those used in the standard
+ * library. It fulfills the requirements of a bidirectional iterator. See the
+ * C++ documentation for further details of iterator specification and usage.
  *
  *
- * In addition to the STL iterators an iterator of this class provides a
+ * In addition to the standard interface, an iterator of this class provides a
  * <tt>-@></tt> operator, i.e. you can write statements like
  * @code
  * i->set_refine_flag ();
@@ -120,10 +119,10 @@ template <typename> class TriaActiveIterator;
  * more functionality.
  *
  * Furthermore, the iterators described here satisfy the requirement of input
- * and bidirectional iterators as stated by the C++ standard and the STL
- * documentation. It is therefore possible to use the functions from the
- * algorithm section of the C++ standard, e.g. <em>count_if</em> (see the
- * documentation for Triangulation for an example) and several others.
+ * and bidirectional iterators as stated by the C++ standard. It is therefore
+ * possible to use the functions from the algorithm section of the C++ standard,
+ * e.g., <em>count_if</em> (see the documentation for Triangulation for an
+ * example) and several others.
  *
  * <h3>Implementation</h3>
  *

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -132,18 +132,7 @@ inline
 bool
 TriaRawIterator<Accessor>::operator != (const TriaRawIterator<Accessor> &i) const
 {
-  // Note that at times, there is a problem
-  // with egcs 1.1 that makes it choose
-  // the global STL operator != (which
-  // does only !(a==b)) over the member
-  // function one, which then results in an
-  // error because the operator == of
-  // the accessor class is
-  // not made public. Strange... don't know
-  // whose fault it is.
-  //
-  // Work around the problem this way:
-  return accessor.operator != (i.accessor);
+  return not (*this == i);
 }
 
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -347,7 +347,8 @@ public:
   typedef MatrixType BlockType;
 
   /**
-   * Type of matrix entries. In analogy to the STL container classes.
+   * Type of matrix entries. These are analogous to typedefs in the standard
+   * library containers.
    */
   typedef typename BlockType::value_type value_type;
   typedef value_type             *pointer;
@@ -697,7 +698,7 @@ public:
               const bool    alternative_output = false) const;
 
   /**
-   * STL-like iterator with the first entry.
+   * Iterator starting at the first entry.
    */
   iterator begin ();
 
@@ -707,7 +708,7 @@ public:
   iterator end ();
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    */
   iterator begin (const size_type r);
 
@@ -716,7 +717,7 @@ public:
    */
   iterator end (const size_type r);
   /**
-   * STL-like iterator with the first entry.
+   * Iterator starting at the first entry.
    */
   const_iterator begin () const;
 
@@ -726,7 +727,7 @@ public:
   const_iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    */
   const_iterator begin (const size_type r) const;
 

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2014 by the deal.II authors
+// Copyright (C) 2000 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -273,7 +273,7 @@ namespace ChunkSparseMatrixIterators
 
 
   /**
-   * STL conforming iterator for constant and non-constant matrices.
+   * Iterator for constant and non-constant matrices.
    *
    * The first template argument denotes the underlying numeric type, the
    * second the constness of the matrix.
@@ -415,7 +415,8 @@ public:
   typedef types::global_dof_index size_type;
 
   /**
-   * Type of matrix entries. In analogy to the STL container classes.
+   * Type of matrix entries. This typedef is analogous to <tt>value_type</tt> in
+   * the standard library containers.
    */
   typedef number value_type;
 
@@ -431,19 +432,18 @@ public:
   typedef typename numbers::NumberTraits<number>::real_type real_type;
 
   /**
-   * Typedef of an STL conforming iterator class walking over all the nonzero
-   * entries of this matrix. This iterator cannot change the values of the
-   * matrix.
+   * Typedef of an iterator class walking over all the nonzero entries of this
+   * matrix. This iterator cannot change the values of the matrix.
    */
   typedef
   ChunkSparseMatrixIterators::Iterator<number,true>
   const_iterator;
 
   /**
-   * Typedef of an STL conforming iterator class walking over all the nonzero
-   * entries of this matrix. This iterator @em can change the values of the
-   * matrix, but of course can't change the sparsity pattern as this is fixed
-   * once a sparse matrix is attached to it.
+   * Typedef of an iterator class walking over all the nonzero entries of this
+   * matrix. This iterator @em can change the values of the matrix, but of
+   * course can't change the sparsity pattern as this is fixed once a sparse
+   * matrix is attached to it.
    */
   typedef
   ChunkSparseMatrixIterators::Iterator<number,false>
@@ -1095,8 +1095,8 @@ public:
 //@{
 
   /**
-   * STL-like iterator with the first entry of the matrix. This is the version
-   * for constant matrices.
+   * Iterator starting at first entry of the matrix. This is the version for
+   * constant matrices.
    *
    * Note that due to the layout in ChunkSparseMatrix, iterating over matrix
    * entries is considerably slower than for a sparse matrix, as the iterator
@@ -1116,7 +1116,7 @@ public:
   const_iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of the matrix. This is the version
+   * Iterator starting at the first entry of the matrix. This is the version
    * for non-constant matrices.
    *
    * Note that due to the layout in ChunkSparseMatrix, iterating over matrix
@@ -1137,8 +1137,8 @@ public:
   iterator end ();
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>. This is the
-   * version for constant matrices.
+   * Iterator starting at the first entry of row <tt>r</tt>. This is the version
+   * for constant matrices.
    *
    * Note that if the given row is empty, i.e. does not contain any nonzero
    * entries, then the iterator returned by this function equals
@@ -1169,8 +1169,8 @@ public:
   const_iterator end (const unsigned int r) const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>. This is the
-   * version for non-constant matrices.
+   * Iterator starting at the first entry of row <tt>r</tt>. This is the version
+   * for non-constant matrices.
    *
    * Note that if the given row is empty, i.e. does not contain any nonzero
    * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -152,7 +152,7 @@ namespace ChunkSparsityPatternIterators
 
 
   /**
-   * STL conforming iterator walking over the elements of a sparsity pattern.
+   * Iterator that walks over the elements of a sparsity pattern.
    */
   class Iterator
   {
@@ -272,13 +272,13 @@ public:
    * Copy constructor. This constructor is only allowed to be called if the
    * matrix structure to be copied is empty. This is so in order to prevent
    * involuntary copies of objects for temporaries, which can use large
-   * amounts of computing time.  However, copy constructors are needed if yo
-   * want to use the STL data types on classes like this, e.g. to write such
+   * amounts of computing time. However, copy constructors are needed if one
+   * wants to place a ChunkSparsityPattern in a container, e.g., to write such
    * statements like <tt>v.push_back (ChunkSparsityPattern());</tt>, with
    * <tt>v</tt> a vector of ChunkSparsityPattern objects.
    *
-   * Usually, it is sufficient to use the explicit keyword to disallow
-   * unwanted temporaries, but for the STL vectors, this does not work. Since
+   * Usually, it is sufficient to use the explicit keyword to disallow unwanted
+   * temporaries, but this does not work for <tt>std::vector</tt>. Since
    * copying a structure like this is not useful anyway because multiple
    * matrices can use the same sparsity structure, copies are only allowed for
    * empty objects, as described above.
@@ -621,9 +621,8 @@ public:
   bool stores_only_added_elements () const;
 
   /**
-   * STL-like iterator with the first entry of the matrix. The resulting
-   * iterator can be used to walk over all nonzero entries of the sparsity
-   * pattern.
+   * Iterator starting at the first entry of the matrix. The resulting iterator
+   * can be used to walk over all nonzero entries of the sparsity pattern.
    */
   iterator begin () const;
 
@@ -633,7 +632,7 @@ public:
   iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    *
    * Note that if the given row is empty, i.e. does not contain any nonzero
    * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -2020,10 +2020,11 @@ make_sorted_row_list (const std::vector<size_type>   &local_dof_indices,
   // so the first step is to create a sorted list of all row values that are
   // possible. these values are either the rows from unconstrained dofs, or
   // some indices introduced by dofs constrained to a combination of some
-  // other dofs. regarding the data type, choose an STL vector of a pair of
-  // unsigned ints (for global columns) and internal data (containing local
-  // columns + possible jumps from constraints). Choosing an STL map or
-  // anything else M.K. knows of would be much more expensive here!
+  // other dofs. regarding the data type, choose a <tt>std::vector</tt> of a
+  // pair of unsigned ints (for global columns) and internal data (containing
+  // local columns + possible jumps from constraints). Choosing
+  // <tt>std::map</tt> or anything else M.K. knows of would be much more
+  // expensive here!
 
   // cache whether we have to resolve any indirect rows generated from
   // resolving constrained dofs.

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -328,7 +328,7 @@ public:
    * sparsity structure to be copied is empty. This is so in order to prevent
    * involuntary copies of objects for temporaries, which can use large
    * amounts of computing time.  However, copy constructors are needed if you
-   * want to use the STL data types on classes like this, e.g. to write such
+   * want to place a DynamicSparsityPattern in a container, e.g. to write such
    * statements like <tt>v.push_back (DynamicSparsityPattern());</tt>, with
    * @p v a vector of @p DynamicSparsityPattern objects.
    */
@@ -473,7 +473,7 @@ public:
 // @{
 
   /**
-   * STL-like iterator with the first entry of the matrix. The resulting
+   * Iterator starting at the first entry of the matrix. The resulting
    * iterator can be used to walk over all nonzero entries of the sparsity
    * pattern.
    *
@@ -494,7 +494,7 @@ public:
   iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    *
    * Note that if the given row is empty, i.e. does not contain any nonzero
    * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2014 by the deal.II authors
+// Copyright (C) 2001 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -252,7 +252,7 @@ public:
   };
 
   /**
-   * STL conforming iterator.
+   * Standard-conforming iterator.
    */
   class const_iterator
   {

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -73,7 +73,8 @@ public:
   typedef unsigned int size_type;
 
   /**
-   * Type of matrix entries. In analogy to the STL container classes.
+   * Type of matrix entries. This typedef is analogous to <tt>value_type</tt> in
+   * the standard library containers.
    */
   typedef number value_type;
 
@@ -144,7 +145,7 @@ public:
   };
 
   /**
-   * STL conforming iterator.
+   * Standard-conforming iterator.
    */
   class const_iterator
   {
@@ -611,7 +612,7 @@ public:
 //@{
 
   /**
-   * STL-like iterator with the first entry.
+   * Iterator starting at the first entry.
    */
   const_iterator begin () const;
 
@@ -621,7 +622,7 @@ public:
   const_iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    */
   const_iterator begin (const size_type r) const;
 

--- a/include/deal.II/lac/matrix_iterator.h
+++ b/include/deal.II/lac/matrix_iterator.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/matrix_iterator.h
+++ b/include/deal.II/lac/matrix_iterator.h
@@ -23,7 +23,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
- * STL conforming iterator for constant and non-constant matrices.
+ * Iterator for constant and non-constant matrices.
  *
  * This iterator is abstracted from the actual matrix type and can be used for
  * any matrix having the required ACCESSOR type.

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -46,10 +46,10 @@ namespace PETScWrappers
   namespace MatrixIterators
   {
     /**
-     * STL conforming iterator. This class acts as an iterator walking over
-     * the elements of PETSc matrices. Since PETSc offers a uniform interface
-     * for all types of matrices, this iterator can be used to access both
-     * sparse and full matrices.
+     * This class acts as an iterator walking over the elements of PETSc
+     * matrices. Since PETSc offers a uniform interface for all types of
+     * matrices, this iterator can be used to access both sparse and full
+     * matrices.
      *
      * Note that PETSc does not give any guarantees as to the order of
      * elements within each row. Note also that accessing the elements of a
@@ -784,7 +784,7 @@ namespace PETScWrappers
                           const VectorBase &b) const;
 
     /**
-     * STL-like iterator with the first entry.
+     * Iterator starting at the first entry.
      */
     const_iterator begin () const;
 
@@ -794,7 +794,7 @@ namespace PETScWrappers
     const_iterator end () const;
 
     /**
-     * STL-like iterator with the first entry of row @p r.
+     * Iterator starting at the first entry of row @p r.
      *
      * Note that if the given row is empty, i.e. does not contain any nonzero
      * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -386,7 +386,7 @@ public:
   typedef types::global_dof_index size_type;
 
   /**
-   * STL conforming iterator.
+   * Standard-conforming iterator.
    */
   class const_iterator
   {
@@ -561,7 +561,7 @@ public:
   void Tstep (Vector<number2> &dst, const Vector<number2> &rhs) const;
 
   /**
-   * STL-like iterator with the first entry.
+   * Iterator starting at the first entry.
    */
   const_iterator begin () const;
 
@@ -571,7 +571,7 @@ public:
   const_iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row @p r.
+   * Iterator starting at the first entry of row @p r.
    */
   const_iterator begin (const size_type r) const;
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -292,7 +292,7 @@ namespace SparseMatrixIterators
 
 
   /**
-   * STL conforming iterator for constant and non-constant matrices.
+   * Iterator for constant and non-constant matrices.
    *
    * The typical use for these iterators is to iterate over the elements of a
    * sparse matrix or over the elements of individual rows. Note that there is
@@ -470,7 +470,8 @@ public:
   typedef types::global_dof_index size_type;
 
   /**
-   * Type of matrix entries. In analogy to the STL container classes.
+   * Type of the matrix entries. This typedef is analogous to
+   * <tt>value_type</tt> in the standard library containers.
    */
   typedef number value_type;
 
@@ -486,19 +487,18 @@ public:
   typedef typename numbers::NumberTraits<number>::real_type real_type;
 
   /**
-   * Typedef of an STL conforming iterator class walking over all the nonzero
-   * entries of this matrix. This iterator cannot change the values of the
-   * matrix.
+   * Typedef of an iterator class walking over all the nonzero entries of this
+   * matrix. This iterator cannot change the values of the matrix.
    */
   typedef
   SparseMatrixIterators::Iterator<number,true>
   const_iterator;
 
   /**
-   * Typedef of an STL conforming iterator class walking over all the nonzero
-   * entries of this matrix. This iterator @em can change the values of the
-   * matrix, but of course can't change the sparsity pattern as this is fixed
-   * once a sparse matrix is attached to it.
+   * Typedef of an iterator class walking over all the nonzero entries of this
+   * matrix. This iterator @em can change the values of the matrix, but of
+   * course can't change the sparsity pattern as this is fixed once a sparse
+   * matrix is attached to it.
    */
   typedef
   SparseMatrixIterators::Iterator<number,false>

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -169,7 +169,7 @@ public:
 public:
 
   /**
-   * STL conforming iterator.
+   * Standard-conforming iterator.
    */
   class const_iterator
   {
@@ -289,7 +289,8 @@ public:
   };
 
   /**
-   * Type of matrix entries. In analogy to the STL container classes.
+   * Type of matrix entries. This typedef is analogous to <tt>value_type</tt> in
+   * the standard library containers.
    */
   typedef number value_type;
 
@@ -663,7 +664,7 @@ public:
    */
 //@{
   /**
-   * STL-like iterator with the first existing entry.
+   * Iterator starting at the first existing entry.
    */
   const_iterator begin () const;
 
@@ -673,8 +674,8 @@ public:
   const_iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row @p r. If this row is empty,
-   * the result is <tt>end(r)</tt>, which does NOT point into row @p r..
+   * Iterator starting at the first entry of row @p r. If this row is empty, the
+   * result is <tt>end(r)</tt>, which does NOT point into row @p r.
    */
   const_iterator begin (const size_type r) const;
 

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -383,13 +383,13 @@ public:
    * Copy constructor. This constructor is only allowed to be called if the
    * matrix structure to be copied is empty. This is so in order to prevent
    * involuntary copies of objects for temporaries, which can use large
-   * amounts of computing time.  However, copy constructors are needed if yo
-   * want to use the STL data types on classes like this, e.g. to write such
+   * amounts of computing time. However, copy constructors are needed if one
+   * wants to place a SparsityPattern in a container, e.g., to write such
    * statements like <tt>v.push_back (SparsityPattern());</tt>, with
    * <tt>v</tt> a vector of SparsityPattern objects.
    *
-   * Usually, it is sufficient to use the explicit keyword to disallow
-   * unwanted temporaries, but for the STL vectors, this does not work. Since
+   * Usually, it is sufficient to use the explicit keyword to disallow unwanted
+   * temporaries, but this does not work for <tt>std::vector</tt>s. Since
    * copying a structure like this is not useful anyway because multiple
    * matrices can use the same sparsity structure, copies are only allowed for
    * empty objects, as described above.
@@ -675,7 +675,7 @@ public:
 // @{
 
   /**
-   * STL-like iterator with the first entry of the matrix. The resulting
+   * Iterator starting at the first entry of the matrix. The resulting
    * iterator can be used to walk over all nonzero entries of the sparsity
    * pattern.
    *
@@ -690,7 +690,7 @@ public:
   iterator end () const;
 
   /**
-   * STL-like iterator with the first entry of row <tt>r</tt>.
+   * Iterator starting at the first entry of row <tt>r</tt>.
    *
    * Note that if the given row is empty, i.e. does not contain any nonzero
    * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -322,9 +322,9 @@ namespace TrilinosWrappers
     };
 
     /**
-     * STL conforming iterator. This class acts as an iterator walking over
-     * the elements of Trilinos matrices. The implementation of this class is
-     * similar to the one for PETSc matrices.
+     * This class acts as an iterator walking over the elements of Trilinos
+     * matrices. The implementation of this class is similar to the one for
+     * PETSc matrices.
      *
      * Note that Trilinos stores the elements within each row in ascending
      * order. This is opposed to the deal.II sparse matrix style where the

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -968,7 +968,7 @@ namespace TrilinosWrappers
 //@{
 
     /**
-     * STL-like iterator with the first entry.
+     * Iterator starting at the first entry.
      */
     const_iterator begin () const;
 
@@ -978,7 +978,7 @@ namespace TrilinosWrappers
     const_iterator end () const;
 
     /**
-     * STL-like iterator with the first entry of row @p r.
+     * Iterator starting at the first entry of row @p r.
      *
      * Note that if the given row is empty, i.e. does not contain any nonzero
      * entries, then the iterator returned by this function equals

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -159,8 +159,8 @@ public:
    * Copy-constructor. Sets the dimension to that of the given vector, and
    * copies all elements.
    *
-   * We would like to make this constructor explicit, but STL insists on using
-   * it implicitly.
+   * We would like to make this constructor explicit, but standard containers
+   * insist on using it implicitly.
    */
   Vector (const Vector<Number> &v);
 
@@ -273,8 +273,8 @@ public:
    * waste some memory, so keep this in mind.  However, if <tt>N==0</tt> all
    * memory is freed, i.e. if you want to resize the vector and release the
    * memory not needed, you have to first call <tt>reinit(0)</tt> and then
-   * <tt>reinit(N)</tt>. This cited behaviour is analogous to that of the STL
-   * containers.
+   * <tt>reinit(N)</tt>. This cited behaviour is analogous to that of the
+   * standard library containers.
    *
    * If @p fast is false, the vector is filled by zeros. Otherwise, the
    * elements are left an unspecified state.

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -167,13 +167,9 @@ namespace
 namespace
 {
   /**
-   * Sorts the vector @p ind as an
-   * index vector of @p a in
-   * increasing order.  This
-   * implementation of quicksort
-   * seems to be faster than the
-   * STL version and is needed in
-   * @p refine_and_coarsen_optimize
+   * Sorts the vector @p ind as an index vector of @p a in increasing order.
+   * This implementation of quicksort seems to be faster than the standard
+   * library version and is needed in @p refine_and_coarsen_optimize.
    */
 
   template <class Vector>


### PR DESCRIPTION
I believe this resolves #868. I made a lot of arbitrary stylistic choices in this commit, such as:  
1. I write `std::vector` and not `vector`.
2. I do not label the iterators as "standard library iterators" unless that is the only possible description. Perhaps the comments consisting solely of `Standard-conforming iterator` should be removed. Writing such comments would be easier if we had concepts available.
3. I do label "standard containers" as such (to differentiate against things like `std::array`).
4. I tend to mash `M-q` a lot so all of the comments are limited at 79 characters per line.

 Please let me know if anyone would prefer a different style.