### PR TITLE
suppress warning unused function 'get_element'

### DIFF
--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -224,6 +224,7 @@ namespace internal
       /**
        * Return the element with given indices of a Trilinos sparse matrix.
        */
+      inline
       double get_element (const TrilinosWrappers::SparseMatrix &matrix,
                           const types::global_dof_index             i,
                           const types::global_dof_index             j)
@@ -237,6 +238,7 @@ namespace internal
        * Return the element with given indices of a Trilinos block sparse
        * matrix.
        */
+      inline
       double get_element (const TrilinosWrappers::BlockSparseMatrix &matrix,
                           const types::global_dof_index                  i,
                           const types::global_dof_index                  j)


### PR DESCRIPTION
For issue #938