### PR TITLE
Remove an unused header inclusion.

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -32,8 +32,6 @@
 #include <utility>
 #include <complex>
 
-#include <boost/scoped_ptr.hpp>
-
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
I noticed this while getting rid of `auto_ptr`s.