### PR TITLE
Include MueLu.hpp only in .cc file.

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -38,11 +38,6 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Teuchos_ParameterList.hpp>
 #  include <Epetra_RowMatrix.h>
 #  include <Epetra_Vector.h>
-
-#  if DEAL_II_TRILINOS_VERSION_GTE(11,14,0)
-#  include <MueLu.hpp>
-#  include <Teuchos_RCP.hpp>
-#  endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 // forward declarations

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -25,13 +25,15 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Ifpack.h>
 #  include <Ifpack_Chebyshev.h>
 #  include <Teuchos_ParameterList.hpp>
+#  include <Teuchos_RCP.hpp>
 #  include <Epetra_MultiVector.h>
 #  include <ml_include.h>
 #  include <ml_MultiLevelPreconditioner.h>
 
 #if DEAL_II_TRILINOS_VERSION_GTE(11,14,0)
-#include <MueLu_EpetraOperator.hpp>
-#include <MueLu_MLParameterListInterpreter.hpp>
+#  include <MueLu.hpp>
+#  include <MueLu_EpetraOperator.hpp>
+#  include <MueLu_MLParameterListInterpreter.hpp>
 #endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 


### PR DESCRIPTION
The file MueLu.hpp turns out to be really expensive to include (even if no MueLu is used) and increases compile time from a few seconds to up to a minute on some of my projects. But we really only need it in trilinos_precondition.cc, so move the include there.