### PR TITLE
Fix two issues with C string memory consumption.

### DIFF
--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -24,6 +24,7 @@
 #include <complex>
 #include <vector>
 #include <cstddef>
+#include <cstring>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -458,7 +459,7 @@ namespace MemoryConsumption
       }
     else
       {
-        return /*Don't forget about the NUL! :]*/ sizeof(char) + strlen(string);
+        return sizeof(char)*(strlen(string) /*Remember the NUL*/ + 1);
       }
   }
 


### PR DESCRIPTION
These were pointed out by @msteigemann.

As far as `string.h` versus `cstring` choice goes, I used `cstring` since the C++-style formatting seems more common in deal.II.