### PR TITLE
Restructure null_operator

### DIFF
--- a/tests/lac/linear_operator_01.cc
+++ b/tests/lac/linear_operator_01.cc
@@ -232,7 +232,7 @@ int main()
 
   // null operator
 
-  auto test4 = null_operator(test2.reinit_range_vector);
+  auto test4 = null_operator(test2);
   test4.vmult(w, u);
   deallog << " 0 * " << u.value << " = " << w.value << std::endl;
 


### PR DESCRIPTION
This commit restructures the null_operator optimization in LinearOperator
slightly and removes an ambiguous constructor variant.