### PR TITLE
Handle the case of lucky breakdown in GMRES better, without testing whether 1/a is actually finite

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -977,7 +977,7 @@ SolverFGMRES<VECTOR>::solve (
 
       for (unsigned int j=0; j<basis_size; ++j)
         {
-          if (numbers::is_finite(1./a)) // treat lucky breakdown
+          if (a != 0) // treat lucky breakdown
             v(j,x).equ(1./a, *aux);
           else
             v(j,x) = 0.;


### PR DESCRIPTION
This, again, yields a floating point exception in the current state.

Addresses #965.