### PR TITLE
Fix Functions::Monomial::gradient

### DIFF
--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2146,12 +2146,21 @@ namespace Functions
       {
         double prod = 1;
         for (unsigned int s=0; s<dim; ++s)
-          prod *= (s==d
-                   ?
-                   exponents[s] * std::pow(p[s], exponents[s]-1)
-                   :
-                   std::pow(p[s], exponents[s]));
-
+          {
+            if ((s==d) && (exponents[s] == 0) && (p[s] == 0))
+              {
+                prod = 0;
+                break;
+              }
+            else
+              {
+                prod *= (s==d
+                         ?
+                         exponents[s] * std::pow(p[s], exponents[s]-1)
+                         :
+                         std::pow(p[s], exponents[s]));
+              }
+          }
         r[d] = prod;
       }
 


### PR DESCRIPTION
Fix to Functions::Monomial::gradient to allow the calculation of the gradient when both base and exponent are equal to zero for one or more components of the monomial.