### PR TITLE
add detection of Gauss points in FE_DGQArbitraryNodes::get_name()

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -526,6 +526,12 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Improved: FE_DGQArbitraryNodes::get_name() now also detects if
+  the quadrature rule was Gauss points.
+  <br>
+  (Guido Kanschat, 2015/06/22)
+  </li>
+  
   <li> Improved: DoFRenumbering::Cuthill_McKee() can now also
   use starting indices for parallel triangulations.
   <br>

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -811,25 +811,45 @@ FE_DGQArbitraryNodes<dim,spacedim>::get_name () const
       }
 
   if (equidistant == true)
-    namebuf << "FE_DGQ<" << dim << ">(" << this->degree << ")";
-  else
     {
-
-      // Check whether the support points come from QGaussLobatto.
-      const QGaussLobatto<1> points_gl(this->degree+1);
-      bool gauss_lobatto = true;
-      for (unsigned int j=0; j<=this->degree; j++)
-        if (points[j] != points_gl.point(j)(0))
-          {
-            gauss_lobatto = false;
-            break;
-          }
-      if (gauss_lobatto == true)
-        namebuf << "FE_DGQArbitraryNodes<" << dim << ">(QGaussLobatto(" << this->degree+1 << "))";
-      else
-        namebuf << "FE_DGQArbitraryNodes<" << dim << ">(QUnknownNodes(" << this->degree << "))";
+      namebuf << "FE_DGQ<" << dim << ">(" << this->degree << ")";
+      return namebuf.str();
     }
 
+  // Check whether the support points come from QGaussLobatto.
+  const QGaussLobatto<1> points_gl(this->degree+1);
+  bool gauss_lobatto = true;
+  for (unsigned int j=0; j<=this->degree; j++)
+    if (points[j] != points_gl.point(j)(0))
+      {
+        gauss_lobatto = false;
+        break;
+      }
+
+  if (gauss_lobatto == true)
+    {
+      namebuf << "FE_DGQArbitraryNodes<" << dim << ">(QGaussLobatto(" << this->degree+1 << "))";
+      return namebuf.str();
+    }
+
+  // Check whether the support points come from QGauss.
+  const QGauss<1> points_g(this->degree+1);
+  bool gauss = true;
+  for (unsigned int j=0; j<=this->degree; j++)
+    if (points[j] != points_g.point(j)(0))
+      {
+        gauss = false;
+        break;
+      }
+
+  if (gauss == true)
+    {
+      namebuf << "FE_DGQArbitraryNodes<" << dim << ">(QGauss(" << this->degree+1 << "))";
+      return namebuf.str();
+    }
+
+  // All guesses exhausted
+  namebuf << "FE_DGQArbitraryNodes<" << dim << ">(QUnknownNodes(" << this->degree+1 << "))";
   return namebuf.str();
 }
 

--- a/tests/fe/fe_data_test.output
+++ b/tests/fe/fe_data_test.output
@@ -9,7 +9,7 @@ DEAL::FE_DGQ<1>(1)
 DEAL::FE_DGQ<1>(2)
 DEAL::FE_DGQ<1>(4)
 DEAL::FE_DGQArbitraryNodes<1>(QGaussLobatto(5))
-DEAL::FE_DGQArbitraryNodes<1>(QUnknownNodes(2))
+DEAL::FE_DGQArbitraryNodes<1>(QGauss(3))
 DEAL::FE_DGP<1>(1)
 DEAL::FE_DGP<1>(2)
 DEAL::FESystem<1>[FE_Q<1>(2)^2]
@@ -299,7 +299,7 @@ DEAL::face_to_cell_index:
 DEAL::support on face 0:	0
 DEAL::support on face 1:	4
 DEAL::
-DEAL::fe_data[10]:FE_DGQArbitraryNodes<1>(QUnknownNodes(2))
+DEAL::fe_data[10]:FE_DGQArbitraryNodes<1>(QGauss(3))
 DEAL::dofs_per_vertex=0
 DEAL::dofs_per_line=3
 DEAL::dofs_per_quad=0
@@ -795,7 +795,7 @@ DEAL::FE_DGQ<2>(1)
 DEAL::FE_DGQ<2>(2)
 DEAL::FE_DGQ<2>(4)
 DEAL::FE_DGQArbitraryNodes<2>(QGaussLobatto(5))
-DEAL::FE_DGQArbitraryNodes<2>(QUnknownNodes(2))
+DEAL::FE_DGQArbitraryNodes<2>(QGauss(3))
 DEAL::FE_DGP<2>(1)
 DEAL::FE_DGP<2>(2)
 DEAL::FESystem<2>[FE_Q<2>(2)^2]
@@ -1142,7 +1142,7 @@ DEAL::support on face 1:	4	9	14	19	24
 DEAL::support on face 2:	0	1	2	3	4
 DEAL::support on face 3:	20	21	22	23	24
 DEAL::
-DEAL::fe_data[10]:FE_DGQArbitraryNodes<2>(QUnknownNodes(2))
+DEAL::fe_data[10]:FE_DGQArbitraryNodes<2>(QGauss(3))
 DEAL::dofs_per_vertex=0
 DEAL::dofs_per_line=0
 DEAL::dofs_per_quad=9
@@ -2237,7 +2237,7 @@ DEAL::FE_DGQ<3>(1)
 DEAL::FE_DGQ<3>(2)
 DEAL::FE_DGQ<3>(4)
 DEAL::FE_DGQArbitraryNodes<3>(QGaussLobatto(5))
-DEAL::FE_DGQArbitraryNodes<3>(QUnknownNodes(2))
+DEAL::FE_DGQArbitraryNodes<3>(QGauss(3))
 DEAL::FE_DGP<3>(1)
 DEAL::FE_DGP<3>(2)
 DEAL::FESystem<3>[FE_Q<3>(2)^2]
@@ -2617,7 +2617,7 @@ DEAL::support on face 3:	20	21	22	23	24	45	46	47	48	49	70	71	72	73	74	95	96	97	9
 DEAL::support on face 4:	0	1	2	3	4	5	6	7	8	9	10	11	12	13	14	15	16	17	18	19	20	21	22	23	24
 DEAL::support on face 5:	100	101	102	103	104	105	106	107	108	109	110	111	112	113	114	115	116	117	118	119	120	121	122	123	124
 DEAL::
-DEAL::fe_data[10]:FE_DGQArbitraryNodes<3>(QUnknownNodes(2))
+DEAL::fe_data[10]:FE_DGQArbitraryNodes<3>(QGauss(3))
 DEAL::dofs_per_vertex=0
 DEAL::dofs_per_line=0
 DEAL::dofs_per_quad=0

--- a/tests/fe/get_name_01.output
+++ b/tests/fe/get_name_01.output
@@ -1,6 +1,6 @@
 
 DEAL::FE_Q<2>(1)
 DEAL::FE_Q<2>(QGaussLobatto(4))
-DEAL::FE_DGQArbitraryNodes<2>(QUnknownNodes(4))
+DEAL::FE_DGQArbitraryNodes<2>(QGauss(5))
 DEAL::FE_DGQArbitraryNodes<2>(QGaussLobatto(5))
-DEAL::FE_DGQArbitraryNodes<2>(QUnknownNodes(2))
+DEAL::FE_DGQArbitraryNodes<2>(QGauss(3))

--- a/tests/fe/get_name_02.output
+++ b/tests/fe/get_name_02.output
@@ -1,6 +1,6 @@
 
 DEAL::FE_Q<2,3>(1)
 DEAL::FE_Q<2,3>(QGaussLobatto(4))
-DEAL::FE_DGQArbitraryNodes<2>(QUnknownNodes(4))
+DEAL::FE_DGQArbitraryNodes<2>(QGauss(5))
 DEAL::FE_DGQArbitraryNodes<2>(QGaussLobatto(5))
-DEAL::FE_DGQArbitraryNodes<2>(QUnknownNodes(2))
+DEAL::FE_DGQArbitraryNodes<2>(QGauss(3))


### PR DESCRIPTION
The function FE_DGQArbitraryNodes::get_name() did not identify Gauss quadrature and returned the identifier "QUnknownNodes". Now, Gauss quadrature is correctly identified as well.

Additionally, "QUnknownNodes" now also reports the number of nodes, not the polynomial degree for consistency.