### PR TITLE
Consistent logical operators

### DIFF
--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -60,6 +60,10 @@ style guidelines outlined in this page.</p>
   functions which clear bits of flags should be named <code>clear_*</code>.
   Example: CellIterator::set_refine_flag().</li>
 
+<li> Traditional logical operators should be used instead of their English
+  equivalents (i.e., use <code>&&</code>, <code>||</code>, and <code>!</code>
+  instead of <code>and</code>, <code>or</code>, and <code>not</code>).
+
 <li> In the implementation files, after each function, at least three
   empty lines are expected to
   enable better readability. One empty line occurs in functions to

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -121,18 +121,18 @@ TriaRawIterator<Accessor>::operator = (const TriaRawIterator<Accessor> &i)
 template <typename Accessor>
 inline
 bool
-TriaRawIterator<Accessor>::operator == (const TriaRawIterator<Accessor> &i) const
+TriaRawIterator<Accessor>::operator == (const TriaRawIterator<Accessor> &other) const
 {
-  return accessor == i.accessor;
+  return accessor == other.accessor;
 }
 
 
 template <typename Accessor>
 inline
 bool
-TriaRawIterator<Accessor>::operator != (const TriaRawIterator<Accessor> &i) const
+TriaRawIterator<Accessor>::operator != (const TriaRawIterator<Accessor> &other) const
 {
-  return not (*this == i);
+  return ! (*this == other);
 }
 
 


### PR DESCRIPTION
This is in response to @tjhei's remark under #878. Specifically, deal.II consistently uses `&&`, `||`, and `!` but this is not mentioned in the coding conventions.