### PR TITLE
Verify that a number is not a NaN before testing for finiteness.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -538,6 +538,14 @@ inconvenience this causes.
   <br>
   (Angel Rodriguez,  2015/06/29)
   </li>
+  
+  <li> Fixed: The function numbers::is_finite() produced incorrect results when
+  called with a NaN number (specifically, it produces an uncatchable floating
+  point exception when called with a signalling NaN). This was clearly not
+  intended since such values are definitely not finite.
+  <br>
+  (Wolfgang Bangerth, 2015/06/29)
+  </li>
 
   <li> Improved: The SparseMatrix class can now also use <code>std::complex</code>
   scalars for its elements.

--- a/source/base/config.cc
+++ b/source/base/config.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2014 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -25,7 +25,7 @@ namespace numbers
   bool is_finite (const double x)
   {
 #ifdef DEAL_II_HAVE_ISFINITE
-    return std::isfinite (x);
+    return !isnan(x) && std::isfinite (x);
 #else
     // Check against infinities. Note
     // that if x is a NaN, then both


### PR DESCRIPTION
While not intuitive, std::isfinite triggers a floating point exception when called
on a signalling NaN. Avoid this.

This addresses #965 in part.