### PR TITLE
exploit symmetries in Local integrators of mass and laplace matrices

### DIFF
--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -63,12 +63,17 @@ namespace LocalIntegrators
           const double dx = fe.JxW(k) * factor;
 
           for (unsigned int i=0; i<n_dofs; ++i)
-            for (unsigned int j=0; j<n_dofs; ++j)
+            for (unsigned int j=i; j<n_dofs; ++j)
               for (unsigned int d=0; d<n_components; ++d)
                 M(i,j) += dx
                           * fe.shape_value_component(j,k,d)
                           * fe.shape_value_component(i,k,d);
         }
+
+      // exploit symmetry
+      for (unsigned int i=0; i<n_dofs; ++i)
+        for (unsigned int j=i+1; j<n_dofs; ++j)
+          M(j,i) = M(i,j);
     }
 
     /**
@@ -103,12 +108,17 @@ namespace LocalIntegrators
           const double dx = fe.JxW(k) * weights[k];
 
           for (unsigned int i=0; i<n_dofs; ++i)
-            for (unsigned int j=0; j<n_dofs; ++j)
+            for (unsigned int j=i; j<n_dofs; ++j)
               for (unsigned int d=0; d<n_components; ++d)
                 M(i,j) += dx
                           * fe.shape_value_component(j,k,d)
                           * fe.shape_value_component(i,k,d);
         }
+
+      //exploit symmetry
+      for (unsigned int i=0; i<n_dofs; ++i)
+        for (unsigned int j=i+1; j<n_dofs; ++j)
+          M(j,i) = M(i,j);
     }
 
     /**

--- a/include/deal.II/integrators/laplace.h
+++ b/include/deal.II/integrators/laplace.h
@@ -62,12 +62,18 @@ namespace LocalIntegrators
           const double dx = fe.JxW(k) * factor;
           for (unsigned int i=0; i<n_dofs; ++i)
             {
-              for (unsigned int j=0; j<n_dofs; ++j)
+              for (unsigned int j=i; j<n_dofs; ++j)
                 for (unsigned int d=0; d<n_components; ++d)
                   M(i,j) += dx *
                             (fe.shape_grad_component(j,k,d) * fe.shape_grad_component(i,k,d));
             }
         }
+
+      // exploit symmetry
+      for (unsigned int i=0; i<n_dofs; ++i)
+        for (unsigned int j=i+1; j<n_dofs; ++j)
+          M(j,i) = M(i,j);
+
     }
 
     /**


### PR DESCRIPTION
can make quite a bit of performance difference for polynomials ~5-10 and big quadrature rules.
All `integrators` unit-tests pass for me on OS-X / clang. 