### PR TITLE
Fix size of a temporary array.

### DIFF
--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -608,7 +608,7 @@ namespace internal
       // least make sure we can deal with complex numbers
       std::vector<std::vector<Tensor<1,DH::space_dimension,typename VectorType::value_type> > > tmp(patch_gradients_system.size());
       for (unsigned int i = 0; i < tmp.size(); i++)
-        tmp[i].resize(patch_gradients_system.size());
+        tmp[i].resize(patch_gradients_system[i].size());
 
       fe_patch_values.get_function_gradients (*vector, tmp);
 


### PR DESCRIPTION
This was broken in the generic-FEValues patch the other day. It
manifested in an erroneous assertion in one of my students
programs while trying out what they had implemented over the
course of the semester.