### PR TITLE
Add a declared but not implemented function.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -532,6 +532,14 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+  <li> Fixed: The specialization of DoFAccessor for zero-dimensional objects,
+  i.e., for vertices as created by accessing the faces of one-dimensional
+  cells, had a member function DoFAccessor::child() that was declared but not
+  implemented. This is now fixed.
+  <br>
+  (Wolfgang Bangerth,  2015/07/01)
+  </li>
+
   <li> Improved: Functions::Monomial::gradient function now works when both base and exponent
   are equal to zero for one or more components of the monomial.
   Also, an assertion is added to avoid exponentiation of negative base numbers with real exponents.

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -294,7 +294,7 @@ public:
    */
 
   /**
-   * Return an iterator pointing to the the @p c-th child.
+   * Return an iterator pointing to the @p c-th child.
    */
   TriaIterator<DoFAccessor<structdim,DH, level_dof_access> >
   child (const unsigned int c) const;
@@ -798,7 +798,9 @@ public:
    */
 
   /**
-   * Return an iterator pointing to the the @p c-th child.
+   * Return an invalid iterator of a type that represents pointing to a child
+   * of the current object. The object is invalid because points (as represented
+   * by the current class) do not have children.
    */
   TriaIterator<DoFAccessor<0,DH<1,spacedim>, level_dof_access > >
   child (const unsigned int c) const;

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2325,6 +2325,18 @@ DoFAccessor<0,DH<1,spacedim>, level_dof_access>::operator != (const DoFAccessor<
 
 
 
+template <template <int, int> class DH, int spacedim, bool level_dof_access>
+inline
+TriaIterator<DoFAccessor<0,DH<1,spacedim>, level_dof_access > >
+DoFAccessor<0,DH<1,spacedim>, level_dof_access>::child (const unsigned int i) const
+{
+  return TriaIterator<DoFAccessor<0,DH<1,spacedim>, level_dof_access > >();
+}
+
+
+
+
+
 /*------------------------- Functions: DoFCellAccessor -----------------------*/
 
 


### PR DESCRIPTION
This addresses a linker error recently posted to the mailing list. The issue
is that we have iterators that represent faces of cells and a specialization
for the faces of 1d cells, i.e., vertices. These class specializations have
most of the regular accessor members declared, but here is one that was
declared without being defined.

This patch adds a definition of the function. The issue is relatively
uncritical since the so-defined function does not actually have to do
anything other than return an invalid object (vertices have no children).