### PR TITLE
Fixed colorization for GridGenerator::half_hyper_shell

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -472,6 +472,11 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Fixed: GridGenerator::half_hyper_shell can now be colorized.
+  <br>
+  (Daniel Arndt, 2015/05/05)
+  </li>
+
   <li> New: The function VectorTools::point_gradient has been added to compute
   the gradient of a given FE function.
   <br>

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -506,9 +506,9 @@ namespace GridGenerator
    * computed adaptively such that the resulting elements have the least
    * aspect ratio.
    *
-   * If colorize is set to true, the inner, outer, left, and right boundary
-   * get indicator 0, 1, 2, and 3, respectively. Otherwise all indicators are
-   * set to 0.
+   * If colorize is set to true, the inner, outer, and the part of the boundary
+   * where $x=0$, get indicator 0, 1, and 2, respectively. Otherwise all
+   * indicators are set to 0.
    *
    * @note The triangulation needs to be void upon calling this function.
    */


### PR DESCRIPTION
The documentation for GridGenerator::half_hyper_shell was kind of misleading. Actually, there was no colorization implemented. This should be fixed now.