### PR TITLE
Use floating point exceptions to catch more errors in the testsuite.

### DIFF
--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -19,6 +19,7 @@
 #   DEAL_II_HAVE_GETHOSTNAME
 #   DEAL_II_HAVE_GETPID
 #   DEAL_II_HAVE_JN
+#   DEAL_II_HAVE_FP_EXCEPTIONS
 #   DEAL_II_HAVE_SYS_RESOURCE_H
 #   DEAL_II_HAVE_SYS_TIME_H
 #   DEAL_II_HAVE_SYS_TIMES_H
@@ -64,6 +65,41 @@ IF(NOT m_LIBRARY MATCHES "-NOTFOUND")
   IF(DEAL_II_HAVE_JN)
     LIST(APPEND DEAL_II_LIBRARIES ${m_LIBRARY})
   ENDIF()
+ENDIF()
+
+
+#
+# Check that we can use feenableexcept. Sets DEAL_II_HAVE_FP_EXCEPTIONS
+#
+# The test is a bit more complicated because we also check that no garbage
+# exception is thrown if we convert -std::numeric_limits<double>::max to a
+# string. This sadly happens with some compiler support libraries :-(
+
+INCLUDE (CheckCXXSourceRuns)
+
+CHECK_CXX_SOURCE_RUNS("
+  #include <fenv.h>
+  #include <limits>
+  #include <sstream>
+
+  int main()
+  {
+    feenableexcept(FE_DIVBYZERO|FE_INVALID);
+    std::ostringstream description;
+    const double lower_bound = -std::numeric_limits<double>::max();  
+
+    description << lower_bound;
+
+    return 0;
+  }
+  " 
+  _HAVE_FP_EXCEPTIONS)
+
+IF(_HAVE_FP_EXCEPTIONS)
+  MESSAGE(STATUS "Checking for Floating Point Exception macros -- Success")
+  SET(DEAL_II_HAVE_FP_EXCEPTIONS 1)
+ELSE()
+  MESSAGE(STATUS "Checking for Floating Point Exception macros -- Failed")
 ENDIF()
 
 

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -95,11 +95,17 @@ CHECK_CXX_SOURCE_RUNS("
   " 
   _HAVE_FP_EXCEPTIONS)
 
-IF(_HAVE_FP_EXCEPTIONS)
-  MESSAGE(STATUS "Checking for Floating Point Exception macros -- Success")
-  SET(DEAL_II_HAVE_FP_EXCEPTIONS 1)
-ELSE()
-  MESSAGE(STATUS "Checking for Floating Point Exception macros -- Failed")
+
+SET(DEAL_II_HAVE_FP_EXCEPTIONS ON CACHE BOOL "If ON, floating point exception are raised in debug mode when running the testsuite.")
+
+IF (DEAL_II_HAVE_FP_EXCEPTIONS)
+  IF(_HAVE_FP_EXCEPTIONS)
+    MESSAGE(STATUS "Checking for Floating Point Exception macros -- Success")
+    # nothing to set here -- DEAL_II_HAVE_FP_EXCEPTIONS is already ON
+  ELSE()
+    MESSAGE(STATUS "Checking for Floating Point Exception macros -- Failed")
+    SET(DEAL_II_HAVE_FP_EXCEPTIONS OFF CACHE BOOL "" FORCE)
+  ENDIF()
 ENDIF()
 
 

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -66,6 +66,12 @@ inconvenience this causes.
 
 <ol>
 
+  <li> New: The testsuite now runs in a mode in which we abort programs for
+  floating point exceptions due to divisions by zero or other invalid arithmetic.
+  <br>
+  (Wolfgang Bangerth, 2015/07/29)
+  </li>
+
   <li> New: MultithreadInfo::set_thread_limit() can now be called more than
   once and the environment variable DEAL_II_NUM_THREADS will be respected
   even if user code never calls it.

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -128,6 +128,7 @@
 #cmakedefine DEAL_II_HAVE_GETPID
 #cmakedefine DEAL_II_HAVE_TIMES
 #cmakedefine DEAL_II_HAVE_JN
+#cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 
 #cmakedefine DEAL_II_MSVC
 

--- a/tests/base/is_finite.cc
+++ b/tests/base/is_finite.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iomanip>
 #include <limits>
+#include <fenv.h>
 
 
 template <typename T>
@@ -62,6 +63,17 @@ int main ()
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
+  // the isnan() function (which we call in is_finite()) helpfully
+  // produces a floating point exception when called with a signalling
+  // NaN if FP exceptions are on. this of course makes it completely
+  // unusable since we can no longer detect whether something is a
+  // NaN. that said, to make the test work in these cases, simply
+  // switch off floating point exceptions for invalid arguments
+#if defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  fedisableexcept(FE_INVALID);
+#endif
+
+  
   check<double> ();
   check<long double> ();
 

--- a/tests/base/is_finite_complex.cc
+++ b/tests/base/is_finite_complex.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iomanip>
 #include <limits>
+#include <fenv.h>
 
 
 template <typename T>
@@ -69,6 +70,16 @@ int main ()
   deallog.attach(logfile);
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
+
+  // the isnan() function (which we call in is_finite()) helpfully
+  // produces a floating point exception when called with a signalling
+  // NaN if FP exceptions are on. this of course makes it completely
+  // unusable since we can no longer detect whether something is a
+  // NaN. that said, to make the test work in these cases, simply
+  // switch off floating point exceptions for invalid arguments
+#if defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  fedisableexcept(FE_INVALID);
+#endif
 
   check<std::complex<double> > ();
   check<std::complex<long double> > ();

--- a/tests/base/log_nan.cc
+++ b/tests/base/log_nan.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <iomanip>
 #include <limits>
+#include <fenv.h>
 
 int main ()
 {
@@ -31,6 +32,16 @@ int main ()
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
+  // the isnan() function (which we call in is_finite()) helpfully
+  // produces a floating point exception when called with a signalling
+  // NaN if FP exceptions are on. this of course makes it completely
+  // unusable since we can no longer detect whether something is a
+  // NaN. that said, to make the test work in these cases, simply
+  // switch off floating point exceptions for invalid arguments
+#if defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  fedisableexcept(FE_INVALID);
+#endif
+  
   deallog << std::numeric_limits<double>::quiet_NaN() << std::endl;
   deallog << std::numeric_limits<double>::signaling_NaN() << std::endl;
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -32,6 +32,9 @@
 #include <sstream>
 #include <iomanip>
 
+#include <cfenv>
+
+
 // silence extra diagnostics in the testsuite
 #ifdef DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
@@ -430,6 +433,22 @@ struct SwitchOffStacktrace
     deal_II_exceptions::suppress_stacktrace_in_exceptions ();
   }
 } deal_II_stacktrace_dummy;
+
+
+
+/* Enable floating point exceptions in debug mode and if we have
+   detected that they are usable: */
+
+struct EnableFPE
+{
+  EnableFPE ()
+  {
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+    // enable floating point exceptions
+    feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+    }
+} deal_II_enable_fpe;
 
 
 /* Set grainsizes for parallel mode smaller than they would otherwise be.


### PR DESCRIPTION
This is inspired by @tjhei 's use here: https://github.com/geodynamics/aspect/pull/441

There are a number of tests that currently fail:
```
        11 - algorithms/newton_01.debug (Failed)
        821 - base/timer_02.debug (Failed)
        841 - base/log_nan.debug (Failed)
        881 - base/is_finite.debug (Failed)
        1000 - base/function_parser_07.debug (Failed)
        1135 - base/is_finite_complex.debug (Failed)
        1266 - base/function_parser_06.debug (Failed)
        2916 - codim_one/integrate_log_2.debug (Failed)
        2932 - codim_one/transform_01.debug (Failed)
        3022 - codim_one/bem_integration.debug (Failed)
```
See also #963 and #964. The `is_finite` tests will need to be treated separately. The `codim_*` tests are real problems. So is the timer test.