### PR TITLE
Introduce generic data types for values extracted from solution vectors

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,27 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li>Changed: Functions such as FEValuesBase::get_function_values() that
+  extracted the values of functions at the quadrature points of a cell
+  implicitly always assumed that <code>double</code> is a reasonable
+  type to store the result in. This, however, is not true if the solution
+  vector's underlying scalar type was, for example,
+  <code>std::complex@<double@></code>. All of the functions of
+  FEValuesBase as well as of the various FEValuesViews class that extract
+  values from solution vectors have been changed so that they now return
+  their results in vectors that use the same underlying scalar type
+  (float, double, or std::complex) as was used in the solution vector.
+  <br>
+  Most user codes will be entirely unaffected by this because they simply
+  use the default vector types which all store their data as doubles.
+  You may have to adjust your code, though, if you use non-standard
+  types such as Vector@<float@> for solution vectors, or use
+  complex-valued data types. This includes compiling PETSc with
+  complex scalars.
+  <br>
+  (David Davydov, 2015/05/08)
+  </li>
+
   <li>Removed: The generic, templated vmult, Tvmult, etc. -interfaces of
   LAPACKFullMatrix - they were never implemented.
   <br>

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1687,9 +1687,9 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_values (const InputVector &fe_function,
-                            std::vector<number> &values) const;
+                            std::vector<typename InputVector::value_type> &values) const;
 
   /**
    * This function does the same as the other get_function_values(), but
@@ -1704,9 +1704,9 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_values (const InputVector       &fe_function,
-                            std::vector<Vector<number> > &values) const;
+                            std::vector<Vector<typename InputVector::value_type> > &values) const;
 
   /**
    * Generate function values from an arbitrary vector.
@@ -1726,10 +1726,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_values (const InputVector &fe_function,
                             const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-                            std::vector<number> &values) const;
+                            std::vector<typename InputVector::value_type> &values) const;
 
   /**
    * Generate vector function values from an arbitrary vector.
@@ -1752,10 +1752,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_values (const InputVector &fe_function,
                             const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-                            std::vector<Vector<number> > &values) const;
+                            std::vector<Vector<typename InputVector::value_type> > &values) const;
 
 
   /**
@@ -1791,7 +1791,7 @@ public:
   template <class InputVector>
   void get_function_values (const InputVector &fe_function,
                             const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-                            VectorSlice<std::vector<std::vector<double> > > values,
+                            VectorSlice<std::vector<std::vector<typename InputVector::value_type> > > values,
                             const bool quadrature_points_fastest) const;
 
   //@}
@@ -1834,7 +1834,7 @@ public:
    */
   template <class InputVector>
   void get_function_gradients (const InputVector      &fe_function,
-                               std::vector<Tensor<1,spacedim> > &gradients) const;
+                               std::vector<Tensor<1,spacedim,typename InputVector::value_type> > &gradients) const;
 
   /**
    * This function does the same as the other get_function_gradients(), but
@@ -1854,7 +1854,7 @@ public:
    */
   template <class InputVector>
   void get_function_gradients (const InputVector               &fe_function,
-                               std::vector<std::vector<Tensor<1,spacedim> > > &gradients) const;
+                               std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > &gradients) const;
 
   /**
    * Function gradient access with more flexibility. See get_function_values()
@@ -1865,7 +1865,7 @@ public:
   template <class InputVector>
   void get_function_gradients (const InputVector &fe_function,
                                const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-                               std::vector<Tensor<1,spacedim> > &gradients) const;
+                               std::vector<Tensor<1,spacedim,typename InputVector::value_type> > &gradients) const;
 
   /**
    * Function gradient access with more flexibility. See get_function_values()
@@ -1876,7 +1876,7 @@ public:
   template <class InputVector>
   void get_function_gradients (const InputVector &fe_function,
                                const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-                               VectorSlice<std::vector<std::vector<Tensor<1,spacedim> > > > gradients,
+                               VectorSlice<std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > > gradients,
                                bool quadrature_points_fastest = false) const;
 
   //@}
@@ -1921,7 +1921,7 @@ public:
   template <class InputVector>
   void
   get_function_hessians (const InputVector &fe_function,
-                         std::vector<Tensor<2,spacedim> > &hessians) const;
+                         std::vector<Tensor<2,spacedim,typename InputVector::value_type> > &hessians) const;
 
   /**
    * This function does the same as the other get_function_hessians(), but
@@ -1943,7 +1943,7 @@ public:
   template <class InputVector>
   void
   get_function_hessians (const InputVector      &fe_function,
-                         std::vector<std::vector<Tensor<2,spacedim> > > &hessians,
+                         std::vector<std::vector<Tensor<2,spacedim,typename InputVector::value_type> > > &hessians,
                          bool quadrature_points_fastest = false) const;
 
   /**
@@ -1954,7 +1954,7 @@ public:
   void get_function_hessians (
     const InputVector &fe_function,
     const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-    std::vector<Tensor<2,spacedim> > &hessians) const;
+    std::vector<Tensor<2,spacedim,typename InputVector::value_type> > &hessians) const;
 
   /**
    * Access to the second derivatives of a function with more flexibility. See
@@ -1966,7 +1966,7 @@ public:
   void get_function_hessians (
     const InputVector &fe_function,
     const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-    VectorSlice<std::vector<std::vector<Tensor<2,spacedim> > > > hessians,
+    VectorSlice<std::vector<std::vector<Tensor<2,spacedim,typename InputVector::value_type> > > > hessians,
     bool quadrature_points_fastest = false) const;
 
   /**
@@ -2008,10 +2008,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void
   get_function_laplacians (const InputVector &fe_function,
-                           std::vector<number> &laplacians) const;
+                           std::vector<typename InputVector::value_type> &laplacians) const;
 
   /**
    * This function does the same as the other get_function_laplacians(), but
@@ -2032,10 +2032,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void
   get_function_laplacians (const InputVector      &fe_function,
-                           std::vector<Vector<number> > &laplacians) const;
+                           std::vector<Vector<typename InputVector::value_type> > &laplacians) const;
 
   /**
    * Access to the second derivatives of a function with more flexibility. See
@@ -2043,11 +2043,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_laplacians (
     const InputVector &fe_function,
     const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-    std::vector<number> &laplacians) const;
+    std::vector<typename InputVector::value_type> &laplacians) const;
 
   /**
    * Access to the second derivatives of a function with more flexibility. See
@@ -2055,11 +2055,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_laplacians (
     const InputVector &fe_function,
     const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-    std::vector<Vector<number> > &laplacians) const;
+    std::vector<Vector<typename InputVector::value_type> > &laplacians) const;
 
   /**
    * Access to the second derivatives of a function with more flexibility. See
@@ -2067,11 +2067,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector, typename number>
+  template <class InputVector>
   void get_function_laplacians (
     const InputVector &fe_function,
     const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-    std::vector<std::vector<number> > &laplacians,
+    std::vector<std::vector<typename InputVector::value_type> > &laplacians,
     bool quadrature_points_fastest = false) const;
   //@}
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -264,11 +264,17 @@ namespace FEValuesViews
      * FEValuesBase::get_function_values function but it only works on the
      * selected scalar component.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the values of shape function (i.e., @p
+     * value_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_values}
      */
     template <class InputVector>
     void get_function_values (const InputVector &fe_function,
-                              std::vector<value_type> &values) const;
+                              std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const;
 
     /**
      * Return the gradients of the selected scalar component of the finite
@@ -280,11 +286,17 @@ namespace FEValuesViews
      * FEValuesBase::get_function_gradients function but it only works on the
      * selected scalar component.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the gradients of shape function (i.e., @p
+     * gradient_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
     template <class InputVector>
     void get_function_gradients (const InputVector &fe_function,
-                                 std::vector<gradient_type> &gradients) const;
+                                 std::vector<typename ProductType<gradient_type,typename InputVector::value_type>::type> &gradients) const;
 
     /**
      * Return the Hessians of the selected scalar component of the finite
@@ -296,11 +308,17 @@ namespace FEValuesViews
      * FEValuesBase::get_function_hessians function but it only works on the
      * selected scalar component.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the Hessians of shape function (i.e., @p
+     * hessian_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
     template <class InputVector>
     void get_function_hessians (const InputVector &fe_function,
-                                std::vector<hessian_type> &hessians) const;
+                                std::vector<typename ProductType<hessian_type,typename InputVector::value_type>::type> &hessians) const;
 
     /**
      * Return the Laplacians of the selected scalar component of the finite
@@ -313,11 +331,17 @@ namespace FEValuesViews
      * FEValuesBase::get_function_laplacians function but it only works on the
      * selected scalar component.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the Laplacians of shape function (i.e., @p
+     * value_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
     template <class InputVector>
     void get_function_laplacians (const InputVector &fe_function,
-                                  std::vector<value_type> &laplacians) const;
+                                  std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &laplacians) const;
 
   private:
     /**

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -265,7 +265,7 @@ namespace FEValuesViews
      * selected scalar component.
      *
      * The data type stored by the output vector must be what you get
-     * when you multiply the values of shape function (i.e., @p
+     * when you multiply the values of shape functions (i.e., @p
      * value_type) times the type used to store the values of the
      * unknowns $U_j$ of your finite element vector $U$ (represented
      * by the @p fe_function argument).
@@ -287,7 +287,7 @@ namespace FEValuesViews
      * selected scalar component.
      *
      * The data type stored by the output vector must be what you get
-     * when you multiply the gradients of shape function (i.e., @p
+     * when you multiply the gradients of shape functions (i.e., @p
      * gradient_type) times the type used to store the values of the
      * unknowns $U_j$ of your finite element vector $U$ (represented
      * by the @p fe_function argument).
@@ -309,7 +309,7 @@ namespace FEValuesViews
      * selected scalar component.
      *
      * The data type stored by the output vector must be what you get
-     * when you multiply the Hessians of shape function (i.e., @p
+     * when you multiply the Hessians of shape functions (i.e., @p
      * hessian_type) times the type used to store the values of the
      * unknowns $U_j$ of your finite element vector $U$ (represented
      * by the @p fe_function argument).
@@ -332,7 +332,7 @@ namespace FEValuesViews
      * selected scalar component.
      *
      * The data type stored by the output vector must be what you get
-     * when you multiply the Laplacians of shape function (i.e., @p
+     * when you multiply the Laplacians of shape functions (i.e., @p
      * value_type) times the type used to store the values of the
      * unknowns $U_j$ of your finite element vector $U$ (represented
      * by the @p fe_function argument).
@@ -622,6 +622,12 @@ namespace FEValuesViews
      * FEValuesBase::get_function_values function but it only works on the
      * selected vector components.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the values of shape functions (i.e., @p
+     * value_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_values}
      */
     template <class InputVector>
@@ -637,6 +643,12 @@ namespace FEValuesViews
      * This function is the equivalent of the
      * FEValuesBase::get_function_gradients function but it only works on the
      * selected vector components.
+     *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the gradients of shape functions (i.e., @p
+     * gradient_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
@@ -659,6 +671,12 @@ namespace FEValuesViews
      * but the information can be obtained from
      * FEValuesBase::get_function_gradients, of course.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the symmetric gradients of shape functions (i.e., @p
+     * symmetric_gradient_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
     template <class InputVector>
@@ -677,6 +695,12 @@ namespace FEValuesViews
      * information can be obtained from FEValuesBase::get_function_gradients,
      * of course.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the divergences of shape functions (i.e., @p
+     * divergence_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
     template <class InputVector>
@@ -694,6 +718,12 @@ namespace FEValuesViews
      * information can be obtained from FEValuesBase::get_function_gradients,
      * of course.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the curls of shape functions (i.e., @p
+     * curl_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
     template <class InputVector>
@@ -709,6 +739,12 @@ namespace FEValuesViews
      * This function is the equivalent of the
      * FEValuesBase::get_function_hessians function but it only works on the
      * selected vector components.
+     *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the Hessians of shape functions (i.e., @p
+     * hessian_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
@@ -726,6 +762,12 @@ namespace FEValuesViews
      * This function is the equivalent of the
      * FEValuesBase::get_function_laplacians function but it only works on the
      * selected vector components.
+     *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the Laplacians of shape functions (i.e., @p
+     * laplacian_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
@@ -913,6 +955,12 @@ namespace FEValuesViews
      * FEValuesBase::get_function_values function but it only works on the
      * selected vector components.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the values of shape functions (i.e., @p
+     * value_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_values}
      */
     template <class InputVector>
@@ -932,6 +980,12 @@ namespace FEValuesViews
      *
      * See the general discussion of this class for a definition of the
      * divergence.
+     *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the divergences of shape functions (i.e., @p
+     * divergence_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
@@ -1107,6 +1161,12 @@ namespace FEValuesViews
      * FEValuesBase::get_function_values function but it only works on the
      * selected vector components.
      *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the values of shape functions (i.e., @p
+     * value_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
+     *
      * @dealiiRequiresUpdateFlags{update_values}
      */
     template <class InputVector>
@@ -1127,6 +1187,12 @@ namespace FEValuesViews
      *
      * See the general discussion of this class for a definition of the
      * divergence.
+     *
+     * The data type stored by the output vector must be what you get
+     * when you multiply the divergences of shape functions (i.e., @p
+     * divergence_type) times the type used to store the values of the
+     * unknowns $U_j$ of your finite element vector $U$ (represented
+     * by the @p fe_function argument).
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
@@ -1673,6 +1739,12 @@ public:
    * @param[out] values The values of the function specified by fe_function at
    * the quadrature points of the current cell.  The object is assume to
    * already have the correct size.
+   * The data type stored by this output vector must be what you get
+   * when you multiply the values of shape function
+   * times the type used to store the values of the
+   * unknowns $U_j$ of your finite element vector $U$ (represented
+   * by the @p fe_function argument). This happens to be equal to the
+   * type of the elements of the solution vector.
    *
    * @post <code>values[q]</code> will contain the value of the field
    * described by fe_function at the $q$th quadrature point.
@@ -1816,6 +1888,11 @@ public:
    * fe_function at the quadrature points of the current cell.  The gradients
    * are computed in real space (as opposed to on the unit cell).  The object
    * is assume to already have the correct size.
+   * The data type stored by this output vector must be what you get
+   * when you multiply the gradients of shape function times the type
+   * used to store the values of the
+   * unknowns $U_j$ of your finite element vector $U$ (represented
+   * by the @p fe_function argument).
    *
    * @post <code>gradients[q]</code> will contain the gradient of the field
    * described by fe_function at the $q$th quadrature point.
@@ -1902,6 +1979,11 @@ public:
    * fe_function at the quadrature points of the current cell.  The Hessians
    * are computed in real space (as opposed to on the unit cell).  The object
    * is assume to already have the correct size.
+   * The data type stored by this output vector must be what you get
+   * when you multiply the Hessians of shape function times the type
+   * used to store the values of the
+   * unknowns $U_j$ of your finite element vector $U$ (represented
+   * by the @p fe_function argument).
    *
    * @post <code>hessians[q]</code> will contain the Hessian of the field
    * described by fe_function at the $q$th quadrature point.
@@ -1988,6 +2070,12 @@ public:
    * fe_function at the quadrature points of the current cell.  The Laplacians
    * are computed in real space (as opposed to on the unit cell).  The object
    * is assume to already have the correct size.
+   * The data type stored by this output vector must be what you get
+   * when you multiply the Laplacians of shape function times the type
+   * used to store the values of the
+   * unknowns $U_j$ of your finite element vector $U$ (represented
+   * by the @p fe_function argument). This happens to be equal to the
+   * type of the elements of the input vector.
    *
    * @post <code>laplacians[q]</code> will contain the Laplacian of the field
    * described by fe_function at the $q$th quadrature point.

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -917,7 +917,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_values (const InputVector &fe_function,
-                              std::vector<value_type> &values) const;
+                              std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const;
 
     /**
      * Return the divergence of the selected vector components of the finite
@@ -937,7 +937,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_divergences (const InputVector &fe_function,
-                                   std::vector<divergence_type> &divergences) const;
+                                   std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const;
 
   private:
     /**
@@ -1111,7 +1111,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_values (const InputVector &fe_function,
-                              std::vector<value_type> &values) const;
+                              std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const;
 
 
     /**
@@ -1132,7 +1132,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_divergences (const InputVector &fe_function,
-                                   std::vector<divergence_type> &divergences) const;
+                                   std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const;
 
   private:
     /**

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -626,7 +626,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_values (const InputVector &fe_function,
-                              std::vector<value_type> &values) const;
+                              std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const;
 
     /**
      * Return the gradients of the selected vector components of the finite
@@ -642,7 +642,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_gradients (const InputVector &fe_function,
-                                 std::vector<gradient_type> &gradients) const;
+                                 std::vector<typename ProductType<gradient_type,typename InputVector::value_type>::type> &gradients) const;
 
     /**
      * Return the symmetrized gradients of the selected vector components of
@@ -664,7 +664,7 @@ namespace FEValuesViews
     template <class InputVector>
     void
     get_function_symmetric_gradients (const InputVector &fe_function,
-                                      std::vector<symmetric_gradient_type> &symmetric_gradients) const;
+                                      std::vector<typename ProductType<symmetric_gradient_type,typename InputVector::value_type>::type> &symmetric_gradients) const;
 
     /**
      * Return the divergence of the selected vector components of the finite
@@ -681,7 +681,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_divergences (const InputVector &fe_function,
-                                   std::vector<divergence_type> &divergences) const;
+                                   std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const;
 
     /**
      * Return the curl of the selected vector components of the finite element
@@ -698,7 +698,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_curls (const InputVector &fe_function,
-                             std::vector<curl_type> &curls) const;
+                             std::vector<typename ProductType<curl_type,typename InputVector::value_type>::type> &curls) const;
 
     /**
      * Return the Hessians of the selected vector components of the finite
@@ -714,7 +714,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_hessians (const InputVector &fe_function,
-                                std::vector<hessian_type> &hessians) const;
+                                std::vector<typename ProductType<hessian_type,typename InputVector::value_type>::type> &hessians) const;
 
     /**
      * Return the Laplacians of the selected vector components of the finite
@@ -731,7 +731,7 @@ namespace FEValuesViews
      */
     template <class InputVector>
     void get_function_laplacians (const InputVector &fe_function,
-                                  std::vector<value_type> &laplacians) const;
+                                  std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &laplacians) const;
 
   private:
     /**

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -313,9 +313,9 @@ namespace MeshWorker
     void initialize(const VECTOR *, const std::string &name);
 
     virtual void fill(
-      std::vector<std::vector<std::vector<double> > > &values,
-      std::vector<std::vector<std::vector<Tensor<1,dim> > > > &gradients,
-      std::vector<std::vector<std::vector<Tensor<2,dim> > > > &hessians,
+      std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
+      std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
+      std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
       const FEValuesBase<dim,spacedim> &fe,
       const std::vector<types::global_dof_index> &index,
       const unsigned int component,
@@ -324,9 +324,9 @@ namespace MeshWorker
       const unsigned int size) const;
 
     virtual void mg_fill(
-      std::vector<std::vector<std::vector<double> > > &values,
-      std::vector<std::vector<std::vector<Tensor<1,dim> > > > &gradients,
-      std::vector<std::vector<std::vector<Tensor<2,dim> > > > &hessians,
+      std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
+      std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
+      std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
       const FEValuesBase<dim,spacedim> &fe,
       const unsigned int level,
       const std::vector<types::global_dof_index> &index,

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -119,9 +119,9 @@ namespace MeshWorker
   template <class VECTOR, int dim, int spacedim>
   void
   VectorData<VECTOR, dim, spacedim>::fill(
-    std::vector<std::vector<std::vector<double> > > &values,
-    std::vector<std::vector<std::vector<Tensor<1,dim> > > > &gradients,
-    std::vector<std::vector<std::vector<Tensor<2,dim> > > > &hessians,
+    std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
+    std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
+    std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
     const FEValuesBase<dim,spacedim> &fe,
     const std::vector<types::global_dof_index> &index,
     const unsigned int component,
@@ -137,21 +137,21 @@ namespace MeshWorker
     for (unsigned int i=0; i<this->n_values(); ++i)
       {
         const VECTOR *src = data.read_ptr<VECTOR>(this->value_index(i));
-        VectorSlice<std::vector<std::vector<double> > > dst(values[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<typename VECTOR::value_type> > > dst(values[i], component, n_comp);
         fe.get_function_values(*src, make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_gradients(); ++i)
       {
         const VECTOR *src = data.read_ptr<VECTOR>(this->gradient_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<1,dim> > > > dst(gradients[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > dst(gradients[i], component, n_comp);
         fe.get_function_gradients(*src, make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_hessians(); ++i)
       {
         const VECTOR *src = data.read_ptr<VECTOR>(this->hessian_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<2,dim> > > > dst(hessians[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > dst(hessians[i], component, n_comp);
         fe.get_function_hessians(*src, make_slice(index, start, size), dst, true);
       }
   }
@@ -203,9 +203,9 @@ namespace MeshWorker
   template <class VECTOR, int dim, int spacedim>
   void
   VectorData<VECTOR, dim, spacedim>::mg_fill(
-    std::vector<std::vector<std::vector<double> > > &values,
-    std::vector<std::vector<std::vector<Tensor<1,dim> > > > &gradients,
-    std::vector<std::vector<std::vector<Tensor<2,dim> > > > &hessians,
+    std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
+    std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
+    std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
     const FEValuesBase<dim,spacedim> &fe,
     const unsigned int level,
     const std::vector<types::global_dof_index> &index,
@@ -222,21 +222,21 @@ namespace MeshWorker
     for (unsigned int i=0; i<this->n_values(); ++i)
       {
         const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<double> > > dst(values[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<typename VECTOR::value_type> > > dst(values[i], component, n_comp);
         fe.get_function_values((*src)[level], make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_gradients(); ++i)
       {
         const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<1,dim> > > > dst(gradients[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > dst(gradients[i], component, n_comp);
         fe.get_function_gradients((*src)[level], make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_hessians(); ++i)
       {
         const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<2,dim> > > > dst(hessians[i], component, n_comp);
+        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > dst(hessians[i], component, n_comp);
         fe.get_function_hessians((*src)[level], make_slice(index, start, size), dst, true);
       }
   }

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -88,7 +88,7 @@ namespace Functions
                        update_values);
     fe_v.reinit(cell);
     std::vector< Vector<typename VECTOR::value_type> >
-      vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
+    vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
     fe_v.get_function_values(data_vector, vvalues);
     values = vvalues[0];
   }
@@ -197,7 +197,7 @@ namespace Functions
                        update_hessians);
     fe_v.reinit(cell);
     std::vector< Vector<typename VECTOR::value_type> >
-      vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
+    vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
     fe_v.get_function_laplacians(data_vector, vvalues);
     values = vvalues[0];
   }

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -321,7 +321,7 @@ namespace Functions
             std::vector< Tensor<1,dim> > &viq = values[maps[i][q]];
             const unsigned int s = vgrads[q].size();
             viq.resize(s);
-            for (unsigned int l=0;l<s;l++)
+            for (unsigned int l=0; l<s; l++)
               viq[l] = vgrads[q][l];
           }
       }

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -139,13 +139,14 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_gradients);
     fe_v.reinit(cell);
+
+    // FIXME: we need a temp argument because get_function_values wants to put
+    // its data into an object storing the correct scalar type, but this
+    // function wants to return everything in a vector<double>
     std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > > vgrads
     (1,  std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components) );
     fe_v.get_function_gradients(data_vector, vgrads);
-    const unsigned int s = vgrads[0].size();
-    gradients.resize(s);
-    for (unsigned int i = 0; i < s; i++)
-      gradients[i] = vgrads[0][i];
+    gradients = std::vector<Tensor<1,dim> >(vgrads[0].begin(), vgrads[0].end());
   }
 
 
@@ -318,11 +319,10 @@ namespace Functions
         fe_v.get_present_fe_values ().get_function_gradients(data_vector, vgrads);
         for (unsigned int q=0; q<nq; ++q)
           {
-            std::vector< Tensor<1,dim> > &viq = values[maps[i][q]];
             const unsigned int s = vgrads[q].size();
-            viq.resize(s);
+            values[maps[i][q]].resize(s);
             for (unsigned int l=0; l<s; l++)
-              viq[l] = vgrads[q][l];
+              values[maps[i][q]][l] = vgrads[q][l];
           }
       }
   }

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -87,7 +87,8 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_values);
     fe_v.reinit(cell);
-    std::vector< Vector<double> > vvalues (1, values);
+    std::vector< Vector<typename VECTOR::value_type> > vvalues (1);
+    vvalues[0].reinit(values.size());
     fe_v.get_function_values(data_vector, vvalues);
     values = vvalues[0];
   }
@@ -138,10 +139,13 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_gradients);
     fe_v.reinit(cell);
-    std::vector< std::vector<Tensor<1,dim> > > vgrads
-    (1,  std::vector<Tensor<1,dim> >(n_components) );
+    std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > > vgrads
+    (1,  std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components) );
     fe_v.get_function_gradients(data_vector, vgrads);
-    gradients = vgrads[0];
+    const unsigned int s = vgrads[0].size();
+    gradients.resize(s);
+    for (unsigned int i = 0; i < s; i++)
+      gradients[i] = vgrads[0][i];
   }
 
 
@@ -191,7 +195,8 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_hessians);
     fe_v.reinit(cell);
-    std::vector< Vector<double> > vvalues (1, values);
+    std::vector< Vector<typename VECTOR::value_type> > vvalues (1);
+    vvalues[0].reinit(values.size());
     fe_v.get_function_laplacians(data_vector, vvalues);
     values = vvalues[0];
   }
@@ -246,7 +251,7 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< Vector<double> > vvalues (nq, Vector<double>(n_components));
+        std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
         fe_v.get_present_fe_values ().get_function_values(data_vector, vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];
@@ -308,11 +313,17 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< std::vector<Tensor<1,dim> > >
-        vgrads (nq, std::vector<Tensor<1,dim> >(n_components));
+        std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > >
+        vgrads (nq, std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components));
         fe_v.get_present_fe_values ().get_function_gradients(data_vector, vgrads);
         for (unsigned int q=0; q<nq; ++q)
-          values[maps[i][q]] = vgrads[q];
+          {
+            std::vector< Tensor<1,dim> > &viq = values[maps[i][q]];
+            const unsigned int s = vgrads[q].size();
+            viq.resize(s);
+            for (unsigned int l=0;l<s;l++)
+              viq[l] = vgrads[q][l];
+          }
       }
   }
 
@@ -368,7 +379,7 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< Vector<double> > vvalues (nq, Vector<double>(n_components));
+        std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
         fe_v.get_present_fe_values ().get_function_laplacians(data_vector, vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -87,8 +87,8 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_values);
     fe_v.reinit(cell);
-    std::vector< Vector<typename VECTOR::value_type> > vvalues (1);
-    vvalues[0].reinit(values.size());
+    std::vector< Vector<typename VECTOR::value_type> >
+      vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
     fe_v.get_function_values(data_vector, vvalues);
     values = vvalues[0];
   }
@@ -195,8 +195,8 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_hessians);
     fe_v.reinit(cell);
-    std::vector< Vector<typename VECTOR::value_type> > vvalues (1);
-    vvalues[0].reinit(values.size());
+    std::vector< Vector<typename VECTOR::value_type> >
+      vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
     fe_v.get_function_laplacians(data_vector, vvalues);
     values = vvalues[0];
   }

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -2122,7 +2122,7 @@ namespace VectorTools
   point_gradient (const DoFHandler<dim,spacedim>    &dof,
                   const InVector                    &fe_function,
                   const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim> > &value);
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &value);
 
   /**
    * Same as above for hp.
@@ -2135,7 +2135,7 @@ namespace VectorTools
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector                     &fe_function,
                   const Point<spacedim>              &point,
-                  std::vector<Tensor<1, spacedim> >  &value);
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> >  &value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -2149,7 +2149,7 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
                   const InVector                 &fe_function,
                   const Point<spacedim>          &point);
@@ -2161,7 +2161,7 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector                     &fe_function,
                   const Point<spacedim>              &point);
@@ -2183,7 +2183,7 @@ namespace VectorTools
                   const DoFHandler<dim,spacedim>    &dof,
                   const InVector                    &fe_function,
                   const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim> > &value);
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &value);
 
   /**
    * Same as above for hp.
@@ -2197,7 +2197,7 @@ namespace VectorTools
                   const hp::DoFHandler<dim,spacedim>         &dof,
                   const InVector                             &fe_function,
                   const Point<spacedim>                      &point,
-                  std::vector<Tensor<1, spacedim> >          &value);
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> >          &value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -2211,7 +2211,7 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const Mapping<dim,spacedim>    &mapping,
                   const DoFHandler<dim,spacedim> &dof,
                   const InVector                 &fe_function,
@@ -2224,7 +2224,7 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const hp::MappingCollection<dim,spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>        &dof,
                   const InVector                            &fe_function,

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6070,9 +6070,9 @@ namespace VectorTools
     IDScratchData<dim,spacedim>::IDScratchData (const IDScratchData &data)
       :
       x_fe_values(data.x_fe_values.get_mapping_collection(),
-                  data.x_fe_values.get_fe_collection(),
-                  data.x_fe_values.get_quadrature_collection(),
-                  data.x_fe_values.get_update_flags())
+                 data.x_fe_values.get_fe_collection(),
+                 data.x_fe_values.get_quadrature_collection(),
+                 data.x_fe_values.get_update_flags())
     {}
 
     template <int dim, int spacedim>

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6070,9 +6070,9 @@ namespace VectorTools
     IDScratchData<dim,spacedim>::IDScratchData (const IDScratchData &data)
       :
       x_fe_values(data.x_fe_values.get_mapping_collection(),
-                 data.x_fe_values.get_fe_collection(),
-                 data.x_fe_values.get_quadrature_collection(),
-                 data.x_fe_values.get_update_flags())
+                  data.x_fe_values.get_fe_collection(),
+                  data.x_fe_values.get_quadrature_collection(),
+                  data.x_fe_values.get_update_flags())
     {}
 
     template <int dim, int spacedim>

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6407,10 +6407,11 @@ namespace VectorTools
       dealii::hp::FECollection<dim,spacedim> fe_collection (dof.get_fe());
       IDScratchData<dim,spacedim> data(mapping, fe_collection, q, update_flags);
 
-      //FIXME
-      // temporary vectors of consistent with InVector type
+      // FIXME
+      // temporary vectors of consistent with InVector type.
+      // Need these because IDScratchData does not have a template type for the InVector
       std::vector<dealii::Vector<Number>> function_values;
-      std::vector<std::vector<Tensor<1,spacedim,Number> >> function_grads;
+      std::vector<std::vector<Tensor<1,spacedim,Number> > > function_grads;
 
       // loop over all cells
       for (typename DH::active_cell_iterator cell = dof.begin_active();
@@ -7059,6 +7060,11 @@ namespace VectorTools
         p_d_triangulation
         = dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim> *>(&dof.get_tria()))
       {
+        // The type used to store the elements of the global vector may be a
+        // real or a complex number. Do the global reduction always with real
+        // and imaginary types so that we don't have to distinguish, and to this
+        // end just copy everything into a complex number and, later, back into
+        // the original data type.
         std::complex<double> mean_double = mean;
         double my_values[3] = { mean_double.real(), mean_double.imag(), area };
         double global_values[3];

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7009,17 +7009,22 @@ namespace VectorTools
       }
   }
 
-  // move to deal.ii/base/numbers.h ?
-  namespace internal
+  namespace
   {
     template <typename Number>
-    void set_possibly_complex_number(Number &n, const double &r, const double &)
+    void set_possibly_complex_number(const double &r,
+                                     const double &,
+                                     Number &n)
     {
       n = r;
     }
 
+
+
     template <typename Type>
-    void set_possibly_complex_number(std::complex<Type> &n, const double &r, const double &i)
+    void set_possibly_complex_number(const double &r,
+                                     const double &i,
+                                     std::complex<Type> &n)
     {
       n = std::complex<Type>(r,i);
     }
@@ -7083,7 +7088,8 @@ namespace VectorTools
                        MPI_SUM,
                        p_d_triangulation->get_communicator());
 
-        internal::set_possibly_complex_number(mean,global_values[0],global_values[1]);
+        set_possibly_complex_number(global_values[0], global_values[1],
+                                    mean);
         area = global_values[2];
       }
 #endif

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6027,7 +6027,7 @@ namespace VectorTools
 
   namespace internal
   {
-    template <int dim, int spacedim>
+    template <int dim, int spacedim, typename Number>
     struct IDScratchData
     {
       IDScratchData (const dealii::hp::MappingCollection<dim,spacedim> &mapping,
@@ -6040,24 +6040,26 @@ namespace VectorTools
       void resize_vectors (const unsigned int n_q_points,
                            const unsigned int n_components);
 
-      std::vector<dealii::Vector<double> > function_values;
-      std::vector<std::vector<Tensor<1,spacedim> > > function_grads;
+      std::vector<dealii::Vector<Number> > function_values;
+      std::vector<std::vector<Tensor<1,spacedim,Number> > > function_grads;
       std::vector<double> weight_values;
       std::vector<dealii::Vector<double> > weight_vectors;
 
-      std::vector<dealii::Vector<double> > psi_values;
-      std::vector<std::vector<Tensor<1,spacedim> > > psi_grads;
-      std::vector<double> psi_scalar;
+      std::vector<dealii::Vector<Number> > psi_values;
+      std::vector<std::vector<Tensor<1,spacedim,Number> > > psi_grads;
+      std::vector<Number> psi_scalar;
 
       std::vector<double>         tmp_values;
+      std::vector<dealii::Vector<double> > tmp_vector_values;
       std::vector<Tensor<1,spacedim> > tmp_gradients;
+      std::vector<std::vector<Tensor<1,spacedim> > > tmp_vector_gradients;
 
       dealii::hp::FEValues<dim,spacedim> x_fe_values;
     };
 
 
-    template <int dim, int spacedim>
-    IDScratchData<dim,spacedim>
+    template <int dim, int spacedim, typename Number>
+    IDScratchData<dim,spacedim,Number>
     ::IDScratchData(const dealii::hp::MappingCollection<dim,spacedim> &mapping,
                     const dealii::hp::FECollection<dim,spacedim> &fe,
                     const dealii::hp::QCollection<dim> &q,
@@ -6066,8 +6068,8 @@ namespace VectorTools
       x_fe_values(mapping, fe, q, update_flags)
     {}
 
-    template <int dim, int spacedim>
-    IDScratchData<dim,spacedim>::IDScratchData (const IDScratchData &data)
+    template <int dim, int spacedim, typename Number>
+    IDScratchData<dim,spacedim,Number>::IDScratchData (const IDScratchData &data)
       :
       x_fe_values(data.x_fe_values.get_mapping_collection(),
                   data.x_fe_values.get_fe_collection(),
@@ -6075,35 +6077,39 @@ namespace VectorTools
                   data.x_fe_values.get_update_flags())
     {}
 
-    template <int dim, int spacedim>
+    template <int dim, int spacedim, typename Number>
     void
-    IDScratchData<dim,spacedim>::resize_vectors (const unsigned int n_q_points,
-                                                 const unsigned int n_components)
+    IDScratchData<dim,spacedim,Number>::resize_vectors (const unsigned int n_q_points,
+                                                        const unsigned int n_components)
     {
       function_values.resize (n_q_points,
-                              dealii::Vector<double>(n_components));
+                              dealii::Vector<Number>(n_components));
       function_grads.resize (n_q_points,
-                             std::vector<Tensor<1,spacedim> >(n_components));
+                             std::vector<Tensor<1,spacedim,Number> >(n_components));
 
       weight_values.resize (n_q_points);
       weight_vectors.resize (n_q_points,
                              dealii::Vector<double>(n_components));
 
       psi_values.resize (n_q_points,
-                         dealii::Vector<double>(n_components));
+                         dealii::Vector<Number>(n_components));
       psi_grads.resize (n_q_points,
-                        std::vector<Tensor<1,spacedim> >(n_components));
+                        std::vector<Tensor<1,spacedim,Number> >(n_components));
       psi_scalar.resize (n_q_points);
 
       tmp_values.resize (n_q_points);
+      tmp_vector_values.resize (n_q_points,
+                                dealii::Vector<double>(n_components));
       tmp_gradients.resize (n_q_points);
+      tmp_vector_gradients.resize (n_q_points,
+                                   std::vector<Tensor<1,spacedim> >(n_components));
     }
 
 
     // avoid compiling inner function for many vector types when we always
     // really do the same thing by putting the main work into this helper
     // function
-    template <int dim, int spacedim>
+    template <int dim, int spacedim, typename Number>
     double
     integrate_difference_inner (const Function<spacedim>   &exact_solution,
                                 const NormType              &norm,
@@ -6111,7 +6117,7 @@ namespace VectorTools
                                 const UpdateFlags            update_flags,
                                 const double                 exponent,
                                 const unsigned int           n_components,
-                                IDScratchData<dim,spacedim> &data)
+                                IDScratchData<dim,spacedim,Number> &data)
     {
       const bool fe_is_system = (n_components != 1);
       const dealii::FEValues<dim, spacedim> &fe_values  = data.x_fe_values.get_present_fe_values ();
@@ -6140,12 +6146,22 @@ namespace VectorTools
       if (update_flags & update_values)
         {
           // first compute the exact solution (vectors) at the quadrature
-          // points try to do this as efficient as possible by avoiding a
+          // points. try to do this as efficient as possible by avoiding a
           // second virtual function call in case the function really has only
           // one component
+          //
+          // TODO: we have to work a bit here because the Function<dim,double>
+          //   interface of the argument denoting the exact function only
+          //   provides us with double/Tensor<1,dim> values, rather than
+          //   with the correct data type. so evaluate into a temp
+          //   object, then copy around
           if (fe_is_system)
-            exact_solution.vector_value_list (fe_values.get_quadrature_points(),
-                                              data.psi_values);
+            {
+              exact_solution.vector_value_list (fe_values.get_quadrature_points(),
+                                                data.tmp_vector_values);
+              for (unsigned int i=0; i<n_q_points; ++i)
+                data.psi_values[i] = data.tmp_vector_values[i];
+            }
           else
             {
               exact_solution.value_list (fe_values.get_quadrature_points(),
@@ -6156,7 +6172,8 @@ namespace VectorTools
 
           // then subtract finite element fe_function
           for (unsigned int q=0; q<n_q_points; ++q)
-            data.psi_values[q] -= data.function_values[q];
+            for (unsigned int i=0; i<data.psi_values[q].size(); ++i)
+              data.psi_values[q][i] -= data.function_values[q][i];
         }
 
       // Do the same for gradients, if required
@@ -6166,8 +6183,13 @@ namespace VectorTools
           // calls when calling gradient_list for functions that are really
           // scalar functions
           if (fe_is_system)
-            exact_solution.vector_gradient_list (fe_values.get_quadrature_points(),
-                                                 data.psi_grads);
+            {
+              exact_solution.vector_gradient_list (fe_values.get_quadrature_points(),
+                                                   data.tmp_vector_gradients);
+              for (unsigned int i=0; i<n_q_points; ++i)
+                for (unsigned int comp=0; comp<data.psi_grads[i].size(); ++comp)
+                  data.psi_grads[i][comp] = data.tmp_vector_gradients[i][comp];
+            }
           else
             {
               exact_solution.gradient_list (fe_values.get_quadrature_points(),
@@ -6184,14 +6206,20 @@ namespace VectorTools
           if (update_flags & update_normal_vectors)
             for (unsigned int k=0; k<n_components; ++k)
               for (unsigned int q=0; q<n_q_points; ++q)
-                data.psi_grads[q][k] -= (data.function_grads[q][k] +
-                                         (data.psi_grads[q][k] * // (f.n) n
-                                          Tensor<1,spacedim>(fe_values.normal_vector(q)))*
-                                         fe_values.normal_vector(q));
+                {
+                  // compute (f.n) n
+                  const Number f_dot_n
+                    = (data.psi_grads[q][k] * Tensor<1,spacedim,Number>(fe_values.normal_vector(q)));
+                  const Tensor<1,spacedim,Number> f_dot_n_times_n
+                    = f_dot_n * Tensor<1,spacedim,Number>(fe_values.normal_vector(q));
+
+                  data.psi_grads[q][k] -= (data.function_grads[q][k] + f_dot_n_times_n);
+                }
           else
             for (unsigned int k=0; k<n_components; ++k)
               for (unsigned int q=0; q<n_q_points; ++q)
-                data.psi_grads[q][k] -= data.function_grads[q][k];
+                for (unsigned int d=0; d<spacedim; ++d)
+                  data.psi_grads[q][k][d] -= data.function_grads[q][k][d];
         }
 
       double diff = 0;
@@ -6246,8 +6274,8 @@ namespace VectorTools
         case W1infty_norm:
           for (unsigned int q=0; q<n_q_points; ++q)
             for (unsigned int k=0; k<n_components; ++k)
-              diff = std::max (diff, std::abs(data.psi_values[q](k)*
-                                              data.weight_vectors[q](k)));
+              diff = std::max (diff, double(std::abs(data.psi_values[q](k)*
+                                                     data.weight_vectors[q](k))));
           break;
 
         case H1_seminorm:
@@ -6313,8 +6341,9 @@ namespace VectorTools
           for (unsigned int q=0; q<n_q_points; ++q)
             for (unsigned int k=0; k<n_components; ++k)
               for (unsigned int d=0; d<dim; ++d)
-                t = std::max(t, std::abs(data.psi_grads[q][k][d]) *
-                             data.weight_vectors[q](k));
+                t = std::max(t,
+                             double(std::abs(data.psi_grads[q][k][d]) *
+                                    data.weight_vectors[q](k)));
 
           // then add seminorm to norm if that had previously been computed
           diff += t;
@@ -6405,13 +6434,7 @@ namespace VectorTools
         }
 
       dealii::hp::FECollection<dim,spacedim> fe_collection (dof.get_fe());
-      IDScratchData<dim,spacedim> data(mapping, fe_collection, q, update_flags);
-
-      // FIXME
-      // temporary vectors of consistent with InVector type.
-      // Need these because IDScratchData does not have a template type for the InVector
-      std::vector<dealii::Vector<Number>> function_values;
-      std::vector<std::vector<Tensor<1,spacedim,Number> > > function_grads;
+      IDScratchData<dim,spacedim,typename InVector::value_type> data(mapping, fe_collection, q, update_flags);
 
       // loop over all cells
       for (typename DH::active_cell_iterator cell = dof.begin_active();
@@ -6425,29 +6448,15 @@ namespace VectorTools
             const unsigned int   n_q_points = fe_values.n_quadrature_points;
             data.resize_vectors (n_q_points, n_components);
 
-            //FIXME:
-            function_values.resize (n_q_points,
-                                    dealii::Vector<Number>(n_components));
-            function_grads.resize (n_q_points,
-                                   std::vector<Tensor<1,spacedim,Number> >(n_components));
-
             if (update_flags & update_values)
-              fe_values.get_function_values (fe_function, function_values);
+              fe_values.get_function_values (fe_function, data.function_values);
             if (update_flags & update_gradients)
-              fe_values.get_function_gradients (fe_function, function_grads);
-
-            // FIXME
-            for (unsigned int q = 0; q < n_q_points; q++)
-              for (unsigned int c = 0; c < n_components; c++)
-                {
-                  data.function_values[q][c] = function_values[q][c];
-                  data.function_grads[q][c] = function_grads[q][c];
-                }
+              fe_values.get_function_gradients (fe_function, data.function_grads);
 
             difference(cell->active_cell_index()) =
-              integrate_difference_inner (exact_solution, norm, weight,
-                                          update_flags, exponent,
-                                          n_components, data);
+              integrate_difference_inner<dim,spacedim,typename InVector::value_type> (exact_solution, norm, weight,
+                  update_flags, exponent,
+                  n_components, data);
           }
         else
           // the cell is a ghost cell or is artificial. write a zero into the
@@ -6781,7 +6790,7 @@ namespace VectorTools
   point_gradient (const DoFHandler<dim,spacedim>    &dof,
                   const InVector                    &fe_function,
                   const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim> > &gradients)
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradients)
   {
 
     point_gradient (StaticMappingQ1<dim,spacedim>::mapping,
@@ -6797,7 +6806,7 @@ namespace VectorTools
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
                   const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim> > &gradients)
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradients)
   {
     point_gradient(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
                    dof,
@@ -6808,7 +6817,7 @@ namespace VectorTools
 
 
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
                   const Point<spacedim>      &point)
@@ -6821,7 +6830,7 @@ namespace VectorTools
 
 
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
                   const Point<spacedim>      &point)
@@ -6839,7 +6848,7 @@ namespace VectorTools
                   const DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
                   const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim> > &gradient)
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradient)
   {
     const FiniteElement<dim> &fe = dof.get_fe();
 
@@ -6868,7 +6877,7 @@ namespace VectorTools
     // the given fe_function at this point
     typedef typename InVector::value_type Number;
     std::vector<std::vector<Tensor<1, dim, Number> > >
-      u_gradient(1, std::vector<Tensor<1, dim, Number> > (fe.n_components()));
+    u_gradient(1, std::vector<Tensor<1, dim, Number> > (fe.n_components()));
     fe_values.get_function_gradients(fe_function, u_gradient);
 
     gradient = u_gradient[0];
@@ -6881,7 +6890,7 @@ namespace VectorTools
                   const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
                   const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim> > &gradient)
+                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradient)
   {
     typedef typename InVector::value_type Number;
     const hp::FECollection<dim, spacedim> &fe = dof.get_fe();
@@ -6910,7 +6919,7 @@ namespace VectorTools
     // the given fe_function at this point
     typedef typename InVector::value_type Number;
     std::vector<std::vector<Tensor<1, dim, Number> > >
-      u_gradient(1, std::vector<Tensor<1, dim, Number> > (fe.n_components()));
+    u_gradient(1, std::vector<Tensor<1, dim, Number> > (fe.n_components()));
     fe_values.get_function_gradients(fe_function, u_gradient);
 
     gradient = u_gradient[0];
@@ -6918,7 +6927,7 @@ namespace VectorTools
 
 
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const Mapping<dim, spacedim>    &mapping,
                   const DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
@@ -6927,15 +6936,16 @@ namespace VectorTools
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
-    std::vector<Tensor<1, dim> > gradient(1);
+    std::vector<Tensor<1, dim, typename InVector::value_type> > gradient(1);
     point_gradient (mapping, dof, fe_function, point, gradient);
 
     return gradient[0];
   }
 
 
+
   template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim>
+  Tensor<1, spacedim, typename InVector::value_type>
   point_gradient (const hp::MappingCollection<dim, spacedim>    &mapping,
                   const hp::DoFHandler<dim,spacedim> &dof,
                   const InVector        &fe_function,
@@ -6944,7 +6954,7 @@ namespace VectorTools
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
-    std::vector<Tensor<1, dim> > gradient(1);
+    std::vector<Tensor<1, dim, typename InVector::value_type> > gradient(1);
     point_gradient (mapping, dof, fe_function, point, gradient);
 
     return gradient[0];
@@ -7003,7 +7013,7 @@ namespace VectorTools
   namespace internal
   {
     template <typename Number>
-    void set_possibly_complex_number(Number &n, const double &r, const double &i)
+    void set_possibly_complex_number(Number &n, const double &r, const double &)
     {
       n = r;
     }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -509,7 +509,7 @@ namespace FEValuesViews
               &shape_derivatives[shape_function_data[shape_function].row_index][0];
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
               derivatives[q_point] += value *
-				      typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
+                                      typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
           }
     }
 
@@ -686,7 +686,7 @@ namespace FEValuesViews
                 &shape_gradients[snc][0];
               for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
                 symmetric_gradients[q_point] += value *
-                  typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type (symmetrize_single_row(comp, *shape_gradient_ptr++));
+                                                typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type (symmetrize_single_row(comp, *shape_gradient_ptr++));
             }
           else
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
@@ -3371,10 +3371,10 @@ FEValues<dim,spacedim>::FEValues (const Mapping<dim,spacedim>       &mapping,
                                   const UpdateFlags                  update_flags)
   :
   FEValuesBase<dim,spacedim> (q.size(),
-                              fe.dofs_per_cell,
-                              update_default,
-                              mapping,
-                              fe),
+                             fe.dofs_per_cell,
+                             update_default,
+                             mapping,
+                             fe),
   quadrature (q)
 {
   initialize (update_flags);
@@ -3388,10 +3388,10 @@ FEValues<dim,spacedim>::FEValues (const FiniteElement<dim,spacedim> &fe,
                                   const UpdateFlags                  update_flags)
   :
   FEValuesBase<dim,spacedim> (q.size(),
-                              fe.dofs_per_cell,
-                              update_default,
-                              StaticMappingQ1<dim,spacedim>::mapping,
-                              fe),
+                             fe.dofs_per_cell,
+                             update_default,
+                             StaticMappingQ1<dim,spacedim>::mapping,
+                             fe),
   quadrature (q)
 {
   initialize (update_flags);
@@ -3567,10 +3567,10 @@ FEFaceValuesBase<dim,spacedim>::FEFaceValuesBase (const unsigned int n_q_points,
                                                   const Quadrature<dim-1>& quadrature)
   :
   FEValuesBase<dim,spacedim> (n_q_points,
-                              dofs_per_cell,
-                              update_default,
-                              mapping,
-                              fe),
+                             dofs_per_cell,
+                             update_default,
+                             mapping,
+                             fe),
   quadrature(quadrature)
 {}
 
@@ -3613,10 +3613,10 @@ FEFaceValues<dim,spacedim>::FEFaceValues (const Mapping<dim,spacedim>       &map
                                           const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                  fe.dofs_per_cell,
-                                  update_flags,
-                                  mapping,
-                                  fe, quadrature)
+                                 fe.dofs_per_cell,
+                                 update_flags,
+                                 mapping,
+                                 fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3629,10 +3629,10 @@ FEFaceValues<dim,spacedim>::FEFaceValues (const FiniteElement<dim,spacedim> &fe,
                                           const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                  fe.dofs_per_cell,
-                                  update_flags,
-                                  StaticMappingQ1<dim,spacedim>::mapping,
-                                  fe, quadrature)
+                                 fe.dofs_per_cell,
+                                 update_flags,
+                                 StaticMappingQ1<dim,spacedim>::mapping,
+                                 fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3772,10 +3772,10 @@ FESubfaceValues<dim,spacedim>::FESubfaceValues (const Mapping<dim,spacedim>     
                                                 const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                  fe.dofs_per_cell,
-                                  update_flags,
-                                  mapping,
-                                  fe, quadrature)
+                                 fe.dofs_per_cell,
+                                 update_flags,
+                                 mapping,
+                                 fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3788,10 +3788,10 @@ FESubfaceValues<dim,spacedim>::FESubfaceValues (const FiniteElement<dim,spacedim
                                                 const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                  fe.dofs_per_cell,
-                                  update_flags,
-                                  StaticMappingQ1<dim,spacedim>::mapping,
-                                  fe, quadrature)
+                                 fe.dofs_per_cell,
+                                 update_flags,
+                                 StaticMappingQ1<dim,spacedim>::mapping,
+                                 fe, quadrature)
 {
   initialize (update_flags);
 }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1530,7 +1530,7 @@ namespace FEValuesViews
   void
   SymmetricTensor<2, dim, spacedim>::
   get_function_values(const InputVector &fe_function,
-                      std::vector<value_type> &values) const
+                      std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
     typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values.update_flags & update_values,
@@ -1541,7 +1541,7 @@ namespace FEValuesViews
                     fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values(fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values(fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_values<dim,spacedim>
     (dof_values, fe_values.shape_values, shape_function_data, values);
@@ -1554,7 +1554,7 @@ namespace FEValuesViews
   void
   SymmetricTensor<2, dim, spacedim>::
   get_function_divergences(const InputVector &fe_function,
-                           std::vector<divergence_type> &divergences) const
+                           std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
     typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values.update_flags & update_gradients,
@@ -1566,7 +1566,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<double> dof_values(fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values(fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_divergences<dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data, divergences);
@@ -1577,7 +1577,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::
   get_function_values(const InputVector &fe_function,
-                      std::vector<value_type> &values) const
+                      std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
     typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values.update_flags & update_values,
@@ -1588,7 +1588,7 @@ namespace FEValuesViews
                     fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values(fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values(fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_values<dim,spacedim>
     (dof_values, fe_values.shape_values, shape_function_data, values);
@@ -1601,7 +1601,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::
   get_function_divergences(const InputVector &fe_function,
-                           std::vector<divergence_type> &divergences) const
+                           std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
     typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values.update_flags & update_gradients,
@@ -1613,7 +1613,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<double> dof_values(fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values(fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_divergences<dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data, divergences);

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2588,11 +2588,12 @@ namespace internal
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_values (
   const InputVector   &fe_function,
-  std::vector<number> &values) const
+  std::vector<typename InputVector::value_type> &values) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_values,
           ExcAccessToUninitializedField("update_values"));
   AssertDimension (fe->n_components(), 1);
@@ -2602,7 +2603,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
                    present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   internal::do_function_values (dof_values.begin(), this->shape_values,
                                 values);
@@ -2611,12 +2612,13 @@ void FEValuesBase<dim,spacedim>::get_function_values (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_values (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<number> &values) const
+  std::vector<typename InputVector::value_type> &values) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_values,
           ExcAccessToUninitializedField("update_values"));
   AssertDimension (fe->n_components(), 1);
@@ -2625,14 +2627,14 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   // avoid allocation when the local size is small enough
   if (dofs_per_cell <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(&dof_values[0], this->shape_values, values);
     }
   else
     {
-      Vector<double> dof_values(dofs_per_cell);
+      Vector<Number> dof_values(dofs_per_cell);
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(dof_values.begin(), this->shape_values,
@@ -2643,11 +2645,12 @@ void FEValuesBase<dim,spacedim>::get_function_values (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_values (
   const InputVector            &fe_function,
-  std::vector<Vector<number> > &values) const
+  std::vector<Vector<typename InputVector::value_type> > &values) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (present_cell.get() != 0,
           ExcMessage ("FEValues object is not reinit'ed to any cell"));
 
@@ -2656,7 +2659,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   VectorSlice<std::vector<Vector<number> > > val(values);
   internal::do_function_values(dof_values.begin(), this->shape_values, *fe,
@@ -2666,12 +2669,13 @@ void FEValuesBase<dim,spacedim>::get_function_values (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_values (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<Vector<number> > &values) const
+  std::vector<Vector<typename InputVector::value_type> > &values) const
 {
+  typedef typename InputVector::value_type Number;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
   // number of function values is generated in each point.
   Assert (indices.size() % dofs_per_cell == 0,
@@ -2682,7 +2686,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   VectorSlice<std::vector<Vector<number> > > val(values);
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(&dof_values[0], this->shape_values, *fe,
@@ -2691,7 +2695,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
     }
   else
     {
-      Vector<double> dof_values(100);
+      Vector<Number> dof_values(100);
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(dof_values.begin(), this->shape_values, *fe,
@@ -2707,9 +2711,10 @@ template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_values (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  VectorSlice<std::vector<std::vector<double> > > values,
+  VectorSlice<std::vector<std::vector<typename InputVector::value_type> > > values,
   bool quadrature_points_fastest) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_values,
           ExcAccessToUninitializedField("update_values"));
 
@@ -2720,7 +2725,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
 
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(&dof_values[0], this->shape_values, *fe,
@@ -2730,7 +2735,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
     }
   else
     {
-      Vector<double> dof_values(indices.size());
+      Vector<Number> dof_values(indices.size());
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_values(dof_values.begin(), this->shape_values, *fe,
@@ -2747,8 +2752,9 @@ template <class InputVector>
 void
 FEValuesBase<dim,spacedim>::get_function_gradients (
   const InputVector           &fe_function,
-  std::vector<Tensor<1,spacedim> > &gradients) const
+  std::vector<Tensor<1,spacedim,typename InputVector::value_type> > &gradients) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_gradients,
           ExcAccessToUninitializedField("update_gradients"));
   AssertDimension (fe->n_components(), 1);
@@ -2757,7 +2763,7 @@ FEValuesBase<dim,spacedim>::get_function_gradients (
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   internal::do_function_derivatives(dof_values.begin(), this->shape_gradients,
                                     gradients);
@@ -2770,15 +2776,16 @@ template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_gradients (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<Tensor<1,spacedim> > &gradients) const
+  std::vector<Tensor<1,spacedim,typename InputVector::value_type> > &gradients) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_gradients,
           ExcAccessToUninitializedField("update_gradients"));
   AssertDimension (fe->n_components(), 1);
   AssertDimension (indices.size(), dofs_per_cell);
   if (dofs_per_cell <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(&dof_values[0], this->shape_gradients,
@@ -2786,7 +2793,7 @@ void FEValuesBase<dim,spacedim>::get_function_gradients (
     }
   else
     {
-      Vector<double> dof_values(dofs_per_cell);
+      Vector<Number> dof_values(dofs_per_cell);
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(dof_values.begin(), this->shape_gradients,
@@ -2802,8 +2809,9 @@ template <class InputVector>
 void
 FEValuesBase<dim,spacedim>::get_function_gradients (
   const InputVector                              &fe_function,
-  std::vector<std::vector<Tensor<1,spacedim> > > &gradients) const
+  std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > &gradients) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_gradients,
           ExcAccessToUninitializedField("update_gradients"));
   Assert (present_cell.get() != 0,
@@ -2811,9 +2819,9 @@ FEValuesBase<dim,spacedim>::get_function_gradients (
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
-  VectorSlice<std::vector<std::vector<Tensor<1,spacedim> > > > grads(gradients);
+  VectorSlice<std::vector<std::vector<Tensor<1,spacedim,Number> > > > grads(gradients);
   internal::do_function_derivatives(dof_values.begin(), this->shape_gradients,
                                     *fe, this->shape_function_to_row_table,
                                     grads);
@@ -2826,9 +2834,10 @@ template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_gradients (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  VectorSlice<std::vector<std::vector<Tensor<1,spacedim> > > > gradients,
+  VectorSlice<std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > > gradients,
   bool quadrature_points_fastest) const
 {
+  typedef typename InputVector::value_type Number;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
   // number of function values is generated in each point.
   Assert (indices.size() % dofs_per_cell == 0,
@@ -2838,7 +2847,7 @@ void FEValuesBase<dim,spacedim>::get_function_gradients (
 
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(&dof_values[0], this->shape_gradients,
@@ -2848,7 +2857,7 @@ void FEValuesBase<dim,spacedim>::get_function_gradients (
     }
   else
     {
-      Vector<double> dof_values(indices.size());
+      Vector<Number> dof_values(indices.size());
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(dof_values.begin(),this->shape_gradients,
@@ -2865,8 +2874,9 @@ template <class InputVector>
 void
 FEValuesBase<dim,spacedim>::
 get_function_hessians (const InputVector                &fe_function,
-                       std::vector<Tensor<2,spacedim> > &hessians) const
+                       std::vector<Tensor<2,spacedim,typename InputVector::value_type> > &hessians) const
 {
+  typedef typename InputVector::value_type Number;
   AssertDimension (fe->n_components(), 1);
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
@@ -2875,7 +2885,7 @@ get_function_hessians (const InputVector                &fe_function,
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   internal::do_function_derivatives(dof_values.begin(), this->shape_hessians,
                                     hessians);
@@ -2888,15 +2898,16 @@ template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_hessians (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<Tensor<2,spacedim> > &hessians) const
+  std::vector<Tensor<2,spacedim,typename InputVector::value_type> > &hessians) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
   AssertDimension (indices.size(), dofs_per_cell);
   if (dofs_per_cell <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(&dof_values[0], this->shape_hessians,
@@ -2904,7 +2915,7 @@ void FEValuesBase<dim,spacedim>::get_function_hessians (
     }
   else
     {
-      Vector<double> dof_values(dofs_per_cell);
+      Vector<Number> dof_values(dofs_per_cell);
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(dof_values.begin(), this->shape_hessians,
@@ -2920,9 +2931,10 @@ template <class InputVector>
 void
 FEValuesBase<dim,spacedim>::
 get_function_hessians (const InputVector                         &fe_function,
-                       std::vector<std::vector<Tensor<2,spacedim> > > &hessians,
+                       std::vector<std::vector<Tensor<2,spacedim,typename InputVector::value_type> > > &hessians,
                        bool quadrature_points_fastest) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   Assert (present_cell.get() != 0,
@@ -2930,9 +2942,9 @@ get_function_hessians (const InputVector                         &fe_function,
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
-  VectorSlice<std::vector<std::vector<Tensor<2,spacedim> > > > hes(hessians);
+  VectorSlice<std::vector<std::vector<Tensor<2,spacedim,Number> > > > hes(hessians);
   internal::do_function_derivatives(dof_values.begin(), this->shape_hessians,
                                     *fe, this->shape_function_to_row_table,
                                     hes, quadrature_points_fastest);
@@ -2945,16 +2957,17 @@ template <class InputVector>
 void FEValuesBase<dim, spacedim>::get_function_hessians (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  VectorSlice<std::vector<std::vector<Tensor<2,spacedim> > > > hessians,
+  VectorSlice<std::vector<std::vector<Tensor<2,spacedim,typename InputVector::value_type> > > > hessians,
   bool quadrature_points_fastest) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(&dof_values[0], this->shape_hessians,
@@ -2964,7 +2977,7 @@ void FEValuesBase<dim, spacedim>::get_function_hessians (
     }
   else
     {
-      Vector<double> dof_values(indices.size());
+      Vector<Number> dof_values(indices.size());
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_derivatives(dof_values.begin(),this->shape_hessians,
@@ -2977,11 +2990,12 @@ void FEValuesBase<dim, spacedim>::get_function_hessians (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_laplacians (
   const InputVector   &fe_function,
-  std::vector<number> &laplacians) const
+  std::vector<typename InputVector::value_type> &laplacians) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   AssertDimension (fe->n_components(), 1);
@@ -2990,7 +3004,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   internal::do_function_laplacians(dof_values.begin(), this->shape_hessians,
                                    laplacians);
@@ -2999,19 +3013,20 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_laplacians (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<number> &laplacians) const
+  std::vector<typename InputVector::value_type> &laplacians) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   AssertDimension (fe->n_components(), 1);
   AssertDimension (indices.size(), dofs_per_cell);
   if (dofs_per_cell <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(&dof_values[0], this->shape_hessians,
@@ -3019,7 +3034,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
     }
   else
     {
-      Vector<double> dof_values(dofs_per_cell);
+      Vector<Number> dof_values(dofs_per_cell);
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(dof_values.begin(), this->shape_hessians,
@@ -3030,11 +3045,12 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_laplacians (
   const InputVector            &fe_function,
-  std::vector<Vector<number> > &laplacians) const
+  std::vector<Vector<typename InputVector::value_type> > &laplacians) const
 {
+  typedef typename InputVector::value_type Number;
   Assert (present_cell.get() != 0,
           ExcMessage ("FEValues object is not reinit'ed to any cell"));
   Assert (this->update_flags & update_hessians,
@@ -3042,7 +3058,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
   AssertDimension (fe_function.size(), present_cell->n_dofs_for_dof_handler());
 
   // get function values of dofs on this cell
-  Vector<double> dof_values (dofs_per_cell);
+  Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
   internal::do_function_laplacians(dof_values.begin(), this->shape_hessians,
                                    *fe, this->shape_function_to_row_table,
@@ -3052,12 +3068,13 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_laplacians (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<Vector<number> > &laplacians) const
+  std::vector<Vector<typename InputVector::value_type> > &laplacians) const
 {
+  typedef typename InputVector::value_type Number;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
   // number of function values is generated in each point.
   Assert (indices.size() % dofs_per_cell == 0,
@@ -3066,7 +3083,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
           ExcAccessToUninitializedField("update_hessians"));
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(&dof_values[0], this->shape_hessians,
@@ -3076,7 +3093,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
     }
   else
     {
-      Vector<double> dof_values(indices.size());
+      Vector<Number> dof_values(indices.size());
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(dof_values.begin(),this->shape_hessians,
@@ -3089,20 +3106,21 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
 
 
 template <int dim, int spacedim>
-template <class InputVector, typename number>
+template <class InputVector>
 void FEValuesBase<dim,spacedim>::get_function_laplacians (
   const InputVector &fe_function,
   const VectorSlice<const std::vector<types::global_dof_index> > &indices,
-  std::vector<std::vector<number> > &laplacians,
+  std::vector<std::vector<typename InputVector::value_type> > &laplacians,
   bool quadrature_points_fastest) const
 {
+  typedef typename InputVector::value_type number;
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
   Assert (this->update_flags & update_hessians,
           ExcAccessToUninitializedField("update_hessians"));
   if (indices.size() <= 100)
     {
-      double dof_values[100];
+      Number dof_values[100];
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(&dof_values[0], this->shape_hessians,
@@ -3112,7 +3130,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
     }
   else
     {
-      Vector<double> dof_values(indices.size());
+      Vector<Number> dof_values(indices.size());
       for (unsigned int i=0; i<indices.size(); ++i)
         dof_values[i] = get_vector_element (fe_function, indices[i]);
       internal::do_function_laplacians(dof_values.begin(),this->shape_hessians,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1358,7 +1358,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_values (const InputVector &fe_function,
-                       std::vector<value_type> &values) const
+                       std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_values,
@@ -1369,7 +1369,7 @@ namespace FEValuesViews
                      fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_values<dim,spacedim>
     (dof_values, fe_values.shape_values, shape_function_data, values);
@@ -1383,7 +1383,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_gradients (const InputVector &fe_function,
-                          std::vector<gradient_type> &gradients) const
+                          std::vector<typename ProductType<gradient_type,typename InputVector::value_type>::type> &gradients) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_gradients,
@@ -1394,7 +1394,7 @@ namespace FEValuesViews
                      fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_derivatives<1,dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data, gradients);
@@ -1407,7 +1407,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_symmetric_gradients (const InputVector &fe_function,
-                                    std::vector<symmetric_gradient_type> &symmetric_gradients) const
+                                    std::vector<typename ProductType<symmetric_gradient_type,typename InputVector::value_type>::type> &symmetric_gradients) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_gradients,
@@ -1418,7 +1418,7 @@ namespace FEValuesViews
                      fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_symmetric_gradients<dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data,
@@ -1432,7 +1432,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_divergences (const InputVector &fe_function,
-                            std::vector<divergence_type> &divergences) const
+                            std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_gradients,
@@ -1444,7 +1444,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_divergences<dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data, divergences);
@@ -1455,7 +1455,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_curls (const InputVector &fe_function,
-                      std::vector<curl_type> &curls) const
+                      std::vector<typename ProductType<curl_type,typename InputVector::value_type>::type> &curls) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
 
@@ -1467,7 +1467,7 @@ namespace FEValuesViews
                      fe_values.present_cell->n_dofs_for_dof_handler ());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values (fe_function, dof_values);
     internal::do_function_curls<dim,spacedim>
     (dof_values, fe_values.shape_gradients, shape_function_data, curls);
@@ -1479,7 +1479,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_hessians (const InputVector &fe_function,
-                         std::vector<hessian_type> &hessians) const
+                         std::vector<typename ProductType<hessian_type,typename InputVector::value_type>::type> &hessians) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_hessians,
@@ -1490,7 +1490,7 @@ namespace FEValuesViews
                      fe_values.present_cell->n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_derivatives<2,dim,spacedim>
     (dof_values, fe_values.shape_hessians, shape_function_data, hessians);
@@ -1503,7 +1503,7 @@ namespace FEValuesViews
   void
   Vector<dim,spacedim>::
   get_function_laplacians (const InputVector &fe_function,
-                           std::vector<value_type> &laplacians) const
+                           std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &laplacians) const
   {
     typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values.update_flags & update_hessians,
@@ -1517,7 +1517,7 @@ namespace FEValuesViews
                                  fe_values.present_cell->n_dofs_for_dof_handler()));
 
     // get function values of dofs on this cell
-    dealii::Vector<double> dof_values (fe_values.dofs_per_cell);
+    dealii::Vector<typename InputVector::value_type> dof_values (fe_values.dofs_per_cell);
     fe_values.present_cell->get_interpolated_dof_values(fe_function, dof_values);
     internal::do_function_laplacians<dim,spacedim>
     (dof_values, fe_values.shape_hessians, shape_function_data, laplacians);

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -673,7 +673,7 @@ namespace FEValuesViews
             continue;
 
           const Number value = dof_values(shape_function);
-          if (value == Number)
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -2661,7 +2661,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   // get function values of dofs on this cell
   Vector<Number> dof_values (dofs_per_cell);
   present_cell->get_interpolated_dof_values(fe_function, dof_values);
-  VectorSlice<std::vector<Vector<number> > > val(values);
+  VectorSlice<std::vector<Vector<Number> > > val(values);
   internal::do_function_values(dof_values.begin(), this->shape_values, *fe,
                                this->shape_function_to_row_table, val);
 }
@@ -2683,7 +2683,7 @@ void FEValuesBase<dim,spacedim>::get_function_values (
   Assert (this->update_flags & update_values,
           ExcAccessToUninitializedField("update_values"));
 
-  VectorSlice<std::vector<Vector<number> > > val(values);
+  VectorSlice<std::vector<Vector<Number> > > val(values);
   if (indices.size() <= 100)
     {
       Number dof_values[100];
@@ -3113,7 +3113,7 @@ void FEValuesBase<dim,spacedim>::get_function_laplacians (
   std::vector<std::vector<typename InputVector::value_type> > &laplacians,
   bool quadrature_points_fastest) const
 {
-  typedef typename InputVector::value_type number;
+  typedef typename InputVector::value_type Number;
   Assert (indices.size() % dofs_per_cell == 0,
           ExcNotMultiple(indices.size(), dofs_per_cell));
   Assert (this->update_flags & update_hessians,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1208,7 +1208,7 @@ namespace FEValuesViews
       AssertDimension (divergences.size(), n_quadrature_points);
 
       std::fill (divergences.begin(), divergences.end(),
-                 dealii::Tensor<1,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<1,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -1219,8 +1219,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -2198,9 +2198,9 @@ namespace internal
   // compilation and reduces the size of the final file since all the
   // different global vectors get channeled through the same code.
 
-  template <typename Number>
+  template <typename Number, typename Number2>
   void
-  do_function_values (const double          *dof_values_ptr,
+  do_function_values (const Number2         *dof_values_ptr,
                       const dealii::Table<2,double> &shape_values,
                       std::vector<Number>   &values)
   {
@@ -2222,8 +2222,8 @@ namespace internal
     // the shape_values data stored contiguously
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
-        const double value = dof_values_ptr[shape_func];
-        if (value == 0.)
+        const Number2 value = dof_values_ptr[shape_func];
+        if (value == Number2())
           continue;
 
         const double *shape_value_ptr = &shape_values(shape_func, 0);
@@ -2232,9 +2232,9 @@ namespace internal
       }
   }
 
-  template <int dim, int spacedim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType, typename Number>
   void
-  do_function_values (const double                      *dof_values_ptr,
+  do_function_values (const Number                      *dof_values_ptr,
                       const dealii::Table<2,double>             &shape_values,
                       const FiniteElement<dim,spacedim> &fe,
                       const std::vector<unsigned int> &shape_function_to_row_table,
@@ -2278,8 +2278,8 @@ namespace internal
     for (unsigned int mc = 0; mc < component_multiple; ++mc)
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
-          const double value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == 0.)
+          const Number value = dof_values_ptr[shape_func+mc*dofs_per_cell];
+          if (value == Number())
             continue;
 
           if (fe.is_primitive(shape_func))
@@ -2330,11 +2330,11 @@ namespace internal
 
   // use the same implementation for gradients and Hessians, distinguish them
   // by the rank of the tensors
-  template <int order, int spacedim>
+  template <int order, int spacedim, typename Number>
   void
-  do_function_derivatives (const double                     *dof_values_ptr,
+  do_function_derivatives (const Number                     *dof_values_ptr,
                            const std::vector<std::vector<Tensor<order,spacedim> > > &shape_derivatives,
-                           std::vector<Tensor<order,spacedim> > &derivatives)
+                           std::vector<Tensor<order,spacedim,Number> > &derivatives)
   {
     const unsigned int dofs_per_cell = shape_derivatives.size();
     const unsigned int n_quadrature_points = dofs_per_cell > 0 ?
@@ -2342,7 +2342,7 @@ namespace internal
     AssertDimension(derivatives.size(), n_quadrature_points);
 
     // initialize with zero
-    std::fill_n (derivatives.begin(), n_quadrature_points, Tensor<order,spacedim>());
+    std::fill_n (derivatives.begin(), n_quadrature_points, Tensor<order,spacedim,Number>());
 
     // add up contributions of trial functions. note that here we deal with
     // scalar finite elements, so no need to check for non-primitivity of
@@ -2353,8 +2353,8 @@ namespace internal
     // access the shape_gradients/hessians data stored contiguously
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
-        const double value = dof_values_ptr[shape_func];
-        if (value == 0.)
+        const Number value = dof_values_ptr[shape_func];
+        if (value == Number())
           continue;
 
         const Tensor<order,spacedim> *shape_derivative_ptr
@@ -2364,20 +2364,20 @@ namespace internal
       }
   }
 
-  template <int order, int dim, int spacedim>
+  template <int order, int dim, int spacedim, typename Number>
   void
-  do_function_derivatives (const double                      *dof_values_ptr,
+  do_function_derivatives (const Number                      *dof_values_ptr,
                            const std::vector<std::vector<Tensor<order,spacedim> > > &shape_derivatives,
                            const FiniteElement<dim,spacedim> &fe,
                            const std::vector<unsigned int> &shape_function_to_row_table,
-                           VectorSlice<std::vector<std::vector<Tensor<order,spacedim> > > > &derivatives,
+                           VectorSlice<std::vector<std::vector<Tensor<order,spacedim,Number> > > > &derivatives,
                            const bool quadrature_points_fastest  = false,
                            const unsigned int component_multiple = 1)
   {
     // initialize with zero
     for (unsigned int i=0; i<derivatives.size(); ++i)
       std::fill_n (derivatives[i].begin(), derivatives[i].size(),
-                   Tensor<order,spacedim>());
+                   Tensor<order,spacedim,Number>());
 
     // see if there the current cell has DoFs at all, and if not
     // then there is nothing else to do.
@@ -2411,8 +2411,8 @@ namespace internal
     for (unsigned int mc = 0; mc < component_multiple; ++mc)
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
-          const double value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == 0.)
+          const Number value = dof_values_ptr[shape_func+mc*dofs_per_cell];
+          if (value == Number())
             continue;
 
           if (fe.is_primitive(shape_func))
@@ -2456,9 +2456,9 @@ namespace internal
         }
   }
 
-  template <int spacedim, typename Number>
+  template <int spacedim, typename Number, typename Number2>
   void
-  do_function_laplacians (const double        *dof_values_ptr,
+  do_function_laplacians (const Number2        *dof_values_ptr,
                           const std::vector<std::vector<Tensor<2,spacedim> > > &shape_hessians,
                           std::vector<Number> &laplacians)
   {
@@ -2475,8 +2475,8 @@ namespace internal
     // the trace of the Hessian.
     for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
       {
-        const double value = dof_values_ptr[shape_func];
-        if (value == 0.)
+        const Number2 value = dof_values_ptr[shape_func];
+        if (value == Number2())
           continue;
 
         const Tensor<2,spacedim> *shape_hessian_ptr
@@ -2486,9 +2486,9 @@ namespace internal
       }
   }
 
-  template <int dim, int spacedim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType, typename Number>
   void
-  do_function_laplacians (const double                    *dof_values_ptr,
+  do_function_laplacians (const Number                    *dof_values_ptr,
                           const std::vector<std::vector<Tensor<2,spacedim> > > &shape_hessians,
                           const FiniteElement<dim,spacedim> &fe,
                           const std::vector<unsigned int> &shape_function_to_row_table,
@@ -2533,8 +2533,8 @@ namespace internal
     for (unsigned int mc = 0; mc < component_multiple; ++mc)
       for (unsigned int shape_func=0; shape_func<dofs_per_cell; ++shape_func)
         {
-          const double value = dof_values_ptr[shape_func+mc*dofs_per_cell];
-          if (value == 0.)
+          const Number value = dof_values_ptr[shape_func+mc*dofs_per_cell];
+          if (value == Number())
             continue;
 
           if (fe.is_primitive(shape_func))

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3371,10 +3371,10 @@ FEValues<dim,spacedim>::FEValues (const Mapping<dim,spacedim>       &mapping,
                                   const UpdateFlags                  update_flags)
   :
   FEValuesBase<dim,spacedim> (q.size(),
-                             fe.dofs_per_cell,
-                             update_default,
-                             mapping,
-                             fe),
+                              fe.dofs_per_cell,
+                              update_default,
+                              mapping,
+                              fe),
   quadrature (q)
 {
   initialize (update_flags);
@@ -3388,10 +3388,10 @@ FEValues<dim,spacedim>::FEValues (const FiniteElement<dim,spacedim> &fe,
                                   const UpdateFlags                  update_flags)
   :
   FEValuesBase<dim,spacedim> (q.size(),
-                             fe.dofs_per_cell,
-                             update_default,
-                             StaticMappingQ1<dim,spacedim>::mapping,
-                             fe),
+                              fe.dofs_per_cell,
+                              update_default,
+                              StaticMappingQ1<dim,spacedim>::mapping,
+                              fe),
   quadrature (q)
 {
   initialize (update_flags);
@@ -3567,10 +3567,10 @@ FEFaceValuesBase<dim,spacedim>::FEFaceValuesBase (const unsigned int n_q_points,
                                                   const Quadrature<dim-1>& quadrature)
   :
   FEValuesBase<dim,spacedim> (n_q_points,
-                             dofs_per_cell,
-                             update_default,
-                             mapping,
-                             fe),
+                              dofs_per_cell,
+                              update_default,
+                              mapping,
+                              fe),
   quadrature(quadrature)
 {}
 
@@ -3613,10 +3613,10 @@ FEFaceValues<dim,spacedim>::FEFaceValues (const Mapping<dim,spacedim>       &map
                                           const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                 fe.dofs_per_cell,
-                                 update_flags,
-                                 mapping,
-                                 fe, quadrature)
+                                  fe.dofs_per_cell,
+                                  update_flags,
+                                  mapping,
+                                  fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3629,10 +3629,10 @@ FEFaceValues<dim,spacedim>::FEFaceValues (const FiniteElement<dim,spacedim> &fe,
                                           const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                 fe.dofs_per_cell,
-                                 update_flags,
-                                 StaticMappingQ1<dim,spacedim>::mapping,
-                                 fe, quadrature)
+                                  fe.dofs_per_cell,
+                                  update_flags,
+                                  StaticMappingQ1<dim,spacedim>::mapping,
+                                  fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3772,10 +3772,10 @@ FESubfaceValues<dim,spacedim>::FESubfaceValues (const Mapping<dim,spacedim>     
                                                 const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                 fe.dofs_per_cell,
-                                 update_flags,
-                                 mapping,
-                                 fe, quadrature)
+                                  fe.dofs_per_cell,
+                                  update_flags,
+                                  mapping,
+                                  fe, quadrature)
 {
   initialize (update_flags);
 }
@@ -3788,10 +3788,10 @@ FESubfaceValues<dim,spacedim>::FESubfaceValues (const FiniteElement<dim,spacedim
                                                 const UpdateFlags         update_flags)
   :
   FEFaceValuesBase<dim,spacedim> (quadrature.size(),
-                                 fe.dofs_per_cell,
-                                 update_flags,
-                                 StaticMappingQ1<dim,spacedim>::mapping,
-                                 fe, quadrature)
+                                  fe.dofs_per_cell,
+                                  update_flags,
+                                  StaticMappingQ1<dim,spacedim>::mapping,
+                                  fe, quadrature)
 {
   initialize (update_flags);
 }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -689,7 +689,7 @@ namespace FEValuesViews
           else
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
               {
-                dealii::Tensor<2,spacedim,Number> grad;
+                typename ProductType<Number,dealii::Tensor<2,spacedim> >::type grad;
                 for (unsigned int d=0; d<spacedim; ++d)
                   if (shape_function_data[shape_function].is_nonzero_shape_function_component[d])
                     grad[d] = value *

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -40,7 +40,7 @@ DEAL_II_NAMESPACE_OPEN
 namespace
 {
   template <class VectorType>
-  double
+  typename VectorType::value_type
   get_vector_element (const VectorType &vector,
                       const types::global_dof_index cell_number)
   {
@@ -48,7 +48,7 @@ namespace
   }
 
 
-  double
+  IndexSet::value_type
   get_vector_element (const IndexSet &is,
                       const types::global_dof_index cell_number)
   {
@@ -461,14 +461,14 @@ namespace FEValuesViews
                                                shape_values.n_cols() : values.size();
       AssertDimension (values.size(), n_quadrature_points);
 
-      std::fill (values.begin(), values.end(), 0.);
+      std::fill (values.begin(), values.end(), Number());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
-            const double value = dof_values(shape_function);
-            if (value == 0.)
+            const Number value = dof_values(shape_function);
+            if (value == Number() )
               continue;
 
             const double *shape_value_ptr =
@@ -495,14 +495,14 @@ namespace FEValuesViews
       AssertDimension (derivatives.size(), n_quadrature_points);
 
       std::fill (derivatives.begin(), derivatives.end(),
-                 dealii::Tensor<order,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<order,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
-            const double value = dof_values(shape_function);
-            if (value == 0.)
+            const Number value = dof_values(shape_function);
+            if (value == Number() )
               continue;
 
             const dealii::Tensor<order,spacedim> *shape_derivative_ptr =
@@ -527,14 +527,14 @@ namespace FEValuesViews
                                                shape_hessians[0].size() : laplacians.size();
       AssertDimension (laplacians.size(), n_quadrature_points);
 
-      std::fill (laplacians.begin(), laplacians.end(), 0.);
+      std::fill (laplacians.begin(), laplacians.end(), typename ProductType<Number,double>::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
         if (shape_function_data[shape_function].is_nonzero_shape_function_component)
           {
-            const double value = dof_values(shape_function);
-            if (value == 0.)
+            const Number value = dof_values(shape_function);
+            if (value == Number())
               continue;
 
             const dealii::Tensor<2,spacedim> *shape_hessian_ptr =
@@ -559,7 +559,7 @@ namespace FEValuesViews
                                                shape_values.n_cols() : values.size();
       AssertDimension (values.size(), n_quadrature_points);
 
-      std::fill (values.begin(), values.end(), dealii::Tensor<1,spacedim>());
+      std::fill (values.begin(), values.end(), typename ProductType<Number,dealii::Tensor<1,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -570,8 +570,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -609,7 +609,7 @@ namespace FEValuesViews
       AssertDimension (derivatives.size(), n_quadrature_points);
 
       std::fill (derivatives.begin(), derivatives.end(),
-                 dealii::Tensor<order+1,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<order+1,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -620,8 +620,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -661,7 +661,7 @@ namespace FEValuesViews
       AssertDimension (symmetric_gradients.size(), n_quadrature_points);
 
       std::fill (symmetric_gradients.begin(), symmetric_gradients.end(),
-                 dealii::SymmetricTensor<2,spacedim>());
+                 typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -672,8 +672,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number)
             continue;
 
           if (snc != -1)
@@ -689,7 +689,7 @@ namespace FEValuesViews
           else
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
               {
-                dealii::Tensor<2,spacedim> grad;
+                dealii::Tensor<2,spacedim,Number> grad;
                 for (unsigned int d=0; d<spacedim; ++d)
                   if (shape_function_data[shape_function].is_nonzero_shape_function_component[d])
                     grad[d] = value *
@@ -713,7 +713,7 @@ namespace FEValuesViews
                                                shape_gradients[0].size() : divergences.size();
       AssertDimension (divergences.size(), n_quadrature_points);
 
-      std::fill (divergences.begin(), divergences.end(), 0.);
+      std::fill (divergences.begin(), divergences.end(), typename ProductType<Number,double>::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -724,8 +724,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -763,7 +763,7 @@ namespace FEValuesViews
                                                shape_gradients[0].size() : curls.size();
       AssertDimension (curls.size(), n_quadrature_points);
 
-      std::fill (curls.begin(), curls.end(), typename dealii::internal::CurlType<spacedim>::type());
+      std::fill (curls.begin(), curls.end(), typename ProductType<Number,typename dealii::internal::CurlType<spacedim>::type>::type());
 
       switch (spacedim)
         {
@@ -784,9 +784,9 @@ namespace FEValuesViews
                 // shape function is zero for the selected components
                 continue;
 
-              const double value = dof_values (shape_function);
+              const Number value = dof_values (shape_function);
 
-              if (value == 0.)
+              if (value == Number())
                 continue;
 
               if (snc != -1)
@@ -844,9 +844,9 @@ namespace FEValuesViews
                 // shape function is zero for the selected components
                 continue;
 
-              const double value = dof_values (shape_function);
+              const Number value = dof_values (shape_function);
 
-              if (value == 0.)
+              if (value == Number())
                 continue;
 
               if (snc != -1)
@@ -956,7 +956,7 @@ namespace FEValuesViews
       AssertDimension (laplacians.size(), n_quadrature_points);
 
       std::fill (laplacians.begin(), laplacians.end(),
-                 dealii::Tensor<1,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<1,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -967,8 +967,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -1010,7 +1010,7 @@ namespace FEValuesViews
       AssertDimension (values.size(), n_quadrature_points);
 
       std::fill (values.begin(), values.end(),
-                 dealii::SymmetricTensor<2,spacedim>());
+                 typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -1021,8 +1021,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -1064,7 +1064,7 @@ namespace FEValuesViews
       AssertDimension (divergences.size(), n_quadrature_points);
 
       std::fill (divergences.begin(), divergences.end(),
-                 dealii::Tensor<1,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<1,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -1075,8 +1075,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)
@@ -1152,7 +1152,7 @@ namespace FEValuesViews
       AssertDimension (values.size(), n_quadrature_points);
 
       std::fill (values.begin(), values.end(),
-                 dealii::Tensor<2,spacedim>());
+                 typename ProductType<Number,dealii::Tensor<2,spacedim> >::type());
 
       for (unsigned int shape_function=0;
            shape_function<dofs_per_cell; ++shape_function)
@@ -1163,8 +1163,8 @@ namespace FEValuesViews
             // shape function is zero for the selected components
             continue;
 
-          const double value = dof_values(shape_function);
-          if (value == 0.)
+          const Number value = dof_values(shape_function);
+          if (value == Number())
             continue;
 
           if (snc != -1)

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -631,7 +631,8 @@ namespace FEValuesViews
               const dealii::Tensor<order,spacedim> *shape_derivative_ptr =
                 &shape_derivatives[snc][0];
               for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
-                derivatives[q_point][comp] += value **shape_derivative_ptr++;
+                derivatives[q_point][comp] += value *
+                                              typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
             }
           else
             for (unsigned int d=0; d<spacedim; ++d)
@@ -641,7 +642,8 @@ namespace FEValuesViews
                     &shape_derivatives[shape_function_data[shape_function].
                                        row_index[d]][0];
                   for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
-                    derivatives[q_point][d] += value **shape_derivative_ptr++;
+                    derivatives[q_point][d] += value *
+                                               typename ProductType<Number,dealii::Tensor<order,spacedim> >::type(*shape_derivative_ptr++);
                 }
         }
     }
@@ -684,7 +686,7 @@ namespace FEValuesViews
                 &shape_gradients[snc][0];
               for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
                 symmetric_gradients[q_point] += value *
-                                                symmetrize_single_row(comp, *shape_gradient_ptr++);
+                  typename ProductType<Number,dealii::SymmetricTensor<2,spacedim> >::type (symmetrize_single_row(comp, *shape_gradient_ptr++));
             }
           else
             for (unsigned int q_point=0; q_point<n_quadrature_points; ++q_point)
@@ -2360,7 +2362,8 @@ namespace internal
         const Tensor<order,spacedim> *shape_derivative_ptr
           = &shape_derivatives[shape_func][0];
         for (unsigned int point=0; point<n_quadrature_points; ++point)
-          derivatives[point] += value **shape_derivative_ptr++;
+          derivatives[point] += value *
+                                dealii::Tensor<order,spacedim,Number>(*shape_derivative_ptr++);
       }
   }
 
@@ -2428,10 +2431,12 @@ namespace internal
 
               if (quadrature_points_fastest)
                 for (unsigned int point=0; point<n_quadrature_points; ++point)
-                  derivatives[comp][point] += value **shape_derivative_ptr++;
+                  derivatives[comp][point] += value *
+                                              dealii::Tensor<order,spacedim,Number>(*shape_derivative_ptr++);
               else
                 for (unsigned int point=0; point<n_quadrature_points; ++point)
-                  derivatives[point][comp] += value **shape_derivative_ptr++;
+                  derivatives[point][comp] += value *
+                                              dealii::Tensor<order,spacedim,Number>(*shape_derivative_ptr++);
             }
           else
             for (unsigned int c=0; c<n_components; ++c)
@@ -2448,10 +2453,12 @@ namespace internal
 
                 if (quadrature_points_fastest)
                   for (unsigned int point=0; point<n_quadrature_points; ++point)
-                    derivatives[comp][point] += value **shape_derivative_ptr++;
+                    derivatives[comp][point] += value *
+                                                dealii::Tensor<order,spacedim,Number>(*shape_derivative_ptr++);
                 else
                   for (unsigned int point=0; point<n_quadrature_points; ++point)
-                    derivatives[point][comp] += value **shape_derivative_ptr++;
+                    derivatives[point][comp] += value *
+                                                dealii::Tensor<order,spacedim,Number>(*shape_derivative_ptr++);
               }
         }
   }

--- a/source/fe/fe_values.decl.1.inst.in
+++ b/source/fe/fe_values.decl.1.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -27,5 +27,5 @@ for (VEC : SERIAL_VECTORS)
     virtual
     void
     get_interpolated_dof_values (const VEC &in,
-				 Vector<double> &out) const = 0;
+				 Vector<VEC::value_type> &out) const = 0;
   }

--- a/source/fe/fe_values.decl.2.inst.in
+++ b/source/fe/fe_values.decl.2.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -27,5 +27,5 @@ for (VEC : SERIAL_VECTORS)
     virtual
     void
     get_interpolated_dof_values (const VEC      &in,
-				 Vector<double> &out) const;
+				 Vector<VEC::value_type> &out) const;
   }

--- a/source/fe/fe_values.impl.1.inst.in
+++ b/source/fe/fe_values.impl.1.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,7 +21,7 @@ for (VEC : SERIAL_VECTORS)
     void
     FEValuesBase<dim,spacedim>::CellIterator<CI>::
     get_interpolated_dof_values (const VEC      &in,
-			         Vector<double> &out) const
+			         Vector<VEC::value_type> &out) const
     \{
       cell->get_interpolated_dof_values (in, out);
     \}

--- a/source/fe/fe_values.impl.2.inst.in
+++ b/source/fe/fe_values.impl.2.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -20,7 +20,7 @@ for (VEC : SERIAL_VECTORS)
     void
     FEValuesBase<dim,spacedim>::TriaCellIterator::
     get_interpolated_dof_values (const VEC &,
-    			         Vector<double> &) const
+    			         Vector<VEC::value_type> &) const
     \{
       Assert (false, ExcMessage (message_string));
     \}

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -87,31 +87,31 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_values<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension>>::type >&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_gradients<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension>>::type >&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_symmetric_gradients<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::SymmetricTensor<2,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension>>::type >&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_curls<dealii::VEC>
-      (const dealii::VEC&, std::vector<curl_type>&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,curl_type>::type>&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_divergences<dealii::VEC>
-      (const dealii::VEC&, std::vector<double>&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,divergence_type>::type>&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_hessians<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<3,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<3,deal_II_space_dimension>>::type >&) const;
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
       ::get_function_laplacians<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension>>::type >&) const;
 
     template
       void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>
@@ -274,25 +274,25 @@ for (deal_II_dimension : DIMENSIONS)
 
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_symmetric_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::SymmetricTensor<2,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_curls<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<curl_type>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,curl_type>::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<double>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,divergence_type>::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_hessians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<3,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_laplacians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
 
     template
 	void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_dimension>::get_function_values<dealii::IndexSet>

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -70,19 +70,19 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
     template
       void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
       ::get_function_values<dealii::VEC>
-      (const dealii::VEC&, std::vector<value_type>&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,value_type>::type>&) const;
     template
       void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
       ::get_function_gradients<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension>>::type>&) const;
     template
       void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
       ::get_function_hessians<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension>>::type>&) const;
     template
       void FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>
       ::get_function_laplacians<dealii::VEC>
-      (const dealii::VEC&, std::vector<double>&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,double>::type> &) const;
 
     template
       void FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>
@@ -261,16 +261,16 @@ for (deal_II_dimension : DIMENSIONS)
 #if (deal_II_dimension == DIM_A) || (deal_II_dimension == DIM_B)
     template
 	void FEValuesViews::Scalar<deal_II_dimension>::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<double>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,double>::type> &) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension>::get_function_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension>::get_function_hessians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension>::get_function_laplacians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<double>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,double>::type>&) const;
 
     template
 	void FEValuesViews::Vector<deal_II_dimension>::get_function_values<dealii::IndexSet>

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -116,20 +116,20 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
     template
       void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>
       ::get_function_values<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::SymmetricTensor<2,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
     template
       void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>
       ::get_function_divergences<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
 
     template
       void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>
       ::get_function_values<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
     template
       void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>
       ::get_function_divergences<dealii::VEC>
-      (const dealii::VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> >&) const;
+      (const dealii::VEC&, std::vector<typename ProductType<typename dealii::VEC::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
 #endif
 #endif
   }
@@ -296,41 +296,41 @@ for (deal_II_dimension : DIMENSIONS)
 
     template
 	void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_dimension>::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::SymmetricTensor<2,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_dimension>::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
 
 	template
 	void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_dimension>::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
     template
 	void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_dimension>::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
 
 
 #if deal_II_dimension != 3
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<value_type>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,value_type> >::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_hessians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_laplacians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<double>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,double>::type>&) const;
 
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_gradients<dealii::IndexSet>
@@ -342,33 +342,33 @@ for (deal_II_dimension : DIMENSIONS)
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<double>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,double>::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_hessians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<3,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_laplacians<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
 
     template
 	void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_dimension+1>
         ::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::SymmetricTensor<2,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_dimension+1>
         ::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
 
     template
 	void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_dimension+1>
         ::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_dimension+1>
         ::get_function_divergences<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
 
 #endif
 #endif

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -143,111 +143,77 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, std::vector<double>&) const;
+      (const VEC&, std::vector<typename VEC::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<typename VEC::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, std::vector<Vector<float> > &) const;
+      (const VEC&, std::vector<Vector<typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<double> > >, bool) const;
-//     template
-//       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<VEC>
-//       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-//        VectorSlice<std::vector<std::vector<float> > >, bool) const;
+       VectorSlice<std::vector<std::vector<typename VEC::value_type> > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-      (const VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension> > &) const;
+      (const VEC&, std::vector<dealii::Tensor<1,deal_II_space_dimension,typename VEC::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<1,deal_II_space_dimension> > &) const;
+       std::vector<dealii::Tensor<1,deal_II_space_dimension,typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
-      (const VEC&, std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension> > > &) const;
+      (const VEC&, std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,typename VEC::value_type> > > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,typename VEC::value_type> > > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-      (const VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension> > &) const;
+      (const VEC&, std::vector<dealii::Tensor<2,deal_II_space_dimension,typename VEC::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<2,deal_II_space_dimension> > &) const;
+       std::vector<dealii::Tensor<2,deal_II_space_dimension,typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
-      (const VEC&, std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension> > > &, bool) const;
+      (const VEC&, std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,typename VEC::value_type> > > &, bool) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,typename VEC::value_type> > > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, std::vector<double>&) const;
+      (const VEC&, std::vector<typename VEC::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<typename VEC::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, std::vector<Vector<float> > &) const;
+      (const VEC&, std::vector<Vector<typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<typename VEC::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
       (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<double> > &, bool) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<VEC>
-      (const VEC&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<float> > &, bool) const;
+       std::vector<std::vector<typename VEC::value_type> > &, bool) const;
 
 #endif
 #endif
@@ -313,7 +279,7 @@ for (deal_II_dimension : DIMENSIONS)
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_values<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,value_type> >::type>&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,value_type>::type>&) const;
     template
 	void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
 	::get_function_gradients<dealii::IndexSet>
@@ -334,11 +300,11 @@ for (deal_II_dimension : DIMENSIONS)
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_symmetric_gradients<dealii::IndexSet>
-	(const dealii::IndexSet&, std::vector<dealii::SymmetricTensor<2,deal_II_dimension+1> >&) const;
+	(const dealii::IndexSet&, std::vector<typename ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension+1> >::type>&) const;
     template
 	void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
 	::get_function_divergences<dealii::IndexSet>
@@ -383,222 +349,154 @@ for (deal_II_dimension : DIMENSIONS)
 #if (deal_II_dimension == DIM_A) || (deal_II_dimension == DIM_B)
     template
 	void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<double>&) const;
+      (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<Vector<float> > &) const;
+      (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<double> > >, bool) const;
-//     template
-//       void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
-//       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-//        VectorSlice<std::vector<std::vector<float> > >, bool) const;
+       VectorSlice<std::vector<std::vector<IndexSet::value_type> > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
-      (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension> > &) const;
+      (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<1,deal_II_dimension> > &) const;
+       std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
-      (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension> > > &) const;
+      (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > > &) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
-      (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension> > &) const;
+      (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<2,deal_II_dimension> > &) const;
+       std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
-      (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension> > > &, bool) const;
+      (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > > &, bool) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > > >, bool) const;
 
     template
 	void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<double>&) const;
+      (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<Vector<float> > &) const;
+      (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<double> > &, bool) const;
-    template
-      void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<float> > &, bool) const;
+       std::vector<std::vector<IndexSet::value_type> > &, bool) const;
 
 
 #if deal_II_dimension != 3
 
     template
 	void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<double>&) const;
+      (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, std::vector<Vector<float> > &) const;
+      (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<double> > >, bool) const;
-//     template
-//       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-//       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-//        VectorSlice<std::vector<std::vector<float> > >, bool) const;
+       VectorSlice<std::vector<std::vector<IndexSet::value_type> > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-      (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1> > &) const;
+      (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<1,deal_II_dimension+1> > &) const;
+       std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-      (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1> > > &) const;
+      (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > > >, bool) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-      (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1> > &) const;
+      (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > &) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<dealii::Tensor<2,deal_II_dimension+1> > &) const;
+       std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-      (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1> > > &, bool) const;
+      (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > > &, bool) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1> > > >, bool) const;
+       VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > > >, bool) const;
 
     template
 	void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<double>&) const;
+      (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<float>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<double>&) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<float>&) const;
+      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, std::vector<Vector<float> > &) const;
+      (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<double> > &) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<Vector<float> > &) const;
+       std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
       void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
       (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<double> > &, bool) const;
-    template
-      void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-      (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-       std::vector<std::vector<float> > &, bool) const;
+       std::vector<std::vector<IndexSet::value_type> > &, bool) const;
 
 #endif
 #endif

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -25,13 +25,13 @@ namespace internal
 {
   namespace Vector
   {
-    template void copy_vector<int,double> (const dealii::Vector<int>&,
-                                           dealii::Vector<double>&);
+    template void copy_vector<int,double> (const dealii::Vector<int> &,
+                                           dealii::Vector<double> &);
   }
 }
 
 template
-void Vector<int>::reinit<double>(const Vector<double>&, const bool);
+void Vector<int>::reinit<double>(const Vector<double> &, const bool);
 
 
 // do a few functions that currently don't fit the scheme because they have

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -19,6 +19,21 @@ DEAL_II_NAMESPACE_OPEN
 
 #include "vector.inst"
 
+// instantiate for integers:
+template class Vector<int>;
+namespace internal
+{
+  namespace Vector
+  {
+    template void copy_vector<int,double> (const dealii::Vector<int>&,
+                                           dealii::Vector<double>&);
+  }
+}
+
+template
+void Vector<int>::reinit<double>(const Vector<double>&, const bool);
+
+
 // do a few functions that currently don't fit the scheme because they have
 // two template arguments that need to be different (the case of same
 // arguments is covered by the default copy constructor and copy operator that

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -545,11 +545,21 @@ namespace internal
     get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                          std::vector<dealii::Vector<double> >    &patch_values_system) const
     {
-      //FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<dealii::Vector<typename VectorType::value_type> > tmp(patch_values_system.size());
       for (unsigned int i = 0; i < patch_values_system.size(); i++)
         tmp[i].reinit(patch_values_system[i]);
+
       fe_patch_values.get_function_values (*vector, tmp);
+
       for (unsigned int i = 0; i < patch_values_system.size(); i++)
         patch_values_system[i] = tmp[i];
     }
@@ -562,9 +572,19 @@ namespace internal
     get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                          std::vector<double>             &patch_values) const
     {
-      //FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<typename VectorType::value_type> tmp (patch_values.size());
+
       fe_patch_values.get_function_values (*vector, tmp);
+
       for (unsigned int i = 0; i < tmp.size(); i++)
         patch_values[i] = tmp[i];
     }
@@ -577,11 +597,21 @@ namespace internal
     get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                             std::vector<std::vector<Tensor<1,DH::space_dimension> > >   &patch_gradients_system) const
     {
-      //FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_gradients_system.size());
       for (unsigned int i = 0; i < tmp.size(); i++)
         tmp[i].resize(patch_gradients_system.size());
+
       fe_patch_values.get_function_gradients (*vector, tmp);
+
       for (unsigned int i = 0; i < tmp.size(); i++)
         for (unsigned int j = 0; j < tmp[i].size(); j++)
           patch_gradients_system[i][j] = tmp[i][j];
@@ -595,10 +625,20 @@ namespace internal
     get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                             std::vector<Tensor<1,DH::space_dimension> >       &patch_gradients) const
     {
-      //FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> >  tmp;
       tmp.resize(patch_gradients.size());
+
       fe_patch_values.get_function_gradients (*vector, tmp);
+
       for (unsigned int i = 0; i < tmp.size(); i++)
         patch_gradients[i] = tmp[i];
     }
@@ -611,11 +651,21 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<std::vector<Tensor<2,DH::space_dimension> > >   &patch_hessians_system) const
     {
-      // FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_hessians_system.size());
       for (unsigned int i = 0; i < tmp.size(); i++)
         tmp[i].resize(patch_hessians_system[i].size());
+
       fe_patch_values.get_function_hessians (*vector, tmp);
+
       for (unsigned int i = 0; i < tmp.size(); i++)
         for (unsigned int j = 0; j < tmp[i].size(); j++)
           patch_hessians_system[i][j] = tmp[i][j];
@@ -629,9 +679,19 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<Tensor<2,DH::space_dimension> >       &patch_hessians) const
     {
-      // FIXME
+      // FIXME: FEValuesBase gives us data in types that match that of
+      // the solution vector. but this function needs to pass it back
+      // up as 'double' vectors. this requires the use of a temporary
+      // variable here
+      //
+      // the correct thing would be to also use the correct data type
+      // upstream somewhere, but this is complicated because we hide
+      // the actual data type from upstream. rather, we should at
+      // least make sure we can deal with complex numbers
       std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > tmp(patch_hessians.size());
+
       fe_patch_values.get_function_hessians (*vector, tmp);
+
       for (unsigned int i = 0; i < tmp.size(); i++)
         patch_hessians[i] = tmp[i];
     }

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -545,7 +545,13 @@ namespace internal
     get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                          std::vector<dealii::Vector<double> >    &patch_values_system) const
     {
-      fe_patch_values.get_function_values (*vector, patch_values_system);
+      //FIXME
+      std::vector<dealii::Vector<typename VectorType::value_type> > tmp(patch_values_system.size());
+      for (unsigned int i = 0; i < patch_values_system.size(); i++)
+        tmp[i].reinit(patch_values_system[i]);
+      fe_patch_values.get_function_values (*vector, tmp);
+      for (unsigned int i = 0; i < patch_values_system.size(); i++)
+        patch_values_system[i] = tmp[i];
     }
 
 
@@ -556,7 +562,11 @@ namespace internal
     get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                          std::vector<double>             &patch_values) const
     {
-      fe_patch_values.get_function_values (*vector, patch_values);
+      //FIXME
+      std::vector<typename VectorType::value_type> tmp (patch_values.size());
+      fe_patch_values.get_function_values (*vector, tmp);
+      for (unsigned int i = 0; i < tmp.size();i++)
+        patch_values[i] = tmp[i];
     }
 
 
@@ -567,7 +577,14 @@ namespace internal
     get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                             std::vector<std::vector<Tensor<1,DH::space_dimension> > >   &patch_gradients_system) const
     {
-      fe_patch_values.get_function_gradients (*vector, patch_gradients_system);
+      //FIXME
+      std::vector<std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_gradients_system.size());
+      for (unsigned int i = 0; i < tmp.size();i++)
+        tmp[i].resize(patch_gradients_system.size());
+      fe_patch_values.get_function_gradients (*vector, tmp);
+      for (unsigned int i = 0; i < tmp.size();i++)
+        for (unsigned int j = 0; j < tmp[i].size();j++)
+          patch_gradients_system[i][j] = tmp[i][j];
     }
 
 
@@ -578,7 +595,12 @@ namespace internal
     get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                             std::vector<Tensor<1,DH::space_dimension> >       &patch_gradients) const
     {
-      fe_patch_values.get_function_gradients (*vector, patch_gradients);
+      //FIXME
+      std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> >  tmp;
+      tmp.resize(patch_gradients.size());
+      fe_patch_values.get_function_gradients (*vector, tmp);
+      for (unsigned int i = 0; i < tmp.size();i++)
+        patch_gradients[i] = tmp[i];
     }
 
 
@@ -589,7 +611,13 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<std::vector<Tensor<2,DH::space_dimension> > >   &patch_hessians_system) const
     {
-      fe_patch_values.get_function_hessians (*vector, patch_hessians_system);
+      std::vector<std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_hessians_system.size());
+      for (unsigned int i = 0; i < tmp.size(); i++)
+        tmp[i].resize(patch_hessians_system[i].size());
+      fe_patch_values.get_function_hessians (*vector, tmp);
+      for (unsigned int i = 0; i < tmp.size(); i++)
+        for (unsigned int j = 0; j < tmp[i].size(); j++)
+          patch_hessians_system[i][j] = tmp[i][j];
     }
 
 
@@ -600,7 +628,10 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<Tensor<2,DH::space_dimension> >       &patch_hessians) const
     {
-      fe_patch_values.get_function_hessians (*vector, patch_hessians);
+      std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > tmp(patch_hessians.size());
+      fe_patch_values.get_function_hessians (*vector, tmp);
+      for (unsigned int i = 0; i < tmp.size(); i++)
+        patch_hessians[i] = tmp[i];
     }
 
 

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -611,6 +611,7 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<std::vector<Tensor<2,DH::space_dimension> > >   &patch_hessians_system) const
     {
+      // FIXME
       std::vector<std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_hessians_system.size());
       for (unsigned int i = 0; i < tmp.size(); i++)
         tmp[i].resize(patch_hessians_system[i].size());
@@ -628,6 +629,7 @@ namespace internal
     get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
                            std::vector<Tensor<2,DH::space_dimension> >       &patch_hessians) const
     {
+      // FIXME
       std::vector<Tensor<2,DH::space_dimension,typename VectorType::value_type> > tmp(patch_hessians.size());
       fe_patch_values.get_function_hessians (*vector, tmp);
       for (unsigned int i = 0; i < tmp.size(); i++)

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -565,7 +565,7 @@ namespace internal
       //FIXME
       std::vector<typename VectorType::value_type> tmp (patch_values.size());
       fe_patch_values.get_function_values (*vector, tmp);
-      for (unsigned int i = 0; i < tmp.size();i++)
+      for (unsigned int i = 0; i < tmp.size(); i++)
         patch_values[i] = tmp[i];
     }
 
@@ -579,11 +579,11 @@ namespace internal
     {
       //FIXME
       std::vector<std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_gradients_system.size());
-      for (unsigned int i = 0; i < tmp.size();i++)
+      for (unsigned int i = 0; i < tmp.size(); i++)
         tmp[i].resize(patch_gradients_system.size());
       fe_patch_values.get_function_gradients (*vector, tmp);
-      for (unsigned int i = 0; i < tmp.size();i++)
-        for (unsigned int j = 0; j < tmp[i].size();j++)
+      for (unsigned int i = 0; i < tmp.size(); i++)
+        for (unsigned int j = 0; j < tmp[i].size(); j++)
           patch_gradients_system[i][j] = tmp[i][j];
     }
 
@@ -599,7 +599,7 @@ namespace internal
       std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> >  tmp;
       tmp.resize(patch_gradients.size());
       fe_patch_values.get_function_gradients (*vector, tmp);
-      for (unsigned int i = 0; i < tmp.size();i++)
+      for (unsigned int i = 0; i < tmp.size(); i++)
         patch_gradients[i] = tmp[i];
     }
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -256,7 +256,7 @@ namespace DerivativeApproximation
       else
         {
           std::vector<std::vector<Tensor<1,dim,typename InputVector::value_type>> > values
-          (1, std::vector<Tensor<1,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
+              (1, std::vector<Tensor<1,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
           fe_values.get_function_gradients (solution, values);
           return ProjectedDerivative(values[0][component]);
         };
@@ -599,7 +599,7 @@ namespace DerivativeApproximation
       else
         {
           std::vector<std::vector<Tensor<2,dim,typename InputVector::value_type>> > values
-          (1, std::vector<Tensor<2,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
+              (1, std::vector<Tensor<2,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
           fe_values.get_function_hessians (solution, values);
           return ProjectedDerivative(values[0][component]);
         };

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -133,14 +133,14 @@ namespace DerivativeApproximation
     {
       if (fe_values.get_fe().n_components() == 1)
         {
-          std::vector<ProjectedDerivative> values (1);
+          std::vector<typename InputVector::value_type> values (1);
           fe_values.get_function_values (solution, values);
           return values[0];
         }
       else
         {
-          std::vector<Vector<double> > values
-          (1, Vector<double>(fe_values.get_fe().n_components()));
+          std::vector<Vector<typename InputVector::value_type> > values
+          (1, Vector<typename InputVector::value_type>(fe_values.get_fe().n_components()));
           fe_values.get_function_values (solution, values);
           return values[0](component);
         }
@@ -249,16 +249,16 @@ namespace DerivativeApproximation
     {
       if (fe_values.get_fe().n_components() == 1)
         {
-          std::vector<ProjectedDerivative> values (1);
+          std::vector<Tensor<1,dim,typename InputVector::value_type>> values (1);
           fe_values.get_function_gradients (solution, values);
-          return values[0];
+          return ProjectedDerivative(values[0]);
         }
       else
         {
-          std::vector<std::vector<ProjectedDerivative> > values
-          (1, std::vector<ProjectedDerivative>(fe_values.get_fe().n_components()));
+          std::vector<std::vector<Tensor<1,dim,typename InputVector::value_type>> > values
+          (1, std::vector<Tensor<1,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
           fe_values.get_function_gradients (solution, values);
-          return values[0][component];
+          return ProjectedDerivative(values[0][component]);
         };
     }
 
@@ -592,16 +592,16 @@ namespace DerivativeApproximation
     {
       if (fe_values.get_fe().n_components() == 1)
         {
-          std::vector<ProjectedDerivative> values (1);
+          std::vector<Tensor<2,dim,typename InputVector::value_type>> values (1);
           fe_values.get_function_hessians (solution, values);
-          return values[0];
+          return ProjectedDerivative(values[0]);
         }
       else
         {
-          std::vector<std::vector<ProjectedDerivative> > values
-          (1, std::vector<ProjectedDerivative>(fe_values.get_fe().n_components()));
+          std::vector<std::vector<Tensor<2,dim,typename InputVector::value_type>> > values
+          (1, std::vector<Tensor<2,dim,typename InputVector::value_type>>(fe_values.get_fe().n_components()));
           fe_values.get_function_hessians (solution, values);
-          return values[0][component];
+          return ProjectedDerivative(values[0][component]);
         };
     }
 

--- a/source/numerics/error_estimator.cc
+++ b/source/numerics/error_estimator.cc
@@ -221,38 +221,38 @@ namespace internal
       finite_element (fe),
       face_quadratures (face_quadratures),
       fe_face_values_cell (mapping,
-                           finite_element,
-                           face_quadratures,
-                           update_gradients      |
-                           update_JxW_values     |
-                           (need_quadrature_points  ?
-                            update_quadrature_points :
-                            UpdateFlags()) |
-                           update_normal_vectors),
+                          finite_element,
+                          face_quadratures,
+                          update_gradients      |
+                          update_JxW_values     |
+                          (need_quadrature_points  ?
+                           update_quadrature_points :
+                           UpdateFlags()) |
+                          update_normal_vectors),
       fe_face_values_neighbor (mapping,
-                               finite_element,
-                               face_quadratures,
-                               update_gradients),
+                              finite_element,
+                              face_quadratures,
+                              update_gradients),
       fe_subface_values (mapping,
-                         finite_element,
-                         face_quadratures,
-                         update_gradients),
+                        finite_element,
+                        face_quadratures,
+                        update_gradients),
       phi (n_solution_vectors,
-           std::vector<std::vector<number> >
-           (face_quadratures.max_n_quadrature_points(),
-            std::vector<number> (fe.n_components()))),
+          std::vector<std::vector<number> >
+          (face_quadratures.max_n_quadrature_points(),
+           std::vector<number> (fe.n_components()))),
       psi (n_solution_vectors,
-           std::vector<std::vector<Tensor<1,spacedim,number> > >
-           (face_quadratures.max_n_quadrature_points(),
-            std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
+          std::vector<std::vector<Tensor<1,spacedim,number> > >
+          (face_quadratures.max_n_quadrature_points(),
+           std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       neighbor_psi (n_solution_vectors,
-                    std::vector<std::vector<Tensor<1,spacedim,number> > >
-                    (face_quadratures.max_n_quadrature_points(),
-                     std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
+                   std::vector<std::vector<Tensor<1,spacedim,number> > >
+                   (face_quadratures.max_n_quadrature_points(),
+                    std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       normal_vectors (face_quadratures.max_n_quadrature_points()),
       coefficient_values1 (face_quadratures.max_n_quadrature_points()),
       coefficient_values (face_quadratures.max_n_quadrature_points(),
-                          dealii::Vector<double> (fe.n_components())),
+                         dealii::Vector<double> (fe.n_components())),
       JxW_values (face_quadratures.max_n_quadrature_points()),
       subdomain_id (subdomain_id),
       material_id (material_id),

--- a/source/numerics/error_estimator.cc
+++ b/source/numerics/error_estimator.cc
@@ -221,38 +221,38 @@ namespace internal
       finite_element (fe),
       face_quadratures (face_quadratures),
       fe_face_values_cell (mapping,
-                          finite_element,
-                          face_quadratures,
-                          update_gradients      |
-                          update_JxW_values     |
-                          (need_quadrature_points  ?
-                           update_quadrature_points :
-                           UpdateFlags()) |
-                          update_normal_vectors),
+                           finite_element,
+                           face_quadratures,
+                           update_gradients      |
+                           update_JxW_values     |
+                           (need_quadrature_points  ?
+                            update_quadrature_points :
+                            UpdateFlags()) |
+                           update_normal_vectors),
       fe_face_values_neighbor (mapping,
-                              finite_element,
-                              face_quadratures,
-                              update_gradients),
+                               finite_element,
+                               face_quadratures,
+                               update_gradients),
       fe_subface_values (mapping,
-                        finite_element,
-                        face_quadratures,
-                        update_gradients),
+                         finite_element,
+                         face_quadratures,
+                         update_gradients),
       phi (n_solution_vectors,
-          std::vector<std::vector<number> >
-          (face_quadratures.max_n_quadrature_points(),
-           std::vector<number> (fe.n_components()))),
+           std::vector<std::vector<number> >
+           (face_quadratures.max_n_quadrature_points(),
+            std::vector<number> (fe.n_components()))),
       psi (n_solution_vectors,
-          std::vector<std::vector<Tensor<1,spacedim,number> > >
-          (face_quadratures.max_n_quadrature_points(),
-           std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
+           std::vector<std::vector<Tensor<1,spacedim,number> > >
+           (face_quadratures.max_n_quadrature_points(),
+            std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       neighbor_psi (n_solution_vectors,
-                   std::vector<std::vector<Tensor<1,spacedim,number> > >
-                   (face_quadratures.max_n_quadrature_points(),
-                    std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
+                    std::vector<std::vector<Tensor<1,spacedim,number> > >
+                    (face_quadratures.max_n_quadrature_points(),
+                     std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       normal_vectors (face_quadratures.max_n_quadrature_points()),
       coefficient_values1 (face_quadratures.max_n_quadrature_points()),
       coefficient_values (face_quadratures.max_n_quadrature_points(),
-                         dealii::Vector<double> (fe.n_components())),
+                          dealii::Vector<double> (fe.n_components())),
       JxW_values (face_quadratures.max_n_quadrature_points()),
       subdomain_id (subdomain_id),
       material_id (material_id),

--- a/source/numerics/error_estimator.cc
+++ b/source/numerics/error_estimator.cc
@@ -96,7 +96,7 @@ namespace internal
      * resizing to a smaller size doesn't imply memory allocation, this is
      * fast.
      */
-    template <class DH>
+    template <class DH,typename number>
     struct ParallelData
     {
       static const unsigned int dim      = DH::dimension;
@@ -128,7 +128,7 @@ namespace internal
        * particular in presence of multiple threads where synchronisation
        * makes things even slower.
        */
-      std::vector<std::vector<std::vector<double> > > phi;
+      std::vector<std::vector<std::vector<number> > > phi;
 
       /**
        * A vector for the gradients of the finite element function on one cell
@@ -138,12 +138,12 @@ namespace internal
        * the number of the quadrature point. The first index denotes the index
        * of the solution vector.
        */
-      std::vector<std::vector<std::vector<Tensor<1,spacedim> > > > psi;
+      std::vector<std::vector<std::vector<Tensor<1,spacedim,number> > > > psi;
 
       /**
        * The same vector for a neighbor cell
        */
-      std::vector<std::vector<std::vector<Tensor<1,spacedim> > > > neighbor_psi;
+      std::vector<std::vector<std::vector<Tensor<1,spacedim,number> > > > neighbor_psi;
 
       /**
        * The normal vectors of the finite element function on one face
@@ -204,9 +204,9 @@ namespace internal
     };
 
 
-    template <class DH>
+    template <class DH,typename number>
     template <class FE>
-    ParallelData<DH>::
+    ParallelData<DH,number>::
     ParallelData (const FE                                           &fe,
                   const dealii::hp::QCollection<dim-1>     &face_quadratures,
                   const dealii::hp::MappingCollection<dim, spacedim> &mapping,
@@ -238,17 +238,17 @@ namespace internal
                          face_quadratures,
                          update_gradients),
       phi (n_solution_vectors,
-           std::vector<std::vector<double> >
+           std::vector<std::vector<number> >
            (face_quadratures.max_n_quadrature_points(),
-            std::vector<double> (fe.n_components()))),
+            std::vector<number> (fe.n_components()))),
       psi (n_solution_vectors,
-           std::vector<std::vector<Tensor<1,spacedim> > >
+           std::vector<std::vector<Tensor<1,spacedim,number> > >
            (face_quadratures.max_n_quadrature_points(),
-            std::vector<Tensor<1,spacedim> > (fe.n_components()))),
+            std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       neighbor_psi (n_solution_vectors,
-                    std::vector<std::vector<Tensor<1,spacedim> > >
+                    std::vector<std::vector<Tensor<1,spacedim,number> > >
                     (face_quadratures.max_n_quadrature_points(),
-                     std::vector<Tensor<1,spacedim> > (fe.n_components()))),
+                     std::vector<Tensor<1,spacedim,number> > (fe.n_components()))),
       normal_vectors (face_quadratures.max_n_quadrature_points()),
       coefficient_values1 (face_quadratures.max_n_quadrature_points()),
       coefficient_values (face_quadratures.max_n_quadrature_points(),
@@ -263,9 +263,9 @@ namespace internal
 
 
 
-    template <class DH>
+    template <class DH, typename number>
     void
-    ParallelData<DH>::resize (const unsigned int active_fe_index)
+    ParallelData<DH,number>::resize (const unsigned int active_fe_index)
     {
       const unsigned int n_q_points   = face_quadratures[active_fe_index].size();
       const unsigned int n_components = finite_element.n_components();
@@ -332,9 +332,9 @@ namespace internal
      * Actually do the computation based on the evaluated gradients in
      * ParallelData.
      */
-    template <class DH>
+    template <class DH, typename number>
     std::vector<double>
-    integrate_over_face (ParallelData<DH>                        &parallel_data,
+    integrate_over_face (ParallelData<DH,number>                 &parallel_data,
                          const typename DH::face_iterator        &face,
                          dealii::hp::FEFaceValues<DH::dimension, DH::space_dimension> &fe_face_values_cell)
     {
@@ -475,7 +475,7 @@ namespace internal
     template <typename InputVector, class DH>
     void
     integrate_over_regular_face (const std::vector<const InputVector *>   &solutions,
-                                 ParallelData<DH>                        &parallel_data,
+                                 ParallelData<DH, typename InputVector::value_type> &parallel_data,
                                  std::map<typename DH::face_iterator,std::vector<double> > &local_face_integrals,
                                  const typename DH::active_cell_iterator &cell,
                                  const unsigned int                       face_no,
@@ -552,7 +552,7 @@ namespace internal
     template <typename InputVector, class DH>
     void
     integrate_over_irregular_face (const std::vector<const InputVector *>   &solutions,
-                                   ParallelData<DH>                         &parallel_data,
+                                   ParallelData<DH, typename InputVector::value_type> &parallel_data,
                                    std::map<typename DH::face_iterator,std::vector<double> > &local_face_integrals,
                                    const typename DH::active_cell_iterator    &cell,
                                    const unsigned int                          face_no,
@@ -646,7 +646,7 @@ namespace internal
     template <typename InputVector, class DH>
     void
     estimate_one_cell (const typename DH::active_cell_iterator &cell,
-                       ParallelData<DH>                    &parallel_data,
+                       ParallelData<DH, typename InputVector::value_type> &parallel_data,
                        std::map<typename DH::face_iterator,std::vector<double> > &local_face_integrals,
                        const std::vector<const InputVector *> &solutions)
     {
@@ -968,7 +968,7 @@ estimate (const Mapping<dim, spacedim>                  &mapping,
   // all the data needed in the error estimator by each of the threads is
   // gathered in the following structures
   const hp::MappingCollection<dim,spacedim> mapping_collection(mapping);
-  const internal::ParallelData<DH>
+  const internal::ParallelData<DH,typename InputVector::value_type>
   parallel_data (dof_handler.get_fe(),
                  face_quadratures,
                  mapping_collection,

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -300,13 +300,13 @@ estimate (const Mapping<1,spacedim>                    &mapping,
   //
   // for the neighbor gradient, we need several auxiliary fields, depending on
   // the way we get it (see below)
-  std::vector<std::vector<std::vector<Tensor<1,spacedim> > > >
+  std::vector<std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > >
   gradients_here (n_solution_vectors,
-                  std::vector<std::vector<Tensor<1,spacedim> > >(2, std::vector<Tensor<1,spacedim> >(n_components)));
-  std::vector<std::vector<std::vector<Tensor<1,spacedim> > > >
+                  std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > >(2, std::vector<Tensor<1,spacedim,typename InputVector::value_type> >(n_components)));
+  std::vector<std::vector<std::vector<Tensor<1,spacedim,typename InputVector::value_type> > > >
   gradients_neighbor (gradients_here);
-  std::vector<Vector<double> >
-  grad_neighbor (n_solution_vectors, Vector<double>(n_components));
+  std::vector<Vector<typename InputVector::value_type> >
+  grad_neighbor (n_solution_vectors, Vector<typename InputVector::value_type>(n_components));
 
   // reserve some space for coefficient values at one point.  if there is no
   // coefficient, then we fill it by unity once and for all and don't set it

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -658,9 +658,9 @@ void PointValueHistory<dim>
         {
           // Extract data for the
           // PostProcessor object
-          std::vector< double > uh (n_quadrature_points, 0.0);
-          std::vector< Tensor< 1, dim > > duh (n_quadrature_points, Tensor <1, dim> ());
-          std::vector< Tensor< 2, dim > > dduh (n_quadrature_points, Tensor <2, dim> ());
+          std::vector< typename VECTOR::value_type > uh (n_quadrature_points, 0.0);
+          std::vector< Tensor< 1, dim, typename VECTOR::value_type > > duh (n_quadrature_points, Tensor <1, dim, typename VECTOR::value_type> ());
+          std::vector< Tensor< 2, dim, typename VECTOR::value_type > > dduh (n_quadrature_points, Tensor <2, dim, typename VECTOR::value_type> ());
           std::vector<Point<dim> > dummy_normals (1, Point<dim> ());
           std::vector<Point<dim> > evaluation_points;
           // at each point there is
@@ -691,10 +691,11 @@ void PointValueHistory<dim>
 
           // Call compute_derived_quantities_vector
           // or compute_derived_quantities_scalar
+          // TODO this function should also operate with typename VECTOR::value_type
           data_postprocessor.
           compute_derived_quantities_scalar(std::vector< double > (1, uh[selected_point]),
-                                            std::vector< Tensor< 1, dim > > (1, duh[selected_point]),
-                                            std::vector< Tensor< 2, dim > > (1, dduh[selected_point]),
+                                            std::vector< Tensor< 1, dim > > (1, Tensor< 1, dim >(duh[selected_point]) ),
+                                            std::vector< Tensor< 2, dim > > (1, Tensor< 2, dim >(dduh[selected_point]) ),
                                             dummy_normals,
                                             std::vector<Point<dim> > (1, evaluation_points[selected_point]),
                                             computed_quantities);
@@ -703,9 +704,9 @@ void PointValueHistory<dim>
       else     // The case of a vector FE
         {
           // Extract data for the PostProcessor object
-          std::vector< Vector< double > > uh (n_quadrature_points, Vector <double> (n_components));
-          std::vector< std::vector< Tensor< 1, dim > > > duh (n_quadrature_points, std::vector< Tensor< 1, dim > > (n_components,  Tensor< 1, dim >()));
-          std::vector< std::vector< Tensor< 2, dim > > > dduh (n_quadrature_points, std::vector< Tensor< 2, dim > > (n_components,  Tensor< 2, dim >()));
+          std::vector< Vector< typename VECTOR::value_type > > uh (n_quadrature_points, Vector <typename VECTOR::value_type> (n_components));
+          std::vector< std::vector< Tensor< 1, dim, typename VECTOR::value_type > > > duh (n_quadrature_points, std::vector< Tensor< 1, dim, typename VECTOR::value_type > > (n_components,  Tensor< 1, dim, typename VECTOR::value_type >()));
+          std::vector< std::vector< Tensor< 2, dim, typename VECTOR::value_type > > > dduh (n_quadrature_points, std::vector< Tensor< 2, dim, typename VECTOR::value_type > > (n_components,  Tensor< 2, dim, typename VECTOR::value_type >()));
           std::vector<Point<dim> > dummy_normals  (1, Point<dim> ());
           std::vector<Point<dim> > evaluation_points;
           // at each point there is
@@ -735,12 +736,27 @@ void PointValueHistory<dim>
                 }
             }
 
+          //FIXME
+          const Vector< typename VECTOR::value_type >                        &uh_s   = uh[selected_point];
+          const std::vector< Tensor< 1, dim, typename VECTOR::value_type > > &duh_s  = duh[selected_point];
+          const std::vector< Tensor< 2, dim, typename VECTOR::value_type > > &dduh_s = dduh[selected_point];
+          std::vector< Tensor< 1, dim > > tmp_d (duh_s.size());
+          for (unsigned int i = 0; i < duh_s.size(); i++)
+            tmp_d[i] = duh_s[i];
+
+          std::vector< Tensor< 2, dim > > tmp_dd (dduh_s.size());
+          for (unsigned int i = 0; i < dduh_s.size(); i++)
+            tmp_dd[i] = dduh_s[i];
+
+          Vector< double > tmp(uh_s.size());
+          for (unsigned int i = 0; i < uh_s.size(); i++)
+            tmp[i] = uh_s[i];
           // Call compute_derived_quantities_vector
           // or compute_derived_quantities_scalar
           data_postprocessor.
-          compute_derived_quantities_vector(std::vector< Vector< double > > (1, uh[selected_point]),
-                                            std::vector< std::vector< Tensor< 1, dim > > > (1, duh[selected_point]),
-                                            std::vector< std::vector< Tensor< 2, dim > > > (1, dduh[selected_point]),
+          compute_derived_quantities_vector(std::vector< Vector< double > > (1, tmp),
+                                            std::vector< std::vector< Tensor< 1, dim > > > (1, tmp_d),
+                                            std::vector< std::vector< Tensor< 2, dim > > > (1, tmp_dd),
                                             dummy_normals,
                                             std::vector<Point<dim> > (1, evaluation_points[selected_point]),
                                             computed_quantities);

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -736,7 +736,9 @@ void PointValueHistory<dim>
                 }
             }
 
-          //FIXME
+          // FIXME
+          // We need tmp vectors belowe because the data postprocessors are not
+          // equipped to deal with anything but doubles (scalars and tensors).
           const Vector< typename VECTOR::value_type >                        &uh_s   = uh[selected_point];
           const std::vector< Tensor< 1, dim, typename VECTOR::value_type > > &duh_s  = duh[selected_point];
           const std::vector< Tensor< 2, dim, typename VECTOR::value_type > > &dduh_s = dduh[selected_point];

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -736,9 +736,9 @@ void PointValueHistory<dim>
                 }
             }
 
-          // FIXME
-          // We need tmp vectors belowe because the data postprocessors are not
-          // equipped to deal with anything but doubles (scalars and tensors).
+          // FIXME: We need tmp vectors below because the data
+          // postprocessors are not equipped to deal with anything but
+          // doubles (scalars and tensors).
           const Vector< typename VECTOR::value_type >                        &uh_s   = uh[selected_point];
           const std::vector< Tensor< 1, dim, typename VECTOR::value_type > > &duh_s  = duh[selected_point];
           const std::vector< Tensor< 2, dim, typename VECTOR::value_type > > &dduh_s = dduh[selected_point];

--- a/source/numerics/vector_tools_point_gradient.inst.in
+++ b/source/numerics/vector_tools_point_gradient.inst.in
@@ -24,10 +24,10 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
       const hp::DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&,
-      std::vector<Tensor<1,deal_II_space_dimension> >&);
+      std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
 
   template
-    Tensor<1,deal_II_space_dimension> point_gradient (
+    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
       const hp::DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&);
@@ -38,10 +38,10 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
       const hp::DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&,
-      std::vector<Tensor<1,deal_II_space_dimension> >&);
+      std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
 
   template
-    Tensor<1,deal_II_space_dimension> point_gradient (
+    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
      const hp::MappingCollection<deal_II_dimension>&,
       const hp::DoFHandler<deal_II_dimension>&,
       const VEC&,
@@ -52,10 +52,10 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
       const DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&,
-      std::vector<Tensor<1,deal_II_space_dimension> >&);
+      std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
 
   template
-    Tensor<1,deal_II_space_dimension> point_gradient (
+    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
       const DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&);
@@ -66,10 +66,10 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
       const DoFHandler<deal_II_dimension>&,
       const VEC&,
       const Point<deal_II_dimension>&,
-      std::vector<Tensor<1,deal_II_space_dimension> >&);
+      std::vector<Tensor<1,deal_II_space_dimension,VEC::value_type> >&);
 
   template
-    Tensor<1,deal_II_space_dimension> point_gradient (
+    Tensor<1,deal_II_space_dimension,VEC::value_type> point_gradient (
       const Mapping<deal_II_dimension>&,
       const DoFHandler<deal_II_dimension>&,
       const VEC&,

--- a/tests/fe/function.cc
+++ b/tests/fe/function.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014 by the deal.II authors
+// Copyright (C) 2013 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,8 +61,8 @@ void vector_values(const FiniteElement<dim> &fe)
     v(i) = i;
 
   FEValues<dim> feval(fe, quadrature, update_values);
-  std::vector<Vector<double> > local(quadrature.size(),
-                                     Vector<double>(fe.n_components()));
+  std::vector<Vector<float> > local(quadrature.size(),
+                                   Vector<float>(fe.n_components()));
 
   typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
   const typename DoFHandler<dim>::active_cell_iterator end = dof.end();

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -30,6 +30,7 @@
 
 using namespace LocalIntegrators::Divergence;
 
+
 template <int dim>
 void test_cell(const FEValuesBase<dim> &fev, const FEValuesBase<dim> &fes)
 {
@@ -63,7 +64,7 @@ void test_cell(const FEValuesBase<dim> &fev, const FEValuesBase<dim> &fes)
       u = 0.;
       u(i) = 1.;
       w = 0.;
-      fev.get_function_gradients(u, indices, ugrad, true);
+      fev.get_function_gradients(u, indices, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(ugrad), true);
       cell_residual(w, fes, make_slice(ugrad));
       Md.vmult(v,u);
       w.add(-1., v);
@@ -119,7 +120,7 @@ void test_boundary(const FEValuesBase<dim> &fev, const FEValuesBase<dim> &fes)
       u = 0.;
       u(i) = 1.;
       w = 0.;
-      fev.get_function_values(u, indices, uval, true);
+      fev.get_function_values(u, indices, VectorSlice<std::vector<std::vector<double> > >(uval), true);
       u_dot_n_residual(w, fev, fes, make_slice(uval));
       M.vmult(v,u);
       w.add(-1., v);

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2014 by the deal.II authors
+// Copyright (C) 2012 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -58,7 +58,7 @@ void test_cell(const FEValuesBase<dim> &fev)
         u = 0.;
         u(i) = 1.;
         w = 0.;
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_gradients(u, indices, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(ugrad), true);
         cell_residual(w, fev, make_slice(ugrad));
         M.vmult(v,u);
         w.add(-1., v);
@@ -99,8 +99,8 @@ void test_boundary(const FEValuesBase<dim> &fev)
         u = 0.;
         u(i) = 1.;
         w = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, VectorSlice<std::vector<std::vector<double> > >(uval), true);
+        fev.get_function_gradients(u, indices, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(ugrad), true);
         nitsche_residual(w, fev, make_slice(uval), make_slice(ugrad), make_slice(null_val), 17);
         M.vmult(v,u);
         w.add(-1., v);
@@ -163,8 +163,8 @@ void test_face(const FEValuesBase<dim> &fev1,
         u1(i1) = 1.;
         w1 = 0.;
         w2 = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
-        fev1.get_function_gradients(u1, indices1, u1grad, true);
+        fev1.get_function_values(u1, indices1, VectorSlice<std::vector<std::vector<double> > >(u1val), true);
+        fev1.get_function_gradients(u1, indices1, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(u1grad), true);
         ip_residual(w1, w2, fev1, fev2,
                     make_slice(u1val), make_slice(u1grad),
                     make_slice(nullval), make_slice(nullgrad),
@@ -177,8 +177,8 @@ void test_face(const FEValuesBase<dim> &fev1,
 
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
-        fev2.get_function_gradients(u1, indices2, u1grad, true);
+        fev2.get_function_values(u1, indices2, VectorSlice<std::vector<std::vector<double> > >(u1val), true);
+        fev2.get_function_gradients(u1, indices2, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(u1grad), true);
         ip_residual(w1, w2, fev1, fev2,
                     make_slice(nullval), make_slice(nullgrad),
                     make_slice(u1val), make_slice(u1grad),

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2014 by the deal.II authors
+// Copyright (C) 2012 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -55,7 +55,7 @@ void test_cell(const FEValuesBase<dim> &fev)
         u = 0.;
         u(i) = 1.;
         w = 0.;
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_gradients(u, indices, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(ugrad), true);
         cell_residual(w, fev, make_slice(ugrad));
         M.vmult(v,u);
         w.add(-1., v);
@@ -103,8 +103,8 @@ void test_boundary(const FEValuesBase<dim> &fev)
         u = 0.;
         u(i) = 1.;
         w = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, VectorSlice<std::vector<std::vector<double> > >(uval), true);
+        fev.get_function_gradients(u, indices, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(ugrad), true);
         nitsche_residual(w, fev, make_slice(uval), make_slice(ugrad), make_slice(null_val), 17);
         M.vmult(v,u);
         w.add(-1., v);
@@ -174,8 +174,8 @@ void test_face(const FEValuesBase<dim> &fev1,
         u1(i1) = 1.;
         w1 = 0.;
         w2 = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
-        fev1.get_function_gradients(u1, indices1, u1grad, true);
+        fev1.get_function_values(u1, indices1, VectorSlice<std::vector<std::vector<double> > >(u1val), true);
+        fev1.get_function_gradients(u1, indices1, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(u1grad), true);
         ip_residual(w1, w2, fev1, fev2,
                     make_slice(u1val), make_slice(u1grad),
                     make_slice(nullval), make_slice(nullgrad),
@@ -200,8 +200,8 @@ void test_face(const FEValuesBase<dim> &fev1,
 
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
-        fev2.get_function_gradients(u1, indices2, u1grad, true);
+        fev2.get_function_values(u1, indices2, VectorSlice<std::vector<std::vector<double> > >(u1val), true);
+        fev2.get_function_gradients(u1, indices2, VectorSlice<std::vector<std::vector<Tensor<1,dim> > > >(u1grad), true);
         ip_residual(w1, w2, fev1, fev2,
                     make_slice(nullval), make_slice(nullgrad),
                     make_slice(u1val), make_slice(u1grad),

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -69,9 +69,9 @@ public:
   {
     FEEvaluation<dim,fe_degree,n_q_points_1d,1,Number> fe_eval (data);
 
-    std::vector<double> reference_values (fe_eval.n_q_points);
-    std::vector<Tensor<1,dim> > reference_grads (fe_eval.n_q_points);
-    std::vector<Tensor<2,dim> > reference_hess (fe_eval.n_q_points);
+    std::vector<Number> reference_values (fe_eval.n_q_points);
+    std::vector<Tensor<1,dim,Number> > reference_grads (fe_eval.n_q_points);
+    std::vector<Tensor<2,dim,Number> > reference_hess (fe_eval.n_q_points);
 
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {


### PR DESCRIPTION
This is a retake of David Davydov's #621 with a couple more patches of mine layered on top (and rebased to master). The basic idea is to make sure that when extracting values from a solution vector, we don't assume that these values are stored as doubles, but use the data type of the solution vector. The first place where this is usually necessary is in the various `FEValues::get_function_*()` functions and friends.

This is in a sense the most boring patch I've looked through in a long time (all 4200 lines of it) as it is almost all simply going through all functions downstream from (and internal to) the `get_function_*()` system. I think it's useful anyway, though. It also completely passes my testsuite.

Closes #621.