### PR TITLE
Add two assertions we had apparently forgotten previously.

### DIFF
--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -547,6 +547,8 @@ namespace parallel
         const double                 bottom_fraction_of_cells,
         const unsigned int           max_n_cells)
       {
+        Assert (criteria.size() == tria.n_active_cells(),
+                ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
         Assert ((top_fraction_of_cells>=0) && (top_fraction_of_cells<=1),
                 dealii::GridRefinement::ExcInvalidParameterValue());
         Assert ((bottom_fraction_of_cells>=0) && (bottom_fraction_of_cells<=1),
@@ -664,6 +666,8 @@ namespace parallel
         const double                top_fraction_of_error,
         const double                bottom_fraction_of_error)
       {
+        Assert (criteria.size() == tria.n_active_cells(),
+                ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
         Assert ((top_fraction_of_error>=0) && (top_fraction_of_error<=1),
                 dealii::GridRefinement::ExcInvalidParameterValue());
         Assert ((bottom_fraction_of_error>=0) && (bottom_fraction_of_error<=1),


### PR DESCRIPTION
The functions refining meshes in parallel get vectors with as many elements
as there are active cells in the triangulation on this processor. Verify
that this so.