### PR TITLE
Silence warnings about unused private members.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -296,6 +296,7 @@ _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")          \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"") \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")        \
+_Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")     \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -509,15 +509,7 @@ namespace DataOutBase
    * @ingroup output
    */
   struct GnuplotFlags : public OutputFlagsBase<GnuplotFlags>
-  {
-  private:
-    /**
-     * Dummy entry to suppress compiler warnings when copying an empty
-     * structure. Remove this member when adding the first flag to this
-     * structure (and remove the <tt>private</tt> as well).
-     */
-    int dummy;
-  };
+  {};
 
   /**
    * Flags controlling the details of output in Povray format. Several flags
@@ -816,15 +808,7 @@ namespace DataOutBase
    * @ingroup output
    */
   struct GmvFlags : public OutputFlagsBase<GmvFlags>
-  {
-  private:
-    /**
-     * Dummy entry to suppress compiler warnings when copying an empty
-     * structure. Remove this member when adding the first flag to this
-     * structure (and remove the <tt>private</tt> as well).
-     */
-    int dummy;
-  };
+  {};
 
   /**
    * Flags controlling the details of output in Tecplot format.
@@ -977,14 +961,6 @@ namespace DataOutBase
      * what the current readers and writers understand.
      */
     static const unsigned int format_version = 3;
-
-  private:
-    /**
-     * Dummy entry to suppress compiler warnings when copying an empty
-     * structure. Remove this member when adding the first flag to this
-     * structure (and remove the <tt>private</tt> as well).
-     */
-    int dummy;
   };
 
   /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -854,7 +854,9 @@ namespace
     /**
      * The flags controlling the output
      */
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     const DataOutBase::GmvFlags flags;
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
   };
 
   /**


### PR DESCRIPTION
Empty structs are implementation-dependent in C, but are acceptable in C++. Therefore unused private members are not needed (and they cause clang to generate warnings).

I have no idea why Clang did not catch this previously.