### PR TITLE
Rewrite the ArpackSolver interface

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,11 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li>Changed: The ArpackSolver::solve() interface takes different arguments.
+  <br>
+  (Guido Kanschat, Matthias Maier, 2015/05/01)
+  </li>
+
   <li>Removed: The generic, templated vmult, Tvmult, etc. -interfaces of
   LAPACKFullMatrix - they were never implemented.
   <br>
@@ -472,6 +477,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li>Fixed: A number of issues with the ArpackSolver class have been
+  resolved. It now computes correct eigenvectors, has a compatible
+  interface with LinearOperator, and a rewritten implementation
+  <br>
+  (Guido Kanschat, Matthias Maier, 2015/05/01)
+  </li>
+
   <li> New: Introduce DoFRenumbering::block_wise for multigrid computation.
   <br>
   (Timo Heister, Florian Sonner, 2015/04/30)

--- a/examples/step-36/doc/results.dox
+++ b/examples/step-36/doc/results.dox
@@ -258,19 +258,15 @@ For solving the eigenvalue problem with ARPACK, we finally need to modify
     SparseDirectUMFPACK inverse;
     inverse.initialize (stiffness_matrix);
 
-    const unsigned int num_arnoldi_vectors = 2*eigenvalues.size() + 2;
-    ArpackSolver::AdditionalData additional_data(num_arnoldi_vectors);
-
-    ArpackSolver eigensolver (solver_control, additional_data);
-    eigensolver.solve (stiffness_matrix,
-                       mass_matrix,
+    ArpackSolver eigensolver (solver_control);
+    eigensolver.solve (mass_matrix,
                        inverse,
                        eigenvalues,
-                       eigenfunctions,
-                       eigenvalues.size());
+                       eigenfunctions);
 
     for (unsigned int i=0; i<eigenfunctions.size(); ++i)
-      eigenfunctions[i] /= eigenfunctions[i].linfty_norm ();
+      if (eigenfunctions[i].linfty_norm () != 0)
+        eigenfunctions[i] /= eigenfunctions[i].linfty_norm ();
 
     return solver_control.last_step ();
   }

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -19,73 +19,81 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector_memory.h>
 
 #include <cstring>
-
 
 #ifdef DEAL_II_WITH_ARPACK
 
 DEAL_II_NAMESPACE_OPEN
 
 
-extern "C" void dnaupd_(int *ido, char *bmat, const unsigned int *n, char *which,
-                        const unsigned int *nev, const double *tol, double *resid, int *ncv,
-                        double *v, int *ldv, int *iparam, int *ipntr,
-                        double *workd, double *workl, int *lworkl,
-                        int *info);
+extern "C" void dnaupd_(int *ido, const char *bmat, const unsigned int *n,
+                        const char *which, const unsigned int *nev, const
+                        double *tol, double *resid, const unsigned int
+                        *ncv, double *v, const unsigned int *ldv, int
+                        *iparam, int *ipntr, double *workd, double *workl,
+                        int *lworkl, int *info);
 
-extern "C" void dneupd_(int *rvec, char *howmany, int *select, double *d,
-                        double *di, double *z, int *ldz, double *sigmar,
-                        double *sigmai, double *workev, char *bmat,const unsigned int *n, char *which,
-                        const unsigned int *nev, const double *tol, double *resid, int *ncv,
-                        double *v, int *ldv, int *iparam, int *ipntr,
-                        double *workd, double *workl, int *lworkl, int *info);
+extern "C" void dneupd_(int *rvec, const char *howmany, const int *select,
+                        double *d, double *di, double *z, const unsigned
+                        int *ldz, double *sigmar, double *sigmai, double
+                        *workev, const char *bmat, const unsigned int *n,
+                        const char *which, const unsigned int *nev, const
+                        double *tol, double *resid, const unsigned int
+                        *ncv, double *v, const unsigned int *ldv, int
+                        *iparam, int *ipntr, double *workd, double *workl,
+                        int *lworkl, int *info);
+
 
 /**
- * Interface for using ARPACK. ARPACK is a collection of Fortran77 subroutines
- * designed to solve large scale eigenvalue problems.  Here we interface to
- * the routines <code>dneupd</code> and <code>dnaupd</code> of ARPACK.  The
- * package is designed to compute a few eigenvalues and corresponding
- * eigenvectors of a general n by n matrix A. It is most appropriate for large
- * sparse matrices A.
+ * Interface for using ARPACK. ARPACK is a collection of Fortran77
+ * subroutines designed to solve large scale eigenvalue problems.  Here we
+ * interface to the routines <code>dneupd</code> and <code>dnaupd</code> of
+ * ARPACK. The package is designed to compute a few eigenvalues and
+ * corresponding eigenvectors of a general $n\times n$ matrix A. It is most
+ * appropriate for large sparse matrices A.
  *
  * In this class we make use of the method applied to the generalized
  * eigenspectrum problem $(A-\lambda B)x=0$, for $x\neq0$; where $A$ is a
  * system matrix, $B$ is a mass matrix, and $\lambda, x$ are a set of
  * eigenvalues and eigenvectors respectively.
  *
- * The ArpackSolver can be used in application codes with serial objects in
- * the following way:
+ * As an example, the ArpackSolver can be used to compute 10 eigenvalues for
+ * the generalized eigenvalue problem $Ax=\lambda Bx$ in the following way:
  * @code
- * SolverControl solver_control (1000, 1e-9);
- * ArpackSolver (solver_control);
- * system.solve (A, B, OP, lambda, x, size_of_spectrum);
- * @endcode
- * for the generalized eigenvalue problem $Ax=B\lambda x$, where the variable
- * <code>size_of_spectrum</code> tells ARPACK the number of
- * eigenvector/eigenvalue pairs to solve for. Here, <code>lambda</code> is a
- * vector that will contain the eigenvalues computed, <code>x</code> a vector
- * that will contain the eigenvectors computed, and <code>OP</code> is an
- * inverse operation for the matrix <code>A</code>. Shift and invert
- * transformation around zero is applied.
+ * SolverControl solver_control(1000, 1e-9);
+ * ArpackSolver arpack_solver(solver_control);
  *
- * Through the AdditionalData the user can specify some of the parameters to
- * be set.
+ * std::vector<std::complex<double> > eigenvalues(10);
+ * std::vector<Vector<double> > eigenvectors(20);
+ * for (std::vector::size_type i = 0; i < eigenvectors.size; i++)
+ *   {
+ *     eigenvectors[i].reinit(...); // system size, e.g. n_dofs
+ *   }
+ * arpack_solver.solve (B, OP, eigenvalues, eigenvectors);
+ * @endcode
+ * Here, <code>eigenvalues</code> is a vector that will contain the computed
+ * eigenvalues and <code>eigenvectors</code> is a vector that will contain
+ * the computed eigenvectors; the first half containing the real parts, the
+ * second half containing the imaginary parts of the eigenvectors.
+ *
+ * <code>OP</code> is an inverse operation for the matrix <code>A</code>.
+ * Shift and invert transformation around zero is applied.
  *
  * For further information on how the ARPACK routines <code>dneupd</code> and
  * <code>dnaupd</code> work and also how to set the parameters appropriately
  * please take a look into the ARPACK manual.
  *
- * @note Whenever you eliminate degrees of freedom using
- * ConstraintMatrix, you generate spurious eigenvalues and
- * eigenvectors. If you make sure that the diagonals of eliminated
- * matrix rows are all equal to one, you get a single additional
- * eigenvalue. But beware that some functions in deal.II set these
- * diagonals to rather arbitrary (from the point of view of
- * eigenvalue problems) values. See also @ref step_36 "step-36" for an
- * example.
+ * @note Whenever you eliminate degrees of freedom using ConstraintMatrix,
+ * you generate spurious eigenvalues and eigenvectors. If you make sure
+ * that the diagonals of eliminated matrix rows are all equal to one, you
+ * get a single additional eigenvalue. But beware that some functions in
+ * deal.II set these diagonals to rather arbitrary (from the point of view
+ * of eigenvalue problems) values. See also step-36 for an example.
  *
- * @author Baerbel Janssen, Agnieszka Miedlar, 2010, Guido Kanschat 2015
+ * @author Baerbel Janssen, Agnieszka Miedlar, 2010, Guido Kanschat, Matthias
+ *Maier 2015
  */
 class ArpackSolver : public Subscriptor
 {
@@ -113,29 +121,18 @@ public:
     both_ends
   };
 
-  /**
-   * Standardized data struct to pipe additional data to the solver, should it
-   * be needed.
-   */
-  struct AdditionalData
-  {
-    const unsigned int number_of_arnoldi_vectors;
-    const WhichEigenvalues eigenvalue_of_interest;
-    AdditionalData(
-      const unsigned int number_of_arnoldi_vectors = 15,
-      const WhichEigenvalues eigenvalue_of_interest = largest_magnitude);
-  };
 
   /**
    * Access to the object that controls convergence.
    */
   SolverControl &control () const;
 
+
   /**
    * Constructor.
    */
-  ArpackSolver(SolverControl &control,
-               const AdditionalData &data = AdditionalData());
+  ArpackSolver(SolverControl &control);
+
 
   /**
    * Solve the generalized eigensprectrum problem $A x=\lambda B x$ by calling
@@ -148,41 +145,38 @@ public:
    * <code>eigenvectors</code> will be the real parts of the
    * eigenvectors, the second <i>n</i> the imaginary parts.
    *
-   * @param A The operator for which we want to compute
-   * eigenvalues. Actually, this parameter is entirely unused.
-   *
    * @param B The inner product of the underlying space, typically the
-   * mass matrix. For constrained problems, it can be a partial mass
-   * matrix, like for instance the velocity mass matrix of a Stokes
-   * problem. Only its function <code>vmult()</code> is used.
+   * mass matrix. Only its function <code>vmult()</code> is used.
    *
-   * @param inverse This is the possibly shifted inverse that is
-   * actually used instead of <code>A</code>. Only its function
-   * <code>vmult()</code> is used.
+   * @param inverse This is the (possibly shifted) inverse that is actually
+   * used instead of <code>A</code>. Only its function <code>vmult()</code>
+   * is used.
    *
    * @param eigenvalues is a vector of complex numbers in which the
-   * eigenvalues are returned.
+   * eigenvalues are returned. The size of the vector determines the number
+   * of eigenvalues to be computed.
    *
    * @param eigenvectors is a <b>real</b> vector of eigenvectors,
-   * containing alternatingly the real parts and the imaginary parts of the
-   * eigenvectors. Therefore, its length should be twice the number of
-   * eigenvalues. The vectors have to be initialized to match the
-   * matrices.
+   * the first half containing the real parts and the second half
+   * containing the corresponding imaginary parts of the eigenvectors.
+   * Therefore, its length should be twice the number of eigenvalues. The
+   * vectors have to be initialized to match the matrices.
    *
-   * @param n_eigenvalues The purpose of this parameter is not clear,
-   * but it is safe to set it to the size of <code>eigenvalues</code>
-   * or greater. Leave it at its default zero, which will be reset to the size
-   * of <code>eigenvalues</code> internally.
+   * @param eigenvalue_of_interest encodes the eigenvalue of interest given
+   * by the enum WhichEigenvalues
+   *
+   * @param number_of_arnoldi_vectors sets the number of internal Storage
+   * for the Arnoldi procedure. If it is left at its default value 0, the
+   * minimal required number of Arnoldi vectors is reserved.
    */
-  template <typename VECTOR, typename MATRIX1,
-            typename MATRIX2, typename INVERSE>
+  template <typename VECTOR, typename MATRIX, typename INVERSE>
   void solve(
-    const MATRIX1 &A,
-    const MATRIX2 &B,
-    const INVERSE &inverse,
+    const MATRIX                       &B,
+    const INVERSE                      &inverse,
     std::vector<std::complex<double> > &eigenvalues,
-    std::vector<VECTOR> &eigenvectors,
-    const unsigned int n_eigenvalues = 0);
+    std::vector<VECTOR>                &eigenvectors,
+    const WhichEigenvalues              eigenvalue_of_interest = largest_magnitude,
+    unsigned int                        number_of_arnoldi_vectors = 0);
 
 protected:
 
@@ -192,11 +186,6 @@ protected:
    */
   SolverControl &solver_control;
 
-  /**
-   * Store a copy of the flags for this particular solver.
-   */
-  const AdditionalData additional_data;
-
 private:
 
   /**
@@ -204,11 +193,11 @@ private:
    */
   DeclException2 (ExcInvalidNumberofEigenvalues, int, int,
                   << "Number of wanted eigenvalues " << arg1
-                  << " is larger that the size of the matrix " << arg2);
+                  << " is larger than the size of the matrix " << arg2);
 
   DeclException2 (ExcInvalidNumberofArnoldiVectors, int, int,
                   << "Number of Arnoldi vectors " << arg1
-                  << " is larger that the size of the matrix " << arg2);
+                  << " is larger than the size of the matrix " << arg2);
 
   DeclException2 (ExcSmallNumberofArnoldiVectors, int, int,
                   << "Number of Arnoldi vectors " << arg1
@@ -216,9 +205,6 @@ private:
                   << " eigenvalues");
 
   DeclException1 (ExcArpackIdo, int, << "This ido " << arg1
-                  << " is not supported. Check documentation of ARPACK");
-
-  DeclException1 (ExcArpackMode, int, << "This mode " << arg1
                   << " is not supported. Check documentation of ARPACK");
 
   DeclException1 (ExcArpackInfodsaupd, int,
@@ -241,306 +227,223 @@ private:
 
 
 inline
-ArpackSolver::AdditionalData::
-AdditionalData (const unsigned int number_of_arnoldi_vectors,
-                const WhichEigenvalues eigenvalue_of_interest)
+ArpackSolver::ArpackSolver (SolverControl &control)
   :
-  number_of_arnoldi_vectors(number_of_arnoldi_vectors),
-  eigenvalue_of_interest(eigenvalue_of_interest)
+  solver_control (control)
 {}
 
 
-inline
-ArpackSolver::ArpackSolver (SolverControl &control,
-                            const AdditionalData &data)
-  :
-  solver_control (control),
-  additional_data (data)
+template <typename VECTOR, typename MATRIX, typename INVERSE>
+inline void
+ArpackSolver::solve(const MATRIX                      &mass_matrix,
+                    const INVERSE                     &inverse,
+                    std::vector<std::complex<double>> &eigenvalues,
+                    std::vector<VECTOR>               &eigenvectors,
+                    const WhichEigenvalues             eigenvalue_of_interest,
+                    unsigned int                       number_of_arnoldi_vectors)
 
-{}
-
-
-template <typename VECTOR, typename MATRIX1,
-          typename MATRIX2, typename INVERSE>
-inline
-void ArpackSolver::solve (
-  const MATRIX1 &system_matrix,
-  const MATRIX2 &mass_matrix,
-  const INVERSE &inverse,
-  std::vector<std::complex<double> > &eigenvalues,
-  std::vector<VECTOR> &eigenvectors,
-  const unsigned int n_eigenvalues)
 {
-  //inside the routines of ARPACK the
-  //values change magically, so store
-  //them here
+  static GrowingVectorMemory<Vector<double> > vector_memory;
 
+  // vector size
   const unsigned int n = eigenvectors[0].size();
-  const unsigned int n_inside_arpack = eigenvectors[0].size();
 
-  // Number of eigenvalues for arpack
-  const unsigned int nev = (n_eigenvalues == 0) ? eigenvalues.size() : n_eigenvalues;
-  AssertIndexRange(eigenvalues.size()-1, nev);
-  /*
-  if(n < 0 || nev <0 || p < 0 || maxit < 0 )
-       std:cout << "All input parameters have to be positive.\n";
-       */
+  // number of eigenvalues to solve for
+  const unsigned int n_eigenvalues = eigenvalues.size();
+
   Assert (n_eigenvalues < n,
-          ExcInvalidNumberofEigenvalues(nev, n));
+          ExcInvalidNumberofEigenvalues(n_eigenvalues, n));
 
-  Assert (additional_data.number_of_arnoldi_vectors < n,
-          ExcInvalidNumberofArnoldiVectors(
-            additional_data.number_of_arnoldi_vectors, n));
+  Assert(eigenvectors.size() >= 2 * n_eigenvalues,
+         ExcMessage("The vector eigenvectors must be at least twice the size "
+                    "of the vector eigenvalues"));
 
-  Assert (additional_data.number_of_arnoldi_vectors > 2*nev+1,
-          ExcSmallNumberofArnoldiVectors(
-            additional_data.number_of_arnoldi_vectors, nev));
-  // ARPACK mode for dnaupd, here only mode 3
-  int mode = 3;
+  Assert(number_of_arnoldi_vectors < n,
+         ExcInvalidNumberofArnoldiVectors(number_of_arnoldi_vectors, n));
 
-  // reverse communication parameter
-  int ido = 0;
+  if (number_of_arnoldi_vectors == 0)
+    number_of_arnoldi_vectors = 2 * n_eigenvalues + 1;
 
-  /**
-   * 'G' generalized eigenvalue problem 'I' standard eigenvalue problem
-   */
-  char bmat[2] = "G";
+  Assert(number_of_arnoldi_vectors > 2 * n_eigenvalues + 1,
+         ExcSmallNumberofArnoldiVectors(number_of_arnoldi_vectors, n_eigenvalues));
 
-  /**
-   * Specify the eigenvalues of interest, possible parameters "LA"
-   * algebraically largest "SA" algebraically smallest "LM" largest magnitude
-   * "SM" smallest magnitude "LR" largest real part "SR" smallest real part
-   * "LI" largest imaginary part "SI" smallest imaginary part "BE" both ends
-   * of spectrum simultaneous
-   */
-  char which[3];
-  switch (additional_data.eigenvalue_of_interest)
+  //
+  // Set up parameters and intermediate storage for the calls to dnaupd, dneupd:
+  //
+
+  // 'G' generalized eigenvalue problem, 'I' standard eigenvalue problem
+  std::string bmat = "G";
+
+  // specify the eigenvalues of interest
+  std::string which;
+  switch (eigenvalue_of_interest)
     {
     case algebraically_largest:
-      std::strcpy (which, "LA");
+      which = "LA";
       break;
     case algebraically_smallest:
-      std::strcpy (which, "SA");
+      which = "SA";
       break;
     case largest_magnitude:
-      std::strcpy (which, "LM");
+      which = "LM";
       break;
     case smallest_magnitude:
-      std::strcpy (which, "SM");
+      which = "SM";
       break;
     case largest_real_part:
-      std::strcpy (which, "LR");
+      which = "LR";
       break;
     case smallest_real_part:
-      std::strcpy (which, "SR");
+      which = "SR";
       break;
     case largest_imaginary_part:
-      std::strcpy (which, "LI");
+      which = "LI";
       break;
     case smallest_imaginary_part:
-      std::strcpy (which, "SI");
+      which = "SI";
       break;
     case both_ends:
-      std::strcpy (which, "BE");
+      which = "BE";
       break;
     }
 
-  // tolerance for ARPACK
-  const double tol = control().tolerance();
+  std::vector<double> resid (n, 1.); // initialize with 1
+  std::vector<double> v (n * number_of_arnoldi_vectors, .0);
 
-  // if the starting vector is used it has to be in resid
-  std::vector<double> resid(n, 1.);
-
-  // number of Arnoldi basis vectors specified
-  // in additional_data
-  int ncv = additional_data.number_of_arnoldi_vectors;
-
-  int ldv = n;
-  std::vector<double> v (ldv*ncv, 0.0);
-
-  //information to the routines
+  // information for arpack routines are passed with an int array:
   std::vector<int> iparam (11, 0);
+  iparam[0] = 1;                     // shift strategy
+  iparam[2] = control().max_steps(); // maximum number of iterations
+  iparam[6] = 3; // sets the mode of dsaupd. 1 is exact shifting, 2 is user-supplied shifts
+  // 3 is shift-invert mode, 4 is buckling mode, 5 is Cayley mode.
 
-  iparam[0] = 1;        // shift strategy
-
-  // maximum number of iterations
-  iparam[2] = control().max_steps();
-
-  /**
-   * Sets the mode of dsaupd. 1 is exact shifting, 2 is user-supplied shifts,
-   * 3 is shift-invert mode, 4 is buckling mode, 5 is Cayley mode.
-   */
-
-  iparam[6] = mode;
   std::vector<int> ipntr (14, 0);
+  std::vector<double> workd (3 * n, .0);
 
-  // work arrays for ARPACK
-  double *workd;
-  workd = new double[3*n];
+  double tol = control().tolerance();
 
-  for (unsigned int i=0; i<3*n; ++i)
-    workd[i] = 0.0;
-
-  int lworkl = 3*ncv*(ncv + 6);
+  int lworkl = 3 * number_of_arnoldi_vectors * (number_of_arnoldi_vectors + 6);
   std::vector<double> workl (lworkl, 0.);
-  //information out of the iteration
-  int info = 1;
+
+  int ido = 0; // reverse communication parameter
+
+  int info = 1; // information about the solver state
+
+  // temporary storage
+  VECTOR &src = *vector_memory.alloc();
+  VECTOR &dst = *vector_memory.alloc();
+  VECTOR &tmp = *vector_memory.alloc();
+  VECTOR &tmp2 = *vector_memory.alloc();
+
+  src.reinit(eigenvectors[0]);
+  dst.reinit(src);
+  tmp.reinit(src);
+  tmp2.reinit(src);
 
   while (ido != 99)
     {
-      // call of ARPACK dnaupd routine
-      dnaupd_(&ido, bmat, &n_inside_arpack, which, &nev, &tol,
-              &resid[0], &ncv, &v[0], &ldv, &iparam[0], &ipntr[0],
-              workd, &workl[0], &lworkl, &info);
+      // call to ARPACK dnaupd routine
+      dnaupd_(&ido, bmat.c_str(), &n, which.c_str(), &n_eigenvalues, &tol,
+              &resid[0], &number_of_arnoldi_vectors, &v[0], &n, &iparam[0], &ipntr[0],
+              &workd[0], &workl[0], &lworkl, &info);
 
       if (ido == 99)
         break;
 
-      switch (mode)
+      if (ido == -1)
         {
-        case 3:
-        {
-          switch (ido)
-            {
-            case -1:
-            {
+          for (size_type i=0; i<src.size(); ++i)
+            src(i) = workd[ipntr[0] - 1 + i];
 
-              VECTOR src,dst,tmp;
-              src.reinit(eigenvectors[0]);
-              dst.reinit(src);
-              tmp.reinit(src);
+          // multiplication with mass matrix M
+          mass_matrix.vmult(tmp, src);
+          // solving linear system
+          inverse.vmult(dst, tmp);
 
-
-              for (size_type i=0; i<src.size(); ++i)
-                src(i) = *(workd+ipntr[0]-1+i);
-
-              // multiplication with mass matrix M
-              mass_matrix.vmult(tmp, src);
-              // solving linear system
-              inverse.vmult(dst,tmp);
-
-              for (size_type i=0; i<dst.size(); ++i)
-                *(workd+ipntr[1]-1+i) = dst(i);
-            }
-            break;
-
-            case  1:
-            {
-
-              VECTOR src,dst,tmp, tmp2;
-              src.reinit(eigenvectors[0]);
-              dst.reinit(src);
-              tmp.reinit(src);
-              tmp2.reinit(src);
-
-              for (size_type i=0; i<src.size(); ++i)
-                {
-                  src(i) = *(workd+ipntr[2]-1+i);
-                  tmp(i) = *(workd+ipntr[0]-1+i);
-                }
-              // solving linear system
-              inverse.vmult(dst,src);
-
-              for (size_type i=0; i<dst.size(); ++i)
-                *(workd+ipntr[1]-1+i) = dst(i);
-            }
-            break;
-
-            case  2:
-            {
-
-              VECTOR src,dst;
-              src.reinit(eigenvectors[0]);
-              dst.reinit(src);
-
-              for (size_type i=0; i<src.size(); ++i)
-                src(i) = *(workd+ipntr[0]-1+i);
-
-              // Multiplication with mass matrix M
-              mass_matrix.vmult(dst, src);
-
-              for (size_type i=0; i<dst.size(); ++i)
-                *(workd+ipntr[1]-1+i) = dst(i);
-
-            }
-            break;
-
-            default:
-              Assert (false, ExcArpackIdo(ido));
-              break;
-            }
+          for (size_type i=0; i<dst.size(); ++i)
+            workd[ipntr[1] - 1 + i] = dst(i);
         }
-        break;
-        default:
-          Assert (false, ExcArpackMode(mode));
-          break;
+
+      else if (ido == 1)
+        {
+          for (size_type i=0; i<src.size(); ++i)
+            {
+              src(i) = workd[ipntr[2] - 1 + i];
+              tmp(i) = workd[ipntr[0] - 1 + i];
+            }
+
+          // solving linear system
+          inverse.vmult(dst,src);
+
+          for (size_type i=0; i<dst.size(); ++i)
+            workd[ipntr[1] - 1 + i] = dst(i);
+        }
+
+      else if (ido == 2)
+        {
+          for (size_type i=0; i<src.size(); ++i)
+            src(i) = workd[ipntr[0] - 1 + i];
+
+          // Multiplication with mass matrix M
+          mass_matrix.vmult(dst, src);
+
+          for (size_type i=0; i<dst.size(); ++i)
+            workd[ipntr[1] - 1 + i] = dst(i);
+        }
+
+      else
+        {
+          AssertThrow (false, ExcArpackIdo(ido));
         }
     }
 
-  if (info<0)
-    {
-      Assert (false, ExcArpackInfodsaupd(info));
-    }
-  else
-    {
-      /**
-       * 1 - compute eigenvectors, 0 - only eigenvalues
-       */
-      int rvec = 1;
+  vector_memory.free(&src);
+  vector_memory.free(&dst);
+  vector_memory.free(&tmp);
+  vector_memory.free(&tmp2);
 
-      // which eigenvectors
-      char howmany = 'A';
-
-      std::vector<int> select (ncv, 1);
-
-      int ldz = n;
-
-      std::vector<double> z (ldz*ncv, 0.);
-
-      double sigmar = 0.0; // real part of the shift
-      double sigmai = 0.0; // imaginary part of the shift
-
-      int lworkev = 3*ncv;
-      std::vector<double> workev (lworkev, 0.);
-
-      std::vector<double> eigenvalues_real (nev, 0.);
-      std::vector<double> eigenvalues_im (nev, 0.);
-
-      // call of ARPACK dneupd routine
-      dneupd_(&rvec, &howmany, &select[0], &eigenvalues_real[0],
-              &eigenvalues_im[0], &z[0], &ldz, &sigmar, &sigmai,
-              &workev[0], bmat, &n_inside_arpack, which, &nev, &tol,
-              &resid[0], &ncv, &v[0], &ldv,
-              &iparam[0], &ipntr[0], workd, &workl[0], &lworkl, &info);
-
-      if (info == 1)
-        {
-          Assert (false, ExcArpackInfoMaxIt(control().max_steps()));
-        }
-      else if (info == 3)
-        {
-          Assert (false, ExcArpackNoShifts(1));
-        }
-      else if (info!=0)
-        {
-          Assert (false, ExcArpackInfodneupd(info));
-        }
+  // Check whether everything worked out as planned:
+  AssertThrow (info >= 0, ExcArpackInfodsaupd(info));
 
 
-      const unsigned int n_eigenvecs = eigenvectors.size();
-      for (size_type i=0; i<n_eigenvecs; ++i)
-        for (unsigned int j=0; j<n; ++j)
-          eigenvectors[i](j) = z[i*n+j];
+  // 1 - compute eigenvectors, 0 - only eigenvalues
+  int rvec = 1;
 
-      delete[] workd;
+  // which eigenvectors
+  char howmany = 'A';
 
-      AssertDimension (eigenvalues.size(), eigenvalues_real.size());
-      AssertDimension (eigenvalues.size(), eigenvalues_im.size());
+  std::vector<int> select (number_of_arnoldi_vectors, 1);
+  std::vector<double> z (n * number_of_arnoldi_vectors, 0.);
 
-      for (size_type i=0; i<eigenvalues.size(); ++i)
-        eigenvalues[i] = std::complex<double> (eigenvalues_real[i],
-                                               eigenvalues_im[i]);
-    }
+  double sigmar = 0.0; // real part of the shift
+  double sigmai = 0.0; // imaginary part of the shift
+
+  int lworkev = 3 * number_of_arnoldi_vectors;
+  std::vector<double> workev (lworkev, 0.);
+
+  std::vector<double> eigenvalues_real (n_eigenvalues, 0.);
+  std::vector<double> eigenvalues_im (n_eigenvalues, 0.);
+
+  // call to ARPACK dneupd routine
+  dneupd_(&rvec, &howmany, &select[0], &eigenvalues_real[0],
+          &eigenvalues_im[0], &z[0], &n, &sigmar, &sigmai,
+          &workev[0], bmat.c_str(), &n, which.c_str(), &n_eigenvalues, &tol,
+          &resid[0], &number_of_arnoldi_vectors, &v[0], &n,
+          &iparam[0], &ipntr[0], &workd[0], &workl[0], &lworkl, &info);
+
+  AssertThrow (info != 1, ExcArpackInfoMaxIt(control().max_steps()));
+
+  AssertThrow (info != 3, ExcArpackNoShifts(1));
+
+  AssertThrow (info == 0, ExcArpackInfodneupd(info));
+
+  for (size_type i = 0; i < eigenvectors.size(); ++i)
+    for (unsigned int j=0; j<n; ++j)
+      eigenvectors[i](j) = z[i*n+j];
+
+  for (size_type i = 0; i < eigenvalues.size(); ++i)
+    eigenvalues[i] = std::complex<double> (eigenvalues_real[i],
+                                           eigenvalues_im[i]);
 }
 
 
@@ -552,6 +455,5 @@ SolverControl &ArpackSolver::control () const
 
 DEAL_II_NAMESPACE_CLOSE
 
-
-#endif
+#endif /* DEAL_II_WITH_ARPACK */
 #endif


### PR DESCRIPTION
This is a complete overhaul of the ArpackSolver class.

It fixes the following issues:

 * compute correct eigenvectors

 * use GrowingVectorMemory for temporary storage

 * clean up the "solve" function. We already require all std::vector
  objects to be correctly set up - there is no point in providing an
  additional n_eigenvectors parameter. Drop unused "stiffness_matrix".

 * remove unnecessary switch statements and temporary variables

Closes #759