### PR TITLE
Auto ptr to scoped ptr

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -297,6 +297,7 @@ _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")          \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"") \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")     \
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")  \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/serialization/split_member.hpp>
@@ -28,7 +29,6 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <memory>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -1952,7 +1952,7 @@ private:
    * than having to include all of the property_tree stuff from boost. This
    * works around a problem with gcc 4.5.
    */
-  std::auto_ptr<boost::property_tree::ptree> entries;
+  std_cxx11::unique_ptr<boost::property_tree::ptree> entries;
 
   /**
    * A list of patterns that are used to describe the parameters of this

--- a/include/deal.II/base/std_cxx11/unique_ptr.h
+++ b/include/deal.II/base/std_cxx11/unique_ptr.h
@@ -31,7 +31,8 @@ DEAL_II_NAMESPACE_CLOSE
 
 #else
 
-#include <boost/shared_ptr.hpp>
+#include <boost/scoped_ptr.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx11
 {
@@ -43,19 +44,17 @@ namespace std_cxx11
    * compiler -- in which case you also have std::unique_ptr; see for example
    * http://stackoverflow.com/questions/2953530/unique-ptr-boost-equivalent)
    *
-   * Consequently, we emulate the class by just wrapping a boost::shared_ptr
+   * Consequently, we emulate the class by just wrapping a boost::scoped_ptr
    * in the cheapest possible way -- by just deriving from it and repeating
-   * the basic constructors. Everything else is inherited from the shared_ptr
+   * the basic constructors. Everything else is inherited from the scoped_ptr
    * class.
    *
-   * This replacement comes with a certain overhead: doing reference counting
-   * instead of just passing ownership of pointers has a cost. But we don't
-   * use unique_ptrs in expensive places, and it is also a cost that will
-   * disappear once we require C++11 (and the cost of course does not apply if
-   * your compiler already supports C++11 and deal.II uses it).
+   * There is no overhead to this approach: scoped_ptr cannot be copied or
+   * moved. Instances of unique_ptr cannot be copied, and if you do not have a
+   * C++11 compiler, then you cannot move anything anyway.
    */
   template <typename T>
-  class unique_ptr : public boost::shared_ptr<T>
+  class unique_ptr : public boost::scoped_ptr<T>
   {
   public:
     unique_ptr () {}
@@ -63,7 +62,7 @@ namespace std_cxx11
     template<class Y>
     explicit unique_ptr (Y *p)
       :
-      boost::shared_ptr<T>(p)
+      boost::scoped_ptr<T>(p)
     {}
   };
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -26,6 +26,7 @@
 #include <deal.II/base/vector_slice.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -37,7 +38,6 @@
 #include <deal.II/fe/mapping.h>
 
 #include <algorithm>
-#include <memory>
 
 // dummy include in order to have the
 // definition of PetscScalar available
@@ -2469,7 +2469,7 @@ protected:
    * is necessary for the <tt>get_function_*</tt> functions as well as the
    * functions of same name in the extractor classes.
    */
-  std::auto_ptr<const CellIteratorBase> present_cell;
+  std_cxx11::unique_ptr<const CellIteratorBase> present_cell;
 
   /**
    * A signal connection we use to ensure we get informed whenever the

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -28,10 +28,13 @@
 #include <deal.II/grid/tria_faces.h>
 #include <deal.II/grid/tria_levels.h>
 
+// Ignore deprecation warnings for auto_ptr.
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/signals2.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/split_member.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <vector>
 #include <list>

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -21,7 +21,10 @@
 #include <deal.II/lac/vector_memory.h>
 #include <deal.II/lac/solver_control.h>
 
+// Ignore deprecation warnings for auto_ptr.
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/signals2.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -33,7 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 //TODO[WB]: do not use a plain pointer for DoFHandler::faces, but rather an
-//auto_ptr or some such thing. alternatively, why not use the DoFFaces object
+//unique_ptr or some such thing. alternatively, why not use the DoFFaces object
 //right away?
 
 template<int dim, int spacedim>

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3466,11 +3466,6 @@ void FEValues<dim,spacedim>::reinit (const typename Triangulation<dim,spacedim>:
   this->maybe_invalidate_previous_present_cell (cell);
   this->check_cell_similarity(cell);
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::TriaCellIterator>
   (this->present_cell, cell);
 
@@ -3501,11 +3496,6 @@ FEValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &c
   this->maybe_invalidate_previous_present_cell (cell);
   this->check_cell_similarity(cell);
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
   (this->present_cell, cell);
 
@@ -3678,11 +3668,6 @@ FEFaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> 
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   this->maybe_invalidate_previous_present_cell (cell);
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
   (this->present_cell, cell);
@@ -3704,11 +3689,6 @@ void FEFaceValues<dim,spacedim>::reinit (const typename Triangulation<dim,spaced
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   this->maybe_invalidate_previous_present_cell (cell);
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::TriaCellIterator>
   (this->present_cell, cell);
@@ -3855,11 +3835,6 @@ void FESubfaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<D
                       "already refined. Iterate over their children "
                       "instead in these cases."));
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   this->maybe_invalidate_previous_present_cell (cell);
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
   (this->present_cell, cell);
@@ -3883,11 +3858,6 @@ void FESubfaceValues<dim,spacedim>::reinit (const typename Triangulation<dim,spa
   Assert (subface_no < cell->face(face_no)->n_children(),
           ExcIndexRange (subface_no, 0, cell->face(face_no)->n_children()));
 
-  // set new cell. auto_ptr will take
-  // care that old object gets
-  // destroyed and also that this
-  // object gets destroyed in the
-  // destruction of the current object
   this->maybe_invalidate_previous_present_cell (cell);
   reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::TriaCellIterator>
   (this->present_cell, cell);

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/parallel_vector.h>
@@ -3427,14 +3428,14 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
 
 namespace
 {
-  // Reset a std::auto_ptr. If we can, do not de-allocate the previously
+  // Reset a unique_ptr. If we can, do not de-allocate the previously
   // held memory but re-use it for the next item to avoid the repeated
   // memory allocation. We do this because FEValues objects are heavily
   // used in multithreaded contexts where memory allocations are evil.
   template <typename Type, typename Pointer, typename Iterator>
   void
   reset_pointer_in_place_if_possible
-  (std::auto_ptr<Pointer> &present_cell,
+  (std_cxx11::unique_ptr<Pointer> &present_cell,
    const Iterator         &new_cell)
   {
     // see if the existing pointer is non-null and if the type of

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -20,6 +20,7 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/tensor_product_polynomials.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_boundary.h>
@@ -36,7 +37,6 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include <numeric>
-#include <memory>
 #include <fstream>
 
 
@@ -782,7 +782,7 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
   update_internal_dofs(cell);
 
   const Quadrature<dim> point_quadrature(p);
-  std::auto_ptr<InternalData>
+  std_cxx11::unique_ptr<InternalData>
   mdata (dynamic_cast<InternalData *> (
            get_data(update_transformation_values, point_quadrature)));
 
@@ -844,7 +844,7 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
   UpdateFlags update_flags = update_transformation_values|update_transformation_gradients;
   if (spacedim>dim)
     update_flags |= update_jacobian_grads;
-  std::auto_ptr<InternalData>
+  std_cxx11::unique_ptr<InternalData>
   mdata (dynamic_cast<InternalData *> (
            get_data(update_flags,point_quadrature)));
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/tensor_product_polynomials.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_boundary.h>
@@ -28,7 +29,6 @@
 #include <deal.II/fe/fe_q.h>
 
 #include <numeric>
-#include <memory>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -1036,7 +1036,7 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
   // the right size and transformation shape values already computed at point
   // p.
   const Quadrature<dim> point_quadrature(p);
-  std::auto_ptr<InternalData>
+  std_cxx11::unique_ptr<InternalData>
   mdata (dynamic_cast<InternalData *> (
            get_data(update_transformation_values, point_quadrature)));
 
@@ -1122,7 +1122,7 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
       UpdateFlags update_flags = update_transformation_values|update_transformation_gradients;
       if (spacedim>dim)
         update_flags |= update_jacobian_grads;
-      std::auto_ptr<InternalData>
+      std_cxx11::unique_ptr<InternalData>
       mdata (dynamic_cast<InternalData *> (
                get_data(update_flags,point_quadrature)));
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_iterator.h>
@@ -28,7 +29,6 @@
 
 #include <cmath>
 #include <algorithm>
-#include <memory>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -1433,7 +1433,7 @@ MappingQ1<dim,spacedim>::transform_unit_to_real_cell (
   // already computed at point p.
   const Quadrature<dim> point_quadrature(p);
 
-  std::auto_ptr<InternalData>
+  std_cxx11::unique_ptr<InternalData>
   mdata (dynamic_cast<InternalData *> (
            get_data(update_transformation_values, point_quadrature)));
 
@@ -1669,7 +1669,7 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
       if (spacedim>dim)
         update_flags |= update_jacobian_grads;
 
-      std::auto_ptr<InternalData>
+      std_cxx11::unique_ptr<InternalData>
       mdata(dynamic_cast<InternalData *> (
               MappingQ1<dim,spacedim>::get_data(update_flags, point_quadrature)));
 

--- a/tests/bits/fe_tools_05.cc
+++ b/tests/bits/fe_tools_05.cc
@@ -45,9 +45,9 @@ check_this (const FiniteElement<dim> &fe1,
   if (!fe2.constraints_are_implemented())
     return;
 
-  std::auto_ptr<Triangulation<dim> > tria(make_tria<dim>());
-  std::auto_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
-  std::auto_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
+  std_cxx11::unique_ptr<Triangulation<dim> > tria(make_tria<dim>());
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
   ConstraintMatrix cm;
   DoFTools::make_hanging_node_constraints (*dof2, cm);
   cm.close ();

--- a/tests/bits/fe_tools_06.cc
+++ b/tests/bits/fe_tools_06.cc
@@ -46,9 +46,9 @@ check_this (const FiniteElement<dim> &fe1,
       !fe2.constraints_are_implemented())
     return;
 
-  std::auto_ptr<Triangulation<dim> > tria(make_tria<dim>());
-  std::auto_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
-  std::auto_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
+  std_cxx11::unique_ptr<Triangulation<dim> > tria(make_tria<dim>());
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
   ConstraintMatrix cm1, cm2;
   DoFTools::make_hanging_node_constraints (*dof1, cm1);
   DoFTools::make_hanging_node_constraints (*dof2, cm2);

--- a/tests/bits/fe_tools_06b.cc
+++ b/tests/bits/fe_tools_06b.cc
@@ -47,9 +47,9 @@ check_this (const FiniteElement<dim> &fe1,
       !fe2.constraints_are_implemented())
     return;
 
-  std::auto_ptr<Triangulation<dim> > tria(make_tria<dim>());
-  std::auto_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
-  std::auto_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
+  std_cxx11::unique_ptr<Triangulation<dim> > tria(make_tria<dim>());
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
   ConstraintMatrix cm1, cm2;
   DoFTools::make_hanging_node_constraints (*dof1, cm1);
   DoFTools::make_hanging_node_constraints (*dof2, cm2);

--- a/tests/bits/fe_tools_07.cc
+++ b/tests/bits/fe_tools_07.cc
@@ -46,9 +46,9 @@ check_this (const FiniteElement<dim> &fe1,
       !fe2.constraints_are_implemented())
     return;
 
-  std::auto_ptr<Triangulation<dim> > tria(make_tria<dim>());
-  std::auto_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
-  std::auto_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
+  std_cxx11::unique_ptr<Triangulation<dim> > tria(make_tria<dim>());
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
   ConstraintMatrix cm1, cm2;
   DoFTools::make_hanging_node_constraints (*dof1, cm1);
   DoFTools::make_hanging_node_constraints (*dof2, cm2);

--- a/tests/bits/fe_tools_08.cc
+++ b/tests/bits/fe_tools_08.cc
@@ -51,9 +51,9 @@ check_this (const FiniteElement<dim> &fe1,
   if (!fe2.isotropic_restriction_is_implemented())
     return;
 
-  std::auto_ptr<Triangulation<dim> > tria(make_tria<dim>());
-  std::auto_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
-  std::auto_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
+  std_cxx11::unique_ptr<Triangulation<dim> > tria(make_tria<dim>());
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof1(make_dof_handler (*tria, fe1));
+  std_cxx11::unique_ptr<DoFHandler<dim> >    dof2(make_dof_handler (*tria, fe2));
   ConstraintMatrix cm;
   DoFTools::make_hanging_node_constraints (*dof2, cm);
   cm.close ();

--- a/tests/bits/fe_tools_common.h
+++ b/tests/bits/fe_tools_common.h
@@ -18,6 +18,7 @@
 
 #include "../tests.h"
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/grid_generator.h>
@@ -37,7 +38,6 @@
 #include <iomanip>
 #include <iomanip>
 #include <string>
-#include <memory>
 
 
 // forward declaration of the function that must be provided in the


### PR DESCRIPTION
GCC 5.1 now issues deprecation warnings when code uses `std::auto_ptr`, so this patch is very necessary for me. I believe this closes #303.

I believe `boost::scoped_ptr` is the correct replacement for `auto_ptr` in deal.II. In particular, since a `shared_ptr` manages multiple heap objects, I suspect its usage will slow down functions like `reset_pointer_in_place_if_possible`. I did not profile that option, so I do not know for sure. There are certainly other options and I can modify the patch if anyone has a better approach.

Edit: One (breaking) change from this is parameter handlers can no longer be copied. Perhaps `shared_ptr` is better there (but copying one right now probably results in broken code due to the `auto_ptr` member).

Something else I did not consider was move constructors. Since `scoped_ptr`s cannot be moved, should we do something like
```cpp
#ifdef DEAL_II_WITH_CXX11
FEValues(FEValues &&) = delete;
#endif
```
to improve error messages?