### PR TITLE
Avoid setting boundary objects that don't fit.

### DIFF
--- a/tests/codim_one/transform_01.cc
+++ b/tests/codim_one/transform_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -63,12 +63,10 @@ int main ()
   Triangulation<3> volume_mesh;
   GridGenerator::half_hyper_ball(volume_mesh);
 
-  volume_mesh.set_boundary (1, boundary_description);
   volume_mesh.set_boundary (0, boundary_description);
   volume_mesh.refine_global (3);
 
   static HyperBallBoundary<3-1,3> surface_description;
-  triangulation.set_boundary (1, surface_description);
   triangulation.set_boundary (0, surface_description);
 
   std::set<types::boundary_id> boundary_ids;
@@ -76,7 +74,6 @@ int main ()
 
   GridGenerator::extract_boundary_mesh (volume_mesh, triangulation,
                                     boundary_ids);
-  triangulation.set_boundary (1);
   triangulation.set_boundary (0);
   GridTools::transform (&warp<3>, triangulation);
 


### PR DESCRIPTION
This test set a hyperball boundary for the flat part of a half-hypersphere. This yields a floating point exception because it makes no sense.

This addresses #965 in part.