### PR TITLE
Deprecate more vector functions

### DIFF
--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1003,7 +1003,8 @@ namespace Step35
   void
   NavierStokesProjection<dim>::diffusion_step (const bool reinit_prec)
   {
-    pres_tmp.equ (-1., pres_n, -4./3., phi_n, 1./3., phi_n_minus_1);
+    pres_tmp = pres_n;
+    pres_tmp.sadd(-1., -4./3., phi_n, 1./3., phi_n_minus_1);
 
     assemble_advection_term();
 

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -826,7 +826,7 @@ namespace parallel
       /**
        * Simple vector addition, equal to the <tt>operator +=</tt>.
        *
-       * This function is deprecated use the <tt>operator +=</tt> instead.
+       * @deprecated Use the <tt>operator +=</tt> instead.
        */
       void add (const Vector<Number> &V) DEAL_II_DEPRECATED;
 
@@ -868,6 +868,8 @@ namespace parallel
       /**
        * Scaling and multiple addition.  <tt>*this = s*(*this)+a*V + b*W +
        * c*X</tt>.
+       *
+       * This function is deprecated.
        */
       void sadd (const Number          s,
                  const Number          a,
@@ -875,7 +877,7 @@ namespace parallel
                  const Number          b,
                  const Vector<Number> &W,
                  const Number          c,
-                 const Vector<Number> &X);
+                 const Vector<Number> &X) DEAL_II_DEPRECATED;
 
       /**
        * Scale each element of the vector by a constant value.
@@ -921,10 +923,12 @@ namespace parallel
 
       /**
        * Assignment <tt>*this = a*u + b*v + b*w</tt>.
+       *
+       * This function is deprecated.
        */
       void equ (const Number a, const Vector<Number> &u,
                 const Number b, const Vector<Number> &v,
-                const Number c, const Vector<Number> &w);
+                const Number c, const Vector<Number> &w) DEAL_II_DEPRECATED;
 
       /**
        * Compute the elementwise ratio of the two given vectors, that is let

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -599,7 +599,7 @@ namespace PETScWrappers
     /**
      * Simple vector addition, equal to the <tt>operator +=</tt>.
      *
-     * This function is deprecated use += instead.
+     * @deprecated Use the <tt>operator +=</tt> instead.
      */
     void add (const VectorBase &V) DEAL_II_DEPRECATED;
 
@@ -639,6 +639,8 @@ namespace PETScWrappers
     /**
      * Scaling and multiple addition. <tt>*this = s*(*this)+a*V + b*W +
      * c*X</tt>.
+     *
+     * This function is deprecated.
      */
     void sadd (const PetscScalar s,
                const PetscScalar a,
@@ -646,7 +648,7 @@ namespace PETScWrappers
                const PetscScalar b,
                const VectorBase     &W,
                const PetscScalar c,
-               const VectorBase     &X);
+               const VectorBase     &X) DEAL_II_DEPRECATED;
 
     /**
      * Scale each element of this vector by the corresponding element in the

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -747,6 +747,8 @@ namespace TrilinosWrappers
     /**
      * Scaling and multiple addition.  <tt>*this = s*(*this) + a*V + b*W +
      * c*X</tt>.
+     *
+     * This function is deprecated.
      */
     void sadd (const TrilinosScalar  s,
                const TrilinosScalar  a,
@@ -754,7 +756,7 @@ namespace TrilinosWrappers
                const TrilinosScalar  b,
                const VectorBase     &W,
                const TrilinosScalar  c,
-               const VectorBase     &X);
+               const VectorBase     &X) DEAL_II_DEPRECATED;
 
     /**
      * Scale each element of this vector by the corresponding element in the

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -665,7 +665,7 @@ public:
   /**
    * Simple vector addition, equal to the <tt>operator +=</tt>.
    *
-   * This function is deprecated use the <tt>operator +=</tt> instead.
+   * @deprecate Use the <tt>operator +=</tt> instead.
    *
    * @dealiiOperationIsMultithreaded
    */
@@ -719,6 +719,8 @@ public:
    * Scaling and multiple addition.  <tt>*this = s*(*this)+a*V + b*W +
    * c*X</tt>.
    *
+   * This function is deprecated.
+   *
    * @dealiiOperationIsMultithreaded
    */
   void sadd (const Number          s,
@@ -727,7 +729,7 @@ public:
              const Number          b,
              const Vector<Number> &W,
              const Number          c,
-             const Vector<Number> &X);
+             const Vector<Number> &X) DEAL_II_DEPRECATED;
 
   /**
    * Scale each element of the vector by a constant value.
@@ -784,11 +786,13 @@ public:
   /**
    * Assignment <tt>*this = a*u + b*v + b*w</tt>.
    *
+   * This function is deprecated.
+   *
    * @dealiiOperationIsMultithreaded
    */
   void equ (const Number a, const Vector<Number> &u,
             const Number b, const Vector<Number> &v,
-            const Number c, const Vector<Number> &w);
+            const Number c, const Vector<Number> &w) DEAL_II_DEPRECATED;
 
   /**
    * Compute the elementwise ratio of the two given vectors, that is let
@@ -848,10 +852,12 @@ public:
    * manipulator, if printing across.  If @p across is @p true then the vector
    * is printed in a line, while if @p false then the elements are printed on
    * a separate line each.
+   *
+   * This function is deprecated.
    */
   void print (LogStream &out,
               const unsigned int width = 6,
-              const bool across = true) const;
+              const bool across = true) const DEAL_II_DEPRECATED;
 
   /**
    * Write the vector en bloc to a file. This is done in a binary mode, so the


### PR DESCRIPTION
Deprecate the following functions: sadd with 7 arguments, equ with 6 arguments, and print with 3 arguments.
