### PR TITLE
Refactor data out flags base class

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -90,3 +90,7 @@ SPARSITY_PATTERNS := { SparsityPattern;
 DIMENSIONS := { 1; 2; 3 }
 
 SPACE_DIMENSIONS := { 1; 2; 3 }
+
+OUTPUT_FLAG_TYPES := { DXFlags; UcdFlags; GnuplotFlags; PovrayFlags; EpsFlags;
+                       GmvFlags; TecplotFlags; VtkFlags; SvgFlags;
+                       Deal_II_IntermediateFlags }

--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -5,36 +5,36 @@ COMPLEX_SCALARS := { std::complex<double>;
                      std::complex<long double> }
 
 DERIVATIVE_TENSORS := { double;
-			Tensor<1,deal_II_dimension>;
-			Tensor<2,deal_II_dimension> }
+                        Tensor<1,deal_II_dimension>;
+                        Tensor<2,deal_II_dimension> }
 
 DEAL_II_VEC_TEMPLATES := { Vector; BlockVector }
 
 SERIAL_VECTORS := { Vector<double>;
                     Vector<float> ;
-		    Vector<long double>;
+                    Vector<long double>;
 
-	            BlockVector<double>;
+                    BlockVector<double>;
                     BlockVector<float>;
                     BlockVector<long double>;
 
-		    parallel::distributed::Vector<double>;
-		    parallel::distributed::Vector<float> ;
-		    parallel::distributed::Vector<long double>;
+                    parallel::distributed::Vector<double>;
+                    parallel::distributed::Vector<float> ;
+                    parallel::distributed::Vector<long double>;
 
                     parallel::distributed::BlockVector<double>;
                     parallel::distributed::BlockVector<float> ;
                     parallel::distributed::BlockVector<long double>;
 
-		    @DEAL_II_EXPAND_TRILINOS_VECTOR@;
-		    @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
-		    @DEAL_II_EXPAND_PETSC_VECTOR@;
-		    @DEAL_II_EXPAND_PETSC_MPI_VECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_VECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
+                    @DEAL_II_EXPAND_PETSC_VECTOR@;
+                    @DEAL_II_EXPAND_PETSC_MPI_VECTOR@;
 
-		    @DEAL_II_EXPAND_TRILINOS_BLOCKVECTOR@;
-		    @DEAL_II_EXPAND_TRILINOS_MPI_BLOCKVECTOR@;
-		    @DEAL_II_EXPAND_PETSC_BLOCKVECTOR@;
-		    @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_MPI_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_PETSC_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@;
                   }
 
 EXTERNAL_SEQUENTIAL_VECTORS := { @DEAL_II_EXPAND_TRILINOS_VECTOR@;
@@ -51,14 +51,14 @@ EXTERNAL_PARALLEL_VECTORS := { @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
 
 VECTORS_WITH_MATRIX := { Vector<double>;
                     Vector<float> ;
-		    Vector<long double>;
+                    Vector<long double>;
 
-	            BlockVector<double>;
+                    BlockVector<double>;
                     BlockVector<float>;
                     BlockVector<long double>;
 
-		    @DEAL_II_EXPAND_TRILINOS_VECTOR@;
-		    @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_VECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
                   }
 
 DOFHANDLERS := { DoFHandler<deal_II_dimension>;
@@ -68,8 +68,8 @@ DOFHANDLER_TEMPLATES := { DoFHandler;
                           hp::DoFHandler }
 
 TRIANGULATION_AND_DOFHANDLER_TEMPLATES := { Triangulation;
-					    DoFHandler;
-					    hp::DoFHandler }
+                                            DoFHandler;
+                                            hp::DoFHandler }
 
 TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
                                    DoFHandler<deal_II_dimension, deal_II_space_dimension>;
@@ -77,7 +77,7 @@ TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, deal_II_spac
 
 
 FEVALUES_BASES := { FEValuesBase<deal_II_dimension>;
-	            FEFaceValuesBase<deal_II_dimension> }
+                    FEFaceValuesBase<deal_II_dimension> }
 
 SPARSITY_PATTERNS := { SparsityPattern;
                        DynamicSparsityPattern;

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -522,20 +522,6 @@ namespace DataOutBase
      * Constructor.
      */
     GnuplotFlags ();
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void declare_parameters (ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void parse_parameters (const ParameterHandler &prm) const;
   };
 
   /**
@@ -849,20 +835,6 @@ namespace DataOutBase
      * Default constructor.
      */
     GmvFlags ();
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void declare_parameters (ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void parse_parameters (const ParameterHandler &prm) const;
   };
 
   /**
@@ -893,20 +865,6 @@ namespace DataOutBase
      */
     TecplotFlags (const char *tecplot_binary_file_name = NULL,
                   const char *zone_name = NULL);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void declare_parameters (ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void parse_parameters (const ParameterHandler &prm) const;
 
     /**
      * Return an estimate for the memory consumption, in bytes, of this
@@ -961,28 +919,6 @@ namespace DataOutBase
     VtkFlags (const double       time   = std::numeric_limits<double>::min(),
               const unsigned int cycle  = std::numeric_limits<unsigned int>::min(),
               const bool print_date_and_time = true);
-
-    /**
-     * Declare the flags with name and type as offered by this class, for use
-     * in input files.
-     *
-     * Unlike the flags in many of the other classes similar to this one, we
-     * do not actually declare parameters for the #cycle and #time member
-     * variables of this class. The reason is that there wouldn't appear to be
-     * a case where one would want to declare these parameters in an input
-     * file. Rather, these are typically values that change during the course
-     * of a simulation and can only reasonably be set as part of the execution
-     * of a program, rather than a priori by a user who runs this program.
-     */
-    static void declare_parameters (ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void parse_parameters (const ParameterHandler &prm) const;
   };
 
 
@@ -1069,20 +1005,6 @@ namespace DataOutBase
      * Constructor.
      */
     Deal_II_IntermediateFlags ();
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void declare_parameters (ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void parse_parameters (const ParameterHandler &prm) const;
   };
 
   /**

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -909,6 +909,8 @@ namespace DataOutBase
 
   /**
    * Flags for SVG output.
+   *
+   * @ingroup output
    */
   struct SvgFlags : public OutputFlagsBase<SvgFlags>
   {

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <string>
 #include <limits>
+#include <typeinfo>
 
 #include <deal.II/base/mpi.h>
 
@@ -2316,55 +2317,14 @@ public:
    */
   void set_default_format (const DataOutBase::OutputFormat default_format);
 
-  /**
-   * Set the flags to be used for output in OpenDX format.
-   */
-  void set_flags (const DataOutBase::DXFlags &dx_flags);
 
   /**
-   * Set the flags to be used for output in UCD format.
+   * Set the flags to be used for output. This method expects <tt>flags</tt> to
+   * be a member of one of the child classes of <tt>OutputFlagsBase</tt>.
    */
-  void set_flags (const DataOutBase::UcdFlags &ucd_flags);
+  template<typename FlagType>
+  void set_flags (const FlagType &flags);
 
-  /**
-   * Set the flags to be used for output in GNUPLOT format.
-   */
-  void set_flags (const DataOutBase::GnuplotFlags &gnuplot_flags);
-
-  /**
-   * Set the flags to be used for output in POVRAY format.
-   */
-  void set_flags (const DataOutBase::PovrayFlags &povray_flags);
-
-  /**
-   * Set the flags to be used for output in EPS output.
-   */
-  void set_flags (const DataOutBase::EpsFlags &eps_flags);
-
-  /**
-   * Set the flags to be used for output in GMV format.
-   */
-  void set_flags (const DataOutBase::GmvFlags &gmv_flags);
-
-  /**
-   * Set the flags to be used for output in Tecplot format.
-   */
-  void set_flags (const DataOutBase::TecplotFlags &tecplot_flags);
-
-  /**
-   * Set the flags to be used for output in VTK format.
-   */
-  void set_flags (const DataOutBase::VtkFlags &vtk_flags);
-
-  /**
-   * Set the flags to be used for output in SVG format.
-   */
-  void set_flags (const DataOutBase::SvgFlags &svg_flags);
-
-  /**
-   * Set the flags to be used for output in deal.II intermediate format.
-   */
-  void set_flags (const DataOutBase::Deal_II_IntermediateFlags &deal_II_intermediate_flags);
 
   /**
    * A function that returns the same string as the respective function in the

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -910,8 +910,7 @@ namespace DataOutBase
 
     /**
      * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
+     * object.
      */
     std::size_t memory_consumption () const;
   };

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -847,7 +847,7 @@ namespace DataOutBase
     const char *zone_name;
 
     /**
-     * Constructor
+     * Constructor.
      */
     TecplotFlags (const char *tecplot_binary_file_name = NULL,
                   const char *zone_name = NULL);
@@ -899,7 +899,7 @@ namespace DataOutBase
     bool print_date_and_time;
 
     /**
-     * Default constructor.
+     * Constructor.
      */
     VtkFlags (const double       time   = std::numeric_limits<double>::min(),
               const unsigned int cycle  = std::numeric_limits<unsigned int>::min(),

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -349,12 +349,70 @@ namespace DataOutBase
     //@}
   };
 
+
+  /**
+   * Base class describing common functionality between different output flags.
+   *
+   * This is implemented with the "Curiously Recurring Template Pattern";
+   * derived classes use their own type to fill in the typename so that
+   * <tt>memory_consumption</tt> works correctly. See the Wikipedia page on the
+   * pattern for more information.
+   *
+   * @ingroup output
+   */
+  template<typename FlagsType>
+  struct OutputFlagsBase
+  {
+    /**
+     * Declare all flags with name and type as offered by this class, for use
+     * in input files.
+     *
+     * This method does nothing, but child classes may override this method to
+     * add fields to <tt>prm</tt>.
+     */
+    static void declare_parameters (ParameterHandler &prm);
+
+    /**
+     * Read the parameters declared in declare_parameters() and set the flags
+     * for this output format accordingly.
+     *
+     * This method does nothing, but child classes may override this method to
+     * add fields to <tt>prm</tt>.
+     */
+    void parse_parameters (const ParameterHandler &prm);
+
+    /**
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object. This is not exact (but will usually be close) because calculating
+     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
+     */
+    std::size_t memory_consumption () const;
+  };
+
+
+  template<typename FlagsType>
+  void OutputFlagsBase<FlagsType>::declare_parameters (ParameterHandler &)
+  {}
+
+
+  template<typename FlagsType>
+  void OutputFlagsBase<FlagsType>::parse_parameters (const ParameterHandler &)
+  {}
+
+
+  template<typename FlagsType>
+  std::size_t OutputFlagsBase<FlagsType>::memory_consumption () const
+  {
+    return sizeof(FlagsType);
+  }
+
+
   /**
    * Flags controlling the details of output in OpenDX format.
    *
    * @ingroup output
    */
-  struct DXFlags
+  struct DXFlags : public OutputFlagsBase<DXFlags>
   {
     /**
      * Write neighbor information. This information is necessary for instance,
@@ -416,7 +474,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct UcdFlags
+  struct UcdFlags : public OutputFlagsBase<UcdFlags>
   {
     /**
      * Write a comment at the beginning of the file stating the date of
@@ -462,7 +520,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct GnuplotFlags
+  struct GnuplotFlags : public OutputFlagsBase<GnuplotFlags>
   {
   private:
     /**
@@ -506,7 +564,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct PovrayFlags
+  struct PovrayFlags : public OutputFlagsBase<PovrayFlags>
   {
     /**
      * Normal vector interpolation, if set to true
@@ -566,7 +624,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct EpsFlags
+  struct EpsFlags : public OutputFlagsBase<EpsFlags>
   {
     /**
      * This denotes the number of the data vector which shall be used for
@@ -810,7 +868,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct GmvFlags
+  struct GmvFlags : public OutputFlagsBase<GmvFlags>
   {
   private:
     /**
@@ -853,7 +911,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct TecplotFlags
+  struct TecplotFlags : public OutputFlagsBase<TecplotFlags>
   {
 
   public:
@@ -904,7 +962,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct VtkFlags
+  struct VtkFlags : public OutputFlagsBase<VtkFlags>
   {
   public:
     /**
@@ -980,7 +1038,7 @@ namespace DataOutBase
   /**
    * Flags for SVG output.
    */
-  struct SvgFlags
+  struct SvgFlags : public OutputFlagsBase<SvgFlags>
   {
   public:
     /**
@@ -1044,7 +1102,7 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct Deal_II_IntermediateFlags
+  struct Deal_II_IntermediateFlags : public OutputFlagsBase<Deal_II_IntermediateFlags>
   {
     /**
      * An indicator of the currect file format version used to write

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -517,12 +517,6 @@ namespace DataOutBase
      * structure (and remove the <tt>private</tt> as well).
      */
     int dummy;
-
-  public:
-    /**
-     * Constructor.
-     */
-    GnuplotFlags ();
   };
 
   /**
@@ -830,12 +824,6 @@ namespace DataOutBase
      * structure (and remove the <tt>private</tt> as well).
      */
     int dummy;
-
-  public:
-    /**
-     * Default constructor.
-     */
-    GmvFlags ();
   };
 
   /**
@@ -1000,12 +988,6 @@ namespace DataOutBase
      * structure (and remove the <tt>private</tt> as well).
      */
     int dummy;
-
-  public:
-    /**
-     * Constructor.
-     */
-    Deal_II_IntermediateFlags ();
   };
 
   /**

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -461,12 +461,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm);
-
-    /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**
@@ -505,13 +499,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm);
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**
@@ -549,13 +536,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm) const;
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**
@@ -608,13 +588,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm);
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
 
@@ -853,13 +826,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm);
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**
@@ -897,13 +863,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm) const;
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**
@@ -1025,13 +984,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm) const;
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
 
@@ -1086,13 +1038,6 @@ namespace DataOutBase
              const unsigned int line_thickness = 1,
              const bool margin = true,
              const bool draw_colorbar = true);
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
 
@@ -1139,13 +1084,6 @@ namespace DataOutBase
      * The flags thus obtained overwrite all previous contents of this object.
      */
     void parse_parameters (const ParameterHandler &prm) const;
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object. This is not exact (but will usually be close) because calculating
-     * the memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-     */
-    std::size_t memory_consumption () const;
   };
 
   /**

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -833,9 +833,6 @@ namespace DataOutBase
    */
   struct TecplotFlags : public OutputFlagsBase<TecplotFlags>
   {
-
-  public:
-
     /**
      * This variable is needed to hold the output file name when using the
      * Tecplot API to write binary files.  If the user doesn't set the file
@@ -869,7 +866,6 @@ namespace DataOutBase
    */
   struct VtkFlags : public OutputFlagsBase<VtkFlags>
   {
-  public:
     /**
      * The time of the time step if this file is part of a time dependent
      * simulation.
@@ -916,7 +912,6 @@ namespace DataOutBase
    */
   struct SvgFlags : public OutputFlagsBase<SvgFlags>
   {
-  public:
     /**
      * Height of the image in SVG units. Default value is 4000.
      */

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -171,6 +171,14 @@ namespace MemoryConsumption
   std::size_t memory_consumption (const long double);
 
   /**
+   * Determine the amount of memory consumed by a C-style string. The returned
+   * value does not include the size of the pointer. This function only measures
+   * up to (and including) the NUL byte; the underlying buffer may be larger.
+   */
+  inline
+  std::size_t memory_consumption (const char *string);
+
+  /**
    * Determine the amount of memory in bytes consumed by a
    * <tt>std::complex</tt> variable.
    */
@@ -437,6 +445,21 @@ namespace MemoryConsumption
   std::size_t memory_consumption (const long double)
   {
     return sizeof(long double);
+  }
+
+
+
+  inline
+  std::size_t memory_consumption (const char *string)
+  {
+    if (string == NULL)
+      {
+        return 0;
+      }
+    else
+      {
+        return /*Don't forget about the NUL! :]*/ sizeof(char) + strlen(string);
+      }
   }
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1976,19 +1976,6 @@ namespace DataOutBase
     :
     dummy (0)
   {}
-
-
-
-  void GnuplotFlags::declare_parameters (ParameterHandler &/*prm*/)
-  {}
-
-
-
-  void GnuplotFlags::parse_parameters (const ParameterHandler &/*prm*/) const
-  {}
-
-
-
   SvgFlags::SvgFlags (const unsigned int height_vector,
                       const int azimuth_angle,
                       const int polar_angle,
@@ -2272,18 +2259,6 @@ namespace DataOutBase
 
   GmvFlags::GmvFlags ()
   {}
-
-
-
-  void GmvFlags::declare_parameters (ParameterHandler &/*prm*/)
-  {}
-
-
-
-  void GmvFlags::parse_parameters (const ParameterHandler &/*prm*/) const
-  {}
-
-
   TecplotFlags::
   TecplotFlags (const char *tecplot_binary_file_name,
                 const char *zone_name)
@@ -2292,15 +2267,6 @@ namespace DataOutBase
     zone_name(zone_name)
   {}
 
-
-
-  void TecplotFlags::declare_parameters (ParameterHandler &/*prm*/)
-  {}
-
-
-
-  void TecplotFlags::parse_parameters (const ParameterHandler &/*prm*/) const
-  {}
 
 
   std::size_t
@@ -2323,31 +2289,11 @@ namespace DataOutBase
   {}
 
 
-
-  void VtkFlags::declare_parameters (ParameterHandler &/*prm*/)
-  {}
-
-
-
-  void VtkFlags::parse_parameters (const ParameterHandler &/*prm*/) const
-  {}
-
-
-
   Deal_II_IntermediateFlags::Deal_II_IntermediateFlags ()
     :
     dummy (0)
   {}
 
-
-
-  void Deal_II_IntermediateFlags::declare_parameters (ParameterHandler &/*prm*/)
-  {}
-
-
-
-  void Deal_II_IntermediateFlags::parse_parameters (const ParameterHandler &/*prm*/) const
-  {}
 
 
   OutputFormat

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7380,94 +7380,33 @@ DataOutInterface<dim,spacedim>::set_default_format(const DataOutBase::OutputForm
   default_fmt = fmt;
 }
 
-
-
 template <int dim, int spacedim>
+template <typename FlagType>
 void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::DXFlags &flags)
+DataOutInterface<dim, spacedim>::set_flags (const FlagType &flags)
 {
-  dx_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::UcdFlags &flags)
-{
-  ucd_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::GnuplotFlags &flags)
-{
-  gnuplot_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::PovrayFlags &flags)
-{
-  povray_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::EpsFlags &flags)
-{
-  eps_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::GmvFlags &flags)
-{
-  gmv_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::TecplotFlags &flags)
-{
-  tecplot_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::VtkFlags &flags)
-{
-  vtk_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::SvgFlags &flags)
-{
-  svg_flags = flags;
-}
-
-
-
-template <int dim, int spacedim>
-void
-DataOutInterface<dim,spacedim>::set_flags (const DataOutBase::Deal_II_IntermediateFlags &flags)
-{
-  deal_II_intermediate_flags = flags;
+  // The price for not writing ten duplicates of this function is some loss in
+  // type safety.
+  if (typeid(flags) == typeid(dx_flags))
+    dx_flags = *reinterpret_cast<const DataOutBase::DXFlags *>(&flags);
+  else if (typeid(flags) == typeid(ucd_flags))
+    ucd_flags = *reinterpret_cast<const DataOutBase::UcdFlags *>(&flags);
+  else if (typeid(flags) == typeid(povray_flags))
+    povray_flags = *reinterpret_cast<const DataOutBase::PovrayFlags *>(&flags);
+  else if (typeid(flags) == typeid(eps_flags))
+    eps_flags = *reinterpret_cast<const DataOutBase::EpsFlags *>(&flags);
+  else if (typeid(flags) == typeid(gmv_flags))
+    gmv_flags = *reinterpret_cast<const DataOutBase::GmvFlags *>(&flags);
+  else if (typeid(flags) == typeid(tecplot_flags))
+    tecplot_flags = *reinterpret_cast<const DataOutBase::TecplotFlags *>(&flags);
+  else if (typeid(flags) == typeid(vtk_flags))
+    vtk_flags = *reinterpret_cast<const DataOutBase::VtkFlags *>(&flags);
+  else if (typeid(flags) == typeid(svg_flags))
+    svg_flags = *reinterpret_cast<const DataOutBase::SvgFlags *>(&flags);
+  else if (typeid(flags) == typeid(deal_II_intermediate_flags))
+    deal_II_intermediate_flags = *reinterpret_cast<const DataOutBase::Deal_II_IntermediateFlags *>(&flags);
+  else
+    Assert(false, ExcNotImplemented());
 }
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2306,9 +2306,9 @@ namespace DataOutBase
   std::size_t
   TecplotFlags::memory_consumption () const
   {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
+    return sizeof(*this)
+           + MemoryConsumption::memory_consumption(tecplot_binary_file_name)
+           + MemoryConsumption::memory_consumption(zone_name);
   }
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1972,10 +1972,7 @@ namespace DataOutBase
   }
 
 
-  GnuplotFlags::GnuplotFlags ()
-    :
-    dummy (0)
-  {}
+
   SvgFlags::SvgFlags (const unsigned int height_vector,
                       const int azimuth_angle,
                       const int polar_angle,
@@ -2257,8 +2254,7 @@ namespace DataOutBase
   }
 
 
-  GmvFlags::GmvFlags ()
-  {}
+
   TecplotFlags::
   TecplotFlags (const char *tecplot_binary_file_name,
                 const char *zone_name)
@@ -2286,12 +2282,6 @@ namespace DataOutBase
     time (time),
     cycle (cycle),
     print_date_and_time (print_date_and_time)
-  {}
-
-
-  Deal_II_IntermediateFlags::Deal_II_IntermediateFlags ()
-    :
-    dummy (0)
   {}
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1907,16 +1907,6 @@ namespace DataOutBase
 
 
 
-  std::size_t
-  DataOutFilterFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
-
-
   DXFlags::DXFlags (const bool write_neighbors,
                     const bool int_binary,
                     const bool coordinates_binary,
@@ -1964,17 +1954,6 @@ namespace DataOutBase
 
 
 
-  std::size_t
-  DXFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
-
-
-
   void UcdFlags::declare_parameters (ParameterHandler &prm)
   {
     prm.declare_entry ("Write preamble", "true",
@@ -1991,16 +1970,6 @@ namespace DataOutBase
   {
     write_preamble = prm.get_bool ("Write preamble");
   }
-
-
-  std::size_t
-  UcdFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
 
 
   GnuplotFlags::GnuplotFlags ()
@@ -2020,15 +1989,6 @@ namespace DataOutBase
 
 
 
-  size_t
-  GnuplotFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
-
   SvgFlags::SvgFlags (const unsigned int height_vector,
                       const int azimuth_angle,
                       const int polar_angle,
@@ -2045,16 +2005,6 @@ namespace DataOutBase
     margin(margin),
     draw_colorbar(draw_colorbar)
   {}
-
-
-  std::size_t
-  SvgFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
 
 
 
@@ -2081,16 +2031,6 @@ namespace DataOutBase
     smooth        = prm.get_bool ("Use smooth triangles");
     bicubic_patch = prm.get_bool ("Use bicubic patches");
     external_data = prm.get_bool ("Include external file");
-  }
-
-
-
-  std::size_t
-  PovrayFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
   }
 
 
@@ -2330,17 +2270,6 @@ namespace DataOutBase
   }
 
 
-
-  std::size_t
-  EpsFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
-
-
   GmvFlags::GmvFlags ()
   {}
 
@@ -2353,16 +2282,6 @@ namespace DataOutBase
 
   void GmvFlags::parse_parameters (const ParameterHandler &/*prm*/) const
   {}
-
-
-  std::size_t
-  GmvFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
 
 
   TecplotFlags::
@@ -2415,15 +2334,6 @@ namespace DataOutBase
 
 
 
-  std::size_t
-  VtkFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
-
   Deal_II_IntermediateFlags::Deal_II_IntermediateFlags ()
     :
     dummy (0)
@@ -2438,16 +2348,6 @@ namespace DataOutBase
 
   void Deal_II_IntermediateFlags::parse_parameters (const ParameterHandler &/*prm*/) const
   {}
-
-
-  std::size_t
-  Deal_II_IntermediateFlags::memory_consumption () const
-  {
-    // only simple data elements, so
-    // use sizeof operator
-    return sizeof (*this);
-  }
-
 
 
   OutputFormat

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -19,7 +19,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 #if deal_II_dimension <= deal_II_space_dimension
   template class DataOutInterface<deal_II_dimension, deal_II_space_dimension>;
   template class DataOutReader<deal_II_dimension, deal_II_space_dimension>;
-  
+
   namespace DataOutBase
   \{
   template struct Patch<deal_II_dimension, deal_II_space_dimension>;
@@ -132,4 +132,11 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
                         std::ostream                            &out);
   \}
 #endif
+}
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; flag_type : OUTPUT_FLAG_TYPES)
+{
+  template
+  void
+  DataOutInterface<deal_II_dimension, deal_II_space_dimension>::set_flags (const DataOutBase::flag_type &flags);
 }


### PR DESCRIPTION
This started out as an experiment attempting to reduce the number of `memory_consumption` reimplementations and I believe the results are useful. The use of CRTP does make the documentation stranger (particularly the inheritance diagram) so I certainly understand if anyone has reservations about merging parts of this.