### PR TITLE
fix instantiation of subdivided_hyper_rectangle

### DIFF
--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -41,7 +41,7 @@ namespace GridGenerator
      const std::vector<unsigned int>&,
      const Point<deal_II_space_dimension>&,
      const Point<deal_II_space_dimension>&,
-     bool);
+     const bool);
 
     template
       void


### PR DESCRIPTION
intel compiler complains about a missing instantiation because of a missing const