### PR TITLE
multiple polynomials_bernstein instantiation, in polynomials_bernstein.c...

### DIFF
--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -94,6 +94,5 @@ FE_Bernstein<dim, spacedim>::renumber_bases(const unsigned int deg)
 
 // explicit instantiations
 #include "fe_bernstein.inst"
-#include "../base/polynomials_bernstein.inst"
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
The same instantiation file was included in fe_bernstein.cc and polynomials_bernstein.cc. My gcc 4.7 was complaining for the multiple class definition at linking time.