### PR TITLE
[RFC] Fix trivially copyable cmake test

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -300,6 +300,20 @@ IF(DEFINED DEAL_II_CXX11_FLAG OR DEFINED DEAL_II_CXX14_FLAG
       SET(DEAL_II_HAVE_CXX11 TRUE)
   ENDIF()
 
+  IF(DEAL_II_HAVE_CXX11)
+    #
+    # Some compilers (such as Intel 15.3 and GCC 4.9.2) support the flags
+    # "-std=c++11" and "-std=c++14" but do not support
+    # 'std::is_trivially_copyable', so check for support in C++11 or newer.
+    #
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+    #include <type_traits>
+    int main(){ std::is_trivially_copyable<int> bob; }
+    "
+      DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE)
+  ENDIF()
+
   #
   # This test does not guarantee full C++14 support, but virtually every
   # compiler with some C++14 support implements this.
@@ -389,15 +403,6 @@ IF (DEAL_II_WITH_CXX14)
 ELSEIF(DEAL_II_WITH_CXX11)
   ADD_FLAGS(DEAL_II_CXX_FLAGS "${DEAL_II_CXX_VERSION_FLAG}")
   MESSAGE(STATUS "DEAL_II_WITH_CXX11 successfully set up")
-
-  PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    #include <type_traits>
-    int main(){ std::is_trivially_copyable<int> bob; }
-    "
-    DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE)
-  RESET_CMAKE_REQUIRED()
 ELSE()
   MESSAGE(STATUS "DEAL_II_WITH_CXX14 and DEAL_II_WITH_CXX11 are both disabled")
 ENDIF()

--- a/cmake/configure/configure_1_threads.cmake
+++ b/cmake/configure/configure_1_threads.cmake
@@ -152,7 +152,7 @@ MACRO(FEATURE_THREADS_CONFIGURE_EXTERNAL)
 
   #
   # Workaround for an issue with C++11 mode, non gcc-compilers and missing
-  # template<typename T> std::ist_trivially_copyable<T>
+  # template<typename T> std::is_trivially_copyable<T>
   #
   IF( DEAL_II_WITH_CXX11 AND
       NOT DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE AND
@@ -191,7 +191,7 @@ MACRO(FEATURE_THREADS_CONFIGURE_BUNDLED)
 
   #
   # Workaround for an issue with C++11 mode, non gcc-compilers and missing
-  # template<typename T> std::ist_trivially_copyable<T>
+  # template<typename T> std::is_trivially_copyable<T>
   #
   IF( DEAL_II_WITH_CXX11 AND
       NOT DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE AND


### PR DESCRIPTION
This fixes another mistake I made when moving things around to get C++14 support, <del>but this one might not actually impact anything. When I search for this test, I see</del>

```zsh
[drwells@archway dealii-dev]$ ack -A 4 -B 4 'TRIVIALLY_COPYABLE' 
cmake/checks/check_01_cxx_features.cmake
310-      "
311-    #include <type_traits>
312-    int main(){ std::is_trivially_copyable<int> bob; }
313-    "
314:      DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE)
315-  ENDIF()
316-
317-  #
318-  # This test does not guarantee full C++14 support, but virtually every

cmake/configure/configure_1_threads.cmake
154-  # Workaround for an issue with C++11 mode, non gcc-compilers and missing
155-  # template<typename T> std::is_trivially_copyable<T>
156-  #
157-  IF( DEAL_II_WITH_CXX11 AND
158:      NOT DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE AND
159-      NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
160-    LIST(APPEND THREADS_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
161-    LIST(APPEND THREADS_USER_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
162-  ENDIF()
--
193-  # Workaround for an issue with C++11 mode, non gcc-compilers and missing
194-  # template<typename T> std::is_trivially_copyable<T>
195-  #
196-  IF( DEAL_II_WITH_CXX11 AND
197:      NOT DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE AND
198-      NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU" )
199-    LIST(APPEND THREADS_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
200-    LIST(APPEND THREADS_USER_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
201-  ENDIF()

include/deal.II/base/config.h.in
104- *
105- * For documentation see cmake/checks/check_01_cxx_features.cmake
106- */
107-
108:#cmakedefine DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE
109-#cmakedefine DEAL_II_HAVE_ISNAN
110-#cmakedefine DEAL_II_HAVE_UNDERSCORE_ISNAN
111-#cmakedefine DEAL_II_HAVE_ISFINITE
112-
```

<del>I do not fully understand how `TBB` is configured, but if I search through the repository sources I see</del>

```zsh
[drwells@archway dealii-dev]$ ack 'THREADS[A-Z_]*DEFINITIONS[A-Z_]*'
build/detailed.log
102:#            THREADS_DEFINITIONS = TBB_IMPLEMENT_CPP0X=1
103:#            THREADS_DEFINITIONS_DEBUG = TBB_USE_DEBUG;TBB_DO_ASSERT=1
104:#            THREADS_USER_DEFINITIONS = TBB_IMPLEMENT_CPP0X=1
105:#            THREADS_USER_DEFINITIONS_DEBUG = TBB_USE_DEBUG;TBB_DO_ASSERT=1

cmake/configure/configure_1_threads.cmake
148:      LIST(APPEND THREADS_DEFINITIONS_DEBUG "TBB_USE_DEBUG" "TBB_DO_ASSERT=1")
149:      LIST(APPEND THREADS_USER_DEFINITIONS_DEBUG "TBB_USE_DEBUG" "TBB_DO_ASSERT=1")
160:    LIST(APPEND THREADS_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
161:    LIST(APPEND THREADS_USER_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
188:    LIST(APPEND THREADS_DEFINITIONS_DEBUG "TBB_USE_DEBUG" "TBB_DO_ASSERT=1")
189:    LIST(APPEND THREADS_USER_DEFINITIONS_DEBUG "TBB_USE_DEBUG" "TBB_DO_ASSERT=1")
199:    LIST(APPEND THREADS_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
200:    LIST(APPEND THREADS_USER_DEFINITIONS "TBB_IMPLEMENT_CPP0X=1")
```

<del>Since the only place `DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE` appears is in `THREADS_DEFINITIONS` and its variants, which are never used, should both this test and the `THREAD_DEFINITIONS` variables be removed?</del>

Update: Those settings are definitely used, so this is a bug (that is, `TBB` should not implement C++11 features when they are available in C++14 mode).