### PR TITLE
Remove unnecessary typename keywords, which cause C++03 problems

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3094,7 +3094,7 @@ namespace GridGenerator
         // We want to use a standard boundary description where
         // the boundary is not curved. Hence set boundary id 2 to
         // to all faces in a first step.
-        typename Triangulation<3>::cell_iterator cell = tria.begin();
+        Triangulation<3>::cell_iterator cell = tria.begin();
         for (; cell!=tria.end(); ++cell)
           for (unsigned int i=0; i<GeometryInfo<3>::faces_per_cell; ++i)
             if (cell->at_boundary(i))
@@ -3108,7 +3108,7 @@ namespace GridGenerator
           for (unsigned int i=0; i<GeometryInfo<3>::faces_per_cell; ++i)
             if (cell->at_boundary(i))
               {
-                const typename Triangulation<3>::face_iterator face
+                const Triangulation<3>::face_iterator face
                   = cell->face(i);
 
                 const Point<3> face_center (face->center());

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -694,7 +694,7 @@ namespace TrilinosWrappers
 
         row_indices.resize (row_length, -1);
         {
-          typename dealii::DynamicSparsityPattern::iterator p = sparsity_pattern.begin(global_row);
+          dealii::DynamicSparsityPattern::iterator p = sparsity_pattern.begin(global_row);
           for (size_type col=0; p != sparsity_pattern.end(global_row); ++p, ++col)
             row_indices[col] = p->column();
         }


### PR DESCRIPTION
Compilers without C++11 support don't like typename keywords in template specializations.