### PR TITLE
[RFC] deprecate Trilinos and PETSc wrappers of serial vectors

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -496,11 +496,6 @@ inconvenience this causes.
   move constructors and move assignment operators in C++11 mode.
   <br>
   (Matthias Maier, 2015/05/01)
-  <li> Changed: TrilinosWrappers::Vector, TrilinosWrappers::BlockVector, 
-  PETScWrappers::Vector, and PETScWrappers::BlockVector are deprecated. Either 
-  use the MPI or the deal.II version of the Vector/BlockVector.
-  <br>
-  (Bruno Turcksin, 2015/05/01)
   </li>
 
   <li> New: Introduce DoFRenumbering::block_wise for multigrid computation.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -472,6 +472,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Changed: TrilinosWrappers::Vector, TrilinosWrappers::BlockVector, 
+  PETScWrappers::Vector, and PETScWrappers::BlockVector are deprecated. Either 
+  use the MPI or the deal.II version of the Vector/BlockVector.
+  <br>
+  (Bruno Turcksin, 2015/05/04)
+  </li>
+
   <li> Fixed: GridGenerator::half_hyper_shell can now be colorized.
   <br>
   (Daniel Arndt, 2015/05/05)
@@ -489,6 +496,11 @@ inconvenience this causes.
   move constructors and move assignment operators in C++11 mode.
   <br>
   (Matthias Maier, 2015/05/01)
+  <li> Changed: TrilinosWrappers::Vector, TrilinosWrappers::BlockVector, 
+  PETScWrappers::Vector, and PETScWrappers::BlockVector are deprecated. Either 
+  use the MPI or the deal.II version of the Vector/BlockVector.
+  <br>
+  (Bruno Turcksin, 2015/05/01)
   </li>
 
   <li> New: Introduce DoFRenumbering::block_wise for multigrid computation.

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -65,7 +65,6 @@
 // simply map to sequential, local vectors and matrices if there is only a
 // single process, i.e. if you are running on only one machine, and without
 // MPI support):
-#include <deal.II/lac/petsc_vector.h>
 #include <deal.II/lac/petsc_parallel_vector.h>
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>
 // Then we also need interfaces for solvers and preconditioners that PETSc
@@ -143,14 +142,9 @@ namespace Step17
 
     // In step-8, this would have been the place where we would have declared
     // the member variables for the sparsity pattern, the system matrix, right
-    // hand, and solution vector. We change these declarations to use
-    // parallel PETSc objects instead (note that the fact that we use the
-    // parallel versions is denoted the fact that we use the classes from the
-    // <code>PETScWrappers::MPI</code> namespace; sequential versions of these
-    // classes are in the <code>PETScWrappers</code> namespace, i.e. without
-    // the <code>MPI</code> part, be aware that these classes are deprecated).
-    // Note also that we do not use a separate sparsity pattern, since PETSc
-    // manages that as part of its matrix data structures.
+    // hand, and solution vector. We change these declarations to use parallel
+    // PETSc objects instead. Note that we do not use a separate sparsity
+    // pattern, since PETSc manages that as part of its matrix data structures.
     PETScWrappers::MPI::SparseMatrix system_matrix;
 
     PETScWrappers::MPI::Vector       solution;

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -655,7 +655,7 @@ namespace Step17
     // vector. This is necessary since the error estimator needs to get at the
     // value of neighboring cells even if they do not belong to the subdomain
     // associated with the present MPI process:
-    const PETScWrappers::Vector localized_solution (solution);
+    const Vector<double> localized_solution (solution);
 
     // Second part: set up a vector of error indicators for all cells and let
     // the Kelly class compute refinement indicators for all cells belonging
@@ -867,112 +867,6 @@ namespace Step17
 
 
   // @sect4{ElasticProblem::run}
-
-  // The sixth step is to take the solution just computed, and evaluate some
-  // kind of refinement indicator to refine the mesh. The problem is basically
-  // the same as with distributing hanging node constraints: in order to
-  // compute the error indicator, we need access to all elements of the
-  // solution vector. We then compute the indicators for the cells that belong
-  // to the present process, but then we need to distribute the refinement
-  // indicators into a distributed vector so that all processes have the
-  // values of the refinement indicator for all cells. But then, in order for
-  // each process to refine its copy of the mesh, they need to have access to
-  // all refinement indicators locally, so they have to copy the global vector
-  // back into a local one. That's a little convoluted, but thinking about it
-  // quite straightforward nevertheless. So here's how we do it:
-  template <int dim>
-  void ElasticProblem<dim>::refine_grid ()
-  {
-    // So, first part: get a local copy of the distributed solution
-    // vector. This is necessary since the error estimator needs to get at the
-    // value of neighboring cells even if they do not belong to the subdomain
-    // associated with the present MPI process:
-    const Vector<double> localized_solution (solution);
-
-    // Second part: set up a vector of error indicators for all cells and let
-    // the Kelly class compute refinement indicators for all cells belonging
-    // to the present subdomain/process. Note that the last argument of the
-    // call indicates which subdomain we are interested in. The three
-    // arguments before it are various other default arguments that one
-    // usually doesn't need (and doesn't state values for, but rather uses the
-    // defaults), but which we have to state here explicitly since we want to
-    // modify the value of a following argument (i.e. the one indicating the
-    // subdomain):
-    Vector<float> local_error_per_cell (triangulation.n_active_cells());
-    KellyErrorEstimator<dim>::estimate (dof_handler,
-                                        QGauss<dim-1>(2),
-                                        typename FunctionMap<dim>::type(),
-                                        localized_solution,
-                                        local_error_per_cell,
-                                        ComponentMask(),
-                                        0,
-                                        MultithreadInfo::n_threads(),
-                                        this_mpi_process);
-
-    // Now all processes have computed error indicators for their own cells
-    // and stored them in the respective elements of the
-    // <code>local_error_per_cell</code> vector. The elements of this vector
-    // for cells not on the present process are zero. However, since all
-    // processes have a copy of a copy of the entire triangulation and need to
-    // keep these copies in sync, they need the values of refinement
-    // indicators for all cells of the triangulation. Thus, we need to
-    // distribute our results. We do this by creating a distributed vector
-    // where each process has its share, and sets the elements it has
-    // computed. We will then later generate a local sequential copy of this
-    // distributed vector to allow each process to access all elements of this
-    // vector.
-    //
-    // So in the first step, we need to set up a %parallel vector. For
-    // simplicity, every process will own a chunk with as many elements as
-    // this process owns cells, so that the first chunk of elements is stored
-    // with process zero, the next chunk with process one, and so on. It is
-    // important to remark, however, that these elements are not necessarily
-    // the ones we will write to. This is so, since the order in which cells
-    // are arranged, i.e. the order in which the elements of the vector
-    // correspond to cells, is not ordered according to the subdomain these
-    // cells belong to. In other words, if on this process we compute
-    // indicators for cells of a certain subdomain, we may write the results
-    // to more or less random elements if the distributed vector, that do not
-    // necessarily lie within the chunk of vector we own on the present
-    // process. They will subsequently have to be copied into another
-    // process's memory space then, an operation that PETSc does for us when
-    // we call the <code>compress</code> function. This inefficiency could be
-    // avoided with some more code, but we refrain from it since it is not a
-    // major factor in the program's total runtime.
-    //
-    // So here's how we do it: count how many cells belong to this process,
-    // set up a distributed vector with that many elements to be stored
-    // locally, and copy over the elements we computed locally, then compress
-    // the result. In fact, we really only copy the elements that are nonzero,
-    // so we may miss a few that we computed to zero, but this won't hurt
-    // since the original values of the vector is zero anyway.
-    const unsigned int n_local_cells
-      = GridTools::count_cells_with_subdomain_association (triangulation,
-                                                           this_mpi_process);
-    PETScWrappers::MPI::Vector
-    distributed_all_errors (mpi_communicator,
-                            triangulation.n_active_cells(),
-                            n_local_cells);
-
-    for (unsigned int i=0; i<local_error_per_cell.size(); ++i)
-      if (local_error_per_cell(i) != 0)
-        distributed_all_errors(i) = local_error_per_cell(i);
-    distributed_all_errors.compress (VectorOperation::insert);
-
-
-    // So now we have this distributed vector out there that contains the
-    // refinement indicators for all cells. To use it, we need to obtain a
-    // local copy...
-    const Vector<float> localized_all_errors (distributed_all_errors);
-
-    // ...which we can the subsequently use to finally refine the grid:
-    GridRefinement::refine_and_coarsen_fixed_number (triangulation,
-                                                     localized_all_errors,
-                                                     0.3, 0.03);
-    triangulation.execute_coarsening_and_refinement ();
-  }
-
-
 
   // Lastly, here is the driver function. It is almost unchanged from step-8,
   // with the exception that we replace <code>std::cout</code> by the

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -30,7 +30,6 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/petsc_vector.h>
 #include <deal.II/lac/petsc_parallel_vector.h>
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>
 #include <deal.II/lac/petsc_solver.h>

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -495,7 +495,7 @@ namespace Step18
 
     PETScWrappers::MPI::Vector       system_rhs;
 
-    PETScWrappers::Vector            incremental_displacement;
+    Vector<double>                   incremental_displacement;
 
     // The next block of variables is then related to the time dependent
     // nature of the problem: they denote the length of the time interval

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -58,6 +58,7 @@
 // preconditioner classes that implement interfaces to the respective Trilinos
 // classes. In particular, we will need interfaces to the matrix and vector
 // classes based on Trilinos as well as Trilinos preconditioners:
+#include <deal.II/base/index_set.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
@@ -378,8 +379,8 @@ namespace Step31
         PreconditionerMp>         &Mpinv,
         const PreconditionerA                         &Apreconditioner);
 
-      void vmult (TrilinosWrappers::BlockVector       &dst,
-                  const TrilinosWrappers::BlockVector &src) const;
+      void vmult (TrilinosWrappers::MPI::BlockVector       &dst,
+                  const TrilinosWrappers::MPI::BlockVector &src) const;
 
     private:
       const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> stokes_matrix;
@@ -387,7 +388,7 @@ namespace Step31
             PreconditionerMp > > m_inverse;
       const PreconditionerA &a_preconditioner;
 
-      mutable TrilinosWrappers::Vector tmp;
+      mutable TrilinosWrappers::MPI::Vector tmp;
     };
 
 
@@ -401,9 +402,19 @@ namespace Step31
       :
       stokes_matrix           (&S),
       m_inverse               (&Mpinv),
-      a_preconditioner        (Apreconditioner),
-      tmp                     (stokes_matrix->block(1,1).m())
-    {}
+      a_preconditioner        (Apreconditioner)
+    {
+      // When using a TrilinosWrappers::MPI::Vector or a
+      // TrilinosWrappers::MPI::BlockVector, the Vector is initialized using an
+      // IndexSet. IndexSet is used not only to resize the
+      // TrilinosWrappers::MPI::Vector but it also associates an index in the
+      // TrilinosWrappers::MPI::Vector with a degree of freedom (see step-40 for
+      // a more detailed explanation). This assocation is done by the add_range()
+      // function.
+      IndexSet tmp_index_set(stokes_matrix->block(1,1).m());
+      tmp_index_set.add_range(0,stokes_matrix->block(1,1).m());
+      tmp.reinit(tmp_index_set);
+    }
 
 
     // Next is the <code>vmult</code> function. We implement the action of
@@ -424,8 +435,8 @@ namespace Step31
     template <class PreconditionerA, class PreconditionerMp>
     void
     BlockSchurPreconditioner<PreconditionerA, PreconditionerMp>::
-    vmult (TrilinosWrappers::BlockVector       &dst,
-           const TrilinosWrappers::BlockVector &src) const
+    vmult (TrilinosWrappers::MPI::BlockVector       &dst,
+           const TrilinosWrappers::MPI::BlockVector &src) const
     {
       a_preconditioner.vmult (dst.block(0), src.block(0));
       stokes_matrix->block(1,0).residual(tmp, dst.block(0), src.block(1));
@@ -502,13 +513,13 @@ namespace Step31
     DoFHandler<dim>                     stokes_dof_handler;
     ConstraintMatrix                    stokes_constraints;
 
-    std::vector<types::global_dof_index> stokes_block_sizes;
+    std::vector<IndexSet>               stokes_block_sizes;
     TrilinosWrappers::BlockSparseMatrix stokes_matrix;
     TrilinosWrappers::BlockSparseMatrix stokes_preconditioner_matrix;
 
-    TrilinosWrappers::BlockVector       stokes_solution;
-    TrilinosWrappers::BlockVector       old_stokes_solution;
-    TrilinosWrappers::BlockVector       stokes_rhs;
+    TrilinosWrappers::MPI::BlockVector  stokes_solution;
+    TrilinosWrappers::MPI::BlockVector  old_stokes_solution;
+    TrilinosWrappers::MPI::BlockVector  stokes_rhs;
 
 
     const unsigned int                  temperature_degree;
@@ -520,10 +531,10 @@ namespace Step31
     TrilinosWrappers::SparseMatrix      temperature_stiffness_matrix;
     TrilinosWrappers::SparseMatrix      temperature_matrix;
 
-    TrilinosWrappers::Vector            temperature_solution;
-    TrilinosWrappers::Vector            old_temperature_solution;
-    TrilinosWrappers::Vector            old_old_temperature_solution;
-    TrilinosWrappers::Vector            temperature_rhs;
+    TrilinosWrappers::MPI::Vector       temperature_solution;
+    TrilinosWrappers::MPI::Vector       old_temperature_solution;
+    TrilinosWrappers::MPI::Vector       old_old_temperature_solution;
+    TrilinosWrappers::MPI::Vector       temperature_rhs;
 
 
     double                              time_step;
@@ -952,9 +963,12 @@ namespace Step31
     // Trilinos matrices store the sparsity pattern internally, there is no
     // need to keep the sparsity pattern around after the initialization of
     // the matrix.
+    stokes_block_sizes.clear();
     stokes_block_sizes.resize (2);
-    stokes_block_sizes[0] = n_u;
-    stokes_block_sizes[1] = n_p;
+    stokes_block_sizes[0].set_size(n_u);
+    stokes_block_sizes[1].set_size(n_p);
+    stokes_block_sizes[0].add_range(0,n_u);
+    stokes_block_sizes[1].add_range(0,n_p);
     {
       stokes_matrix.clear ();
 
@@ -1040,15 +1054,17 @@ namespace Step31
     // and $\mathbf u^{n-2}$, as well as for the temperatures $T^{n}$,
     // $T^{n-1}$ and $T^{n-2}$ (required for time stepping) and all the system
     // right hand sides to their correct sizes and block structure:
+    IndexSet temperature_partitioning (n_T);
+    temperature_partitioning.add_range(0,n_T);
     stokes_solution.reinit (stokes_block_sizes);
     old_stokes_solution.reinit (stokes_block_sizes);
     stokes_rhs.reinit (stokes_block_sizes);
 
-    temperature_solution.reinit (temperature_dof_handler.n_dofs());
-    old_temperature_solution.reinit (temperature_dof_handler.n_dofs());
-    old_old_temperature_solution.reinit (temperature_dof_handler.n_dofs());
+    temperature_solution.reinit (temperature_partitioning);
+    old_temperature_solution.reinit (temperature_partitioning);
+    old_old_temperature_solution.reinit (temperature_partitioning);
 
-    temperature_rhs.reinit (temperature_dof_handler.n_dofs());
+    temperature_rhs.reinit (temperature_partitioning);
   }
 
 
@@ -1793,9 +1809,9 @@ namespace Step31
       SolverControl solver_control (stokes_matrix.m(),
                                     1e-6*stokes_rhs.l2_norm());
 
-      SolverGMRES<TrilinosWrappers::BlockVector>
+      SolverGMRES<TrilinosWrappers::MPI::BlockVector>
       gmres (solver_control,
-             SolverGMRES<TrilinosWrappers::BlockVector >::AdditionalData(100));
+             SolverGMRES<TrilinosWrappers::MPI::BlockVector >::AdditionalData(100));
 
       for (unsigned int i=0; i<stokes_solution.size(); ++i)
         if (stokes_constraints.is_constrained(i))
@@ -1864,7 +1880,7 @@ namespace Step31
     // preconditioner (IC) as we also use for preconditioning the pressure
     // mass matrix solver. As a solver, we choose the conjugate gradient
     // method CG. As before, we tell the solver to use Trilinos vectors via
-    // the template argument <code>TrilinosWrappers::Vector</code>.  Finally,
+    // the template argument <code>TrilinosWrappers::MPI::Vector</code>.  Finally,
     // we solve, distribute the hanging node constraints and write out the
     // number of iterations.
     assemble_temperature_system (maximal_velocity);
@@ -1872,7 +1888,7 @@ namespace Step31
 
       SolverControl solver_control (temperature_matrix.m(),
                                     1e-8*temperature_rhs.l2_norm());
-      SolverCG<TrilinosWrappers::Vector> cg (solver_control);
+      SolverCG<TrilinosWrappers::MPI::Vector> cg (solver_control);
 
       TrilinosWrappers::PreconditionIC preconditioner;
       preconditioner.initialize (temperature_matrix);
@@ -2033,14 +2049,14 @@ namespace Step31
     // and temperature DoFHandler objects, by attaching them to the old dof
     // handlers. With this at place, we can prepare the triangulation and the
     // data vectors for refinement (in this order).
-    std::vector<TrilinosWrappers::Vector> x_temperature (2);
+    std::vector<TrilinosWrappers::MPI::Vector> x_temperature (2);
     x_temperature[0] = temperature_solution;
     x_temperature[1] = old_temperature_solution;
-    TrilinosWrappers::BlockVector x_stokes = stokes_solution;
+    TrilinosWrappers::MPI::BlockVector x_stokes = stokes_solution;
 
-    SolutionTransfer<dim,TrilinosWrappers::Vector>
+    SolutionTransfer<dim,TrilinosWrappers::MPI::Vector>
     temperature_trans(temperature_dof_handler);
-    SolutionTransfer<dim,TrilinosWrappers::BlockVector>
+    SolutionTransfer<dim,TrilinosWrappers::MPI::BlockVector>
     stokes_trans(stokes_dof_handler);
 
     triangulation.prepare_coarsening_and_refinement();
@@ -2062,7 +2078,7 @@ namespace Step31
     triangulation.execute_coarsening_and_refinement ();
     setup_dofs ();
 
-    std::vector<TrilinosWrappers::Vector> tmp (2);
+    std::vector<TrilinosWrappers::MPI::Vector> tmp (2);
     tmp[0].reinit (temperature_solution);
     tmp[1].reinit (temperature_solution);
     temperature_trans.interpolate(x_temperature, tmp);

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -2215,7 +2215,7 @@ int main (int argc, char *argv[])
 
       // This program can only be run in serial. Otherwise, throw an exception.
       AssertThrow(Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)==1,
-                  ExcMessage("This program can only be run in serial, use mpirun -np 1 ./step-31"));
+                  ExcMessage("This program can only be run in serial, use ./step-31"));
 
       BoussinesqFlowProblem<2> flow_problem;
       flow_problem.run ();

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -413,7 +413,7 @@ namespace Step31
       // function.
       IndexSet tmp_index_set(stokes_matrix->block(1,1).m());
       tmp_index_set.add_range(0,stokes_matrix->block(1,1).m());
-      tmp.reinit(tmp_index_set);
+      tmp.reinit(tmp_index_set, MPI_COMM_WORLD);
     }
 
 
@@ -1056,15 +1056,15 @@ namespace Step31
     // right hand sides to their correct sizes and block structure:
     IndexSet temperature_partitioning (n_T);
     temperature_partitioning.add_range(0,n_T);
-    stokes_solution.reinit (stokes_block_sizes);
-    old_stokes_solution.reinit (stokes_block_sizes);
-    stokes_rhs.reinit (stokes_block_sizes);
+    stokes_solution.reinit (stokes_block_sizes, MPI_COMM_WORLD);
+    old_stokes_solution.reinit (stokes_block_sizes, MPI_COMM_WORLD);
+    stokes_rhs.reinit (stokes_block_sizes, MPI_COMM_WORLD);
 
-    temperature_solution.reinit (temperature_partitioning);
-    old_temperature_solution.reinit (temperature_partitioning);
-    old_old_temperature_solution.reinit (temperature_partitioning);
+    temperature_solution.reinit (temperature_partitioning, MPI_COMM_WORLD);
+    old_temperature_solution.reinit (temperature_partitioning, MPI_COMM_WORLD);
+    old_old_temperature_solution.reinit (temperature_partitioning, MPI_COMM_WORLD);
 
-    temperature_rhs.reinit (temperature_partitioning);
+    temperature_rhs.reinit (temperature_partitioning, MPI_COMM_WORLD);
   }
 
 
@@ -2217,6 +2217,12 @@ int main (int argc, char *argv[])
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv,
                                                            numbers::invalid_unsigned_int);
+
+      // This program can only be run in serial. Otherwise, throw an exception.
+      int size;
+      MPI_Comm_size(MPI_COMM_WORLD,&size);
+      AssertThrow(size==1, ExcMessage("This program can only be run in serial,"
+                                      " use mpirun -np 1 ./step-31"));
 
       BoussinesqFlowProblem<2> flow_problem;
       flow_problem.run ();

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -865,18 +865,20 @@ namespace Step32
     // happen to use the same class names for %parallel and sequential data
     // structures, i.e., all matrices will actually be considered %parallel
     // below. On the other hand, for vectors, only those from namespace
-    // TrilinosWrappers::MPI are actually distributed. In particular, we will
-    // frequently have to query velocities and temperatures at arbitrary
-    // quadrature points; consequently, rather than importing ghost
-    // information of a vector whenever we need access to degrees of freedom
-    // that are relevant locally but owned by another processor, we solve
-    // linear systems in %parallel but then immediately initialize a vector
-    // including ghost entries of the solution for further processing. The
-    // various <code>*_solution</code> vectors are therefore filled
-    // immediately after solving their respective linear system in %parallel
-    // and will always contain values for all @ref GlossLocallyRelevantDof
-    // "locally relevant degrees of freedom"; the fully distributed vectors
-    // that we obtain from the solution process and that only ever contain the
+    // TrilinosWrappers::MPI are actually distributed (be aware that
+    // TrilinosWrappers::Vector and TrilinosWrappers::BlockVector are
+    // deprecated). In particular, we will frequently have to query velocities
+    // and temperatures at arbitrary quadrature points; consequently, rather
+    // than importing ghost information of a vector whenever we need access
+    // to degrees of freedom that are relevant locally but owned by another
+    // processor, we solve linear systems in %parallel but then immediately
+    // initialize a vector including ghost entries of the solution for further
+    // processing. The various <code>*_solution</code> vectors are therefore
+    // filled immediately after solving their respective linear system in
+    // %parallel and will always contain values for all
+    // @ref GlossLocallyRelevantDof "locally relevant degrees of freedom";
+    // the fully distributed vectors that we obtain from the solution process
+    // and that only ever contain the
     // @ref GlossLocallyOwnedDof "locally owned degrees of freedom" are
     // destroyed immediately after the solution process and after we have
     // copied the relevant values into the member variable vectors.

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -861,13 +861,8 @@ namespace Step32
     // - In a bit of naming confusion, you will notice below that some of the
     // variables from namespace TrilinosWrappers are taken from namespace
     // TrilinosWrappers::MPI (such as the right hand side vectors) whereas
-    // others are not (such as the various matrices). For the matrices, we
-    // happen to use the same class names for %parallel and sequential data
-    // structures, i.e., all matrices will actually be considered %parallel
-    // below. On the other hand, for vectors, only those from namespace
-    // TrilinosWrappers::MPI are actually distributed (be aware that
-    // TrilinosWrappers::Vector and TrilinosWrappers::BlockVector are
-    // deprecated). In particular, we will frequently have to query velocities
+    // others are not (such as the various matrices). This is due to legacy
+    // reasons. We will frequently have to query velocities
     // and temperatures at arbitrary quadrature points; consequently, rather
     // than importing ghost information of a vector whenever we need access
     // to degrees of freedom that are relevant locally but owned by another

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -481,7 +481,7 @@ int main (int argc, char **argv)
 
       // This program can only be run in serial. Otherwise, throw an exception.
       AssertThrow(Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)==1,
-                  ExcMessage("This program can only be run in serial, use mpirun -np 1 ./step-36"));
+                  ExcMessage("This program can only be run in serial, use ./step-36"));
 
       {
         deallog.depth_console (0);

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -197,10 +197,10 @@ namespace Step36
     // The next step is to take care of the eigenspectrum. In this case, the
     // outputs are eigenvalues and eigenfunctions, so we set the size of the
     // list of eigenfunctions and eigenvalues to be as large as we asked for
-    // in the input file. When using a PETScWrappers::MPI::Vector, the Vector 
+    // in the input file. When using a PETScWrappers::MPI::Vector, the Vector
     // is initialized using an IndexSet. IndexSet is used not only to resize the
-    // PETScWrappers::MPI::Vector but it also associates an index in the 
-    // PETScWrappers::MPI::Vector with a degree of freedom (see step-40 for a 
+    // PETScWrappers::MPI::Vector but it also associates an index in the
+    // PETScWrappers::MPI::Vector with a degree of freedom (see step-40 for a
     // more detailed explanation). This assocation is done by the add_range()
     // function:
     IndexSet eigenfunction_index_set(dof_handler.n_dofs ());
@@ -476,6 +476,13 @@ int main (int argc, char **argv)
       using namespace Step36;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      // This program can only be run in serial. Otherwise, throw an exception.
+      int size;
+      MPI_Comm_size(MPI_COMM_WORLD,&size);
+      AssertThrow(size==1, ExcMessage("This program can only be run in serial,"
+                                      " use mpirun -np 1 ./step-36"));
+
       {
         deallog.depth_console (0);
 

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -205,11 +205,11 @@ namespace Step36
     // an IndexSet where every valid index is part of the set. Note that this
     // program can only be run sequentially and will throw an exception if used
     // in parallel.
-    IndexSet eigenfunction_partitioning = complete_index_set(dof_handler.n_dofs ());
+    IndexSet eigenfunction_index_set = dof_handler.locally_owned_dofs ();
     eigenfunctions
     .resize (parameters.get_integer ("Number of eigenvalues/eigenfunctions"));
     for (unsigned int i=0; i<eigenfunctions.size (); ++i)
-      eigenfunctions[i].reinit (eigenfunction_partitioning, MPI_COMM_WORLD);
+      eigenfunctions[i].reinit (eigenfunction_index_set, MPI_COMM_WORLD);
 
     eigenvalues.resize (eigenfunctions.size ());
   }

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -168,9 +168,9 @@ namespace Step40
 
     ConstraintMatrix                          constraints;
 
-    LA::MPI::SparseMatrix system_matrix;
-    LA::MPI::Vector locally_relevant_solution;
-    LA::MPI::Vector system_rhs;
+    LA::MPI::SparseMatrix                     system_matrix;
+    LA::MPI::Vector                           locally_relevant_solution;
+    LA::MPI::Vector                           system_rhs;
 
     ConditionalOStream                        pcout;
     TimerOutput                               computing_timer;

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -674,7 +674,7 @@ int main (int argc, char *argv[])
 
       // This program can only be run in serial. Otherwise, throw an exception.
       AssertThrow(Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)==1,
-                  ExcMessage("This program can only be run in serial, use mpirun -np 1 ./step-41"));
+                  ExcMessage("This program can only be run in serial, use ./step-41"));
 
       ObstacleProblem<2> obstacle_problem;
       obstacle_problem.run ();

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -258,10 +258,10 @@ namespace Step41
 
     solution_index_set.set_size(dof_handler.n_dofs());
     solution_index_set.add_range(0, dof_handler.n_dofs());
-    solution.reinit (solution_index_set);
-    system_rhs.reinit (solution_index_set);
-    complete_system_rhs.reinit (solution_index_set);
-    contact_force.reinit (solution_index_set);
+    solution.reinit (solution_index_set, MPI_COMM_WORLD);
+    system_rhs.reinit (solution_index_set, MPI_COMM_WORLD);
+    complete_system_rhs.reinit (solution_index_set, MPI_COMM_WORLD);
+    contact_force.reinit (solution_index_set, MPI_COMM_WORLD);
 
     // The only other thing to do here is to compute the factors in the $B$
     // matrix which is used to scale the residual. As discussed in the
@@ -673,6 +673,12 @@ int main (int argc, char *argv[])
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv,
                                                            numbers::invalid_unsigned_int);
+
+      // This program can only be run in serial. Otherwise, throw an exception.
+      int size;
+      MPI_Comm_size(MPI_COMM_WORLD,&size);
+      AssertThrow(size==1, ExcMessage("This program can only be run in serial,"
+                                      " use mpirun -np 1 ./step-41"));
 
       ObstacleProblem<2> obstacle_problem;
       obstacle_problem.run ();

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -255,11 +255,11 @@ namespace Step41
     system_matrix.reinit (dsp);
     complete_system_matrix.reinit (dsp);
 
-    IndexSet solution_partitioning = complete_index_set(dof_handler.n_dofs());
-    solution.reinit (solution_partitioning, MPI_COMM_WORLD);
-    system_rhs.reinit (solution_partitioning, MPI_COMM_WORLD);
-    complete_system_rhs.reinit (solution_partitioning, MPI_COMM_WORLD);
-    contact_force.reinit (solution_partitioning, MPI_COMM_WORLD);
+    IndexSet solution_index_set = dof_handler.locally_owned_dofs();
+    solution.reinit (solution_index_set, MPI_COMM_WORLD);
+    system_rhs.reinit (solution_index_set, MPI_COMM_WORLD);
+    complete_system_rhs.reinit (solution_index_set, MPI_COMM_WORLD);
+    contact_force.reinit (solution_index_set, MPI_COMM_WORLD);
 
     // The only other thing to do here is to compute the factors in the $B$
     // matrix which is used to scale the residual. As discussed in the
@@ -269,7 +269,7 @@ namespace Step41
     TrilinosWrappers::SparseMatrix mass_matrix;
     mass_matrix.reinit (dsp);
     assemble_mass_matrix_diagonal (mass_matrix);
-    diagonal_of_mass_matrix.reinit (solution_partitioning);
+    diagonal_of_mass_matrix.reinit (solution_index_set);
     for (unsigned int j=0; j<solution.size (); j++)
       diagonal_of_mass_matrix (j) = mass_matrix.diag_element (j);
   }

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -448,8 +448,8 @@ namespace Step43
       a_preconditioner        (Apreconditioner)
     {
       IndexSet tmp_index_set(darcy_matrix->block(1,1).m());
-      tmp_index_set.add_range(0,darcy_matrix->block(1,1).m()); 
-      tmp.reinit(tmp_index_set);
+      tmp_index_set.add_range(0,darcy_matrix->block(1,1).m());
+      tmp.reinit(tmp_index_set, MPI_COMM_WORLD);
     }
 
 
@@ -814,28 +814,29 @@ namespace Step43
     darcy_index_set[1].set_size(n_p);
     darcy_index_set[0].add_range(0,n_u);
     darcy_index_set[1].add_range(0,n_p);
-    darcy_solution.reinit (darcy_index_set);
+    darcy_solution.reinit (darcy_index_set, MPI_COMM_WORLD);
     darcy_solution.collect_sizes ();
 
-    last_computed_darcy_solution.reinit (darcy_index_set);
+    last_computed_darcy_solution.reinit (darcy_index_set, MPI_COMM_WORLD);
     last_computed_darcy_solution.collect_sizes ();
 
-    second_last_computed_darcy_solution.reinit (darcy_index_set);
+    second_last_computed_darcy_solution.reinit (darcy_index_set, MPI_COMM_WORLD);
     second_last_computed_darcy_solution.collect_sizes ();
 
-    darcy_rhs.reinit (darcy_index_set);
+    darcy_rhs.reinit (darcy_index_set, MPI_COMM_WORLD);
     darcy_rhs.collect_sizes ();
 
     saturation_index_set.clear();
     saturation_index_set.set_size(n_s);
     saturation_index_set.add_range(0,n_s);
-    saturation_solution.reinit (saturation_index_set);
-    old_saturation_solution.reinit (saturation_index_set);
-    old_old_saturation_solution.reinit (saturation_index_set);
+    saturation_solution.reinit (saturation_index_set, MPI_COMM_WORLD);
+    old_saturation_solution.reinit (saturation_index_set, MPI_COMM_WORLD);
+    old_old_saturation_solution.reinit (saturation_index_set, MPI_COMM_WORLD);
 
-    saturation_matching_last_computed_darcy_solution.reinit (saturation_index_set);
+    saturation_matching_last_computed_darcy_solution.reinit (saturation_index_set,
+                                                             MPI_COMM_WORLD);
 
-    saturation_rhs.reinit (saturation_index_set);
+    saturation_rhs.reinit (saturation_index_set, MPI_COMM_WORLD);
   }
 
 
@@ -2259,6 +2260,12 @@ int main (int argc, char *argv[])
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv,
                                                            numbers::invalid_unsigned_int);
+
+      // This program can only be run in serial. Otherwise, throw an exception.
+      int size;
+      MPI_Comm_size(MPI_COMM_WORLD,&size);
+      AssertThrow(size==1, ExcMessage("This program can only be run in serial,"
+                                      " use mpirun -np 1 ./step-43"));
 
       TwoPhaseFlowProblem<2> two_phase_flow_problem(1);
       two_phase_flow_problem.run ();

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -2253,7 +2253,7 @@ int main (int argc, char *argv[])
 
       // This program can only be run in serial. Otherwise, throw an exception.
       AssertThrow(Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)==1,
-                  ExcMessage("This program can only be run in serial, use mpirun -np 1 ./step-43"));
+                  ExcMessage("This program can only be run in serial, use ./step-43"));
 
       TwoPhaseFlowProblem<2> two_phase_flow_problem(1);
       two_phase_flow_problem.run ();

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -43,6 +43,8 @@ namespace PETScWrappers
    * interface, this class handles the actual allocation of vectors and
    * provides functions that are specific to the underlying vector type.
    *
+   * This class is deprecated use PETScWrappers::MPI::BlockVector.
+   *
    * @ingroup Vectors
    *
    * @see
@@ -85,13 +87,13 @@ namespace PETScWrappers
      * of different sizes.
      */
     explicit BlockVector (const unsigned int num_blocks = 0,
-                          const size_type    block_size = 0);
+                          const size_type    block_size = 0) DEAL_II_DEPRECATED;
 
     /**
      * Copy-Constructor. Dimension set to that of V, all components are copied
      * from V
      */
-    BlockVector (const BlockVector  &V);
+    BlockVector (const BlockVector  &V) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor: copy the values from a PETSc wrapper parallel block
@@ -103,13 +105,13 @@ namespace PETScWrappers
      * It is not sufficient if only one processor tries to copy the elements
      * from the other processors over to its own process space.
      */
-    explicit BlockVector (const MPI::BlockVector &v);
+    explicit BlockVector (const MPI::BlockVector &v) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt> and
      * initialize each block with <tt>n[i]</tt> zero elements.
      */
-    BlockVector (const std::vector<size_type> &n);
+    BlockVector (const std::vector<size_type> &n) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
@@ -122,7 +124,7 @@ namespace PETScWrappers
     template <typename InputIterator>
     BlockVector (const std::vector<size_type> &n,
                  const InputIterator           first,
-                 const InputIterator           end);
+                 const InputIterator           end) DEAL_II_DEPRECATED;
 
     /**
      * Destructor. Clears memory

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -43,7 +43,7 @@ namespace PETScWrappers
    * interface, this class handles the actual allocation of vectors and
    * provides functions that are specific to the underlying vector type.
    *
-   * This class is deprecated use PETScWrappers::MPI::BlockVector.
+   * This class is deprecated, use PETScWrappers::MPI::BlockVector.
    *
    * @ingroup Vectors
    *
@@ -87,13 +87,13 @@ namespace PETScWrappers
      * of different sizes.
      */
     explicit BlockVector (const unsigned int num_blocks = 0,
-                          const size_type    block_size = 0) DEAL_II_DEPRECATED;
+                          const size_type    block_size = 0);
 
     /**
      * Copy-Constructor. Dimension set to that of V, all components are copied
      * from V
      */
-    BlockVector (const BlockVector  &V) DEAL_II_DEPRECATED;
+    BlockVector (const BlockVector  &V);
 
     /**
      * Copy-constructor: copy the values from a PETSc wrapper parallel block
@@ -105,13 +105,13 @@ namespace PETScWrappers
      * It is not sufficient if only one processor tries to copy the elements
      * from the other processors over to its own process space.
      */
-    explicit BlockVector (const MPI::BlockVector &v) DEAL_II_DEPRECATED;
+    explicit BlockVector (const MPI::BlockVector &v);
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt> and
      * initialize each block with <tt>n[i]</tt> zero elements.
      */
-    BlockVector (const std::vector<size_type> &n) DEAL_II_DEPRECATED;
+    BlockVector (const std::vector<size_type> &n);
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
@@ -124,7 +124,7 @@ namespace PETScWrappers
     template <typename InputIterator>
     BlockVector (const std::vector<size_type> &n,
                  const InputIterator           first,
-                 const InputIterator           end) DEAL_II_DEPRECATED;
+                 const InputIterator           end);
 
     /**
      * Destructor. Clears memory
@@ -244,7 +244,7 @@ namespace PETScWrappers
      */
     DeclException0 (ExcIteratorRangeDoesNotMatchVectorSize);
     ///@}
-  };
+  } DEAL_II_DEPRECATED;
 
   /*@}*/
 

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -45,6 +45,8 @@ namespace PETScWrappers
    * virtual functions). Only the functions creating a vector of specific type
    * differ, and are implemented in this particular class.
    *
+   * This class is deprecated use PETScWrappers::MPI::Vector instead.
+   *
    * @ingroup Vectors
    * @author Wolfgang Bangerth, 2004
    */
@@ -71,7 +73,7 @@ namespace PETScWrappers
     /**
      * Default constructor. Initialize the vector as empty.
      */
-    Vector ();
+    Vector () DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set dimension to @p n and initialize all elements with
@@ -83,14 +85,14 @@ namespace PETScWrappers
      * <tt>v=Vector@<number@>(0);</tt>, i.e. the vector is replaced by one of
      * length zero.
      */
-    explicit Vector (const size_type n);
+    explicit Vector (const size_type n) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor from deal.II vectors. Sets the dimension to that of
      * the given vector, and copies all elements.
      */
     template <typename Number>
-    explicit Vector (const dealii::Vector<Number> &v);
+    explicit Vector (const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
 
     /**
      * Construct it from an existing PETSc Vector of type Vec. Note: this does
@@ -98,12 +100,12 @@ namespace PETScWrappers
      * the vector is not used twice at the same time or destroyed while in
      * use. This class does not destroy the PETSc object. Handle with care!
      */
-    explicit Vector (const Vec &v);
+    explicit Vector (const Vec &v) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor the values from a PETSc wrapper vector class.
      */
-    Vector (const Vector &v);
+    Vector (const Vector &v) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor: copy the values from a PETSc wrapper parallel vector
@@ -114,7 +116,7 @@ namespace PETScWrappers
      * It is not sufficient if only one processor tries to copy the elements
      * from the other processors over to its own process space.
      */
-    explicit Vector (const MPI::Vector &v);
+    explicit Vector (const MPI::Vector &v) DEAL_II_DEPRECATED;
 
     /**
      * Copy the given vector. Resize the present vector if necessary.

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -45,7 +45,7 @@ namespace PETScWrappers
    * virtual functions). Only the functions creating a vector of specific type
    * differ, and are implemented in this particular class.
    *
-   * This class is deprecated use PETScWrappers::MPI::Vector instead.
+   * This class is deprecated, use PETScWrappers::MPI::Vector instead.
    *
    * @ingroup Vectors
    * @author Wolfgang Bangerth, 2004
@@ -73,7 +73,7 @@ namespace PETScWrappers
     /**
      * Default constructor. Initialize the vector as empty.
      */
-    Vector () DEAL_II_DEPRECATED;
+    Vector ();
 
     /**
      * Constructor. Set dimension to @p n and initialize all elements with
@@ -85,14 +85,14 @@ namespace PETScWrappers
      * <tt>v=Vector@<number@>(0);</tt>, i.e. the vector is replaced by one of
      * length zero.
      */
-    explicit Vector (const size_type n) DEAL_II_DEPRECATED;
+    explicit Vector (const size_type n);
 
     /**
      * Copy-constructor from deal.II vectors. Sets the dimension to that of
      * the given vector, and copies all elements.
      */
     template <typename Number>
-    explicit Vector (const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
+    explicit Vector (const dealii::Vector<Number> &v);
 
     /**
      * Construct it from an existing PETSc Vector of type Vec. Note: this does
@@ -100,12 +100,12 @@ namespace PETScWrappers
      * the vector is not used twice at the same time or destroyed while in
      * use. This class does not destroy the PETSc object. Handle with care!
      */
-    explicit Vector (const Vec &v) DEAL_II_DEPRECATED;
+    explicit Vector (const Vec &v);
 
     /**
      * Copy-constructor the values from a PETSc wrapper vector class.
      */
-    Vector (const Vector &v) DEAL_II_DEPRECATED;
+    Vector (const Vector &v);
 
     /**
      * Copy-constructor: copy the values from a PETSc wrapper parallel vector
@@ -116,7 +116,7 @@ namespace PETScWrappers
      * It is not sufficient if only one processor tries to copy the elements
      * from the other processors over to its own process space.
      */
-    explicit Vector (const MPI::Vector &v) DEAL_II_DEPRECATED;
+    explicit Vector (const MPI::Vector &v);
 
     /**
      * Copy the given vector. Resize the present vector if necessary.
@@ -183,7 +183,7 @@ namespace PETScWrappers
      * vector. @p n denotes the total size of the vector to be created.
      */
     void create_vector (const size_type n);
-  };
+  } DEAL_II_DEPRECATED;
 
   /*@}*/
 

--- a/include/deal.II/lac/trilinos_block_vector.h
+++ b/include/deal.II/lac/trilinos_block_vector.h
@@ -59,7 +59,7 @@ namespace TrilinosWrappers
    * block vector class do only work in case the program is run on only one
    * processor, since the Trilinos matrices are inherently parallel.
    *
-   * This class is deprecated use TrilinosWrappers::MPI::BlockVector instead.
+   * This class is deprecated, use TrilinosWrappers::MPI::BlockVector instead.
    *
    * @ingroup Vectors
    * @ingroup TrilinosWrappers @see
@@ -94,14 +94,14 @@ namespace TrilinosWrappers
     /**
      * Default constructor. Generate an empty vector without any blocks.
      */
-    BlockVector () DEAL_II_DEPRECATED;
+    BlockVector ();
 
     /**
      * Constructor. Generate a block vector with as many blocks as there are
      * entries in Input_Maps.  For this non-distributed vector, the %parallel
      * partitioning is not used, just the global size of the partitioner.
      */
-    explicit BlockVector (const std::vector<Epetra_Map> &partitioner) DEAL_II_DEPRECATED;
+    explicit BlockVector (const std::vector<Epetra_Map> &partitioner);
 
     /**
      * Constructor. Generate a block vector with as many blocks as there are
@@ -109,26 +109,26 @@ namespace TrilinosWrappers
      * partitioning is not used, just the global size of the partitioner.
      */
     explicit BlockVector (const std::vector<IndexSet> &partitioner,
-                          const MPI_Comm              &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
+                          const MPI_Comm              &communicator = MPI_COMM_WORLD);
 
     /**
      * Copy-Constructor. Set all the properties of the non-%parallel vector to
      * those of the given %parallel vector and import the elements.
      */
-    BlockVector (const MPI::BlockVector &V) DEAL_II_DEPRECATED;
+    BlockVector (const MPI::BlockVector &V);
 
     /**
      * Copy-Constructor. Set all the properties of the vector to those of the
      * given input vector and copy the elements.
      */
-    BlockVector (const BlockVector  &V) DEAL_II_DEPRECATED;
+    BlockVector (const BlockVector  &V);
 
     /**
      * Creates a block vector consisting of <tt>num_blocks</tt> components,
      * but there is no content in the individual components and the user has
      * to fill appropriate data using a reinit of the blocks.
      */
-    explicit BlockVector (const size_type num_blocks) DEAL_II_DEPRECATED;
+    explicit BlockVector (const size_type num_blocks);
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt> and
@@ -136,7 +136,7 @@ namespace TrilinosWrappers
      *
      * References BlockVector.reinit().
      */
-    explicit BlockVector (const std::vector<size_type> &N) DEAL_II_DEPRECATED;
+    explicit BlockVector (const std::vector<size_type> &N);
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
@@ -149,7 +149,7 @@ namespace TrilinosWrappers
     template <typename InputIterator>
     BlockVector (const std::vector<size_type> &n,
                  const InputIterator           first,
-                 const InputIterator           end) DEAL_II_DEPRECATED;
+                 const InputIterator           end);
 
     /**
      * Destructor. Clears memory
@@ -303,7 +303,7 @@ namespace TrilinosWrappers
                     << "local_size = global_size is a necessary condition, but"
                     << arg1 << " != " << arg2 << " was given!");
 
-  };
+  } DEAL_II_DEPRECATED;
 
 
 

--- a/include/deal.II/lac/trilinos_block_vector.h
+++ b/include/deal.II/lac/trilinos_block_vector.h
@@ -101,7 +101,7 @@ namespace TrilinosWrappers
      * entries in Input_Maps.  For this non-distributed vector, the %parallel
      * partitioning is not used, just the global size of the partitioner.
      */
-    explicit BlockVector (const std::vector<Epetra_Map> &partitioner);
+    explicit BlockVector (const std::vector<Epetra_Map> &partitioner DEAL_II_DEPRECATED);
 
     /**
      * Constructor. Generate a block vector with as many blocks as there are
@@ -109,26 +109,26 @@ namespace TrilinosWrappers
      * partitioning is not used, just the global size of the partitioner.
      */
     explicit BlockVector (const std::vector<IndexSet> &partitioner,
-                          const MPI_Comm              &communicator = MPI_COMM_WORLD);
+                          const MPI_Comm              &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
 
     /**
      * Copy-Constructor. Set all the properties of the non-%parallel vector to
      * those of the given %parallel vector and import the elements.
      */
-    BlockVector (const MPI::BlockVector &V);
+    BlockVector (const MPI::BlockVector &V) DEAL_II_DEPRECATED;
 
     /**
      * Copy-Constructor. Set all the properties of the vector to those of the
      * given input vector and copy the elements.
      */
-    BlockVector (const BlockVector  &V);
+    BlockVector (const BlockVector  &V) DEAL_II_DEPRECATED;
 
     /**
      * Creates a block vector consisting of <tt>num_blocks</tt> components,
      * but there is no content in the individual components and the user has
      * to fill appropriate data using a reinit of the blocks.
      */
-    explicit BlockVector (const size_type num_blocks);
+    explicit BlockVector (const size_type num_blocks) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt> and
@@ -136,7 +136,7 @@ namespace TrilinosWrappers
      *
      * References BlockVector.reinit().
      */
-    explicit BlockVector (const std::vector<size_type> &N);
+    explicit BlockVector (const std::vector<size_type> &N) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
@@ -149,7 +149,7 @@ namespace TrilinosWrappers
     template <typename InputIterator>
     BlockVector (const std::vector<size_type> &n,
                  const InputIterator           first,
-                 const InputIterator           end);
+                 const InputIterator           end) DEAL_II_DEPRECATED;
 
     /**
      * Destructor. Clears memory
@@ -303,7 +303,7 @@ namespace TrilinosWrappers
                     << "local_size = global_size is a necessary condition, but"
                     << arg1 << " != " << arg2 << " was given!");
 
-  } DEAL_II_DEPRECATED;
+  };
 
 
 

--- a/include/deal.II/lac/trilinos_block_vector.h
+++ b/include/deal.II/lac/trilinos_block_vector.h
@@ -59,6 +59,8 @@ namespace TrilinosWrappers
    * block vector class do only work in case the program is run on only one
    * processor, since the Trilinos matrices are inherently parallel.
    *
+   * This class is deprecated use TrilinosWrappers::MPI::BlockVector instead.
+   *
    * @ingroup Vectors
    * @ingroup TrilinosWrappers @see
    * @ref GlossBlockLA "Block (linear algebra)"
@@ -92,14 +94,14 @@ namespace TrilinosWrappers
     /**
      * Default constructor. Generate an empty vector without any blocks.
      */
-    BlockVector ();
+    BlockVector () DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Generate a block vector with as many blocks as there are
      * entries in Input_Maps.  For this non-distributed vector, the %parallel
      * partitioning is not used, just the global size of the partitioner.
      */
-    explicit BlockVector (const std::vector<Epetra_Map> &partitioner);
+    explicit BlockVector (const std::vector<Epetra_Map> &partitioner) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Generate a block vector with as many blocks as there are
@@ -107,26 +109,26 @@ namespace TrilinosWrappers
      * partitioning is not used, just the global size of the partitioner.
      */
     explicit BlockVector (const std::vector<IndexSet> &partitioner,
-                          const MPI_Comm              &communicator = MPI_COMM_WORLD);
+                          const MPI_Comm              &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
 
     /**
      * Copy-Constructor. Set all the properties of the non-%parallel vector to
      * those of the given %parallel vector and import the elements.
      */
-    BlockVector (const MPI::BlockVector &V);
+    BlockVector (const MPI::BlockVector &V) DEAL_II_DEPRECATED;
 
     /**
      * Copy-Constructor. Set all the properties of the vector to those of the
      * given input vector and copy the elements.
      */
-    BlockVector (const BlockVector  &V);
+    BlockVector (const BlockVector  &V) DEAL_II_DEPRECATED;
 
     /**
      * Creates a block vector consisting of <tt>num_blocks</tt> components,
      * but there is no content in the individual components and the user has
      * to fill appropriate data using a reinit of the blocks.
      */
-    explicit BlockVector (const size_type num_blocks);
+    explicit BlockVector (const size_type num_blocks) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt> and
@@ -134,7 +136,7 @@ namespace TrilinosWrappers
      *
      * References BlockVector.reinit().
      */
-    explicit BlockVector (const std::vector<size_type> &N);
+    explicit BlockVector (const std::vector<size_type> &N) DEAL_II_DEPRECATED;
 
     /**
      * Constructor. Set the number of blocks to <tt>n.size()</tt>. Initialize
@@ -147,7 +149,7 @@ namespace TrilinosWrappers
     template <typename InputIterator>
     BlockVector (const std::vector<size_type> &n,
                  const InputIterator           first,
-                 const InputIterator           end);
+                 const InputIterator           end) DEAL_II_DEPRECATED;
 
     /**
      * Destructor. Clears memory

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -710,7 +710,7 @@ namespace TrilinosWrappers
    * in order to be able to access all elements in the vector or to apply
    * certain deal.II functions.
    *
-   * This class is deprecated use TrilinosWrappers::MPI::Vector instead.
+   * This class is deprecated, use TrilinosWrappers::MPI::Vector instead.
    *
    * @ingroup TrilinosWrappers
    * @ingroup Vectors
@@ -741,12 +741,12 @@ namespace TrilinosWrappers
      * function <tt>reinit()</tt> will have to give the vector the correct
      * size.
      */
-    Vector () DEAL_II_DEPRECATED;
+    Vector ();
 
     /**
      * This constructor takes as input the number of elements in the vector.
      */
-    explicit Vector (const size_type n) DEAL_II_DEPRECATED;
+    explicit Vector (const size_type n);
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -757,7 +757,7 @@ namespace TrilinosWrappers
      * ignored, the only thing that matters is the size of the index space
      * described by this argument.
      */
-    explicit Vector (const Epetra_Map &partitioning) DEAL_II_DEPRECATED;
+    explicit Vector (const Epetra_Map &partitioning);
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -769,20 +769,20 @@ namespace TrilinosWrappers
      * size of the index space described by this argument.
      */
     explicit Vector (const IndexSet &partitioning,
-                     const MPI_Comm &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
+                     const MPI_Comm &communicator = MPI_COMM_WORLD);
 
     /**
      * This constructor takes a (possibly parallel) Trilinos Vector and
      * generates a localized version of the whole content on each processor.
      */
-    explicit Vector (const VectorBase &V) DEAL_II_DEPRECATED;
+    explicit Vector (const VectorBase &V);
 
     /**
      * Copy-constructor from deal.II vectors. Sets the dimension to that of
      * the given vector, and copies all elements.
      */
     template <typename Number>
-    explicit Vector (const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
+    explicit Vector (const dealii::Vector<Number> &v);
 
     /**
      * Reinit function that resizes the vector to the size specified by
@@ -870,7 +870,7 @@ namespace TrilinosWrappers
      * thus an empty function.
      */
     void update_ghost_values () const;
-  };
+  } DEAL_II_DEPRECATED;
 
 
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -757,7 +757,7 @@ namespace TrilinosWrappers
      * ignored, the only thing that matters is the size of the index space
      * described by this argument.
      */
-    explicit Vector (Const Epetra_Map &partitioning) DEAL_II_DEPRECATED;
+    explicit Vector (const Epetra_Map &partitioning) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -710,6 +710,8 @@ namespace TrilinosWrappers
    * in order to be able to access all elements in the vector or to apply
    * certain deal.II functions.
    *
+   * This class is deprecated use TrilinosWrappers::MPI::Vector instead.
+   *
    * @ingroup TrilinosWrappers
    * @ingroup Vectors
    * @author Martin Kronbichler, 2008
@@ -739,12 +741,12 @@ namespace TrilinosWrappers
      * function <tt>reinit()</tt> will have to give the vector the correct
      * size.
      */
-    Vector ();
+    Vector () DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
      */
-    explicit Vector (const size_type n);
+    explicit Vector (const size_type n) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -755,7 +757,7 @@ namespace TrilinosWrappers
      * ignored, the only thing that matters is the size of the index space
      * described by this argument.
      */
-    explicit Vector (const Epetra_Map &partitioning);
+    explicit Vector (const Epetra_Map &partitioning) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -767,20 +769,20 @@ namespace TrilinosWrappers
      * size of the index space described by this argument.
      */
     explicit Vector (const IndexSet &partitioning,
-                     const MPI_Comm &communicator = MPI_COMM_WORLD);
+                     const MPI_Comm &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes a (possibly parallel) Trilinos Vector and
      * generates a localized version of the whole content on each processor.
      */
-    explicit Vector (const VectorBase &V);
+    explicit Vector (const VectorBase &V) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor from deal.II vectors. Sets the dimension to that of
      * the given vector, and copies all elements.
      */
     template <typename Number>
-    explicit Vector (const dealii::Vector<Number> &v);
+    explicit Vector (const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
 
     /**
      * Reinit function that resizes the vector to the size specified by

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -741,12 +741,12 @@ namespace TrilinosWrappers
      * function <tt>reinit()</tt> will have to give the vector the correct
      * size.
      */
-    Vector ();
+    Vector () DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
      */
-    explicit Vector (const size_type n);
+    explicit Vector (const size_type n) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -757,7 +757,7 @@ namespace TrilinosWrappers
      * ignored, the only thing that matters is the size of the index space
      * described by this argument.
      */
-    explicit Vector (const Epetra_Map &partitioning);
+    explicit Vector (Const Epetra_Map &partitioning) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes as input the number of elements in the vector.
@@ -769,20 +769,20 @@ namespace TrilinosWrappers
      * size of the index space described by this argument.
      */
     explicit Vector (const IndexSet &partitioning,
-                     const MPI_Comm &communicator = MPI_COMM_WORLD);
+                     const MPI_Comm &communicator = MPI_COMM_WORLD) DEAL_II_DEPRECATED;
 
     /**
      * This constructor takes a (possibly parallel) Trilinos Vector and
      * generates a localized version of the whole content on each processor.
      */
-    explicit Vector (const VectorBase &V);
+    explicit Vector (const VectorBase &V) DEAL_II_DEPRECATED;
 
     /**
      * Copy-constructor from deal.II vectors. Sets the dimension to that of
      * the given vector, and copies all elements.
      */
     template <typename Number>
-    explicit Vector (const dealii::Vector<Number> &v);
+    explicit Vector (const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
 
     /**
      * Reinit function that resizes the vector to the size specified by
@@ -870,7 +870,7 @@ namespace TrilinosWrappers
      * thus an empty function.
      */
     void update_ghost_values () const;
-  } DEAL_II_DEPRECATED;
+  };
 
 
 


### PR DESCRIPTION
This should close #684. I have deprecated TrilinosWrappers::Vector, TrilinosWrappers::BlockVector, PETScWrappers::Vector, and PETScWrappers::BlockVector by deprecating all the constructors. I have also changed the tutorials so they don't use the deprecated classes. I haven't deprecated any function in dealii::Vector. The issue was open to make it easier to add vectors from new libraries but since we only use our own vector in serial, I don't think that we need to deprecate anything in dealii::Vector. Let me know if you disagree.