### PR TITLE
Deprecate more vector functions

### DIFF
--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -2577,7 +2577,7 @@ namespace Step14
                           FaceIntegrals                                     &face_integrals) const
     {
       // Because of WorkStream, estimate_on_one_cell requires a CopyData object
-      // even if it is no used. The next line silence a warning about this unused
+      // even if it is no used. The next line silences a warning about this unused
       // variable.
       (void) copy_data;
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -982,7 +982,10 @@ namespace Step35
   NavierStokesProjection<dim>::interpolate_velocity()
   {
     for (unsigned int d=0; d<dim; ++d)
-      u_star[d].equ (2., u_n[d], -1, u_n_minus_1[d]);
+      {
+        u_star[d].equ (2., u_n[d]);
+        u_star[d].add (-1, u_n_minus_1[d]);
+      }
   }
 
 
@@ -1003,15 +1006,16 @@ namespace Step35
   void
   NavierStokesProjection<dim>::diffusion_step (const bool reinit_prec)
   {
-    pres_tmp = pres_n;
-    pres_tmp.sadd(-1., -4./3., phi_n, 1./3., phi_n_minus_1);
+    pres_tmp.equ (-1., pres_n);
+    pres_tmp.add (-4./3., phi_n, 1./3., phi_n_minus_1);
 
     assemble_advection_term();
 
     for (unsigned int d=0; d<dim; ++d)
       {
         force[d] = 0.;
-        v_tmp.equ (2./dt,u_n[d],-.5/dt,u_n_minus_1[d]);
+        v_tmp.equ (2./dt,u_n[d]);
+        v_tmp.add (-.5/dt,u_n_minus_1[d]);
         vel_Mass.vmult_add (force[d], v_tmp);
 
         pres_Diff[d].vmult_add (force[d], pres_tmp);
@@ -1239,7 +1243,8 @@ namespace Step35
           prec_mass.initialize (pres_Mass);
         pres_n = pres_tmp;
         prec_mass.solve (pres_n);
-        pres_n.sadd(1./Re, 1., pres_n_minus_1, 1., phi_n);
+        pres_n.sadd(1./Re, 1., pres_n_minus_1);
+        pres_n += phi_n;
         break;
       default:
         Assert (false, ExcNotImplemented());

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -984,7 +984,7 @@ namespace Step35
     for (unsigned int d=0; d<dim; ++d)
       {
         u_star[d].equ (2., u_n[d]);
-        u_star[d].add (-1, u_n_minus_1[d]);
+        u_star[d] -=  u_n_minus_1[d];
       }
   }
 

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -2663,8 +2663,8 @@ namespace Step44
       //      \mathsf{\mathbf{K}}^{-1}_{\widetilde{p} \widetilde{J}}
       //      \mathsf{\mathbf{F}}_{\widetilde{p}}
       //      $
-      A.block(J_dof).equ(1.0, system_rhs.block(J_dof));
-      A.block(J_dof).add(-1.0, B.block(J_dof));
+      A.block(J_dof) = system_rhs.block(J_dof);
+      A.block(J_dof) -= B.block(J_dof);
       //      $
       //      \mathsf{\mathbf{A}}_{\widetilde{J}}
       //      =

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -2663,7 +2663,8 @@ namespace Step44
       //      \mathsf{\mathbf{K}}^{-1}_{\widetilde{p} \widetilde{J}}
       //      \mathsf{\mathbf{F}}_{\widetilde{p}}
       //      $
-      A.block(J_dof).equ(1.0, system_rhs.block(J_dof), -1.0, B.block(J_dof));
+      A.block(J_dof).equ(1.0, system_rhs.block(J_dof));
+      A.block(J_dof).add(-1.0, B.block(J_dof));
       //      $
       //      \mathsf{\mathbf{A}}_{\widetilde{J}}
       //      =

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -351,6 +351,7 @@ namespace Step52
                                                     const double tau,
                                                     const Vector<double> &y)
   {
+    (void) time;
     SparseDirectUMFPACK inverse_mass_minus_tau_Jacobian;
 
     mass_minus_tau_Jacobian.copy_from(mass_matrix);

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -858,12 +858,14 @@ namespace parallel
 
       /**
        * Scaling and multiple addition.
+       *
+       * This function is deprecated.
        */
       void sadd (const Number          s,
                  const Number          a,
                  const Vector<Number> &V,
                  const Number          b,
-                 const Vector<Number> &W);
+                 const Vector<Number> &W) DEAL_II_DEPRECATED;
 
       /**
        * Scaling and multiple addition.  <tt>*this = s*(*this)+a*V + b*W +
@@ -917,9 +919,11 @@ namespace parallel
 
       /**
        * Assignment <tt>*this = a*u + b*v</tt>.
+       *
+       * This function is deprecated.
        */
       void equ (const Number a, const Vector<Number> &u,
-                const Number b, const Vector<Number> &v);
+                const Number b, const Vector<Number> &v) DEAL_II_DEPRECATED;
 
       /**
        * Assignment <tt>*this = a*u + b*v + b*w</tt>.

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -629,12 +629,14 @@ namespace PETScWrappers
 
     /**
      * Scaling and multiple addition.
+     *
+     * This function is deprecated.
      */
     void sadd (const PetscScalar s,
                const PetscScalar a,
                const VectorBase     &V,
                const PetscScalar b,
-               const VectorBase     &W);
+               const VectorBase     &W) DEAL_II_DEPRECATED;
 
     /**
      * Scaling and multiple addition. <tt>*this = s*(*this)+a*V + b*W +
@@ -664,9 +666,11 @@ namespace PETScWrappers
 
     /**
      * Assignment <tt>*this = a*V + b*W</tt>.
+     *
+     * This function is deprecated.
      */
     void equ (const PetscScalar a, const VectorBase &V,
-              const PetscScalar b, const VectorBase &W);
+              const PetscScalar b, const VectorBase &W) DEAL_II_DEPRECATED;
 
     /**
      * Compute the elementwise ratio of the two given vectors, that is let

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -376,7 +376,10 @@ SolverBicgstab<VECTOR>::iterate(const MATRIX &A,
           startup = false;
         }
       else
-        p.sadd(beta, 1., r, -beta*omega, v);
+        {
+          p.sadd(beta, 1., r);
+          p.add(-beta*omega, v);
+        }
 
       precondition.vmult(y,p);
       A.vmult(v,y);

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -737,12 +737,14 @@ namespace TrilinosWrappers
 
     /**
      * Scaling and multiple addition.
+     *
+     * This function is deprecated.
      */
     void sadd (const TrilinosScalar  s,
                const TrilinosScalar  a,
                const VectorBase     &V,
                const TrilinosScalar  b,
-               const VectorBase     &W);
+               const VectorBase     &W) DEAL_II_DEPRECATED;
 
     /**
      * Scaling and multiple addition.  <tt>*this = s*(*this) + a*V + b*W +
@@ -773,11 +775,13 @@ namespace TrilinosWrappers
 
     /**
      * Assignment <tt>*this = a*V + b*W</tt>.
+     *
+     * This function is deprecated.
      */
     void equ (const TrilinosScalar  a,
               const VectorBase     &V,
               const TrilinosScalar  b,
-              const VectorBase     &W);
+              const VectorBase     &W) DEAL_II_DEPRECATED;
 
     /**
      * Compute the elementwise ratio of the two given vectors, that is let
@@ -1932,45 +1936,6 @@ namespace TrilinosWrappers
         last_action = Zero;
       }
 
-  }
-
-
-
-  inline
-  void
-  VectorBase::equ (const TrilinosScalar  a,
-                   const VectorBase     &v,
-                   const TrilinosScalar  b,
-                   const VectorBase     &w)
-  {
-    // if we have ghost values, do not allow
-    // writing to this vector at all.
-    Assert (!has_ghost_elements(), ExcGhostsPresent());
-    Assert (v.local_size() == w.local_size(),
-            ExcDimensionMismatch (v.local_size(), w.local_size()));
-
-    AssertIsFinite(a);
-    AssertIsFinite(b);
-
-    // If we don't have the same map, copy.
-    if (vector->Map().SameAs(v.vector->Map())==false)
-      {
-        sadd(0., a, v, b, w);
-      }
-    else
-      {
-        // Otherwise, just update. verify
-        // that *this does not only have
-        // the same map as v (the
-        // if-condition above) but also as
-        // w
-        Assert (vector->Map().SameAs(w.vector->Map()),
-                ExcDifferentParallelPartitioning());
-        int ierr = vector->Update(a, *v.vector, b, *w.vector, 0.0);
-        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
-
-        last_action = Zero;
-      }
   }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -707,13 +707,15 @@ public:
   /**
    * Scaling and multiple addition.
    *
+   * This function is deprecated.
+   *
    * @dealiiOperationIsMultithreaded
    */
   void sadd (const Number          s,
              const Number          a,
              const Vector<Number> &V,
              const Number          b,
-             const Vector<Number> &W);
+             const Vector<Number> &W) DEAL_II_DEPRECATED;
 
   /**
    * Scaling and multiple addition.  <tt>*this = s*(*this)+a*V + b*W +
@@ -778,10 +780,12 @@ public:
   /**
    * Assignment <tt>*this = a*u + b*v</tt>.
    *
+   * This function is deprecated.
+   *
    * @dealiiOperationIsMultithreaded
    */
   void equ (const Number a, const Vector<Number> &u,
-            const Number b, const Vector<Number> &v);
+            const Number b, const Vector<Number> &v) DEAL_II_DEPRECATED;
 
   /**
    * Assignment <tt>*this = a*u + b*v + b*w</tt>.


### PR DESCRIPTION
Deprecate the following functions: sadd with 5 arguments and equ with 4 arguments.