### PR TITLE
[RFC] Clean distributed vectors

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1709,9 +1709,12 @@ namespace Step32
 
     std::vector<double> rhs_values(n_q_points);
 
-    TrilinosWrappers::MPI::Vector
-    rhs (temperature_mass_matrix.row_partitioner()),
-        solution (temperature_mass_matrix.row_partitioner());
+    IndexSet row_temp_matrix_partitioning(temperature_mass_matrix.n());
+    row_temp_matrix_partitioning.add_range(temperature_mass_matrix.local_range().first,
+                                           temperature_mass_matrix.local_range().second);
+    TrilinosWrappers::MPI::Vector rhs (row_temp_matrix_partitioning),
+                     solution (row_temp_matrix_partitioning);
+
 
     const EquationData::TemperatureInitialValues<dim> initial_temperature;
 
@@ -3391,7 +3394,7 @@ namespace Step32
     locally_relevant_joint_solution = joint_solution;
 
     Postprocessor postprocessor (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD),
-                                 stokes_solution.block(1).minimal_value());
+                                 stokes_solution.block(1).min());
 
     DataOut<dim> data_out;
     data_out.attach_dof_handler (joint_dof_handler);

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -321,8 +321,10 @@ public:
 
   /**
    * Output of vector in user-defined format.
+   *
+   * This function is deprecated.
    */
-  void print (const char *format = 0) const;
+  void print (const char *format = 0) const DEAL_II_DEPRECATED;
 
   /**
    * Print to a stream.

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -897,8 +897,10 @@ public:
 
   /**
    * U+=V. Simple vector addition, equal to the <tt>operator +=</tt>.
+   *
+   * This function is deprecated use the <tt>operator +=</tt> instead.
    */
-  void add (const BlockVectorBase &V);
+  void add (const BlockVectorBase &V) DEAL_II_DEPRECATED;
 
   /**
    * U+=a*V. Simple addition of a scaled vector.
@@ -1866,7 +1868,14 @@ template <class VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator += (const BlockVectorBase<VectorType> &v)
 {
-  add (v);
+  Assert (n_blocks() == v.n_blocks(),
+          ExcDimensionMismatch(n_blocks(), v.n_blocks()));
+
+  for (size_type i=0; i<n_blocks(); ++i)
+    {
+      components[i] += v.components[i];
+    }
+
   return *this;
 }
 
@@ -1948,13 +1957,7 @@ void BlockVectorBase<VectorType>::add (const value_type a)
 template <class VectorType>
 void BlockVectorBase<VectorType>::add (const BlockVectorBase<VectorType> &v)
 {
-  Assert (n_blocks() == v.n_blocks(),
-          ExcDimensionMismatch(n_blocks(), v.n_blocks()));
-
-  for (size_type i=0; i<n_blocks(); ++i)
-    {
-      components[i].add(v.components[i]);
-    }
+  *this += v;
 }
 
 

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -360,9 +360,11 @@ namespace parallel
       /**
        * This method copies the local range from another vector with the same
        * local range, but possibly different layout of ghost indices.
+       *
+       * This function is deprecated.
        */
       void copy_from (const Vector<Number> &in_vector,
-                      const bool            call_update_ghost_values = false);
+                      const bool            call_update_ghost_values = false) DEAL_II_DEPRECATED;
 
       /**
        * Sets all elements of the vector to the scalar @p s. If the scalar is
@@ -636,22 +638,28 @@ namespace parallel
 
       /**
        * Returns the number of ghost elements present on the vector.
+       *
+       * This function is deprecated.
        */
-      size_type n_ghost_entries () const;
+      size_type n_ghost_entries () const DEAL_II_DEPRECATED;
 
       /**
        * Return an index set that describes which elements of this vector are
        * not owned by the current processor but can be written into or read
        * from locally (ghost elements).
+       *
+       * This function is deprecated.
        */
-      const IndexSet &ghost_elements() const;
+      const IndexSet &ghost_elements() const DEAL_II_DEPRECATED;
 
       /**
        * Returns whether the given global index is a ghost index on the
        * present processor. Returns false for indices that are owned locally
        * and for indices not present at all.
+       *
+       * This function is deprecated.
        */
-      bool is_ghost_entry (const types::global_dof_index global_index) const;
+      bool is_ghost_entry (const types::global_dof_index global_index) const DEAL_II_DEPRECATED;
 
       /**
        * Make the @p Vector class a bit like the <tt>vector<></tt> class of
@@ -817,8 +825,10 @@ namespace parallel
 
       /**
        * Simple vector addition, equal to the <tt>operator +=</tt>.
+       *
+       * This function is deprecated use the <tt>operator +=</tt> instead.
        */
-      void add (const Vector<Number> &V);
+      void add (const Vector<Number> &V) DEAL_II_DEPRECATED;
 
       /**
        * Simple addition of a multiple of a vector, i.e. <tt>*this +=

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -383,8 +383,7 @@ namespace PETScWrappers
     operator [] (const size_type index);
 
     /**
-     * Provide read-only access to an element. This is equivalent to the
-     * <code>el()</code> command.
+     * Provide read-only access to an element.
      *
      * Exactly the same as operator().
      */
@@ -502,8 +501,10 @@ namespace PETScWrappers
     /**
      * Normalize vector by dividing by the $l_2$-norm of the vector. Return
      * the vector norm before normalization.
+     *
+     * This function is deprecated.
      */
-    real_type normalize () const;
+    real_type normalize () const DEAL_II_DEPRECATED;
 
     /**
      * Return the value of the vector element with the largest negative value.
@@ -517,33 +518,43 @@ namespace PETScWrappers
 
     /**
      * Replace every element in a vector with its absolute value.
+     *
+     * This function is deprecated.
      */
-    VectorBase &abs ();
+    VectorBase &abs () DEAL_II_DEPRECATED;
 
     /**
      * Conjugate a vector.
+     *
+     * This function is deprecated.
      */
-    VectorBase &conjugate ();
+    VectorBase &conjugate () DEAL_II_DEPRECATED;
 
     /**
      * A collective piecewise multiply operation on <code>this</code> vector
      * with itself. TODO: The model for this function should be similer to add
      * ().
+     *
+     * This function is deprecated.
      */
-    VectorBase &mult ();
+    VectorBase &mult () DEAL_II_DEPRECATED;
 
     /**
      * Same as above, but a collective piecewise multiply operation of
      * <code>this</code> vector with <b>v</b>.
+     *
+     * This function is deprecated.
      */
-    VectorBase &mult (const VectorBase &v);
+    VectorBase &mult (const VectorBase &v) DEAL_II_DEPRECATED;
 
     /**
      * Same as above, but a collective piecewise multiply operation of
      * <b>u</b> with <b>v</b>.
+     *
+     * This function is deprecated.
      */
     VectorBase &mult (const VectorBase &u,
-                      const VectorBase &v);
+                      const VectorBase &v) DEAL_II_DEPRECATED;
 
     /**
      * Return whether the vector contains only elements with value zero. This
@@ -587,8 +598,10 @@ namespace PETScWrappers
 
     /**
      * Simple vector addition, equal to the <tt>operator +=</tt>.
+     *
+     * This function is deprecated use += instead.
      */
-    void add (const VectorBase &V);
+    void add (const VectorBase &V) DEAL_II_DEPRECATED;
 
     /**
      * Simple addition of a multiple of a vector, i.e. <tt>*this += a*V</tt>.

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -102,8 +102,10 @@ namespace TrilinosWrappers
        * Constructor. Generate a block vector with as many blocks as there are
        * entries in @p partitioning. Each Epetra_Map contains the layout of
        * the distribution of data among the MPI processes.
+       *
+       * This function is deprecated.
        */
-      explicit BlockVector (const std::vector<Epetra_Map> &parallel_partitioning);
+      explicit BlockVector (const std::vector<Epetra_Map> &parallel_partitioning) DEAL_II_DEPRECATED;
 
       /**
        * Constructor. Generate a block vector with as many blocks as there are
@@ -200,9 +202,11 @@ namespace TrilinosWrappers
        * distribution of the individual components described in the maps.
        *
        * If <tt>fast==false</tt>, the vector is filled with zeros.
+       *
+       * This function is deprecated.
        */
       void reinit (const std::vector<Epetra_Map> &parallel_partitioning,
-                   const bool                     fast = false);
+                   const bool                     fast = false) DEAL_II_DEPRECATED;
 
       /**
        * Reinitialize the BlockVector to contain as many blocks as there are
@@ -289,8 +293,10 @@ namespace TrilinosWrappers
        * non-true values when used in <tt>debug</tt> mode, since it is quite
        * expensive to keep track of all operations that lead to the need for
        * compress().
+       *
+       * This function is deprecated.
        */
-      bool is_compressed () const;
+      bool is_compressed () const DEAL_II_DEPRECATED;
 
       /**
        * Returns if this Vector contains ghost elements.
@@ -350,14 +356,6 @@ namespace TrilinosWrappers
 
 
     inline
-    BlockVector::BlockVector (const std::vector<Epetra_Map> &parallel_partitioning)
-    {
-      reinit (parallel_partitioning, false);
-    }
-
-
-
-    inline
     BlockVector::BlockVector (const std::vector<IndexSet> &parallel_partitioning,
                               const MPI_Comm              &communicator)
     {
@@ -409,23 +407,6 @@ namespace TrilinosWrappers
       swap(v);
     }
 #endif
-
-
-
-    inline
-    bool
-    BlockVector::is_compressed () const
-    {
-      bool compressed = true;
-      for (unsigned int row=0; row<n_blocks(); ++row)
-        if (block(row).is_compressed() == false)
-          {
-            compressed = false;
-            break;
-          }
-
-      return compressed;
-    }
 
 
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -413,10 +413,12 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * This function is deprecated.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
-      explicit Vector (const Epetra_Map &parallel_partitioning);
+      explicit Vector (const Epetra_Map &parallel_partitioning)  DEAL_II_DEPRECATED;
 
       /**
        * Copy constructor from the TrilinosWrappers vector class. Since a
@@ -429,11 +431,13 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * This function is deprecated.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       Vector (const Epetra_Map &parallel_partitioning,
-              const VectorBase &v);
+              const VectorBase &v) DEAL_II_DEPRECATED;
 
       /**
        * Reinitialize from a deal.II vector. The Epetra_Map specifies the
@@ -444,12 +448,14 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * This function is deprecated.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       template <typename number>
       void reinit (const Epetra_Map             &parallel_partitioner,
-                   const dealii::Vector<number> &v);
+                   const dealii::Vector<number> &v) DEAL_II_DEPRECATED;
 
       /**
        * Reinit functionality. This function destroys the old vector content
@@ -460,11 +466,13 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * This function is deprecated.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       void reinit (const Epetra_Map &parallel_partitioning,
-                   const bool        fast = false);
+                   const bool        fast = false) DEAL_II_DEPRECATED;
 
       /**
        * Copy-constructor from deal.II vectors. Sets the dimension to that of
@@ -475,12 +483,14 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * This function is deprecated.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       template <typename Number>
       Vector (const Epetra_Map             &parallel_partitioning,
-              const dealii::Vector<Number> &v);
+              const dealii::Vector<Number> &v) DEAL_II_DEPRECATED;
 //@}
       /**
        * @name Initialization with an IndexSet

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -287,8 +287,10 @@ namespace TrilinosWrappers
     /**
      * Returns the state of the vector, i.e., whether compress() has already
      * been called after an operation requiring data exchange.
+     *
+     * This function is deprecated.
      */
-    bool is_compressed () const;
+    bool is_compressed () const DEAL_II_DEPRECATED;
 
     /**
      * Set all components of the vector to the given number @p s. Simply pass
@@ -431,8 +433,20 @@ namespace TrilinosWrappers
 
     /**
      * Compute the minimal value of the elements of this vector.
+     *
+     * This function is deprecated use min() instead.
      */
-    TrilinosScalar minimal_value () const;
+    TrilinosScalar minimal_value () const DEAL_II_DEPRECATED;
+
+    /**
+     * Compute the minimal value of the elements of this vector.
+     */
+    TrilinosScalar min () const;
+
+    /**
+     * Compute the maximal value of the elements of this vector.
+     */
+    TrilinosScalar max () const;
 
     /**
      * $l_1$-norm of the vector.  The sum of the absolute values.
@@ -561,8 +575,10 @@ namespace TrilinosWrappers
      * returns 0 which might or might not be appropriate in a given situation.
      * If you rely on consistent results, use the access functions () or []
      * that throw an assertion in case a non-local element is used.
+     *
+     * This function is deprecated.
      */
-    TrilinosScalar el (const size_type index) const;
+    TrilinosScalar el (const size_type index) const DEAL_II_DEPRECATED;
 
     /**
      * Make the Vector class a bit like the <tt>vector<></tt> class of the C++
@@ -802,8 +818,10 @@ namespace TrilinosWrappers
     /**
      * Output of vector in user-defined format in analogy to the
      * dealii::Vector class.
+     *
+     * This function is deprecated.
      */
-    void print (const char *format = 0) const;
+    void print (const char *format = 0) const DEAL_II_DEPRECATED;
 
     /**
      * Print to a stream. @p precision denotes the desired precision with
@@ -1466,11 +1484,33 @@ namespace TrilinosWrappers
   TrilinosScalar
   VectorBase::minimal_value () const
   {
+    return min();
+  }
+
+
+
+  inline
+  TrilinosScalar
+  VectorBase::min () const
+  {
     TrilinosScalar min_value;
     const int ierr = vector->MinValue (&min_value);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
 
     return min_value;
+  }
+
+
+
+  inline
+  TrilinosScalar
+  VectorBase::max () const
+  {
+    TrilinosScalar max_value;
+    const int ierr = vector->MaxValue (&max_value);
+    AssertThrow (ierr == 0, ExcTrilinosError(ierr));
+
+    return max_value;
   }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -665,9 +665,11 @@ public:
   /**
    * Simple vector addition, equal to the <tt>operator +=</tt>.
    *
+   * This function is deprecated use the <tt>operator +=</tt> instead.
+   *
    * @dealiiOperationIsMultithreaded
    */
-  void add (const Vector<Number> &V);
+  void add (const Vector<Number> &V) DEAL_II_DEPRECATED;
 
 
   /**
@@ -825,8 +827,10 @@ public:
   /**
    * Output of vector in user-defined format. For complex-valued vectors, the
    * format should include specifiers for both the real and imaginary parts.
+   *
+   * This funcion is deprecated.
    */
-  void print (const char *format = 0) const;
+  void print (const char *format = 0) const DEAL_II_DEPRECATED;
 
   /**
    * Print to a stream. @p precision denotes the desired precision with which

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -63,6 +63,7 @@ SET(_src
   tridiagonal_matrix.cc
   trilinos_block_sparse_matrix.cc
   trilinos_block_vector.cc
+  trilinos_parallel_block_vector.cc
   trilinos_precondition.cc
   trilinos_solver.cc
   trilinos_sparse_matrix.cc

--- a/source/lac/trilinos_parallel_block_vector.cc
+++ b/source/lac/trilinos_parallel_block_vector.cc
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace TrilinosWrappers
+{
+  namespace MPI
+  {
+    BlockVector::BlockVector (const std::vector<Epetra_Map> &parallel_partitioning)
+    {
+      reinit (parallel_partitioning, false);
+    }
+
+
+
+    bool
+    BlockVector::is_compressed () const
+    {
+      bool compressed = true;
+      for (unsigned int row=0; row<n_blocks(); ++row)
+        if (block(row).is_compressed() == false)
+          {
+            compressed = false;
+            break;
+          }
+
+      return compressed;
+    }
+  }
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_TRILINOS


### PR DESCRIPTION
I have deprecated a few functions for distributed vectors. I tried to get ride of functions that exist only for one kind of vector. I had to move some functions in trilinos_parallel_block_vector.cc otherwise including trilinos_parallel_block_vector.h would trigger a warning. I haven't deprecated as many functions as I could because we use them in the tutorials (for example equ with six arguments). Let me know if you think that we should deprecate more. 