### PR TITLE
Remove warnings due to disabling unknown warnings

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -327,6 +327,17 @@ CHECK_CXX_SOURCE_COMPILES(
   "
   _Pragma(\"GCC diagnostic push\")
   _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wpragmas\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Woverloaded-virtual\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-function\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-parameter\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-variable\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-but-set-parameter\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wnested-anon-types\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-private-field\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wdeprecated-declarations\\\\\\\"\")
+  _Pragma(\"GCC diagnostic warning \\\\\\\"-Wpragmas\\\\\\\"\")
   int main() { return 0; }
   _Pragma(\"GCC diagnostic pop\")
   "

--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -328,16 +328,6 @@ CHECK_CXX_SOURCE_COMPILES(
   _Pragma(\"GCC diagnostic push\")
   _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
   _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wpragmas\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Woverloaded-virtual\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-function\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-parameter\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-variable\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-but-set-parameter\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wnested-anon-types\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunused-private-field\\\\\\\"\")
-  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wdeprecated-declarations\\\\\\\"\")
-  _Pragma(\"GCC diagnostic warning \\\\\\\"-Wpragmas\\\\\\\"\")
   int main() { return 0; }
   _Pragma(\"GCC diagnostic pop\")
   "


### PR DESCRIPTION
On clang 3.4, some of the pragmas in the definition of `DEAL_II_DISABLE_EXTRA_DIAGNOSTICS` are undefined and thus cause a warning themselves. This pull request addresses the issue by testing exactly the pragmas found there during configuration.

Currently,  `DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA` is only used in that definition, such that more refined checks seem unnecessary.