### PR TITLE
RelaxationBlock::clear() did not clear additional_data; fixed now

### DIFF
--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -79,6 +79,7 @@ void
 RelaxationBlock<MATRIX,inverse_type>::clear ()
 {
   A = 0;
+  additional_data = 0;
   PreconditionBlockBase<inverse_type>::clear ();
 }
 


### PR DESCRIPTION
When reinitializing RelaxationBlock and RelaxationBlock::AdditionalData, we ran into a deadlock, since the SmartPointer in RelaxationBlock was not released by clear().