### PR TITLE
Bugfix: Compile fixes for Functions::Polynomial<dim>

### DIFF
--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -1280,8 +1280,8 @@ namespace Functions
      * $a_{i}\prod_{d=1}^{dim} x_{d}^{\alpha_{i,d}}$. The i-th element of the coefficients
      * vector contains the coefficient $a_{i}$ for the i-th monomial.
      */
-    Polynomial (const Table<2,double> &exponents,
-                const Vector<double>   &coefficients);
+    Polynomial (const Table<2,double>     &exponents,
+                const std::vector<double> &coefficients);
 
     /**
      * Function value at one point.
@@ -1313,7 +1313,7 @@ namespace Functions
     /**
      * The set of coefficients.
      */
-    const Vector<double> coefficients;
+    const std::vector<double> coefficients;
   };
 
 

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2489,8 +2489,8 @@ namespace Functions
 
   template <int dim>
   Polynomial<dim>::
-  Polynomial(const Table<2,double> &exponents,
-             const Vector<double>   &coefficients)
+  Polynomial(const Table<2,double>     &exponents,
+             const std::vector<double> &coefficients)
     :
     Function<dim> (1),
     exponents (exponents),

--- a/tests/base/functions_12.cc
+++ b/tests/base/functions_12.cc
@@ -30,12 +30,11 @@ void check()
     for (unsigned int d = 0; d < dim; ++d)
       exponents[i][d] = i + d;
 
-  Vector<double> coeffs(n_mon);
+  std::vector<double> coeffs(n_mon);
   for (unsigned int i = 0; i < n_mon; ++i)
     coeffs[i] = std::pow(-1,i)*(i+1);
 
-
-  CustomFunctions::Polynomial<dim> poly(exponents,coeffs);
+  Functions::Polynomial<dim> poly(exponents, coeffs);
 
   Point<dim> p;
   for (unsigned int d=0; d<dim; ++d)


### PR DESCRIPTION
Change dealii::Vector to std::vector to not have to include vector.h in
function_lib.h. This fixes a compilation error encountered with several
compilers.

Further, fix the corresponding test