### PR TITLE
Add move constructor and operator to Vector and BlockVector

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -472,6 +472,14 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> New: dealii:Vector, dealii::BlockVector,
+  TrilinosWrappers::MPI::Vector, TrilinosWrappers::MPI::BlockVector,
+  PETScWrappers::MPI::Vector and PETScWrappers::MPI::BlockVector now have
+  move constructors and move assignment operators in C++11 mode.
+  <br>
+  (Matthias Maier, 2015/05/01)
+  </li>
+
   <li> New: Introduce DoFRenumbering::block_wise for multigrid computation.
   <br>
   (Timo Heister, Florian Sonner, 2015/04/30)

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -99,10 +99,22 @@ public:
                         const size_type block_size = 0);
 
   /**
-   * Copy-Constructor. Dimension set to that of V, all components are copied
-   * from V
+   * Copy Constructor. Dimension set to that of @p v, all components are
+   * copied from @p v.
    */
   BlockVector (const BlockVector<Number> &V);
+
+
+#ifdef DEAL_II_WITH_CXX11
+  /**
+   * Move constructor. Creates a new vector by stealing the internal data
+   * of the vector @p v.
+   *
+   * @note This constructor is only available if deal.II is configured with
+   * C++11 support.
+   */
+  BlockVector (BlockVector<Number> &&v);
+#endif
 
 
 #ifndef DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
@@ -180,27 +192,39 @@ public:
    * Copy operator: fill all components of the vector with the given scalar
    * value.
    */
-  BlockVector &operator = (const value_type s);
+  BlockVector &operator= (const value_type s);
 
   /**
    * Copy operator for arguments of the same type. Resize the present vector
    * if necessary.
    */
-  BlockVector &
-  operator= (const BlockVector &V);
+  BlockVector<Number> &
+  operator= (const BlockVector<Number> &v);
+
+#ifdef DEAL_II_WITH_CXX11
+  /**
+   * Move the given vector. This operator replaces the present vector with
+   * @p v by efficiently swapping the internal data structures. @p v is
+   * left empty.
+   *
+   * @note This operator is only available if deal.II is configured with
+   * C++11 support.
+   */
+  BlockVector<Number> &operator= (BlockVector<Number> &&v);
+#endif
 
   /**
    * Copy operator for template arguments of different types. Resize the
    * present vector if necessary.
    */
   template <class Number2>
-  BlockVector &
+  BlockVector<Number> &
   operator= (const BlockVector<Number2> &V);
 
   /**
    * Copy a regular vector into a block vector.
    */
-  BlockVector &
+  BlockVector<Number> &
   operator= (const Vector<Number> &V);
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -208,9 +232,10 @@ public:
    * A copy constructor from a Trilinos block vector to a deal.II block
    * vector.
    */
-  BlockVector &
+  BlockVector<Number> &
   operator= (const TrilinosWrappers::BlockVector &V);
 #endif
+
   /**
    * Reinitialize the BlockVector to contain <tt>n_blocks</tt> blocks of size
    * <tt>block_size</tt> each.
@@ -378,12 +403,12 @@ BlockVector<Number>::BlockVector (const std::vector<size_type>    &block_sizes,
 template <typename Number>
 inline
 BlockVector<Number> &
-BlockVector<Number>::operator = (const value_type s)
+BlockVector<Number>::operator= (const value_type s)
 {
 
   AssertIsFinite(s);
 
-  BaseClass::operator = (s);
+  BaseClass::operator= (s);
   return *this;
 }
 
@@ -392,21 +417,37 @@ BlockVector<Number>::operator = (const value_type s)
 template <typename Number>
 inline
 BlockVector<Number> &
-BlockVector<Number>::operator = (const BlockVector &v)
+BlockVector<Number>::operator= (const BlockVector<Number> &v)
 {
   reinit (v, true);
-  BaseClass::operator = (v);
+  BaseClass::operator= (v);
   return *this;
 }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+template <typename Number>
+inline
+BlockVector<Number> &
+BlockVector<Number>::operator= (BlockVector<Number> &&v)
+{
+  swap(v);
+  // be nice and reset v to zero
+  v.reinit(0, 0, false);
+
+  return *this;
+}
+#endif
 
 
 
 template <typename Number>
 inline
 BlockVector<Number> &
-BlockVector<Number>::operator = (const Vector<Number> &v)
+BlockVector<Number>::operator= (const Vector<Number> &v)
 {
-  BaseClass::operator = (v);
+  BaseClass::operator= (v);
   return *this;
 }
 
@@ -416,10 +457,10 @@ template <typename Number>
 template <typename Number2>
 inline
 BlockVector<Number> &
-BlockVector<Number>::operator = (const BlockVector<Number2> &v)
+BlockVector<Number>::operator= (const BlockVector<Number2> &v)
 {
   reinit (v, true);
-  BaseClass::operator = (v);
+  BaseClass::operator= (v);
   return *this;
 }
 

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -64,11 +64,11 @@ BlockVector<Number>::BlockVector (const BlockVector<Number> &v)
 #ifdef DEAL_II_WITH_CXX11
 template <typename Number>
 BlockVector<Number>::BlockVector (BlockVector<Number> &&v)
-  {
-    swap(v);
-    // be nice and reset v to zero
-    v.reinit(0, 0, false);
-  }
+{
+  swap(v);
+  // be nice and reset v to zero
+  v.reinit(0, 0, false);
+}
 #endif
 
 

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -61,6 +61,17 @@ BlockVector<Number>::BlockVector (const BlockVector<Number> &v)
 }
 
 
+#ifdef DEAL_II_WITH_CXX11
+template <typename Number>
+BlockVector<Number>::BlockVector (BlockVector<Number> &&v)
+  {
+    swap(v);
+    // be nice and reset v to zero
+    v.reinit(0, 0, false);
+  }
+#endif
+
+
 #ifndef DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
 
 template <typename Number>
@@ -151,9 +162,9 @@ BlockVector<Number>::~BlockVector ()
 template <typename Number>
 inline
 BlockVector<Number> &
-BlockVector<Number>::operator = (const TrilinosWrappers::BlockVector &v)
+BlockVector<Number>::operator= (const TrilinosWrappers::BlockVector &v)
 {
-  BaseClass::operator = (v);
+  BaseClass::operator= (v);
   return *this;
 }
 #endif

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -113,12 +113,7 @@ namespace PETScWrappers
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      BlockVector (BlockVector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.reinit(0, v.get_mpi_communicator(), 0, 0, false);
-      }
+      BlockVector (BlockVector &&v);
 #endif
 
       /**
@@ -168,20 +163,12 @@ namespace PETScWrappers
 #ifdef DEAL_II_WITH_CXX11
       /**
        * Move the given vector. This operator replaces the present vector with
-       * @p v by efficiently swapping the internal data structures. @p v is
-       * left empty.
+       * @p v by efficiently swapping the internal data structures.
        *
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      BlockVector &operator= (BlockVector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.reinit(0, v.get_mpi_communicator(), 0, 0, false);
-
-        return *this;
-      }
+      BlockVector &operator= (BlockVector &&v);
 #endif
 
       /**
@@ -371,6 +358,14 @@ namespace PETScWrappers
         this->components[i] = v.components[i];
     }
 
+#ifdef DEAL_II_WITH_CXX11
+    inline
+    BlockVector::BlockVector (BlockVector &&v)
+    {
+      swap(v);
+    }
+#endif
+
     inline
     BlockVector::BlockVector (const std::vector<IndexSet> &parallel_partitioning,
                               const MPI_Comm              &communicator)
@@ -413,6 +408,16 @@ namespace PETScWrappers
 
       return *this;
     }
+
+#ifdef DEAL_II_WITH_CXX11
+    inline
+    BlockVector &
+    BlockVector::operator= (BlockVector &&v)
+    {
+      swap(v);
+      return *this;
+    }
+#endif
 
     inline
     BlockVector::~BlockVector ()

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2014 by the deal.II authors
+// Copyright (C) 2004 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -185,6 +185,26 @@ namespace PETScWrappers
        */
       Vector ();
 
+#ifdef DEAL_II_WITH_CXX11
+      // explicitly declare default variant, such that below move constructor
+      // does not dissallow it
+      Vector (const Vector &v) = default;
+
+      /**
+       * Move constructor. Creates a new vector by stealing the internal data
+       * of the vector @p v.
+       *
+       * @note This operator is only available if deal.II is configured with
+       * C++11 support.
+       */
+      Vector (Vector &&v)
+      {
+        swap(v);
+        // be nice and reset v to zero
+        v.reinit(v.communicator, 0, 0, false);
+      }
+#endif
+
       /**
        * Constructor. Set dimension to @p n and initialize all elements with
        * zero.
@@ -266,8 +286,26 @@ namespace PETScWrappers
        * Copy the given vector. Resize the present vector if necessary. Also
        * take over the MPI communicator of @p v.
        */
-      Vector &operator = (const Vector &v);
+      Vector &operator= (const Vector &v);
 
+#ifdef DEAL_II_WITH_CXX11
+      /**
+       * Move the given vector. This operator replaces the present vector with
+       * @p v by efficiently swapping the internal data structures. @p v is
+       * left empty.
+       *
+       * @note This operator is only available if deal.II is configured with
+       * C++11 support.
+       */
+      Vector &operator= (Vector &&v)
+      {
+        swap(v);
+        // be nice and reset v to zero
+        v.reinit(v.communicator, 0, 0, false);
+
+        return *this;
+      }
+#endif
 
       /**
        * Copy the given sequential (non-distributed) vector into the present
@@ -284,7 +322,7 @@ namespace PETScWrappers
        * change the local part of a parallel vector on only one process,
        * independent of what other processes do, with this function.
        */
-      Vector &operator = (const PETScWrappers::Vector &v);
+      Vector &operator= (const PETScWrappers::Vector &v);
 
       /**
        * Set all components of the vector to the given number @p s. Simply
@@ -292,7 +330,7 @@ namespace PETScWrappers
        * function to make the example given in the discussion about making the
        * constructor explicit work.
        */
-      Vector &operator = (const PetscScalar s);
+      Vector &operator= (const PetscScalar s);
 
       /**
        * Copy the values of a deal.II vector (as opposed to those of the PETSc
@@ -304,7 +342,7 @@ namespace PETScWrappers
        * can't get from the source vector.
        */
       template <typename number>
-      Vector &operator = (const dealii::Vector<number> &v);
+      Vector &operator= (const dealii::Vector<number> &v);
 
       /**
        * Change the dimension of the vector to @p N. It is unspecified how
@@ -455,9 +493,9 @@ namespace PETScWrappers
 
     inline
     Vector &
-    Vector::operator = (const PetscScalar s)
+    Vector::operator= (const PetscScalar s)
     {
-      VectorBase::operator = (s);
+      VectorBase::operator= (s);
 
       return *this;
     }
@@ -466,7 +504,7 @@ namespace PETScWrappers
 
     inline
     Vector &
-    Vector::operator = (const Vector &v)
+    Vector::operator= (const Vector &v)
     {
       // make sure left- and right-hand side of the assignment are compress()'ed:
       Assert(v.last_action == VectorOperation::unknown,
@@ -530,53 +568,37 @@ namespace PETScWrappers
     template <typename number>
     inline
     Vector &
-    Vector::operator = (const dealii::Vector<number> &v)
+    Vector::operator= (const dealii::Vector<number> &v)
     {
       Assert (size() == v.size(),
               ExcDimensionMismatch (size(), v.size()));
 
-      // the following isn't necessarily fast,
-      // but this is due to the fact that PETSc
-      // doesn't offer an inlined access
-      // operator.
+      // FIXME: the following isn't necessarily fast, but this is due to
+      // the fact that PETSc doesn't offer an inlined access operator.
       //
-      // if someone wants to contribute some
-      // code: to make this code faster, one
-      // could either first convert all values
-      // to PetscScalar, and then set them all
-      // at once using VecSetValues. This has
-      // the drawback that it could take quite
-      // some memory, if the vector is large,
-      // and it would in addition allocate
-      // memory on the heap, which is
-      // expensive. an alternative would be to
-      // split the vector into chunks of, say,
-      // 128 elements, convert a chunk at a
-      // time and set it in the output vector
-      // using VecSetValues. since 128 elements
-      // is small enough, this could easily be
-      // allocated on the stack (as a local
-      // variable) which would make the whole
-      // thing much more efficient.
+      // if someone wants to contribute some code: to make this code
+      // faster, one could either first convert all values to PetscScalar,
+      // and then set them all at once using VecSetValues. This has the
+      // drawback that it could take quite some memory, if the vector is
+      // large, and it would in addition allocate memory on the heap, which
+      // is expensive. an alternative would be to split the vector into
+      // chunks of, say, 128 elements, convert a chunk at a time and set it
+      // in the output vector using VecSetValues. since 128 elements is
+      // small enough, this could easily be allocated on the stack (as a
+      // local variable) which would make the whole thing much more
+      // efficient.
       //
-      // a second way to make things faster is
-      // for the special case that
-      // number==PetscScalar. we could then
-      // declare a specialization of this
-      // template, and omit the conversion. the
-      // problem with this is that the best we
-      // can do is to use VecSetValues, but
-      // this isn't very efficient either: it
-      // wants to see an array of indices,
-      // which in this case a) again takes up a
-      // whole lot of memory on the heap, and
-      // b) is totally dumb since its content
-      // would simply be the sequence
-      // 0,1,2,3,...,n. the best of all worlds
-      // would probably be a function in Petsc
-      // that would take a pointer to an array
-      // of PetscScalar values and simply copy
-      // n elements verbatim into the vector...
+      // a second way to make things faster is for the special case that
+      // number==PetscScalar. we could then declare a specialization of
+      // this template, and omit the conversion. the problem with this is
+      // that the best we can do is to use VecSetValues, but this isn't
+      // very efficient either: it wants to see an array of indices, which
+      // in this case a) again takes up a whole lot of memory on the heap,
+      // and b) is totally dumb since its content would simply be the
+      // sequence 0,1,2,3,...,n. the best of all worlds would probably be a
+      // function in Petsc that would take a pointer to an array of
+      // PetscScalar values and simply copy n elements verbatim into the
+      // vector...
       for (size_type i=0; i<v.size(); ++i)
         (*this)(i) = v(i);
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -197,12 +197,7 @@ namespace PETScWrappers
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      Vector (Vector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.reinit(v.communicator, 0, 0, false);
-      }
+      Vector (Vector &&v);
 #endif
 
       /**
@@ -291,20 +286,12 @@ namespace PETScWrappers
 #ifdef DEAL_II_WITH_CXX11
       /**
        * Move the given vector. This operator replaces the present vector with
-       * @p v by efficiently swapping the internal data structures. @p v is
-       * left empty.
+       * @p v by efficiently swapping the internal data structures.
        *
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      Vector &operator= (Vector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.reinit(v.communicator, 0, 0, false);
-
-        return *this;
-      }
+      Vector &operator= (Vector &&v);
 #endif
 
       /**
@@ -562,6 +549,17 @@ namespace PETScWrappers
         }
       return *this;
     }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+    inline
+    Vector & Vector::operator= (Vector &&v)
+    {
+      swap(v);
+      return *this;
+    }
+#endif
 
 
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -554,7 +554,7 @@ namespace PETScWrappers
 
 #ifdef DEAL_II_WITH_CXX11
     inline
-    Vector & Vector::operator= (Vector &&v)
+    Vector &Vector::operator= (Vector &&v)
     {
       swap(v);
       return *this;

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -128,7 +128,22 @@ namespace TrilinosWrappers
        * Copy-Constructor. Set all the properties of the parallel vector to
        * those of the given argument and copy the elements.
        */
-      BlockVector (const BlockVector  &V);
+      BlockVector (const BlockVector  &v);
+
+#ifdef DEAL_II_WITH_CXX11
+      /**
+       * Move constructor. Creates a new vector by stealing the internal data
+       * of the vector @p v.
+       *
+       * @note This constructor is only available if deal.II is configured with
+       * C++11 support.
+       */
+      BlockVector (BlockVector &&v)
+      {
+        swap(v);
+        v.reinit (0);
+      }
+#endif
 
       /**
        * Creates a block vector consisting of <tt>num_blocks</tt> components,
@@ -146,20 +161,37 @@ namespace TrilinosWrappers
        * Copy operator: fill all components of the vector that are locally
        * stored with the given scalar value.
        */
-      BlockVector &
-      operator = (const value_type s);
+      BlockVector &operator= (const value_type s);
 
       /**
        * Copy operator for arguments of the same type.
        */
-      BlockVector &
-      operator = (const BlockVector &V);
+      BlockVector &operator= (const BlockVector &v);
+
+#ifdef DEAL_II_WITH_CXX11
+      /**
+       * Move the given vector. This operator replaces the present vector with
+       * @p v by efficiently swapping the internal data structures. @p v is
+       * left empty.
+       *
+       * @note This operator is only available if deal.II is configured with
+       * C++11 support.
+       */
+      BlockVector &operator= (BlockVector &&v)
+      {
+        swap(v);
+        // be nice and reset v to zero
+        v.reinit (0);
+
+        return *this;
+      }
+#endif
 
       /**
        * Copy operator for arguments of the localized Trilinos vector type.
        */
       BlockVector &
-      operator = (const ::dealii::TrilinosWrappers::BlockVector &V);
+      operator= (const ::dealii::TrilinosWrappers::BlockVector &v);
 
       /**
        * Another copy function. This one takes a deal.II block vector and
@@ -172,8 +204,7 @@ namespace TrilinosWrappers
        * accept only one possible number type in the deal.II vector.
        */
       template <typename Number>
-      BlockVector &
-      operator = (const ::dealii::BlockVector<Number> &V);
+      BlockVector &operator= (const ::dealii::BlockVector<Number> &v);
 
       /**
        * Reinitialize the BlockVector to contain as many blocks as there are
@@ -400,7 +431,7 @@ namespace TrilinosWrappers
 
     template <typename Number>
     BlockVector &
-    BlockVector::operator = (const ::dealii::BlockVector<Number> &v)
+    BlockVector::operator= (const ::dealii::BlockVector<Number> &v)
     {
       if (n_blocks() != v.n_blocks())
         {

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -138,11 +138,7 @@ namespace TrilinosWrappers
        * @note This constructor is only available if deal.II is configured with
        * C++11 support.
        */
-      BlockVector (BlockVector &&v)
-      {
-        swap(v);
-        v.reinit (0);
-      }
+      BlockVector (BlockVector &&v);
 #endif
 
       /**
@@ -171,20 +167,12 @@ namespace TrilinosWrappers
 #ifdef DEAL_II_WITH_CXX11
       /**
        * Move the given vector. This operator replaces the present vector with
-       * @p v by efficiently swapping the internal data structures. @p v is
-       * left empty.
+       * @p v by efficiently swapping the internal data structures.
        *
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      BlockVector &operator= (BlockVector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.reinit (0);
-
-        return *this;
-      }
+      BlockVector &operator= (BlockVector &&v);
 #endif
 
       /**
@@ -409,6 +397,16 @@ namespace TrilinosWrappers
       for (size_type i=0; i<this->n_blocks(); ++i)
         this->components[i] = v.components[i];
     }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+    inline
+    BlockVector::BlockVector (BlockVector &&v)
+    {
+      swap(v);
+    }
+#endif
 
 
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -284,7 +284,23 @@ namespace TrilinosWrappers
       /**
        * Copy constructor using the given vector.
        */
-      Vector (const Vector &V);
+      Vector (const Vector &v);
+
+#ifdef DEAL_II_WITH_CXX11
+      /**
+       * Move constructor. Creates a new vector by stealing the internal data
+       * of the vector @p v.
+       *
+       * @note This constructor is only available if deal.II is configured with
+       * C++11 support.
+       */
+      Vector (Vector &&v)
+      {
+        swap(v);
+        // be nice and reset v to zero
+        v.clear();
+      }
+#endif
 
       /**
        * Destructor.
@@ -326,15 +342,33 @@ namespace TrilinosWrappers
        * function to make the example given in the discussion about making the
        * constructor explicit work.
        */
-      Vector &operator = (const TrilinosScalar s);
+      Vector &operator= (const TrilinosScalar s);
 
       /**
        * Copy the given vector. Resize the present vector if necessary. In
        * this case, also the Epetra_Map that designs the parallel partitioning
        * is taken from the input vector.
        */
-      Vector &
-      operator = (const Vector &V);
+      Vector &operator= (const Vector &v);
+
+#ifdef DEAL_II_WITH_CXX11
+      /**
+       * Move the given vector. This operator replaces the present vector with
+       * @p v by efficiently swapping the internal data structures. @p v is
+       * left empty.
+       *
+       * @note This operator is only available if deal.II is configured with
+       * C++11 support.
+       */
+      Vector &operator= (Vector &&v)
+      {
+        swap(v);
+        // be nice and reset v to zero
+        v.clear();
+
+        return *this;
+      }
+#endif
 
       /**
        * Copy operator from a given localized vector (present on all
@@ -343,8 +377,7 @@ namespace TrilinosWrappers
        * object) already is of the same size as the right hand side vector.
        * Otherwise, an exception will be thrown.
        */
-      Vector &
-      operator = (const ::dealii::TrilinosWrappers::Vector &V);
+      Vector &operator= (const ::dealii::TrilinosWrappers::Vector &v);
 
       /**
        * Another copy function. This one takes a deal.II vector and copies it
@@ -355,8 +388,7 @@ namespace TrilinosWrappers
        * the reinit(const Epetra_Map &input_map) function.
        */
       template <typename Number>
-      Vector &
-      operator = (const ::dealii::Vector<Number> &v);
+      Vector &operator= (const ::dealii::Vector<Number> &v);
 
       /**
        * This reinit function is meant to be used for parallel calculations
@@ -649,9 +681,9 @@ namespace TrilinosWrappers
 
     inline
     Vector &
-    Vector::operator = (const TrilinosScalar s)
+    Vector::operator= (const TrilinosScalar s)
     {
-      VectorBase::operator = (s);
+      VectorBase::operator= (s);
 
       return *this;
     }
@@ -659,7 +691,7 @@ namespace TrilinosWrappers
 
     template <typename Number>
     Vector &
-    Vector::operator = (const ::dealii::Vector<Number> &v)
+    Vector::operator= (const ::dealii::Vector<Number> &v)
     {
       if (size() != v.size())
         {
@@ -678,7 +710,7 @@ namespace TrilinosWrappers
     }
 
 
-#endif
+#endif /* DOXYGEN */
 
   } /* end of namespace MPI */
 
@@ -817,28 +849,25 @@ namespace TrilinosWrappers
      * to make the example given in the discussion about making the
      * constructor explicit work.
      */
-    Vector &operator = (const TrilinosScalar s);
+    Vector &operator= (const TrilinosScalar s);
 
     /**
      * Sets the left hand argument to the (parallel) Trilinos Vector.
      * Equivalent to the @p reinit function.
      */
-    Vector &
-    operator = (const MPI::Vector &V);
+    Vector &operator= (const MPI::Vector &v);
 
     /**
      * Sets the left hand argument to the deal.II vector.
      */
     template <typename Number>
-    Vector &
-    operator = (const ::dealii::Vector<Number> &V);
+    Vector &operator= (const ::dealii::Vector<Number> &v);
 
     /**
      * Copy operator. Copies both the dimension and the content in the right
      * hand argument.
      */
-    Vector &
-    operator = (const Vector &V);
+    Vector &operator= (const Vector &v);
 
     /**
      * This function does nothing but is there for compatibility with the @p
@@ -888,9 +917,9 @@ namespace TrilinosWrappers
 
   inline
   Vector &
-  Vector::operator = (const TrilinosScalar s)
+  Vector::operator= (const TrilinosScalar s)
   {
-    VectorBase::operator = (s);
+    VectorBase::operator= (s);
 
     return *this;
   }
@@ -899,7 +928,7 @@ namespace TrilinosWrappers
 
   template <typename Number>
   Vector &
-  Vector::operator = (const ::dealii::Vector<Number> &v)
+  Vector::operator= (const ::dealii::Vector<Number> &v)
   {
     if (size() != v.size())
       {

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -294,12 +294,7 @@ namespace TrilinosWrappers
        * @note This constructor is only available if deal.II is configured with
        * C++11 support.
        */
-      Vector (Vector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.clear();
-      }
+      Vector (Vector &&v);
 #endif
 
       /**
@@ -354,20 +349,12 @@ namespace TrilinosWrappers
 #ifdef DEAL_II_WITH_CXX11
       /**
        * Move the given vector. This operator replaces the present vector with
-       * @p v by efficiently swapping the internal data structures. @p v is
-       * left empty.
+       * @p v by efficiently swapping the internal data structures.
        *
        * @note This operator is only available if deal.II is configured with
        * C++11 support.
        */
-      Vector &operator= (Vector &&v)
-      {
-        swap(v);
-        // be nice and reset v to zero
-        v.clear();
-
-        return *this;
-      }
+      Vector &operator= (Vector &&v);
 #endif
 
       /**

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -558,7 +558,6 @@ namespace internal
 
 
 
-
 template <typename Number>
 Vector<Number>::Vector (const Vector<Number> &v)
   :
@@ -575,8 +574,20 @@ Vector<Number>::Vector (const Vector<Number> &v)
 }
 
 
-#ifndef DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
 
+#ifdef DEAL_II_WITH_CXX11
+template <typename Number>
+Vector<Number>::Vector (Vector<Number> &&v)
+{
+  swap(v);
+  // be nice and reset v to zero
+  v.reinit(0, false);
+}
+#endif
+
+
+
+#ifndef DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
 template <typename Number>
 template <typename OtherNumber>
 Vector<Number>::Vector (const Vector<OtherNumber> &v)
@@ -592,11 +603,10 @@ Vector<Number>::Vector (const Vector<OtherNumber> &v)
       std::copy (v.begin(), v.end(), begin());
     }
 }
-
 #endif
 
-#ifdef DEAL_II_WITH_PETSC
 
+#ifdef DEAL_II_WITH_PETSC
 
 template <typename Number>
 Vector<Number>::Vector (const PETScWrappers::Vector &v)
@@ -646,6 +656,7 @@ Vector<Number>::Vector (const PETScWrappers::MPI::Vector &v)
 }
 
 #endif
+
 
 #ifdef DEAL_II_WITH_TRILINOS
 
@@ -707,6 +718,7 @@ Vector<Number>::Vector (const TrilinosWrappers::Vector &v)
 
 #endif
 
+
 template <typename Number>
 template <typename Number2>
 void Vector<Number>::reinit (const Vector<Number2> &v,
@@ -714,18 +726,6 @@ void Vector<Number>::reinit (const Vector<Number2> &v,
 {
   reinit (v.size(), fast);
 }
-
-// Moved to vector.h as an inline function by Luca Heltai on
-// 2009/04/12 to prevent strange compiling errors, after making swap
-// virtual.
-// template <typename Number>
-// void
-// Vector<Number>::swap (Vector<Number> &v)
-// {
-//   std::swap (vec_size,     v.vec_size);
-//   std::swap (max_vec_size, v.max_vec_size);
-//   std::swap (val,          v.val);
-// }
 
 
 
@@ -830,7 +830,7 @@ namespace internal
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const Number s)
+Vector<Number>::operator= (const Number s)
 {
   AssertIsFinite(s);
   if (s != Number())
@@ -852,7 +852,7 @@ Vector<Number>::operator = (const Number s)
 #ifdef DEAL_II_BOOST_BIND_COMPILER_BUG
 template <>
 Vector<std::complex<float> > &
-Vector<std::complex<float> >::operator = (const std::complex<float> s)
+Vector<std::complex<float> >::operator= (const std::complex<float> s)
 {
   AssertIsFinite(s);
   if (s != std::complex<float>())
@@ -1769,7 +1769,7 @@ void Vector<Number>::ratio (const Vector<Number> &a,
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const BlockVector<Number> &v)
+Vector<Number>::operator= (const BlockVector<Number> &v)
 {
   if (v.size() != vec_size)
     reinit (v.size(), true);
@@ -1788,7 +1788,7 @@ Vector<Number>::operator = (const BlockVector<Number> &v)
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const PETScWrappers::Vector &v)
+Vector<Number>::operator= (const PETScWrappers::Vector &v)
 {
   if (v.size() != vec_size)
     reinit (v.size(), true);
@@ -1815,7 +1815,7 @@ Vector<Number>::operator = (const PETScWrappers::Vector &v)
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const PETScWrappers::MPI::Vector &v)
+Vector<Number>::operator= (const PETScWrappers::MPI::Vector &v)
 {
   // do this in a two-stage process:
   // first convert to a sequential petsc
@@ -1833,7 +1833,7 @@ Vector<Number>::operator = (const PETScWrappers::MPI::Vector &v)
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const TrilinosWrappers::MPI::Vector &v)
+Vector<Number>::operator= (const TrilinosWrappers::MPI::Vector &v)
 {
   // Generate a localized version
   // of the Trilinos vectors and
@@ -1848,7 +1848,7 @@ Vector<Number>::operator = (const TrilinosWrappers::MPI::Vector &v)
 
 template <typename Number>
 Vector<Number> &
-Vector<Number>::operator = (const TrilinosWrappers::Vector &v)
+Vector<Number>::operator= (const TrilinosWrappers::Vector &v)
 {
   if (v.size() != vec_size)
     reinit (v.size(), true);
@@ -1871,7 +1871,7 @@ Vector<Number>::operator = (const TrilinosWrappers::Vector &v)
 template <typename Number>
 template <typename Number2>
 bool
-Vector<Number>::operator == (const Vector<Number2> &v) const
+Vector<Number>::operator== (const Vector<Number2> &v) const
 {
   Assert (vec_size!=0, ExcEmptyObject());
   Assert (vec_size == v.size(), ExcDimensionMismatch(vec_size, v.size()));

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2014 by the deal.II authors
+// Copyright (C) 2004 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -40,6 +40,15 @@ namespace PETScWrappers
       AssertThrow (ierr == 0, ExcPETScError(ierr));
       ghosted = false;
     }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+    Vector::Vector (Vector &&v)
+    {
+      swap(v);
+    }
+#endif
 
 
 

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2014 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -73,6 +73,17 @@ namespace TrilinosWrappers
 
       return *this;
     }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+    BlockVector &
+    BlockVector::operator= (BlockVector &&v)
+    {
+      swap(v);
+      return *this;
+    }
+#endif
 
 
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -431,11 +431,11 @@ namespace TrilinosWrappers
 
 
 #ifdef DEAL_II_WITH_CXX11
-      Vector & Vector::operator= (Vector &&v)
-      {
-        swap(v);
-        return *this;
-      }
+    Vector &Vector::operator= (Vector &&v)
+    {
+      swap(v);
+      return *this;
+    }
 #endif
 
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -125,6 +125,15 @@ namespace TrilinosWrappers
 
 
 
+#ifdef DEAL_II_WITH_CXX11
+    Vector::Vector (Vector &&v)
+    {
+      swap(v);
+    }
+#endif
+
+
+
     Vector::Vector (const Epetra_Map &input_map,
                     const VectorBase &v)
       :
@@ -418,6 +427,16 @@ namespace TrilinosWrappers
 
       return *this;
     }
+
+
+
+#ifdef DEAL_II_WITH_CXX11
+      Vector & Vector::operator= (Vector &&v)
+      {
+        swap(v);
+        return *this;
+      }
+#endif
 
 
 

--- a/tests/lac/vector_move_operations.cc
+++ b/tests/lac/vector_move_operations.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2012 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/block_vector.h>
+
+#define PRINTME(name, var) \
+  deallog << "Block vector: " name << ":" << std::endl; \
+  for (unsigned int i = 0; i < var.n_blocks(); ++i) \
+    deallog << "[block " << i << " ]  " << var.block(i);
+
+int main()
+{
+  initlog();
+
+  {
+    Vector<double> w(Vector<double>(10));
+    deallog << "move constructor:  " << w;
+  }
+
+  deallog << std::endl;
+
+  {
+    Vector<double> u(10);
+    for (unsigned int i = 0; i < u.size(); ++i)
+      u[i] = (double)(i+1);
+
+    deallog << "vector:          " << u;
+
+    Vector<double> v;
+    v = u;
+    deallog << "copy assignment: " << v;
+    deallog << "old object:      " << u;
+
+    v = std::move(u);
+    deallog << "move assignment: " << v;
+    deallog << "old object size: " << u.size() << std::endl;
+
+    // and swap again with different sizes
+    u = std::move(v);
+    deallog << "move assignment: " << u;
+    deallog << "old object size: " << v.size() << std::endl;
+  }
+
+  deallog << std::endl;
+
+  {
+    BlockVector<double> w(BlockVector<double>(5, 2));
+    PRINTME("move constructor", w);
+  }
+
+  deallog << std::endl;
+
+  {
+    BlockVector<double> u(5, 2);
+    for (unsigned int i = 0; i < 5; ++i)
+      for (unsigned int j = 0; j < 2; ++j)
+        u.block(i)[j] = (double)(10 * i + j);
+
+    PRINTME("BlockVector", u);
+
+    BlockVector<double> v;
+    v = u;
+    PRINTME("copy assignemnt", v);
+    PRINTME("old object", u);
+
+    v = std::move(u);
+    PRINTME("move assignemnt", v);
+    deallog << "old object size: " << u.n_blocks() << std::endl;
+
+    // and swap again with different sizes
+    u = std::move(v);
+    PRINTME("move assignemnt", u);
+    deallog << "old object size: " << v.n_blocks() << std::endl;
+  }
+}
+
+

--- a/tests/lac/vector_move_operations.with_cxx11=on.output
+++ b/tests/lac/vector_move_operations.with_cxx11=on.output
@@ -1,0 +1,50 @@
+
+DEAL::move constructor:  0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 
+DEAL::
+DEAL::vector:          1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::copy assignment: 1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::old object:      1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::move assignment: 1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::old object size: 0
+DEAL::move assignment: 1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::old object size: 0
+DEAL::
+DEAL::Block vector: move constructor:
+DEAL::[block 0 ]  0.00000 0.00000 
+DEAL::[block 1 ]  0.00000 0.00000 
+DEAL::[block 2 ]  0.00000 0.00000 
+DEAL::[block 3 ]  0.00000 0.00000 
+DEAL::[block 4 ]  0.00000 0.00000 
+DEAL::
+DEAL::Block vector: BlockVector:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: copy assignemnt:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: old object:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: move assignemnt:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::old object size: 0
+DEAL::Block vector: move assignemnt:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::old object size: 0

--- a/tests/trilinos/vector_move_operations.cc
+++ b/tests/trilinos/vector_move_operations.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2012 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+
+#define PRINTME(name, var)                                 \
+  deallog << "Vector: " name << ":" << std::endl;          \
+  for (unsigned int i = 0; i < var.size(); ++i)            \
+    deallog << var[i] << " ";                              \
+  deallog << std::endl;
+
+#define PRINTBLOCK(name, var)                                \
+  deallog << "Block vector: " name << ":" << std::endl;      \
+  for (unsigned int i = 0; i < var.n_blocks(); ++i)          \
+    {                                                        \
+      deallog << "[block " << i << " ]  ";                   \
+      for (unsigned int j = 0; j < var.block(i).size(); ++j) \
+        deallog << var.block(i)[j] << " ";                   \
+      deallog << std::endl;                                  \
+    }
+
+
+int main (int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+
+  {
+    IndexSet local_owned(10);
+    local_owned.add_range (0,10);
+
+    TrilinosWrappers::MPI::Vector u(local_owned, MPI_COMM_WORLD);
+    for (unsigned int i = 0; i < u.size(); ++i)
+      u[i] = (double)(i+1);
+
+    PRINTME("Vector", u);
+
+    TrilinosWrappers::MPI::Vector v;
+    v = u;
+    PRINTME("copy assignemnt", v);
+    PRINTME("old object", u);
+
+    v = std::move(u);
+    PRINTME("move assignemnt", v);
+    deallog << "old object size: " << u.size() << std::endl;
+  }
+
+  deallog << std::endl;
+
+  {
+    std::vector<IndexSet> local_owned(5);
+    for (auto &index : local_owned)
+      {
+        index.set_size(2);
+        index.add_range(0,2);
+      }
+
+    TrilinosWrappers::MPI::BlockVector u(local_owned, MPI_COMM_WORLD);
+    for (unsigned int i = 0; i < 5; ++i)
+      for (unsigned int j = 0; j < 2; ++j)
+        u.block(i)[j] = (double)(10 * i + j);
+
+    PRINTBLOCK("BlockVector", u);
+
+    TrilinosWrappers::MPI::BlockVector v;
+    v = u;
+    PRINTBLOCK("copy assignemnt", v);
+    PRINTBLOCK("old object", u);
+
+    v = std::move(u);
+    PRINTBLOCK("move assignemnt", v);
+    deallog << "old object size: " << u.n_blocks() << std::endl;
+  }
+}
+
+

--- a/tests/trilinos/vector_move_operations.cc
+++ b/tests/trilinos/vector_move_operations.cc
@@ -56,6 +56,7 @@ int main (int argc, char **argv)
     PRINTME("copy assignemnt", v);
     PRINTME("old object", u);
 
+    v.clear();
     v = std::move(u);
     PRINTME("move assignemnt", v);
     deallog << "old object size: " << u.size() << std::endl;
@@ -83,6 +84,7 @@ int main (int argc, char **argv)
     PRINTBLOCK("copy assignemnt", v);
     PRINTBLOCK("old object", u);
 
+    v.reinit(0);
     v = std::move(u);
     PRINTBLOCK("move assignemnt", v);
     deallog << "old object size: " << u.n_blocks() << std::endl;

--- a/tests/trilinos/vector_move_operations.with_cxx11=on.output
+++ b/tests/trilinos/vector_move_operations.with_cxx11=on.output
@@ -1,0 +1,36 @@
+
+DEAL::Vector: Vector:
+DEAL::1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::Vector: copy assignemnt:
+DEAL::1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::Vector: old object:
+DEAL::1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::Vector: move assignemnt:
+DEAL::1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000 8.00000 9.00000 10.0000 
+DEAL::old object size: 0
+DEAL::
+DEAL::Block vector: BlockVector:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: copy assignemnt:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: old object:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::Block vector: move assignemnt:
+DEAL::[block 0 ]  0.00000 1.00000 
+DEAL::[block 1 ]  10.0000 11.0000 
+DEAL::[block 2 ]  20.0000 21.0000 
+DEAL::[block 3 ]  30.0000 31.0000 
+DEAL::[block 4 ]  40.0000 41.0000 
+DEAL::old object size: 0


### PR DESCRIPTION
This pull request adds C++11 move semantic to all Vector and BlockVector
classes (except for the serial variants that will be deprecated).