### PR TITLE
Add a clear function for PETSc serial and parallel vectors

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -512,6 +512,12 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> New: Add a clear function to the PETSc::Vector
+  and PETSc::MPI::Vector classes similar to the Trilinos vector classes.
+  <br>
+  (Martin Steigemann 2015/05/22)
+  </li>
+
   <li> New: Three new quadrature formulas in quadrature_lib, based on
   Chebyshev quadrature rules. See functions QGaussChebyshev,
   QGaussRadauChebyshev and QGaussLobattoChebyshev.

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -263,6 +263,12 @@ namespace PETScWrappers
                        const MPI_Comm &communicator);
 
       /**
+       * Release all memory and return to a state just like after having called
+       * the default constructor.
+       */
+      void clear ();
+
+      /**
        * Copy the given vector. Resize the present vector if necessary. Also
        * take over the MPI communicator of @p v.
        */

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -119,6 +119,12 @@ namespace PETScWrappers
     explicit Vector (const MPI::Vector &v);
 
     /**
+     * Release all memory and return to a state just like after having called
+     * the default constructor.
+     */
+    void clear ();
+
+    /**
      * Copy the given vector. Resize the present vector if necessary.
      */
     Vector &operator = (const Vector &v);

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -261,6 +261,12 @@ namespace PETScWrappers
     virtual ~VectorBase ();
 
     /**
+     * Release all memory and return to a state just like after having called
+     * the default constructor.
+     */
+    virtual void clear ();
+
+    /**
      * Compress the underlying representation of the PETSc object, i.e. flush
      * the buffers of the vector object if it has any. This function is
      * necessary after writing into a vector element-by-element and before

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -80,6 +80,7 @@ namespace PETScWrappers
     }
 
 
+
     Vector::Vector (const IndexSet   &local,
                     const MPI_Comm     &communicator)
       :
@@ -88,6 +89,23 @@ namespace PETScWrappers
       Assert(local.is_contiguous(), ExcNotImplemented());
       Vector::create_vector(local.size(), local.n_elements());
     }
+
+
+
+    void
+    Vector::clear ()
+    {
+      // destroy the PETSc Vec and create an invalid empty vector,
+      // so we can just as well create a sequential one to avoid
+      // all the overhead incurred by parallelism
+      attained_ownership = true;
+      VectorBase::clear ();
+
+      const int n = 0;
+      int ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
+      AssertThrow (ierr == 0, ExcPETScError(ierr));
+    }
+
 
 
     void

--- a/source/lac/petsc_vector.cc
+++ b/source/lac/petsc_vector.cc
@@ -62,6 +62,15 @@ namespace PETScWrappers
 
 
   void
+  Vector::clear ()
+  {
+    VectorBase::clear ();
+    Vector::create_vector (0);
+  }
+
+
+
+  void
   Vector::reinit (const size_type n,
                   const bool      fast)
   {

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -210,6 +210,27 @@ namespace PETScWrappers
 
 
 
+  void
+  VectorBase::clear ()
+  {
+    if (attained_ownership)
+      {
+#if DEAL_II_PETSC_VERSION_LT(3,2,0)
+        const int ierr = VecDestroy (vector);
+#else
+        const int ierr = VecDestroy (&vector);
+#endif
+        AssertThrow (ierr == 0, ExcPETScError(ierr));
+      }
+
+    ghosted = false;
+    ghost_indices.clear ();
+    last_action = ::dealii::VectorOperation::unknown;
+    attained_ownership = true;
+  }
+
+
+
   VectorBase &
   VectorBase::operator = (const PetscScalar s)
   {


### PR DESCRIPTION
This PR adds a clear function to the PETSc serial and parallel vector classes. The clear function destroys the PETSc Vec and resets the class to a state of an empty invalid vector just like after having called the default constructor. The main intention of adding this function is to have the same interface as for Trilinos vectors.