### PR TITLE
Fix font sizes in SVG output

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -547,6 +547,14 @@ inconvenience this causes.
   (Guido Kanschat, 2015/07/05)
   </li>
 
+  <li>Improved: The font scaling in GridOut::write_svg() was broken,
+  since the units were missing. It has been fixed and an additional
+  parameter GridOutFlags::Svg::cell_font_scaling has been introduced
+  for tuning.
+  <br>
+  (Guido Kanschat, 2015/07/04)
+  </li>
+  
   <li>New: GridGenerator::cheese() for a mesh with many holes;
   GridGenerator::simplex() for simplices in 2 and 3 dimensions;
   GridGenerator::hyper_cross() for crosses in 2 and 3 dimensions.

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -664,17 +664,18 @@ namespace GridOutFlags
     /// The factor determining the vertical distance between levels (default = 0.3)
     float level_height_factor;
 
-    /**
-     * Cell labeling (fixed order).
-     *
-     * The following booleans determine which properties of the cell shall be
-     * displayed as text in the middle of each cell.
-     */
-    bool label_level_number;    // default: true
-    bool label_cell_index;      // default: true
-    bool label_material_id;     // default: false
-    bool label_subdomain_id;    // default: false
-    bool label_level_subdomain_id;  // default: false
+    /// Scaling of the font for cell annotations. Defaults to 1.
+    float cell_font_scaling;
+    /// Write level number into each cell. Defaults to true
+    bool label_level_number;
+    /// Write cell index into each cell. Defaults to true
+    bool label_cell_index;
+    /// Write material id of each cell. Defaults to false
+    bool label_material_id;
+    /// Write subdomain id of each cell. Defaults to false
+    bool label_subdomain_id;
+    /// Write level subdomain id of each cell. Defaults to false
+    bool label_level_subdomain_id;
 
     /// Draw a colorbar next to the plotted grid with respect to the chosen coloring of the cells
     bool draw_colorbar;

--- a/tests/grid/grid_out_svg_01.output
+++ b/tests/grid/grid_out_svg_01.output
@@ -24,229 +24,229 @@
  <rect class="background" width="1000" height="1000"/>
   <!-- cells -->
   <path class="p1" d="M 920 500 L 920 290 L 800 358 L 815 500 L 920 500"/>
-  <text x="864" y="412" style="font-size:32">1,0,0</text>
+  <text x="864" y="421" style="font-size:19px">1,0,0</text>
   <line x1="920" y1="500" x2="920" y2="290"/>
   <path class="p1" d="M 920 290 L 920 80 L 784 216 L 800 358 L 920 290"/>
-  <text x="856" y="236" style="font-size:31">1,1,0</text>
+  <text x="856" y="245" style="font-size:19px">1,1,0</text>
   <line x1="920" y1="290" x2="920" y2="80"/>
   <path class="p1" d="M 920 80 L 710 80 L 642 200 L 784 216 L 920 80"/>
-  <text x="764" y="144" style="font-size:31">1,4,0</text>
+  <text x="764" y="154" style="font-size:19px">1,4,0</text>
   <line x1="920" y1="80" x2="710" y2="80"/>
   <path class="p1" d="M 710 80 L 500 80 L 500 185 L 642 200 L 710 80"/>
-  <text x="588" y="136" style="font-size:32">1,5,0</text>
+  <text x="588" y="146" style="font-size:19px">1,5,0</text>
   <line x1="710" y1="80" x2="500" y2="80"/>
   <path class="p1" d="M 500 80 L 290 80 L 358 200 L 500 185 L 500 80"/>
-  <text x="412" y="136" style="font-size:32">1,8,0</text>
+  <text x="412" y="146" style="font-size:19px">1,8,0</text>
   <line x1="500" y1="80" x2="290" y2="80"/>
   <path class="p1" d="M 290 80 L 80 80 L 216 216 L 358 200 L 290 80"/>
-  <text x="236" y="144" style="font-size:31">1,9,0</text>
+  <text x="236" y="154" style="font-size:19px">1,9,0</text>
   <line x1="290" y1="80" x2="80" y2="80"/>
   <path class="p1" d="M 80 80 L 80 290 L 200 358 L 216 216 L 80 80"/>
-  <text x="144" y="236" style="font-size:31">1,12,0</text>
+  <text x="144" y="245" style="font-size:19px">1,12,0</text>
   <line x1="80" y1="80" x2="80" y2="290"/>
   <path class="p1" d="M 80 290 L 80 500 L 185 500 L 200 358 L 80 290"/>
-  <text x="136" y="412" style="font-size:32">1,13,0</text>
+  <text x="136" y="421" style="font-size:19px">1,13,0</text>
   <line x1="80" y1="290" x2="80" y2="500"/>
   <path class="p1" d="M 80 500 L 80 710 L 200 642 L 185 500 L 80 500"/>
-  <text x="136" y="588" style="font-size:32">1,16,0</text>
+  <text x="136" y="598" style="font-size:19px">1,16,0</text>
   <line x1="80" y1="500" x2="80" y2="710"/>
   <path class="p1" d="M 80 710 L 80 920 L 216 784 L 200 642 L 80 710"/>
-  <text x="144" y="764" style="font-size:31">1,17,0</text>
+  <text x="144" y="774" style="font-size:19px">1,17,0</text>
   <line x1="80" y1="710" x2="80" y2="920"/>
   <path class="p1" d="M 80 920 L 290 920 L 358 800 L 216 784 L 80 920"/>
-  <text x="236" y="856" style="font-size:31">1,20,0</text>
+  <text x="236" y="865" style="font-size:19px">1,20,0</text>
   <line x1="80" y1="920" x2="290" y2="920"/>
   <path class="p1" d="M 290 920 L 500 920 L 500 815 L 358 800 L 290 920"/>
-  <text x="412" y="864" style="font-size:32">1,21,0</text>
+  <text x="412" y="873" style="font-size:19px">1,21,0</text>
   <line x1="290" y1="920" x2="500" y2="920"/>
   <path class="p1" d="M 500 920 L 710 920 L 642 800 L 500 815 L 500 920"/>
-  <text x="588" y="864" style="font-size:32">1,24,0</text>
+  <text x="588" y="873" style="font-size:19px">1,24,0</text>
   <line x1="500" y1="920" x2="710" y2="920"/>
   <path class="p1" d="M 710 920 L 920 920 L 784 784 L 642 800 L 710 920"/>
-  <text x="764" y="856" style="font-size:31">1,25,0</text>
+  <text x="764" y="865" style="font-size:19px">1,25,0</text>
   <line x1="710" y1="920" x2="920" y2="920"/>
   <path class="p1" d="M 920 920 L 920 710 L 800 642 L 784 784 L 920 920"/>
-  <text x="856" y="764" style="font-size:31">1,28,0</text>
+  <text x="856" y="774" style="font-size:19px">1,28,0</text>
   <line x1="920" y1="920" x2="920" y2="710"/>
   <path class="p1" d="M 920 710 L 920 500 L 815 500 L 800 642 L 920 710"/>
-  <text x="864" y="588" style="font-size:32">1,29,0</text>
+  <text x="864" y="598" style="font-size:19px">1,29,0</text>
   <line x1="920" y1="710" x2="920" y2="500"/>
   <path class="p2" d="M 815 500 L 807 429 L 751 446 L 763 500 L 815 500"/>
-  <text x="784" y="469" style="font-size:16">2,0,0</text>
+  <text x="784" y="474" style="font-size:10px">2,0,0</text>
   <path class="p2" d="M 807 429 L 800 358 L 739 392 L 751 446 L 807 429"/>
-  <text x="774" y="406" style="font-size:16">2,1,0</text>
+  <text x="774" y="411" style="font-size:10px">2,1,0</text>
   <path class="p2" d="M 763 500 L 751 446 L 695 463 L 710 500 L 763 500"/>
-  <text x="730" y="477" style="font-size:17">2,2,0</text>
+  <text x="730" y="482" style="font-size:10px">2,2,0</text>
   <line x1="710" y1="500" x2="695" y2="463"/>
   <path class="p2" d="M 751 446 L 739 392 L 679 426 L 695 463 L 751 446"/>
-  <text x="716" y="432" style="font-size:17">2,3,0</text>
+  <text x="716" y="437" style="font-size:10px">2,3,0</text>
   <line x1="695" y1="463" x2="679" y2="426"/>
   <path class="p2" d="M 800 358 L 792 287 L 728 338 L 739 392 L 800 358"/>
-  <text x="765" y="344" style="font-size:16">2,4,0</text>
+  <text x="765" y="349" style="font-size:10px">2,4,0</text>
   <path class="p2" d="M 792 287 L 784 216 L 716 284 L 728 338 L 792 287"/>
-  <text x="755" y="281" style="font-size:16">2,5,0</text>
+  <text x="755" y="286" style="font-size:10px">2,5,0</text>
   <path class="p2" d="M 739 392 L 728 338 L 664 389 L 679 426 L 739 392"/>
-  <text x="703" y="386" style="font-size:17">2,6,0</text>
+  <text x="703" y="391" style="font-size:10px">2,6,0</text>
   <line x1="679" y1="426" x2="664" y2="389"/>
   <path class="p2" d="M 728 338 L 716 284 L 648 352 L 664 389 L 728 338"/>
-  <text x="689" y="340" style="font-size:17">2,7,0</text>
+  <text x="689" y="345" style="font-size:10px">2,7,0</text>
   <line x1="664" y1="389" x2="648" y2="352"/>
   <path class="p2" d="M 784 216 L 713 208 L 662 272 L 716 284 L 784 216"/>
-  <text x="719" y="245" style="font-size:16">2,8,0</text>
+  <text x="719" y="250" style="font-size:10px">2,8,0</text>
   <path class="p2" d="M 713 208 L 642 200 L 608 261 L 662 272 L 713 208"/>
-  <text x="656" y="235" style="font-size:16">2,9,0</text>
+  <text x="656" y="240" style="font-size:10px">2,9,0</text>
   <path class="p2" d="M 716 284 L 662 272 L 611 336 L 648 352 L 716 284"/>
-  <text x="660" y="311" style="font-size:17">2,10,0</text>
+  <text x="660" y="316" style="font-size:10px">2,10,0</text>
   <line x1="648" y1="352" x2="611" y2="336"/>
   <path class="p2" d="M 662 272 L 608 261 L 574 321 L 611 336 L 662 272"/>
-  <text x="614" y="297" style="font-size:17">2,11,0</text>
+  <text x="614" y="302" style="font-size:10px">2,11,0</text>
   <line x1="611" y1="336" x2="574" y2="321"/>
   <path class="p2" d="M 642 200 L 571 193 L 554 249 L 608 261 L 642 200"/>
-  <text x="594" y="226" style="font-size:16">2,12,0</text>
+  <text x="594" y="231" style="font-size:10px">2,12,0</text>
   <path class="p2" d="M 571 193 L 500 185 L 500 238 L 554 249 L 571 193"/>
-  <text x="531" y="216" style="font-size:16">2,13,0</text>
+  <text x="531" y="221" style="font-size:10px">2,13,0</text>
   <path class="p2" d="M 608 261 L 554 249 L 537 305 L 574 321 L 608 261"/>
-  <text x="568" y="284" style="font-size:17">2,14,0</text>
+  <text x="568" y="289" style="font-size:10px">2,14,0</text>
   <line x1="574" y1="321" x2="537" y2="305"/>
   <path class="p2" d="M 554 249 L 500 238 L 500 290 L 537 305 L 554 249"/>
-  <text x="523" y="270" style="font-size:17">2,15,0</text>
+  <text x="523" y="275" style="font-size:10px">2,15,0</text>
   <line x1="537" y1="305" x2="500" y2="290"/>
   <path class="p2" d="M 500 185 L 429 193 L 446 249 L 500 238 L 500 185"/>
-  <text x="469" y="216" style="font-size:16">2,16,0</text>
+  <text x="469" y="221" style="font-size:10px">2,16,0</text>
   <path class="p2" d="M 429 193 L 358 200 L 392 261 L 446 249 L 429 193"/>
-  <text x="406" y="226" style="font-size:16">2,17,0</text>
+  <text x="406" y="231" style="font-size:10px">2,17,0</text>
   <path class="p2" d="M 500 238 L 446 249 L 463 305 L 500 290 L 500 238"/>
-  <text x="477" y="270" style="font-size:17">2,18,0</text>
+  <text x="477" y="275" style="font-size:10px">2,18,0</text>
   <line x1="500" y1="290" x2="463" y2="305"/>
   <path class="p2" d="M 446 249 L 392 261 L 426 321 L 463 305 L 446 249"/>
-  <text x="432" y="284" style="font-size:17">2,19,0</text>
+  <text x="432" y="289" style="font-size:10px">2,19,0</text>
   <line x1="463" y1="305" x2="426" y2="321"/>
   <path class="p2" d="M 358 200 L 287 208 L 338 272 L 392 261 L 358 200"/>
-  <text x="344" y="235" style="font-size:16">2,20,0</text>
+  <text x="344" y="240" style="font-size:10px">2,20,0</text>
   <path class="p2" d="M 287 208 L 216 216 L 284 284 L 338 272 L 287 208"/>
-  <text x="281" y="245" style="font-size:16">2,21,0</text>
+  <text x="281" y="250" style="font-size:10px">2,21,0</text>
   <path class="p2" d="M 392 261 L 338 272 L 389 336 L 426 321 L 392 261"/>
-  <text x="386" y="297" style="font-size:17">2,22,0</text>
+  <text x="386" y="302" style="font-size:10px">2,22,0</text>
   <line x1="426" y1="321" x2="389" y2="336"/>
   <path class="p2" d="M 338 272 L 284 284 L 352 352 L 389 336 L 338 272"/>
-  <text x="340" y="311" style="font-size:17">2,23,0</text>
+  <text x="340" y="316" style="font-size:10px">2,23,0</text>
   <line x1="389" y1="336" x2="352" y2="352"/>
   <path class="p2" d="M 216 216 L 208 287 L 272 338 L 284 284 L 216 216"/>
-  <text x="245" y="281" style="font-size:16">2,24,0</text>
+  <text x="245" y="286" style="font-size:10px">2,24,0</text>
   <path class="p2" d="M 208 287 L 200 358 L 261 392 L 272 338 L 208 287"/>
-  <text x="235" y="344" style="font-size:16">2,25,0</text>
+  <text x="235" y="349" style="font-size:10px">2,25,0</text>
   <path class="p2" d="M 284 284 L 272 338 L 336 389 L 352 352 L 284 284"/>
-  <text x="311" y="340" style="font-size:17">2,26,0</text>
+  <text x="311" y="345" style="font-size:10px">2,26,0</text>
   <line x1="352" y1="352" x2="336" y2="389"/>
   <path class="p2" d="M 272 338 L 261 392 L 321 426 L 336 389 L 272 338"/>
-  <text x="297" y="386" style="font-size:17">2,27,0</text>
+  <text x="297" y="391" style="font-size:10px">2,27,0</text>
   <line x1="336" y1="389" x2="321" y2="426"/>
   <path class="p2" d="M 200 358 L 193 429 L 249 446 L 261 392 L 200 358"/>
-  <text x="226" y="406" style="font-size:16">2,28,0</text>
+  <text x="226" y="411" style="font-size:10px">2,28,0</text>
   <path class="p2" d="M 193 429 L 185 500 L 238 500 L 249 446 L 193 429"/>
-  <text x="216" y="469" style="font-size:16">2,29,0</text>
+  <text x="216" y="474" style="font-size:10px">2,29,0</text>
   <path class="p2" d="M 261 392 L 249 446 L 305 463 L 321 426 L 261 392"/>
-  <text x="284" y="432" style="font-size:17">2,30,0</text>
+  <text x="284" y="437" style="font-size:10px">2,30,0</text>
   <line x1="321" y1="426" x2="305" y2="463"/>
   <path class="p2" d="M 249 446 L 238 500 L 290 500 L 305 463 L 249 446"/>
-  <text x="270" y="477" style="font-size:17">2,31,0</text>
+  <text x="270" y="482" style="font-size:10px">2,31,0</text>
   <line x1="305" y1="463" x2="290" y2="500"/>
   <path class="p2" d="M 185 500 L 193 571 L 249 554 L 238 500 L 185 500"/>
-  <text x="216" y="531" style="font-size:16">2,32,0</text>
+  <text x="216" y="536" style="font-size:10px">2,32,0</text>
   <path class="p2" d="M 193 571 L 200 642 L 261 608 L 249 554 L 193 571"/>
-  <text x="226" y="594" style="font-size:16">2,33,0</text>
+  <text x="226" y="599" style="font-size:10px">2,33,0</text>
   <path class="p2" d="M 238 500 L 249 554 L 305 537 L 290 500 L 238 500"/>
-  <text x="270" y="523" style="font-size:17">2,34,0</text>
+  <text x="270" y="528" style="font-size:10px">2,34,0</text>
   <line x1="290" y1="500" x2="305" y2="537"/>
   <path class="p2" d="M 249 554 L 261 608 L 321 574 L 305 537 L 249 554"/>
-  <text x="284" y="568" style="font-size:17">2,35,0</text>
+  <text x="284" y="573" style="font-size:10px">2,35,0</text>
   <line x1="305" y1="537" x2="321" y2="574"/>
   <path class="p2" d="M 200 642 L 208 713 L 272 662 L 261 608 L 200 642"/>
-  <text x="235" y="656" style="font-size:16">2,36,0</text>
+  <text x="235" y="661" style="font-size:10px">2,36,0</text>
   <path class="p2" d="M 208 713 L 216 784 L 284 716 L 272 662 L 208 713"/>
-  <text x="245" y="719" style="font-size:16">2,37,0</text>
+  <text x="245" y="724" style="font-size:10px">2,37,0</text>
   <path class="p2" d="M 261 608 L 272 662 L 336 611 L 321 574 L 261 608"/>
-  <text x="297" y="614" style="font-size:17">2,38,0</text>
+  <text x="297" y="619" style="font-size:10px">2,38,0</text>
   <line x1="321" y1="574" x2="336" y2="611"/>
   <path class="p2" d="M 272 662 L 284 716 L 352 648 L 336 611 L 272 662"/>
-  <text x="311" y="660" style="font-size:17">2,39,0</text>
+  <text x="311" y="665" style="font-size:10px">2,39,0</text>
   <line x1="336" y1="611" x2="352" y2="648"/>
   <path class="p2" d="M 216 784 L 287 792 L 338 728 L 284 716 L 216 784"/>
-  <text x="281" y="755" style="font-size:16">2,40,0</text>
+  <text x="281" y="760" style="font-size:10px">2,40,0</text>
   <path class="p2" d="M 287 792 L 358 800 L 392 739 L 338 728 L 287 792"/>
-  <text x="344" y="765" style="font-size:16">2,41,0</text>
+  <text x="344" y="770" style="font-size:10px">2,41,0</text>
   <path class="p2" d="M 284 716 L 338 728 L 389 664 L 352 648 L 284 716"/>
-  <text x="340" y="689" style="font-size:17">2,42,0</text>
+  <text x="340" y="694" style="font-size:10px">2,42,0</text>
   <line x1="352" y1="648" x2="389" y2="664"/>
   <path class="p2" d="M 338 728 L 392 739 L 426 679 L 389 664 L 338 728"/>
-  <text x="386" y="703" style="font-size:17">2,43,0</text>
+  <text x="386" y="708" style="font-size:10px">2,43,0</text>
   <line x1="389" y1="664" x2="426" y2="679"/>
   <path class="p2" d="M 358 800 L 429 807 L 446 751 L 392 739 L 358 800"/>
-  <text x="406" y="774" style="font-size:16">2,44,0</text>
+  <text x="406" y="779" style="font-size:10px">2,44,0</text>
   <path class="p2" d="M 429 807 L 500 815 L 500 763 L 446 751 L 429 807"/>
-  <text x="469" y="784" style="font-size:16">2,45,0</text>
+  <text x="469" y="789" style="font-size:10px">2,45,0</text>
   <path class="p2" d="M 392 739 L 446 751 L 463 695 L 426 679 L 392 739"/>
-  <text x="432" y="716" style="font-size:17">2,46,0</text>
+  <text x="432" y="721" style="font-size:10px">2,46,0</text>
   <line x1="426" y1="679" x2="463" y2="695"/>
   <path class="p2" d="M 446 751 L 500 763 L 500 710 L 463 695 L 446 751"/>
-  <text x="477" y="730" style="font-size:17">2,47,0</text>
+  <text x="477" y="735" style="font-size:10px">2,47,0</text>
   <line x1="463" y1="695" x2="500" y2="710"/>
   <path class="p2" d="M 500 815 L 571 807 L 554 751 L 500 763 L 500 815"/>
-  <text x="531" y="784" style="font-size:16">2,48,0</text>
+  <text x="531" y="789" style="font-size:10px">2,48,0</text>
   <path class="p2" d="M 571 807 L 642 800 L 608 739 L 554 751 L 571 807"/>
-  <text x="594" y="774" style="font-size:16">2,49,0</text>
+  <text x="594" y="779" style="font-size:10px">2,49,0</text>
   <path class="p2" d="M 500 763 L 554 751 L 537 695 L 500 710 L 500 763"/>
-  <text x="523" y="730" style="font-size:17">2,50,0</text>
+  <text x="523" y="735" style="font-size:10px">2,50,0</text>
   <line x1="500" y1="710" x2="537" y2="695"/>
   <path class="p2" d="M 554 751 L 608 739 L 574 679 L 537 695 L 554 751"/>
-  <text x="568" y="716" style="font-size:17">2,51,0</text>
+  <text x="568" y="721" style="font-size:10px">2,51,0</text>
   <line x1="537" y1="695" x2="574" y2="679"/>
   <path class="p2" d="M 642 800 L 713 792 L 662 728 L 608 739 L 642 800"/>
-  <text x="656" y="765" style="font-size:16">2,52,0</text>
+  <text x="656" y="770" style="font-size:10px">2,52,0</text>
   <path class="p2" d="M 713 792 L 784 784 L 716 716 L 662 728 L 713 792"/>
-  <text x="719" y="755" style="font-size:16">2,53,0</text>
+  <text x="719" y="760" style="font-size:10px">2,53,0</text>
   <path class="p2" d="M 608 739 L 662 728 L 611 664 L 574 679 L 608 739"/>
-  <text x="614" y="703" style="font-size:17">2,54,0</text>
+  <text x="614" y="708" style="font-size:10px">2,54,0</text>
   <line x1="574" y1="679" x2="611" y2="664"/>
   <path class="p2" d="M 662 728 L 716 716 L 648 648 L 611 664 L 662 728"/>
-  <text x="660" y="689" style="font-size:17">2,55,0</text>
+  <text x="660" y="694" style="font-size:10px">2,55,0</text>
   <line x1="611" y1="664" x2="648" y2="648"/>
   <path class="p2" d="M 784 784 L 792 713 L 728 662 L 716 716 L 784 784"/>
-  <text x="755" y="719" style="font-size:16">2,56,0</text>
+  <text x="755" y="724" style="font-size:10px">2,56,0</text>
   <path class="p2" d="M 792 713 L 800 642 L 739 608 L 728 662 L 792 713"/>
-  <text x="765" y="656" style="font-size:16">2,57,0</text>
+  <text x="765" y="661" style="font-size:10px">2,57,0</text>
   <path class="p2" d="M 716 716 L 728 662 L 664 611 L 648 648 L 716 716"/>
-  <text x="689" y="660" style="font-size:17">2,58,0</text>
+  <text x="689" y="665" style="font-size:10px">2,58,0</text>
   <line x1="648" y1="648" x2="664" y2="611"/>
   <path class="p2" d="M 728 662 L 739 608 L 679 574 L 664 611 L 728 662"/>
-  <text x="703" y="614" style="font-size:17">2,59,0</text>
+  <text x="703" y="619" style="font-size:10px">2,59,0</text>
   <line x1="664" y1="611" x2="679" y2="574"/>
   <path class="p2" d="M 800 642 L 807 571 L 751 554 L 739 608 L 800 642"/>
-  <text x="774" y="594" style="font-size:16">2,60,0</text>
+  <text x="774" y="599" style="font-size:10px">2,60,0</text>
   <path class="p2" d="M 807 571 L 815 500 L 763 500 L 751 554 L 807 571"/>
-  <text x="784" y="531" style="font-size:16">2,61,0</text>
+  <text x="784" y="536" style="font-size:10px">2,61,0</text>
   <path class="p2" d="M 739 608 L 751 554 L 695 537 L 679 574 L 739 608"/>
-  <text x="716" y="568" style="font-size:17">2,62,0</text>
+  <text x="716" y="573" style="font-size:10px">2,62,0</text>
   <line x1="679" y1="574" x2="695" y2="537"/>
   <path class="p2" d="M 751 554 L 763 500 L 710 500 L 695 537 L 751 554"/>
-  <text x="730" y="523" style="font-size:17">2,63,0</text>
+  <text x="730" y="528" style="font-size:10px">2,63,0</text>
   <line x1="695" y1="537" x2="710" y2="500"/>
 
  <!-- legend -->
  <rect x="1000" y="80" width="320" height="165"/>
- <text x="1013" y="107" style="text-anchor:start; font-weight:bold; font-size:18">cell label</text>
-  <text x="1020" y="134" style="text-anchor:start; font-style:oblique; font-size:18">level_number,</text>
-  <text x="1020" y="161" style="text-anchor:start; font-style:oblique; font-size:18">cell_index,</text>
-  <text x="1020" y="188" style="text-anchor:start; font-style:oblique; font-size:18">material_id</text>
-  <text x="1000" y="274" style="text-anchor:start; font-size:18">azimuth: 0°, polar: 0°</text>
+ <text x="1013" y="107" style="text-anchor:start; font-weight:bold; font-size:18px">cell label</text>
+  <text x="1020" y="134" style="text-anchor:start; font-style:oblique; font-size:18px">level_number,</text>
+  <text x="1020" y="161" style="text-anchor:start; font-style:oblique; font-size:18px">cell_index,</text>
+  <text x="1020" y="188" style="text-anchor:start; font-style:oblique; font-size:18px">material_id</text>
+  <text x="1000" y="274" style="text-anchor:start; font-size:18px">azimuth: 0°, polar: 0°</text>
 
  <!-- colorbar -->
- <text x="1000" y="356" style="text-anchor:start; font-weight:bold; font-size:18">level_number</text>
+ <text x="1000" y="356" style="text-anchor:start; font-weight:bold; font-size:18px">level_number</text>
   <rect class="r0" x="1000" y="736" width="25" height="183"/>
-  <text x="1037.50" y="833.500" style="text-anchor:start; font-size:18; font-weight:bold">0 min</text>
+  <text x="1037.50" y="833.500" style="text-anchor:start; font-size:18px; font-weight:bold">0 min</text>
   <rect class="r1" x="1000" y="553" width="25" height="183"/>
-  <text x="1037.50" y="650.500" style="text-anchor:start; font-size:18">1</text>
+  <text x="1037.50" y="650.500" style="text-anchor:start; font-size:18px">1</text>
   <rect class="r2" x="1000" y="370" width="25" height="183"/>
-  <text x="1037.50" y="467.500" style="text-anchor:start; font-size:18; font-weight:bold">2 max</text>
+  <text x="1037.50" y="467.500" style="text-anchor:start; font-size:18px; font-weight:bold">2 max</text>
 
 </svg>

--- a/tests/grid/grid_out_svg_02.output
+++ b/tests/grid/grid_out_svg_02.output
@@ -30,3291 +30,3291 @@
  <rect class="background" width="2000" height="1205"/>
   <!-- cells -->
   <path class="ps0" d="M 1616 716 L 1506 462 L 1202 614 L 1308 716 L 1616 716"/>
-  <text x="1410" y="618" style="font-size:64">0,0,0,X,0</text>
+  <text x="1410" y="638" style="font-size:40px">0,0,0,X,0</text>
   <line x1="1616" y1="716" x2="1506" y2="462"/>
   <line x1="1308" y1="716" x2="1202" y2="614"/>
   <path class="ps0" d="M 1506 462 L 1000 462 L 1000 577 L 1202 614 L 1506 462"/>
-  <text x="1181" y="525" style="font-size:54">0,1,0,X,0</text>
+  <text x="1181" y="542" style="font-size:33px">0,1,0,X,0</text>
   <line x1="1506" y1="462" x2="1000" y2="462"/>
   <line x1="1202" y1="614" x2="1000" y2="577"/>
   <path class="ps0" d="M 1000 462 L 494 462 L 798 614 L 1000 577 L 1000 462"/>
-  <text x="819" y="525" style="font-size:54">0,2,0,X,0</text>
+  <text x="819" y="542" style="font-size:33px">0,2,0,X,0</text>
   <line x1="1000" y1="462" x2="494" y2="462"/>
   <line x1="1000" y1="577" x2="798" y2="614"/>
   <path class="ps0" d="M 494 462 L 384 716 L 692 716 L 798 614 L 494 462"/>
-  <text x="590" y="618" style="font-size:64">0,3,0,X,0</text>
+  <text x="590" y="638" style="font-size:40px">0,3,0,X,0</text>
   <line x1="494" y1="462" x2="384" y2="716"/>
   <line x1="798" y1="614" x2="692" y2="716"/>
   <path class="ps0" d="M 384 716 L 214 1109 L 764 833 L 692 716 L 384 716"/>
-  <text x="526" y="828" style="font-size:91">0,4,0,X,0</text>
+  <text x="526" y="856" style="font-size:57px">0,4,0,X,0</text>
   <line x1="384" y1="716" x2="214" y2="1109"/>
   <line x1="692" y1="716" x2="764" y2="833"/>
   <path class="ps0" d="M 214 1109 L 1000 1109 L 1000 888 L 764 833 L 214 1109"/>
-  <text x="753" y="975" style="font-size:113">0,5,0,X,0</text>
+  <text x="753" y="1010" style="font-size:70px">0,5,0,X,0</text>
   <line x1="214" y1="1109" x2="1000" y2="1109"/>
   <line x1="764" y1="833" x2="1000" y2="888"/>
   <path class="ps0" d="M 1000 1109 L 1786 1109 L 1236 833 L 1000 888 L 1000 1109"/>
-  <text x="1247" y="975" style="font-size:113">0,6,0,X,0</text>
+  <text x="1247" y="1010" style="font-size:70px">0,6,0,X,0</text>
   <line x1="1000" y1="1109" x2="1786" y2="1109"/>
   <line x1="1000" y1="888" x2="1236" y2="833"/>
   <path class="ps0" d="M 1786 1109 L 1616 716 L 1308 716 L 1236 833 L 1786 1109"/>
-  <text x="1474" y="828" style="font-size:91">0,7,0,X,0</text>
+  <text x="1474" y="856" style="font-size:57px">0,7,0,X,0</text>
   <line x1="1786" y1="1109" x2="1616" y2="716"/>
   <line x1="1236" y1="833" x2="1308" y2="716"/>
   <path class="ps1" d="M 1632 606 L 1569 475 L 1419 514 L 1474 606 L 1632 606"/>
-  <text x="1523" y="548" style="font-size:35">1,0,0,X,0</text>
+  <text x="1523" y="559" style="font-size:22px">1,0,0,X,0</text>
   <line x1="1632" y1="606" x2="1569" y2="475"/>
   <path class="ps1" d="M 1569 475 L 1517 367 L 1372 435 L 1419 514 L 1569 475"/>
-  <text x="1470" y="445" style="font-size:28">1,1,0,X,0</text>
+  <text x="1470" y="454" style="font-size:18px">1,1,0,X,0</text>
   <line x1="1569" y1="475" x2="1517" y2="367"/>
   <path class="ps1" d="M 1474 606 L 1419 514 L 1260 556 L 1316 606 L 1474 606"/>
-  <text x="1367" y="570" style="font-size:38">1,2,0,X,0</text>
+  <text x="1367" y="582" style="font-size:24px">1,2,0,X,0</text>
   <line x1="1316" y1="606" x2="1260" y2="556"/>
   <path class="ps1" d="M 1419 514 L 1372 435 L 1207 511 L 1260 556 L 1419 514"/>
-  <text x="1316" y="502" style="font-size:33">1,3,0,X,0</text>
+  <text x="1316" y="513" style="font-size:21px">1,3,0,X,0</text>
   <line x1="1260" y1="556" x2="1207" y2="511"/>
   <path class="ps1" d="M 1517 367 L 1259 367 L 1185 427 L 1372 435 L 1517 367"/>
-  <text x="1334" y="398" style="font-size:26">1,4,0,X,0</text>
+  <text x="1334" y="406" style="font-size:16px">1,4,0,X,0</text>
   <line x1="1517" y1="367" x2="1259" y2="367"/>
   <path class="ps1" d="M 1259 367 L 1000 367 L 1000 419 L 1185 427 L 1259 367"/>
-  <text x="1111" y="394" style="font-size:26">1,5,0,X,0</text>
+  <text x="1111" y="402" style="font-size:16px">1,5,0,X,0</text>
   <line x1="1259" y1="367" x2="1000" y2="367"/>
   <path class="ps1" d="M 1372 435 L 1185 427 L 1102 492 L 1207 511 L 1372 435"/>
-  <text x="1218" y="465" style="font-size:31">1,6,0,X,0</text>
+  <text x="1218" y="474" style="font-size:19px">1,6,0,X,0</text>
   <line x1="1207" y1="511" x2="1102" y2="492"/>
   <path class="ps1" d="M 1185 427 L 1000 419 L 1000 475 L 1102 492 L 1185 427"/>
-  <text x="1072" y="452" style="font-size:30">1,7,0,X,0</text>
+  <text x="1072" y="462" style="font-size:19px">1,7,0,X,0</text>
   <line x1="1102" y1="492" x2="1000" y2="475"/>
   <path class="ps1" d="M 1000 367 L 741 367 L 815 427 L 1000 419 L 1000 367"/>
-  <text x="889" y="394" style="font-size:26">1,8,0,X,0</text>
+  <text x="889" y="402" style="font-size:16px">1,8,0,X,0</text>
   <line x1="1000" y1="367" x2="741" y2="367"/>
   <path class="ps1" d="M 741 367 L 483 367 L 628 435 L 815 427 L 741 367"/>
-  <text x="666" y="398" style="font-size:26">1,9,0,X,0</text>
+  <text x="666" y="406" style="font-size:16px">1,9,0,X,0</text>
   <line x1="741" y1="367" x2="483" y2="367"/>
   <path class="ps1" d="M 1000 419 L 815 427 L 898 492 L 1000 475 L 1000 419"/>
-  <text x="928" y="452" style="font-size:30">1,10,0,X,0</text>
+  <text x="928" y="462" style="font-size:19px">1,10,0,X,0</text>
   <line x1="1000" y1="475" x2="898" y2="492"/>
   <path class="ps1" d="M 815 427 L 628 435 L 793 511 L 898 492 L 815 427"/>
-  <text x="782" y="465" style="font-size:31">1,11,0,X,0</text>
+  <text x="782" y="474" style="font-size:19px">1,11,0,X,0</text>
   <line x1="898" y1="492" x2="793" y2="511"/>
   <path class="ps1" d="M 483 367 L 431 475 L 581 514 L 628 435 L 483 367"/>
-  <text x="530" y="445" style="font-size:28">1,12,0,X,0</text>
+  <text x="530" y="454" style="font-size:18px">1,12,0,X,0</text>
   <line x1="483" y1="367" x2="431" y2="475"/>
   <path class="ps1" d="M 431 475 L 368 606 L 526 606 L 581 514 L 431 475"/>
-  <text x="477" y="548" style="font-size:35">1,13,0,X,0</text>
+  <text x="477" y="559" style="font-size:22px">1,13,0,X,0</text>
   <line x1="431" y1="475" x2="368" y2="606"/>
   <path class="ps1" d="M 628 435 L 581 514 L 740 556 L 793 511 L 628 435"/>
-  <text x="684" y="502" style="font-size:33">1,14,0,X,0</text>
+  <text x="684" y="513" style="font-size:21px">1,14,0,X,0</text>
   <line x1="793" y1="511" x2="740" y2="556"/>
   <path class="ps1" d="M 581 514 L 526 606 L 684 606 L 740 556 L 581 514"/>
-  <text x="633" y="570" style="font-size:38">1,15,0,X,0</text>
+  <text x="633" y="582" style="font-size:24px">1,15,0,X,0</text>
   <line x1="740" y1="556" x2="684" y2="606"/>
   <path class="ps1" d="M 368 606 L 289 770 L 513 713 L 526 606 L 368 606"/>
-  <text x="426" y="670" style="font-size:44">1,16,0,X,0</text>
+  <text x="426" y="684" style="font-size:28px">1,16,0,X,0</text>
   <line x1="368" y1="606" x2="289" y2="770"/>
   <path class="ps1" d="M 289 770 L 188 981 L 497 838 L 513 713 L 289 770"/>
-  <text x="377" y="819" style="font-size:55">1,17,0,X,0</text>
+  <text x="377" y="836" style="font-size:34px">1,17,0,X,0</text>
   <line x1="289" y1="770" x2="188" y2="981"/>
   <path class="ps1" d="M 526 606 L 513 713 L 719 660 L 684 606 L 526 606"/>
-  <text x="611" y="645" style="font-size:44">1,18,0,X,0</text>
+  <text x="611" y="658" style="font-size:27px">1,18,0,X,0</text>
   <line x1="684" y1="606" x2="719" y2="660"/>
   <path class="ps1" d="M 513 713 L 497 838 L 758 718 L 719 660 L 513 713"/>
-  <text x="625" y="729" style="font-size:50">1,19,0,X,0</text>
+  <text x="625" y="745" style="font-size:31px">1,19,0,X,0</text>
   <line x1="719" y1="660" x2="758" y2="718"/>
   <path class="ps1" d="M 188 981 L 594 981 L 746 853 L 497 838 L 188 981"/>
-  <text x="511" y="911" style="font-size:63">1,20,0,X,0</text>
+  <text x="511" y="930" style="font-size:39px">1,20,0,X,0</text>
   <line x1="188" y1="981" x2="594" y2="981"/>
   <path class="ps1" d="M 594 981 L 1000 981 L 1000 868 L 746 853 L 594 981"/>
-  <text x="836" y="919" style="font-size:66">1,21,0,X,0</text>
+  <text x="836" y="939" style="font-size:41px">1,21,0,X,0</text>
   <line x1="594" y1="981" x2="1000" y2="981"/>
   <path class="ps1" d="M 497 838 L 746 853 L 877 744 L 758 718 L 497 838"/>
-  <text x="722" y="786" style="font-size:55">1,22,0,X,0</text>
+  <text x="722" y="803" style="font-size:34px">1,22,0,X,0</text>
   <line x1="758" y1="718" x2="877" y2="744"/>
   <path class="ps1" d="M 746 853 L 1000 868 L 1000 770 L 877 744 L 746 853"/>
-  <text x="906" y="807" style="font-size:57">1,23,0,X,0</text>
+  <text x="906" y="825" style="font-size:36px">1,23,0,X,0</text>
   <line x1="877" y1="744" x2="1000" y2="770"/>
   <path class="ps1" d="M 1000 981 L 1406 981 L 1254 853 L 1000 868 L 1000 981"/>
-  <text x="1164" y="919" style="font-size:66">1,24,0,X,0</text>
+  <text x="1164" y="939" style="font-size:41px">1,24,0,X,0</text>
   <line x1="1000" y1="981" x2="1406" y2="981"/>
   <path class="ps1" d="M 1406 981 L 1812 981 L 1503 838 L 1254 853 L 1406 981"/>
-  <text x="1489" y="911" style="font-size:63">1,25,0,X,0</text>
+  <text x="1489" y="930" style="font-size:39px">1,25,0,X,0</text>
   <line x1="1406" y1="981" x2="1812" y2="981"/>
   <path class="ps1" d="M 1000 868 L 1254 853 L 1123 744 L 1000 770 L 1000 868"/>
-  <text x="1094" y="807" style="font-size:57">1,26,0,X,0</text>
+  <text x="1094" y="825" style="font-size:36px">1,26,0,X,0</text>
   <line x1="1000" y1="770" x2="1123" y2="744"/>
   <path class="ps1" d="M 1254 853 L 1503 838 L 1242 718 L 1123 744 L 1254 853"/>
-  <text x="1278" y="786" style="font-size:55">1,27,0,X,0</text>
+  <text x="1278" y="803" style="font-size:34px">1,27,0,X,0</text>
   <line x1="1123" y1="744" x2="1242" y2="718"/>
   <path class="ps1" d="M 1812 981 L 1711 770 L 1487 713 L 1503 838 L 1812 981"/>
-  <text x="1623" y="819" style="font-size:55">1,28,0,X,0</text>
+  <text x="1623" y="836" style="font-size:34px">1,28,0,X,0</text>
   <line x1="1812" y1="981" x2="1711" y2="770"/>
   <path class="ps1" d="M 1711 770 L 1632 606 L 1474 606 L 1487 713 L 1711 770"/>
-  <text x="1574" y="670" style="font-size:44">1,29,0,X,0</text>
+  <text x="1574" y="684" style="font-size:28px">1,29,0,X,0</text>
   <line x1="1711" y1="770" x2="1632" y2="606"/>
   <path class="ps1" d="M 1503 838 L 1487 713 L 1281 660 L 1242 718 L 1503 838"/>
-  <text x="1375" y="729" style="font-size:50">1,30,0,X,0</text>
+  <text x="1375" y="745" style="font-size:31px">1,30,0,X,0</text>
   <line x1="1242" y1="718" x2="1281" y2="660"/>
   <path class="ps1" d="M 1487 713 L 1474 606 L 1316 606 L 1281 660 L 1487 713"/>
-  <text x="1389" y="645" style="font-size:44">1,31,0,X,0</text>
+  <text x="1389" y="658" style="font-size:27px">1,31,0,X,0</text>
   <line x1="1281" y1="660" x2="1316" y2="606"/>
   <path class="ps2" d="M 1486 491 L 1457 446 L 1376 457 L 1405 491 L 1486 491"/>
-  <text x="1431" y="471" style="font-size:21">2,0,0,X,0</text>
+  <text x="1431" y="477" style="font-size:13px">2,0,0,X,0</text>
   <path class="ps2" d="M 1457 446 L 1430 405 L 1349 424 L 1376 457 L 1457 446"/>
-  <text x="1403" y="433" style="font-size:19">2,1,0,X,0</text>
+  <text x="1403" y="439" style="font-size:12px">2,1,0,X,0</text>
   <path class="ps2" d="M 1405 491 L 1376 457 L 1295 467 L 1324 491 L 1405 491"/>
-  <text x="1350" y="476" style="font-size:21">2,2,0,X,0</text>
+  <text x="1350" y="483" style="font-size:13px">2,2,0,X,0</text>
   <line x1="1324" y1="491" x2="1295" y2="467"/>
   <path class="ps2" d="M 1376 457 L 1349 424 L 1266 445 L 1295 467 L 1376 457"/>
-  <text x="1322" y="448" style="font-size:20">2,3,0,X,0</text>
+  <text x="1322" y="454" style="font-size:12px">2,3,0,X,0</text>
   <line x1="1295" y1="467" x2="1266" y2="445"/>
   <path class="ps2" d="M 1430 405 L 1404 367 L 1323 394 L 1349 424 L 1430 405"/>
-  <text x="1377" y="397" style="font-size:17">2,4,0,X,0</text>
+  <text x="1377" y="403" style="font-size:11px">2,4,0,X,0</text>
   <path class="ps2" d="M 1404 367 L 1380 331 L 1299 365 L 1323 394 L 1404 367"/>
-  <text x="1352" y="364" style="font-size:16">2,5,0,X,0</text>
+  <text x="1352" y="369" style="font-size:10px">2,5,0,X,0</text>
   <path class="ps2" d="M 1349 424 L 1323 394 L 1239 423 L 1266 445 L 1349 424"/>
-  <text x="1295" y="421" style="font-size:19">2,6,0,X,0</text>
+  <text x="1295" y="427" style="font-size:12px">2,6,0,X,0</text>
   <line x1="1266" y1="445" x2="1239" y2="423"/>
   <path class="ps2" d="M 1323 394 L 1299 365 L 1212 402 L 1239 423 L 1323 394"/>
-  <text x="1269" y="395" style="font-size:18">2,7,0,X,0</text>
+  <text x="1269" y="401" style="font-size:11px">2,7,0,X,0</text>
   <line x1="1239" y1="423" x2="1212" y2="402"/>
   <path class="ps2" d="M 1380 331 L 1284 327 L 1223 359 L 1299 365 L 1380 331"/>
-  <text x="1297" y="345" style="font-size:15">2,8,0,X,0</text>
+  <text x="1297" y="350" style="font-size:10px">2,8,0,X,0</text>
   <path class="ps2" d="M 1284 327 L 1189 323 L 1148 353 L 1223 359 L 1284 327"/>
-  <text x="1211" y="340" style="font-size:15">2,9,0,X,0</text>
+  <text x="1211" y="345" style="font-size:10px">2,9,0,X,0</text>
   <path class="ps2" d="M 1299 365 L 1223 359 L 1158 393 L 1212 402 L 1299 365"/>
-  <text x="1224" y="379" style="font-size:17">2,10,0,X,0</text>
+  <text x="1224" y="385" style="font-size:11px">2,10,0,X,0</text>
   <line x1="1212" y1="402" x2="1158" y2="393"/>
   <path class="ps2" d="M 1223 359 L 1148 353 L 1104 385 L 1158 393 L 1223 359"/>
-  <text x="1159" y="372" style="font-size:17">2,11,0,X,0</text>
+  <text x="1159" y="378" style="font-size:11px">2,11,0,X,0</text>
   <line x1="1158" y1="393" x2="1104" y2="385"/>
   <path class="ps2" d="M 1189 323 L 1094 320 L 1074 347 L 1148 353 L 1189 323"/>
-  <text x="1126" y="336" style="font-size:15">2,12,0,X,0</text>
+  <text x="1126" y="341" style="font-size:10px">2,12,0,X,0</text>
   <path class="ps2" d="M 1094 320 L 1000 316 L 1000 342 L 1074 347 L 1094 320"/>
-  <text x="1042" y="331" style="font-size:15">2,13,0,X,0</text>
+  <text x="1042" y="335" style="font-size:9px">2,13,0,X,0</text>
   <path class="ps2" d="M 1148 353 L 1074 347 L 1052 376 L 1104 385 L 1148 353"/>
-  <text x="1095" y="365" style="font-size:17">2,14,0,X,0</text>
+  <text x="1095" y="370" style="font-size:10px">2,14,0,X,0</text>
   <line x1="1104" y1="385" x2="1052" y2="376"/>
   <path class="ps2" d="M 1074 347 L 1000 342 L 1000 368 L 1052 376 L 1074 347"/>
-  <text x="1031" y="358" style="font-size:16">2,15,0,X,0</text>
+  <text x="1031" y="363" style="font-size:10px">2,15,0,X,0</text>
   <line x1="1052" y1="376" x2="1000" y2="368"/>
   <path class="ps2" d="M 1000 316 L 906 320 L 926 347 L 1000 342 L 1000 316"/>
-  <text x="958" y="331" style="font-size:15">2,16,0,X,0</text>
+  <text x="958" y="335" style="font-size:9px">2,16,0,X,0</text>
   <path class="ps2" d="M 906 320 L 811 323 L 852 353 L 926 347 L 906 320"/>
-  <text x="874" y="336" style="font-size:15">2,17,0,X,0</text>
+  <text x="874" y="341" style="font-size:10px">2,17,0,X,0</text>
   <path class="ps2" d="M 1000 342 L 926 347 L 948 376 L 1000 368 L 1000 342"/>
-  <text x="969" y="358" style="font-size:16">2,18,0,X,0</text>
+  <text x="969" y="363" style="font-size:10px">2,18,0,X,0</text>
   <line x1="1000" y1="368" x2="948" y2="376"/>
   <path class="ps2" d="M 926 347 L 852 353 L 896 385 L 948 376 L 926 347"/>
-  <text x="905" y="365" style="font-size:17">2,19,0,X,0</text>
+  <text x="905" y="370" style="font-size:10px">2,19,0,X,0</text>
   <line x1="948" y1="376" x2="896" y2="385"/>
   <path class="ps2" d="M 811 323 L 716 327 L 777 359 L 852 353 L 811 323"/>
-  <text x="789" y="340" style="font-size:15">2,20,0,X,0</text>
+  <text x="789" y="345" style="font-size:10px">2,20,0,X,0</text>
   <path class="ps2" d="M 716 327 L 620 331 L 701 365 L 777 359 L 716 327"/>
-  <text x="703" y="345" style="font-size:15">2,21,0,X,0</text>
+  <text x="703" y="350" style="font-size:10px">2,21,0,X,0</text>
   <path class="ps2" d="M 852 353 L 777 359 L 842 393 L 896 385 L 852 353"/>
-  <text x="841" y="372" style="font-size:17">2,22,0,X,0</text>
+  <text x="841" y="378" style="font-size:11px">2,22,0,X,0</text>
   <line x1="896" y1="385" x2="842" y2="393"/>
   <path class="ps2" d="M 777 359 L 701 365 L 788 402 L 842 393 L 777 359"/>
-  <text x="776" y="379" style="font-size:17">2,23,0,X,0</text>
+  <text x="776" y="385" style="font-size:11px">2,23,0,X,0</text>
   <line x1="842" y1="393" x2="788" y2="402"/>
   <path class="ps2" d="M 620 331 L 596 367 L 677 394 L 701 365 L 620 331"/>
-  <text x="648" y="364" style="font-size:16">2,24,0,X,0</text>
+  <text x="648" y="369" style="font-size:10px">2,24,0,X,0</text>
   <path class="ps2" d="M 596 367 L 570 405 L 651 424 L 677 394 L 596 367"/>
-  <text x="623" y="397" style="font-size:17">2,25,0,X,0</text>
+  <text x="623" y="403" style="font-size:11px">2,25,0,X,0</text>
   <path class="ps2" d="M 701 365 L 677 394 L 761 423 L 788 402 L 701 365"/>
-  <text x="731" y="395" style="font-size:18">2,26,0,X,0</text>
+  <text x="731" y="401" style="font-size:11px">2,26,0,X,0</text>
   <line x1="788" y1="402" x2="761" y2="423"/>
   <path class="ps2" d="M 677 394 L 651 424 L 734 445 L 761 423 L 677 394"/>
-  <text x="705" y="421" style="font-size:19">2,27,0,X,0</text>
+  <text x="705" y="427" style="font-size:12px">2,27,0,X,0</text>
   <line x1="761" y1="423" x2="734" y2="445"/>
   <path class="ps2" d="M 570 405 L 543 446 L 624 457 L 651 424 L 570 405"/>
-  <text x="597" y="433" style="font-size:19">2,28,0,X,0</text>
+  <text x="597" y="439" style="font-size:12px">2,28,0,X,0</text>
   <path class="ps2" d="M 543 446 L 514 491 L 595 491 L 624 457 L 543 446"/>
-  <text x="569" y="471" style="font-size:21">2,29,0,X,0</text>
+  <text x="569" y="477" style="font-size:13px">2,29,0,X,0</text>
   <path class="ps2" d="M 651 424 L 624 457 L 705 467 L 734 445 L 651 424"/>
-  <text x="678" y="448" style="font-size:20">2,30,0,X,0</text>
+  <text x="678" y="454" style="font-size:12px">2,30,0,X,0</text>
   <line x1="734" y1="445" x2="705" y2="467"/>
   <path class="ps2" d="M 624 457 L 595 491 L 676 491 L 705 467 L 624 457"/>
-  <text x="650" y="476" style="font-size:21">2,31,0,X,0</text>
+  <text x="650" y="483" style="font-size:13px">2,31,0,X,0</text>
   <line x1="705" y1="467" x2="676" y2="491"/>
   <path class="ps2" d="M 514 491 L 506 539 L 601 527 L 595 491 L 514 491"/>
-  <text x="554" y="512" style="font-size:22">2,32,0,X,0</text>
+  <text x="554" y="519" style="font-size:14px">2,32,0,X,0</text>
   <path class="ps2" d="M 506 539 L 499 591 L 607 566 L 601 527 L 506 539"/>
-  <text x="554" y="555" style="font-size:24">2,33,0,X,0</text>
+  <text x="554" y="563" style="font-size:15px">2,33,0,X,0</text>
   <path class="ps2" d="M 595 491 L 601 527 L 693 516 L 676 491 L 595 491"/>
-  <text x="641" y="506" style="font-size:22">2,34,0,X,0</text>
+  <text x="641" y="513" style="font-size:14px">2,34,0,X,0</text>
   <line x1="676" y1="491" x2="693" y2="516"/>
   <path class="ps2" d="M 601 527 L 607 566 L 712 541 L 693 516 L 601 527"/>
-  <text x="653" y="537" style="font-size:24">2,35,0,X,0</text>
+  <text x="653" y="545" style="font-size:15px">2,35,0,X,0</text>
   <line x1="693" y1="516" x2="712" y2="541"/>
   <path class="ps2" d="M 499 591 L 490 648 L 614 607 L 607 566 L 499 591"/>
-  <text x="553" y="602" style="font-size:26">2,36,0,X,0</text>
+  <text x="553" y="610" style="font-size:16px">2,36,0,X,0</text>
   <path class="ps2" d="M 490 648 L 481 709 L 621 650 L 614 607 L 490 648"/>
-  <text x="553" y="652" style="font-size:28">2,37,0,X,0</text>
+  <text x="553" y="661" style="font-size:18px">2,37,0,X,0</text>
   <path class="ps2" d="M 607 566 L 614 607 L 731 568 L 712 541 L 607 566"/>
-  <text x="666" y="570" style="font-size:25">2,38,0,X,0</text>
+  <text x="666" y="578" style="font-size:16px">2,38,0,X,0</text>
   <line x1="712" y1="541" x2="731" y2="568"/>
   <path class="ps2" d="M 614 607 L 621 650 L 751 596 L 731 568 L 614 607"/>
-  <text x="680" y="605" style="font-size:27">2,39,0,X,0</text>
+  <text x="680" y="613" style="font-size:17px">2,39,0,X,0</text>
   <line x1="731" y1="568" x2="751" y2="596"/>
   <path class="ps2" d="M 481 709 L 609 716 L 714 660 L 621 650 L 481 709"/>
-  <text x="607" y="683" style="font-size:30">2,40,0,X,0</text>
+  <text x="607" y="693" style="font-size:19px">2,40,0,X,0</text>
   <path class="ps2" d="M 609 716 L 738 723 L 808 670 L 714 660 L 609 716"/>
-  <text x="718" y="692" style="font-size:31">2,41,0,X,0</text>
+  <text x="718" y="701" style="font-size:19px">2,41,0,X,0</text>
   <path class="ps2" d="M 621 650 L 714 660 L 811 608 L 751 596 L 621 650"/>
-  <text x="725" y="628" style="font-size:28">2,42,0,X,0</text>
+  <text x="725" y="636" style="font-size:17px">2,42,0,X,0</text>
   <line x1="751" y1="596" x2="811" y2="608"/>
   <path class="ps2" d="M 714 660 L 808 670 L 873 620 L 811 608 L 714 660"/>
-  <text x="802" y="639" style="font-size:29">2,43,0,X,0</text>
+  <text x="802" y="648" style="font-size:18px">2,43,0,X,0</text>
   <line x1="811" y1="608" x2="873" y2="620"/>
   <path class="ps2" d="M 738 723 L 868 731 L 903 680 L 808 670 L 738 723"/>
-  <text x="830" y="700" style="font-size:31">2,44,0,X,0</text>
+  <text x="830" y="710" style="font-size:20px">2,44,0,X,0</text>
   <path class="ps2" d="M 868 731 L 1000 738 L 1000 690 L 903 680 L 868 731"/>
-  <text x="943" y="709" style="font-size:32">2,45,0,X,0</text>
+  <text x="943" y="719" style="font-size:20px">2,45,0,X,0</text>
   <path class="ps2" d="M 808 670 L 903 680 L 936 632 L 873 620 L 808 670"/>
-  <text x="880" y="650" style="font-size:29">2,46,0,X,0</text>
+  <text x="880" y="659" style="font-size:18px">2,46,0,X,0</text>
   <line x1="873" y1="620" x2="936" y2="632"/>
   <path class="ps2" d="M 903 680 L 1000 690 L 1000 645 L 936 632 L 903 680"/>
-  <text x="960" y="661" style="font-size:30">2,47,0,X,0</text>
+  <text x="960" y="671" style="font-size:19px">2,47,0,X,0</text>
   <line x1="936" y1="632" x2="1000" y2="645"/>
   <path class="ps2" d="M 1000 738 L 1132 731 L 1097 680 L 1000 690 L 1000 738"/>
-  <text x="1057" y="709" style="font-size:32">2,48,0,X,0</text>
+  <text x="1057" y="719" style="font-size:20px">2,48,0,X,0</text>
   <path class="ps2" d="M 1132 731 L 1262 723 L 1192 670 L 1097 680 L 1132 731"/>
-  <text x="1170" y="700" style="font-size:31">2,49,0,X,0</text>
+  <text x="1170" y="710" style="font-size:20px">2,49,0,X,0</text>
   <path class="ps2" d="M 1000 690 L 1097 680 L 1064 632 L 1000 645 L 1000 690"/>
-  <text x="1040" y="661" style="font-size:30">2,50,0,X,0</text>
+  <text x="1040" y="671" style="font-size:19px">2,50,0,X,0</text>
   <line x1="1000" y1="645" x2="1064" y2="632"/>
   <path class="ps2" d="M 1097 680 L 1192 670 L 1127 620 L 1064 632 L 1097 680"/>
-  <text x="1120" y="650" style="font-size:29">2,51,0,X,0</text>
+  <text x="1120" y="659" style="font-size:18px">2,51,0,X,0</text>
   <line x1="1064" y1="632" x2="1127" y2="620"/>
   <path class="ps2" d="M 1262 723 L 1391 716 L 1286 660 L 1192 670 L 1262 723"/>
-  <text x="1282" y="692" style="font-size:31">2,52,0,X,0</text>
+  <text x="1282" y="701" style="font-size:19px">2,52,0,X,0</text>
   <path class="ps2" d="M 1391 716 L 1519 709 L 1379 650 L 1286 660 L 1391 716"/>
-  <text x="1393" y="683" style="font-size:30">2,53,0,X,0</text>
+  <text x="1393" y="693" style="font-size:19px">2,53,0,X,0</text>
   <path class="ps2" d="M 1192 670 L 1286 660 L 1189 608 L 1127 620 L 1192 670"/>
-  <text x="1198" y="639" style="font-size:29">2,54,0,X,0</text>
+  <text x="1198" y="648" style="font-size:18px">2,54,0,X,0</text>
   <line x1="1127" y1="620" x2="1189" y2="608"/>
   <path class="ps2" d="M 1286 660 L 1379 650 L 1249 596 L 1189 608 L 1286 660"/>
-  <text x="1275" y="628" style="font-size:28">2,55,0,X,0</text>
+  <text x="1275" y="636" style="font-size:17px">2,55,0,X,0</text>
   <line x1="1189" y1="608" x2="1249" y2="596"/>
   <path class="ps2" d="M 1519 709 L 1510 648 L 1386 607 L 1379 650 L 1519 709"/>
-  <text x="1447" y="652" style="font-size:28">2,56,0,X,0</text>
+  <text x="1447" y="661" style="font-size:18px">2,56,0,X,0</text>
   <path class="ps2" d="M 1510 648 L 1501 591 L 1393 566 L 1386 607 L 1510 648"/>
-  <text x="1447" y="602" style="font-size:26">2,57,0,X,0</text>
+  <text x="1447" y="610" style="font-size:16px">2,57,0,X,0</text>
   <path class="ps2" d="M 1379 650 L 1386 607 L 1269 568 L 1249 596 L 1379 650"/>
-  <text x="1320" y="605" style="font-size:27">2,58,0,X,0</text>
+  <text x="1320" y="613" style="font-size:17px">2,58,0,X,0</text>
   <line x1="1249" y1="596" x2="1269" y2="568"/>
   <path class="ps2" d="M 1386 607 L 1393 566 L 1288 541 L 1269 568 L 1386 607"/>
-  <text x="1334" y="570" style="font-size:25">2,59,0,X,0</text>
+  <text x="1334" y="578" style="font-size:16px">2,59,0,X,0</text>
   <line x1="1269" y1="568" x2="1288" y2="541"/>
   <path class="ps2" d="M 1501 591 L 1494 539 L 1399 527 L 1393 566 L 1501 591"/>
-  <text x="1446" y="555" style="font-size:24">2,60,0,X,0</text>
+  <text x="1446" y="563" style="font-size:15px">2,60,0,X,0</text>
   <path class="ps2" d="M 1494 539 L 1486 491 L 1405 491 L 1399 527 L 1494 539"/>
-  <text x="1446" y="512" style="font-size:22">2,61,0,X,0</text>
+  <text x="1446" y="519" style="font-size:14px">2,61,0,X,0</text>
   <path class="ps2" d="M 1393 566 L 1399 527 L 1307 516 L 1288 541 L 1393 566"/>
-  <text x="1347" y="537" style="font-size:24">2,62,0,X,0</text>
+  <text x="1347" y="545" style="font-size:15px">2,62,0,X,0</text>
   <line x1="1288" y1="541" x2="1307" y2="516"/>
   <path class="ps2" d="M 1399 527 L 1405 491 L 1324 491 L 1307 516 L 1399 527"/>
-  <text x="1359" y="506" style="font-size:22">2,63,0,X,0</text>
+  <text x="1359" y="513" style="font-size:14px">2,63,0,X,0</text>
   <line x1="1307" y1="516" x2="1324" y2="491"/>
   <path class="p2" d="M 1649 491 L 1614 426 L 1536 436 L 1567 491 L 1649 491"/>
-  <text x="1591" y="460" style="font-size:19">2,64,0,0,0</text>
+  <text x="1591" y="466" style="font-size:12px">2,64,0,0,0</text>
   <line x1="1649" y1="491" x2="1614" y2="426"/>
   <path class="p2" d="M 1614 426 L 1582 368 L 1507 386 L 1536 436 L 1614 426"/>
-  <text x="1560" y="404" style="font-size:17">2,65,0,0,0</text>
+  <text x="1560" y="409" style="font-size:11px">2,65,0,0,0</text>
   <line x1="1614" y1="426" x2="1582" y2="368"/>
   <path class="ps2" d="M 1567 491 L 1536 436 L 1457 446 L 1486 491 L 1567 491"/>
-  <text x="1511" y="466" style="font-size:20">2,66,0,X,0</text>
+  <text x="1511" y="472" style="font-size:12px">2,66,0,X,0</text>
   <path class="ps2" d="M 1536 436 L 1507 386 L 1430 405 L 1457 446 L 1536 436"/>
-  <text x="1482" y="418" style="font-size:18">2,67,0,X,0</text>
+  <text x="1482" y="424" style="font-size:11px">2,67,0,X,0</text>
   <path class="p2" d="M 1582 368 L 1554 316 L 1481 341 L 1507 386 L 1582 368"/>
-  <text x="1531" y="352" style="font-size:15">2,68,0,0,0</text>
+  <text x="1531" y="357" style="font-size:9px">2,68,0,0,0</text>
   <line x1="1582" y1="368" x2="1554" y2="316"/>
   <path class="p2" d="M 1554 316 L 1528 269 L 1457 299 L 1481 341 L 1554 316"/>
-  <text x="1505" y="305" style="font-size:13">2,69,0,0,0</text>
+  <text x="1505" y="309" style="font-size:8px">2,69,0,0,0</text>
   <line x1="1554" y1="316" x2="1528" y2="269"/>
   <path class="ps2" d="M 1507 386 L 1481 341 L 1404 367 L 1430 405 L 1507 386"/>
-  <text x="1456" y="374" style="font-size:16">2,70,0,X,0</text>
+  <text x="1456" y="379" style="font-size:10px">2,70,0,X,0</text>
   <path class="p2" d="M 1481 341 L 1457 299 L 1380 331 L 1404 367 L 1481 341"/>
-  <text x="1431" y="334" style="font-size:15">2,71,0,0,0</text>
+  <text x="1431" y="338" style="font-size:9px">2,71,0,0,0</text>
   <path class="p2" d="M 1528 269 L 1396 269 L 1342 297 L 1457 299 L 1528 269"/>
-  <text x="1431" y="283" style="font-size:13">2,72,0,0,0</text>
+  <text x="1431" y="287" style="font-size:8px">2,72,0,0,0</text>
   <line x1="1528" y1="269" x2="1396" y2="269"/>
   <path class="p2" d="M 1396 269 L 1264 269 L 1227 295 L 1342 297 L 1396 269"/>
-  <text x="1308" y="282" style="font-size:13">2,73,0,0,0</text>
+  <text x="1308" y="286" style="font-size:8px">2,73,0,0,0</text>
   <line x1="1396" y1="269" x2="1264" y2="269"/>
   <path class="p2" d="M 1457 299 L 1342 297 L 1284 327 L 1380 331 L 1457 299"/>
-  <text x="1366" y="313" style="font-size:14">2,74,0,0,0</text>
+  <text x="1366" y="318" style="font-size:9px">2,74,0,0,0</text>
   <path class="ps2" d="M 1342 297 L 1227 295 L 1189 323 L 1284 327 L 1342 297"/>
-  <text x="1261" y="310" style="font-size:14">2,75,0,X,0</text>
+  <text x="1261" y="315" style="font-size:9px">2,75,0,X,0</text>
   <path class="p2" d="M 1264 269 L 1132 269 L 1114 293 L 1227 295 L 1264 269"/>
-  <text x="1184" y="281" style="font-size:13">2,76,0,0,0</text>
+  <text x="1184" y="285" style="font-size:8px">2,76,0,0,0</text>
   <line x1="1264" y1="269" x2="1132" y2="269"/>
   <path class="p2" d="M 1132 269 L 1000 269 L 1000 292 L 1114 293 L 1132 269"/>
-  <text x="1061" y="280" style="font-size:13">2,77,0,0,0</text>
+  <text x="1061" y="284" style="font-size:8px">2,77,0,0,0</text>
   <line x1="1132" y1="269" x2="1000" y2="269"/>
   <path class="ps2" d="M 1227 295 L 1114 293 L 1094 320 L 1189 323 L 1227 295"/>
-  <text x="1156" y="308" style="font-size:14">2,78,0,X,0</text>
+  <text x="1156" y="312" style="font-size:9px">2,78,0,X,0</text>
   <path class="ps2" d="M 1114 293 L 1000 292 L 1000 316 L 1094 320 L 1114 293"/>
-  <text x="1052" y="305" style="font-size:14">2,79,0,X,0</text>
+  <text x="1052" y="310" style="font-size:9px">2,79,0,X,0</text>
   <path class="p2" d="M 1000 269 L 868 269 L 886 293 L 1000 292 L 1000 269"/>
-  <text x="939" y="280" style="font-size:13">2,80,0,0,0</text>
+  <text x="939" y="284" style="font-size:8px">2,80,0,0,0</text>
   <line x1="1000" y1="269" x2="868" y2="269"/>
   <path class="p2" d="M 868 269 L 736 269 L 773 295 L 886 293 L 868 269"/>
-  <text x="816" y="281" style="font-size:13">2,81,0,0,0</text>
+  <text x="816" y="285" style="font-size:8px">2,81,0,0,0</text>
   <line x1="868" y1="269" x2="736" y2="269"/>
   <path class="ps2" d="M 1000 292 L 886 293 L 906 320 L 1000 316 L 1000 292"/>
-  <text x="948" y="305" style="font-size:14">2,82,0,X,0</text>
+  <text x="948" y="310" style="font-size:9px">2,82,0,X,0</text>
   <path class="ps2" d="M 886 293 L 773 295 L 811 323 L 906 320 L 886 293"/>
-  <text x="844" y="308" style="font-size:14">2,83,0,X,0</text>
+  <text x="844" y="312" style="font-size:9px">2,83,0,X,0</text>
   <path class="p2" d="M 736 269 L 604 269 L 658 297 L 773 295 L 736 269"/>
-  <text x="692" y="282" style="font-size:13">2,84,0,0,0</text>
+  <text x="692" y="286" style="font-size:8px">2,84,0,0,0</text>
   <line x1="736" y1="269" x2="604" y2="269"/>
   <path class="p2" d="M 604 269 L 472 269 L 543 299 L 658 297 L 604 269"/>
-  <text x="569" y="283" style="font-size:13">2,85,0,0,0</text>
+  <text x="569" y="287" style="font-size:8px">2,85,0,0,0</text>
   <line x1="604" y1="269" x2="472" y2="269"/>
   <path class="ps2" d="M 773 295 L 658 297 L 716 327 L 811 323 L 773 295"/>
-  <text x="739" y="310" style="font-size:14">2,86,0,X,0</text>
+  <text x="739" y="315" style="font-size:9px">2,86,0,X,0</text>
   <path class="p2" d="M 658 297 L 543 299 L 620 331 L 716 327 L 658 297"/>
-  <text x="634" y="313" style="font-size:14">2,87,0,0,0</text>
+  <text x="634" y="318" style="font-size:9px">2,87,0,0,0</text>
   <path class="p2" d="M 472 269 L 446 316 L 519 341 L 543 299 L 472 269"/>
-  <text x="495" y="305" style="font-size:13">2,88,0,0,0</text>
+  <text x="495" y="309" style="font-size:8px">2,88,0,0,0</text>
   <line x1="472" y1="269" x2="446" y2="316"/>
   <path class="p2" d="M 446 316 L 418 368 L 493 386 L 519 341 L 446 316"/>
-  <text x="469" y="352" style="font-size:15">2,89,0,0,0</text>
+  <text x="469" y="357" style="font-size:9px">2,89,0,0,0</text>
   <line x1="446" y1="316" x2="418" y2="368"/>
   <path class="p2" d="M 543 299 L 519 341 L 596 367 L 620 331 L 543 299"/>
-  <text x="569" y="334" style="font-size:15">2,90,0,0,0</text>
+  <text x="569" y="338" style="font-size:9px">2,90,0,0,0</text>
   <path class="ps2" d="M 519 341 L 493 386 L 570 405 L 596 367 L 519 341"/>
-  <text x="544" y="374" style="font-size:16">2,91,0,X,0</text>
+  <text x="544" y="379" style="font-size:10px">2,91,0,X,0</text>
   <path class="p2" d="M 418 368 L 386 426 L 464 436 L 493 386 L 418 368"/>
-  <text x="440" y="404" style="font-size:17">2,92,0,0,0</text>
+  <text x="440" y="409" style="font-size:11px">2,92,0,0,0</text>
   <line x1="418" y1="368" x2="386" y2="426"/>
   <path class="p2" d="M 386 426 L 351 491 L 433 491 L 464 436 L 386 426"/>
-  <text x="409" y="460" style="font-size:19">2,93,0,0,0</text>
+  <text x="409" y="466" style="font-size:12px">2,93,0,0,0</text>
   <line x1="386" y1="426" x2="351" y2="491"/>
   <path class="ps2" d="M 493 386 L 464 436 L 543 446 L 570 405 L 493 386"/>
-  <text x="518" y="418" style="font-size:18">2,94,0,X,0</text>
+  <text x="518" y="424" style="font-size:11px">2,94,0,X,0</text>
   <path class="ps2" d="M 464 436 L 433 491 L 514 491 L 543 446 L 464 436"/>
-  <text x="489" y="466" style="font-size:20">2,95,0,X,0</text>
+  <text x="489" y="472" style="font-size:12px">2,95,0,X,0</text>
   <path class="p2" d="M 351 491 L 312 563 L 410 551 L 433 491 L 351 491"/>
-  <text x="377" y="523" style="font-size:22">2,96,0,0,0</text>
+  <text x="377" y="530" style="font-size:14px">2,96,0,0,0</text>
   <line x1="351" y1="491" x2="312" y2="563"/>
   <path class="p2" d="M 312 563 L 268 645 L 386 617 L 410 551 L 312 563"/>
-  <text x="345" y="593" style="font-size:25">2,97,0,0,0</text>
+  <text x="345" y="601" style="font-size:16px">2,97,0,0,0</text>
   <line x1="312" y1="563" x2="268" y2="645"/>
   <path class="ps2" d="M 433 491 L 410 551 L 506 539 L 514 491 L 433 491"/>
-  <text x="466" y="517" style="font-size:22">2,98,0,X,0</text>
+  <text x="466" y="524" style="font-size:14px">2,98,0,X,0</text>
   <path class="ps2" d="M 410 551 L 386 617 L 499 591 L 506 539 L 410 551"/>
-  <text x="451" y="574" style="font-size:25">2,99,0,X,0</text>
+  <text x="451" y="581" style="font-size:15px">2,99,0,X,0</text>
   <path class="p2" d="M 268 645 L 218 738 L 358 691 L 386 617 L 268 645"/>
-  <text x="309" y="671" style="font-size:28">2,100,0,0,0</text>
+  <text x="309" y="680" style="font-size:17px">2,100,0,0,0</text>
   <line x1="268" y1="645" x2="218" y2="738"/>
   <path class="p2" d="M 218 738 L 160 844 L 328 774 L 358 691 L 218 738"/>
-  <text x="268" y="760" style="font-size:31">2,101,0,0,0</text>
+  <text x="268" y="770" style="font-size:20px">2,101,0,0,0</text>
   <line x1="218" y1="738" x2="160" y2="844"/>
   <path class="ps2" d="M 386 617 L 358 691 L 490 648 L 499 591 L 386 617"/>
-  <text x="434" y="636" style="font-size:27">2,102,0,X,0</text>
+  <text x="434" y="644" style="font-size:17px">2,102,0,X,0</text>
   <path class="p2" d="M 358 691 L 328 774 L 481 709 L 490 648 L 358 691"/>
-  <text x="416" y="704" style="font-size:30">2,103,0,0,0</text>
+  <text x="416" y="714" style="font-size:19px">2,103,0,0,0</text>
   <path class="p2" d="M 160 844 L 370 844 L 495 778 L 328 774 L 160 844"/>
-  <text x="340" y="809" style="font-size:34">2,104,0,0,0</text>
+  <text x="340" y="820" style="font-size:21px">2,104,0,0,0</text>
   <line x1="160" y1="844" x2="370" y2="844"/>
   <path class="p2" d="M 370 844 L 580 844 L 662 782 L 495 778 L 370 844"/>
-  <text x="528" y="811" style="font-size:35">2,105,0,0,0</text>
+  <text x="528" y="822" style="font-size:22px">2,105,0,0,0</text>
   <line x1="370" y1="844" x2="580" y2="844"/>
   <path class="p2" d="M 328 774 L 495 778 L 609 716 L 481 709 L 328 774"/>
-  <text x="479" y="744" style="font-size:32">2,106,0,0,0</text>
+  <text x="479" y="754" style="font-size:20px">2,106,0,0,0</text>
   <path class="ps2" d="M 495 778 L 662 782 L 738 723 L 609 716 L 495 778"/>
-  <text x="627" y="749" style="font-size:33">2,107,0,X,0</text>
+  <text x="627" y="760" style="font-size:21px">2,107,0,X,0</text>
   <path class="p2" d="M 580 844 L 790 844 L 831 785 L 662 782 L 580 844"/>
-  <text x="716" y="813" style="font-size:36">2,108,0,0,0</text>
+  <text x="716" y="824" style="font-size:22px">2,108,0,0,0</text>
   <line x1="580" y1="844" x2="790" y2="844"/>
   <path class="p2" d="M 790 844 L 1000 844 L 1000 789 L 831 785 L 790 844"/>
-  <text x="905" y="815" style="font-size:36">2,109,0,0,0</text>
+  <text x="905" y="827" style="font-size:23px">2,109,0,0,0</text>
   <line x1="790" y1="844" x2="1000" y2="844"/>
   <path class="ps2" d="M 662 782 L 831 785 L 868 731 L 738 723 L 662 782"/>
-  <text x="775" y="755" style="font-size:34">2,110,0,X,0</text>
+  <text x="775" y="765" style="font-size:21px">2,110,0,X,0</text>
   <path class="ps2" d="M 831 785 L 1000 789 L 1000 738 L 868 731 L 831 785"/>
-  <text x="925" y="760" style="font-size:34">2,111,0,X,0</text>
+  <text x="925" y="771" style="font-size:21px">2,111,0,X,0</text>
   <path class="p2" d="M 1000 844 L 1210 844 L 1169 785 L 1000 789 L 1000 844"/>
-  <text x="1095" y="815" style="font-size:36">2,112,0,0,0</text>
+  <text x="1095" y="827" style="font-size:23px">2,112,0,0,0</text>
   <line x1="1000" y1="844" x2="1210" y2="844"/>
   <path class="p2" d="M 1210 844 L 1420 844 L 1338 782 L 1169 785 L 1210 844"/>
-  <text x="1284" y="813" style="font-size:36">2,113,0,0,0</text>
+  <text x="1284" y="824" style="font-size:22px">2,113,0,0,0</text>
   <line x1="1210" y1="844" x2="1420" y2="844"/>
   <path class="ps2" d="M 1000 789 L 1169 785 L 1132 731 L 1000 738 L 1000 789"/>
-  <text x="1075" y="760" style="font-size:34">2,114,0,X,0</text>
+  <text x="1075" y="771" style="font-size:21px">2,114,0,X,0</text>
   <path class="ps2" d="M 1169 785 L 1338 782 L 1262 723 L 1132 731 L 1169 785"/>
-  <text x="1225" y="755" style="font-size:34">2,115,0,X,0</text>
+  <text x="1225" y="765" style="font-size:21px">2,115,0,X,0</text>
   <path class="p2" d="M 1420 844 L 1630 844 L 1505 778 L 1338 782 L 1420 844"/>
-  <text x="1472" y="811" style="font-size:35">2,116,0,0,0</text>
+  <text x="1472" y="822" style="font-size:22px">2,116,0,0,0</text>
   <line x1="1420" y1="844" x2="1630" y2="844"/>
   <path class="p2" d="M 1630 844 L 1840 844 L 1672 774 L 1505 778 L 1630 844"/>
-  <text x="1660" y="809" style="font-size:34">2,117,0,0,0</text>
+  <text x="1660" y="820" style="font-size:21px">2,117,0,0,0</text>
   <line x1="1630" y1="844" x2="1840" y2="844"/>
   <path class="ps2" d="M 1338 782 L 1505 778 L 1391 716 L 1262 723 L 1338 782"/>
-  <text x="1373" y="749" style="font-size:33">2,118,0,X,0</text>
+  <text x="1373" y="760" style="font-size:21px">2,118,0,X,0</text>
   <path class="p2" d="M 1505 778 L 1672 774 L 1519 709 L 1391 716 L 1505 778"/>
-  <text x="1521" y="744" style="font-size:32">2,119,0,0,0</text>
+  <text x="1521" y="754" style="font-size:20px">2,119,0,0,0</text>
   <path class="p2" d="M 1840 844 L 1782 738 L 1642 691 L 1672 774 L 1840 844"/>
-  <text x="1732" y="760" style="font-size:31">2,120,0,0,0</text>
+  <text x="1732" y="770" style="font-size:20px">2,120,0,0,0</text>
   <line x1="1840" y1="844" x2="1782" y2="738"/>
   <path class="p2" d="M 1782 738 L 1732 645 L 1614 617 L 1642 691 L 1782 738"/>
-  <text x="1691" y="671" style="font-size:28">2,121,0,0,0</text>
+  <text x="1691" y="680" style="font-size:17px">2,121,0,0,0</text>
   <line x1="1782" y1="738" x2="1732" y2="645"/>
   <path class="p2" d="M 1672 774 L 1642 691 L 1510 648 L 1519 709 L 1672 774"/>
-  <text x="1584" y="704" style="font-size:30">2,122,0,0,0</text>
+  <text x="1584" y="714" style="font-size:19px">2,122,0,0,0</text>
   <path class="ps2" d="M 1642 691 L 1614 617 L 1501 591 L 1510 648 L 1642 691"/>
-  <text x="1566" y="636" style="font-size:27">2,123,0,X,0</text>
+  <text x="1566" y="644" style="font-size:17px">2,123,0,X,0</text>
   <path class="p2" d="M 1732 645 L 1688 563 L 1590 551 L 1614 617 L 1732 645"/>
-  <text x="1655" y="593" style="font-size:25">2,124,0,0,0</text>
+  <text x="1655" y="601" style="font-size:16px">2,124,0,0,0</text>
   <line x1="1732" y1="645" x2="1688" y2="563"/>
   <path class="p2" d="M 1688 563 L 1649 491 L 1567 491 L 1590 551 L 1688 563"/>
-  <text x="1623" y="523" style="font-size:22">2,125,0,0,0</text>
+  <text x="1623" y="530" style="font-size:14px">2,125,0,0,0</text>
   <line x1="1688" y1="563" x2="1649" y2="491"/>
   <path class="ps2" d="M 1614 617 L 1590 551 L 1494 539 L 1501 591 L 1614 617"/>
-  <text x="1549" y="574" style="font-size:25">2,126,0,X,0</text>
+  <text x="1549" y="581" style="font-size:15px">2,126,0,X,0</text>
   <path class="ps2" d="M 1590 551 L 1567 491 L 1486 491 L 1494 539 L 1590 551"/>
-  <text x="1534" y="517" style="font-size:22">2,127,0,X,0</text>
+  <text x="1534" y="524" style="font-size:14px">2,127,0,X,0</text>
   <path class="ps3" d="M 1500 370 L 1484 349 L 1443 351 L 1458 370 L 1500 370"/>
-  <text x="1471" y="360" style="font-size:11">3,0,0,X,0</text>
+  <text x="1471" y="363" style="font-size:7px">3,0,0,X,0</text>
   <path class="ps3" d="M 1484 349 L 1469 328 L 1428 333 L 1443 351 L 1484 349"/>
-  <text x="1456" y="340" style="font-size:10">3,1,0,X,0</text>
+  <text x="1456" y="344" style="font-size:7px">3,1,0,X,0</text>
   <path class="ps3" d="M 1458 370 L 1443 351 L 1401 354 L 1416 370 L 1458 370"/>
-  <text x="1429" y="361" style="font-size:11">3,2,0,X,0</text>
+  <text x="1429" y="364" style="font-size:7px">3,2,0,X,0</text>
   <path class="ps3" d="M 1443 351 L 1428 333 L 1386 338 L 1401 354 L 1443 351"/>
-  <text x="1414" y="344" style="font-size:11">3,3,0,X,0</text>
+  <text x="1414" y="347" style="font-size:7px">3,3,0,X,0</text>
   <path class="ps3" d="M 1469 328 L 1454 309 L 1413 316 L 1428 333 L 1469 328"/>
-  <text x="1441" y="322" style="font-size:10">3,4,0,X,0</text>
+  <text x="1441" y="325" style="font-size:6px">3,4,0,X,0</text>
   <path class="ps3" d="M 1454 309 L 1440 290 L 1400 299 L 1413 316 L 1454 309"/>
-  <text x="1427" y="304" style="font-size:10">3,5,0,X,0</text>
+  <text x="1427" y="307" style="font-size:6px">3,5,0,X,0</text>
   <path class="ps3" d="M 1428 333 L 1413 316 L 1372 323 L 1386 338 L 1428 333"/>
-  <text x="1400" y="327" style="font-size:10">3,6,0,X,0</text>
+  <text x="1400" y="330" style="font-size:6px">3,6,0,X,0</text>
   <path class="ps3" d="M 1413 316 L 1400 299 L 1358 308 L 1372 323 L 1413 316"/>
-  <text x="1386" y="312" style="font-size:10">3,7,0,X,0</text>
+  <text x="1386" y="315" style="font-size:6px">3,7,0,X,0</text>
   <path class="ps3" d="M 1416 370 L 1401 354 L 1359 356 L 1375 370 L 1416 370"/>
-  <text x="1388" y="362" style="font-size:11">3,8,0,X,0</text>
+  <text x="1388" y="366" style="font-size:7px">3,8,0,X,0</text>
   <path class="ps3" d="M 1401 354 L 1386 338 L 1345 343 L 1359 356 L 1401 354"/>
-  <text x="1373" y="348" style="font-size:11">3,9,0,X,0</text>
+  <text x="1373" y="351" style="font-size:7px">3,9,0,X,0</text>
   <path class="ps3" d="M 1375 370 L 1359 356 L 1318 358 L 1333 370 L 1375 370"/>
-  <text x="1346" y="363" style="font-size:11">3,10,0,X,0</text>
+  <text x="1346" y="367" style="font-size:7px">3,10,0,X,0</text>
   <line x1="1333" y1="370" x2="1318" y2="358"/>
   <path class="ps3" d="M 1359 356 L 1345 343 L 1302 348 L 1318 358 L 1359 356"/>
-  <text x="1331" y="351" style="font-size:11">3,11,0,X,0</text>
+  <text x="1331" y="355" style="font-size:7px">3,11,0,X,0</text>
   <line x1="1318" y1="358" x2="1302" y2="348"/>
   <path class="ps3" d="M 1386 338 L 1372 323 L 1330 330 L 1345 343 L 1386 338"/>
-  <text x="1358" y="333" style="font-size:10">3,12,0,X,0</text>
+  <text x="1358" y="337" style="font-size:7px">3,12,0,X,0</text>
   <path class="ps3" d="M 1372 323 L 1358 308 L 1316 317 L 1330 330 L 1372 323"/>
-  <text x="1344" y="320" style="font-size:10">3,13,0,X,0</text>
+  <text x="1344" y="323" style="font-size:6px">3,13,0,X,0</text>
   <path class="ps3" d="M 1345 343 L 1330 330 L 1288 337 L 1302 348 L 1345 343"/>
-  <text x="1316" y="339" style="font-size:11">3,14,0,X,0</text>
+  <text x="1316" y="343" style="font-size:7px">3,14,0,X,0</text>
   <line x1="1302" y1="348" x2="1288" y2="337"/>
   <path class="ps3" d="M 1330 330 L 1316 317 L 1273 327 L 1288 337 L 1330 330"/>
-  <text x="1302" y="328" style="font-size:10">3,15,0,X,0</text>
+  <text x="1302" y="331" style="font-size:6px">3,15,0,X,0</text>
   <line x1="1288" y1="337" x2="1273" y2="327"/>
   <path class="ps3" d="M 1440 290 L 1427 273 L 1386 283 L 1400 299 L 1440 290"/>
-  <text x="1413" y="286" style="font-size:9">3,16,0,X,0</text>
+  <text x="1413" y="289" style="font-size:6px">3,16,0,X,0</text>
   <path class="ps3" d="M 1427 273 L 1414 255 L 1373 268 L 1386 283 L 1427 273"/>
-  <text x="1400" y="270" style="font-size:9">3,17,0,X,0</text>
+  <text x="1400" y="272" style="font-size:5px">3,17,0,X,0</text>
   <path class="ps3" d="M 1400 299 L 1386 283 L 1345 294 L 1358 308 L 1400 299"/>
-  <text x="1372" y="296" style="font-size:9">3,18,0,X,0</text>
+  <text x="1372" y="299" style="font-size:6px">3,18,0,X,0</text>
   <path class="ps3" d="M 1386 283 L 1373 268 L 1331 280 L 1345 294 L 1386 283"/>
-  <text x="1359" y="281" style="font-size:9">3,19,0,X,0</text>
+  <text x="1359" y="284" style="font-size:6px">3,19,0,X,0</text>
   <path class="p3" d="M 1414 255 L 1401 238 L 1361 252 L 1373 268 L 1414 255"/>
-  <text x="1387" y="253" style="font-size:8">3,20,0,0,0</text>
+  <text x="1387" y="256" style="font-size:5px">3,20,0,0,0</text>
   <path class="p3" d="M 1401 238 L 1389 222 L 1348 238 L 1361 252 L 1401 238"/>
-  <text x="1375" y="238" style="font-size:8">3,21,0,0,0</text>
+  <text x="1375" y="240" style="font-size:5px">3,21,0,0,0</text>
   <path class="ps3" d="M 1373 268 L 1361 252 L 1319 267 L 1331 280 L 1373 268"/>
-  <text x="1346" y="267" style="font-size:9">3,22,0,X,0</text>
+  <text x="1346" y="269" style="font-size:5px">3,22,0,X,0</text>
   <path class="ps3" d="M 1361 252 L 1348 238 L 1306 254 L 1319 267 L 1361 252"/>
-  <text x="1334" y="253" style="font-size:8">3,23,0,X,0</text>
+  <text x="1334" y="255" style="font-size:5px">3,23,0,X,0</text>
   <path class="ps3" d="M 1358 308 L 1345 294 L 1302 305 L 1316 317 L 1358 308"/>
-  <text x="1330" y="306" style="font-size:10">3,24,0,X,0</text>
+  <text x="1330" y="309" style="font-size:6px">3,24,0,X,0</text>
   <path class="ps3" d="M 1345 294 L 1331 280 L 1289 293 L 1302 305 L 1345 294"/>
-  <text x="1317" y="293" style="font-size:9">3,25,0,X,0</text>
+  <text x="1317" y="296" style="font-size:6px">3,25,0,X,0</text>
   <path class="ps3" d="M 1316 317 L 1302 305 L 1259 317 L 1273 327 L 1316 317"/>
-  <text x="1288" y="316" style="font-size:10">3,26,0,X,0</text>
+  <text x="1288" y="319" style="font-size:6px">3,26,0,X,0</text>
   <line x1="1273" y1="327" x2="1259" y2="317"/>
   <path class="ps3" d="M 1302 305 L 1289 293 L 1245 307 L 1259 317 L 1302 305"/>
-  <text x="1274" y="305" style="font-size:10">3,27,0,X,0</text>
+  <text x="1274" y="308" style="font-size:6px">3,27,0,X,0</text>
   <line x1="1259" y1="317" x2="1245" y2="307"/>
   <path class="ps3" d="M 1331 280 L 1319 267 L 1275 282 L 1289 293 L 1331 280"/>
-  <text x="1304" y="280" style="font-size:9">3,28,0,X,0</text>
+  <text x="1304" y="283" style="font-size:6px">3,28,0,X,0</text>
   <path class="ps3" d="M 1319 267 L 1306 254 L 1263 270 L 1275 282 L 1319 267"/>
-  <text x="1291" y="268" style="font-size:9">3,29,0,X,0</text>
+  <text x="1291" y="271" style="font-size:6px">3,29,0,X,0</text>
   <path class="ps3" d="M 1289 293 L 1275 282 L 1231 297 L 1245 307 L 1289 293"/>
-  <text x="1260" y="294" style="font-size:10">3,30,0,X,0</text>
+  <text x="1260" y="297" style="font-size:6px">3,30,0,X,0</text>
   <line x1="1245" y1="307" x2="1231" y2="297"/>
   <path class="ps3" d="M 1275 282 L 1263 270 L 1218 287 L 1231 297 L 1275 282"/>
-  <text x="1247" y="284" style="font-size:9">3,31,0,X,0</text>
+  <text x="1247" y="287" style="font-size:6px">3,31,0,X,0</text>
   <line x1="1231" y1="297" x2="1218" y2="287"/>
   <path class="p3" d="M 1389 222 L 1340 221 L 1304 236 L 1348 238 L 1389 222"/>
-  <text x="1346" y="229" style="font-size:8">3,32,0,0,0</text>
+  <text x="1346" y="231" style="font-size:5px">3,32,0,0,0</text>
   <path class="p3" d="M 1340 221 L 1291 219 L 1260 233 L 1304 236 L 1340 221"/>
-  <text x="1299" y="227" style="font-size:8">3,33,0,0,0</text>
+  <text x="1299" y="230" style="font-size:5px">3,33,0,0,0</text>
   <path class="ps3" d="M 1348 238 L 1304 236 L 1267 251 L 1306 254 L 1348 238"/>
-  <text x="1307" y="244" style="font-size:8">3,34,0,X,0</text>
+  <text x="1307" y="247" style="font-size:5px">3,34,0,X,0</text>
   <path class="ps3" d="M 1304 236 L 1260 233 L 1228 248 L 1267 251 L 1304 236"/>
-  <text x="1265" y="242" style="font-size:8">3,35,0,X,0</text>
+  <text x="1265" y="244" style="font-size:5px">3,35,0,X,0</text>
   <path class="ps3" d="M 1291 219 L 1242 217 L 1216 231 L 1260 233 L 1291 219"/>
-  <text x="1252" y="225" style="font-size:8">3,36,0,X,0</text>
+  <text x="1252" y="228" style="font-size:5px">3,36,0,X,0</text>
   <path class="ps3" d="M 1242 217 L 1193 215 L 1173 229 L 1216 231 L 1242 217"/>
-  <text x="1206" y="223" style="font-size:8">3,37,0,X,0</text>
+  <text x="1206" y="226" style="font-size:5px">3,37,0,X,0</text>
   <path class="ps3" d="M 1260 233 L 1216 231 L 1190 245 L 1228 248 L 1260 233"/>
-  <text x="1224" y="239" style="font-size:8">3,38,0,X,0</text>
+  <text x="1224" y="242" style="font-size:5px">3,38,0,X,0</text>
   <path class="ps3" d="M 1216 231 L 1173 229 L 1151 243 L 1190 245 L 1216 231"/>
-  <text x="1183" y="237" style="font-size:8">3,39,0,X,0</text>
+  <text x="1183" y="240" style="font-size:5px">3,39,0,X,0</text>
   <path class="ps3" d="M 1306 254 L 1267 251 L 1229 267 L 1263 270 L 1306 254"/>
-  <text x="1266" y="260" style="font-size:9">3,40,0,X,0</text>
+  <text x="1266" y="263" style="font-size:5px">3,40,0,X,0</text>
   <path class="ps3" d="M 1267 251 L 1228 248 L 1196 264 L 1229 267 L 1267 251"/>
-  <text x="1230" y="257" style="font-size:9">3,41,0,X,0</text>
+  <text x="1230" y="260" style="font-size:5px">3,41,0,X,0</text>
   <path class="ps3" d="M 1263 270 L 1229 267 L 1190 283 L 1218 287 L 1263 270"/>
-  <text x="1225" y="277" style="font-size:9">3,42,0,X,0</text>
+  <text x="1225" y="280" style="font-size:6px">3,42,0,X,0</text>
   <line x1="1218" y1="287" x2="1190" y2="283"/>
   <path class="ps3" d="M 1229 267 L 1196 264 L 1162 279 L 1190 283 L 1229 267"/>
-  <text x="1194" y="273" style="font-size:9">3,43,0,X,0</text>
+  <text x="1194" y="276" style="font-size:6px">3,43,0,X,0</text>
   <line x1="1190" y1="283" x2="1162" y2="279"/>
   <path class="ps3" d="M 1228 248 L 1190 245 L 1162 260 L 1196 264 L 1228 248"/>
-  <text x="1194" y="254" style="font-size:9">3,44,0,X,0</text>
+  <text x="1194" y="257" style="font-size:5px">3,44,0,X,0</text>
   <path class="ps3" d="M 1190 245 L 1151 243 L 1130 257 L 1162 260 L 1190 245"/>
-  <text x="1158" y="251" style="font-size:9">3,45,0,X,0</text>
+  <text x="1158" y="254" style="font-size:5px">3,45,0,X,0</text>
   <path class="ps3" d="M 1196 264 L 1162 260 L 1134 276 L 1162 279 L 1196 264"/>
-  <text x="1164" y="270" style="font-size:9">3,46,0,X,0</text>
+  <text x="1164" y="273" style="font-size:6px">3,46,0,X,0</text>
   <line x1="1162" y1="279" x2="1134" y2="276"/>
   <path class="ps3" d="M 1162 260 L 1130 257 L 1107 272 L 1134 276 L 1162 260"/>
-  <text x="1133" y="266" style="font-size:9">3,47,0,X,0</text>
+  <text x="1133" y="269" style="font-size:6px">3,47,0,X,0</text>
   <line x1="1134" y1="276" x2="1107" y2="272"/>
   <path class="ps3" d="M 1193 215 L 1145 214 L 1129 227 L 1173 229 L 1193 215"/>
-  <text x="1160" y="221" style="font-size:8">3,48,0,X,0</text>
+  <text x="1160" y="224" style="font-size:5px">3,48,0,X,0</text>
   <path class="ps3" d="M 1145 214 L 1096 212 L 1086 225 L 1129 227 L 1145 214"/>
-  <text x="1114" y="219" style="font-size:8">3,49,0,X,0</text>
+  <text x="1114" y="222" style="font-size:5px">3,49,0,X,0</text>
   <path class="ps3" d="M 1173 229 L 1129 227 L 1113 240 L 1151 243 L 1173 229"/>
-  <text x="1142" y="235" style="font-size:8">3,50,0,X,0</text>
+  <text x="1142" y="237" style="font-size:5px">3,50,0,X,0</text>
   <path class="ps3" d="M 1129 227 L 1086 225 L 1075 237 L 1113 240 L 1129 227"/>
-  <text x="1101" y="232" style="font-size:8">3,51,0,X,0</text>
+  <text x="1101" y="235" style="font-size:5px">3,51,0,X,0</text>
   <path class="ps3" d="M 1096 212 L 1048 210 L 1043 222 L 1086 225 L 1096 212"/>
-  <text x="1068" y="217" style="font-size:8">3,52,0,X,0</text>
+  <text x="1068" y="220" style="font-size:5px">3,52,0,X,0</text>
   <path class="ps3" d="M 1048 210 L 1000 209 L 1000 220 L 1043 222 L 1048 210"/>
-  <text x="1023" y="215" style="font-size:8">3,53,0,X,0</text>
+  <text x="1023" y="218" style="font-size:5px">3,53,0,X,0</text>
   <path class="ps3" d="M 1086 225 L 1043 222 L 1038 235 L 1075 237 L 1086 225"/>
-  <text x="1060" y="230" style="font-size:8">3,54,0,X,0</text>
+  <text x="1060" y="232" style="font-size:5px">3,54,0,X,0</text>
   <path class="ps3" d="M 1043 222 L 1000 220 L 1000 232 L 1038 235 L 1043 222"/>
-  <text x="1020" y="227" style="font-size:8">3,55,0,X,0</text>
+  <text x="1020" y="230" style="font-size:5px">3,55,0,X,0</text>
   <path class="ps3" d="M 1151 243 L 1113 240 L 1097 254 L 1130 257 L 1151 243"/>
-  <text x="1123" y="248" style="font-size:9">3,56,0,X,0</text>
+  <text x="1123" y="251" style="font-size:5px">3,56,0,X,0</text>
   <path class="ps3" d="M 1113 240 L 1075 237 L 1064 251 L 1097 254 L 1113 240"/>
-  <text x="1087" y="245" style="font-size:8">3,57,0,X,0</text>
+  <text x="1087" y="248" style="font-size:5px">3,57,0,X,0</text>
   <path class="ps3" d="M 1130 257 L 1097 254 L 1080 268 L 1107 272 L 1130 257"/>
-  <text x="1103" y="263" style="font-size:9">3,58,0,X,0</text>
+  <text x="1103" y="266" style="font-size:6px">3,58,0,X,0</text>
   <line x1="1107" y1="272" x2="1080" y2="268"/>
   <path class="ps3" d="M 1097 254 L 1064 251 L 1053 264 L 1080 268 L 1097 254"/>
-  <text x="1074" y="259" style="font-size:9">3,59,0,X,0</text>
+  <text x="1074" y="262" style="font-size:5px">3,59,0,X,0</text>
   <line x1="1080" y1="268" x2="1053" y2="264"/>
   <path class="ps3" d="M 1075 237 L 1038 235 L 1032 247 L 1064 251 L 1075 237"/>
-  <text x="1052" y="243" style="font-size:8">3,60,0,X,0</text>
+  <text x="1052" y="245" style="font-size:5px">3,60,0,X,0</text>
   <path class="ps3" d="M 1038 235 L 1000 232 L 1000 244 L 1032 247 L 1038 235"/>
-  <text x="1017" y="240" style="font-size:8">3,61,0,X,0</text>
+  <text x="1017" y="242" style="font-size:5px">3,61,0,X,0</text>
   <path class="ps3" d="M 1064 251 L 1032 247 L 1026 260 L 1053 264 L 1064 251"/>
-  <text x="1044" y="256" style="font-size:9">3,62,0,X,0</text>
+  <text x="1044" y="258" style="font-size:5px">3,62,0,X,0</text>
   <line x1="1053" y1="264" x2="1026" y2="260"/>
   <path class="ps3" d="M 1032 247 L 1000 244 L 1000 257 L 1026 260 L 1032 247"/>
-  <text x="1015" y="252" style="font-size:9">3,63,0,X,0</text>
+  <text x="1015" y="255" style="font-size:5px">3,63,0,X,0</text>
   <line x1="1026" y1="260" x2="1000" y2="257"/>
   <path class="ps3" d="M 1000 209 L 952 210 L 957 222 L 1000 220 L 1000 209"/>
-  <text x="977" y="215" style="font-size:8">3,64,0,X,0</text>
+  <text x="977" y="218" style="font-size:5px">3,64,0,X,0</text>
   <path class="ps3" d="M 952 210 L 904 212 L 914 225 L 957 222 L 952 210"/>
-  <text x="932" y="217" style="font-size:8">3,65,0,X,0</text>
+  <text x="932" y="220" style="font-size:5px">3,65,0,X,0</text>
   <path class="ps3" d="M 1000 220 L 957 222 L 962 235 L 1000 232 L 1000 220"/>
-  <text x="980" y="227" style="font-size:8">3,66,0,X,0</text>
+  <text x="980" y="230" style="font-size:5px">3,66,0,X,0</text>
   <path class="ps3" d="M 957 222 L 914 225 L 925 237 L 962 235 L 957 222"/>
-  <text x="940" y="230" style="font-size:8">3,67,0,X,0</text>
+  <text x="940" y="232" style="font-size:5px">3,67,0,X,0</text>
   <path class="ps3" d="M 904 212 L 855 214 L 871 227 L 914 225 L 904 212"/>
-  <text x="886" y="219" style="font-size:8">3,68,0,X,0</text>
+  <text x="886" y="222" style="font-size:5px">3,68,0,X,0</text>
   <path class="ps3" d="M 855 214 L 807 215 L 827 229 L 871 227 L 855 214"/>
-  <text x="840" y="221" style="font-size:8">3,69,0,X,0</text>
+  <text x="840" y="224" style="font-size:5px">3,69,0,X,0</text>
   <path class="ps3" d="M 914 225 L 871 227 L 887 240 L 925 237 L 914 225"/>
-  <text x="899" y="232" style="font-size:8">3,70,0,X,0</text>
+  <text x="899" y="235" style="font-size:5px">3,70,0,X,0</text>
   <path class="ps3" d="M 871 227 L 827 229 L 849 243 L 887 240 L 871 227"/>
-  <text x="858" y="235" style="font-size:8">3,71,0,X,0</text>
+  <text x="858" y="237" style="font-size:5px">3,71,0,X,0</text>
   <path class="ps3" d="M 1000 232 L 962 235 L 968 247 L 1000 244 L 1000 232"/>
-  <text x="983" y="240" style="font-size:8">3,72,0,X,0</text>
+  <text x="983" y="242" style="font-size:5px">3,72,0,X,0</text>
   <path class="ps3" d="M 962 235 L 925 237 L 936 251 L 968 247 L 962 235"/>
-  <text x="948" y="243" style="font-size:8">3,73,0,X,0</text>
+  <text x="948" y="245" style="font-size:5px">3,73,0,X,0</text>
   <path class="ps3" d="M 1000 244 L 968 247 L 974 260 L 1000 257 L 1000 244"/>
-  <text x="985" y="252" style="font-size:9">3,74,0,X,0</text>
+  <text x="985" y="255" style="font-size:5px">3,74,0,X,0</text>
   <line x1="1000" y1="257" x2="974" y2="260"/>
   <path class="ps3" d="M 968 247 L 936 251 L 947 264 L 974 260 L 968 247"/>
-  <text x="956" y="256" style="font-size:9">3,75,0,X,0</text>
+  <text x="956" y="258" style="font-size:5px">3,75,0,X,0</text>
   <line x1="974" y1="260" x2="947" y2="264"/>
   <path class="ps3" d="M 925 237 L 887 240 L 903 254 L 936 251 L 925 237"/>
-  <text x="913" y="245" style="font-size:8">3,76,0,X,0</text>
+  <text x="913" y="248" style="font-size:5px">3,76,0,X,0</text>
   <path class="ps3" d="M 887 240 L 849 243 L 870 257 L 903 254 L 887 240"/>
-  <text x="877" y="248" style="font-size:9">3,77,0,X,0</text>
+  <text x="877" y="251" style="font-size:5px">3,77,0,X,0</text>
   <path class="ps3" d="M 936 251 L 903 254 L 920 268 L 947 264 L 936 251"/>
-  <text x="926" y="259" style="font-size:9">3,78,0,X,0</text>
+  <text x="926" y="262" style="font-size:5px">3,78,0,X,0</text>
   <line x1="947" y1="264" x2="920" y2="268"/>
   <path class="ps3" d="M 903 254 L 870 257 L 893 272 L 920 268 L 903 254"/>
-  <text x="897" y="263" style="font-size:9">3,79,0,X,0</text>
+  <text x="897" y="266" style="font-size:6px">3,79,0,X,0</text>
   <line x1="920" y1="268" x2="893" y2="272"/>
   <path class="ps3" d="M 807 215 L 758 217 L 784 231 L 827 229 L 807 215"/>
-  <text x="794" y="223" style="font-size:8">3,80,0,X,0</text>
+  <text x="794" y="226" style="font-size:5px">3,80,0,X,0</text>
   <path class="ps3" d="M 758 217 L 709 219 L 740 233 L 784 231 L 758 217"/>
-  <text x="748" y="225" style="font-size:8">3,81,0,X,0</text>
+  <text x="748" y="228" style="font-size:5px">3,81,0,X,0</text>
   <path class="ps3" d="M 827 229 L 784 231 L 810 245 L 849 243 L 827 229"/>
-  <text x="817" y="237" style="font-size:8">3,82,0,X,0</text>
+  <text x="817" y="240" style="font-size:5px">3,82,0,X,0</text>
   <path class="ps3" d="M 784 231 L 740 233 L 772 248 L 810 245 L 784 231"/>
-  <text x="776" y="239" style="font-size:8">3,83,0,X,0</text>
+  <text x="776" y="242" style="font-size:5px">3,83,0,X,0</text>
   <path class="p3" d="M 709 219 L 660 221 L 696 236 L 740 233 L 709 219"/>
-  <text x="701" y="227" style="font-size:8">3,84,0,0,0</text>
+  <text x="701" y="230" style="font-size:5px">3,84,0,0,0</text>
   <path class="p3" d="M 660 221 L 611 222 L 652 238 L 696 236 L 660 221"/>
-  <text x="654" y="229" style="font-size:8">3,85,0,0,0</text>
+  <text x="654" y="231" style="font-size:5px">3,85,0,0,0</text>
   <path class="ps3" d="M 740 233 L 696 236 L 733 251 L 772 248 L 740 233"/>
-  <text x="735" y="242" style="font-size:8">3,86,0,X,0</text>
+  <text x="735" y="244" style="font-size:5px">3,86,0,X,0</text>
   <path class="ps3" d="M 696 236 L 652 238 L 694 254 L 733 251 L 696 236"/>
-  <text x="693" y="244" style="font-size:8">3,87,0,X,0</text>
+  <text x="693" y="247" style="font-size:5px">3,87,0,X,0</text>
   <path class="ps3" d="M 849 243 L 810 245 L 838 260 L 870 257 L 849 243"/>
-  <text x="842" y="251" style="font-size:9">3,88,0,X,0</text>
+  <text x="842" y="254" style="font-size:5px">3,88,0,X,0</text>
   <path class="ps3" d="M 810 245 L 772 248 L 804 264 L 838 260 L 810 245"/>
-  <text x="806" y="254" style="font-size:9">3,89,0,X,0</text>
+  <text x="806" y="257" style="font-size:5px">3,89,0,X,0</text>
   <path class="ps3" d="M 870 257 L 838 260 L 866 276 L 893 272 L 870 257"/>
-  <text x="867" y="266" style="font-size:9">3,90,0,X,0</text>
+  <text x="867" y="269" style="font-size:6px">3,90,0,X,0</text>
   <line x1="893" y1="272" x2="866" y2="276"/>
   <path class="ps3" d="M 838 260 L 804 264 L 838 279 L 866 276 L 838 260"/>
-  <text x="836" y="270" style="font-size:9">3,91,0,X,0</text>
+  <text x="836" y="273" style="font-size:6px">3,91,0,X,0</text>
   <line x1="866" y1="276" x2="838" y2="279"/>
   <path class="ps3" d="M 772 248 L 733 251 L 771 267 L 804 264 L 772 248"/>
-  <text x="770" y="257" style="font-size:9">3,92,0,X,0</text>
+  <text x="770" y="260" style="font-size:5px">3,92,0,X,0</text>
   <path class="ps3" d="M 733 251 L 694 254 L 737 270 L 771 267 L 733 251"/>
-  <text x="734" y="260" style="font-size:9">3,93,0,X,0</text>
+  <text x="734" y="263" style="font-size:5px">3,93,0,X,0</text>
   <path class="ps3" d="M 804 264 L 771 267 L 810 283 L 838 279 L 804 264"/>
-  <text x="806" y="273" style="font-size:9">3,94,0,X,0</text>
+  <text x="806" y="276" style="font-size:6px">3,94,0,X,0</text>
   <line x1="838" y1="279" x2="810" y2="283"/>
   <path class="ps3" d="M 771 267 L 737 270 L 782 287 L 810 283 L 771 267"/>
-  <text x="775" y="277" style="font-size:9">3,95,0,X,0</text>
+  <text x="775" y="280" style="font-size:6px">3,95,0,X,0</text>
   <line x1="810" y1="283" x2="782" y2="287"/>
   <path class="p3" d="M 611 222 L 599 238 L 639 252 L 652 238 L 611 222"/>
-  <text x="625" y="238" style="font-size:8">3,96,0,0,0</text>
+  <text x="625" y="240" style="font-size:5px">3,96,0,0,0</text>
   <path class="p3" d="M 599 238 L 586 255 L 627 268 L 639 252 L 599 238"/>
-  <text x="613" y="253" style="font-size:8">3,97,0,0,0</text>
+  <text x="613" y="256" style="font-size:5px">3,97,0,0,0</text>
   <path class="ps3" d="M 652 238 L 639 252 L 681 267 L 694 254 L 652 238"/>
-  <text x="666" y="253" style="font-size:8">3,98,0,X,0</text>
+  <text x="666" y="255" style="font-size:5px">3,98,0,X,0</text>
   <path class="ps3" d="M 639 252 L 627 268 L 669 280 L 681 267 L 639 252"/>
-  <text x="654" y="267" style="font-size:9">3,99,0,X,0</text>
+  <text x="654" y="269" style="font-size:5px">3,99,0,X,0</text>
   <path class="ps3" d="M 586 255 L 573 273 L 614 283 L 627 268 L 586 255"/>
-  <text x="600" y="270" style="font-size:9">3,100,0,X,0</text>
+  <text x="600" y="272" style="font-size:5px">3,100,0,X,0</text>
   <path class="ps3" d="M 573 273 L 560 290 L 600 299 L 614 283 L 573 273"/>
-  <text x="587" y="286" style="font-size:9">3,101,0,X,0</text>
+  <text x="587" y="289" style="font-size:6px">3,101,0,X,0</text>
   <path class="ps3" d="M 627 268 L 614 283 L 655 294 L 669 280 L 627 268"/>
-  <text x="641" y="281" style="font-size:9">3,102,0,X,0</text>
+  <text x="641" y="284" style="font-size:6px">3,102,0,X,0</text>
   <path class="ps3" d="M 614 283 L 600 299 L 642 308 L 655 294 L 614 283"/>
-  <text x="628" y="296" style="font-size:9">3,103,0,X,0</text>
+  <text x="628" y="299" style="font-size:6px">3,103,0,X,0</text>
   <path class="ps3" d="M 694 254 L 681 267 L 725 282 L 737 270 L 694 254"/>
-  <text x="709" y="268" style="font-size:9">3,104,0,X,0</text>
+  <text x="709" y="271" style="font-size:6px">3,104,0,X,0</text>
   <path class="ps3" d="M 681 267 L 669 280 L 711 293 L 725 282 L 681 267"/>
-  <text x="696" y="280" style="font-size:9">3,105,0,X,0</text>
+  <text x="696" y="283" style="font-size:6px">3,105,0,X,0</text>
   <path class="ps3" d="M 737 270 L 725 282 L 769 297 L 782 287 L 737 270"/>
-  <text x="753" y="284" style="font-size:9">3,106,0,X,0</text>
+  <text x="753" y="287" style="font-size:6px">3,106,0,X,0</text>
   <line x1="782" y1="287" x2="769" y2="297"/>
   <path class="ps3" d="M 725 282 L 711 293 L 755 307 L 769 297 L 725 282"/>
-  <text x="740" y="294" style="font-size:10">3,107,0,X,0</text>
+  <text x="740" y="297" style="font-size:6px">3,107,0,X,0</text>
   <line x1="769" y1="297" x2="755" y2="307"/>
   <path class="ps3" d="M 669 280 L 655 294 L 698 305 L 711 293 L 669 280"/>
-  <text x="683" y="293" style="font-size:9">3,108,0,X,0</text>
+  <text x="683" y="296" style="font-size:6px">3,108,0,X,0</text>
   <path class="ps3" d="M 655 294 L 642 308 L 684 317 L 698 305 L 655 294"/>
-  <text x="670" y="306" style="font-size:10">3,109,0,X,0</text>
+  <text x="670" y="309" style="font-size:6px">3,109,0,X,0</text>
   <path class="ps3" d="M 711 293 L 698 305 L 741 317 L 755 307 L 711 293"/>
-  <text x="726" y="305" style="font-size:10">3,110,0,X,0</text>
+  <text x="726" y="308" style="font-size:6px">3,110,0,X,0</text>
   <line x1="755" y1="307" x2="741" y2="317"/>
   <path class="ps3" d="M 698 305 L 684 317 L 727 327 L 741 317 L 698 305"/>
-  <text x="712" y="316" style="font-size:10">3,111,0,X,0</text>
+  <text x="712" y="319" style="font-size:6px">3,111,0,X,0</text>
   <line x1="741" y1="317" x2="727" y2="327"/>
   <path class="ps3" d="M 560 290 L 546 309 L 587 316 L 600 299 L 560 290"/>
-  <text x="573" y="304" style="font-size:10">3,112,0,X,0</text>
+  <text x="573" y="307" style="font-size:6px">3,112,0,X,0</text>
   <path class="ps3" d="M 546 309 L 531 328 L 572 333 L 587 316 L 546 309"/>
-  <text x="559" y="322" style="font-size:10">3,113,0,X,0</text>
+  <text x="559" y="325" style="font-size:6px">3,113,0,X,0</text>
   <path class="ps3" d="M 600 299 L 587 316 L 628 323 L 642 308 L 600 299"/>
-  <text x="614" y="312" style="font-size:10">3,114,0,X,0</text>
+  <text x="614" y="315" style="font-size:6px">3,114,0,X,0</text>
   <path class="ps3" d="M 587 316 L 572 333 L 614 338 L 628 323 L 587 316"/>
-  <text x="600" y="327" style="font-size:10">3,115,0,X,0</text>
+  <text x="600" y="330" style="font-size:6px">3,115,0,X,0</text>
   <path class="ps3" d="M 531 328 L 516 349 L 557 351 L 572 333 L 531 328"/>
-  <text x="544" y="340" style="font-size:10">3,116,0,X,0</text>
+  <text x="544" y="344" style="font-size:7px">3,116,0,X,0</text>
   <path class="ps3" d="M 516 349 L 500 370 L 542 370 L 557 351 L 516 349"/>
-  <text x="529" y="360" style="font-size:11">3,117,0,X,0</text>
+  <text x="529" y="363" style="font-size:7px">3,117,0,X,0</text>
   <path class="ps3" d="M 572 333 L 557 351 L 599 354 L 614 338 L 572 333"/>
-  <text x="586" y="344" style="font-size:11">3,118,0,X,0</text>
+  <text x="586" y="347" style="font-size:7px">3,118,0,X,0</text>
   <path class="ps3" d="M 557 351 L 542 370 L 584 370 L 599 354 L 557 351"/>
-  <text x="571" y="361" style="font-size:11">3,119,0,X,0</text>
+  <text x="571" y="364" style="font-size:7px">3,119,0,X,0</text>
   <path class="ps3" d="M 642 308 L 628 323 L 670 330 L 684 317 L 642 308"/>
-  <text x="656" y="320" style="font-size:10">3,120,0,X,0</text>
+  <text x="656" y="323" style="font-size:6px">3,120,0,X,0</text>
   <path class="ps3" d="M 628 323 L 614 338 L 655 343 L 670 330 L 628 323"/>
-  <text x="642" y="333" style="font-size:10">3,121,0,X,0</text>
+  <text x="642" y="337" style="font-size:7px">3,121,0,X,0</text>
   <path class="ps3" d="M 684 317 L 670 330 L 712 337 L 727 327 L 684 317"/>
-  <text x="698" y="328" style="font-size:10">3,122,0,X,0</text>
+  <text x="698" y="331" style="font-size:6px">3,122,0,X,0</text>
   <line x1="727" y1="327" x2="712" y2="337"/>
   <path class="ps3" d="M 670 330 L 655 343 L 698 348 L 712 337 L 670 330"/>
-  <text x="684" y="339" style="font-size:11">3,123,0,X,0</text>
+  <text x="684" y="343" style="font-size:7px">3,123,0,X,0</text>
   <line x1="712" y1="337" x2="698" y2="348"/>
   <path class="ps3" d="M 614 338 L 599 354 L 641 356 L 655 343 L 614 338"/>
-  <text x="627" y="348" style="font-size:11">3,124,0,X,0</text>
+  <text x="627" y="351" style="font-size:7px">3,124,0,X,0</text>
   <path class="ps3" d="M 599 354 L 584 370 L 625 370 L 641 356 L 599 354"/>
-  <text x="612" y="362" style="font-size:11">3,125,0,X,0</text>
+  <text x="612" y="366" style="font-size:7px">3,125,0,X,0</text>
   <path class="ps3" d="M 655 343 L 641 356 L 682 358 L 698 348 L 655 343"/>
-  <text x="669" y="351" style="font-size:11">3,126,0,X,0</text>
+  <text x="669" y="355" style="font-size:7px">3,126,0,X,0</text>
   <line x1="698" y1="348" x2="682" y2="358"/>
   <path class="ps3" d="M 641 356 L 625 370 L 667 370 L 682 358 L 641 356"/>
-  <text x="654" y="363" style="font-size:11">3,127,0,X,0</text>
+  <text x="654" y="367" style="font-size:7px">3,127,0,X,0</text>
   <line x1="682" y1="358" x2="667" y2="370"/>
   <path class="ps3" d="M 500 370 L 497 391 L 542 389 L 542 370 L 500 370"/>
-  <text x="520" y="380" style="font-size:11">3,128,0,X,0</text>
+  <text x="520" y="383" style="font-size:7px">3,128,0,X,0</text>
   <path class="ps3" d="M 497 391 L 493 414 L 541 408 L 542 389 L 497 391"/>
-  <text x="518" y="400" style="font-size:12">3,129,0,X,0</text>
+  <text x="518" y="404" style="font-size:7px">3,129,0,X,0</text>
   <path class="ps3" d="M 542 370 L 542 389 L 587 386 L 584 370 L 542 370"/>
-  <text x="564" y="378" style="font-size:11">3,130,0,X,0</text>
+  <text x="564" y="382" style="font-size:7px">3,130,0,X,0</text>
   <path class="ps3" d="M 542 389 L 541 408 L 590 403 L 587 386 L 542 389"/>
-  <text x="565" y="396" style="font-size:12">3,131,0,X,0</text>
+  <text x="565" y="400" style="font-size:7px">3,131,0,X,0</text>
   <path class="ps3" d="M 493 414 L 488 437 L 541 429 L 541 408 L 493 414"/>
-  <text x="516" y="422" style="font-size:12">3,132,0,X,0</text>
+  <text x="516" y="426" style="font-size:8px">3,132,0,X,0</text>
   <path class="ps3" d="M 488 437 L 484 462 L 540 450 L 541 429 L 488 437"/>
-  <text x="514" y="445" style="font-size:13">3,133,0,X,0</text>
+  <text x="514" y="449" style="font-size:8px">3,133,0,X,0</text>
   <path class="ps3" d="M 541 408 L 541 429 L 593 420 L 590 403 L 541 408"/>
-  <text x="566" y="415" style="font-size:12">3,134,0,X,0</text>
+  <text x="566" y="419" style="font-size:8px">3,134,0,X,0</text>
   <path class="ps3" d="M 541 429 L 540 450 L 596 439 L 593 420 L 541 429"/>
-  <text x="568" y="434" style="font-size:13">3,135,0,X,0</text>
+  <text x="568" y="438" style="font-size:8px">3,135,0,X,0</text>
   <path class="ps3" d="M 584 370 L 587 386 L 631 383 L 625 370 L 584 370"/>
-  <text x="607" y="377" style="font-size:11">3,136,0,X,0</text>
+  <text x="607" y="381" style="font-size:7px">3,136,0,X,0</text>
   <path class="ps3" d="M 587 386 L 590 403 L 637 398 L 631 383 L 587 386"/>
-  <text x="611" y="392" style="font-size:12">3,137,0,X,0</text>
+  <text x="611" y="396" style="font-size:7px">3,137,0,X,0</text>
   <path class="ps3" d="M 625 370 L 631 383 L 676 381 L 667 370 L 625 370"/>
-  <text x="650" y="376" style="font-size:12">3,138,0,X,0</text>
+  <text x="650" y="379" style="font-size:7px">3,138,0,X,0</text>
   <line x1="667" y1="370" x2="676" y2="381"/>
   <path class="ps3" d="M 631 383 L 637 398 L 685 392 L 676 381 L 631 383"/>
-  <text x="657" y="388" style="font-size:12">3,139,0,X,0</text>
+  <text x="657" y="392" style="font-size:7px">3,139,0,X,0</text>
   <line x1="676" y1="381" x2="685" y2="392"/>
   <path class="ps3" d="M 590 403 L 593 420 L 644 412 L 637 398 L 590 403"/>
-  <text x="616" y="408" style="font-size:12">3,140,0,X,0</text>
+  <text x="616" y="412" style="font-size:8px">3,140,0,X,0</text>
   <path class="ps3" d="M 593 420 L 596 439 L 650 427 L 644 412 L 593 420"/>
-  <text x="621" y="425" style="font-size:13">3,141,0,X,0</text>
+  <text x="621" y="429" style="font-size:8px">3,141,0,X,0</text>
   <path class="ps3" d="M 637 398 L 644 412 L 694 404 L 685 392 L 637 398"/>
-  <text x="665" y="401" style="font-size:12">3,142,0,X,0</text>
+  <text x="665" y="405" style="font-size:8px">3,142,0,X,0</text>
   <line x1="685" y1="392" x2="694" y2="404"/>
   <path class="ps3" d="M 644 412 L 650 427 L 703 416 L 694 404 L 644 412"/>
-  <text x="673" y="415" style="font-size:13">3,143,0,X,0</text>
+  <text x="673" y="419" style="font-size:8px">3,143,0,X,0</text>
   <line x1="694" y1="404" x2="703" y2="416"/>
   <path class="ps3" d="M 484 462 L 479 488 L 540 472 L 540 450 L 484 462"/>
-  <text x="511" y="468" style="font-size:14">3,144,0,X,0</text>
+  <text x="511" y="472" style="font-size:9px">3,144,0,X,0</text>
   <path class="ps3" d="M 479 488 L 475 515 L 540 495 L 540 472 L 479 488"/>
-  <text x="509" y="492" style="font-size:14">3,145,0,X,0</text>
+  <text x="509" y="497" style="font-size:9px">3,145,0,X,0</text>
   <path class="ps3" d="M 540 450 L 540 472 L 599 457 L 596 439 L 540 450"/>
-  <text x="569" y="454" style="font-size:13">3,146,0,X,0</text>
+  <text x="569" y="458" style="font-size:8px">3,146,0,X,0</text>
   <path class="ps3" d="M 540 472 L 540 495 L 603 477 L 599 457 L 540 472"/>
-  <text x="571" y="475" style="font-size:14">3,147,0,X,0</text>
+  <text x="571" y="480" style="font-size:9px">3,147,0,X,0</text>
   <path class="p3" d="M 475 515 L 470 543 L 539 519 L 540 495 L 475 515"/>
-  <text x="506" y="518" style="font-size:15">3,148,0,0,0</text>
+  <text x="506" y="522" style="font-size:9px">3,148,0,0,0</text>
   <path class="p3" d="M 470 543 L 464 572 L 539 544 L 539 519 L 470 543"/>
-  <text x="503" y="544" style="font-size:16">3,149,0,0,0</text>
+  <text x="503" y="549" style="font-size:10px">3,149,0,0,0</text>
   <path class="ps3" d="M 540 495 L 539 519 L 606 496 L 603 477 L 540 495"/>
-  <text x="572" y="497" style="font-size:14">3,150,0,X,0</text>
+  <text x="572" y="501" style="font-size:9px">3,150,0,X,0</text>
   <path class="ps3" d="M 539 519 L 539 544 L 610 517 L 606 496 L 539 519"/>
-  <text x="574" y="519" style="font-size:15">3,151,0,X,0</text>
+  <text x="574" y="523" style="font-size:9px">3,151,0,X,0</text>
   <path class="ps3" d="M 596 439 L 599 457 L 657 443 L 650 427 L 596 439"/>
-  <text x="626" y="441" style="font-size:13">3,152,0,X,0</text>
+  <text x="626" y="445" style="font-size:8px">3,152,0,X,0</text>
   <path class="ps3" d="M 599 457 L 603 477 L 664 458 L 657 443 L 599 457"/>
-  <text x="631" y="459" style="font-size:14">3,153,0,X,0</text>
+  <text x="631" y="463" style="font-size:9px">3,153,0,X,0</text>
   <path class="ps3" d="M 650 427 L 657 443 L 713 428 L 703 416 L 650 427"/>
-  <text x="681" y="428" style="font-size:13">3,154,0,X,0</text>
+  <text x="681" y="432" style="font-size:8px">3,154,0,X,0</text>
   <line x1="703" y1="416" x2="713" y2="428"/>
   <path class="ps3" d="M 657 443 L 664 458 L 723 441 L 713 428 L 657 443"/>
-  <text x="689" y="442" style="font-size:13">3,155,0,X,0</text>
+  <text x="689" y="446" style="font-size:8px">3,155,0,X,0</text>
   <line x1="713" y1="428" x2="723" y2="441"/>
   <path class="ps3" d="M 603 477 L 606 496 L 671 475 L 664 458 L 603 477"/>
-  <text x="636" y="476" style="font-size:14">3,156,0,X,0</text>
+  <text x="636" y="481" style="font-size:9px">3,156,0,X,0</text>
   <path class="ps3" d="M 606 496 L 610 517 L 678 491 L 671 475 L 606 496"/>
-  <text x="641" y="495" style="font-size:15">3,157,0,X,0</text>
+  <text x="641" y="499" style="font-size:9px">3,157,0,X,0</text>
   <path class="ps3" d="M 664 458 L 671 475 L 733 454 L 723 441 L 664 458"/>
-  <text x="698" y="457" style="font-size:14">3,158,0,X,0</text>
+  <text x="698" y="461" style="font-size:9px">3,158,0,X,0</text>
   <line x1="723" y1="441" x2="733" y2="454"/>
   <path class="ps3" d="M 671 475 L 678 491 L 743 467 L 733 454 L 671 475"/>
-  <text x="707" y="471" style="font-size:14">3,159,0,X,0</text>
+  <text x="707" y="476" style="font-size:9px">3,159,0,X,0</text>
   <line x1="733" y1="454" x2="743" y2="467"/>
   <path class="p3" d="M 464 572 L 530 575 L 595 548 L 539 544 L 464 572"/>
-  <text x="532" y="560" style="font-size:16">3,160,0,0,0</text>
+  <text x="532" y="565" style="font-size:10px">3,160,0,0,0</text>
   <path class="p3" d="M 530 575 L 596 579 L 652 552 L 595 548 L 530 575"/>
-  <text x="594" y="563" style="font-size:16">3,161,0,0,0</text>
+  <text x="594" y="568" style="font-size:10px">3,161,0,0,0</text>
   <path class="ps3" d="M 539 544 L 595 548 L 657 522 L 610 517 L 539 544"/>
-  <text x="601" y="533" style="font-size:15">3,162,0,X,0</text>
+  <text x="601" y="538" style="font-size:10px">3,162,0,X,0</text>
   <path class="ps3" d="M 595 548 L 652 552 L 705 526 L 657 522 L 595 548"/>
-  <text x="653" y="537" style="font-size:16">3,163,0,X,0</text>
+  <text x="653" y="542" style="font-size:10px">3,163,0,X,0</text>
   <path class="ps3" d="M 596 579 L 663 582 L 709 556 L 652 552 L 596 579"/>
-  <text x="655" y="567" style="font-size:16">3,164,0,X,0</text>
+  <text x="655" y="572" style="font-size:10px">3,164,0,X,0</text>
   <path class="ps3" d="M 663 582 L 729 585 L 766 560 L 709 556 L 663 582"/>
-  <text x="717" y="571" style="font-size:17">3,165,0,X,0</text>
+  <text x="717" y="576" style="font-size:10px">3,165,0,X,0</text>
   <path class="ps3" d="M 652 552 L 709 556 L 753 531 L 705 526 L 652 552"/>
-  <text x="705" y="541" style="font-size:16">3,166,0,X,0</text>
+  <text x="705" y="546" style="font-size:10px">3,166,0,X,0</text>
   <path class="ps3" d="M 709 556 L 766 560 L 802 535 L 753 531 L 709 556"/>
-  <text x="758" y="545" style="font-size:16">3,167,0,X,0</text>
+  <text x="758" y="550" style="font-size:10px">3,167,0,X,0</text>
   <path class="ps3" d="M 610 517 L 657 522 L 717 496 L 678 491 L 610 517"/>
-  <text x="666" y="506" style="font-size:15">3,168,0,X,0</text>
+  <text x="666" y="511" style="font-size:9px">3,168,0,X,0</text>
   <path class="ps3" d="M 657 522 L 705 526 L 756 501 L 717 496 L 657 522"/>
-  <text x="709" y="511" style="font-size:15">3,169,0,X,0</text>
+  <text x="709" y="516" style="font-size:9px">3,169,0,X,0</text>
   <path class="ps3" d="M 678 491 L 717 496 L 774 472 L 743 467 L 678 491"/>
-  <text x="728" y="481" style="font-size:14">3,170,0,X,0</text>
+  <text x="728" y="486" style="font-size:9px">3,170,0,X,0</text>
   <line x1="743" y1="467" x2="774" y2="472"/>
   <path class="ps3" d="M 717 496 L 756 501 L 806 478 L 774 472 L 717 496"/>
-  <text x="764" y="487" style="font-size:15">3,171,0,X,0</text>
+  <text x="764" y="491" style="font-size:9px">3,171,0,X,0</text>
   <line x1="774" y1="472" x2="806" y2="478"/>
   <path class="ps3" d="M 705 526 L 753 531 L 796 507 L 756 501 L 705 526"/>
-  <text x="753" y="516" style="font-size:15">3,172,0,X,0</text>
+  <text x="753" y="521" style="font-size:10px">3,172,0,X,0</text>
   <path class="ps3" d="M 753 531 L 802 535 L 836 512 L 796 507 L 753 531"/>
-  <text x="797" y="521" style="font-size:15">3,173,0,X,0</text>
+  <text x="797" y="526" style="font-size:10px">3,173,0,X,0</text>
   <path class="ps3" d="M 756 501 L 796 507 L 837 483 L 806 478 L 756 501"/>
-  <text x="799" y="492" style="font-size:15">3,174,0,X,0</text>
+  <text x="799" y="497" style="font-size:9px">3,174,0,X,0</text>
   <line x1="806" y1="478" x2="837" y2="483"/>
   <path class="ps3" d="M 796 507 L 836 512 L 869 489 L 837 483 L 796 507"/>
-  <text x="835" y="498" style="font-size:15">3,175,0,X,0</text>
+  <text x="835" y="502" style="font-size:9px">3,175,0,X,0</text>
   <line x1="837" y1="483" x2="869" y2="489"/>
   <path class="ps3" d="M 729 585 L 797 589 L 824 564 L 766 560 L 729 585"/>
-  <text x="779" y="574" style="font-size:17">3,176,0,X,0</text>
+  <text x="779" y="580" style="font-size:11px">3,176,0,X,0</text>
   <path class="ps3" d="M 797 589 L 864 592 L 882 568 L 824 564 L 797 589"/>
-  <text x="842" y="578" style="font-size:17">3,177,0,X,0</text>
+  <text x="842" y="583" style="font-size:11px">3,177,0,X,0</text>
   <path class="ps3" d="M 766 560 L 824 564 L 851 540 L 802 535 L 766 560"/>
-  <text x="811" y="550" style="font-size:16">3,178,0,X,0</text>
+  <text x="811" y="555" style="font-size:10px">3,178,0,X,0</text>
   <path class="ps3" d="M 824 564 L 882 568 L 900 545 L 851 540 L 824 564"/>
-  <text x="865" y="554" style="font-size:16">3,179,0,X,0</text>
+  <text x="865" y="559" style="font-size:10px">3,179,0,X,0</text>
   <path class="ps3" d="M 864 592 L 932 595 L 941 572 L 882 568 L 864 592"/>
-  <text x="905" y="582" style="font-size:17">3,180,0,X,0</text>
+  <text x="905" y="587" style="font-size:11px">3,180,0,X,0</text>
   <path class="ps3" d="M 932 595 L 1000 599 L 1000 576 L 941 572 L 932 595"/>
-  <text x="968" y="585" style="font-size:17">3,181,0,X,0</text>
+  <text x="968" y="591" style="font-size:11px">3,181,0,X,0</text>
   <path class="ps3" d="M 882 568 L 941 572 L 950 549 L 900 545 L 882 568"/>
-  <text x="918" y="558" style="font-size:17">3,182,0,X,0</text>
+  <text x="918" y="563" style="font-size:10px">3,182,0,X,0</text>
   <path class="ps3" d="M 941 572 L 1000 576 L 1000 554 L 950 549 L 941 572"/>
-  <text x="973" y="563" style="font-size:17">3,183,0,X,0</text>
+  <text x="973" y="568" style="font-size:10px">3,183,0,X,0</text>
   <path class="ps3" d="M 802 535 L 851 540 L 877 517 L 836 512 L 802 535"/>
-  <text x="842" y="526" style="font-size:16">3,184,0,X,0</text>
+  <text x="842" y="531" style="font-size:10px">3,184,0,X,0</text>
   <path class="ps3" d="M 851 540 L 900 545 L 917 522 L 877 517 L 851 540"/>
-  <text x="886" y="531" style="font-size:16">3,185,0,X,0</text>
+  <text x="886" y="536" style="font-size:10px">3,185,0,X,0</text>
   <path class="ps3" d="M 836 512 L 877 517 L 901 495 L 869 489 L 836 512"/>
-  <text x="871" y="503" style="font-size:15">3,186,0,X,0</text>
+  <text x="871" y="507" style="font-size:9px">3,186,0,X,0</text>
   <line x1="869" y1="489" x2="901" y2="495"/>
   <path class="ps3" d="M 877 517 L 917 522 L 934 500 L 901 495 L 877 517"/>
-  <text x="907" y="508" style="font-size:15">3,187,0,X,0</text>
+  <text x="907" y="513" style="font-size:10px">3,187,0,X,0</text>
   <line x1="901" y1="495" x2="934" y2="500"/>
   <path class="ps3" d="M 900 545 L 950 549 L 959 527 L 917 522 L 900 545"/>
-  <text x="932" y="536" style="font-size:16">3,188,0,X,0</text>
+  <text x="932" y="541" style="font-size:10px">3,188,0,X,0</text>
   <path class="ps3" d="M 950 549 L 1000 554 L 1000 533 L 959 527 L 950 549"/>
-  <text x="977" y="541" style="font-size:16">3,189,0,X,0</text>
+  <text x="977" y="546" style="font-size:10px">3,189,0,X,0</text>
   <path class="ps3" d="M 917 522 L 959 527 L 967 506 L 934 500 L 917 522"/>
-  <text x="944" y="514" style="font-size:15">3,190,0,X,0</text>
+  <text x="944" y="519" style="font-size:10px">3,190,0,X,0</text>
   <line x1="934" y1="500" x2="967" y2="506"/>
   <path class="ps3" d="M 959 527 L 1000 533 L 1000 512 L 967 506 L 959 527"/>
-  <text x="981" y="520" style="font-size:16">3,191,0,X,0</text>
+  <text x="981" y="525" style="font-size:10px">3,191,0,X,0</text>
   <line x1="967" y1="506" x2="1000" y2="512"/>
   <path class="ps3" d="M 1000 599 L 1068 595 L 1059 572 L 1000 576 L 1000 599"/>
-  <text x="1032" y="585" style="font-size:17">3,192,0,X,0</text>
+  <text x="1032" y="591" style="font-size:11px">3,192,0,X,0</text>
   <path class="ps3" d="M 1068 595 L 1136 592 L 1118 568 L 1059 572 L 1068 595"/>
-  <text x="1095" y="582" style="font-size:17">3,193,0,X,0</text>
+  <text x="1095" y="587" style="font-size:11px">3,193,0,X,0</text>
   <path class="ps3" d="M 1000 576 L 1059 572 L 1050 549 L 1000 554 L 1000 576"/>
-  <text x="1027" y="563" style="font-size:17">3,194,0,X,0</text>
+  <text x="1027" y="568" style="font-size:10px">3,194,0,X,0</text>
   <path class="ps3" d="M 1059 572 L 1118 568 L 1100 545 L 1050 549 L 1059 572"/>
-  <text x="1082" y="558" style="font-size:17">3,195,0,X,0</text>
+  <text x="1082" y="563" style="font-size:10px">3,195,0,X,0</text>
   <path class="ps3" d="M 1136 592 L 1203 589 L 1176 564 L 1118 568 L 1136 592"/>
-  <text x="1158" y="578" style="font-size:17">3,196,0,X,0</text>
+  <text x="1158" y="583" style="font-size:11px">3,196,0,X,0</text>
   <path class="ps3" d="M 1203 589 L 1271 585 L 1234 560 L 1176 564 L 1203 589"/>
-  <text x="1221" y="574" style="font-size:17">3,197,0,X,0</text>
+  <text x="1221" y="580" style="font-size:11px">3,197,0,X,0</text>
   <path class="ps3" d="M 1118 568 L 1176 564 L 1149 540 L 1100 545 L 1118 568"/>
-  <text x="1135" y="554" style="font-size:16">3,198,0,X,0</text>
+  <text x="1135" y="559" style="font-size:10px">3,198,0,X,0</text>
   <path class="ps3" d="M 1176 564 L 1234 560 L 1198 535 L 1149 540 L 1176 564"/>
-  <text x="1189" y="550" style="font-size:16">3,199,0,X,0</text>
+  <text x="1189" y="555" style="font-size:10px">3,199,0,X,0</text>
   <path class="ps3" d="M 1000 554 L 1050 549 L 1041 527 L 1000 533 L 1000 554"/>
-  <text x="1023" y="541" style="font-size:16">3,200,0,X,0</text>
+  <text x="1023" y="546" style="font-size:10px">3,200,0,X,0</text>
   <path class="ps3" d="M 1050 549 L 1100 545 L 1083 522 L 1041 527 L 1050 549"/>
-  <text x="1068" y="536" style="font-size:16">3,201,0,X,0</text>
+  <text x="1068" y="541" style="font-size:10px">3,201,0,X,0</text>
   <path class="ps3" d="M 1000 533 L 1041 527 L 1033 506 L 1000 512 L 1000 533"/>
-  <text x="1019" y="520" style="font-size:16">3,202,0,X,0</text>
+  <text x="1019" y="525" style="font-size:10px">3,202,0,X,0</text>
   <line x1="1000" y1="512" x2="1033" y2="506"/>
   <path class="ps3" d="M 1041 527 L 1083 522 L 1066 500 L 1033 506 L 1041 527"/>
-  <text x="1056" y="514" style="font-size:15">3,203,0,X,0</text>
+  <text x="1056" y="519" style="font-size:10px">3,203,0,X,0</text>
   <line x1="1033" y1="506" x2="1066" y2="500"/>
   <path class="ps3" d="M 1100 545 L 1149 540 L 1123 517 L 1083 522 L 1100 545"/>
-  <text x="1114" y="531" style="font-size:16">3,204,0,X,0</text>
+  <text x="1114" y="536" style="font-size:10px">3,204,0,X,0</text>
   <path class="ps3" d="M 1149 540 L 1198 535 L 1164 512 L 1123 517 L 1149 540"/>
-  <text x="1158" y="526" style="font-size:16">3,205,0,X,0</text>
+  <text x="1158" y="531" style="font-size:10px">3,205,0,X,0</text>
   <path class="ps3" d="M 1083 522 L 1123 517 L 1099 495 L 1066 500 L 1083 522"/>
-  <text x="1093" y="508" style="font-size:15">3,206,0,X,0</text>
+  <text x="1093" y="513" style="font-size:10px">3,206,0,X,0</text>
   <line x1="1066" y1="500" x2="1099" y2="495"/>
   <path class="ps3" d="M 1123 517 L 1164 512 L 1131 489 L 1099 495 L 1123 517"/>
-  <text x="1129" y="503" style="font-size:15">3,207,0,X,0</text>
+  <text x="1129" y="507" style="font-size:9px">3,207,0,X,0</text>
   <line x1="1099" y1="495" x2="1131" y2="489"/>
   <path class="ps3" d="M 1271 585 L 1337 582 L 1291 556 L 1234 560 L 1271 585"/>
-  <text x="1283" y="571" style="font-size:17">3,208,0,X,0</text>
+  <text x="1283" y="576" style="font-size:10px">3,208,0,X,0</text>
   <path class="ps3" d="M 1337 582 L 1404 579 L 1348 552 L 1291 556 L 1337 582"/>
-  <text x="1345" y="567" style="font-size:16">3,209,0,X,0</text>
+  <text x="1345" y="572" style="font-size:10px">3,209,0,X,0</text>
   <path class="ps3" d="M 1234 560 L 1291 556 L 1247 531 L 1198 535 L 1234 560"/>
-  <text x="1242" y="545" style="font-size:16">3,210,0,X,0</text>
+  <text x="1242" y="550" style="font-size:10px">3,210,0,X,0</text>
   <path class="ps3" d="M 1291 556 L 1348 552 L 1295 526 L 1247 531 L 1291 556"/>
-  <text x="1295" y="541" style="font-size:16">3,211,0,X,0</text>
+  <text x="1295" y="546" style="font-size:10px">3,211,0,X,0</text>
   <path class="p3" d="M 1404 579 L 1470 575 L 1405 548 L 1348 552 L 1404 579"/>
-  <text x="1406" y="563" style="font-size:16">3,212,0,0,0</text>
+  <text x="1406" y="568" style="font-size:10px">3,212,0,0,0</text>
   <path class="p3" d="M 1470 575 L 1536 572 L 1461 544 L 1405 548 L 1470 575"/>
-  <text x="1468" y="560" style="font-size:16">3,213,0,0,0</text>
+  <text x="1468" y="565" style="font-size:10px">3,213,0,0,0</text>
   <path class="ps3" d="M 1348 552 L 1405 548 L 1343 522 L 1295 526 L 1348 552"/>
-  <text x="1347" y="537" style="font-size:16">3,214,0,X,0</text>
+  <text x="1347" y="542" style="font-size:10px">3,214,0,X,0</text>
   <path class="ps3" d="M 1405 548 L 1461 544 L 1390 517 L 1343 522 L 1405 548"/>
-  <text x="1399" y="533" style="font-size:15">3,215,0,X,0</text>
+  <text x="1399" y="538" style="font-size:10px">3,215,0,X,0</text>
   <path class="ps3" d="M 1198 535 L 1247 531 L 1204 507 L 1164 512 L 1198 535"/>
-  <text x="1203" y="521" style="font-size:15">3,216,0,X,0</text>
+  <text x="1203" y="526" style="font-size:10px">3,216,0,X,0</text>
   <path class="ps3" d="M 1247 531 L 1295 526 L 1244 501 L 1204 507 L 1247 531"/>
-  <text x="1247" y="516" style="font-size:15">3,217,0,X,0</text>
+  <text x="1247" y="521" style="font-size:10px">3,217,0,X,0</text>
   <path class="ps3" d="M 1164 512 L 1204 507 L 1163 483 L 1131 489 L 1164 512"/>
-  <text x="1165" y="498" style="font-size:15">3,218,0,X,0</text>
+  <text x="1165" y="502" style="font-size:9px">3,218,0,X,0</text>
   <line x1="1131" y1="489" x2="1163" y2="483"/>
   <path class="ps3" d="M 1204 507 L 1244 501 L 1194 478 L 1163 483 L 1204 507"/>
-  <text x="1201" y="492" style="font-size:15">3,219,0,X,0</text>
+  <text x="1201" y="497" style="font-size:9px">3,219,0,X,0</text>
   <line x1="1163" y1="483" x2="1194" y2="478"/>
   <path class="ps3" d="M 1295 526 L 1343 522 L 1283 496 L 1244 501 L 1295 526"/>
-  <text x="1291" y="511" style="font-size:15">3,220,0,X,0</text>
+  <text x="1291" y="516" style="font-size:9px">3,220,0,X,0</text>
   <path class="ps3" d="M 1343 522 L 1390 517 L 1322 491 L 1283 496 L 1343 522"/>
-  <text x="1334" y="506" style="font-size:15">3,221,0,X,0</text>
+  <text x="1334" y="511" style="font-size:9px">3,221,0,X,0</text>
   <path class="ps3" d="M 1244 501 L 1283 496 L 1226 472 L 1194 478 L 1244 501"/>
-  <text x="1236" y="487" style="font-size:15">3,222,0,X,0</text>
+  <text x="1236" y="491" style="font-size:9px">3,222,0,X,0</text>
   <line x1="1194" y1="478" x2="1226" y2="472"/>
   <path class="ps3" d="M 1283 496 L 1322 491 L 1257 467 L 1226 472 L 1283 496"/>
-  <text x="1272" y="481" style="font-size:14">3,223,0,X,0</text>
+  <text x="1272" y="486" style="font-size:9px">3,223,0,X,0</text>
   <line x1="1226" y1="472" x2="1257" y2="467"/>
   <path class="p3" d="M 1536 572 L 1530 543 L 1461 519 L 1461 544 L 1536 572"/>
-  <text x="1497" y="544" style="font-size:16">3,224,0,0,0</text>
+  <text x="1497" y="549" style="font-size:10px">3,224,0,0,0</text>
   <path class="p3" d="M 1530 543 L 1525 515 L 1460 495 L 1461 519 L 1530 543"/>
-  <text x="1494" y="518" style="font-size:15">3,225,0,0,0</text>
+  <text x="1494" y="522" style="font-size:9px">3,225,0,0,0</text>
   <path class="ps3" d="M 1461 544 L 1461 519 L 1394 496 L 1390 517 L 1461 544"/>
-  <text x="1426" y="519" style="font-size:15">3,226,0,X,0</text>
+  <text x="1426" y="523" style="font-size:9px">3,226,0,X,0</text>
   <path class="ps3" d="M 1461 519 L 1460 495 L 1397 477 L 1394 496 L 1461 519"/>
-  <text x="1428" y="497" style="font-size:14">3,227,0,X,0</text>
+  <text x="1428" y="501" style="font-size:9px">3,227,0,X,0</text>
   <path class="ps3" d="M 1525 515 L 1521 488 L 1460 472 L 1460 495 L 1525 515"/>
-  <text x="1491" y="492" style="font-size:14">3,228,0,X,0</text>
+  <text x="1491" y="497" style="font-size:9px">3,228,0,X,0</text>
   <path class="ps3" d="M 1521 488 L 1516 462 L 1460 450 L 1460 472 L 1521 488"/>
-  <text x="1489" y="468" style="font-size:14">3,229,0,X,0</text>
+  <text x="1489" y="472" style="font-size:9px">3,229,0,X,0</text>
   <path class="ps3" d="M 1460 495 L 1460 472 L 1401 457 L 1397 477 L 1460 495"/>
-  <text x="1429" y="475" style="font-size:14">3,230,0,X,0</text>
+  <text x="1429" y="480" style="font-size:9px">3,230,0,X,0</text>
   <path class="ps3" d="M 1460 472 L 1460 450 L 1404 439 L 1401 457 L 1460 472"/>
-  <text x="1431" y="454" style="font-size:13">3,231,0,X,0</text>
+  <text x="1431" y="458" style="font-size:8px">3,231,0,X,0</text>
   <path class="ps3" d="M 1390 517 L 1394 496 L 1329 475 L 1322 491 L 1390 517"/>
-  <text x="1359" y="495" style="font-size:15">3,232,0,X,0</text>
+  <text x="1359" y="499" style="font-size:9px">3,232,0,X,0</text>
   <path class="ps3" d="M 1394 496 L 1397 477 L 1336 458 L 1329 475 L 1394 496"/>
-  <text x="1364" y="476" style="font-size:14">3,233,0,X,0</text>
+  <text x="1364" y="481" style="font-size:9px">3,233,0,X,0</text>
   <path class="ps3" d="M 1322 491 L 1329 475 L 1267 454 L 1257 467 L 1322 491"/>
-  <text x="1293" y="471" style="font-size:14">3,234,0,X,0</text>
+  <text x="1293" y="476" style="font-size:9px">3,234,0,X,0</text>
   <line x1="1257" y1="467" x2="1267" y2="454"/>
   <path class="ps3" d="M 1329 475 L 1336 458 L 1277 441 L 1267 454 L 1329 475"/>
-  <text x="1302" y="457" style="font-size:14">3,235,0,X,0</text>
+  <text x="1302" y="461" style="font-size:9px">3,235,0,X,0</text>
   <line x1="1267" y1="454" x2="1277" y2="441"/>
   <path class="ps3" d="M 1397 477 L 1401 457 L 1343 443 L 1336 458 L 1397 477"/>
-  <text x="1369" y="459" style="font-size:14">3,236,0,X,0</text>
+  <text x="1369" y="463" style="font-size:9px">3,236,0,X,0</text>
   <path class="ps3" d="M 1401 457 L 1404 439 L 1350 427 L 1343 443 L 1401 457"/>
-  <text x="1374" y="441" style="font-size:13">3,237,0,X,0</text>
+  <text x="1374" y="445" style="font-size:8px">3,237,0,X,0</text>
   <path class="ps3" d="M 1336 458 L 1343 443 L 1287 428 L 1277 441 L 1336 458"/>
-  <text x="1311" y="442" style="font-size:13">3,238,0,X,0</text>
+  <text x="1311" y="446" style="font-size:8px">3,238,0,X,0</text>
   <line x1="1277" y1="441" x2="1287" y2="428"/>
   <path class="ps3" d="M 1343 443 L 1350 427 L 1297 416 L 1287 428 L 1343 443"/>
-  <text x="1319" y="428" style="font-size:13">3,239,0,X,0</text>
+  <text x="1319" y="432" style="font-size:8px">3,239,0,X,0</text>
   <line x1="1287" y1="428" x2="1297" y2="416"/>
   <path class="ps3" d="M 1516 462 L 1512 437 L 1459 429 L 1460 450 L 1516 462"/>
-  <text x="1486" y="445" style="font-size:13">3,240,0,X,0</text>
+  <text x="1486" y="449" style="font-size:8px">3,240,0,X,0</text>
   <path class="ps3" d="M 1512 437 L 1507 414 L 1459 408 L 1459 429 L 1512 437"/>
-  <text x="1484" y="422" style="font-size:12">3,241,0,X,0</text>
+  <text x="1484" y="426" style="font-size:8px">3,241,0,X,0</text>
   <path class="ps3" d="M 1460 450 L 1459 429 L 1407 420 L 1404 439 L 1460 450"/>
-  <text x="1432" y="434" style="font-size:13">3,242,0,X,0</text>
+  <text x="1432" y="438" style="font-size:8px">3,242,0,X,0</text>
   <path class="ps3" d="M 1459 429 L 1459 408 L 1410 403 L 1407 420 L 1459 429"/>
-  <text x="1434" y="415" style="font-size:12">3,243,0,X,0</text>
+  <text x="1434" y="419" style="font-size:8px">3,243,0,X,0</text>
   <path class="ps3" d="M 1507 414 L 1503 391 L 1458 389 L 1459 408 L 1507 414"/>
-  <text x="1482" y="400" style="font-size:12">3,244,0,X,0</text>
+  <text x="1482" y="404" style="font-size:7px">3,244,0,X,0</text>
   <path class="ps3" d="M 1503 391 L 1500 370 L 1458 370 L 1458 389 L 1503 391"/>
-  <text x="1480" y="380" style="font-size:11">3,245,0,X,0</text>
+  <text x="1480" y="383" style="font-size:7px">3,245,0,X,0</text>
   <path class="ps3" d="M 1459 408 L 1458 389 L 1413 386 L 1410 403 L 1459 408"/>
-  <text x="1435" y="396" style="font-size:12">3,246,0,X,0</text>
+  <text x="1435" y="400" style="font-size:7px">3,246,0,X,0</text>
   <path class="ps3" d="M 1458 389 L 1458 370 L 1416 370 L 1413 386 L 1458 389"/>
-  <text x="1436" y="378" style="font-size:11">3,247,0,X,0</text>
+  <text x="1436" y="382" style="font-size:7px">3,247,0,X,0</text>
   <path class="ps3" d="M 1404 439 L 1407 420 L 1356 412 L 1350 427 L 1404 439"/>
-  <text x="1379" y="425" style="font-size:13">3,248,0,X,0</text>
+  <text x="1379" y="429" style="font-size:8px">3,248,0,X,0</text>
   <path class="ps3" d="M 1407 420 L 1410 403 L 1363 398 L 1356 412 L 1407 420"/>
-  <text x="1384" y="408" style="font-size:12">3,249,0,X,0</text>
+  <text x="1384" y="412" style="font-size:8px">3,249,0,X,0</text>
   <path class="ps3" d="M 1350 427 L 1356 412 L 1306 404 L 1297 416 L 1350 427"/>
-  <text x="1327" y="415" style="font-size:13">3,250,0,X,0</text>
+  <text x="1327" y="419" style="font-size:8px">3,250,0,X,0</text>
   <line x1="1297" y1="416" x2="1306" y2="404"/>
   <path class="ps3" d="M 1356 412 L 1363 398 L 1315 392 L 1306 404 L 1356 412"/>
-  <text x="1335" y="401" style="font-size:12">3,251,0,X,0</text>
+  <text x="1335" y="405" style="font-size:8px">3,251,0,X,0</text>
   <line x1="1306" y1="404" x2="1315" y2="392"/>
   <path class="ps3" d="M 1410 403 L 1413 386 L 1369 383 L 1363 398 L 1410 403"/>
-  <text x="1389" y="392" style="font-size:12">3,252,0,X,0</text>
+  <text x="1389" y="396" style="font-size:7px">3,252,0,X,0</text>
   <path class="ps3" d="M 1413 386 L 1416 370 L 1375 370 L 1369 383 L 1413 386"/>
-  <text x="1393" y="377" style="font-size:11">3,253,0,X,0</text>
+  <text x="1393" y="381" style="font-size:7px">3,253,0,X,0</text>
   <path class="ps3" d="M 1363 398 L 1369 383 L 1324 381 L 1315 392 L 1363 398"/>
-  <text x="1343" y="388" style="font-size:12">3,254,0,X,0</text>
+  <text x="1343" y="392" style="font-size:7px">3,254,0,X,0</text>
   <line x1="1315" y1="392" x2="1324" y2="381"/>
   <path class="ps3" d="M 1369 383 L 1375 370 L 1333 370 L 1324 381 L 1369 383"/>
-  <text x="1350" y="376" style="font-size:12">3,255,0,X,0</text>
+  <text x="1350" y="379" style="font-size:7px">3,255,0,X,0</text>
   <line x1="1324" y1="381" x2="1333" y2="370"/>
   <path class="p3" d="M 1583 370 L 1566 344 L 1525 346 L 1541 370 L 1583 370"/>
-  <text x="1554" y="357" style="font-size:11">3,256,0,0,0</text>
+  <text x="1554" y="361" style="font-size:7px">3,256,0,0,0</text>
   <path class="p3" d="M 1566 344 L 1550 319 L 1509 324 L 1525 346 L 1566 344"/>
-  <text x="1537" y="333" style="font-size:10">3,257,0,0,0</text>
+  <text x="1537" y="336" style="font-size:6px">3,257,0,0,0</text>
   <path class="p3" d="M 1541 370 L 1525 346 L 1484 349 L 1500 370 L 1541 370"/>
-  <text x="1512" y="358" style="font-size:11">3,258,0,0,0</text>
+  <text x="1512" y="362" style="font-size:7px">3,258,0,0,0</text>
   <path class="p3" d="M 1525 346 L 1509 324 L 1469 328 L 1484 349 L 1525 346"/>
-  <text x="1497" y="337" style="font-size:10">3,259,0,0,0</text>
+  <text x="1497" y="340" style="font-size:6px">3,259,0,0,0</text>
   <path class="p3" d="M 1550 319 L 1534 296 L 1495 302 L 1509 324 L 1550 319"/>
-  <text x="1522" y="310" style="font-size:10">3,260,0,0,0</text>
+  <text x="1522" y="313" style="font-size:6px">3,260,0,0,0</text>
   <path class="p3" d="M 1534 296 L 1520 273 L 1480 282 L 1495 302 L 1534 296"/>
-  <text x="1507" y="288" style="font-size:9">3,261,0,0,0</text>
+  <text x="1507" y="291" style="font-size:6px">3,261,0,0,0</text>
   <path class="p3" d="M 1509 324 L 1495 302 L 1454 309 L 1469 328 L 1509 324"/>
-  <text x="1482" y="316" style="font-size:10">3,262,0,0,0</text>
+  <text x="1482" y="319" style="font-size:6px">3,262,0,0,0</text>
   <path class="p3" d="M 1495 302 L 1480 282 L 1440 290 L 1454 309 L 1495 302"/>
-  <text x="1467" y="296" style="font-size:9">3,263,0,0,0</text>
+  <text x="1467" y="299" style="font-size:6px">3,263,0,0,0</text>
   <path class="p3" d="M 1520 273 L 1506 252 L 1467 262 L 1480 282 L 1520 273"/>
-  <text x="1493" y="267" style="font-size:9">3,264,0,0,0</text>
+  <text x="1493" y="270" style="font-size:5px">3,264,0,0,0</text>
   <path class="p3" d="M 1506 252 L 1492 231 L 1453 243 L 1467 262 L 1506 252"/>
-  <text x="1479" y="247" style="font-size:8">3,265,0,0,0</text>
+  <text x="1479" y="250" style="font-size:5px">3,265,0,0,0</text>
   <path class="p3" d="M 1480 282 L 1467 262 L 1427 273 L 1440 290 L 1480 282"/>
-  <text x="1454" y="277" style="font-size:9">3,266,0,0,0</text>
+  <text x="1454" y="280" style="font-size:6px">3,266,0,0,0</text>
   <path class="p3" d="M 1467 262 L 1453 243 L 1414 255 L 1427 273 L 1467 262"/>
-  <text x="1440" y="258" style="font-size:8">3,267,0,0,0</text>
+  <text x="1440" y="261" style="font-size:5px">3,267,0,0,0</text>
   <path class="p3" d="M 1350 191 L 1291 191 L 1267 204 L 1321 205 L 1350 191"/>
-  <text x="1307" y="198" style="font-size:7">3,268,0,0,0</text>
+  <text x="1307" y="200" style="font-size:4px">3,268,0,0,0</text>
   <path class="p3" d="M 1291 191 L 1233 190 L 1213 202 L 1267 204 L 1291 191"/>
-  <text x="1251" y="197" style="font-size:7">3,269,0,0,0</text>
+  <text x="1251" y="199" style="font-size:4px">3,269,0,0,0</text>
   <path class="p3" d="M 1321 205 L 1267 204 L 1242 217 L 1291 219 L 1321 205"/>
-  <text x="1280" y="211" style="font-size:8">3,270,0,0,0</text>
+  <text x="1280" y="214" style="font-size:5px">3,270,0,0,0</text>
   <path class="p3" d="M 1267 204 L 1213 202 L 1193 215 L 1242 217 L 1267 204"/>
-  <text x="1229" y="210" style="font-size:8">3,271,0,0,0</text>
+  <text x="1229" y="212" style="font-size:5px">3,271,0,0,0</text>
   <path class="p3" d="M 1233 190 L 1174 189 L 1160 201 L 1213 202 L 1233 190"/>
-  <text x="1195" y="195" style="font-size:7">3,272,0,0,0</text>
+  <text x="1195" y="198" style="font-size:5px">3,272,0,0,0</text>
   <path class="p3" d="M 1174 189 L 1116 188 L 1106 200 L 1160 201 L 1174 189"/>
-  <text x="1139" y="194" style="font-size:7">3,273,0,0,0</text>
+  <text x="1139" y="197" style="font-size:5px">3,273,0,0,0</text>
   <path class="p3" d="M 1213 202 L 1160 201 L 1145 214 L 1193 215 L 1213 202"/>
-  <text x="1178" y="208" style="font-size:8">3,274,0,0,0</text>
+  <text x="1178" y="211" style="font-size:5px">3,274,0,0,0</text>
   <path class="p3" d="M 1160 201 L 1106 200 L 1096 212 L 1145 214 L 1160 201"/>
-  <text x="1127" y="207" style="font-size:8">3,275,0,0,0</text>
+  <text x="1127" y="209" style="font-size:5px">3,275,0,0,0</text>
   <path class="p3" d="M 1116 188 L 1058 187 L 1053 199 L 1106 200 L 1116 188"/>
-  <text x="1083" y="193" style="font-size:7">3,276,0,0,0</text>
+  <text x="1083" y="196" style="font-size:5px">3,276,0,0,0</text>
   <path class="p3" d="M 1058 187 L 1000 187 L 1000 197 L 1053 199 L 1058 187"/>
-  <text x="1028" y="192" style="font-size:7">3,277,0,0,0</text>
+  <text x="1028" y="194" style="font-size:4px">3,277,0,0,0</text>
   <path class="p3" d="M 1106 200 L 1053 199 L 1048 210 L 1096 212 L 1106 200"/>
-  <text x="1076" y="205" style="font-size:7">3,278,0,0,0</text>
+  <text x="1076" y="208" style="font-size:5px">3,278,0,0,0</text>
   <path class="p3" d="M 1053 199 L 1000 197 L 1000 209 L 1048 210 L 1053 199"/>
-  <text x="1025" y="204" style="font-size:7">3,279,0,0,0</text>
+  <text x="1025" y="206" style="font-size:5px">3,279,0,0,0</text>
   <path class="p3" d="M 1000 187 L 942 187 L 947 199 L 1000 197 L 1000 187"/>
-  <text x="972" y="192" style="font-size:7">3,280,0,0,0</text>
+  <text x="972" y="194" style="font-size:4px">3,280,0,0,0</text>
   <path class="p3" d="M 942 187 L 884 188 L 894 200 L 947 199 L 942 187"/>
-  <text x="917" y="193" style="font-size:7">3,281,0,0,0</text>
+  <text x="917" y="196" style="font-size:5px">3,281,0,0,0</text>
   <path class="p3" d="M 1000 197 L 947 199 L 952 210 L 1000 209 L 1000 197"/>
-  <text x="975" y="204" style="font-size:7">3,282,0,0,0</text>
+  <text x="975" y="206" style="font-size:5px">3,282,0,0,0</text>
   <path class="p3" d="M 947 199 L 894 200 L 904 212 L 952 210 L 947 199"/>
-  <text x="924" y="205" style="font-size:7">3,283,0,0,0</text>
+  <text x="924" y="208" style="font-size:5px">3,283,0,0,0</text>
   <path class="p3" d="M 884 188 L 826 189 L 840 201 L 894 200 L 884 188"/>
-  <text x="861" y="194" style="font-size:7">3,284,0,0,0</text>
+  <text x="861" y="197" style="font-size:5px">3,284,0,0,0</text>
   <path class="p3" d="M 826 189 L 767 190 L 787 202 L 840 201 L 826 189"/>
-  <text x="805" y="195" style="font-size:7">3,285,0,0,0</text>
+  <text x="805" y="198" style="font-size:5px">3,285,0,0,0</text>
   <path class="p3" d="M 894 200 L 840 201 L 855 214 L 904 212 L 894 200"/>
-  <text x="873" y="207" style="font-size:8">3,286,0,0,0</text>
+  <text x="873" y="209" style="font-size:5px">3,286,0,0,0</text>
   <path class="p3" d="M 840 201 L 787 202 L 807 215 L 855 214 L 840 201"/>
-  <text x="822" y="208" style="font-size:8">3,287,0,0,0</text>
+  <text x="822" y="211" style="font-size:5px">3,287,0,0,0</text>
   <path class="p3" d="M 767 190 L 709 191 L 733 204 L 787 202 L 767 190"/>
-  <text x="749" y="197" style="font-size:7">3,288,0,0,0</text>
+  <text x="749" y="199" style="font-size:4px">3,288,0,0,0</text>
   <path class="p3" d="M 709 191 L 650 191 L 679 205 L 733 204 L 709 191"/>
-  <text x="693" y="198" style="font-size:7">3,289,0,0,0</text>
+  <text x="693" y="200" style="font-size:4px">3,289,0,0,0</text>
   <path class="p3" d="M 787 202 L 733 204 L 758 217 L 807 215 L 787 202"/>
-  <text x="771" y="210" style="font-size:8">3,290,0,0,0</text>
+  <text x="771" y="212" style="font-size:5px">3,290,0,0,0</text>
   <path class="p3" d="M 733 204 L 679 205 L 709 219 L 758 217 L 733 204"/>
-  <text x="720" y="211" style="font-size:8">3,291,0,0,0</text>
+  <text x="720" y="214" style="font-size:5px">3,291,0,0,0</text>
   <path class="p3" d="M 508 231 L 494 252 L 533 262 L 547 243 L 508 231"/>
-  <text x="521" y="247" style="font-size:8">3,292,0,0,0</text>
+  <text x="521" y="250" style="font-size:5px">3,292,0,0,0</text>
   <path class="p3" d="M 494 252 L 480 273 L 520 282 L 533 262 L 494 252"/>
-  <text x="507" y="267" style="font-size:9">3,293,0,0,0</text>
+  <text x="507" y="270" style="font-size:5px">3,293,0,0,0</text>
   <path class="p3" d="M 547 243 L 533 262 L 573 273 L 586 255 L 547 243"/>
-  <text x="560" y="258" style="font-size:8">3,294,0,0,0</text>
+  <text x="560" y="261" style="font-size:5px">3,294,0,0,0</text>
   <path class="p3" d="M 533 262 L 520 282 L 560 290 L 573 273 L 533 262"/>
-  <text x="546" y="277" style="font-size:9">3,295,0,0,0</text>
+  <text x="546" y="280" style="font-size:6px">3,295,0,0,0</text>
   <path class="p3" d="M 480 273 L 466 296 L 505 302 L 520 282 L 480 273"/>
-  <text x="493" y="288" style="font-size:9">3,296,0,0,0</text>
+  <text x="493" y="291" style="font-size:6px">3,296,0,0,0</text>
   <path class="p3" d="M 466 296 L 450 319 L 491 324 L 505 302 L 466 296"/>
-  <text x="478" y="310" style="font-size:10">3,297,0,0,0</text>
+  <text x="478" y="313" style="font-size:6px">3,297,0,0,0</text>
   <path class="p3" d="M 520 282 L 505 302 L 546 309 L 560 290 L 520 282"/>
-  <text x="533" y="296" style="font-size:9">3,298,0,0,0</text>
+  <text x="533" y="299" style="font-size:6px">3,298,0,0,0</text>
   <path class="p3" d="M 505 302 L 491 324 L 531 328 L 546 309 L 505 302"/>
-  <text x="518" y="316" style="font-size:10">3,299,0,0,0</text>
+  <text x="518" y="319" style="font-size:6px">3,299,0,0,0</text>
   <path class="p3" d="M 450 319 L 434 344 L 475 346 L 491 324 L 450 319"/>
-  <text x="463" y="333" style="font-size:10">3,300,0,0,0</text>
+  <text x="463" y="336" style="font-size:6px">3,300,0,0,0</text>
   <path class="p3" d="M 434 344 L 417 370 L 459 370 L 475 346 L 434 344"/>
-  <text x="446" y="357" style="font-size:11">3,301,0,0,0</text>
+  <text x="446" y="361" style="font-size:7px">3,301,0,0,0</text>
   <path class="p3" d="M 491 324 L 475 346 L 516 349 L 531 328 L 491 324"/>
-  <text x="503" y="337" style="font-size:10">3,302,0,0,0</text>
+  <text x="503" y="340" style="font-size:6px">3,302,0,0,0</text>
   <path class="p3" d="M 475 346 L 459 370 L 500 370 L 516 349 L 475 346"/>
-  <text x="488" y="358" style="font-size:11">3,303,0,0,0</text>
+  <text x="488" y="362" style="font-size:7px">3,303,0,0,0</text>
   <path class="p3" d="M 417 370 L 406 397 L 451 394 L 459 370 L 417 370"/>
-  <text x="433" y="382" style="font-size:11">3,304,0,0,0</text>
+  <text x="433" y="386" style="font-size:7px">3,304,0,0,0</text>
   <path class="p3" d="M 406 397 L 394 425 L 443 419 L 451 394 L 406 397"/>
-  <text x="424" y="409" style="font-size:12">3,305,0,0,0</text>
+  <text x="424" y="412" style="font-size:7px">3,305,0,0,0</text>
   <path class="p3" d="M 459 370 L 451 394 L 497 391 L 500 370 L 459 370"/>
-  <text x="477" y="381" style="font-size:11">3,306,0,0,0</text>
+  <text x="477" y="384" style="font-size:7px">3,306,0,0,0</text>
   <path class="p3" d="M 451 394 L 443 419 L 493 414 L 497 391 L 451 394"/>
-  <text x="471" y="404" style="font-size:12">3,307,0,0,0</text>
+  <text x="471" y="408" style="font-size:7px">3,307,0,0,0</text>
   <path class="p3" d="M 394 425 L 381 455 L 435 446 L 443 419 L 394 425"/>
-  <text x="413" y="436" style="font-size:13">3,308,0,0,0</text>
+  <text x="413" y="440" style="font-size:8px">3,308,0,0,0</text>
   <path class="p3" d="M 381 455 L 367 487 L 426 474 L 435 446 L 381 455"/>
-  <text x="402" y="465" style="font-size:13">3,309,0,0,0</text>
+  <text x="402" y="469" style="font-size:8px">3,309,0,0,0</text>
   <path class="p3" d="M 443 419 L 435 446 L 488 437 L 493 414 L 443 419"/>
-  <text x="465" y="429" style="font-size:13">3,310,0,0,0</text>
+  <text x="465" y="433" style="font-size:8px">3,310,0,0,0</text>
   <path class="p3" d="M 435 446 L 426 474 L 484 462 L 488 437 L 435 446"/>
-  <text x="459" y="455" style="font-size:13">3,311,0,0,0</text>
+  <text x="459" y="459" style="font-size:8px">3,311,0,0,0</text>
   <path class="p3" d="M 367 487 L 353 520 L 417 504 L 426 474 L 367 487"/>
-  <text x="391" y="496" style="font-size:14">3,312,0,0,0</text>
+  <text x="391" y="500" style="font-size:9px">3,312,0,0,0</text>
   <path class="p3" d="M 353 520 L 338 555 L 407 535 L 417 504 L 353 520"/>
-  <text x="379" y="528" style="font-size:15">3,313,0,0,0</text>
+  <text x="379" y="533" style="font-size:9px">3,313,0,0,0</text>
   <path class="p3" d="M 426 474 L 417 504 L 479 488 L 484 462 L 426 474"/>
-  <text x="452" y="482" style="font-size:14">3,314,0,0,0</text>
+  <text x="452" y="486" style="font-size:9px">3,314,0,0,0</text>
   <path class="p3" d="M 417 504 L 407 535 L 475 515 L 479 488 L 417 504"/>
-  <text x="445" y="510" style="font-size:15">3,315,0,0,0</text>
+  <text x="445" y="514" style="font-size:9px">3,315,0,0,0</text>
   <path class="p3" d="M 478 636 L 564 638 L 614 609 L 538 607 L 478 636"/>
-  <text x="549" y="622" style="font-size:18">3,316,0,0,0</text>
+  <text x="549" y="628" style="font-size:11px">3,316,0,0,0</text>
   <path class="p3" d="M 564 638 L 651 639 L 691 612 L 614 609 L 564 638"/>
-  <text x="630" y="624" style="font-size:18">3,317,0,0,0</text>
+  <text x="630" y="630" style="font-size:11px">3,317,0,0,0</text>
   <path class="p3" d="M 538 607 L 614 609 L 663 582 L 596 579 L 538 607"/>
-  <text x="603" y="594" style="font-size:17">3,318,0,0,0</text>
+  <text x="603" y="599" style="font-size:11px">3,318,0,0,0</text>
   <path class="p3" d="M 614 609 L 691 612 L 729 585 L 663 582 L 614 609"/>
-  <text x="675" y="597" style="font-size:17">3,319,0,0,0</text>
+  <text x="675" y="602" style="font-size:11px">3,319,0,0,0</text>
   <path class="p3" d="M 651 639 L 738 641 L 768 614 L 691 612 L 651 639"/>
-  <text x="712" y="627" style="font-size:18">3,320,0,0,0</text>
+  <text x="712" y="632" style="font-size:11px">3,320,0,0,0</text>
   <path class="p3" d="M 738 641 L 825 643 L 845 617 L 768 614 L 738 641"/>
-  <text x="794" y="629" style="font-size:18">3,321,0,0,0</text>
+  <text x="794" y="634" style="font-size:11px">3,321,0,0,0</text>
   <path class="p3" d="M 691 612 L 768 614 L 797 589 L 729 585 L 691 612"/>
-  <text x="746" y="600" style="font-size:17">3,322,0,0,0</text>
+  <text x="746" y="605" style="font-size:11px">3,322,0,0,0</text>
   <path class="p3" d="M 768 614 L 845 617 L 864 592 L 797 589 L 768 614"/>
-  <text x="818" y="603" style="font-size:18">3,323,0,0,0</text>
+  <text x="818" y="608" style="font-size:11px">3,323,0,0,0</text>
   <path class="p3" d="M 825 643 L 912 645 L 922 620 L 845 617 L 825 643"/>
-  <text x="876" y="631" style="font-size:18">3,324,0,0,0</text>
+  <text x="876" y="637" style="font-size:11px">3,324,0,0,0</text>
   <path class="p3" d="M 912 645 L 1000 647 L 1000 622 L 922 620 L 912 645"/>
-  <text x="959" y="633" style="font-size:18">3,325,0,0,0</text>
+  <text x="959" y="639" style="font-size:12px">3,325,0,0,0</text>
   <path class="p3" d="M 845 617 L 922 620 L 932 595 L 864 592 L 845 617"/>
-  <text x="891" y="606" style="font-size:18">3,326,0,0,0</text>
+  <text x="891" y="611" style="font-size:11px">3,326,0,0,0</text>
   <path class="p3" d="M 922 620 L 1000 622 L 1000 599 L 932 595 L 922 620"/>
-  <text x="964" y="609" style="font-size:18">3,327,0,0,0</text>
+  <text x="964" y="614" style="font-size:11px">3,327,0,0,0</text>
   <path class="p3" d="M 1000 647 L 1088 645 L 1078 620 L 1000 622 L 1000 647"/>
-  <text x="1041" y="633" style="font-size:18">3,328,0,0,0</text>
+  <text x="1041" y="639" style="font-size:12px">3,328,0,0,0</text>
   <path class="p3" d="M 1088 645 L 1175 643 L 1155 617 L 1078 620 L 1088 645"/>
-  <text x="1124" y="631" style="font-size:18">3,329,0,0,0</text>
+  <text x="1124" y="637" style="font-size:11px">3,329,0,0,0</text>
   <path class="p3" d="M 1000 622 L 1078 620 L 1068 595 L 1000 599 L 1000 622"/>
-  <text x="1036" y="609" style="font-size:18">3,330,0,0,0</text>
+  <text x="1036" y="614" style="font-size:11px">3,330,0,0,0</text>
   <path class="p3" d="M 1078 620 L 1155 617 L 1136 592 L 1068 595 L 1078 620"/>
-  <text x="1109" y="606" style="font-size:18">3,331,0,0,0</text>
+  <text x="1109" y="611" style="font-size:11px">3,331,0,0,0</text>
   <path class="p3" d="M 1175 643 L 1262 641 L 1232 614 L 1155 617 L 1175 643"/>
-  <text x="1206" y="629" style="font-size:18">3,332,0,0,0</text>
+  <text x="1206" y="634" style="font-size:11px">3,332,0,0,0</text>
   <path class="p3" d="M 1262 641 L 1349 639 L 1309 612 L 1232 614 L 1262 641"/>
-  <text x="1288" y="627" style="font-size:18">3,333,0,0,0</text>
+  <text x="1288" y="632" style="font-size:11px">3,333,0,0,0</text>
   <path class="p3" d="M 1155 617 L 1232 614 L 1203 589 L 1136 592 L 1155 617"/>
-  <text x="1182" y="603" style="font-size:18">3,334,0,0,0</text>
+  <text x="1182" y="608" style="font-size:11px">3,334,0,0,0</text>
   <path class="p3" d="M 1232 614 L 1309 612 L 1271 585 L 1203 589 L 1232 614"/>
-  <text x="1254" y="600" style="font-size:17">3,335,0,0,0</text>
+  <text x="1254" y="605" style="font-size:11px">3,335,0,0,0</text>
   <path class="p3" d="M 1349 639 L 1436 638 L 1386 609 L 1309 612 L 1349 639"/>
-  <text x="1370" y="624" style="font-size:18">3,336,0,0,0</text>
+  <text x="1370" y="630" style="font-size:11px">3,336,0,0,0</text>
   <path class="p3" d="M 1436 638 L 1522 636 L 1462 607 L 1386 609 L 1436 638"/>
-  <text x="1451" y="622" style="font-size:18">3,337,0,0,0</text>
+  <text x="1451" y="628" style="font-size:11px">3,337,0,0,0</text>
   <path class="p3" d="M 1309 612 L 1386 609 L 1337 582 L 1271 585 L 1309 612"/>
-  <text x="1325" y="597" style="font-size:17">3,338,0,0,0</text>
+  <text x="1325" y="602" style="font-size:11px">3,338,0,0,0</text>
   <path class="p3" d="M 1386 609 L 1462 607 L 1404 579 L 1337 582 L 1386 609"/>
-  <text x="1397" y="594" style="font-size:17">3,339,0,0,0</text>
+  <text x="1397" y="599" style="font-size:11px">3,339,0,0,0</text>
   <path class="p3" d="M 1662 555 L 1647 520 L 1583 504 L 1593 535 L 1662 555"/>
-  <text x="1621" y="528" style="font-size:15">3,340,0,0,0</text>
+  <text x="1621" y="533" style="font-size:9px">3,340,0,0,0</text>
   <path class="p3" d="M 1647 520 L 1633 487 L 1574 474 L 1583 504 L 1647 520"/>
-  <text x="1609" y="496" style="font-size:14">3,341,0,0,0</text>
+  <text x="1609" y="500" style="font-size:9px">3,341,0,0,0</text>
   <path class="p3" d="M 1593 535 L 1583 504 L 1521 488 L 1525 515 L 1593 535"/>
-  <text x="1555" y="510" style="font-size:15">3,342,0,0,0</text>
+  <text x="1555" y="514" style="font-size:9px">3,342,0,0,0</text>
   <path class="p3" d="M 1583 504 L 1574 474 L 1516 462 L 1521 488 L 1583 504"/>
-  <text x="1548" y="482" style="font-size:14">3,343,0,0,0</text>
+  <text x="1548" y="486" style="font-size:9px">3,343,0,0,0</text>
   <path class="p3" d="M 1633 487 L 1619 455 L 1565 446 L 1574 474 L 1633 487"/>
-  <text x="1598" y="465" style="font-size:13">3,344,0,0,0</text>
+  <text x="1598" y="469" style="font-size:8px">3,344,0,0,0</text>
   <path class="p3" d="M 1619 455 L 1606 425 L 1557 419 L 1565 446 L 1619 455"/>
-  <text x="1587" y="436" style="font-size:13">3,345,0,0,0</text>
+  <text x="1587" y="440" style="font-size:8px">3,345,0,0,0</text>
   <path class="p3" d="M 1574 474 L 1565 446 L 1512 437 L 1516 462 L 1574 474"/>
-  <text x="1541" y="455" style="font-size:13">3,346,0,0,0</text>
+  <text x="1541" y="459" style="font-size:8px">3,346,0,0,0</text>
   <path class="p3" d="M 1565 446 L 1557 419 L 1507 414 L 1512 437 L 1565 446"/>
-  <text x="1535" y="429" style="font-size:13">3,347,0,0,0</text>
+  <text x="1535" y="433" style="font-size:8px">3,347,0,0,0</text>
   <path class="p3" d="M 1606 425 L 1594 397 L 1549 394 L 1557 419 L 1606 425"/>
-  <text x="1576" y="409" style="font-size:12">3,348,0,0,0</text>
+  <text x="1576" y="412" style="font-size:7px">3,348,0,0,0</text>
   <path class="p3" d="M 1594 397 L 1583 370 L 1541 370 L 1549 394 L 1594 397"/>
-  <text x="1567" y="382" style="font-size:11">3,349,0,0,0</text>
+  <text x="1567" y="386" style="font-size:7px">3,349,0,0,0</text>
   <path class="p3" d="M 1557 419 L 1549 394 L 1503 391 L 1507 414 L 1557 419"/>
-  <text x="1529" y="404" style="font-size:12">3,350,0,0,0</text>
+  <text x="1529" y="408" style="font-size:7px">3,350,0,0,0</text>
   <path class="p3" d="M 1549 394 L 1541 370 L 1500 370 L 1503 391 L 1549 394"/>
-  <text x="1523" y="381" style="font-size:11">3,351,0,0,0</text>
+  <text x="1523" y="384" style="font-size:7px">3,351,0,0,0</text>
   <path class="p4" d="M 1513 241 L 1505 232 L 1484 232 L 1492 241 L 1513 241"/>
-  <text x="1499" y="237" style="font-size:6">4,0,0,0,0</text>
+  <text x="1499" y="239" style="font-size:4px">4,0,0,0,0</text>
   <path class="p4" d="M 1505 232 L 1497 222 L 1476 224 L 1484 232 L 1505 232"/>
-  <text x="1490" y="228" style="font-size:6">4,1,0,0,0</text>
+  <text x="1490" y="230" style="font-size:4px">4,1,0,0,0</text>
   <path class="p4" d="M 1492 241 L 1484 232 L 1463 233 L 1471 241 L 1492 241"/>
-  <text x="1477" y="237" style="font-size:6">4,2,0,0,0</text>
+  <text x="1477" y="239" style="font-size:4px">4,2,0,0,0</text>
   <path class="p4" d="M 1484 232 L 1476 224 L 1455 225 L 1463 233 L 1484 232"/>
-  <text x="1469" y="228" style="font-size:6">4,3,0,0,0</text>
+  <text x="1469" y="230" style="font-size:4px">4,3,0,0,0</text>
   <path class="p4" d="M 1497 222 L 1489 213 L 1468 215 L 1476 224 L 1497 222"/>
-  <text x="1483" y="219" style="font-size:5">4,4,0,0,0</text>
+  <text x="1483" y="220" style="font-size:3px">4,4,0,0,0</text>
   <path class="p4" d="M 1489 213 L 1481 204 L 1460 206 L 1468 215 L 1489 213"/>
-  <text x="1475" y="210" style="font-size:5">4,5,0,0,0</text>
+  <text x="1475" y="211" style="font-size:3px">4,5,0,0,0</text>
   <path class="p4" d="M 1476 224 L 1468 215 L 1447 217 L 1455 225 L 1476 224"/>
-  <text x="1461" y="220" style="font-size:6">4,6,0,0,0</text>
+  <text x="1461" y="221" style="font-size:3px">4,6,0,0,0</text>
   <path class="p4" d="M 1468 215 L 1460 206 L 1439 209 L 1447 217 L 1468 215"/>
-  <text x="1454" y="212" style="font-size:5">4,7,0,0,0</text>
+  <text x="1454" y="213" style="font-size:3px">4,7,0,0,0</text>
   <path class="p4" d="M 1471 241 L 1463 233 L 1441 233 L 1449 241 L 1471 241"/>
-  <text x="1456" y="237" style="font-size:6">4,8,0,0,0</text>
+  <text x="1456" y="239" style="font-size:4px">4,8,0,0,0</text>
   <path class="p4" d="M 1463 233 L 1455 225 L 1433 226 L 1441 233 L 1463 233"/>
-  <text x="1448" y="229" style="font-size:6">4,9,0,0,0</text>
+  <text x="1448" y="231" style="font-size:4px">4,9,0,0,0</text>
   <path class="p4" d="M 1449 241 L 1441 233 L 1420 234 L 1428 241 L 1449 241"/>
-  <text x="1435" y="238" style="font-size:6">4,10,0,0,0</text>
+  <text x="1435" y="240" style="font-size:4px">4,10,0,0,0</text>
   <path class="p4" d="M 1441 233 L 1433 226 L 1412 227 L 1420 234 L 1441 233"/>
-  <text x="1427" y="230" style="font-size:6">4,11,0,0,0</text>
+  <text x="1427" y="232" style="font-size:4px">4,11,0,0,0</text>
   <path class="p4" d="M 1455 225 L 1447 217 L 1426 218 L 1433 226 L 1455 225"/>
-  <text x="1440" y="221" style="font-size:6">4,12,0,0,0</text>
+  <text x="1440" y="223" style="font-size:3px">4,12,0,0,0</text>
   <path class="p4" d="M 1447 217 L 1439 209 L 1418 211 L 1426 218 L 1447 217"/>
-  <text x="1432" y="213" style="font-size:5">4,13,0,0,0</text>
+  <text x="1432" y="215" style="font-size:3px">4,13,0,0,0</text>
   <path class="p4" d="M 1433 226 L 1426 218 L 1404 220 L 1412 227 L 1433 226"/>
-  <text x="1419" y="223" style="font-size:6">4,14,0,0,0</text>
+  <text x="1419" y="224" style="font-size:3px">4,14,0,0,0</text>
   <path class="p4" d="M 1426 218 L 1418 211 L 1397 213 L 1404 220 L 1426 218"/>
-  <text x="1411" y="215" style="font-size:5">4,15,0,0,0</text>
+  <text x="1411" y="217" style="font-size:3px">4,15,0,0,0</text>
   <path class="p4" d="M 1481 204 L 1474 195 L 1453 198 L 1460 206 L 1481 204"/>
-  <text x="1467" y="201" style="font-size:5">4,16,0,0,0</text>
+  <text x="1467" y="203" style="font-size:3px">4,16,0,0,0</text>
   <path class="p4" d="M 1474 195 L 1466 187 L 1445 190 L 1453 198 L 1474 195"/>
-  <text x="1459" y="193" style="font-size:5">4,17,0,0,0</text>
+  <text x="1459" y="194" style="font-size:3px">4,17,0,0,0</text>
   <path class="p4" d="M 1460 206 L 1453 198 L 1432 201 L 1439 209 L 1460 206"/>
-  <text x="1446" y="203" style="font-size:5">4,18,0,0,0</text>
+  <text x="1446" y="205" style="font-size:3px">4,18,0,0,0</text>
   <path class="p4" d="M 1453 198 L 1445 190 L 1424 193 L 1432 201 L 1453 198"/>
-  <text x="1439" y="195" style="font-size:5">4,19,0,0,0</text>
+  <text x="1439" y="197" style="font-size:3px">4,19,0,0,0</text>
   <path class="p4" d="M 1466 187 L 1459 178 L 1438 182 L 1445 190 L 1466 187"/>
-  <text x="1452" y="184" style="font-size:5">4,20,0,0,0</text>
+  <text x="1452" y="186" style="font-size:3px">4,20,0,0,0</text>
   <path class="p4" d="M 1459 178 L 1452 170 L 1431 174 L 1438 182 L 1459 178"/>
-  <text x="1445" y="176" style="font-size:5">4,21,0,0,0</text>
+  <text x="1445" y="177" style="font-size:3px">4,21,0,0,0</text>
   <path class="p4" d="M 1445 190 L 1438 182 L 1417 185 L 1424 193 L 1445 190"/>
-  <text x="1431" y="187" style="font-size:5">4,22,0,0,0</text>
+  <text x="1431" y="189" style="font-size:3px">4,22,0,0,0</text>
   <path class="p4" d="M 1438 182 L 1431 174 L 1410 178 L 1417 185 L 1438 182"/>
-  <text x="1424" y="180" style="font-size:5">4,23,0,0,0</text>
+  <text x="1424" y="181" style="font-size:3px">4,23,0,0,0</text>
   <path class="p4" d="M 1439 209 L 1432 201 L 1411 203 L 1418 211 L 1439 209"/>
-  <text x="1425" y="206" style="font-size:5">4,24,0,0,0</text>
+  <text x="1425" y="207" style="font-size:3px">4,24,0,0,0</text>
   <path class="p4" d="M 1432 201 L 1424 193 L 1403 196 L 1411 203 L 1432 201"/>
-  <text x="1417" y="198" style="font-size:5">4,25,0,0,0</text>
+  <text x="1417" y="200" style="font-size:3px">4,25,0,0,0</text>
   <path class="p4" d="M 1418 211 L 1411 203 L 1389 206 L 1397 213 L 1418 211"/>
-  <text x="1404" y="208" style="font-size:5">4,26,0,0,0</text>
+  <text x="1404" y="210" style="font-size:3px">4,26,0,0,0</text>
   <path class="p4" d="M 1411 203 L 1403 196 L 1382 199 L 1389 206 L 1411 203"/>
-  <text x="1396" y="201" style="font-size:5">4,27,0,0,0</text>
+  <text x="1396" y="203" style="font-size:3px">4,27,0,0,0</text>
   <path class="p4" d="M 1424 193 L 1417 185 L 1396 189 L 1403 196 L 1424 193"/>
-  <text x="1410" y="191" style="font-size:5">4,28,0,0,0</text>
+  <text x="1410" y="192" style="font-size:3px">4,28,0,0,0</text>
   <path class="p4" d="M 1417 185 L 1410 178 L 1389 182 L 1396 189 L 1417 185"/>
-  <text x="1403" y="184" style="font-size:5">4,29,0,0,0</text>
+  <text x="1403" y="185" style="font-size:3px">4,29,0,0,0</text>
   <path class="p4" d="M 1403 196 L 1396 189 L 1375 193 L 1382 199 L 1403 196"/>
-  <text x="1389" y="194" style="font-size:5">4,30,0,0,0</text>
+  <text x="1389" y="196" style="font-size:3px">4,30,0,0,0</text>
   <path class="p4" d="M 1396 189 L 1389 182 L 1368 186 L 1375 193 L 1396 189"/>
-  <text x="1382" y="187" style="font-size:5">4,31,0,0,0</text>
+  <text x="1382" y="189" style="font-size:3px">4,31,0,0,0</text>
   <path class="p4" d="M 1428 241 L 1420 234 L 1399 235 L 1406 241 L 1428 241"/>
-  <text x="1413" y="238" style="font-size:6">4,32,0,0,0</text>
+  <text x="1413" y="240" style="font-size:4px">4,32,0,0,0</text>
   <path class="p4" d="M 1420 234 L 1412 227 L 1391 228 L 1399 235 L 1420 234"/>
-  <text x="1405" y="231" style="font-size:6">4,33,0,0,0</text>
+  <text x="1405" y="233" style="font-size:4px">4,33,0,0,0</text>
   <path class="p4" d="M 1406 241 L 1399 235 L 1377 235 L 1385 241 L 1406 241"/>
-  <text x="1392" y="238" style="font-size:6">4,34,0,0,0</text>
+  <text x="1392" y="240" style="font-size:4px">4,34,0,0,0</text>
   <path class="p4" d="M 1399 235 L 1391 228 L 1369 229 L 1377 235 L 1399 235"/>
-  <text x="1384" y="232" style="font-size:6">4,35,0,0,0</text>
+  <text x="1384" y="234" style="font-size:4px">4,35,0,0,0</text>
   <path class="p4" d="M 1412 227 L 1404 220 L 1383 221 L 1391 228 L 1412 227"/>
-  <text x="1398" y="224" style="font-size:6">4,36,0,0,0</text>
+  <text x="1398" y="226" style="font-size:4px">4,36,0,0,0</text>
   <path class="p4" d="M 1404 220 L 1397 213 L 1375 215 L 1383 221 L 1404 220"/>
-  <text x="1390" y="217" style="font-size:6">4,37,0,0,0</text>
+  <text x="1390" y="219" style="font-size:3px">4,37,0,0,0</text>
   <path class="p4" d="M 1391 228 L 1383 221 L 1362 223 L 1369 229 L 1391 228"/>
-  <text x="1376" y="225" style="font-size:6">4,38,0,0,0</text>
+  <text x="1376" y="227" style="font-size:4px">4,38,0,0,0</text>
   <path class="p4" d="M 1383 221 L 1375 215 L 1354 217 L 1362 223 L 1383 221"/>
-  <text x="1368" y="219" style="font-size:6">4,39,0,0,0</text>
+  <text x="1368" y="221" style="font-size:3px">4,39,0,0,0</text>
   <path class="p4" d="M 1385 241 L 1377 235 L 1356 236 L 1364 241 L 1385 241"/>
-  <text x="1370" y="238" style="font-size:6">4,40,0,0,0</text>
+  <text x="1370" y="240" style="font-size:4px">4,40,0,0,0</text>
   <path class="p4" d="M 1377 235 L 1369 229 L 1348 230 L 1356 236 L 1377 235"/>
-  <text x="1362" y="233" style="font-size:6">4,41,0,0,0</text>
+  <text x="1362" y="235" style="font-size:4px">4,41,0,0,0</text>
   <path class="p4" d="M 1364 241 L 1356 236 L 1334 236 L 1342 241 L 1364 241"/>
-  <text x="1349" y="239" style="font-size:6">4,42,0,0,0</text>
+  <text x="1349" y="241" style="font-size:4px">4,42,0,0,0</text>
   <line x1="1342" y1="241" x2="1334" y2="236"/>
   <path class="p4" d="M 1356 236 L 1348 230 L 1326 231 L 1334 236 L 1356 236"/>
-  <text x="1341" y="233" style="font-size:6">4,43,0,0,0</text>
+  <text x="1341" y="235" style="font-size:4px">4,43,0,0,0</text>
   <line x1="1334" y1="236" x2="1326" y2="231"/>
   <path class="p4" d="M 1369 229 L 1362 223 L 1340 225 L 1348 230 L 1369 229"/>
-  <text x="1355" y="227" style="font-size:6">4,44,0,0,0</text>
+  <text x="1355" y="229" style="font-size:4px">4,44,0,0,0</text>
   <path class="p4" d="M 1362 223 L 1354 217 L 1332 219 L 1340 225 L 1362 223"/>
-  <text x="1347" y="221" style="font-size:6">4,45,0,0,0</text>
+  <text x="1347" y="223" style="font-size:4px">4,45,0,0,0</text>
   <path class="p4" d="M 1348 230 L 1340 225 L 1318 226 L 1326 231 L 1348 230"/>
-  <text x="1333" y="228" style="font-size:6">4,46,0,0,0</text>
+  <text x="1333" y="230" style="font-size:4px">4,46,0,0,0</text>
   <line x1="1326" y1="231" x2="1318" y2="226"/>
   <path class="p4" d="M 1340 225 L 1332 219 L 1311 222 L 1318 226 L 1340 225"/>
-  <text x="1325" y="223" style="font-size:6">4,47,0,0,0</text>
+  <text x="1325" y="225" style="font-size:4px">4,47,0,0,0</text>
   <line x1="1318" y1="226" x2="1311" y2="222"/>
   <path class="p4" d="M 1397 213 L 1389 206 L 1368 209 L 1375 215 L 1397 213"/>
-  <text x="1382" y="211" style="font-size:5">4,48,0,0,0</text>
+  <text x="1382" y="212" style="font-size:3px">4,48,0,0,0</text>
   <path class="p4" d="M 1389 206 L 1382 199 L 1360 202 L 1368 209 L 1389 206"/>
-  <text x="1375" y="204" style="font-size:5">4,49,0,0,0</text>
+  <text x="1375" y="206" style="font-size:3px">4,49,0,0,0</text>
   <path class="p4" d="M 1375 215 L 1368 209 L 1346 211 L 1354 217 L 1375 215"/>
-  <text x="1361" y="213" style="font-size:6">4,50,0,0,0</text>
+  <text x="1361" y="215" style="font-size:3px">4,50,0,0,0</text>
   <path class="p4" d="M 1368 209 L 1360 202 L 1339 206 L 1346 211 L 1368 209"/>
-  <text x="1353" y="207" style="font-size:5">4,51,0,0,0</text>
+  <text x="1353" y="208" style="font-size:3px">4,51,0,0,0</text>
   <path class="p4" d="M 1382 199 L 1375 193 L 1353 196 L 1360 202 L 1382 199"/>
-  <text x="1368" y="198" style="font-size:5">4,52,0,0,0</text>
+  <text x="1368" y="199" style="font-size:3px">4,52,0,0,0</text>
   <path class="p4" d="M 1375 193 L 1368 186 L 1346 190 L 1353 196 L 1375 193"/>
-  <text x="1360" y="191" style="font-size:5">4,53,0,0,0</text>
+  <text x="1360" y="193" style="font-size:3px">4,53,0,0,0</text>
   <path class="p4" d="M 1360 202 L 1353 196 L 1332 200 L 1339 206 L 1360 202"/>
-  <text x="1346" y="201" style="font-size:5">4,54,0,0,0</text>
+  <text x="1346" y="203" style="font-size:3px">4,54,0,0,0</text>
   <path class="p4" d="M 1353 196 L 1346 190 L 1324 194 L 1332 200 L 1353 196"/>
-  <text x="1339" y="195" style="font-size:5">4,55,0,0,0</text>
+  <text x="1339" y="197" style="font-size:3px">4,55,0,0,0</text>
   <path class="p4" d="M 1354 217 L 1346 211 L 1325 214 L 1332 219 L 1354 217"/>
-  <text x="1339" y="215" style="font-size:6">4,56,0,0,0</text>
+  <text x="1339" y="217" style="font-size:3px">4,56,0,0,0</text>
   <path class="p4" d="M 1346 211 L 1339 206 L 1317 209 L 1325 214 L 1346 211"/>
-  <text x="1332" y="210" style="font-size:5">4,57,0,0,0</text>
+  <text x="1332" y="211" style="font-size:3px">4,57,0,0,0</text>
   <path class="p4" d="M 1332 219 L 1325 214 L 1303 217 L 1311 222 L 1332 219"/>
-  <text x="1318" y="218" style="font-size:6">4,58,0,0,0</text>
+  <text x="1318" y="220" style="font-size:4px">4,58,0,0,0</text>
   <line x1="1311" y1="222" x2="1303" y2="217"/>
   <path class="p4" d="M 1325 214 L 1317 209 L 1295 212 L 1303 217 L 1325 214"/>
-  <text x="1310" y="213" style="font-size:6">4,59,0,0,0</text>
+  <text x="1310" y="214" style="font-size:3px">4,59,0,0,0</text>
   <line x1="1303" y1="217" x2="1295" y2="212"/>
   <path class="p4" d="M 1339 206 L 1332 200 L 1310 204 L 1317 209 L 1339 206"/>
-  <text x="1324" y="204" style="font-size:5">4,60,0,0,0</text>
+  <text x="1324" y="206" style="font-size:3px">4,60,0,0,0</text>
   <path class="p4" d="M 1332 200 L 1324 194 L 1302 198 L 1310 204 L 1332 200"/>
-  <text x="1317" y="199" style="font-size:5">4,61,0,0,0</text>
+  <text x="1317" y="201" style="font-size:3px">4,61,0,0,0</text>
   <path class="p4" d="M 1317 209 L 1310 204 L 1288 207 L 1295 212 L 1317 209"/>
-  <text x="1302" y="208" style="font-size:5">4,62,0,0,0</text>
+  <text x="1302" y="209" style="font-size:3px">4,62,0,0,0</text>
   <line x1="1295" y1="212" x2="1288" y2="207"/>
   <path class="p4" d="M 1310 204 L 1302 198 L 1280 203 L 1288 207 L 1310 204"/>
-  <text x="1295" y="203" style="font-size:5">4,63,0,0,0</text>
+  <text x="1295" y="204" style="font-size:3px">4,63,0,0,0</text>
   <line x1="1288" y1="207" x2="1280" y2="203"/>
   <path class="p4" d="M 1452 170 L 1445 162 L 1424 166 L 1431 174 L 1452 170"/>
-  <text x="1438" y="168" style="font-size:5">4,64,0,0,0</text>
+  <text x="1438" y="169" style="font-size:3px">4,64,0,0,0</text>
   <path class="p4" d="M 1445 162 L 1438 154 L 1417 159 L 1424 166 L 1445 162"/>
-  <text x="1431" y="160" style="font-size:5">4,65,0,0,0</text>
+  <text x="1431" y="162" style="font-size:3px">4,65,0,0,0</text>
   <path class="p4" d="M 1431 174 L 1424 166 L 1403 171 L 1410 178 L 1431 174"/>
-  <text x="1417" y="172" style="font-size:5">4,66,0,0,0</text>
+  <text x="1417" y="174" style="font-size:3px">4,66,0,0,0</text>
   <path class="p4" d="M 1424 166 L 1417 159 L 1396 163 L 1403 171 L 1424 166"/>
-  <text x="1410" y="165" style="font-size:5">4,67,0,0,0</text>
+  <text x="1410" y="166" style="font-size:3px">4,67,0,0,0</text>
   <path class="p4" d="M 1438 154 L 1431 146 L 1410 151 L 1417 159 L 1438 154"/>
-  <text x="1424" y="152" style="font-size:5">4,68,0,0,0</text>
+  <text x="1424" y="154" style="font-size:3px">4,68,0,0,0</text>
   <path class="p4" d="M 1431 146 L 1424 138 L 1403 144 L 1410 151 L 1431 146"/>
-  <text x="1417" y="145" style="font-size:4">4,69,0,0,0</text>
+  <text x="1417" y="146" style="font-size:3px">4,69,0,0,0</text>
   <path class="p4" d="M 1417 159 L 1410 151 L 1389 156 L 1396 163 L 1417 159"/>
-  <text x="1403" y="157" style="font-size:5">4,70,0,0,0</text>
+  <text x="1403" y="159" style="font-size:3px">4,70,0,0,0</text>
   <path class="p4" d="M 1410 151 L 1403 144 L 1383 149 L 1389 156 L 1410 151"/>
-  <text x="1396" y="150" style="font-size:5">4,71,0,0,0</text>
+  <text x="1396" y="152" style="font-size:3px">4,71,0,0,0</text>
   <path class="p4" d="M 1410 178 L 1403 171 L 1382 175 L 1389 182 L 1410 178"/>
-  <text x="1396" y="176" style="font-size:5">4,72,0,0,0</text>
+  <text x="1396" y="178" style="font-size:3px">4,72,0,0,0</text>
   <path class="p4" d="M 1403 171 L 1396 163 L 1375 168 L 1382 175 L 1403 171"/>
-  <text x="1389" y="169" style="font-size:5">4,73,0,0,0</text>
+  <text x="1389" y="171" style="font-size:3px">4,73,0,0,0</text>
   <path class="p4" d="M 1389 182 L 1382 175 L 1360 180 L 1368 186 L 1389 182"/>
-  <text x="1375" y="181" style="font-size:5">4,74,0,0,0</text>
+  <text x="1375" y="182" style="font-size:3px">4,74,0,0,0</text>
   <path class="p4" d="M 1382 175 L 1375 168 L 1353 173 L 1360 180 L 1382 175"/>
-  <text x="1368" y="174" style="font-size:5">4,75,0,0,0</text>
+  <text x="1368" y="175" style="font-size:3px">4,75,0,0,0</text>
   <path class="p4" d="M 1396 163 L 1389 156 L 1368 162 L 1375 168 L 1396 163"/>
-  <text x="1382" y="162" style="font-size:5">4,76,0,0,0</text>
+  <text x="1382" y="164" style="font-size:3px">4,76,0,0,0</text>
   <path class="p4" d="M 1389 156 L 1383 149 L 1361 155 L 1368 162 L 1389 156"/>
-  <text x="1375" y="155" style="font-size:5">4,77,0,0,0</text>
+  <text x="1375" y="157" style="font-size:3px">4,77,0,0,0</text>
   <path class="p4" d="M 1375 168 L 1368 162 L 1347 167 L 1353 173 L 1375 168"/>
-  <text x="1361" y="167" style="font-size:5">4,78,0,0,0</text>
+  <text x="1361" y="169" style="font-size:3px">4,78,0,0,0</text>
   <path class="p4" d="M 1368 162 L 1361 155 L 1340 161 L 1347 167 L 1368 162"/>
-  <text x="1354" y="161" style="font-size:5">4,79,0,0,0</text>
+  <text x="1354" y="163" style="font-size:3px">4,79,0,0,0</text>
   <path class="p4" d="M 1383 149 L 1376 142 L 1355 148 L 1361 155 L 1383 149"/>
-  <text x="1369" y="149" style="font-size:5">4,80,0,0,0</text>
+  <text x="1369" y="150" style="font-size:3px">4,80,0,0,0</text>
   <path class="p4" d="M 1376 142 L 1369 136 L 1348 142 L 1355 148 L 1376 142"/>
-  <text x="1362" y="142" style="font-size:4">4,81,0,0,0</text>
+  <text x="1362" y="144" style="font-size:3px">4,81,0,0,0</text>
   <path class="p4" d="M 1361 155 L 1355 148 L 1333 155 L 1340 161 L 1361 155"/>
-  <text x="1347" y="155" style="font-size:5">4,82,0,0,0</text>
+  <text x="1347" y="156" style="font-size:3px">4,82,0,0,0</text>
   <path class="p4" d="M 1355 148 L 1348 142 L 1327 149 L 1333 155 L 1355 148"/>
-  <text x="1341" y="148" style="font-size:5">4,83,0,0,0</text>
+  <text x="1341" y="150" style="font-size:3px">4,83,0,0,0</text>
   <path class="p4" d="M 1369 136 L 1363 129 L 1342 136 L 1348 142 L 1369 136"/>
-  <text x="1356" y="136" style="font-size:4">4,84,0,0,0</text>
+  <text x="1356" y="137" style="font-size:3px">4,84,0,0,0</text>
   <path class="p4" d="M 1363 129 L 1357 122 L 1335 130 L 1342 136 L 1363 129"/>
-  <text x="1349" y="129" style="font-size:4">4,85,0,0,0</text>
+  <text x="1349" y="131" style="font-size:3px">4,85,0,0,0</text>
   <path class="p4" d="M 1348 142 L 1342 136 L 1320 143 L 1327 149 L 1348 142"/>
-  <text x="1334" y="142" style="font-size:4">4,86,0,0,0</text>
+  <text x="1334" y="144" style="font-size:3px">4,86,0,0,0</text>
   <path class="p4" d="M 1342 136 L 1335 130 L 1314 137 L 1320 143 L 1342 136"/>
-  <text x="1328" y="136" style="font-size:4">4,87,0,0,0</text>
+  <text x="1328" y="138" style="font-size:3px">4,87,0,0,0</text>
   <path class="p4" d="M 1368 186 L 1360 180 L 1339 184 L 1346 190 L 1368 186"/>
-  <text x="1353" y="185" style="font-size:5">4,88,0,0,0</text>
+  <text x="1353" y="186" style="font-size:3px">4,88,0,0,0</text>
   <path class="p4" d="M 1360 180 L 1353 173 L 1332 178 L 1339 184 L 1360 180"/>
-  <text x="1346" y="179" style="font-size:5">4,89,0,0,0</text>
+  <text x="1346" y="180" style="font-size:3px">4,89,0,0,0</text>
   <path class="p4" d="M 1346 190 L 1339 184 L 1317 189 L 1324 194 L 1346 190"/>
-  <text x="1332" y="189" style="font-size:5">4,90,0,0,0</text>
+  <text x="1332" y="191" style="font-size:3px">4,90,0,0,0</text>
   <path class="p4" d="M 1339 184 L 1332 178 L 1310 183 L 1317 189 L 1339 184"/>
-  <text x="1324" y="184" style="font-size:5">4,91,0,0,0</text>
+  <text x="1324" y="185" style="font-size:3px">4,91,0,0,0</text>
   <path class="p4" d="M 1353 173 L 1347 167 L 1325 172 L 1332 178 L 1353 173"/>
-  <text x="1339" y="173" style="font-size:5">4,92,0,0,0</text>
+  <text x="1339" y="174" style="font-size:3px">4,92,0,0,0</text>
   <path class="p4" d="M 1347 167 L 1340 161 L 1318 167 L 1325 172 L 1347 167"/>
-  <text x="1332" y="167" style="font-size:5">4,93,0,0,0</text>
+  <text x="1332" y="168" style="font-size:3px">4,93,0,0,0</text>
   <path class="p4" d="M 1332 178 L 1325 172 L 1303 178 L 1310 183 L 1332 178"/>
-  <text x="1317" y="178" style="font-size:5">4,94,0,0,0</text>
+  <text x="1317" y="179" style="font-size:3px">4,94,0,0,0</text>
   <path class="p4" d="M 1325 172 L 1318 167 L 1296 172 L 1303 178 L 1325 172"/>
-  <text x="1311" y="172" style="font-size:5">4,95,0,0,0</text>
+  <text x="1311" y="174" style="font-size:3px">4,95,0,0,0</text>
   <path class="p4" d="M 1324 194 L 1317 189 L 1295 193 L 1302 198 L 1324 194"/>
-  <text x="1310" y="194" style="font-size:5">4,96,0,0,0</text>
+  <text x="1310" y="195" style="font-size:3px">4,96,0,0,0</text>
   <path class="p4" d="M 1317 189 L 1310 183 L 1288 188 L 1295 193 L 1317 189"/>
-  <text x="1303" y="188" style="font-size:5">4,97,0,0,0</text>
+  <text x="1303" y="190" style="font-size:3px">4,97,0,0,0</text>
   <path class="p4" d="M 1302 198 L 1295 193 L 1273 198 L 1280 203 L 1302 198"/>
-  <text x="1288" y="198" style="font-size:5">4,98,0,0,0</text>
+  <text x="1288" y="200" style="font-size:3px">4,98,0,0,0</text>
   <line x1="1280" y1="203" x2="1273" y2="198"/>
   <path class="p4" d="M 1295 193 L 1288 188 L 1266 193 L 1273 198 L 1295 193"/>
-  <text x="1280" y="193" style="font-size:5">4,99,0,0,0</text>
+  <text x="1280" y="195" style="font-size:3px">4,99,0,0,0</text>
   <line x1="1273" y1="198" x2="1266" y2="193"/>
   <path class="p4" d="M 1310 183 L 1303 178 L 1281 183 L 1288 188 L 1310 183"/>
-  <text x="1295" y="183" style="font-size:5">4,100,0,0,0</text>
+  <text x="1295" y="185" style="font-size:3px">4,100,0,0,0</text>
   <path class="p4" d="M 1303 178 L 1296 172 L 1274 178 L 1281 183 L 1303 178"/>
-  <text x="1288" y="178" style="font-size:5">4,101,0,0,0</text>
+  <text x="1288" y="179" style="font-size:3px">4,101,0,0,0</text>
   <path class="p4" d="M 1288 188 L 1281 183 L 1258 189 L 1266 193 L 1288 188"/>
-  <text x="1273" y="189" style="font-size:5">4,102,0,0,0</text>
+  <text x="1273" y="190" style="font-size:3px">4,102,0,0,0</text>
   <line x1="1266" y1="193" x2="1258" y2="189"/>
   <path class="p4" d="M 1281 183 L 1274 178 L 1251 184 L 1258 189 L 1281 183"/>
-  <text x="1266" y="184" style="font-size:5">4,103,0,0,0</text>
+  <text x="1266" y="185" style="font-size:3px">4,103,0,0,0</text>
   <line x1="1258" y1="189" x2="1251" y2="184"/>
   <path class="p4" d="M 1340 161 L 1333 155 L 1311 161 L 1318 167 L 1340 161"/>
-  <text x="1326" y="161" style="font-size:5">4,104,0,0,0</text>
+  <text x="1326" y="162" style="font-size:3px">4,104,0,0,0</text>
   <path class="p4" d="M 1333 155 L 1327 149 L 1305 155 L 1311 161 L 1333 155"/>
-  <text x="1319" y="155" style="font-size:5">4,105,0,0,0</text>
+  <text x="1319" y="156" style="font-size:3px">4,105,0,0,0</text>
   <path class="p4" d="M 1318 167 L 1311 161 L 1289 167 L 1296 172 L 1318 167"/>
-  <text x="1304" y="167" style="font-size:5">4,106,0,0,0</text>
+  <text x="1304" y="168" style="font-size:3px">4,106,0,0,0</text>
   <path class="p4" d="M 1311 161 L 1305 155 L 1282 162 L 1289 167 L 1311 161"/>
-  <text x="1297" y="161" style="font-size:5">4,107,0,0,0</text>
+  <text x="1297" y="163" style="font-size:3px">4,107,0,0,0</text>
   <path class="p4" d="M 1327 149 L 1320 143 L 1298 150 L 1305 155 L 1327 149"/>
-  <text x="1312" y="149" style="font-size:5">4,108,0,0,0</text>
+  <text x="1312" y="150" style="font-size:3px">4,108,0,0,0</text>
   <path class="p4" d="M 1320 143 L 1314 137 L 1292 144 L 1298 150 L 1320 143"/>
-  <text x="1306" y="143" style="font-size:5">4,109,0,0,0</text>
+  <text x="1306" y="145" style="font-size:3px">4,109,0,0,0</text>
   <path class="p4" d="M 1305 155 L 1298 150 L 1276 157 L 1282 162 L 1305 155"/>
-  <text x="1290" y="156" style="font-size:5">4,110,0,0,0</text>
+  <text x="1290" y="157" style="font-size:3px">4,110,0,0,0</text>
   <path class="p4" d="M 1298 150 L 1292 144 L 1269 152 L 1276 157 L 1298 150"/>
-  <text x="1284" y="151" style="font-size:5">4,111,0,0,0</text>
+  <text x="1284" y="152" style="font-size:3px">4,111,0,0,0</text>
   <path class="p4" d="M 1296 172 L 1289 167 L 1267 174 L 1274 178 L 1296 172"/>
-  <text x="1281" y="173" style="font-size:5">4,112,0,0,0</text>
+  <text x="1281" y="174" style="font-size:3px">4,112,0,0,0</text>
   <path class="p4" d="M 1289 167 L 1282 162 L 1260 169 L 1267 174 L 1289 167"/>
-  <text x="1275" y="168" style="font-size:5">4,113,0,0,0</text>
+  <text x="1275" y="169" style="font-size:3px">4,113,0,0,0</text>
   <path class="p4" d="M 1274 178 L 1267 174 L 1244 180 L 1251 184 L 1274 178"/>
-  <text x="1259" y="179" style="font-size:5">4,114,0,0,0</text>
+  <text x="1259" y="181" style="font-size:3px">4,114,0,0,0</text>
   <line x1="1251" y1="184" x2="1244" y2="180"/>
   <path class="p4" d="M 1267 174 L 1260 169 L 1237 176 L 1244 180 L 1267 174"/>
-  <text x="1252" y="174" style="font-size:5">4,115,0,0,0</text>
+  <text x="1252" y="176" style="font-size:3px">4,115,0,0,0</text>
   <line x1="1244" y1="180" x2="1237" y2="176"/>
   <path class="p4" d="M 1282 162 L 1276 157 L 1253 164 L 1260 169 L 1282 162"/>
-  <text x="1268" y="163" style="font-size:5">4,116,0,0,0</text>
+  <text x="1268" y="164" style="font-size:3px">4,116,0,0,0</text>
   <path class="p4" d="M 1276 157 L 1269 152 L 1246 159 L 1253 164 L 1276 157"/>
-  <text x="1261" y="158" style="font-size:5">4,117,0,0,0</text>
+  <text x="1261" y="159" style="font-size:3px">4,117,0,0,0</text>
   <path class="p4" d="M 1260 169 L 1253 164 L 1230 171 L 1237 176 L 1260 169"/>
-  <text x="1245" y="170" style="font-size:5">4,118,0,0,0</text>
+  <text x="1245" y="171" style="font-size:3px">4,118,0,0,0</text>
   <line x1="1237" y1="176" x2="1230" y2="171"/>
   <path class="p4" d="M 1253 164 L 1246 159 L 1223 167 L 1230 171 L 1253 164"/>
-  <text x="1238" y="165" style="font-size:5">4,119,0,0,0</text>
+  <text x="1238" y="167" style="font-size:3px">4,119,0,0,0</text>
   <line x1="1230" y1="171" x2="1223" y2="167"/>
   <path class="p4" d="M 1357 122 L 1334 121 L 1314 128 L 1335 130 L 1357 122"/>
-  <text x="1335" y="125" style="font-size:4">4,120,0,0,0</text>
+  <text x="1335" y="127" style="font-size:3px">4,120,0,0,0</text>
   <path class="p4" d="M 1334 121 L 1311 120 L 1293 127 L 1314 128 L 1334 121"/>
-  <text x="1313" y="124" style="font-size:4">4,121,0,0,0</text>
+  <text x="1313" y="126" style="font-size:3px">4,121,0,0,0</text>
   <path class="p4" d="M 1335 130 L 1314 128 L 1294 136 L 1314 137 L 1335 130"/>
-  <text x="1314" y="133" style="font-size:4">4,122,0,0,0</text>
+  <text x="1314" y="134" style="font-size:3px">4,122,0,0,0</text>
   <path class="p4" d="M 1314 128 L 1293 127 L 1274 134 L 1294 136 L 1314 128"/>
-  <text x="1294" y="131" style="font-size:4">4,123,0,0,0</text>
+  <text x="1294" y="133" style="font-size:3px">4,123,0,0,0</text>
   <path class="p4" d="M 1311 120 L 1289 119 L 1272 126 L 1293 127 L 1311 120"/>
-  <text x="1291" y="123" style="font-size:4">4,124,0,0,0</text>
+  <text x="1291" y="125" style="font-size:3px">4,124,0,0,0</text>
   <path class="p4" d="M 1289 119 L 1266 118 L 1250 125 L 1272 126 L 1289 119"/>
-  <text x="1269" y="122" style="font-size:4">4,125,0,0,0</text>
+  <text x="1269" y="124" style="font-size:3px">4,125,0,0,0</text>
   <path class="p4" d="M 1293 127 L 1272 126 L 1254 133 L 1274 134 L 1293 127"/>
-  <text x="1273" y="130" style="font-size:4">4,126,0,0,0</text>
+  <text x="1273" y="132" style="font-size:3px">4,126,0,0,0</text>
   <path class="p4" d="M 1272 126 L 1250 125 L 1234 132 L 1254 133 L 1272 126"/>
-  <text x="1252" y="129" style="font-size:4">4,127,0,0,0</text>
+  <text x="1252" y="131" style="font-size:3px">4,127,0,0,0</text>
   <path class="p4" d="M 1298 105 L 1273 105 L 1258 111 L 1282 112 L 1298 105"/>
-  <text x="1278" y="108" style="font-size:4">4,128,0,0,0</text>
+  <text x="1278" y="110" style="font-size:3px">4,128,0,0,0</text>
   <path class="p4" d="M 1273 105 L 1248 104 L 1235 110 L 1258 111 L 1273 105"/>
-  <text x="1253" y="107" style="font-size:4">4,129,0,0,0</text>
+  <text x="1253" y="109" style="font-size:3px">4,129,0,0,0</text>
   <path class="p4" d="M 1282 112 L 1258 111 L 1244 117 L 1266 118 L 1282 112"/>
-  <text x="1263" y="115" style="font-size:4">4,130,0,0,0</text>
+  <text x="1263" y="116" style="font-size:3px">4,130,0,0,0</text>
   <path class="p4" d="M 1258 111 L 1235 110 L 1221 116 L 1244 117 L 1258 111"/>
-  <text x="1240" y="114" style="font-size:4">4,131,0,0,0</text>
+  <text x="1240" y="115" style="font-size:3px">4,131,0,0,0</text>
   <path class="p4" d="M 1248 104 L 1223 103 L 1211 109 L 1235 110 L 1248 104"/>
-  <text x="1229" y="107" style="font-size:4">4,132,0,0,0</text>
+  <text x="1229" y="108" style="font-size:3px">4,132,0,0,0</text>
   <path class="p4" d="M 1223 103 L 1198 102 L 1187 108 L 1211 109 L 1223 103"/>
-  <text x="1205" y="106" style="font-size:4">4,133,0,0,0</text>
+  <text x="1205" y="107" style="font-size:3px">4,133,0,0,0</text>
   <path class="p4" d="M 1235 110 L 1211 109 L 1199 116 L 1221 116 L 1235 110"/>
-  <text x="1217" y="113" style="font-size:4">4,134,0,0,0</text>
+  <text x="1217" y="114" style="font-size:3px">4,134,0,0,0</text>
   <path class="p4" d="M 1211 109 L 1187 108 L 1177 115 L 1199 116 L 1211 109"/>
-  <text x="1194" y="112" style="font-size:4">4,135,0,0,0</text>
+  <text x="1194" y="113" style="font-size:3px">4,135,0,0,0</text>
   <path class="p4" d="M 1266 118 L 1244 117 L 1229 124 L 1250 125 L 1266 118"/>
-  <text x="1247" y="121" style="font-size:4">4,136,0,0,0</text>
+  <text x="1247" y="123" style="font-size:3px">4,136,0,0,0</text>
   <path class="p4" d="M 1244 117 L 1221 116 L 1208 123 L 1229 124 L 1244 117"/>
-  <text x="1226" y="120" style="font-size:4">4,137,0,0,0</text>
+  <text x="1226" y="122" style="font-size:3px">4,137,0,0,0</text>
   <path class="p4" d="M 1250 125 L 1229 124 L 1214 131 L 1234 132 L 1250 125"/>
-  <text x="1232" y="128" style="font-size:4">4,138,0,0,0</text>
+  <text x="1232" y="129" style="font-size:3px">4,138,0,0,0</text>
   <path class="p4" d="M 1229 124 L 1208 123 L 1194 129 L 1214 131 L 1229 124"/>
-  <text x="1211" y="127" style="font-size:4">4,139,0,0,0</text>
+  <text x="1211" y="128" style="font-size:3px">4,139,0,0,0</text>
   <path class="p4" d="M 1221 116 L 1199 116 L 1187 122 L 1208 123 L 1221 116"/>
-  <text x="1204" y="119" style="font-size:4">4,140,0,0,0</text>
+  <text x="1204" y="121" style="font-size:3px">4,140,0,0,0</text>
   <path class="p4" d="M 1199 116 L 1177 115 L 1166 121 L 1187 122 L 1199 116"/>
-  <text x="1182" y="118" style="font-size:4">4,141,0,0,0</text>
+  <text x="1182" y="120" style="font-size:3px">4,141,0,0,0</text>
   <path class="p4" d="M 1208 123 L 1187 122 L 1175 128 L 1194 129 L 1208 123"/>
-  <text x="1191" y="126" style="font-size:4">4,142,0,0,0</text>
+  <text x="1191" y="127" style="font-size:3px">4,142,0,0,0</text>
   <path class="p4" d="M 1187 122 L 1166 121 L 1155 127 L 1175 128 L 1187 122"/>
-  <text x="1171" y="124" style="font-size:4">4,143,0,0,0</text>
+  <text x="1171" y="126" style="font-size:3px">4,143,0,0,0</text>
   <path class="p4" d="M 1314 137 L 1294 136 L 1273 143 L 1292 144 L 1314 137"/>
-  <text x="1293" y="140" style="font-size:4">4,144,0,0,0</text>
+  <text x="1293" y="141" style="font-size:3px">4,144,0,0,0</text>
   <path class="p4" d="M 1294 136 L 1274 134 L 1254 141 L 1273 143 L 1294 136"/>
-  <text x="1274" y="138" style="font-size:4">4,145,0,0,0</text>
+  <text x="1274" y="140" style="font-size:3px">4,145,0,0,0</text>
   <path class="p4" d="M 1292 144 L 1273 143 L 1252 150 L 1269 152 L 1292 144"/>
-  <text x="1272" y="147" style="font-size:5">4,146,0,0,0</text>
+  <text x="1272" y="149" style="font-size:3px">4,146,0,0,0</text>
   <path class="p4" d="M 1273 143 L 1254 141 L 1235 149 L 1252 150 L 1273 143"/>
-  <text x="1254" y="146" style="font-size:5">4,147,0,0,0</text>
+  <text x="1254" y="147" style="font-size:3px">4,147,0,0,0</text>
   <path class="p4" d="M 1274 134 L 1254 133 L 1236 140 L 1254 141 L 1274 134"/>
-  <text x="1255" y="137" style="font-size:4">4,148,0,0,0</text>
+  <text x="1255" y="139" style="font-size:3px">4,148,0,0,0</text>
   <path class="p4" d="M 1254 133 L 1234 132 L 1217 139 L 1236 140 L 1254 133"/>
-  <text x="1235" y="136" style="font-size:4">4,149,0,0,0</text>
+  <text x="1235" y="137" style="font-size:3px">4,149,0,0,0</text>
   <path class="p4" d="M 1254 141 L 1236 140 L 1218 147 L 1235 149 L 1254 141"/>
-  <text x="1236" y="144" style="font-size:5">4,150,0,0,0</text>
+  <text x="1236" y="146" style="font-size:3px">4,150,0,0,0</text>
   <path class="p4" d="M 1236 140 L 1217 139 L 1201 146 L 1218 147 L 1236 140"/>
-  <text x="1218" y="143" style="font-size:5">4,151,0,0,0</text>
+  <text x="1218" y="144" style="font-size:3px">4,151,0,0,0</text>
   <path class="p4" d="M 1269 152 L 1252 150 L 1231 158 L 1246 159 L 1269 152"/>
-  <text x="1250" y="155" style="font-size:5">4,152,0,0,0</text>
+  <text x="1250" y="156" style="font-size:3px">4,152,0,0,0</text>
   <path class="p4" d="M 1252 150 L 1235 149 L 1215 156 L 1231 158 L 1252 150"/>
-  <text x="1233" y="153" style="font-size:5">4,153,0,0,0</text>
+  <text x="1233" y="155" style="font-size:3px">4,153,0,0,0</text>
   <path class="p4" d="M 1246 159 L 1231 158 L 1209 165 L 1223 167 L 1246 159"/>
-  <text x="1227" y="162" style="font-size:5">4,154,0,0,0</text>
+  <text x="1227" y="164" style="font-size:3px">4,154,0,0,0</text>
   <line x1="1223" y1="167" x2="1209" y2="165"/>
   <path class="p4" d="M 1231 158 L 1215 156 L 1194 163 L 1209 165 L 1231 158"/>
-  <text x="1212" y="161" style="font-size:5">4,155,0,0,0</text>
+  <text x="1212" y="162" style="font-size:3px">4,155,0,0,0</text>
   <line x1="1209" y1="165" x2="1194" y2="163"/>
   <path class="p4" d="M 1235 149 L 1218 147 L 1199 154 L 1215 156 L 1235 149"/>
-  <text x="1217" y="152" style="font-size:5">4,156,0,0,0</text>
+  <text x="1217" y="153" style="font-size:3px">4,156,0,0,0</text>
   <path class="p4" d="M 1218 147 L 1201 146 L 1183 153 L 1199 154 L 1218 147"/>
-  <text x="1200" y="150" style="font-size:5">4,157,0,0,0</text>
+  <text x="1200" y="151" style="font-size:3px">4,157,0,0,0</text>
   <path class="p4" d="M 1215 156 L 1199 154 L 1180 162 L 1194 163 L 1215 156"/>
-  <text x="1197" y="159" style="font-size:5">4,158,0,0,0</text>
+  <text x="1197" y="160" style="font-size:3px">4,158,0,0,0</text>
   <line x1="1194" y1="163" x2="1180" y2="162"/>
   <path class="p4" d="M 1199 154 L 1183 153 L 1166 160 L 1180 162 L 1199 154"/>
-  <text x="1182" y="157" style="font-size:5">4,159,0,0,0</text>
+  <text x="1182" y="159" style="font-size:3px">4,159,0,0,0</text>
   <line x1="1180" y1="162" x2="1166" y2="160"/>
   <path class="p4" d="M 1234 132 L 1214 131 L 1199 137 L 1217 139 L 1234 132"/>
-  <text x="1216" y="135" style="font-size:4">4,160,0,0,0</text>
+  <text x="1216" y="136" style="font-size:3px">4,160,0,0,0</text>
   <path class="p4" d="M 1214 131 L 1194 129 L 1181 136 L 1199 137 L 1214 131"/>
-  <text x="1197" y="133" style="font-size:4">4,161,0,0,0</text>
+  <text x="1197" y="135" style="font-size:3px">4,161,0,0,0</text>
   <path class="p4" d="M 1217 139 L 1199 137 L 1183 144 L 1201 146 L 1217 139"/>
-  <text x="1200" y="141" style="font-size:5">4,162,0,0,0</text>
+  <text x="1200" y="143" style="font-size:3px">4,162,0,0,0</text>
   <path class="p4" d="M 1199 137 L 1181 136 L 1167 143 L 1183 144 L 1199 137"/>
-  <text x="1182" y="140" style="font-size:5">4,163,0,0,0</text>
+  <text x="1182" y="142" style="font-size:3px">4,163,0,0,0</text>
   <path class="p4" d="M 1194 129 L 1175 128 L 1162 135 L 1181 136 L 1194 129"/>
-  <text x="1178" y="132" style="font-size:4">4,164,0,0,0</text>
+  <text x="1178" y="134" style="font-size:3px">4,164,0,0,0</text>
   <path class="p4" d="M 1175 128 L 1155 127 L 1144 133 L 1162 135 L 1175 128"/>
-  <text x="1159" y="131" style="font-size:4">4,165,0,0,0</text>
+  <text x="1159" y="132" style="font-size:3px">4,165,0,0,0</text>
   <path class="p4" d="M 1181 136 L 1162 135 L 1150 141 L 1167 143 L 1181 136"/>
-  <text x="1165" y="139" style="font-size:5">4,166,0,0,0</text>
+  <text x="1165" y="140" style="font-size:3px">4,166,0,0,0</text>
   <path class="p4" d="M 1162 135 L 1144 133 L 1133 140 L 1150 141 L 1162 135"/>
-  <text x="1147" y="137" style="font-size:4">4,167,0,0,0</text>
+  <text x="1147" y="139" style="font-size:3px">4,167,0,0,0</text>
   <path class="p4" d="M 1201 146 L 1183 144 L 1168 151 L 1183 153 L 1201 146"/>
-  <text x="1184" y="148" style="font-size:5">4,168,0,0,0</text>
+  <text x="1184" y="150" style="font-size:3px">4,168,0,0,0</text>
   <path class="p4" d="M 1183 144 L 1167 143 L 1152 150 L 1168 151 L 1183 144"/>
-  <text x="1168" y="147" style="font-size:5">4,169,0,0,0</text>
+  <text x="1168" y="148" style="font-size:3px">4,169,0,0,0</text>
   <path class="p4" d="M 1183 153 L 1168 151 L 1152 158 L 1166 160 L 1183 153"/>
-  <text x="1167" y="156" style="font-size:5">4,170,0,0,0</text>
+  <text x="1167" y="157" style="font-size:3px">4,170,0,0,0</text>
   <line x1="1166" y1="160" x2="1152" y2="158"/>
   <path class="p4" d="M 1168 151 L 1152 150 L 1138 156 L 1152 158 L 1168 151"/>
-  <text x="1152" y="154" style="font-size:5">4,171,0,0,0</text>
+  <text x="1152" y="155" style="font-size:3px">4,171,0,0,0</text>
   <line x1="1152" y1="158" x2="1138" y2="156"/>
   <path class="p4" d="M 1167 143 L 1150 141 L 1137 148 L 1152 150 L 1167 143"/>
-  <text x="1151" y="145" style="font-size:5">4,172,0,0,0</text>
+  <text x="1151" y="147" style="font-size:3px">4,172,0,0,0</text>
   <path class="p4" d="M 1150 141 L 1133 140 L 1121 146 L 1137 148 L 1150 141"/>
-  <text x="1135" y="144" style="font-size:5">4,173,0,0,0</text>
+  <text x="1135" y="145" style="font-size:3px">4,173,0,0,0</text>
   <path class="p4" d="M 1152 150 L 1137 148 L 1124 155 L 1138 156 L 1152 150"/>
-  <text x="1138" y="152" style="font-size:5">4,174,0,0,0</text>
+  <text x="1138" y="154" style="font-size:3px">4,174,0,0,0</text>
   <line x1="1138" y1="156" x2="1124" y2="155"/>
   <path class="p4" d="M 1137 148 L 1121 146 L 1110 153 L 1124 155 L 1137 148"/>
-  <text x="1123" y="151" style="font-size:5">4,175,0,0,0</text>
+  <text x="1123" y="152" style="font-size:3px">4,175,0,0,0</text>
   <line x1="1124" y1="155" x2="1110" y2="153"/>
   <path class="p4" d="M 1198 102 L 1173 102 L 1164 108 L 1187 108 L 1198 102"/>
-  <text x="1180" y="105" style="font-size:4">4,176,0,0,0</text>
+  <text x="1180" y="107" style="font-size:3px">4,176,0,0,0</text>
   <path class="p4" d="M 1173 102 L 1148 101 L 1140 107 L 1164 108 L 1173 102"/>
-  <text x="1156" y="104" style="font-size:4">4,177,0,0,0</text>
+  <text x="1156" y="106" style="font-size:3px">4,177,0,0,0</text>
   <path class="p4" d="M 1187 108 L 1164 108 L 1154 114 L 1177 115 L 1187 108"/>
-  <text x="1171" y="111" style="font-size:4">4,178,0,0,0</text>
+  <text x="1171" y="113" style="font-size:3px">4,178,0,0,0</text>
   <path class="p4" d="M 1164 108 L 1140 107 L 1132 113 L 1154 114 L 1164 108"/>
-  <text x="1148" y="110" style="font-size:4">4,179,0,0,0</text>
+  <text x="1148" y="112" style="font-size:3px">4,179,0,0,0</text>
   <path class="p4" d="M 1148 101 L 1123 100 L 1117 106 L 1140 107 L 1148 101"/>
-  <text x="1132" y="103" style="font-size:4">4,180,0,0,0</text>
+  <text x="1132" y="105" style="font-size:3px">4,180,0,0,0</text>
   <path class="p4" d="M 1123 100 L 1098 99 L 1093 105 L 1117 106 L 1123 100"/>
-  <text x="1108" y="103" style="font-size:4">4,181,0,0,0</text>
+  <text x="1108" y="104" style="font-size:3px">4,181,0,0,0</text>
   <path class="p4" d="M 1140 107 L 1117 106 L 1110 112 L 1132 113 L 1140 107"/>
-  <text x="1125" y="109" style="font-size:4">4,182,0,0,0</text>
+  <text x="1125" y="111" style="font-size:3px">4,182,0,0,0</text>
   <path class="p4" d="M 1117 106 L 1093 105 L 1088 111 L 1110 112 L 1117 106"/>
-  <text x="1102" y="108" style="font-size:4">4,183,0,0,0</text>
+  <text x="1102" y="110" style="font-size:3px">4,183,0,0,0</text>
   <path class="p4" d="M 1177 115 L 1154 114 L 1145 120 L 1166 121 L 1177 115"/>
-  <text x="1161" y="117" style="font-size:4">4,184,0,0,0</text>
+  <text x="1161" y="119" style="font-size:3px">4,184,0,0,0</text>
   <path class="p4" d="M 1154 114 L 1132 113 L 1124 119 L 1145 120 L 1154 114"/>
-  <text x="1139" y="116" style="font-size:4">4,185,0,0,0</text>
+  <text x="1139" y="118" style="font-size:3px">4,185,0,0,0</text>
   <path class="p4" d="M 1166 121 L 1145 120 L 1135 126 L 1155 127 L 1166 121"/>
-  <text x="1150" y="123" style="font-size:4">4,186,0,0,0</text>
+  <text x="1150" y="125" style="font-size:3px">4,186,0,0,0</text>
   <path class="p4" d="M 1145 120 L 1124 119 L 1116 125 L 1135 126 L 1145 120"/>
-  <text x="1130" y="122" style="font-size:4">4,187,0,0,0</text>
+  <text x="1130" y="124" style="font-size:3px">4,187,0,0,0</text>
   <path class="p4" d="M 1132 113 L 1110 112 L 1103 117 L 1124 119 L 1132 113"/>
-  <text x="1117" y="115" style="font-size:4">4,188,0,0,0</text>
+  <text x="1117" y="117" style="font-size:3px">4,188,0,0,0</text>
   <path class="p4" d="M 1110 112 L 1088 111 L 1083 116 L 1103 117 L 1110 112"/>
-  <text x="1096" y="114" style="font-size:4">4,189,0,0,0</text>
+  <text x="1096" y="115" style="font-size:3px">4,189,0,0,0</text>
   <path class="p4" d="M 1124 119 L 1103 117 L 1097 123 L 1116 125 L 1124 119"/>
-  <text x="1110" y="121" style="font-size:4">4,190,0,0,0</text>
+  <text x="1110" y="122" style="font-size:3px">4,190,0,0,0</text>
   <path class="p4" d="M 1103 117 L 1083 116 L 1077 122 L 1097 123 L 1103 117"/>
-  <text x="1090" y="120" style="font-size:4">4,191,0,0,0</text>
+  <text x="1090" y="121" style="font-size:3px">4,191,0,0,0</text>
   <path class="p4" d="M 1098 99 L 1074 99 L 1070 104 L 1093 105 L 1098 99"/>
-  <text x="1084" y="102" style="font-size:4">4,192,0,0,0</text>
+  <text x="1084" y="103" style="font-size:2px">4,192,0,0,0</text>
   <path class="p4" d="M 1074 99 L 1049 98 L 1047 103 L 1070 104 L 1074 99"/>
-  <text x="1060" y="101" style="font-size:4">4,193,0,0,0</text>
+  <text x="1060" y="102" style="font-size:2px">4,193,0,0,0</text>
   <path class="p4" d="M 1093 105 L 1070 104 L 1066 110 L 1088 111 L 1093 105"/>
-  <text x="1079" y="107" style="font-size:4">4,194,0,0,0</text>
+  <text x="1079" y="109" style="font-size:3px">4,194,0,0,0</text>
   <path class="p4" d="M 1070 104 L 1047 103 L 1044 109 L 1066 110 L 1070 104"/>
-  <text x="1057" y="106" style="font-size:4">4,195,0,0,0</text>
+  <text x="1057" y="108" style="font-size:3px">4,195,0,0,0</text>
   <path class="p4" d="M 1049 98 L 1025 97 L 1023 102 L 1047 103 L 1049 98"/>
-  <text x="1036" y="100" style="font-size:4">4,196,0,0,0</text>
+  <text x="1036" y="101" style="font-size:2px">4,196,0,0,0</text>
   <path class="p4" d="M 1025 97 L 1000 96 L 1000 102 L 1023 102 L 1025 97"/>
-  <text x="1012" y="99" style="font-size:4">4,197,0,0,0</text>
+  <text x="1012" y="100" style="font-size:2px">4,197,0,0,0</text>
   <path class="p4" d="M 1047 103 L 1023 102 L 1022 108 L 1044 109 L 1047 103"/>
-  <text x="1034" y="106" style="font-size:4">4,198,0,0,0</text>
+  <text x="1034" y="107" style="font-size:3px">4,198,0,0,0</text>
   <path class="p4" d="M 1023 102 L 1000 102 L 1000 107 L 1022 108 L 1023 102"/>
-  <text x="1011" y="105" style="font-size:4">4,199,0,0,0</text>
+  <text x="1011" y="106" style="font-size:3px">4,199,0,0,0</text>
   <path class="p4" d="M 1088 111 L 1066 110 L 1062 115 L 1083 116 L 1088 111"/>
-  <text x="1075" y="113" style="font-size:4">4,200,0,0,0</text>
+  <text x="1075" y="114" style="font-size:3px">4,200,0,0,0</text>
   <path class="p4" d="M 1066 110 L 1044 109 L 1041 114 L 1062 115 L 1066 110"/>
-  <text x="1053" y="112" style="font-size:4">4,201,0,0,0</text>
+  <text x="1053" y="113" style="font-size:3px">4,201,0,0,0</text>
   <path class="p4" d="M 1083 116 L 1062 115 L 1058 121 L 1077 122 L 1083 116"/>
-  <text x="1070" y="119" style="font-size:4">4,202,0,0,0</text>
+  <text x="1070" y="120" style="font-size:3px">4,202,0,0,0</text>
   <path class="p4" d="M 1062 115 L 1041 114 L 1038 120 L 1058 121 L 1062 115"/>
-  <text x="1050" y="118" style="font-size:4">4,203,0,0,0</text>
+  <text x="1050" y="119" style="font-size:3px">4,203,0,0,0</text>
   <path class="p4" d="M 1044 109 L 1022 108 L 1021 113 L 1041 114 L 1044 109"/>
-  <text x="1032" y="111" style="font-size:4">4,204,0,0,0</text>
+  <text x="1032" y="112" style="font-size:3px">4,204,0,0,0</text>
   <path class="p4" d="M 1022 108 L 1000 107 L 1000 112 L 1021 113 L 1022 108"/>
-  <text x="1011" y="110" style="font-size:4">4,205,0,0,0</text>
+  <text x="1011" y="111" style="font-size:3px">4,205,0,0,0</text>
   <path class="p4" d="M 1041 114 L 1021 113 L 1019 119 L 1038 120 L 1041 114"/>
-  <text x="1030" y="116" style="font-size:4">4,206,0,0,0</text>
+  <text x="1030" y="118" style="font-size:3px">4,206,0,0,0</text>
   <path class="p4" d="M 1021 113 L 1000 112 L 1000 117 L 1019 119 L 1021 113"/>
-  <text x="1010" y="115" style="font-size:4">4,207,0,0,0</text>
+  <text x="1010" y="117" style="font-size:3px">4,207,0,0,0</text>
   <path class="p4" d="M 1155 127 L 1135 126 L 1126 132 L 1144 133 L 1155 127"/>
-  <text x="1140" y="130" style="font-size:4">4,208,0,0,0</text>
+  <text x="1140" y="131" style="font-size:3px">4,208,0,0,0</text>
   <path class="p4" d="M 1135 126 L 1116 125 L 1108 131 L 1126 132 L 1135 126"/>
-  <text x="1121" y="128" style="font-size:4">4,209,0,0,0</text>
+  <text x="1121" y="130" style="font-size:3px">4,209,0,0,0</text>
   <path class="p4" d="M 1144 133 L 1126 132 L 1116 138 L 1133 140 L 1144 133"/>
-  <text x="1130" y="136" style="font-size:4">4,210,0,0,0</text>
+  <text x="1130" y="137" style="font-size:3px">4,210,0,0,0</text>
   <path class="p4" d="M 1126 132 L 1108 131 L 1099 137 L 1116 138 L 1126 132"/>
-  <text x="1112" y="134" style="font-size:4">4,211,0,0,0</text>
+  <text x="1112" y="136" style="font-size:3px">4,211,0,0,0</text>
   <path class="p4" d="M 1116 125 L 1097 123 L 1090 129 L 1108 131 L 1116 125"/>
-  <text x="1102" y="127" style="font-size:4">4,212,0,0,0</text>
+  <text x="1102" y="128" style="font-size:3px">4,212,0,0,0</text>
   <path class="p4" d="M 1097 123 L 1077 122 L 1072 128 L 1090 129 L 1097 123"/>
-  <text x="1084" y="126" style="font-size:4">4,213,0,0,0</text>
+  <text x="1084" y="127" style="font-size:3px">4,213,0,0,0</text>
   <path class="p4" d="M 1108 131 L 1090 129 L 1083 135 L 1099 137 L 1108 131"/>
-  <text x="1095" y="133" style="font-size:4">4,214,0,0,0</text>
+  <text x="1095" y="135" style="font-size:3px">4,214,0,0,0</text>
   <path class="p4" d="M 1090 129 L 1072 128 L 1066 134 L 1083 135 L 1090 129"/>
-  <text x="1077" y="132" style="font-size:4">4,215,0,0,0</text>
+  <text x="1077" y="133" style="font-size:3px">4,215,0,0,0</text>
   <path class="p4" d="M 1133 140 L 1116 138 L 1106 145 L 1121 146 L 1133 140"/>
-  <text x="1119" y="142" style="font-size:5">4,216,0,0,0</text>
+  <text x="1119" y="144" style="font-size:3px">4,216,0,0,0</text>
   <path class="p4" d="M 1116 138 L 1099 137 L 1091 143 L 1106 145 L 1116 138"/>
-  <text x="1103" y="141" style="font-size:5">4,217,0,0,0</text>
+  <text x="1103" y="142" style="font-size:3px">4,217,0,0,0</text>
   <path class="p4" d="M 1121 146 L 1106 145 L 1096 151 L 1110 153 L 1121 146"/>
-  <text x="1108" y="149" style="font-size:5">4,218,0,0,0</text>
+  <text x="1108" y="150" style="font-size:3px">4,218,0,0,0</text>
   <line x1="1110" y1="153" x2="1096" y2="151"/>
   <path class="p4" d="M 1106 145 L 1091 143 L 1082 150 L 1096 151 L 1106 145"/>
-  <text x="1094" y="147" style="font-size:5">4,219,0,0,0</text>
+  <text x="1094" y="149" style="font-size:3px">4,219,0,0,0</text>
   <line x1="1096" y1="151" x2="1082" y2="150"/>
   <path class="p4" d="M 1099 137 L 1083 135 L 1075 142 L 1091 143 L 1099 137"/>
-  <text x="1087" y="139" style="font-size:5">4,220,0,0,0</text>
+  <text x="1087" y="141" style="font-size:3px">4,220,0,0,0</text>
   <path class="p4" d="M 1083 135 L 1066 134 L 1060 140 L 1075 142 L 1083 135"/>
-  <text x="1071" y="138" style="font-size:5">4,221,0,0,0</text>
+  <text x="1071" y="139" style="font-size:3px">4,221,0,0,0</text>
   <path class="p4" d="M 1091 143 L 1075 142 L 1068 148 L 1082 150 L 1091 143"/>
-  <text x="1079" y="146" style="font-size:5">4,222,0,0,0</text>
+  <text x="1079" y="147" style="font-size:3px">4,222,0,0,0</text>
   <line x1="1082" y1="150" x2="1068" y2="148"/>
   <path class="p4" d="M 1075 142 L 1060 140 L 1054 146 L 1068 148 L 1075 142"/>
-  <text x="1065" y="144" style="font-size:5">4,223,0,0,0</text>
+  <text x="1065" y="145" style="font-size:3px">4,223,0,0,0</text>
   <line x1="1068" y1="148" x2="1054" y2="146"/>
   <path class="p4" d="M 1077 122 L 1058 121 L 1054 127 L 1072 128 L 1077 122"/>
-  <text x="1065" y="124" style="font-size:4">4,224,0,0,0</text>
+  <text x="1065" y="126" style="font-size:3px">4,224,0,0,0</text>
   <path class="p4" d="M 1058 121 L 1038 120 L 1036 125 L 1054 127 L 1058 121"/>
-  <text x="1046" y="123" style="font-size:4">4,225,0,0,0</text>
+  <text x="1046" y="125" style="font-size:3px">4,225,0,0,0</text>
   <path class="p4" d="M 1072 128 L 1054 127 L 1049 133 L 1066 134 L 1072 128"/>
-  <text x="1060" y="130" style="font-size:4">4,226,0,0,0</text>
+  <text x="1060" y="132" style="font-size:3px">4,226,0,0,0</text>
   <path class="p4" d="M 1054 127 L 1036 125 L 1033 131 L 1049 133 L 1054 127"/>
-  <text x="1043" y="129" style="font-size:4">4,227,0,0,0</text>
+  <text x="1043" y="130" style="font-size:3px">4,227,0,0,0</text>
   <path class="p4" d="M 1038 120 L 1019 119 L 1018 124 L 1036 125 L 1038 120"/>
-  <text x="1028" y="122" style="font-size:4">4,228,0,0,0</text>
+  <text x="1028" y="123" style="font-size:3px">4,228,0,0,0</text>
   <path class="p4" d="M 1019 119 L 1000 117 L 1000 123 L 1018 124 L 1019 119"/>
-  <text x="1009" y="121" style="font-size:4">4,229,0,0,0</text>
+  <text x="1009" y="122" style="font-size:3px">4,229,0,0,0</text>
   <path class="p4" d="M 1036 125 L 1018 124 L 1016 130 L 1033 131 L 1036 125"/>
-  <text x="1026" y="128" style="font-size:4">4,230,0,0,0</text>
+  <text x="1026" y="129" style="font-size:3px">4,230,0,0,0</text>
   <path class="p4" d="M 1018 124 L 1000 123 L 1000 128 L 1016 130 L 1018 124"/>
-  <text x="1009" y="126" style="font-size:4">4,231,0,0,0</text>
+  <text x="1009" y="128" style="font-size:3px">4,231,0,0,0</text>
   <path class="p4" d="M 1066 134 L 1049 133 L 1045 139 L 1060 140 L 1066 134"/>
-  <text x="1055" y="136" style="font-size:4">4,232,0,0,0</text>
+  <text x="1055" y="138" style="font-size:3px">4,232,0,0,0</text>
   <path class="p4" d="M 1049 133 L 1033 131 L 1030 137 L 1045 139 L 1049 133"/>
-  <text x="1039" y="135" style="font-size:4">4,233,0,0,0</text>
+  <text x="1039" y="136" style="font-size:3px">4,233,0,0,0</text>
   <path class="p4" d="M 1060 140 L 1045 139 L 1041 145 L 1054 146 L 1060 140"/>
-  <text x="1050" y="142" style="font-size:5">4,234,0,0,0</text>
+  <text x="1050" y="144" style="font-size:3px">4,234,0,0,0</text>
   <line x1="1054" y1="146" x2="1041" y2="145"/>
   <path class="p4" d="M 1045 139 L 1030 137 L 1027 143 L 1041 145 L 1045 139"/>
-  <text x="1036" y="141" style="font-size:5">4,235,0,0,0</text>
+  <text x="1036" y="142" style="font-size:3px">4,235,0,0,0</text>
   <line x1="1041" y1="145" x2="1027" y2="143"/>
   <path class="p4" d="M 1033 131 L 1016 130 L 1015 135 L 1030 137 L 1033 131"/>
-  <text x="1024" y="133" style="font-size:4">4,236,0,0,0</text>
+  <text x="1024" y="135" style="font-size:3px">4,236,0,0,0</text>
   <path class="p4" d="M 1016 130 L 1000 128 L 1000 134 L 1015 135 L 1016 130"/>
-  <text x="1008" y="132" style="font-size:4">4,237,0,0,0</text>
+  <text x="1008" y="133" style="font-size:3px">4,237,0,0,0</text>
   <path class="p4" d="M 1030 137 L 1015 135 L 1014 141 L 1027 143 L 1030 137"/>
-  <text x="1021" y="139" style="font-size:5">4,238,0,0,0</text>
+  <text x="1021" y="141" style="font-size:3px">4,238,0,0,0</text>
   <line x1="1027" y1="143" x2="1014" y2="141"/>
   <path class="p4" d="M 1015 135 L 1000 134 L 1000 140 L 1014 141 L 1015 135"/>
-  <text x="1007" y="137" style="font-size:5">4,239,0,0,0</text>
+  <text x="1007" y="139" style="font-size:3px">4,239,0,0,0</text>
   <line x1="1014" y1="141" x2="1000" y2="140"/>
   <path class="p4" d="M 1000 96 L 975 97 L 977 102 L 1000 102 L 1000 96"/>
-  <text x="988" y="99" style="font-size:4">4,240,0,0,0</text>
+  <text x="988" y="100" style="font-size:2px">4,240,0,0,0</text>
   <path class="p4" d="M 975 97 L 951 98 L 953 103 L 977 102 L 975 97"/>
-  <text x="964" y="100" style="font-size:4">4,241,0,0,0</text>
+  <text x="964" y="101" style="font-size:2px">4,241,0,0,0</text>
   <path class="p4" d="M 1000 102 L 977 102 L 978 108 L 1000 107 L 1000 102"/>
-  <text x="989" y="105" style="font-size:4">4,242,0,0,0</text>
+  <text x="989" y="106" style="font-size:3px">4,242,0,0,0</text>
   <path class="p4" d="M 977 102 L 953 103 L 956 109 L 978 108 L 977 102"/>
-  <text x="966" y="106" style="font-size:4">4,243,0,0,0</text>
+  <text x="966" y="107" style="font-size:3px">4,243,0,0,0</text>
   <path class="p4" d="M 951 98 L 926 99 L 930 104 L 953 103 L 951 98"/>
-  <text x="940" y="101" style="font-size:4">4,244,0,0,0</text>
+  <text x="940" y="102" style="font-size:2px">4,244,0,0,0</text>
   <path class="p4" d="M 926 99 L 902 99 L 907 105 L 930 104 L 926 99"/>
-  <text x="916" y="102" style="font-size:4">4,245,0,0,0</text>
+  <text x="916" y="103" style="font-size:2px">4,245,0,0,0</text>
   <path class="p4" d="M 953 103 L 930 104 L 934 110 L 956 109 L 953 103"/>
-  <text x="943" y="106" style="font-size:4">4,246,0,0,0</text>
+  <text x="943" y="108" style="font-size:3px">4,246,0,0,0</text>
   <path class="p4" d="M 930 104 L 907 105 L 912 111 L 934 110 L 930 104"/>
-  <text x="921" y="107" style="font-size:4">4,247,0,0,0</text>
+  <text x="921" y="109" style="font-size:3px">4,247,0,0,0</text>
   <path class="p4" d="M 1000 107 L 978 108 L 979 113 L 1000 112 L 1000 107"/>
-  <text x="989" y="110" style="font-size:4">4,248,0,0,0</text>
+  <text x="989" y="111" style="font-size:3px">4,248,0,0,0</text>
   <path class="p4" d="M 978 108 L 956 109 L 959 114 L 979 113 L 978 108"/>
-  <text x="968" y="111" style="font-size:4">4,249,0,0,0</text>
+  <text x="968" y="112" style="font-size:3px">4,249,0,0,0</text>
   <path class="p4" d="M 1000 112 L 979 113 L 981 119 L 1000 117 L 1000 112"/>
-  <text x="990" y="115" style="font-size:4">4,250,0,0,0</text>
+  <text x="990" y="117" style="font-size:3px">4,250,0,0,0</text>
   <path class="p4" d="M 979 113 L 959 114 L 962 120 L 981 119 L 979 113"/>
-  <text x="970" y="116" style="font-size:4">4,251,0,0,0</text>
+  <text x="970" y="118" style="font-size:3px">4,251,0,0,0</text>
   <path class="p4" d="M 956 109 L 934 110 L 938 115 L 959 114 L 956 109"/>
-  <text x="947" y="112" style="font-size:4">4,252,0,0,0</text>
+  <text x="947" y="113" style="font-size:3px">4,252,0,0,0</text>
   <path class="p4" d="M 934 110 L 912 111 L 917 116 L 938 115 L 934 110"/>
-  <text x="925" y="113" style="font-size:4">4,253,0,0,0</text>
+  <text x="925" y="114" style="font-size:3px">4,253,0,0,0</text>
   <path class="p4" d="M 959 114 L 938 115 L 942 121 L 962 120 L 959 114"/>
-  <text x="950" y="118" style="font-size:4">4,254,0,0,0</text>
+  <text x="950" y="119" style="font-size:3px">4,254,0,0,0</text>
   <path class="p4" d="M 938 115 L 917 116 L 923 122 L 942 121 L 938 115"/>
-  <text x="930" y="119" style="font-size:4">4,255,0,0,0</text>
+  <text x="930" y="120" style="font-size:3px">4,255,0,0,0</text>
   <path class="p4" d="M 902 99 L 877 100 L 883 106 L 907 105 L 902 99"/>
-  <text x="892" y="103" style="font-size:4">4,256,0,0,0</text>
+  <text x="892" y="104" style="font-size:3px">4,256,0,0,0</text>
   <path class="p4" d="M 877 100 L 852 101 L 860 107 L 883 106 L 877 100"/>
-  <text x="868" y="103" style="font-size:4">4,257,0,0,0</text>
+  <text x="868" y="105" style="font-size:3px">4,257,0,0,0</text>
   <path class="p4" d="M 907 105 L 883 106 L 890 112 L 912 111 L 907 105"/>
-  <text x="898" y="108" style="font-size:4">4,258,0,0,0</text>
+  <text x="898" y="110" style="font-size:3px">4,258,0,0,0</text>
   <path class="p4" d="M 883 106 L 860 107 L 868 113 L 890 112 L 883 106"/>
-  <text x="875" y="109" style="font-size:4">4,259,0,0,0</text>
+  <text x="875" y="111" style="font-size:3px">4,259,0,0,0</text>
   <path class="p4" d="M 852 101 L 827 102 L 836 108 L 860 107 L 852 101"/>
-  <text x="844" y="104" style="font-size:4">4,260,0,0,0</text>
+  <text x="844" y="106" style="font-size:3px">4,260,0,0,0</text>
   <path class="p4" d="M 827 102 L 802 102 L 813 108 L 836 108 L 827 102"/>
-  <text x="820" y="105" style="font-size:4">4,261,0,0,0</text>
+  <text x="820" y="107" style="font-size:3px">4,261,0,0,0</text>
   <path class="p4" d="M 860 107 L 836 108 L 846 114 L 868 113 L 860 107"/>
-  <text x="852" y="110" style="font-size:4">4,262,0,0,0</text>
+  <text x="852" y="112" style="font-size:3px">4,262,0,0,0</text>
   <path class="p4" d="M 836 108 L 813 108 L 823 115 L 846 114 L 836 108"/>
-  <text x="829" y="111" style="font-size:4">4,263,0,0,0</text>
+  <text x="829" y="113" style="font-size:3px">4,263,0,0,0</text>
   <path class="p4" d="M 912 111 L 890 112 L 897 117 L 917 116 L 912 111"/>
-  <text x="904" y="114" style="font-size:4">4,264,0,0,0</text>
+  <text x="904" y="115" style="font-size:3px">4,264,0,0,0</text>
   <path class="p4" d="M 890 112 L 868 113 L 876 119 L 897 117 L 890 112"/>
-  <text x="883" y="115" style="font-size:4">4,265,0,0,0</text>
+  <text x="883" y="117" style="font-size:3px">4,265,0,0,0</text>
   <path class="p4" d="M 917 116 L 897 117 L 903 123 L 923 122 L 917 116"/>
-  <text x="910" y="120" style="font-size:4">4,266,0,0,0</text>
+  <text x="910" y="121" style="font-size:3px">4,266,0,0,0</text>
   <path class="p4" d="M 897 117 L 876 119 L 884 125 L 903 123 L 897 117"/>
-  <text x="890" y="121" style="font-size:4">4,267,0,0,0</text>
+  <text x="890" y="122" style="font-size:3px">4,267,0,0,0</text>
   <path class="p4" d="M 868 113 L 846 114 L 855 120 L 876 119 L 868 113"/>
-  <text x="861" y="116" style="font-size:4">4,268,0,0,0</text>
+  <text x="861" y="118" style="font-size:3px">4,268,0,0,0</text>
   <path class="p4" d="M 846 114 L 823 115 L 834 121 L 855 120 L 846 114"/>
-  <text x="839" y="117" style="font-size:4">4,269,0,0,0</text>
+  <text x="839" y="119" style="font-size:3px">4,269,0,0,0</text>
   <path class="p4" d="M 876 119 L 855 120 L 865 126 L 884 125 L 876 119"/>
-  <text x="870" y="122" style="font-size:4">4,270,0,0,0</text>
+  <text x="870" y="124" style="font-size:3px">4,270,0,0,0</text>
   <path class="p4" d="M 855 120 L 834 121 L 845 127 L 865 126 L 855 120"/>
-  <text x="850" y="123" style="font-size:4">4,271,0,0,0</text>
+  <text x="850" y="125" style="font-size:3px">4,271,0,0,0</text>
   <path class="p4" d="M 1000 117 L 981 119 L 982 124 L 1000 123 L 1000 117"/>
-  <text x="991" y="121" style="font-size:4">4,272,0,0,0</text>
+  <text x="991" y="122" style="font-size:3px">4,272,0,0,0</text>
   <path class="p4" d="M 981 119 L 962 120 L 964 125 L 982 124 L 981 119"/>
-  <text x="972" y="122" style="font-size:4">4,273,0,0,0</text>
+  <text x="972" y="123" style="font-size:3px">4,273,0,0,0</text>
   <path class="p4" d="M 1000 123 L 982 124 L 984 130 L 1000 128 L 1000 123"/>
-  <text x="991" y="126" style="font-size:4">4,274,0,0,0</text>
+  <text x="991" y="128" style="font-size:3px">4,274,0,0,0</text>
   <path class="p4" d="M 982 124 L 964 125 L 967 131 L 984 130 L 982 124"/>
-  <text x="974" y="128" style="font-size:4">4,275,0,0,0</text>
+  <text x="974" y="129" style="font-size:3px">4,275,0,0,0</text>
   <path class="p4" d="M 962 120 L 942 121 L 946 127 L 964 125 L 962 120"/>
-  <text x="954" y="123" style="font-size:4">4,276,0,0,0</text>
+  <text x="954" y="125" style="font-size:3px">4,276,0,0,0</text>
   <path class="p4" d="M 942 121 L 923 122 L 928 128 L 946 127 L 942 121"/>
-  <text x="935" y="124" style="font-size:4">4,277,0,0,0</text>
+  <text x="935" y="126" style="font-size:3px">4,277,0,0,0</text>
   <path class="p4" d="M 964 125 L 946 127 L 951 133 L 967 131 L 964 125"/>
-  <text x="957" y="129" style="font-size:4">4,278,0,0,0</text>
+  <text x="957" y="130" style="font-size:3px">4,278,0,0,0</text>
   <path class="p4" d="M 946 127 L 928 128 L 934 134 L 951 133 L 946 127"/>
-  <text x="940" y="130" style="font-size:4">4,279,0,0,0</text>
+  <text x="940" y="132" style="font-size:3px">4,279,0,0,0</text>
   <path class="p4" d="M 1000 128 L 984 130 L 985 135 L 1000 134 L 1000 128"/>
-  <text x="992" y="132" style="font-size:4">4,280,0,0,0</text>
+  <text x="992" y="133" style="font-size:3px">4,280,0,0,0</text>
   <path class="p4" d="M 984 130 L 967 131 L 970 137 L 985 135 L 984 130"/>
-  <text x="976" y="133" style="font-size:4">4,281,0,0,0</text>
+  <text x="976" y="135" style="font-size:3px">4,281,0,0,0</text>
   <path class="p4" d="M 1000 134 L 985 135 L 986 141 L 1000 140 L 1000 134"/>
-  <text x="993" y="137" style="font-size:5">4,282,0,0,0</text>
+  <text x="993" y="139" style="font-size:3px">4,282,0,0,0</text>
   <line x1="1000" y1="140" x2="986" y2="141"/>
   <path class="p4" d="M 985 135 L 970 137 L 973 143 L 986 141 L 985 135"/>
-  <text x="979" y="139" style="font-size:5">4,283,0,0,0</text>
+  <text x="979" y="141" style="font-size:3px">4,283,0,0,0</text>
   <line x1="986" y1="141" x2="973" y2="143"/>
   <path class="p4" d="M 967 131 L 951 133 L 955 139 L 970 137 L 967 131"/>
-  <text x="961" y="135" style="font-size:4">4,284,0,0,0</text>
+  <text x="961" y="136" style="font-size:3px">4,284,0,0,0</text>
   <path class="p4" d="M 951 133 L 934 134 L 940 140 L 955 139 L 951 133"/>
-  <text x="945" y="136" style="font-size:4">4,285,0,0,0</text>
+  <text x="945" y="138" style="font-size:3px">4,285,0,0,0</text>
   <path class="p4" d="M 970 137 L 955 139 L 959 145 L 973 143 L 970 137"/>
-  <text x="964" y="141" style="font-size:5">4,286,0,0,0</text>
+  <text x="964" y="142" style="font-size:3px">4,286,0,0,0</text>
   <line x1="973" y1="143" x2="959" y2="145"/>
   <path class="p4" d="M 955 139 L 940 140 L 946 146 L 959 145 L 955 139"/>
-  <text x="950" y="142" style="font-size:5">4,287,0,0,0</text>
+  <text x="950" y="144" style="font-size:3px">4,287,0,0,0</text>
   <line x1="959" y1="145" x2="946" y2="146"/>
   <path class="p4" d="M 923 122 L 903 123 L 910 129 L 928 128 L 923 122"/>
-  <text x="916" y="126" style="font-size:4">4,288,0,0,0</text>
+  <text x="916" y="127" style="font-size:3px">4,288,0,0,0</text>
   <path class="p4" d="M 903 123 L 884 125 L 892 131 L 910 129 L 903 123"/>
-  <text x="898" y="127" style="font-size:4">4,289,0,0,0</text>
+  <text x="898" y="128" style="font-size:3px">4,289,0,0,0</text>
   <path class="p4" d="M 928 128 L 910 129 L 917 135 L 934 134 L 928 128"/>
-  <text x="923" y="132" style="font-size:4">4,290,0,0,0</text>
+  <text x="923" y="133" style="font-size:3px">4,290,0,0,0</text>
   <path class="p4" d="M 910 129 L 892 131 L 901 137 L 917 135 L 910 129"/>
-  <text x="905" y="133" style="font-size:4">4,291,0,0,0</text>
+  <text x="905" y="135" style="font-size:3px">4,291,0,0,0</text>
   <path class="p4" d="M 884 125 L 865 126 L 874 132 L 892 131 L 884 125"/>
-  <text x="879" y="128" style="font-size:4">4,292,0,0,0</text>
+  <text x="879" y="130" style="font-size:3px">4,292,0,0,0</text>
   <path class="p4" d="M 865 126 L 845 127 L 856 133 L 874 132 L 865 126"/>
-  <text x="860" y="130" style="font-size:4">4,293,0,0,0</text>
+  <text x="860" y="131" style="font-size:3px">4,293,0,0,0</text>
   <path class="p4" d="M 892 131 L 874 132 L 884 138 L 901 137 L 892 131"/>
-  <text x="888" y="134" style="font-size:4">4,294,0,0,0</text>
+  <text x="888" y="136" style="font-size:3px">4,294,0,0,0</text>
   <path class="p4" d="M 874 132 L 856 133 L 867 140 L 884 138 L 874 132"/>
-  <text x="870" y="136" style="font-size:4">4,295,0,0,0</text>
+  <text x="870" y="137" style="font-size:3px">4,295,0,0,0</text>
   <path class="p4" d="M 934 134 L 917 135 L 925 142 L 940 140 L 934 134"/>
-  <text x="929" y="138" style="font-size:5">4,296,0,0,0</text>
+  <text x="929" y="139" style="font-size:3px">4,296,0,0,0</text>
   <path class="p4" d="M 917 135 L 901 137 L 909 143 L 925 142 L 917 135"/>
-  <text x="913" y="139" style="font-size:5">4,297,0,0,0</text>
+  <text x="913" y="141" style="font-size:3px">4,297,0,0,0</text>
   <path class="p4" d="M 940 140 L 925 142 L 932 148 L 946 146 L 940 140"/>
-  <text x="935" y="144" style="font-size:5">4,298,0,0,0</text>
+  <text x="935" y="145" style="font-size:3px">4,298,0,0,0</text>
   <line x1="946" y1="146" x2="932" y2="148"/>
   <path class="p4" d="M 925 142 L 909 143 L 918 150 L 932 148 L 925 142"/>
-  <text x="921" y="146" style="font-size:5">4,299,0,0,0</text>
+  <text x="921" y="147" style="font-size:3px">4,299,0,0,0</text>
   <line x1="932" y1="148" x2="918" y2="150"/>
   <path class="p4" d="M 901 137 L 884 138 L 894 145 L 909 143 L 901 137"/>
-  <text x="897" y="141" style="font-size:5">4,300,0,0,0</text>
+  <text x="897" y="142" style="font-size:3px">4,300,0,0,0</text>
   <path class="p4" d="M 884 138 L 867 140 L 879 146 L 894 145 L 884 138"/>
-  <text x="881" y="142" style="font-size:5">4,301,0,0,0</text>
+  <text x="881" y="144" style="font-size:3px">4,301,0,0,0</text>
   <path class="p4" d="M 909 143 L 894 145 L 904 151 L 918 150 L 909 143"/>
-  <text x="906" y="147" style="font-size:5">4,302,0,0,0</text>
+  <text x="906" y="149" style="font-size:3px">4,302,0,0,0</text>
   <line x1="918" y1="150" x2="904" y2="151"/>
   <path class="p4" d="M 894 145 L 879 146 L 890 153 L 904 151 L 894 145"/>
-  <text x="892" y="149" style="font-size:5">4,303,0,0,0</text>
+  <text x="892" y="150" style="font-size:3px">4,303,0,0,0</text>
   <line x1="904" y1="151" x2="890" y2="153"/>
   <path class="p4" d="M 802 102 L 777 103 L 789 109 L 813 108 L 802 102"/>
-  <text x="795" y="106" style="font-size:4">4,304,0,0,0</text>
+  <text x="795" y="107" style="font-size:3px">4,304,0,0,0</text>
   <path class="p4" d="M 777 103 L 752 104 L 765 110 L 789 109 L 777 103"/>
-  <text x="771" y="107" style="font-size:4">4,305,0,0,0</text>
+  <text x="771" y="108" style="font-size:3px">4,305,0,0,0</text>
   <path class="p4" d="M 813 108 L 789 109 L 801 116 L 823 115 L 813 108"/>
-  <text x="806" y="112" style="font-size:4">4,306,0,0,0</text>
+  <text x="806" y="113" style="font-size:3px">4,306,0,0,0</text>
   <path class="p4" d="M 789 109 L 765 110 L 779 116 L 801 116 L 789 109"/>
-  <text x="783" y="113" style="font-size:4">4,307,0,0,0</text>
+  <text x="783" y="114" style="font-size:3px">4,307,0,0,0</text>
   <path class="p4" d="M 752 104 L 727 105 L 742 111 L 765 110 L 752 104"/>
-  <text x="747" y="107" style="font-size:4">4,308,0,0,0</text>
+  <text x="747" y="109" style="font-size:3px">4,308,0,0,0</text>
   <path class="p4" d="M 727 105 L 702 105 L 718 112 L 742 111 L 727 105"/>
-  <text x="722" y="108" style="font-size:4">4,309,0,0,0</text>
+  <text x="722" y="110" style="font-size:3px">4,309,0,0,0</text>
   <path class="p4" d="M 765 110 L 742 111 L 756 117 L 779 116 L 765 110"/>
-  <text x="760" y="114" style="font-size:4">4,310,0,0,0</text>
+  <text x="760" y="115" style="font-size:3px">4,310,0,0,0</text>
   <path class="p4" d="M 742 111 L 718 112 L 734 118 L 756 117 L 742 111"/>
-  <text x="737" y="115" style="font-size:4">4,311,0,0,0</text>
+  <text x="737" y="116" style="font-size:3px">4,311,0,0,0</text>
   <path class="p4" d="M 823 115 L 801 116 L 813 122 L 834 121 L 823 115"/>
-  <text x="818" y="118" style="font-size:4">4,312,0,0,0</text>
+  <text x="818" y="120" style="font-size:3px">4,312,0,0,0</text>
   <path class="p4" d="M 801 116 L 779 116 L 792 123 L 813 122 L 801 116"/>
-  <text x="796" y="119" style="font-size:4">4,313,0,0,0</text>
+  <text x="796" y="121" style="font-size:3px">4,313,0,0,0</text>
   <path class="p4" d="M 834 121 L 813 122 L 825 128 L 845 127 L 834 121"/>
-  <text x="829" y="124" style="font-size:4">4,314,0,0,0</text>
+  <text x="829" y="126" style="font-size:3px">4,314,0,0,0</text>
   <path class="p4" d="M 813 122 L 792 123 L 806 129 L 825 128 L 813 122"/>
-  <text x="809" y="126" style="font-size:4">4,315,0,0,0</text>
+  <text x="809" y="127" style="font-size:3px">4,315,0,0,0</text>
   <path class="p4" d="M 779 116 L 756 117 L 771 124 L 792 123 L 779 116"/>
-  <text x="774" y="120" style="font-size:4">4,316,0,0,0</text>
+  <text x="774" y="122" style="font-size:3px">4,316,0,0,0</text>
   <path class="p4" d="M 756 117 L 734 118 L 750 125 L 771 124 L 756 117"/>
-  <text x="753" y="121" style="font-size:4">4,317,0,0,0</text>
+  <text x="753" y="123" style="font-size:3px">4,317,0,0,0</text>
   <path class="p4" d="M 792 123 L 771 124 L 786 131 L 806 129 L 792 123"/>
-  <text x="789" y="127" style="font-size:4">4,318,0,0,0</text>
+  <text x="789" y="128" style="font-size:3px">4,318,0,0,0</text>
   <path class="p4" d="M 771 124 L 750 125 L 766 132 L 786 131 L 771 124"/>
-  <text x="768" y="128" style="font-size:4">4,319,0,0,0</text>
+  <text x="768" y="129" style="font-size:3px">4,319,0,0,0</text>
   <path class="p4" d="M 734 118 L 711 119 L 728 126 L 750 125 L 734 118"/>
-  <text x="731" y="122" style="font-size:4">4,320,0,0,0</text>
+  <text x="731" y="124" style="font-size:3px">4,320,0,0,0</text>
   <path class="p4" d="M 711 119 L 689 120 L 707 127 L 728 126 L 711 119"/>
-  <text x="709" y="123" style="font-size:4">4,321,0,0,0</text>
+  <text x="709" y="125" style="font-size:3px">4,321,0,0,0</text>
   <path class="p4" d="M 750 125 L 728 126 L 746 133 L 766 132 L 750 125"/>
-  <text x="748" y="129" style="font-size:4">4,322,0,0,0</text>
+  <text x="748" y="131" style="font-size:3px">4,322,0,0,0</text>
   <path class="p4" d="M 728 126 L 707 127 L 726 134 L 746 133 L 728 126"/>
-  <text x="727" y="130" style="font-size:4">4,323,0,0,0</text>
+  <text x="727" y="132" style="font-size:3px">4,323,0,0,0</text>
   <path class="p4" d="M 689 120 L 666 121 L 686 128 L 707 127 L 689 120"/>
-  <text x="687" y="124" style="font-size:4">4,324,0,0,0</text>
+  <text x="687" y="126" style="font-size:3px">4,324,0,0,0</text>
   <path class="p4" d="M 666 121 L 643 122 L 665 130 L 686 128 L 666 121"/>
-  <text x="665" y="125" style="font-size:4">4,325,0,0,0</text>
+  <text x="665" y="127" style="font-size:3px">4,325,0,0,0</text>
   <path class="p4" d="M 707 127 L 686 128 L 706 136 L 726 134 L 707 127"/>
-  <text x="706" y="131" style="font-size:4">4,326,0,0,0</text>
+  <text x="706" y="133" style="font-size:3px">4,326,0,0,0</text>
   <path class="p4" d="M 686 128 L 665 130 L 686 137 L 706 136 L 686 128"/>
-  <text x="686" y="133" style="font-size:4">4,327,0,0,0</text>
+  <text x="686" y="134" style="font-size:3px">4,327,0,0,0</text>
   <path class="p4" d="M 845 127 L 825 128 L 838 135 L 856 133 L 845 127"/>
-  <text x="841" y="131" style="font-size:4">4,328,0,0,0</text>
+  <text x="841" y="132" style="font-size:3px">4,328,0,0,0</text>
   <path class="p4" d="M 825 128 L 806 129 L 819 136 L 838 135 L 825 128"/>
-  <text x="822" y="132" style="font-size:4">4,329,0,0,0</text>
+  <text x="822" y="134" style="font-size:3px">4,329,0,0,0</text>
   <path class="p4" d="M 856 133 L 838 135 L 850 141 L 867 140 L 856 133"/>
-  <text x="853" y="137" style="font-size:4">4,330,0,0,0</text>
+  <text x="853" y="139" style="font-size:3px">4,330,0,0,0</text>
   <path class="p4" d="M 838 135 L 819 136 L 833 143 L 850 141 L 838 135"/>
-  <text x="835" y="139" style="font-size:5">4,331,0,0,0</text>
+  <text x="835" y="140" style="font-size:3px">4,331,0,0,0</text>
   <path class="p4" d="M 806 129 L 786 131 L 801 137 L 819 136 L 806 129"/>
-  <text x="803" y="133" style="font-size:4">4,332,0,0,0</text>
+  <text x="803" y="135" style="font-size:3px">4,332,0,0,0</text>
   <path class="p4" d="M 786 131 L 766 132 L 783 139 L 801 137 L 786 131"/>
-  <text x="784" y="135" style="font-size:4">4,333,0,0,0</text>
+  <text x="784" y="136" style="font-size:3px">4,333,0,0,0</text>
   <path class="p4" d="M 819 136 L 801 137 L 817 144 L 833 143 L 819 136"/>
-  <text x="818" y="140" style="font-size:5">4,334,0,0,0</text>
+  <text x="818" y="142" style="font-size:3px">4,334,0,0,0</text>
   <path class="p4" d="M 801 137 L 783 139 L 799 146 L 817 144 L 801 137"/>
-  <text x="800" y="141" style="font-size:5">4,335,0,0,0</text>
+  <text x="800" y="143" style="font-size:3px">4,335,0,0,0</text>
   <path class="p4" d="M 867 140 L 850 141 L 863 148 L 879 146 L 867 140"/>
-  <text x="865" y="144" style="font-size:5">4,336,0,0,0</text>
+  <text x="865" y="145" style="font-size:3px">4,336,0,0,0</text>
   <path class="p4" d="M 850 141 L 833 143 L 848 150 L 863 148 L 850 141"/>
-  <text x="849" y="145" style="font-size:5">4,337,0,0,0</text>
+  <text x="849" y="147" style="font-size:3px">4,337,0,0,0</text>
   <path class="p4" d="M 879 146 L 863 148 L 876 155 L 890 153 L 879 146"/>
-  <text x="877" y="151" style="font-size:5">4,338,0,0,0</text>
+  <text x="877" y="152" style="font-size:3px">4,338,0,0,0</text>
   <line x1="890" y1="153" x2="876" y2="155"/>
   <path class="p4" d="M 863 148 L 848 150 L 862 156 L 876 155 L 863 148"/>
-  <text x="862" y="152" style="font-size:5">4,339,0,0,0</text>
+  <text x="862" y="154" style="font-size:3px">4,339,0,0,0</text>
   <line x1="876" y1="155" x2="862" y2="156"/>
   <path class="p4" d="M 833 143 L 817 144 L 832 151 L 848 150 L 833 143"/>
-  <text x="832" y="147" style="font-size:5">4,340,0,0,0</text>
+  <text x="832" y="148" style="font-size:3px">4,340,0,0,0</text>
   <path class="p4" d="M 817 144 L 799 146 L 817 153 L 832 151 L 817 144"/>
-  <text x="816" y="148" style="font-size:5">4,341,0,0,0</text>
+  <text x="816" y="150" style="font-size:3px">4,341,0,0,0</text>
   <path class="p4" d="M 848 150 L 832 151 L 848 158 L 862 156 L 848 150"/>
-  <text x="848" y="154" style="font-size:5">4,342,0,0,0</text>
+  <text x="848" y="155" style="font-size:3px">4,342,0,0,0</text>
   <line x1="862" y1="156" x2="848" y2="158"/>
   <path class="p4" d="M 832 151 L 817 153 L 834 160 L 848 158 L 832 151"/>
-  <text x="833" y="156" style="font-size:5">4,343,0,0,0</text>
+  <text x="833" y="157" style="font-size:3px">4,343,0,0,0</text>
   <line x1="848" y1="158" x2="834" y2="160"/>
   <path class="p4" d="M 766 132 L 746 133 L 764 140 L 783 139 L 766 132"/>
-  <text x="765" y="136" style="font-size:4">4,344,0,0,0</text>
+  <text x="765" y="137" style="font-size:3px">4,344,0,0,0</text>
   <path class="p4" d="M 746 133 L 726 134 L 746 141 L 764 140 L 746 133"/>
-  <text x="745" y="137" style="font-size:4">4,345,0,0,0</text>
+  <text x="745" y="139" style="font-size:3px">4,345,0,0,0</text>
   <path class="p4" d="M 783 139 L 764 140 L 782 147 L 799 146 L 783 139"/>
-  <text x="782" y="143" style="font-size:5">4,346,0,0,0</text>
+  <text x="782" y="144" style="font-size:3px">4,346,0,0,0</text>
   <path class="p4" d="M 764 140 L 746 141 L 765 149 L 782 147 L 764 140"/>
-  <text x="764" y="144" style="font-size:5">4,347,0,0,0</text>
+  <text x="764" y="146" style="font-size:3px">4,347,0,0,0</text>
   <path class="p4" d="M 726 134 L 706 136 L 727 143 L 746 141 L 726 134"/>
-  <text x="726" y="138" style="font-size:4">4,348,0,0,0</text>
+  <text x="726" y="140" style="font-size:3px">4,348,0,0,0</text>
   <path class="p4" d="M 706 136 L 686 137 L 708 144 L 727 143 L 706 136"/>
-  <text x="707" y="140" style="font-size:4">4,349,0,0,0</text>
+  <text x="707" y="141" style="font-size:3px">4,349,0,0,0</text>
   <path class="p4" d="M 746 141 L 727 143 L 748 150 L 765 149 L 746 141"/>
-  <text x="746" y="146" style="font-size:5">4,350,0,0,0</text>
+  <text x="746" y="147" style="font-size:3px">4,350,0,0,0</text>
   <path class="p4" d="M 727 143 L 708 144 L 731 152 L 748 150 L 727 143"/>
-  <text x="728" y="147" style="font-size:5">4,351,0,0,0</text>
+  <text x="728" y="149" style="font-size:3px">4,351,0,0,0</text>
   <path class="p4" d="M 799 146 L 782 147 L 801 154 L 817 153 L 799 146"/>
-  <text x="800" y="150" style="font-size:5">4,352,0,0,0</text>
+  <text x="800" y="151" style="font-size:3px">4,352,0,0,0</text>
   <path class="p4" d="M 782 147 L 765 149 L 785 156 L 801 154 L 782 147"/>
-  <text x="783" y="152" style="font-size:5">4,353,0,0,0</text>
+  <text x="783" y="153" style="font-size:3px">4,353,0,0,0</text>
   <path class="p4" d="M 817 153 L 801 154 L 820 162 L 834 160 L 817 153"/>
-  <text x="818" y="157" style="font-size:5">4,354,0,0,0</text>
+  <text x="818" y="159" style="font-size:3px">4,354,0,0,0</text>
   <line x1="834" y1="160" x2="820" y2="162"/>
   <path class="p4" d="M 801 154 L 785 156 L 806 163 L 820 162 L 801 154"/>
-  <text x="803" y="159" style="font-size:5">4,355,0,0,0</text>
+  <text x="803" y="160" style="font-size:3px">4,355,0,0,0</text>
   <line x1="820" y1="162" x2="806" y2="163"/>
   <path class="p4" d="M 765 149 L 748 150 L 769 158 L 785 156 L 765 149"/>
-  <text x="767" y="153" style="font-size:5">4,356,0,0,0</text>
+  <text x="767" y="155" style="font-size:3px">4,356,0,0,0</text>
   <path class="p4" d="M 748 150 L 731 152 L 754 159 L 769 158 L 748 150"/>
-  <text x="750" y="155" style="font-size:5">4,357,0,0,0</text>
+  <text x="750" y="156" style="font-size:3px">4,357,0,0,0</text>
   <path class="p4" d="M 785 156 L 769 158 L 791 165 L 806 163 L 785 156"/>
-  <text x="788" y="161" style="font-size:5">4,358,0,0,0</text>
+  <text x="788" y="162" style="font-size:3px">4,358,0,0,0</text>
   <line x1="806" y1="163" x2="791" y2="165"/>
   <path class="p4" d="M 769 158 L 754 159 L 777 167 L 791 165 L 769 158"/>
-  <text x="773" y="162" style="font-size:5">4,359,0,0,0</text>
+  <text x="773" y="164" style="font-size:3px">4,359,0,0,0</text>
   <line x1="791" y1="165" x2="777" y2="167"/>
   <path class="p4" d="M 643 122 L 637 129 L 658 136 L 665 130 L 643 122"/>
-  <text x="651" y="129" style="font-size:4">4,360,0,0,0</text>
+  <text x="651" y="131" style="font-size:3px">4,360,0,0,0</text>
   <path class="p4" d="M 637 129 L 631 136 L 652 142 L 658 136 L 637 129"/>
-  <text x="644" y="136" style="font-size:4">4,361,0,0,0</text>
+  <text x="644" y="137" style="font-size:3px">4,361,0,0,0</text>
   <path class="p4" d="M 665 130 L 658 136 L 680 143 L 686 137 L 665 130"/>
-  <text x="672" y="136" style="font-size:4">4,362,0,0,0</text>
+  <text x="672" y="138" style="font-size:3px">4,362,0,0,0</text>
   <path class="p4" d="M 658 136 L 652 142 L 673 149 L 680 143 L 658 136"/>
-  <text x="666" y="142" style="font-size:4">4,363,0,0,0</text>
+  <text x="666" y="144" style="font-size:3px">4,363,0,0,0</text>
   <path class="p4" d="M 631 136 L 624 142 L 645 148 L 652 142 L 631 136"/>
-  <text x="638" y="142" style="font-size:4">4,364,0,0,0</text>
+  <text x="638" y="144" style="font-size:3px">4,364,0,0,0</text>
   <path class="p4" d="M 624 142 L 617 149 L 639 155 L 645 148 L 624 142"/>
-  <text x="631" y="149" style="font-size:5">4,365,0,0,0</text>
+  <text x="631" y="150" style="font-size:3px">4,365,0,0,0</text>
   <path class="p4" d="M 652 142 L 645 148 L 667 155 L 673 149 L 652 142"/>
-  <text x="659" y="148" style="font-size:5">4,366,0,0,0</text>
+  <text x="659" y="150" style="font-size:3px">4,366,0,0,0</text>
   <path class="p4" d="M 645 148 L 639 155 L 660 161 L 667 155 L 645 148"/>
-  <text x="653" y="155" style="font-size:5">4,367,0,0,0</text>
+  <text x="653" y="156" style="font-size:3px">4,367,0,0,0</text>
   <path class="p4" d="M 576 138 L 569 146 L 590 151 L 597 144 L 576 138"/>
-  <text x="583" y="145" style="font-size:4">4,368,0,0,0</text>
+  <text x="583" y="146" style="font-size:3px">4,368,0,0,0</text>
   <path class="p4" d="M 569 146 L 562 154 L 583 159 L 590 151 L 569 146"/>
-  <text x="576" y="152" style="font-size:5">4,369,0,0,0</text>
+  <text x="576" y="154" style="font-size:3px">4,369,0,0,0</text>
   <path class="p4" d="M 597 144 L 590 151 L 611 156 L 617 149 L 597 144"/>
-  <text x="604" y="150" style="font-size:5">4,370,0,0,0</text>
+  <text x="604" y="152" style="font-size:3px">4,370,0,0,0</text>
   <path class="p4" d="M 590 151 L 583 159 L 604 163 L 611 156 L 590 151"/>
-  <text x="597" y="157" style="font-size:5">4,371,0,0,0</text>
+  <text x="597" y="159" style="font-size:3px">4,371,0,0,0</text>
   <path class="p4" d="M 562 154 L 555 162 L 576 166 L 583 159 L 562 154"/>
-  <text x="569" y="160" style="font-size:5">4,372,0,0,0</text>
+  <text x="569" y="162" style="font-size:3px">4,372,0,0,0</text>
   <path class="p4" d="M 555 162 L 548 170 L 569 174 L 576 166 L 555 162"/>
-  <text x="562" y="168" style="font-size:5">4,373,0,0,0</text>
+  <text x="562" y="169" style="font-size:3px">4,373,0,0,0</text>
   <path class="p4" d="M 583 159 L 576 166 L 597 171 L 604 163 L 583 159"/>
-  <text x="590" y="165" style="font-size:5">4,374,0,0,0</text>
+  <text x="590" y="166" style="font-size:3px">4,374,0,0,0</text>
   <path class="p4" d="M 576 166 L 569 174 L 590 178 L 597 171 L 576 166"/>
-  <text x="583" y="172" style="font-size:5">4,375,0,0,0</text>
+  <text x="583" y="174" style="font-size:3px">4,375,0,0,0</text>
   <path class="p4" d="M 617 149 L 611 156 L 632 162 L 639 155 L 617 149"/>
-  <text x="625" y="155" style="font-size:5">4,376,0,0,0</text>
+  <text x="625" y="157" style="font-size:3px">4,376,0,0,0</text>
   <path class="p4" d="M 611 156 L 604 163 L 625 168 L 632 162 L 611 156"/>
-  <text x="618" y="162" style="font-size:5">4,377,0,0,0</text>
+  <text x="618" y="164" style="font-size:3px">4,377,0,0,0</text>
   <path class="p4" d="M 639 155 L 632 162 L 653 167 L 660 161 L 639 155"/>
-  <text x="646" y="161" style="font-size:5">4,378,0,0,0</text>
+  <text x="646" y="163" style="font-size:3px">4,378,0,0,0</text>
   <path class="p4" d="M 632 162 L 625 168 L 647 173 L 653 167 L 632 162"/>
-  <text x="639" y="167" style="font-size:5">4,379,0,0,0</text>
+  <text x="639" y="169" style="font-size:3px">4,379,0,0,0</text>
   <path class="p4" d="M 604 163 L 597 171 L 618 175 L 625 168 L 604 163"/>
-  <text x="611" y="169" style="font-size:5">4,380,0,0,0</text>
+  <text x="611" y="171" style="font-size:3px">4,380,0,0,0</text>
   <path class="p4" d="M 597 171 L 590 178 L 611 182 L 618 175 L 597 171"/>
-  <text x="604" y="176" style="font-size:5">4,381,0,0,0</text>
+  <text x="604" y="178" style="font-size:3px">4,381,0,0,0</text>
   <path class="p4" d="M 625 168 L 618 175 L 640 180 L 647 173 L 625 168"/>
-  <text x="632" y="174" style="font-size:5">4,382,0,0,0</text>
+  <text x="632" y="175" style="font-size:3px">4,382,0,0,0</text>
   <path class="p4" d="M 618 175 L 611 182 L 632 186 L 640 180 L 618 175"/>
-  <text x="625" y="181" style="font-size:5">4,383,0,0,0</text>
+  <text x="625" y="182" style="font-size:3px">4,383,0,0,0</text>
   <path class="p4" d="M 686 137 L 680 143 L 702 150 L 708 144 L 686 137"/>
-  <text x="694" y="143" style="font-size:5">4,384,0,0,0</text>
+  <text x="694" y="145" style="font-size:3px">4,384,0,0,0</text>
   <path class="p4" d="M 680 143 L 673 149 L 695 155 L 702 150 L 680 143"/>
-  <text x="688" y="149" style="font-size:5">4,385,0,0,0</text>
+  <text x="688" y="150" style="font-size:3px">4,385,0,0,0</text>
   <path class="p4" d="M 708 144 L 702 150 L 724 157 L 731 152 L 708 144"/>
-  <text x="716" y="151" style="font-size:5">4,386,0,0,0</text>
+  <text x="716" y="152" style="font-size:3px">4,386,0,0,0</text>
   <path class="p4" d="M 702 150 L 695 155 L 718 162 L 724 157 L 702 150"/>
-  <text x="710" y="156" style="font-size:5">4,387,0,0,0</text>
+  <text x="710" y="157" style="font-size:3px">4,387,0,0,0</text>
   <path class="p4" d="M 673 149 L 667 155 L 689 161 L 695 155 L 673 149"/>
-  <text x="681" y="155" style="font-size:5">4,388,0,0,0</text>
+  <text x="681" y="156" style="font-size:3px">4,388,0,0,0</text>
   <path class="p4" d="M 667 155 L 660 161 L 682 167 L 689 161 L 667 155"/>
-  <text x="674" y="161" style="font-size:5">4,389,0,0,0</text>
+  <text x="674" y="162" style="font-size:3px">4,389,0,0,0</text>
   <path class="p4" d="M 695 155 L 689 161 L 711 167 L 718 162 L 695 155"/>
-  <text x="703" y="161" style="font-size:5">4,390,0,0,0</text>
+  <text x="703" y="163" style="font-size:3px">4,390,0,0,0</text>
   <path class="p4" d="M 689 161 L 682 167 L 704 172 L 711 167 L 689 161"/>
-  <text x="696" y="167" style="font-size:5">4,391,0,0,0</text>
+  <text x="696" y="168" style="font-size:3px">4,391,0,0,0</text>
   <path class="p4" d="M 731 152 L 724 157 L 747 164 L 754 159 L 731 152"/>
-  <text x="739" y="158" style="font-size:5">4,392,0,0,0</text>
+  <text x="739" y="159" style="font-size:3px">4,392,0,0,0</text>
   <path class="p4" d="M 724 157 L 718 162 L 740 169 L 747 164 L 724 157"/>
-  <text x="732" y="163" style="font-size:5">4,393,0,0,0</text>
+  <text x="732" y="164" style="font-size:3px">4,393,0,0,0</text>
   <path class="p4" d="M 754 159 L 747 164 L 770 171 L 777 167 L 754 159"/>
-  <text x="762" y="165" style="font-size:5">4,394,0,0,0</text>
+  <text x="762" y="167" style="font-size:3px">4,394,0,0,0</text>
   <line x1="777" y1="167" x2="770" y2="171"/>
   <path class="p4" d="M 747 164 L 740 169 L 763 176 L 770 171 L 747 164"/>
-  <text x="755" y="170" style="font-size:5">4,395,0,0,0</text>
+  <text x="755" y="171" style="font-size:3px">4,395,0,0,0</text>
   <line x1="770" y1="171" x2="763" y2="176"/>
   <path class="p4" d="M 718 162 L 711 167 L 733 174 L 740 169 L 718 162"/>
-  <text x="725" y="168" style="font-size:5">4,396,0,0,0</text>
+  <text x="725" y="169" style="font-size:3px">4,396,0,0,0</text>
   <path class="p4" d="M 711 167 L 704 172 L 726 178 L 733 174 L 711 167"/>
-  <text x="719" y="173" style="font-size:5">4,397,0,0,0</text>
+  <text x="719" y="174" style="font-size:3px">4,397,0,0,0</text>
   <path class="p4" d="M 740 169 L 733 174 L 756 180 L 763 176 L 740 169"/>
-  <text x="748" y="174" style="font-size:5">4,398,0,0,0</text>
+  <text x="748" y="176" style="font-size:3px">4,398,0,0,0</text>
   <line x1="763" y1="176" x2="756" y2="180"/>
   <path class="p4" d="M 733 174 L 726 178 L 749 184 L 756 180 L 733 174"/>
-  <text x="741" y="179" style="font-size:5">4,399,0,0,0</text>
+  <text x="741" y="181" style="font-size:3px">4,399,0,0,0</text>
   <line x1="756" y1="180" x2="749" y2="184"/>
   <path class="p4" d="M 660 161 L 653 167 L 675 172 L 682 167 L 660 161"/>
-  <text x="668" y="167" style="font-size:5">4,400,0,0,0</text>
+  <text x="668" y="168" style="font-size:3px">4,400,0,0,0</text>
   <path class="p4" d="M 653 167 L 647 173 L 668 178 L 675 172 L 653 167"/>
-  <text x="661" y="173" style="font-size:5">4,401,0,0,0</text>
+  <text x="661" y="174" style="font-size:3px">4,401,0,0,0</text>
   <path class="p4" d="M 682 167 L 675 172 L 697 178 L 704 172 L 682 167"/>
-  <text x="689" y="172" style="font-size:5">4,402,0,0,0</text>
+  <text x="689" y="174" style="font-size:3px">4,402,0,0,0</text>
   <path class="p4" d="M 675 172 L 668 178 L 690 183 L 697 178 L 675 172"/>
-  <text x="683" y="178" style="font-size:5">4,403,0,0,0</text>
+  <text x="683" y="179" style="font-size:3px">4,403,0,0,0</text>
   <path class="p4" d="M 647 173 L 640 180 L 661 184 L 668 178 L 647 173"/>
-  <text x="654" y="179" style="font-size:5">4,404,0,0,0</text>
+  <text x="654" y="180" style="font-size:3px">4,404,0,0,0</text>
   <path class="p4" d="M 640 180 L 632 186 L 654 190 L 661 184 L 640 180"/>
-  <text x="647" y="185" style="font-size:5">4,405,0,0,0</text>
+  <text x="647" y="186" style="font-size:3px">4,405,0,0,0</text>
   <path class="p4" d="M 668 178 L 661 184 L 683 189 L 690 183 L 668 178"/>
-  <text x="676" y="184" style="font-size:5">4,406,0,0,0</text>
+  <text x="676" y="185" style="font-size:3px">4,406,0,0,0</text>
   <path class="p4" d="M 661 184 L 654 190 L 676 194 L 683 189 L 661 184"/>
-  <text x="668" y="189" style="font-size:5">4,407,0,0,0</text>
+  <text x="668" y="191" style="font-size:3px">4,407,0,0,0</text>
   <path class="p4" d="M 704 172 L 697 178 L 719 183 L 726 178 L 704 172"/>
-  <text x="712" y="178" style="font-size:5">4,408,0,0,0</text>
+  <text x="712" y="179" style="font-size:3px">4,408,0,0,0</text>
   <path class="p4" d="M 697 178 L 690 183 L 712 188 L 719 183 L 697 178"/>
-  <text x="705" y="183" style="font-size:5">4,409,0,0,0</text>
+  <text x="705" y="185" style="font-size:3px">4,409,0,0,0</text>
   <path class="p4" d="M 726 178 L 719 183 L 742 189 L 749 184 L 726 178"/>
-  <text x="734" y="184" style="font-size:5">4,410,0,0,0</text>
+  <text x="734" y="185" style="font-size:3px">4,410,0,0,0</text>
   <line x1="749" y1="184" x2="742" y2="189"/>
   <path class="p4" d="M 719 183 L 712 188 L 734 193 L 742 189 L 719 183"/>
-  <text x="727" y="189" style="font-size:5">4,411,0,0,0</text>
+  <text x="727" y="190" style="font-size:3px">4,411,0,0,0</text>
   <line x1="742" y1="189" x2="734" y2="193"/>
   <path class="p4" d="M 690 183 L 683 189 L 705 193 L 712 188 L 690 183"/>
-  <text x="697" y="188" style="font-size:5">4,412,0,0,0</text>
+  <text x="697" y="190" style="font-size:3px">4,412,0,0,0</text>
   <path class="p4" d="M 683 189 L 676 194 L 698 198 L 705 193 L 683 189"/>
-  <text x="690" y="194" style="font-size:5">4,413,0,0,0</text>
+  <text x="690" y="195" style="font-size:3px">4,413,0,0,0</text>
   <path class="p4" d="M 712 188 L 705 193 L 727 198 L 734 193 L 712 188"/>
-  <text x="720" y="193" style="font-size:5">4,414,0,0,0</text>
+  <text x="720" y="195" style="font-size:3px">4,414,0,0,0</text>
   <line x1="734" y1="193" x2="727" y2="198"/>
   <path class="p4" d="M 705 193 L 698 198 L 720 203 L 727 198 L 705 193"/>
-  <text x="712" y="198" style="font-size:5">4,415,0,0,0</text>
+  <text x="712" y="200" style="font-size:3px">4,415,0,0,0</text>
   <line x1="727" y1="198" x2="720" y2="203"/>
   <path class="p4" d="M 548 170 L 541 178 L 562 182 L 569 174 L 548 170"/>
-  <text x="555" y="176" style="font-size:5">4,416,0,0,0</text>
+  <text x="555" y="177" style="font-size:3px">4,416,0,0,0</text>
   <path class="p4" d="M 541 178 L 534 187 L 555 190 L 562 182 L 541 178"/>
-  <text x="548" y="184" style="font-size:5">4,417,0,0,0</text>
+  <text x="548" y="186" style="font-size:3px">4,417,0,0,0</text>
   <path class="p4" d="M 569 174 L 562 182 L 583 185 L 590 178 L 569 174"/>
-  <text x="576" y="180" style="font-size:5">4,418,0,0,0</text>
+  <text x="576" y="181" style="font-size:3px">4,418,0,0,0</text>
   <path class="p4" d="M 562 182 L 555 190 L 576 193 L 583 185 L 562 182"/>
-  <text x="569" y="187" style="font-size:5">4,419,0,0,0</text>
+  <text x="569" y="189" style="font-size:3px">4,419,0,0,0</text>
   <path class="p4" d="M 534 187 L 526 195 L 547 198 L 555 190 L 534 187"/>
-  <text x="541" y="193" style="font-size:5">4,420,0,0,0</text>
+  <text x="541" y="194" style="font-size:3px">4,420,0,0,0</text>
   <path class="p4" d="M 526 195 L 519 204 L 540 206 L 547 198 L 526 195"/>
-  <text x="533" y="201" style="font-size:5">4,421,0,0,0</text>
+  <text x="533" y="203" style="font-size:3px">4,421,0,0,0</text>
   <path class="p4" d="M 555 190 L 547 198 L 568 201 L 576 193 L 555 190"/>
-  <text x="561" y="195" style="font-size:5">4,422,0,0,0</text>
+  <text x="561" y="197" style="font-size:3px">4,422,0,0,0</text>
   <path class="p4" d="M 547 198 L 540 206 L 561 209 L 568 201 L 547 198"/>
-  <text x="554" y="203" style="font-size:5">4,423,0,0,0</text>
+  <text x="554" y="205" style="font-size:3px">4,423,0,0,0</text>
   <path class="p4" d="M 590 178 L 583 185 L 604 189 L 611 182 L 590 178"/>
-  <text x="597" y="184" style="font-size:5">4,424,0,0,0</text>
+  <text x="597" y="185" style="font-size:3px">4,424,0,0,0</text>
   <path class="p4" d="M 583 185 L 576 193 L 597 196 L 604 189 L 583 185"/>
-  <text x="590" y="191" style="font-size:5">4,425,0,0,0</text>
+  <text x="590" y="192" style="font-size:3px">4,425,0,0,0</text>
   <path class="p4" d="M 611 182 L 604 189 L 625 193 L 632 186 L 611 182"/>
-  <text x="618" y="187" style="font-size:5">4,426,0,0,0</text>
+  <text x="618" y="189" style="font-size:3px">4,426,0,0,0</text>
   <path class="p4" d="M 604 189 L 597 196 L 618 199 L 625 193 L 604 189"/>
-  <text x="611" y="194" style="font-size:5">4,427,0,0,0</text>
+  <text x="611" y="196" style="font-size:3px">4,427,0,0,0</text>
   <path class="p4" d="M 576 193 L 568 201 L 589 203 L 597 196 L 576 193"/>
-  <text x="583" y="198" style="font-size:5">4,428,0,0,0</text>
+  <text x="583" y="200" style="font-size:3px">4,428,0,0,0</text>
   <path class="p4" d="M 568 201 L 561 209 L 582 211 L 589 203 L 568 201"/>
-  <text x="575" y="206" style="font-size:5">4,429,0,0,0</text>
+  <text x="575" y="207" style="font-size:3px">4,429,0,0,0</text>
   <path class="p4" d="M 597 196 L 589 203 L 611 206 L 618 199 L 597 196"/>
-  <text x="604" y="201" style="font-size:5">4,430,0,0,0</text>
+  <text x="604" y="203" style="font-size:3px">4,430,0,0,0</text>
   <path class="p4" d="M 589 203 L 582 211 L 603 213 L 611 206 L 589 203"/>
-  <text x="596" y="208" style="font-size:5">4,431,0,0,0</text>
+  <text x="596" y="210" style="font-size:3px">4,431,0,0,0</text>
   <path class="p4" d="M 519 204 L 511 213 L 532 215 L 540 206 L 519 204"/>
-  <text x="525" y="210" style="font-size:5">4,432,0,0,0</text>
+  <text x="525" y="211" style="font-size:3px">4,432,0,0,0</text>
   <path class="p4" d="M 511 213 L 503 222 L 524 224 L 532 215 L 511 213"/>
-  <text x="517" y="219" style="font-size:5">4,433,0,0,0</text>
+  <text x="517" y="220" style="font-size:3px">4,433,0,0,0</text>
   <path class="p4" d="M 540 206 L 532 215 L 553 217 L 561 209 L 540 206"/>
-  <text x="546" y="212" style="font-size:5">4,434,0,0,0</text>
+  <text x="546" y="213" style="font-size:3px">4,434,0,0,0</text>
   <path class="p4" d="M 532 215 L 524 224 L 545 225 L 553 217 L 532 215"/>
-  <text x="539" y="220" style="font-size:6">4,435,0,0,0</text>
+  <text x="539" y="221" style="font-size:3px">4,435,0,0,0</text>
   <path class="p4" d="M 503 222 L 495 232 L 516 232 L 524 224 L 503 222"/>
-  <text x="510" y="228" style="font-size:6">4,436,0,0,0</text>
+  <text x="510" y="230" style="font-size:4px">4,436,0,0,0</text>
   <path class="p4" d="M 495 232 L 487 241 L 508 241 L 516 232 L 495 232"/>
-  <text x="501" y="237" style="font-size:6">4,437,0,0,0</text>
+  <text x="501" y="239" style="font-size:4px">4,437,0,0,0</text>
   <path class="p4" d="M 524 224 L 516 232 L 537 233 L 545 225 L 524 224"/>
-  <text x="531" y="228" style="font-size:6">4,438,0,0,0</text>
+  <text x="531" y="230" style="font-size:4px">4,438,0,0,0</text>
   <path class="p4" d="M 516 232 L 508 241 L 529 241 L 537 233 L 516 232"/>
-  <text x="523" y="237" style="font-size:6">4,439,0,0,0</text>
+  <text x="523" y="239" style="font-size:4px">4,439,0,0,0</text>
   <path class="p4" d="M 561 209 L 553 217 L 574 218 L 582 211 L 561 209"/>
-  <text x="568" y="213" style="font-size:5">4,440,0,0,0</text>
+  <text x="568" y="215" style="font-size:3px">4,440,0,0,0</text>
   <path class="p4" d="M 553 217 L 545 225 L 567 226 L 574 218 L 553 217"/>
-  <text x="560" y="221" style="font-size:6">4,441,0,0,0</text>
+  <text x="560" y="223" style="font-size:3px">4,441,0,0,0</text>
   <path class="p4" d="M 582 211 L 574 218 L 596 220 L 603 213 L 582 211"/>
-  <text x="589" y="215" style="font-size:5">4,442,0,0,0</text>
+  <text x="589" y="217" style="font-size:3px">4,442,0,0,0</text>
   <path class="p4" d="M 574 218 L 567 226 L 588 227 L 596 220 L 574 218"/>
-  <text x="581" y="223" style="font-size:6">4,443,0,0,0</text>
+  <text x="581" y="224" style="font-size:3px">4,443,0,0,0</text>
   <path class="p4" d="M 545 225 L 537 233 L 559 233 L 567 226 L 545 225"/>
-  <text x="552" y="229" style="font-size:6">4,444,0,0,0</text>
+  <text x="552" y="231" style="font-size:4px">4,444,0,0,0</text>
   <path class="p4" d="M 537 233 L 529 241 L 551 241 L 559 233 L 537 233"/>
-  <text x="544" y="237" style="font-size:6">4,445,0,0,0</text>
+  <text x="544" y="239" style="font-size:4px">4,445,0,0,0</text>
   <path class="p4" d="M 567 226 L 559 233 L 580 234 L 588 227 L 567 226"/>
-  <text x="573" y="230" style="font-size:6">4,446,0,0,0</text>
+  <text x="573" y="232" style="font-size:4px">4,446,0,0,0</text>
   <path class="p4" d="M 559 233 L 551 241 L 572 241 L 580 234 L 559 233"/>
-  <text x="565" y="238" style="font-size:6">4,447,0,0,0</text>
+  <text x="565" y="240" style="font-size:4px">4,447,0,0,0</text>
   <path class="p4" d="M 632 186 L 625 193 L 647 196 L 654 190 L 632 186"/>
-  <text x="640" y="191" style="font-size:5">4,448,0,0,0</text>
+  <text x="640" y="193" style="font-size:3px">4,448,0,0,0</text>
   <path class="p4" d="M 625 193 L 618 199 L 640 202 L 647 196 L 625 193"/>
-  <text x="632" y="198" style="font-size:5">4,449,0,0,0</text>
+  <text x="632" y="199" style="font-size:3px">4,449,0,0,0</text>
   <path class="p4" d="M 654 190 L 647 196 L 668 200 L 676 194 L 654 190"/>
-  <text x="661" y="195" style="font-size:5">4,450,0,0,0</text>
+  <text x="661" y="197" style="font-size:3px">4,450,0,0,0</text>
   <path class="p4" d="M 647 196 L 640 202 L 661 206 L 668 200 L 647 196"/>
-  <text x="654" y="201" style="font-size:5">4,451,0,0,0</text>
+  <text x="654" y="203" style="font-size:3px">4,451,0,0,0</text>
   <path class="p4" d="M 618 199 L 611 206 L 632 209 L 640 202 L 618 199"/>
-  <text x="625" y="204" style="font-size:5">4,452,0,0,0</text>
+  <text x="625" y="206" style="font-size:3px">4,452,0,0,0</text>
   <path class="p4" d="M 611 206 L 603 213 L 625 215 L 632 209 L 611 206"/>
-  <text x="618" y="211" style="font-size:5">4,453,0,0,0</text>
+  <text x="618" y="212" style="font-size:3px">4,453,0,0,0</text>
   <path class="p4" d="M 640 202 L 632 209 L 654 211 L 661 206 L 640 202"/>
-  <text x="647" y="207" style="font-size:5">4,454,0,0,0</text>
+  <text x="647" y="208" style="font-size:3px">4,454,0,0,0</text>
   <path class="p4" d="M 632 209 L 625 215 L 646 217 L 654 211 L 632 209"/>
-  <text x="639" y="213" style="font-size:6">4,455,0,0,0</text>
+  <text x="639" y="215" style="font-size:3px">4,455,0,0,0</text>
   <path class="p4" d="M 676 194 L 668 200 L 690 204 L 698 198 L 676 194"/>
-  <text x="683" y="199" style="font-size:5">4,456,0,0,0</text>
+  <text x="683" y="201" style="font-size:3px">4,456,0,0,0</text>
   <path class="p4" d="M 668 200 L 661 206 L 683 209 L 690 204 L 668 200"/>
-  <text x="676" y="204" style="font-size:5">4,457,0,0,0</text>
+  <text x="676" y="206" style="font-size:3px">4,457,0,0,0</text>
   <path class="p4" d="M 698 198 L 690 204 L 712 207 L 720 203 L 698 198"/>
-  <text x="705" y="203" style="font-size:5">4,458,0,0,0</text>
+  <text x="705" y="204" style="font-size:3px">4,458,0,0,0</text>
   <line x1="720" y1="203" x2="712" y2="207"/>
   <path class="p4" d="M 690 204 L 683 209 L 705 212 L 712 207 L 690 204"/>
-  <text x="698" y="208" style="font-size:5">4,459,0,0,0</text>
+  <text x="698" y="209" style="font-size:3px">4,459,0,0,0</text>
   <line x1="712" y1="207" x2="705" y2="212"/>
   <path class="p4" d="M 661 206 L 654 211 L 675 214 L 683 209 L 661 206"/>
-  <text x="668" y="210" style="font-size:5">4,460,0,0,0</text>
+  <text x="668" y="211" style="font-size:3px">4,460,0,0,0</text>
   <path class="p4" d="M 654 211 L 646 217 L 668 219 L 675 214 L 654 211"/>
-  <text x="661" y="215" style="font-size:6">4,461,0,0,0</text>
+  <text x="661" y="217" style="font-size:3px">4,461,0,0,0</text>
   <path class="p4" d="M 683 209 L 675 214 L 697 217 L 705 212 L 683 209"/>
-  <text x="690" y="213" style="font-size:6">4,462,0,0,0</text>
+  <text x="690" y="214" style="font-size:3px">4,462,0,0,0</text>
   <line x1="705" y1="212" x2="697" y2="217"/>
   <path class="p4" d="M 675 214 L 668 219 L 689 222 L 697 217 L 675 214"/>
-  <text x="682" y="218" style="font-size:6">4,463,0,0,0</text>
+  <text x="682" y="220" style="font-size:4px">4,463,0,0,0</text>
   <line x1="697" y1="217" x2="689" y2="222"/>
   <path class="p4" d="M 603 213 L 596 220 L 617 221 L 625 215 L 603 213"/>
-  <text x="610" y="217" style="font-size:6">4,464,0,0,0</text>
+  <text x="610" y="219" style="font-size:3px">4,464,0,0,0</text>
   <path class="p4" d="M 596 220 L 588 227 L 609 228 L 617 221 L 596 220"/>
-  <text x="602" y="224" style="font-size:6">4,465,0,0,0</text>
+  <text x="602" y="226" style="font-size:4px">4,465,0,0,0</text>
   <path class="p4" d="M 625 215 L 617 221 L 638 223 L 646 217 L 625 215"/>
-  <text x="632" y="219" style="font-size:6">4,466,0,0,0</text>
+  <text x="632" y="221" style="font-size:3px">4,466,0,0,0</text>
   <path class="p4" d="M 617 221 L 609 228 L 631 229 L 638 223 L 617 221"/>
-  <text x="624" y="225" style="font-size:6">4,467,0,0,0</text>
+  <text x="624" y="227" style="font-size:4px">4,467,0,0,0</text>
   <path class="p4" d="M 588 227 L 580 234 L 601 235 L 609 228 L 588 227"/>
-  <text x="595" y="231" style="font-size:6">4,468,0,0,0</text>
+  <text x="595" y="233" style="font-size:4px">4,468,0,0,0</text>
   <path class="p4" d="M 580 234 L 572 241 L 594 241 L 601 235 L 580 234"/>
-  <text x="587" y="238" style="font-size:6">4,469,0,0,0</text>
+  <text x="587" y="240" style="font-size:4px">4,469,0,0,0</text>
   <path class="p4" d="M 609 228 L 601 235 L 623 235 L 631 229 L 609 228"/>
-  <text x="616" y="232" style="font-size:6">4,470,0,0,0</text>
+  <text x="616" y="234" style="font-size:4px">4,470,0,0,0</text>
   <path class="p4" d="M 601 235 L 594 241 L 615 241 L 623 235 L 601 235"/>
-  <text x="608" y="238" style="font-size:6">4,471,0,0,0</text>
+  <text x="608" y="240" style="font-size:4px">4,471,0,0,0</text>
   <path class="p4" d="M 646 217 L 638 223 L 660 225 L 668 219 L 646 217"/>
-  <text x="653" y="221" style="font-size:6">4,472,0,0,0</text>
+  <text x="653" y="223" style="font-size:4px">4,472,0,0,0</text>
   <path class="p4" d="M 638 223 L 631 229 L 652 230 L 660 225 L 638 223"/>
-  <text x="645" y="227" style="font-size:6">4,473,0,0,0</text>
+  <text x="645" y="229" style="font-size:4px">4,473,0,0,0</text>
   <path class="p4" d="M 668 219 L 660 225 L 682 226 L 689 222 L 668 219"/>
-  <text x="675" y="223" style="font-size:6">4,474,0,0,0</text>
+  <text x="675" y="225" style="font-size:4px">4,474,0,0,0</text>
   <line x1="689" y1="222" x2="682" y2="226"/>
   <path class="p4" d="M 660 225 L 652 230 L 674 231 L 682 226 L 660 225"/>
-  <text x="667" y="228" style="font-size:6">4,475,0,0,0</text>
+  <text x="667" y="230" style="font-size:4px">4,475,0,0,0</text>
   <line x1="682" y1="226" x2="674" y2="231"/>
   <path class="p4" d="M 631 229 L 623 235 L 644 236 L 652 230 L 631 229"/>
-  <text x="638" y="233" style="font-size:6">4,476,0,0,0</text>
+  <text x="638" y="235" style="font-size:4px">4,476,0,0,0</text>
   <path class="p4" d="M 623 235 L 615 241 L 636 241 L 644 236 L 623 235"/>
-  <text x="630" y="238" style="font-size:6">4,477,0,0,0</text>
+  <text x="630" y="240" style="font-size:4px">4,477,0,0,0</text>
   <path class="p4" d="M 652 230 L 644 236 L 666 236 L 674 231 L 652 230"/>
-  <text x="659" y="233" style="font-size:6">4,478,0,0,0</text>
+  <text x="659" y="235" style="font-size:4px">4,478,0,0,0</text>
   <line x1="674" y1="231" x2="666" y2="236"/>
   <path class="p4" d="M 644 236 L 636 241 L 658 241 L 666 236 L 644 236"/>
-  <text x="651" y="239" style="font-size:6">4,479,0,0,0</text>
+  <text x="651" y="241" style="font-size:4px">4,479,0,0,0</text>
   <line x1="666" y1="236" x2="658" y2="241"/>
   <path class="p4" d="M 487 241 L 484 251 L 507 251 L 508 241 L 487 241"/>
-  <text x="496" y="246" style="font-size:6">4,480,0,0,0</text>
+  <text x="496" y="248" style="font-size:4px">4,480,0,0,0</text>
   <path class="p4" d="M 484 251 L 482 261 L 506 260 L 507 251 L 484 251"/>
-  <text x="495" y="256" style="font-size:6">4,481,0,0,0</text>
+  <text x="495" y="258" style="font-size:4px">4,481,0,0,0</text>
   <path class="p4" d="M 508 241 L 507 251 L 529 250 L 529 241 L 508 241"/>
-  <text x="518" y="246" style="font-size:6">4,482,0,0,0</text>
+  <text x="518" y="248" style="font-size:4px">4,482,0,0,0</text>
   <path class="p4" d="M 507 251 L 506 260 L 529 259 L 529 250 L 507 251"/>
-  <text x="518" y="255" style="font-size:6">4,483,0,0,0</text>
+  <text x="518" y="257" style="font-size:4px">4,483,0,0,0</text>
   <path class="p4" d="M 482 261 L 480 271 L 504 269 L 506 260 L 482 261"/>
-  <text x="493" y="265" style="font-size:6">4,484,0,0,0</text>
+  <text x="493" y="267" style="font-size:4px">4,484,0,0,0</text>
   <path class="p4" d="M 480 271 L 478 282 L 503 279 L 504 269 L 480 271"/>
-  <text x="491" y="275" style="font-size:6">4,485,0,0,0</text>
+  <text x="491" y="277" style="font-size:4px">4,485,0,0,0</text>
   <path class="p4" d="M 506 260 L 504 269 L 528 268 L 529 259 L 506 260"/>
-  <text x="517" y="264" style="font-size:6">4,486,0,0,0</text>
+  <text x="517" y="266" style="font-size:4px">4,486,0,0,0</text>
   <path class="p4" d="M 504 269 L 503 279 L 528 277 L 528 268 L 504 269"/>
-  <text x="516" y="273" style="font-size:6">4,487,0,0,0</text>
+  <text x="516" y="275" style="font-size:4px">4,487,0,0,0</text>
   <path class="p4" d="M 529 241 L 529 250 L 551 249 L 551 241 L 529 241"/>
-  <text x="540" y="245" style="font-size:6">4,488,0,0,0</text>
+  <text x="540" y="247" style="font-size:4px">4,488,0,0,0</text>
   <path class="p4" d="M 529 250 L 529 259 L 552 257 L 551 249 L 529 250"/>
-  <text x="540" y="254" style="font-size:6">4,489,0,0,0</text>
+  <text x="540" y="256" style="font-size:4px">4,489,0,0,0</text>
   <path class="p4" d="M 551 241 L 551 249 L 574 249 L 572 241 L 551 241"/>
-  <text x="562" y="245" style="font-size:6">4,490,0,0,0</text>
+  <text x="562" y="247" style="font-size:4px">4,490,0,0,0</text>
   <path class="p4" d="M 551 249 L 552 257 L 575 256 L 574 249 L 551 249"/>
-  <text x="563" y="253" style="font-size:6">4,491,0,0,0</text>
+  <text x="563" y="255" style="font-size:4px">4,491,0,0,0</text>
   <path class="p4" d="M 529 259 L 528 268 L 552 266 L 552 257 L 529 259"/>
-  <text x="540" y="262" style="font-size:6">4,492,0,0,0</text>
+  <text x="540" y="264" style="font-size:4px">4,492,0,0,0</text>
   <path class="p4" d="M 528 268 L 528 277 L 553 274 L 552 266 L 528 268"/>
-  <text x="541" y="271" style="font-size:6">4,493,0,0,0</text>
+  <text x="541" y="273" style="font-size:4px">4,493,0,0,0</text>
   <path class="p4" d="M 552 257 L 552 266 L 576 264 L 575 256 L 552 257"/>
-  <text x="564" y="261" style="font-size:6">4,494,0,0,0</text>
+  <text x="564" y="263" style="font-size:4px">4,494,0,0,0</text>
   <path class="p4" d="M 552 266 L 553 274 L 578 272 L 576 264 L 552 266"/>
-  <text x="565" y="269" style="font-size:6">4,495,0,0,0</text>
+  <text x="565" y="271" style="font-size:4px">4,495,0,0,0</text>
   <path class="p4" d="M 478 282 L 476 292 L 502 289 L 503 279 L 478 282"/>
-  <text x="490" y="285" style="font-size:6">4,496,0,0,0</text>
+  <text x="490" y="287" style="font-size:4px">4,496,0,0,0</text>
   <path class="p4" d="M 476 292 L 473 303 L 500 299 L 502 289 L 476 292"/>
-  <text x="488" y="296" style="font-size:7">4,497,0,0,0</text>
+  <text x="488" y="298" style="font-size:4px">4,497,0,0,0</text>
   <path class="p4" d="M 503 279 L 502 289 L 528 286 L 528 277 L 503 279"/>
-  <text x="515" y="283" style="font-size:6">4,498,0,0,0</text>
+  <text x="515" y="285" style="font-size:4px">4,498,0,0,0</text>
   <path class="p4" d="M 502 289 L 500 299 L 527 295 L 528 286 L 502 289"/>
-  <text x="514" y="292" style="font-size:7">4,499,0,0,0</text>
+  <text x="514" y="294" style="font-size:4px">4,499,0,0,0</text>
   <path class="p4" d="M 473 303 L 471 314 L 499 309 L 500 299 L 473 303"/>
-  <text x="486" y="306" style="font-size:7">4,500,0,0,0</text>
+  <text x="486" y="308" style="font-size:4px">4,500,0,0,0</text>
   <path class="p4" d="M 471 314 L 468 325 L 498 320 L 499 309 L 471 314"/>
-  <text x="484" y="317" style="font-size:7">4,501,0,0,0</text>
+  <text x="484" y="319" style="font-size:4px">4,501,0,0,0</text>
   <path class="p4" d="M 500 299 L 499 309 L 527 305 L 527 295 L 500 299"/>
-  <text x="514" y="302" style="font-size:7">4,502,0,0,0</text>
+  <text x="514" y="304" style="font-size:4px">4,502,0,0,0</text>
   <path class="p4" d="M 499 309 L 498 320 L 527 315 L 527 305 L 499 309"/>
-  <text x="513" y="312" style="font-size:7">4,503,0,0,0</text>
+  <text x="513" y="314" style="font-size:4px">4,503,0,0,0</text>
   <path class="p4" d="M 528 277 L 528 286 L 554 283 L 553 274 L 528 277"/>
-  <text x="541" y="280" style="font-size:6">4,504,0,0,0</text>
+  <text x="541" y="282" style="font-size:4px">4,504,0,0,0</text>
   <path class="p4" d="M 528 286 L 527 295 L 554 291 L 554 283 L 528 286"/>
-  <text x="541" y="289" style="font-size:7">4,505,0,0,0</text>
+  <text x="541" y="291" style="font-size:4px">4,505,0,0,0</text>
   <path class="p4" d="M 553 274 L 554 283 L 579 280 L 578 272 L 553 274"/>
-  <text x="566" y="277" style="font-size:6">4,506,0,0,0</text>
+  <text x="566" y="279" style="font-size:4px">4,506,0,0,0</text>
   <path class="p4" d="M 554 283 L 554 291 L 581 288 L 579 280 L 554 283"/>
-  <text x="567" y="285" style="font-size:7">4,507,0,0,0</text>
+  <text x="567" y="287" style="font-size:4px">4,507,0,0,0</text>
   <path class="p4" d="M 527 295 L 527 305 L 555 300 L 554 291 L 527 295"/>
-  <text x="541" y="298" style="font-size:7">4,508,0,0,0</text>
+  <text x="541" y="300" style="font-size:4px">4,508,0,0,0</text>
   <path class="p4" d="M 527 305 L 527 315 L 555 309 L 555 300 L 527 305"/>
-  <text x="541" y="307" style="font-size:7">4,509,0,0,0</text>
+  <text x="541" y="309" style="font-size:4px">4,509,0,0,0</text>
   <path class="p4" d="M 554 291 L 555 300 L 582 296 L 581 288 L 554 291"/>
-  <text x="568" y="294" style="font-size:7">4,510,0,0,0</text>
+  <text x="568" y="296" style="font-size:4px">4,510,0,0,0</text>
   <path class="p4" d="M 555 300 L 555 309 L 584 304 L 582 296 L 555 300"/>
-  <text x="569" y="302" style="font-size:7">4,511,0,0,0</text>
+  <text x="569" y="304" style="font-size:4px">4,511,0,0,0</text>
   <path class="p4" d="M 572 241 L 574 249 L 596 248 L 594 241 L 572 241"/>
-  <text x="584" y="245" style="font-size:6">4,512,0,0,0</text>
+  <text x="584" y="247" style="font-size:4px">4,512,0,0,0</text>
   <path class="p4" d="M 574 249 L 575 256 L 598 255 L 596 248 L 574 249"/>
-  <text x="586" y="252" style="font-size:6">4,513,0,0,0</text>
+  <text x="586" y="254" style="font-size:4px">4,513,0,0,0</text>
   <path class="p4" d="M 594 241 L 596 248 L 618 248 L 615 241 L 594 241"/>
-  <text x="606" y="245" style="font-size:6">4,514,0,0,0</text>
+  <text x="606" y="247" style="font-size:4px">4,514,0,0,0</text>
   <path class="p4" d="M 596 248 L 598 255 L 621 254 L 618 248 L 596 248"/>
-  <text x="608" y="251" style="font-size:6">4,515,0,0,0</text>
+  <text x="608" y="253" style="font-size:4px">4,515,0,0,0</text>
   <path class="p4" d="M 575 256 L 576 264 L 600 262 L 598 255 L 575 256"/>
-  <text x="587" y="259" style="font-size:6">4,516,0,0,0</text>
+  <text x="587" y="261" style="font-size:4px">4,516,0,0,0</text>
   <path class="p4" d="M 576 264 L 578 272 L 603 269 L 600 262 L 576 264"/>
-  <text x="589" y="267" style="font-size:6">4,517,0,0,0</text>
+  <text x="589" y="269" style="font-size:4px">4,517,0,0,0</text>
   <path class="p4" d="M 598 255 L 600 262 L 624 260 L 621 254 L 598 255"/>
-  <text x="611" y="258" style="font-size:6">4,518,0,0,0</text>
+  <text x="611" y="260" style="font-size:4px">4,518,0,0,0</text>
   <path class="p4" d="M 600 262 L 603 269 L 627 267 L 624 260 L 600 262"/>
-  <text x="613" y="265" style="font-size:6">4,519,0,0,0</text>
+  <text x="613" y="267" style="font-size:4px">4,519,0,0,0</text>
   <path class="p4" d="M 615 241 L 618 248 L 640 247 L 636 241 L 615 241"/>
-  <text x="627" y="244" style="font-size:6">4,520,0,0,0</text>
+  <text x="627" y="246" style="font-size:4px">4,520,0,0,0</text>
   <path class="p4" d="M 618 248 L 621 254 L 644 253 L 640 247 L 618 248"/>
-  <text x="631" y="250" style="font-size:6">4,521,0,0,0</text>
+  <text x="631" y="252" style="font-size:4px">4,521,0,0,0</text>
   <path class="p4" d="M 636 241 L 640 247 L 662 246 L 658 241 L 636 241"/>
-  <text x="649" y="244" style="font-size:6">4,522,0,0,0</text>
+  <text x="649" y="246" style="font-size:4px">4,522,0,0,0</text>
   <line x1="658" y1="241" x2="662" y2="246"/>
   <path class="p4" d="M 640 247 L 644 253 L 667 252 L 662 246 L 640 247"/>
-  <text x="653" y="249" style="font-size:6">4,523,0,0,0</text>
+  <text x="653" y="251" style="font-size:4px">4,523,0,0,0</text>
   <line x1="662" y1="246" x2="667" y2="252"/>
   <path class="p4" d="M 621 254 L 624 260 L 648 259 L 644 253 L 621 254"/>
-  <text x="634" y="256" style="font-size:6">4,524,0,0,0</text>
+  <text x="634" y="258" style="font-size:4px">4,524,0,0,0</text>
   <path class="p4" d="M 624 260 L 627 267 L 652 264 L 648 259 L 624 260"/>
-  <text x="638" y="262" style="font-size:6">4,525,0,0,0</text>
+  <text x="638" y="264" style="font-size:4px">4,525,0,0,0</text>
   <path class="p4" d="M 644 253 L 648 259 L 671 257 L 667 252 L 644 253"/>
-  <text x="657" y="255" style="font-size:6">4,526,0,0,0</text>
+  <text x="657" y="257" style="font-size:4px">4,526,0,0,0</text>
   <line x1="667" y1="252" x2="671" y2="257"/>
   <path class="p4" d="M 648 259 L 652 264 L 676 262 L 671 257 L 648 259"/>
-  <text x="662" y="260" style="font-size:6">4,527,0,0,0</text>
+  <text x="662" y="262" style="font-size:4px">4,527,0,0,0</text>
   <line x1="671" y1="257" x2="676" y2="262"/>
   <path class="p4" d="M 578 272 L 579 280 L 605 276 L 603 269 L 578 272"/>
-  <text x="591" y="274" style="font-size:6">4,528,0,0,0</text>
+  <text x="591" y="276" style="font-size:4px">4,528,0,0,0</text>
   <path class="p4" d="M 579 280 L 581 288 L 607 284 L 605 276 L 579 280"/>
-  <text x="593" y="282" style="font-size:6">4,529,0,0,0</text>
+  <text x="593" y="284" style="font-size:4px">4,529,0,0,0</text>
   <path class="p4" d="M 603 269 L 605 276 L 630 273 L 627 267 L 603 269"/>
-  <text x="616" y="271" style="font-size:6">4,530,0,0,0</text>
+  <text x="616" y="273" style="font-size:4px">4,530,0,0,0</text>
   <path class="p4" d="M 605 276 L 607 284 L 633 280 L 630 273 L 605 276"/>
-  <text x="619" y="278" style="font-size:6">4,531,0,0,0</text>
+  <text x="619" y="280" style="font-size:4px">4,531,0,0,0</text>
   <path class="p4" d="M 581 288 L 582 296 L 610 291 L 607 284 L 581 288"/>
-  <text x="595" y="290" style="font-size:7">4,532,0,0,0</text>
+  <text x="595" y="292" style="font-size:4px">4,532,0,0,0</text>
   <path class="p4" d="M 582 296 L 584 304 L 612 299 L 610 291 L 582 296"/>
-  <text x="597" y="297" style="font-size:7">4,533,0,0,0</text>
+  <text x="597" y="299" style="font-size:4px">4,533,0,0,0</text>
   <path class="p4" d="M 607 284 L 610 291 L 637 287 L 633 280 L 607 284"/>
-  <text x="622" y="285" style="font-size:7">4,534,0,0,0</text>
+  <text x="622" y="287" style="font-size:4px">4,534,0,0,0</text>
   <path class="p4" d="M 610 291 L 612 299 L 640 294 L 637 287 L 610 291"/>
-  <text x="625" y="293" style="font-size:7">4,535,0,0,0</text>
+  <text x="625" y="295" style="font-size:4px">4,535,0,0,0</text>
   <path class="p4" d="M 627 267 L 630 273 L 655 270 L 652 264 L 627 267"/>
-  <text x="641" y="269" style="font-size:6">4,536,0,0,0</text>
+  <text x="641" y="271" style="font-size:4px">4,536,0,0,0</text>
   <path class="p4" d="M 630 273 L 633 280 L 659 276 L 655 270 L 630 273"/>
-  <text x="645" y="275" style="font-size:6">4,537,0,0,0</text>
+  <text x="645" y="277" style="font-size:4px">4,537,0,0,0</text>
   <path class="p4" d="M 652 264 L 655 270 L 681 267 L 676 262 L 652 264"/>
-  <text x="666" y="266" style="font-size:6">4,538,0,0,0</text>
+  <text x="666" y="268" style="font-size:4px">4,538,0,0,0</text>
   <line x1="676" y1="262" x2="681" y2="267"/>
   <path class="p4" d="M 655 270 L 659 276 L 685 273 L 681 267 L 655 270"/>
-  <text x="670" y="272" style="font-size:6">4,539,0,0,0</text>
+  <text x="670" y="274" style="font-size:4px">4,539,0,0,0</text>
   <line x1="681" y1="267" x2="685" y2="273"/>
   <path class="p4" d="M 633 280 L 637 287 L 663 282 L 659 276 L 633 280"/>
-  <text x="648" y="281" style="font-size:7">4,540,0,0,0</text>
+  <text x="648" y="283" style="font-size:4px">4,540,0,0,0</text>
   <path class="p4" d="M 637 287 L 640 294 L 668 289 L 663 282 L 637 287"/>
-  <text x="652" y="288" style="font-size:7">4,541,0,0,0</text>
+  <text x="652" y="290" style="font-size:4px">4,541,0,0,0</text>
   <path class="p4" d="M 659 276 L 663 282 L 690 278 L 685 273 L 659 276"/>
-  <text x="675" y="277" style="font-size:6">4,542,0,0,0</text>
+  <text x="675" y="279" style="font-size:4px">4,542,0,0,0</text>
   <line x1="685" y1="273" x2="690" y2="278"/>
   <path class="p4" d="M 663 282 L 668 289 L 695 283 L 690 278 L 663 282"/>
-  <text x="679" y="283" style="font-size:7">4,543,0,0,0</text>
+  <text x="679" y="285" style="font-size:4px">4,543,0,0,0</text>
   <line x1="690" y1="278" x2="695" y2="283"/>
   <path class="p4" d="M 468 325 L 466 337 L 496 331 L 498 320 L 468 325"/>
-  <text x="482" y="328" style="font-size:7">4,544,0,0,0</text>
+  <text x="482" y="330" style="font-size:4px">4,544,0,0,0</text>
   <path class="p4" d="M 466 337 L 463 349 L 495 342 L 496 331 L 466 337"/>
-  <text x="480" y="339" style="font-size:7">4,545,0,0,0</text>
+  <text x="480" y="342" style="font-size:5px">4,545,0,0,0</text>
   <path class="p4" d="M 498 320 L 496 331 L 526 325 L 527 315 L 498 320"/>
-  <text x="512" y="322" style="font-size:7">4,546,0,0,0</text>
+  <text x="512" y="324" style="font-size:4px">4,546,0,0,0</text>
   <path class="p4" d="M 496 331 L 495 342 L 526 335 L 526 325 L 496 331"/>
-  <text x="511" y="333" style="font-size:7">4,547,0,0,0</text>
+  <text x="511" y="335" style="font-size:4px">4,547,0,0,0</text>
   <path class="p4" d="M 463 349 L 461 361 L 493 353 L 495 342 L 463 349"/>
-  <text x="478" y="351" style="font-size:7">4,548,0,0,0</text>
+  <text x="478" y="354" style="font-size:5px">4,548,0,0,0</text>
   <path class="p4" d="M 461 361 L 458 373 L 492 364 L 493 353 L 461 361"/>
-  <text x="476" y="363" style="font-size:8">4,549,0,0,0</text>
+  <text x="476" y="365" style="font-size:5px">4,549,0,0,0</text>
   <path class="p4" d="M 495 342 L 493 353 L 526 345 L 526 335 L 495 342"/>
-  <text x="510" y="344" style="font-size:7">4,550,0,0,0</text>
+  <text x="510" y="346" style="font-size:5px">4,550,0,0,0</text>
   <path class="p4" d="M 493 353 L 492 364 L 525 356 L 526 345 L 493 353"/>
-  <text x="509" y="354" style="font-size:8">4,551,0,0,0</text>
+  <text x="509" y="357" style="font-size:5px">4,551,0,0,0</text>
   <path class="p4" d="M 527 315 L 526 325 L 556 318 L 555 309 L 527 315"/>
-  <text x="541" y="317" style="font-size:7">4,552,0,0,0</text>
+  <text x="541" y="319" style="font-size:4px">4,552,0,0,0</text>
   <path class="p4" d="M 526 325 L 526 335 L 557 328 L 556 318 L 526 325"/>
-  <text x="541" y="326" style="font-size:7">4,553,0,0,0</text>
+  <text x="541" y="328" style="font-size:4px">4,553,0,0,0</text>
   <path class="p4" d="M 555 309 L 556 318 L 586 312 L 584 304 L 555 309"/>
-  <text x="570" y="311" style="font-size:7">4,554,0,0,0</text>
+  <text x="570" y="313" style="font-size:4px">4,554,0,0,0</text>
   <path class="p4" d="M 556 318 L 557 328 L 587 321 L 586 312 L 556 318"/>
-  <text x="571" y="320" style="font-size:7">4,555,0,0,0</text>
+  <text x="571" y="322" style="font-size:4px">4,555,0,0,0</text>
   <path class="p4" d="M 526 335 L 526 345 L 557 337 L 557 328 L 526 335"/>
-  <text x="542" y="336" style="font-size:7">4,556,0,0,0</text>
+  <text x="542" y="339" style="font-size:5px">4,556,0,0,0</text>
   <path class="p4" d="M 526 345 L 525 356 L 558 347 L 557 337 L 526 345"/>
-  <text x="542" y="346" style="font-size:7">4,557,0,0,0</text>
+  <text x="542" y="349" style="font-size:5px">4,557,0,0,0</text>
   <path class="p4" d="M 557 328 L 557 337 L 589 330 L 587 321 L 557 328"/>
-  <text x="573" y="329" style="font-size:7">4,558,0,0,0</text>
+  <text x="573" y="331" style="font-size:4px">4,558,0,0,0</text>
   <path class="p4" d="M 557 337 L 558 347 L 590 339 L 589 330 L 557 337"/>
-  <text x="574" y="338" style="font-size:7">4,559,0,0,0</text>
+  <text x="574" y="341" style="font-size:5px">4,559,0,0,0</text>
   <path class="p4" d="M 525 356 L 525 366 L 559 357 L 558 347 L 525 356"/>
-  <text x="542" y="356" style="font-size:8">4,560,0,0,0</text>
+  <text x="542" y="359" style="font-size:5px">4,560,0,0,0</text>
   <path class="p4" d="M 525 366 L 525 377 L 560 367 L 559 357 L 525 366"/>
-  <text x="542" y="367" style="font-size:8">4,561,0,0,0</text>
+  <text x="542" y="369" style="font-size:5px">4,561,0,0,0</text>
   <path class="p4" d="M 558 347 L 559 357 L 592 348 L 590 339 L 558 347"/>
-  <text x="575" y="347" style="font-size:7">4,562,0,0,0</text>
+  <text x="575" y="350" style="font-size:5px">4,562,0,0,0</text>
   <path class="p4" d="M 559 357 L 560 367 L 594 357 L 592 348 L 559 357"/>
-  <text x="576" y="357" style="font-size:8">4,563,0,0,0</text>
+  <text x="576" y="359" style="font-size:5px">4,563,0,0,0</text>
   <path class="p4" d="M 525 377 L 524 389 L 560 377 L 560 367 L 525 377"/>
-  <text x="542" y="377" style="font-size:8">4,564,0,0,0</text>
+  <text x="542" y="380" style="font-size:5px">4,564,0,0,0</text>
   <path class="p4" d="M 524 389 L 524 400 L 561 388 L 560 377 L 524 389"/>
-  <text x="542" y="388" style="font-size:8">4,565,0,0,0</text>
+  <text x="542" y="391" style="font-size:5px">4,565,0,0,0</text>
   <path class="p4" d="M 560 367 L 560 377 L 596 366 L 594 357 L 560 367"/>
-  <text x="577" y="367" style="font-size:8">4,566,0,0,0</text>
+  <text x="577" y="369" style="font-size:5px">4,566,0,0,0</text>
   <path class="p4" d="M 560 377 L 561 388 L 597 375 L 596 366 L 560 377"/>
-  <text x="579" y="377" style="font-size:8">4,567,0,0,0</text>
+  <text x="579" y="379" style="font-size:5px">4,567,0,0,0</text>
   <path class="p4" d="M 584 304 L 586 312 L 615 306 L 612 299 L 584 304"/>
-  <text x="599" y="305" style="font-size:7">4,568,0,0,0</text>
+  <text x="599" y="307" style="font-size:4px">4,568,0,0,0</text>
   <path class="p4" d="M 586 312 L 587 321 L 617 314 L 615 306 L 586 312"/>
-  <text x="601" y="313" style="font-size:7">4,569,0,0,0</text>
+  <text x="601" y="315" style="font-size:4px">4,569,0,0,0</text>
   <path class="p4" d="M 612 299 L 615 306 L 643 301 L 640 294 L 612 299"/>
-  <text x="628" y="300" style="font-size:7">4,570,0,0,0</text>
+  <text x="628" y="302" style="font-size:4px">4,570,0,0,0</text>
   <path class="p4" d="M 615 306 L 617 314 L 647 308 L 643 301 L 615 306"/>
-  <text x="630" y="307" style="font-size:7">4,571,0,0,0</text>
+  <text x="630" y="309" style="font-size:4px">4,571,0,0,0</text>
   <path class="p4" d="M 587 321 L 589 330 L 620 322 L 617 314 L 587 321"/>
-  <text x="603" y="322" style="font-size:7">4,572,0,0,0</text>
+  <text x="603" y="324" style="font-size:4px">4,572,0,0,0</text>
   <path class="p4" d="M 589 330 L 590 339 L 622 330 L 620 322 L 589 330"/>
-  <text x="605" y="330" style="font-size:7">4,573,0,0,0</text>
+  <text x="605" y="333" style="font-size:5px">4,573,0,0,0</text>
   <path class="p4" d="M 617 314 L 620 322 L 650 315 L 647 308 L 617 314"/>
-  <text x="633" y="315" style="font-size:7">4,574,0,0,0</text>
+  <text x="633" y="317" style="font-size:4px">4,574,0,0,0</text>
   <path class="p4" d="M 620 322 L 622 330 L 654 322 L 650 315 L 620 322"/>
-  <text x="636" y="322" style="font-size:7">4,575,0,0,0</text>
+  <text x="636" y="324" style="font-size:4px">4,575,0,0,0</text>
   <path class="p4" d="M 640 294 L 643 301 L 672 295 L 668 289 L 640 294"/>
-  <text x="656" y="294" style="font-size:7">4,576,0,0,0</text>
+  <text x="656" y="296" style="font-size:4px">4,576,0,0,0</text>
   <path class="p4" d="M 643 301 L 647 308 L 676 301 L 672 295 L 643 301"/>
-  <text x="659" y="301" style="font-size:7">4,577,0,0,0</text>
+  <text x="659" y="303" style="font-size:4px">4,577,0,0,0</text>
   <path class="p4" d="M 668 289 L 672 295 L 700 289 L 695 283 L 668 289"/>
-  <text x="683" y="289" style="font-size:7">4,578,0,0,0</text>
+  <text x="683" y="291" style="font-size:4px">4,578,0,0,0</text>
   <line x1="695" y1="283" x2="700" y2="289"/>
   <path class="p4" d="M 672 295 L 676 301 L 705 295 L 700 289 L 672 295"/>
-  <text x="688" y="295" style="font-size:7">4,579,0,0,0</text>
+  <text x="688" y="297" style="font-size:4px">4,579,0,0,0</text>
   <line x1="700" y1="289" x2="705" y2="295"/>
   <path class="p4" d="M 647 308 L 650 315 L 680 307 L 676 301 L 647 308"/>
-  <text x="663" y="308" style="font-size:7">4,580,0,0,0</text>
+  <text x="663" y="310" style="font-size:4px">4,580,0,0,0</text>
   <path class="p4" d="M 650 315 L 654 322 L 684 314 L 680 307 L 650 315"/>
-  <text x="667" y="314" style="font-size:7">4,581,0,0,0</text>
+  <text x="667" y="316" style="font-size:4px">4,581,0,0,0</text>
   <path class="p4" d="M 676 301 L 680 307 L 710 300 L 705 295 L 676 301"/>
-  <text x="693" y="301" style="font-size:7">4,582,0,0,0</text>
+  <text x="693" y="303" style="font-size:4px">4,582,0,0,0</text>
   <line x1="705" y1="295" x2="710" y2="300"/>
   <path class="p4" d="M 680 307 L 684 314 L 715 306 L 710 300 L 680 307"/>
-  <text x="697" y="307" style="font-size:7">4,583,0,0,0</text>
+  <text x="697" y="309" style="font-size:4px">4,583,0,0,0</text>
   <line x1="710" y1="300" x2="715" y2="306"/>
   <path class="p4" d="M 590 339 L 592 348 L 625 338 L 622 330 L 590 339"/>
-  <text x="608" y="339" style="font-size:7">4,584,0,0,0</text>
+  <text x="608" y="341" style="font-size:5px">4,584,0,0,0</text>
   <path class="p4" d="M 592 348 L 594 357 L 628 347 L 625 338 L 592 348"/>
-  <text x="610" y="347" style="font-size:8">4,585,0,0,0</text>
+  <text x="610" y="350" style="font-size:5px">4,585,0,0,0</text>
   <path class="p4" d="M 622 330 L 625 338 L 657 329 L 654 322 L 622 330"/>
-  <text x="640" y="330" style="font-size:7">4,586,0,0,0</text>
+  <text x="640" y="332" style="font-size:5px">4,586,0,0,0</text>
   <path class="p4" d="M 625 338 L 628 347 L 661 337 L 657 329 L 625 338"/>
-  <text x="643" y="338" style="font-size:7">4,587,0,0,0</text>
+  <text x="643" y="340" style="font-size:5px">4,587,0,0,0</text>
   <path class="p4" d="M 594 357 L 596 366 L 630 355 L 628 347 L 594 357"/>
-  <text x="612" y="356" style="font-size:8">4,588,0,0,0</text>
+  <text x="612" y="359" style="font-size:5px">4,588,0,0,0</text>
   <path class="p4" d="M 596 366 L 597 375 L 633 364 L 630 355 L 596 366"/>
-  <text x="614" y="365" style="font-size:8">4,589,0,0,0</text>
+  <text x="614" y="368" style="font-size:5px">4,589,0,0,0</text>
   <path class="p4" d="M 628 347 L 630 355 L 664 344 L 661 337 L 628 347"/>
-  <text x="646" y="346" style="font-size:8">4,590,0,0,0</text>
+  <text x="646" y="348" style="font-size:5px">4,590,0,0,0</text>
   <path class="p4" d="M 630 355 L 633 364 L 668 352 L 664 344 L 630 355"/>
-  <text x="649" y="354" style="font-size:8">4,591,0,0,0</text>
+  <text x="649" y="356" style="font-size:5px">4,591,0,0,0</text>
   <path class="p4" d="M 654 322 L 657 329 L 689 320 L 684 314 L 654 322"/>
-  <text x="671" y="321" style="font-size:7">4,592,0,0,0</text>
+  <text x="671" y="323" style="font-size:4px">4,592,0,0,0</text>
   <path class="p4" d="M 657 329 L 661 337 L 693 327 L 689 320 L 657 329"/>
-  <text x="675" y="328" style="font-size:7">4,593,0,0,0</text>
+  <text x="675" y="331" style="font-size:5px">4,593,0,0,0</text>
   <path class="p4" d="M 684 314 L 689 320 L 720 312 L 715 306 L 684 314"/>
-  <text x="702" y="313" style="font-size:7">4,594,0,0,0</text>
+  <text x="702" y="315" style="font-size:4px">4,594,0,0,0</text>
   <line x1="715" y1="306" x2="720" y2="312"/>
   <path class="p4" d="M 689 320 L 693 327 L 725 318 L 720 312 L 689 320"/>
-  <text x="707" y="319" style="font-size:7">4,595,0,0,0</text>
+  <text x="707" y="321" style="font-size:4px">4,595,0,0,0</text>
   <line x1="720" y1="312" x2="725" y2="318"/>
   <path class="p4" d="M 661 337 L 664 344 L 698 334 L 693 327 L 661 337"/>
-  <text x="679" y="335" style="font-size:7">4,596,0,0,0</text>
+  <text x="679" y="338" style="font-size:5px">4,596,0,0,0</text>
   <path class="p4" d="M 664 344 L 668 352 L 702 341 L 698 334 L 664 344"/>
-  <text x="683" y="343" style="font-size:7">4,597,0,0,0</text>
+  <text x="683" y="345" style="font-size:5px">4,597,0,0,0</text>
   <path class="p4" d="M 693 327 L 698 334 L 730 324 L 725 318 L 693 327"/>
-  <text x="712" y="325" style="font-size:7">4,598,0,0,0</text>
+  <text x="712" y="328" style="font-size:5px">4,598,0,0,0</text>
   <line x1="725" y1="318" x2="730" y2="324"/>
   <path class="p4" d="M 698 334 L 702 341 L 735 330 L 730 324 L 698 334"/>
-  <text x="716" y="332" style="font-size:7">4,599,0,0,0</text>
+  <text x="716" y="334" style="font-size:5px">4,599,0,0,0</text>
   <line x1="730" y1="324" x2="735" y2="330"/>
   <path class="p4" d="M 524 400 L 553 402 L 588 390 L 561 388 L 524 400"/>
-  <text x="556" y="395" style="font-size:8">4,600,0,0,0</text>
+  <text x="556" y="397" style="font-size:5px">4,600,0,0,0</text>
   <path class="p4" d="M 553 402 L 582 404 L 615 391 L 588 390 L 553 402"/>
-  <text x="584" y="397" style="font-size:8">4,601,0,0,0</text>
+  <text x="584" y="399" style="font-size:5px">4,601,0,0,0</text>
   <path class="p4" d="M 561 388 L 588 390 L 622 378 L 597 375 L 561 388"/>
-  <text x="592" y="383" style="font-size:8">4,602,0,0,0</text>
+  <text x="592" y="385" style="font-size:5px">4,602,0,0,0</text>
   <path class="p4" d="M 588 390 L 615 391 L 646 380 L 622 378 L 588 390"/>
-  <text x="618" y="385" style="font-size:8">4,603,0,0,0</text>
+  <text x="618" y="387" style="font-size:5px">4,603,0,0,0</text>
   <path class="p4" d="M 582 404 L 611 405 L 641 393 L 615 391 L 582 404"/>
-  <text x="612" y="398" style="font-size:8">4,604,0,0,0</text>
+  <text x="612" y="401" style="font-size:5px">4,604,0,0,0</text>
   <path class="p4" d="M 611 405 L 640 407 L 668 395 L 641 393 L 611 405"/>
-  <text x="640" y="400" style="font-size:8">4,605,0,0,0</text>
+  <text x="640" y="403" style="font-size:5px">4,605,0,0,0</text>
   <path class="p4" d="M 615 391 L 641 393 L 671 382 L 646 380 L 615 391"/>
-  <text x="643" y="387" style="font-size:8">4,606,0,0,0</text>
+  <text x="643" y="389" style="font-size:5px">4,606,0,0,0</text>
   <path class="p4" d="M 641 393 L 668 395 L 696 384 L 671 382 L 641 393"/>
-  <text x="669" y="389" style="font-size:8">4,607,0,0,0</text>
+  <text x="669" y="391" style="font-size:5px">4,607,0,0,0</text>
   <path class="p4" d="M 583 432 L 617 433 L 644 421 L 612 419 L 583 432"/>
-  <text x="614" y="426" style="font-size:9">4,608,0,0,0</text>
+  <text x="614" y="429" style="font-size:5px">4,608,0,0,0</text>
   <path class="p4" d="M 617 433 L 651 435 L 676 423 L 644 421 L 617 433"/>
-  <text x="647" y="428" style="font-size:9">4,609,0,0,0</text>
+  <text x="647" y="430" style="font-size:5px">4,609,0,0,0</text>
   <path class="p4" d="M 612 419 L 644 421 L 670 409 L 640 407 L 612 419"/>
-  <text x="642" y="414" style="font-size:9">4,610,0,0,0</text>
+  <text x="642" y="417" style="font-size:5px">4,610,0,0,0</text>
   <path class="p4" d="M 644 421 L 676 423 L 699 411 L 670 409 L 644 421"/>
-  <text x="672" y="416" style="font-size:9">4,611,0,0,0</text>
+  <text x="672" y="418" style="font-size:5px">4,611,0,0,0</text>
   <path class="p4" d="M 651 435 L 686 436 L 708 424 L 676 423 L 651 435"/>
-  <text x="680" y="429" style="font-size:9">4,612,0,0,0</text>
+  <text x="680" y="432" style="font-size:6px">4,612,0,0,0</text>
   <path class="p4" d="M 686 436 L 720 438 L 740 426 L 708 424 L 686 436"/>
-  <text x="713" y="431" style="font-size:9">4,613,0,0,0</text>
+  <text x="713" y="434" style="font-size:6px">4,613,0,0,0</text>
   <path class="p4" d="M 676 423 L 708 424 L 729 413 L 699 411 L 676 423"/>
-  <text x="703" y="418" style="font-size:9">4,614,0,0,0</text>
+  <text x="703" y="420" style="font-size:5px">4,614,0,0,0</text>
   <path class="p4" d="M 708 424 L 740 426 L 759 414 L 729 413 L 708 424"/>
-  <text x="734" y="419" style="font-size:9">4,615,0,0,0</text>
+  <text x="734" y="422" style="font-size:5px">4,615,0,0,0</text>
   <path class="p4" d="M 640 407 L 670 409 L 696 397 L 668 395 L 640 407"/>
-  <text x="669" y="402" style="font-size:8">4,616,0,0,0</text>
+  <text x="669" y="405" style="font-size:5px">4,616,0,0,0</text>
   <path class="p4" d="M 670 409 L 699 411 L 723 399 L 696 397 L 670 409"/>
-  <text x="697" y="404" style="font-size:8">4,617,0,0,0</text>
+  <text x="697" y="407" style="font-size:5px">4,617,0,0,0</text>
   <path class="p4" d="M 668 395 L 696 397 L 721 386 L 696 384 L 668 395"/>
-  <text x="695" y="391" style="font-size:8">4,618,0,0,0</text>
+  <text x="695" y="393" style="font-size:5px">4,618,0,0,0</text>
   <path class="p4" d="M 696 397 L 723 399 L 746 388 L 721 386 L 696 397"/>
-  <text x="721" y="393" style="font-size:8">4,619,0,0,0</text>
+  <text x="721" y="395" style="font-size:5px">4,619,0,0,0</text>
   <path class="p4" d="M 699 411 L 729 413 L 750 401 L 723 399 L 699 411"/>
-  <text x="725" y="406" style="font-size:8">4,620,0,0,0</text>
+  <text x="725" y="408" style="font-size:5px">4,620,0,0,0</text>
   <path class="p4" d="M 729 413 L 759 414 L 777 403 L 750 401 L 729 413"/>
-  <text x="754" y="408" style="font-size:9">4,621,0,0,0</text>
+  <text x="754" y="410" style="font-size:5px">4,621,0,0,0</text>
   <path class="p4" d="M 723 399 L 750 401 L 771 390 L 746 388 L 723 399"/>
-  <text x="747" y="395" style="font-size:8">4,622,0,0,0</text>
+  <text x="747" y="397" style="font-size:5px">4,622,0,0,0</text>
   <path class="p4" d="M 750 401 L 777 403 L 796 392 L 771 390 L 750 401"/>
-  <text x="773" y="397" style="font-size:8">4,623,0,0,0</text>
+  <text x="773" y="399" style="font-size:5px">4,623,0,0,0</text>
   <path class="p4" d="M 597 375 L 622 378 L 655 366 L 633 364 L 597 375"/>
-  <text x="627" y="371" style="font-size:8">4,624,0,0,0</text>
+  <text x="627" y="373" style="font-size:5px">4,624,0,0,0</text>
   <path class="p4" d="M 622 378 L 646 380 L 678 368 L 655 366 L 622 378"/>
-  <text x="650" y="373" style="font-size:8">4,625,0,0,0</text>
+  <text x="650" y="375" style="font-size:5px">4,625,0,0,0</text>
   <path class="p4" d="M 633 364 L 655 366 L 688 354 L 668 352 L 633 364"/>
-  <text x="661" y="359" style="font-size:8">4,626,0,0,0</text>
+  <text x="661" y="361" style="font-size:5px">4,626,0,0,0</text>
   <path class="p4" d="M 655 366 L 678 368 L 708 357 L 688 354 L 655 366"/>
-  <text x="682" y="361" style="font-size:8">4,627,0,0,0</text>
+  <text x="682" y="364" style="font-size:5px">4,627,0,0,0</text>
   <path class="p4" d="M 646 380 L 671 382 L 700 370 L 678 368 L 646 380"/>
-  <text x="674" y="375" style="font-size:8">4,628,0,0,0</text>
+  <text x="674" y="377" style="font-size:5px">4,628,0,0,0</text>
   <path class="p4" d="M 671 382 L 696 384 L 723 372 L 700 370 L 671 382"/>
-  <text x="697" y="377" style="font-size:8">4,629,0,0,0</text>
+  <text x="697" y="379" style="font-size:5px">4,629,0,0,0</text>
   <path class="p4" d="M 678 368 L 700 370 L 728 359 L 708 357 L 678 368"/>
-  <text x="704" y="363" style="font-size:8">4,630,0,0,0</text>
+  <text x="704" y="366" style="font-size:5px">4,630,0,0,0</text>
   <path class="p4" d="M 700 370 L 723 372 L 749 361 L 728 359 L 700 370"/>
-  <text x="725" y="366" style="font-size:8">4,631,0,0,0</text>
+  <text x="725" y="368" style="font-size:5px">4,631,0,0,0</text>
   <path class="p4" d="M 668 352 L 688 354 L 720 343 L 702 341 L 668 352"/>
-  <text x="695" y="347" style="font-size:8">4,632,0,0,0</text>
+  <text x="695" y="350" style="font-size:5px">4,632,0,0,0</text>
   <path class="p4" d="M 688 354 L 708 357 L 738 345 L 720 343 L 688 354"/>
-  <text x="714" y="350" style="font-size:8">4,633,0,0,0</text>
+  <text x="714" y="352" style="font-size:5px">4,633,0,0,0</text>
   <path class="p4" d="M 702 341 L 720 343 L 751 332 L 735 330 L 702 341"/>
-  <text x="727" y="336" style="font-size:7">4,634,0,0,0</text>
+  <text x="727" y="339" style="font-size:5px">4,634,0,0,0</text>
   <line x1="735" y1="330" x2="751" y2="332"/>
   <path class="p4" d="M 720 343 L 738 345 L 767 335 L 751 332 L 720 343"/>
-  <text x="744" y="339" style="font-size:7">4,635,0,0,0</text>
+  <text x="744" y="341" style="font-size:5px">4,635,0,0,0</text>
   <line x1="751" y1="332" x2="767" y2="335"/>
   <path class="p4" d="M 708 357 L 728 359 L 756 348 L 738 345 L 708 357"/>
-  <text x="733" y="352" style="font-size:8">4,636,0,0,0</text>
+  <text x="733" y="355" style="font-size:5px">4,636,0,0,0</text>
   <path class="p4" d="M 728 359 L 749 361 L 774 350 L 756 348 L 728 359"/>
-  <text x="752" y="355" style="font-size:8">4,637,0,0,0</text>
+  <text x="752" y="357" style="font-size:5px">4,637,0,0,0</text>
   <path class="p4" d="M 738 345 L 756 348 L 783 337 L 767 335 L 738 345"/>
-  <text x="761" y="341" style="font-size:8">4,638,0,0,0</text>
+  <text x="761" y="344" style="font-size:5px">4,638,0,0,0</text>
   <line x1="767" y1="335" x2="783" y2="337"/>
   <path class="p4" d="M 756 348 L 774 350 L 800 340 L 783 337 L 756 348"/>
-  <text x="779" y="344" style="font-size:8">4,639,0,0,0</text>
+  <text x="779" y="346" style="font-size:5px">4,639,0,0,0</text>
   <line x1="783" y1="337" x2="800" y2="340"/>
   <path class="p4" d="M 696 384 L 721 386 L 745 375 L 723 372 L 696 384"/>
-  <text x="721" y="379" style="font-size:8">4,640,0,0,0</text>
+  <text x="721" y="382" style="font-size:5px">4,640,0,0,0</text>
   <path class="p4" d="M 721 386 L 746 388 L 768 377 L 745 375 L 721 386"/>
-  <text x="745" y="381" style="font-size:8">4,641,0,0,0</text>
+  <text x="745" y="384" style="font-size:5px">4,641,0,0,0</text>
   <path class="p4" d="M 723 372 L 745 375 L 769 364 L 749 361 L 723 372"/>
-  <text x="746" y="368" style="font-size:8">4,642,0,0,0</text>
+  <text x="746" y="370" style="font-size:5px">4,642,0,0,0</text>
   <path class="p4" d="M 745 375 L 768 377 L 790 366 L 769 364 L 745 375"/>
-  <text x="768" y="370" style="font-size:8">4,643,0,0,0</text>
+  <text x="768" y="373" style="font-size:5px">4,643,0,0,0</text>
   <path class="p4" d="M 746 388 L 771 390 L 791 379 L 768 377 L 746 388"/>
-  <text x="769" y="383" style="font-size:8">4,644,0,0,0</text>
+  <text x="769" y="386" style="font-size:5px">4,644,0,0,0</text>
   <path class="p4" d="M 771 390 L 796 392 L 814 381 L 791 379 L 771 390"/>
-  <text x="793" y="386" style="font-size:8">4,645,0,0,0</text>
+  <text x="793" y="388" style="font-size:5px">4,645,0,0,0</text>
   <path class="p4" d="M 768 377 L 791 379 L 810 368 L 790 366 L 768 377"/>
-  <text x="790" y="372" style="font-size:8">4,646,0,0,0</text>
+  <text x="790" y="375" style="font-size:5px">4,646,0,0,0</text>
   <path class="p4" d="M 791 379 L 814 381 L 831 371 L 810 368 L 791 379"/>
-  <text x="811" y="375" style="font-size:8">4,647,0,0,0</text>
+  <text x="811" y="377" style="font-size:5px">4,647,0,0,0</text>
   <path class="p4" d="M 749 361 L 769 364 L 793 353 L 774 350 L 749 361"/>
-  <text x="771" y="357" style="font-size:8">4,648,0,0,0</text>
+  <text x="771" y="359" style="font-size:5px">4,648,0,0,0</text>
   <path class="p4" d="M 769 364 L 790 366 L 811 355 L 793 353 L 769 364"/>
-  <text x="791" y="359" style="font-size:8">4,649,0,0,0</text>
+  <text x="791" y="362" style="font-size:5px">4,649,0,0,0</text>
   <path class="p4" d="M 774 350 L 793 353 L 816 342 L 800 340 L 774 350"/>
-  <text x="796" y="346" style="font-size:8">4,650,0,0,0</text>
+  <text x="796" y="349" style="font-size:5px">4,650,0,0,0</text>
   <line x1="800" y1="340" x2="816" y2="342"/>
   <path class="p4" d="M 793 353 L 811 355 L 832 345 L 816 342 L 793 353"/>
-  <text x="813" y="349" style="font-size:8">4,651,0,0,0</text>
+  <text x="813" y="351" style="font-size:5px">4,651,0,0,0</text>
   <line x1="816" y1="342" x2="832" y2="345"/>
   <path class="p4" d="M 790 366 L 810 368 L 830 358 L 811 355 L 790 366"/>
-  <text x="810" y="362" style="font-size:8">4,652,0,0,0</text>
+  <text x="810" y="364" style="font-size:5px">4,652,0,0,0</text>
   <path class="p4" d="M 810 368 L 831 371 L 848 360 L 830 358 L 810 368"/>
-  <text x="830" y="364" style="font-size:8">4,653,0,0,0</text>
+  <text x="830" y="367" style="font-size:5px">4,653,0,0,0</text>
   <path class="p4" d="M 811 355 L 830 358 L 849 347 L 832 345 L 811 355"/>
-  <text x="830" y="351" style="font-size:8">4,654,0,0,0</text>
+  <text x="830" y="354" style="font-size:5px">4,654,0,0,0</text>
   <line x1="832" y1="345" x2="849" y2="347"/>
   <path class="p4" d="M 830 358 L 848 360 L 865 350 L 849 347 L 830 358"/>
-  <text x="848" y="354" style="font-size:8">4,655,0,0,0</text>
+  <text x="848" y="356" style="font-size:5px">4,655,0,0,0</text>
   <line x1="849" y1="347" x2="865" y2="350"/>
   <path class="p4" d="M 720 438 L 755 439 L 772 428 L 740 426 L 720 438"/>
-  <text x="747" y="433" style="font-size:9">4,656,0,0,0</text>
+  <text x="747" y="436" style="font-size:6px">4,656,0,0,0</text>
   <path class="p4" d="M 755 439 L 790 441 L 804 429 L 772 428 L 755 439"/>
-  <text x="780" y="434" style="font-size:9">4,657,0,0,0</text>
+  <text x="780" y="437" style="font-size:6px">4,657,0,0,0</text>
   <path class="p4" d="M 740 426 L 772 428 L 789 416 L 759 414 L 740 426"/>
-  <text x="765" y="421" style="font-size:9">4,658,0,0,0</text>
+  <text x="765" y="424" style="font-size:5px">4,658,0,0,0</text>
   <path class="p4" d="M 772 428 L 804 429 L 818 418 L 789 416 L 772 428"/>
-  <text x="796" y="423" style="font-size:9">4,659,0,0,0</text>
+  <text x="796" y="425" style="font-size:5px">4,659,0,0,0</text>
   <path class="p4" d="M 790 441 L 825 442 L 837 431 L 804 429 L 790 441"/>
-  <text x="814" y="436" style="font-size:9">4,660,0,0,0</text>
+  <text x="814" y="439" style="font-size:6px">4,660,0,0,0</text>
   <path class="p4" d="M 825 442 L 859 444 L 869 433 L 837 431 L 825 442"/>
-  <text x="847" y="438" style="font-size:9">4,661,0,0,0</text>
+  <text x="847" y="441" style="font-size:6px">4,661,0,0,0</text>
   <path class="p4" d="M 804 429 L 837 431 L 848 420 L 818 418 L 804 429"/>
-  <text x="827" y="425" style="font-size:9">4,662,0,0,0</text>
+  <text x="827" y="428" style="font-size:6px">4,662,0,0,0</text>
   <path class="p4" d="M 837 431 L 869 433 L 879 422 L 848 420 L 837 431"/>
-  <text x="858" y="426" style="font-size:9">4,663,0,0,0</text>
+  <text x="858" y="429" style="font-size:6px">4,663,0,0,0</text>
   <path class="p4" d="M 759 414 L 789 416 L 805 405 L 777 403 L 759 414"/>
-  <text x="782" y="410" style="font-size:9">4,664,0,0,0</text>
+  <text x="782" y="412" style="font-size:5px">4,664,0,0,0</text>
   <path class="p4" d="M 789 416 L 818 418 L 832 407 L 805 405 L 789 416"/>
-  <text x="811" y="412" style="font-size:9">4,665,0,0,0</text>
+  <text x="811" y="414" style="font-size:5px">4,665,0,0,0</text>
   <path class="p4" d="M 777 403 L 805 405 L 821 394 L 796 392 L 777 403"/>
-  <text x="800" y="399" style="font-size:8">4,666,0,0,0</text>
+  <text x="800" y="401" style="font-size:5px">4,666,0,0,0</text>
   <path class="p4" d="M 805 405 L 832 407 L 846 396 L 821 394 L 805 405"/>
-  <text x="826" y="401" style="font-size:8">4,667,0,0,0</text>
+  <text x="826" y="403" style="font-size:5px">4,667,0,0,0</text>
   <path class="p4" d="M 818 418 L 848 420 L 860 409 L 832 407 L 818 418"/>
-  <text x="840" y="414" style="font-size:9">4,668,0,0,0</text>
+  <text x="840" y="416" style="font-size:5px">4,668,0,0,0</text>
   <path class="p4" d="M 848 420 L 879 422 L 888 411 L 860 409 L 848 420"/>
-  <text x="869" y="415" style="font-size:9">4,669,0,0,0</text>
+  <text x="869" y="418" style="font-size:5px">4,669,0,0,0</text>
   <path class="p4" d="M 832 407 L 860 409 L 872 398 L 846 396 L 832 407"/>
-  <text x="853" y="403" style="font-size:9">4,670,0,0,0</text>
+  <text x="853" y="405" style="font-size:5px">4,670,0,0,0</text>
   <path class="p4" d="M 860 409 L 888 411 L 897 401 L 872 398 L 860 409"/>
-  <text x="879" y="405" style="font-size:9">4,671,0,0,0</text>
+  <text x="879" y="407" style="font-size:5px">4,671,0,0,0</text>
   <path class="p4" d="M 859 444 L 894 445 L 902 434 L 869 433 L 859 444"/>
-  <text x="881" y="439" style="font-size:9">4,672,0,0,0</text>
+  <text x="881" y="442" style="font-size:6px">4,672,0,0,0</text>
   <path class="p4" d="M 894 445 L 930 447 L 934 436 L 902 434 L 894 445"/>
-  <text x="915" y="441" style="font-size:9">4,673,0,0,0</text>
+  <text x="915" y="444" style="font-size:6px">4,673,0,0,0</text>
   <path class="p4" d="M 869 433 L 902 434 L 909 424 L 879 422 L 869 433"/>
-  <text x="890" y="428" style="font-size:9">4,674,0,0,0</text>
+  <text x="890" y="431" style="font-size:6px">4,674,0,0,0</text>
   <path class="p4" d="M 902 434 L 934 436 L 939 426 L 909 424 L 902 434"/>
-  <text x="921" y="430" style="font-size:9">4,675,0,0,0</text>
+  <text x="921" y="433" style="font-size:6px">4,675,0,0,0</text>
   <path class="p4" d="M 930 447 L 965 449 L 967 438 L 934 436 L 930 447"/>
-  <text x="949" y="442" style="font-size:9">4,676,0,0,0</text>
+  <text x="949" y="445" style="font-size:6px">4,676,0,0,0</text>
   <path class="p4" d="M 965 449 L 1000 450 L 1000 440 L 967 438 L 965 449"/>
-  <text x="983" y="444" style="font-size:9">4,677,0,0,0</text>
+  <text x="983" y="447" style="font-size:6px">4,677,0,0,0</text>
   <path class="p4" d="M 934 436 L 967 438 L 969 427 L 939 426 L 934 436"/>
-  <text x="953" y="432" style="font-size:9">4,678,0,0,0</text>
+  <text x="953" y="435" style="font-size:6px">4,678,0,0,0</text>
   <path class="p4" d="M 967 438 L 1000 440 L 1000 429 L 969 427 L 967 438"/>
-  <text x="984" y="434" style="font-size:9">4,679,0,0,0</text>
+  <text x="984" y="437" style="font-size:6px">4,679,0,0,0</text>
   <path class="p4" d="M 879 422 L 909 424 L 916 413 L 888 411 L 879 422"/>
-  <text x="898" y="417" style="font-size:9">4,680,0,0,0</text>
+  <text x="898" y="420" style="font-size:5px">4,680,0,0,0</text>
   <path class="p4" d="M 909 424 L 939 426 L 944 415 L 916 413 L 909 424"/>
-  <text x="927" y="419" style="font-size:9">4,681,0,0,0</text>
+  <text x="927" y="422" style="font-size:5px">4,681,0,0,0</text>
   <path class="p4" d="M 888 411 L 916 413 L 923 403 L 897 401 L 888 411"/>
-  <text x="906" y="407" style="font-size:9">4,682,0,0,0</text>
+  <text x="906" y="409" style="font-size:5px">4,682,0,0,0</text>
   <path class="p4" d="M 916 413 L 944 415 L 948 405 L 923 403 L 916 413"/>
-  <text x="933" y="409" style="font-size:9">4,683,0,0,0</text>
+  <text x="933" y="411" style="font-size:5px">4,683,0,0,0</text>
   <path class="p4" d="M 939 426 L 969 427 L 972 417 L 944 415 L 939 426"/>
-  <text x="956" y="421" style="font-size:9">4,684,0,0,0</text>
+  <text x="956" y="424" style="font-size:6px">4,684,0,0,0</text>
   <path class="p4" d="M 969 427 L 1000 429 L 1000 419 L 972 417 L 969 427"/>
-  <text x="985" y="423" style="font-size:9">4,685,0,0,0</text>
+  <text x="985" y="426" style="font-size:6px">4,685,0,0,0</text>
   <path class="p4" d="M 944 415 L 972 417 L 974 407 L 948 405 L 944 415"/>
-  <text x="959" y="411" style="font-size:9">4,686,0,0,0</text>
+  <text x="959" y="413" style="font-size:5px">4,686,0,0,0</text>
   <path class="p4" d="M 972 417 L 1000 419 L 1000 409 L 974 407 L 972 417"/>
-  <text x="986" y="413" style="font-size:9">4,687,0,0,0</text>
+  <text x="986" y="416" style="font-size:5px">4,687,0,0,0</text>
   <path class="p4" d="M 796 392 L 821 394 L 836 383 L 814 381 L 796 392"/>
-  <text x="817" y="388" style="font-size:8">4,688,0,0,0</text>
+  <text x="817" y="390" style="font-size:5px">4,688,0,0,0</text>
   <path class="p4" d="M 821 394 L 846 396 L 860 386 L 836 383 L 821 394"/>
-  <text x="841" y="390" style="font-size:8">4,689,0,0,0</text>
+  <text x="841" y="392" style="font-size:5px">4,689,0,0,0</text>
   <path class="p4" d="M 814 381 L 836 383 L 852 373 L 831 371 L 814 381"/>
-  <text x="833" y="377" style="font-size:8">4,690,0,0,0</text>
+  <text x="833" y="379" style="font-size:5px">4,690,0,0,0</text>
   <path class="p4" d="M 836 383 L 860 386 L 873 375 L 852 373 L 836 383"/>
-  <text x="855" y="379" style="font-size:8">4,691,0,0,0</text>
+  <text x="855" y="382" style="font-size:5px">4,691,0,0,0</text>
   <path class="p4" d="M 846 396 L 872 398 L 883 388 L 860 386 L 846 396"/>
-  <text x="865" y="392" style="font-size:8">4,692,0,0,0</text>
+  <text x="865" y="395" style="font-size:5px">4,692,0,0,0</text>
   <path class="p4" d="M 872 398 L 897 401 L 906 390 L 883 388 L 872 398"/>
-  <text x="889" y="394" style="font-size:8">4,693,0,0,0</text>
+  <text x="889" y="397" style="font-size:5px">4,693,0,0,0</text>
   <path class="p4" d="M 860 386 L 883 388 L 894 378 L 873 375 L 860 386"/>
-  <text x="877" y="382" style="font-size:8">4,694,0,0,0</text>
+  <text x="877" y="384" style="font-size:5px">4,694,0,0,0</text>
   <path class="p4" d="M 883 388 L 906 390 L 915 380 L 894 378 L 883 388"/>
-  <text x="899" y="384" style="font-size:8">4,695,0,0,0</text>
+  <text x="899" y="386" style="font-size:5px">4,695,0,0,0</text>
   <path class="p4" d="M 831 371 L 852 373 L 867 363 L 848 360 L 831 371"/>
-  <text x="850" y="367" style="font-size:8">4,696,0,0,0</text>
+  <text x="850" y="369" style="font-size:5px">4,696,0,0,0</text>
   <path class="p4" d="M 852 373 L 873 375 L 886 365 L 867 363 L 852 373"/>
-  <text x="869" y="369" style="font-size:8">4,697,0,0,0</text>
+  <text x="869" y="371" style="font-size:5px">4,697,0,0,0</text>
   <path class="p4" d="M 848 360 L 867 363 L 882 352 L 865 350 L 848 360"/>
-  <text x="866" y="356" style="font-size:8">4,698,0,0,0</text>
+  <text x="866" y="359" style="font-size:5px">4,698,0,0,0</text>
   <line x1="865" y1="350" x2="882" y2="352"/>
   <path class="p4" d="M 867 363 L 886 365 L 898 355 L 882 352 L 867 363"/>
-  <text x="883" y="359" style="font-size:8">4,699,0,0,0</text>
+  <text x="883" y="361" style="font-size:5px">4,699,0,0,0</text>
   <line x1="882" y1="352" x2="898" y2="355"/>
   <path class="p4" d="M 873 375 L 894 378 L 904 368 L 886 365 L 873 375"/>
-  <text x="889" y="371" style="font-size:8">4,700,0,0,0</text>
+  <text x="889" y="374" style="font-size:5px">4,700,0,0,0</text>
   <path class="p4" d="M 894 378 L 915 380 L 923 370 L 904 368 L 894 378"/>
-  <text x="909" y="374" style="font-size:8">4,701,0,0,0</text>
+  <text x="909" y="376" style="font-size:5px">4,701,0,0,0</text>
   <path class="p4" d="M 886 365 L 904 368 L 915 358 L 898 355 L 886 365"/>
-  <text x="901" y="361" style="font-size:8">4,702,0,0,0</text>
+  <text x="901" y="364" style="font-size:5px">4,702,0,0,0</text>
   <line x1="898" y1="355" x2="915" y2="358"/>
   <path class="p4" d="M 904 368 L 923 370 L 932 360 L 915 358 L 904 368"/>
-  <text x="919" y="364" style="font-size:8">4,703,0,0,0</text>
+  <text x="919" y="366" style="font-size:5px">4,703,0,0,0</text>
   <line x1="915" y1="358" x2="932" y2="360"/>
   <path class="p4" d="M 897 401 L 923 403 L 929 392 L 906 390 L 897 401"/>
-  <text x="914" y="396" style="font-size:8">4,704,0,0,0</text>
+  <text x="914" y="399" style="font-size:5px">4,704,0,0,0</text>
   <path class="p4" d="M 923 403 L 948 405 L 953 395 L 929 392 L 923 403"/>
-  <text x="938" y="399" style="font-size:8">4,705,0,0,0</text>
+  <text x="938" y="401" style="font-size:5px">4,705,0,0,0</text>
   <path class="p4" d="M 906 390 L 929 392 L 936 382 L 915 380 L 906 390"/>
-  <text x="922" y="386" style="font-size:8">4,706,0,0,0</text>
+  <text x="922" y="389" style="font-size:5px">4,706,0,0,0</text>
   <path class="p4" d="M 929 392 L 953 395 L 957 385 L 936 382 L 929 392"/>
-  <text x="944" y="389" style="font-size:8">4,707,0,0,0</text>
+  <text x="944" y="391" style="font-size:5px">4,707,0,0,0</text>
   <path class="p4" d="M 948 405 L 974 407 L 976 397 L 953 395 L 948 405"/>
-  <text x="963" y="401" style="font-size:9">4,708,0,0,0</text>
+  <text x="963" y="403" style="font-size:5px">4,708,0,0,0</text>
   <path class="p4" d="M 974 407 L 1000 409 L 1000 399 L 976 397 L 974 407"/>
-  <text x="988" y="403" style="font-size:9">4,709,0,0,0</text>
+  <text x="988" y="406" style="font-size:5px">4,709,0,0,0</text>
   <path class="p4" d="M 953 395 L 976 397 L 979 387 L 957 385 L 953 395"/>
-  <text x="966" y="391" style="font-size:8">4,710,0,0,0</text>
+  <text x="966" y="393" style="font-size:5px">4,710,0,0,0</text>
   <path class="p4" d="M 976 397 L 1000 399 L 1000 390 L 979 387 L 976 397"/>
-  <text x="989" y="393" style="font-size:8">4,711,0,0,0</text>
+  <text x="989" y="396" style="font-size:5px">4,711,0,0,0</text>
   <path class="p4" d="M 915 380 L 936 382 L 942 373 L 923 370 L 915 380"/>
-  <text x="929" y="376" style="font-size:8">4,712,0,0,0</text>
+  <text x="929" y="379" style="font-size:5px">4,712,0,0,0</text>
   <path class="p4" d="M 936 382 L 957 385 L 962 375 L 942 373 L 936 382"/>
-  <text x="949" y="379" style="font-size:8">4,713,0,0,0</text>
+  <text x="949" y="381" style="font-size:5px">4,713,0,0,0</text>
   <path class="p4" d="M 923 370 L 942 373 L 949 363 L 932 360 L 923 370"/>
-  <text x="937" y="366" style="font-size:8">4,714,0,0,0</text>
+  <text x="937" y="369" style="font-size:5px">4,714,0,0,0</text>
   <line x1="932" y1="360" x2="949" y2="363"/>
   <path class="p4" d="M 942 373 L 962 375 L 966 366 L 949 363 L 942 373"/>
-  <text x="955" y="369" style="font-size:8">4,715,0,0,0</text>
+  <text x="955" y="372" style="font-size:5px">4,715,0,0,0</text>
   <line x1="949" y1="363" x2="966" y2="366"/>
   <path class="p4" d="M 957 385 L 979 387 L 981 378 L 962 375 L 957 385"/>
-  <text x="969" y="381" style="font-size:8">4,716,0,0,0</text>
+  <text x="969" y="384" style="font-size:5px">4,716,0,0,0</text>
   <path class="p4" d="M 979 387 L 1000 390 L 1000 380 L 981 378 L 979 387"/>
-  <text x="990" y="384" style="font-size:8">4,717,0,0,0</text>
+  <text x="990" y="386" style="font-size:5px">4,717,0,0,0</text>
   <path class="p4" d="M 962 375 L 981 378 L 983 368 L 966 366 L 962 375"/>
-  <text x="973" y="372" style="font-size:8">4,718,0,0,0</text>
+  <text x="973" y="374" style="font-size:5px">4,718,0,0,0</text>
   <line x1="966" y1="366" x2="983" y2="368"/>
   <path class="p4" d="M 981 378 L 1000 380 L 1000 371 L 983 368 L 981 378"/>
-  <text x="991" y="374" style="font-size:8">4,719,0,0,0</text>
+  <text x="991" y="377" style="font-size:5px">4,719,0,0,0</text>
   <line x1="983" y1="368" x2="1000" y2="371"/>
   <path class="p4" d="M 1000 450 L 1035 449 L 1033 438 L 1000 440 L 1000 450"/>
-  <text x="1017" y="444" style="font-size:9">4,720,0,0,0</text>
+  <text x="1017" y="447" style="font-size:6px">4,720,0,0,0</text>
   <path class="p4" d="M 1035 449 L 1070 447 L 1066 436 L 1033 438 L 1035 449"/>
-  <text x="1051" y="442" style="font-size:9">4,721,0,0,0</text>
+  <text x="1051" y="445" style="font-size:6px">4,721,0,0,0</text>
   <path class="p4" d="M 1000 440 L 1033 438 L 1031 427 L 1000 429 L 1000 440"/>
-  <text x="1016" y="434" style="font-size:9">4,722,0,0,0</text>
+  <text x="1016" y="437" style="font-size:6px">4,722,0,0,0</text>
   <path class="p4" d="M 1033 438 L 1066 436 L 1061 426 L 1031 427 L 1033 438"/>
-  <text x="1047" y="432" style="font-size:9">4,723,0,0,0</text>
+  <text x="1047" y="435" style="font-size:6px">4,723,0,0,0</text>
   <path class="p4" d="M 1070 447 L 1106 445 L 1098 434 L 1066 436 L 1070 447"/>
-  <text x="1085" y="441" style="font-size:9">4,724,0,0,0</text>
+  <text x="1085" y="444" style="font-size:6px">4,724,0,0,0</text>
   <path class="p4" d="M 1106 445 L 1141 444 L 1131 433 L 1098 434 L 1106 445"/>
-  <text x="1119" y="439" style="font-size:9">4,725,0,0,0</text>
+  <text x="1119" y="442" style="font-size:6px">4,725,0,0,0</text>
   <path class="p4" d="M 1066 436 L 1098 434 L 1091 424 L 1061 426 L 1066 436"/>
-  <text x="1079" y="430" style="font-size:9">4,726,0,0,0</text>
+  <text x="1079" y="433" style="font-size:6px">4,726,0,0,0</text>
   <path class="p4" d="M 1098 434 L 1131 433 L 1121 422 L 1091 424 L 1098 434"/>
-  <text x="1110" y="428" style="font-size:9">4,727,0,0,0</text>
+  <text x="1110" y="431" style="font-size:6px">4,727,0,0,0</text>
   <path class="p4" d="M 1000 429 L 1031 427 L 1028 417 L 1000 419 L 1000 429"/>
-  <text x="1015" y="423" style="font-size:9">4,728,0,0,0</text>
+  <text x="1015" y="426" style="font-size:6px">4,728,0,0,0</text>
   <path class="p4" d="M 1031 427 L 1061 426 L 1056 415 L 1028 417 L 1031 427"/>
-  <text x="1044" y="421" style="font-size:9">4,729,0,0,0</text>
+  <text x="1044" y="424" style="font-size:6px">4,729,0,0,0</text>
   <path class="p4" d="M 1000 419 L 1028 417 L 1026 407 L 1000 409 L 1000 419"/>
-  <text x="1014" y="413" style="font-size:9">4,730,0,0,0</text>
+  <text x="1014" y="416" style="font-size:5px">4,730,0,0,0</text>
   <path class="p4" d="M 1028 417 L 1056 415 L 1052 405 L 1026 407 L 1028 417"/>
-  <text x="1041" y="411" style="font-size:9">4,731,0,0,0</text>
+  <text x="1041" y="413" style="font-size:5px">4,731,0,0,0</text>
   <path class="p4" d="M 1061 426 L 1091 424 L 1084 413 L 1056 415 L 1061 426"/>
-  <text x="1073" y="419" style="font-size:9">4,732,0,0,0</text>
+  <text x="1073" y="422" style="font-size:5px">4,732,0,0,0</text>
   <path class="p4" d="M 1091 424 L 1121 422 L 1112 411 L 1084 413 L 1091 424"/>
-  <text x="1102" y="417" style="font-size:9">4,733,0,0,0</text>
+  <text x="1102" y="420" style="font-size:5px">4,733,0,0,0</text>
   <path class="p4" d="M 1056 415 L 1084 413 L 1077 403 L 1052 405 L 1056 415"/>
-  <text x="1067" y="409" style="font-size:9">4,734,0,0,0</text>
+  <text x="1067" y="411" style="font-size:5px">4,734,0,0,0</text>
   <path class="p4" d="M 1084 413 L 1112 411 L 1103 401 L 1077 403 L 1084 413"/>
-  <text x="1094" y="407" style="font-size:9">4,735,0,0,0</text>
+  <text x="1094" y="409" style="font-size:5px">4,735,0,0,0</text>
   <path class="p4" d="M 1141 444 L 1175 442 L 1163 431 L 1131 433 L 1141 444"/>
-  <text x="1153" y="438" style="font-size:9">4,736,0,0,0</text>
+  <text x="1153" y="441" style="font-size:6px">4,736,0,0,0</text>
   <path class="p4" d="M 1175 442 L 1210 441 L 1196 429 L 1163 431 L 1175 442"/>
-  <text x="1186" y="436" style="font-size:9">4,737,0,0,0</text>
+  <text x="1186" y="439" style="font-size:6px">4,737,0,0,0</text>
   <path class="p4" d="M 1131 433 L 1163 431 L 1152 420 L 1121 422 L 1131 433"/>
-  <text x="1142" y="426" style="font-size:9">4,738,0,0,0</text>
+  <text x="1142" y="429" style="font-size:6px">4,738,0,0,0</text>
   <path class="p4" d="M 1163 431 L 1196 429 L 1182 418 L 1152 420 L 1163 431"/>
-  <text x="1173" y="425" style="font-size:9">4,739,0,0,0</text>
+  <text x="1173" y="428" style="font-size:6px">4,739,0,0,0</text>
   <path class="p4" d="M 1210 441 L 1245 439 L 1228 428 L 1196 429 L 1210 441"/>
-  <text x="1220" y="434" style="font-size:9">4,740,0,0,0</text>
+  <text x="1220" y="437" style="font-size:6px">4,740,0,0,0</text>
   <path class="p4" d="M 1245 439 L 1280 438 L 1260 426 L 1228 428 L 1245 439"/>
-  <text x="1253" y="433" style="font-size:9">4,741,0,0,0</text>
+  <text x="1253" y="436" style="font-size:6px">4,741,0,0,0</text>
   <path class="p4" d="M 1196 429 L 1228 428 L 1211 416 L 1182 418 L 1196 429"/>
-  <text x="1204" y="423" style="font-size:9">4,742,0,0,0</text>
+  <text x="1204" y="425" style="font-size:5px">4,742,0,0,0</text>
   <path class="p4" d="M 1228 428 L 1260 426 L 1241 414 L 1211 416 L 1228 428"/>
-  <text x="1235" y="421" style="font-size:9">4,743,0,0,0</text>
+  <text x="1235" y="424" style="font-size:5px">4,743,0,0,0</text>
   <path class="p4" d="M 1121 422 L 1152 420 L 1140 409 L 1112 411 L 1121 422"/>
-  <text x="1131" y="415" style="font-size:9">4,744,0,0,0</text>
+  <text x="1131" y="418" style="font-size:5px">4,744,0,0,0</text>
   <path class="p4" d="M 1152 420 L 1182 418 L 1168 407 L 1140 409 L 1152 420"/>
-  <text x="1160" y="414" style="font-size:9">4,745,0,0,0</text>
+  <text x="1160" y="416" style="font-size:5px">4,745,0,0,0</text>
   <path class="p4" d="M 1112 411 L 1140 409 L 1128 398 L 1103 401 L 1112 411"/>
-  <text x="1121" y="405" style="font-size:9">4,746,0,0,0</text>
+  <text x="1121" y="407" style="font-size:5px">4,746,0,0,0</text>
   <path class="p4" d="M 1140 409 L 1168 407 L 1154 396 L 1128 398 L 1140 409"/>
-  <text x="1147" y="403" style="font-size:9">4,747,0,0,0</text>
+  <text x="1147" y="405" style="font-size:5px">4,747,0,0,0</text>
   <path class="p4" d="M 1182 418 L 1211 416 L 1195 405 L 1168 407 L 1182 418"/>
-  <text x="1189" y="412" style="font-size:9">4,748,0,0,0</text>
+  <text x="1189" y="414" style="font-size:5px">4,748,0,0,0</text>
   <path class="p4" d="M 1211 416 L 1241 414 L 1223 403 L 1195 405 L 1211 416"/>
-  <text x="1218" y="410" style="font-size:9">4,749,0,0,0</text>
+  <text x="1218" y="412" style="font-size:5px">4,749,0,0,0</text>
   <path class="p4" d="M 1168 407 L 1195 405 L 1179 394 L 1154 396 L 1168 407"/>
-  <text x="1174" y="401" style="font-size:8">4,750,0,0,0</text>
+  <text x="1174" y="403" style="font-size:5px">4,750,0,0,0</text>
   <path class="p4" d="M 1195 405 L 1223 403 L 1204 392 L 1179 394 L 1195 405"/>
-  <text x="1200" y="399" style="font-size:8">4,751,0,0,0</text>
+  <text x="1200" y="401" style="font-size:5px">4,751,0,0,0</text>
   <path class="p4" d="M 1000 409 L 1026 407 L 1024 397 L 1000 399 L 1000 409"/>
-  <text x="1012" y="403" style="font-size:9">4,752,0,0,0</text>
+  <text x="1012" y="406" style="font-size:5px">4,752,0,0,0</text>
   <path class="p4" d="M 1026 407 L 1052 405 L 1047 395 L 1024 397 L 1026 407"/>
-  <text x="1037" y="401" style="font-size:9">4,753,0,0,0</text>
+  <text x="1037" y="403" style="font-size:5px">4,753,0,0,0</text>
   <path class="p4" d="M 1000 399 L 1024 397 L 1021 387 L 1000 390 L 1000 399"/>
-  <text x="1011" y="393" style="font-size:8">4,754,0,0,0</text>
+  <text x="1011" y="396" style="font-size:5px">4,754,0,0,0</text>
   <path class="p4" d="M 1024 397 L 1047 395 L 1043 385 L 1021 387 L 1024 397"/>
-  <text x="1034" y="391" style="font-size:8">4,755,0,0,0</text>
+  <text x="1034" y="393" style="font-size:5px">4,755,0,0,0</text>
   <path class="p4" d="M 1052 405 L 1077 403 L 1071 392 L 1047 395 L 1052 405"/>
-  <text x="1062" y="399" style="font-size:8">4,756,0,0,0</text>
+  <text x="1062" y="401" style="font-size:5px">4,756,0,0,0</text>
   <path class="p4" d="M 1077 403 L 1103 401 L 1094 390 L 1071 392 L 1077 403"/>
-  <text x="1086" y="396" style="font-size:8">4,757,0,0,0</text>
+  <text x="1086" y="399" style="font-size:5px">4,757,0,0,0</text>
   <path class="p4" d="M 1047 395 L 1071 392 L 1064 382 L 1043 385 L 1047 395"/>
-  <text x="1056" y="389" style="font-size:8">4,758,0,0,0</text>
+  <text x="1056" y="391" style="font-size:5px">4,758,0,0,0</text>
   <path class="p4" d="M 1071 392 L 1094 390 L 1085 380 L 1064 382 L 1071 392"/>
-  <text x="1078" y="386" style="font-size:8">4,759,0,0,0</text>
+  <text x="1078" y="389" style="font-size:5px">4,759,0,0,0</text>
   <path class="p4" d="M 1000 390 L 1021 387 L 1019 378 L 1000 380 L 1000 390"/>
-  <text x="1010" y="384" style="font-size:8">4,760,0,0,0</text>
+  <text x="1010" y="386" style="font-size:5px">4,760,0,0,0</text>
   <path class="p4" d="M 1021 387 L 1043 385 L 1038 375 L 1019 378 L 1021 387"/>
-  <text x="1031" y="381" style="font-size:8">4,761,0,0,0</text>
+  <text x="1031" y="384" style="font-size:5px">4,761,0,0,0</text>
   <path class="p4" d="M 1000 380 L 1019 378 L 1017 368 L 1000 371 L 1000 380"/>
-  <text x="1009" y="374" style="font-size:8">4,762,0,0,0</text>
+  <text x="1009" y="377" style="font-size:5px">4,762,0,0,0</text>
   <line x1="1000" y1="371" x2="1017" y2="368"/>
   <path class="p4" d="M 1019 378 L 1038 375 L 1034 366 L 1017 368 L 1019 378"/>
-  <text x="1027" y="372" style="font-size:8">4,763,0,0,0</text>
+  <text x="1027" y="374" style="font-size:5px">4,763,0,0,0</text>
   <line x1="1017" y1="368" x2="1034" y2="366"/>
   <path class="p4" d="M 1043 385 L 1064 382 L 1058 373 L 1038 375 L 1043 385"/>
-  <text x="1051" y="379" style="font-size:8">4,764,0,0,0</text>
+  <text x="1051" y="381" style="font-size:5px">4,764,0,0,0</text>
   <path class="p4" d="M 1064 382 L 1085 380 L 1077 370 L 1058 373 L 1064 382"/>
-  <text x="1071" y="376" style="font-size:8">4,765,0,0,0</text>
+  <text x="1071" y="379" style="font-size:5px">4,765,0,0,0</text>
   <path class="p4" d="M 1038 375 L 1058 373 L 1051 363 L 1034 366 L 1038 375"/>
-  <text x="1045" y="369" style="font-size:8">4,766,0,0,0</text>
+  <text x="1045" y="372" style="font-size:5px">4,766,0,0,0</text>
   <line x1="1034" y1="366" x2="1051" y2="363"/>
   <path class="p4" d="M 1058 373 L 1077 370 L 1068 360 L 1051 363 L 1058 373"/>
-  <text x="1063" y="366" style="font-size:8">4,767,0,0,0</text>
+  <text x="1063" y="369" style="font-size:5px">4,767,0,0,0</text>
   <line x1="1051" y1="363" x2="1068" y2="360"/>
   <path class="p4" d="M 1103 401 L 1128 398 L 1117 388 L 1094 390 L 1103 401"/>
-  <text x="1111" y="394" style="font-size:8">4,768,0,0,0</text>
+  <text x="1111" y="397" style="font-size:5px">4,768,0,0,0</text>
   <path class="p4" d="M 1128 398 L 1154 396 L 1140 386 L 1117 388 L 1128 398"/>
-  <text x="1135" y="392" style="font-size:8">4,769,0,0,0</text>
+  <text x="1135" y="395" style="font-size:5px">4,769,0,0,0</text>
   <path class="p4" d="M 1094 390 L 1117 388 L 1106 378 L 1085 380 L 1094 390"/>
-  <text x="1101" y="384" style="font-size:8">4,770,0,0,0</text>
+  <text x="1101" y="386" style="font-size:5px">4,770,0,0,0</text>
   <path class="p4" d="M 1117 388 L 1140 386 L 1127 375 L 1106 378 L 1117 388"/>
-  <text x="1123" y="382" style="font-size:8">4,771,0,0,0</text>
+  <text x="1123" y="384" style="font-size:5px">4,771,0,0,0</text>
   <path class="p4" d="M 1154 396 L 1179 394 L 1164 383 L 1140 386 L 1154 396"/>
-  <text x="1159" y="390" style="font-size:8">4,772,0,0,0</text>
+  <text x="1159" y="392" style="font-size:5px">4,772,0,0,0</text>
   <path class="p4" d="M 1179 394 L 1204 392 L 1186 381 L 1164 383 L 1179 394"/>
-  <text x="1183" y="388" style="font-size:8">4,773,0,0,0</text>
+  <text x="1183" y="390" style="font-size:5px">4,773,0,0,0</text>
   <path class="p4" d="M 1140 386 L 1164 383 L 1148 373 L 1127 375 L 1140 386"/>
-  <text x="1145" y="379" style="font-size:8">4,774,0,0,0</text>
+  <text x="1145" y="382" style="font-size:5px">4,774,0,0,0</text>
   <path class="p4" d="M 1164 383 L 1186 381 L 1169 371 L 1148 373 L 1164 383"/>
-  <text x="1167" y="377" style="font-size:8">4,775,0,0,0</text>
+  <text x="1167" y="379" style="font-size:5px">4,775,0,0,0</text>
   <path class="p4" d="M 1085 380 L 1106 378 L 1096 368 L 1077 370 L 1085 380"/>
-  <text x="1091" y="374" style="font-size:8">4,776,0,0,0</text>
+  <text x="1091" y="376" style="font-size:5px">4,776,0,0,0</text>
   <path class="p4" d="M 1106 378 L 1127 375 L 1114 365 L 1096 368 L 1106 378"/>
-  <text x="1111" y="371" style="font-size:8">4,777,0,0,0</text>
+  <text x="1111" y="374" style="font-size:5px">4,777,0,0,0</text>
   <path class="p4" d="M 1077 370 L 1096 368 L 1085 358 L 1068 360 L 1077 370"/>
-  <text x="1081" y="364" style="font-size:8">4,778,0,0,0</text>
+  <text x="1081" y="366" style="font-size:5px">4,778,0,0,0</text>
   <line x1="1068" y1="360" x2="1085" y2="358"/>
   <path class="p4" d="M 1096 368 L 1114 365 L 1102 355 L 1085 358 L 1096 368"/>
-  <text x="1099" y="361" style="font-size:8">4,779,0,0,0</text>
+  <text x="1099" y="364" style="font-size:5px">4,779,0,0,0</text>
   <line x1="1085" y1="358" x2="1102" y2="355"/>
   <path class="p4" d="M 1127 375 L 1148 373 L 1133 363 L 1114 365 L 1127 375"/>
-  <text x="1131" y="369" style="font-size:8">4,780,0,0,0</text>
+  <text x="1131" y="371" style="font-size:5px">4,780,0,0,0</text>
   <path class="p4" d="M 1148 373 L 1169 371 L 1152 360 L 1133 363 L 1148 373"/>
-  <text x="1150" y="367" style="font-size:8">4,781,0,0,0</text>
+  <text x="1150" y="369" style="font-size:5px">4,781,0,0,0</text>
   <path class="p4" d="M 1114 365 L 1133 363 L 1118 352 L 1102 355 L 1114 365"/>
-  <text x="1117" y="359" style="font-size:8">4,782,0,0,0</text>
+  <text x="1117" y="361" style="font-size:5px">4,782,0,0,0</text>
   <line x1="1102" y1="355" x2="1118" y2="352"/>
   <path class="p4" d="M 1133 363 L 1152 360 L 1135 350 L 1118 352 L 1133 363"/>
-  <text x="1134" y="356" style="font-size:8">4,783,0,0,0</text>
+  <text x="1134" y="359" style="font-size:5px">4,783,0,0,0</text>
   <line x1="1118" y1="352" x2="1135" y2="350"/>
   <path class="p4" d="M 1280 438 L 1314 436 L 1292 424 L 1260 426 L 1280 438"/>
-  <text x="1287" y="431" style="font-size:9">4,784,0,0,0</text>
+  <text x="1287" y="434" style="font-size:6px">4,784,0,0,0</text>
   <path class="p4" d="M 1314 436 L 1349 435 L 1324 423 L 1292 424 L 1314 436"/>
-  <text x="1320" y="429" style="font-size:9">4,785,0,0,0</text>
+  <text x="1320" y="432" style="font-size:6px">4,785,0,0,0</text>
   <path class="p4" d="M 1260 426 L 1292 424 L 1271 413 L 1241 414 L 1260 426"/>
-  <text x="1266" y="419" style="font-size:9">4,786,0,0,0</text>
+  <text x="1266" y="422" style="font-size:5px">4,786,0,0,0</text>
   <path class="p4" d="M 1292 424 L 1324 423 L 1301 411 L 1271 413 L 1292 424"/>
-  <text x="1297" y="418" style="font-size:9">4,787,0,0,0</text>
+  <text x="1297" y="420" style="font-size:5px">4,787,0,0,0</text>
   <path class="p4" d="M 1349 435 L 1383 433 L 1356 421 L 1324 423 L 1349 435"/>
-  <text x="1353" y="428" style="font-size:9">4,788,0,0,0</text>
+  <text x="1353" y="430" style="font-size:5px">4,788,0,0,0</text>
   <path class="p4" d="M 1383 433 L 1417 432 L 1388 419 L 1356 421 L 1383 433"/>
-  <text x="1386" y="426" style="font-size:9">4,789,0,0,0</text>
+  <text x="1386" y="429" style="font-size:5px">4,789,0,0,0</text>
   <path class="p4" d="M 1324 423 L 1356 421 L 1330 409 L 1301 411 L 1324 423"/>
-  <text x="1328" y="416" style="font-size:9">4,790,0,0,0</text>
+  <text x="1328" y="418" style="font-size:5px">4,790,0,0,0</text>
   <path class="p4" d="M 1356 421 L 1388 419 L 1360 407 L 1330 409 L 1356 421"/>
-  <text x="1358" y="414" style="font-size:9">4,791,0,0,0</text>
+  <text x="1358" y="417" style="font-size:5px">4,791,0,0,0</text>
   <path class="p4" d="M 1241 414 L 1271 413 L 1250 401 L 1223 403 L 1241 414"/>
-  <text x="1246" y="408" style="font-size:9">4,792,0,0,0</text>
+  <text x="1246" y="410" style="font-size:5px">4,792,0,0,0</text>
   <path class="p4" d="M 1271 413 L 1301 411 L 1277 399 L 1250 401 L 1271 413"/>
-  <text x="1275" y="406" style="font-size:8">4,793,0,0,0</text>
+  <text x="1275" y="408" style="font-size:5px">4,793,0,0,0</text>
   <path class="p4" d="M 1223 403 L 1250 401 L 1229 390 L 1204 392 L 1223 403"/>
-  <text x="1227" y="397" style="font-size:8">4,794,0,0,0</text>
+  <text x="1227" y="399" style="font-size:5px">4,794,0,0,0</text>
   <path class="p4" d="M 1250 401 L 1277 399 L 1254 388 L 1229 390 L 1250 401"/>
-  <text x="1253" y="395" style="font-size:8">4,795,0,0,0</text>
+  <text x="1253" y="397" style="font-size:5px">4,795,0,0,0</text>
   <path class="p4" d="M 1301 411 L 1330 409 L 1304 397 L 1277 399 L 1301 411"/>
-  <text x="1303" y="404" style="font-size:8">4,796,0,0,0</text>
+  <text x="1303" y="407" style="font-size:5px">4,796,0,0,0</text>
   <path class="p4" d="M 1330 409 L 1360 407 L 1332 395 L 1304 397 L 1330 409"/>
-  <text x="1331" y="402" style="font-size:8">4,797,0,0,0</text>
+  <text x="1331" y="405" style="font-size:5px">4,797,0,0,0</text>
   <path class="p4" d="M 1277 399 L 1304 397 L 1279 386 L 1254 388 L 1277 399"/>
-  <text x="1279" y="393" style="font-size:8">4,798,0,0,0</text>
+  <text x="1279" y="395" style="font-size:5px">4,798,0,0,0</text>
   <path class="p4" d="M 1304 397 L 1332 395 L 1304 384 L 1279 386 L 1304 397"/>
-  <text x="1305" y="391" style="font-size:8">4,799,0,0,0</text>
+  <text x="1305" y="393" style="font-size:5px">4,799,0,0,0</text>
   <path class="p4" d="M 1360 407 L 1389 405 L 1359 393 L 1332 395 L 1360 407"/>
-  <text x="1360" y="400" style="font-size:8">4,800,0,0,0</text>
+  <text x="1360" y="403" style="font-size:5px">4,800,0,0,0</text>
   <path class="p4" d="M 1389 405 L 1418 404 L 1385 391 L 1359 393 L 1389 405"/>
-  <text x="1388" y="398" style="font-size:8">4,801,0,0,0</text>
+  <text x="1388" y="401" style="font-size:5px">4,801,0,0,0</text>
   <path class="p4" d="M 1332 395 L 1359 393 L 1329 382 L 1304 384 L 1332 395"/>
-  <text x="1331" y="389" style="font-size:8">4,802,0,0,0</text>
+  <text x="1331" y="391" style="font-size:5px">4,802,0,0,0</text>
   <path class="p4" d="M 1359 393 L 1385 391 L 1354 380 L 1329 382 L 1359 393"/>
-  <text x="1357" y="387" style="font-size:8">4,803,0,0,0</text>
+  <text x="1357" y="389" style="font-size:5px">4,803,0,0,0</text>
   <path class="p4" d="M 1418 404 L 1447 402 L 1412 390 L 1385 391 L 1418 404"/>
-  <text x="1416" y="397" style="font-size:8">4,804,0,0,0</text>
+  <text x="1416" y="399" style="font-size:5px">4,804,0,0,0</text>
   <path class="p4" d="M 1447 402 L 1476 400 L 1439 388 L 1412 390 L 1447 402"/>
-  <text x="1444" y="395" style="font-size:8">4,805,0,0,0</text>
+  <text x="1444" y="397" style="font-size:5px">4,805,0,0,0</text>
   <path class="p4" d="M 1385 391 L 1412 390 L 1378 378 L 1354 380 L 1385 391"/>
-  <text x="1382" y="385" style="font-size:8">4,806,0,0,0</text>
+  <text x="1382" y="387" style="font-size:5px">4,806,0,0,0</text>
   <path class="p4" d="M 1412 390 L 1439 388 L 1403 375 L 1378 378 L 1412 390"/>
-  <text x="1408" y="383" style="font-size:8">4,807,0,0,0</text>
+  <text x="1408" y="385" style="font-size:5px">4,807,0,0,0</text>
   <path class="p4" d="M 1204 392 L 1229 390 L 1209 379 L 1186 381 L 1204 392"/>
-  <text x="1207" y="386" style="font-size:8">4,808,0,0,0</text>
+  <text x="1207" y="388" style="font-size:5px">4,808,0,0,0</text>
   <path class="p4" d="M 1229 390 L 1254 388 L 1232 377 L 1209 379 L 1229 390"/>
-  <text x="1231" y="383" style="font-size:8">4,809,0,0,0</text>
+  <text x="1231" y="386" style="font-size:5px">4,809,0,0,0</text>
   <path class="p4" d="M 1186 381 L 1209 379 L 1190 368 L 1169 371 L 1186 381"/>
-  <text x="1189" y="375" style="font-size:8">4,810,0,0,0</text>
+  <text x="1189" y="377" style="font-size:5px">4,810,0,0,0</text>
   <path class="p4" d="M 1209 379 L 1232 377 L 1210 366 L 1190 368 L 1209 379"/>
-  <text x="1210" y="372" style="font-size:8">4,811,0,0,0</text>
+  <text x="1210" y="375" style="font-size:5px">4,811,0,0,0</text>
   <path class="p4" d="M 1254 388 L 1279 386 L 1255 375 L 1232 377 L 1254 388"/>
-  <text x="1255" y="381" style="font-size:8">4,812,0,0,0</text>
+  <text x="1255" y="384" style="font-size:5px">4,812,0,0,0</text>
   <path class="p4" d="M 1279 386 L 1304 384 L 1277 372 L 1255 375 L 1279 386"/>
-  <text x="1279" y="379" style="font-size:8">4,813,0,0,0</text>
+  <text x="1279" y="382" style="font-size:5px">4,813,0,0,0</text>
   <path class="p4" d="M 1232 377 L 1255 375 L 1231 364 L 1210 366 L 1232 377"/>
-  <text x="1232" y="370" style="font-size:8">4,814,0,0,0</text>
+  <text x="1232" y="373" style="font-size:5px">4,814,0,0,0</text>
   <path class="p4" d="M 1255 375 L 1277 372 L 1251 361 L 1231 364 L 1255 375"/>
-  <text x="1254" y="368" style="font-size:8">4,815,0,0,0</text>
+  <text x="1254" y="370" style="font-size:5px">4,815,0,0,0</text>
   <path class="p4" d="M 1169 371 L 1190 368 L 1170 358 L 1152 360 L 1169 371"/>
-  <text x="1170" y="364" style="font-size:8">4,816,0,0,0</text>
+  <text x="1170" y="367" style="font-size:5px">4,816,0,0,0</text>
   <path class="p4" d="M 1190 368 L 1210 366 L 1189 355 L 1170 358 L 1190 368"/>
-  <text x="1190" y="362" style="font-size:8">4,817,0,0,0</text>
+  <text x="1190" y="364" style="font-size:5px">4,817,0,0,0</text>
   <path class="p4" d="M 1152 360 L 1170 358 L 1151 347 L 1135 350 L 1152 360"/>
-  <text x="1152" y="354" style="font-size:8">4,818,0,0,0</text>
+  <text x="1152" y="356" style="font-size:5px">4,818,0,0,0</text>
   <line x1="1135" y1="350" x2="1151" y2="347"/>
   <path class="p4" d="M 1170 358 L 1189 355 L 1168 345 L 1151 347 L 1170 358"/>
-  <text x="1170" y="351" style="font-size:8">4,819,0,0,0</text>
+  <text x="1170" y="354" style="font-size:5px">4,819,0,0,0</text>
   <line x1="1151" y1="347" x2="1168" y2="345"/>
   <path class="p4" d="M 1210 366 L 1231 364 L 1207 353 L 1189 355 L 1210 366"/>
-  <text x="1209" y="359" style="font-size:8">4,820,0,0,0</text>
+  <text x="1209" y="362" style="font-size:5px">4,820,0,0,0</text>
   <path class="p4" d="M 1231 364 L 1251 361 L 1226 350 L 1207 353 L 1231 364"/>
-  <text x="1229" y="357" style="font-size:8">4,821,0,0,0</text>
+  <text x="1229" y="359" style="font-size:5px">4,821,0,0,0</text>
   <path class="p4" d="M 1189 355 L 1207 353 L 1184 342 L 1168 345 L 1189 355"/>
-  <text x="1187" y="349" style="font-size:8">4,822,0,0,0</text>
+  <text x="1187" y="351" style="font-size:5px">4,822,0,0,0</text>
   <line x1="1168" y1="345" x2="1184" y2="342"/>
   <path class="p4" d="M 1207 353 L 1226 350 L 1200 340 L 1184 342 L 1207 353"/>
-  <text x="1204" y="346" style="font-size:8">4,823,0,0,0</text>
+  <text x="1204" y="349" style="font-size:5px">4,823,0,0,0</text>
   <line x1="1184" y1="342" x2="1200" y2="340"/>
   <path class="p4" d="M 1304 384 L 1329 382 L 1300 370 L 1277 372 L 1304 384"/>
-  <text x="1303" y="377" style="font-size:8">4,824,0,0,0</text>
+  <text x="1303" y="379" style="font-size:5px">4,824,0,0,0</text>
   <path class="p4" d="M 1329 382 L 1354 380 L 1322 368 L 1300 370 L 1329 382"/>
-  <text x="1326" y="375" style="font-size:8">4,825,0,0,0</text>
+  <text x="1326" y="377" style="font-size:5px">4,825,0,0,0</text>
   <path class="p4" d="M 1277 372 L 1300 370 L 1272 359 L 1251 361 L 1277 372"/>
-  <text x="1275" y="366" style="font-size:8">4,826,0,0,0</text>
+  <text x="1275" y="368" style="font-size:5px">4,826,0,0,0</text>
   <path class="p4" d="M 1300 370 L 1322 368 L 1292 357 L 1272 359 L 1300 370"/>
-  <text x="1296" y="363" style="font-size:8">4,827,0,0,0</text>
+  <text x="1296" y="366" style="font-size:5px">4,827,0,0,0</text>
   <path class="p4" d="M 1354 380 L 1378 378 L 1345 366 L 1322 368 L 1354 380"/>
-  <text x="1350" y="373" style="font-size:8">4,828,0,0,0</text>
+  <text x="1350" y="375" style="font-size:5px">4,828,0,0,0</text>
   <path class="p4" d="M 1378 378 L 1403 375 L 1367 364 L 1345 366 L 1378 378"/>
-  <text x="1373" y="371" style="font-size:8">4,829,0,0,0</text>
+  <text x="1373" y="373" style="font-size:5px">4,829,0,0,0</text>
   <path class="p4" d="M 1322 368 L 1345 366 L 1312 354 L 1292 357 L 1322 368"/>
-  <text x="1318" y="361" style="font-size:8">4,830,0,0,0</text>
+  <text x="1318" y="364" style="font-size:5px">4,830,0,0,0</text>
   <path class="p4" d="M 1345 366 L 1367 364 L 1332 352 L 1312 354 L 1345 366"/>
-  <text x="1339" y="359" style="font-size:8">4,831,0,0,0</text>
+  <text x="1339" y="361" style="font-size:5px">4,831,0,0,0</text>
   <path class="p4" d="M 1251 361 L 1272 359 L 1244 348 L 1226 350 L 1251 361"/>
-  <text x="1248" y="355" style="font-size:8">4,832,0,0,0</text>
+  <text x="1248" y="357" style="font-size:5px">4,832,0,0,0</text>
   <path class="p4" d="M 1272 359 L 1292 357 L 1262 345 L 1244 348 L 1272 359"/>
-  <text x="1267" y="352" style="font-size:8">4,833,0,0,0</text>
+  <text x="1267" y="355" style="font-size:5px">4,833,0,0,0</text>
   <path class="p4" d="M 1226 350 L 1244 348 L 1217 337 L 1200 340 L 1226 350"/>
-  <text x="1221" y="344" style="font-size:8">4,834,0,0,0</text>
+  <text x="1221" y="346" style="font-size:5px">4,834,0,0,0</text>
   <line x1="1200" y1="340" x2="1217" y2="337"/>
   <path class="p4" d="M 1244 348 L 1262 345 L 1233 335 L 1217 337 L 1244 348"/>
-  <text x="1239" y="341" style="font-size:8">4,835,0,0,0</text>
+  <text x="1239" y="344" style="font-size:5px">4,835,0,0,0</text>
   <line x1="1217" y1="337" x2="1233" y2="335"/>
   <path class="p4" d="M 1292 357 L 1312 354 L 1280 343 L 1262 345 L 1292 357"/>
-  <text x="1286" y="350" style="font-size:8">4,836,0,0,0</text>
+  <text x="1286" y="352" style="font-size:5px">4,836,0,0,0</text>
   <path class="p4" d="M 1312 354 L 1332 352 L 1298 341 L 1280 343 L 1312 354"/>
-  <text x="1305" y="347" style="font-size:8">4,837,0,0,0</text>
+  <text x="1305" y="350" style="font-size:5px">4,837,0,0,0</text>
   <path class="p4" d="M 1262 345 L 1280 343 L 1249 332 L 1233 335 L 1262 345"/>
-  <text x="1256" y="339" style="font-size:7">4,838,0,0,0</text>
+  <text x="1256" y="341" style="font-size:5px">4,838,0,0,0</text>
   <line x1="1233" y1="335" x2="1249" y2="332"/>
   <path class="p4" d="M 1280 343 L 1298 341 L 1265 330 L 1249 332 L 1280 343"/>
-  <text x="1273" y="336" style="font-size:7">4,839,0,0,0</text>
+  <text x="1273" y="339" style="font-size:5px">4,839,0,0,0</text>
   <line x1="1249" y1="332" x2="1265" y2="330"/>
   <path class="p4" d="M 1476 400 L 1476 389 L 1440 377 L 1439 388 L 1476 400"/>
-  <text x="1458" y="388" style="font-size:8">4,840,0,0,0</text>
+  <text x="1458" y="391" style="font-size:5px">4,840,0,0,0</text>
   <path class="p4" d="M 1476 389 L 1475 377 L 1440 367 L 1440 377 L 1476 389"/>
-  <text x="1458" y="377" style="font-size:8">4,841,0,0,0</text>
+  <text x="1458" y="380" style="font-size:5px">4,841,0,0,0</text>
   <path class="p4" d="M 1439 388 L 1440 377 L 1404 366 L 1403 375 L 1439 388"/>
-  <text x="1421" y="377" style="font-size:8">4,842,0,0,0</text>
+  <text x="1421" y="379" style="font-size:5px">4,842,0,0,0</text>
   <path class="p4" d="M 1440 377 L 1440 367 L 1406 357 L 1404 366 L 1440 377"/>
-  <text x="1423" y="367" style="font-size:8">4,843,0,0,0</text>
+  <text x="1423" y="369" style="font-size:5px">4,843,0,0,0</text>
   <path class="p4" d="M 1475 377 L 1475 366 L 1441 357 L 1440 367 L 1475 377"/>
-  <text x="1458" y="367" style="font-size:8">4,844,0,0,0</text>
+  <text x="1458" y="369" style="font-size:5px">4,844,0,0,0</text>
   <path class="p4" d="M 1475 366 L 1475 356 L 1442 347 L 1441 357 L 1475 366"/>
-  <text x="1458" y="356" style="font-size:8">4,845,0,0,0</text>
+  <text x="1458" y="359" style="font-size:5px">4,845,0,0,0</text>
   <path class="p4" d="M 1440 367 L 1441 357 L 1408 348 L 1406 357 L 1440 367"/>
-  <text x="1424" y="357" style="font-size:8">4,846,0,0,0</text>
+  <text x="1424" y="359" style="font-size:5px">4,846,0,0,0</text>
   <path class="p4" d="M 1441 357 L 1442 347 L 1410 339 L 1408 348 L 1441 357"/>
-  <text x="1425" y="347" style="font-size:7">4,847,0,0,0</text>
+  <text x="1425" y="350" style="font-size:5px">4,847,0,0,0</text>
   <path class="p4" d="M 1542 373 L 1539 361 L 1507 353 L 1508 364 L 1542 373"/>
-  <text x="1524" y="363" style="font-size:8">4,848,0,0,0</text>
+  <text x="1524" y="365" style="font-size:5px">4,848,0,0,0</text>
   <path class="p4" d="M 1539 361 L 1537 349 L 1505 342 L 1507 353 L 1539 361"/>
-  <text x="1522" y="351" style="font-size:7">4,849,0,0,0</text>
+  <text x="1522" y="354" style="font-size:5px">4,849,0,0,0</text>
   <path class="p4" d="M 1508 364 L 1507 353 L 1474 345 L 1475 356 L 1508 364"/>
-  <text x="1491" y="354" style="font-size:8">4,850,0,0,0</text>
+  <text x="1491" y="357" style="font-size:5px">4,850,0,0,0</text>
   <path class="p4" d="M 1507 353 L 1505 342 L 1474 335 L 1474 345 L 1507 353"/>
-  <text x="1490" y="344" style="font-size:7">4,851,0,0,0</text>
+  <text x="1490" y="346" style="font-size:5px">4,851,0,0,0</text>
   <path class="p4" d="M 1537 349 L 1534 337 L 1504 331 L 1505 342 L 1537 349"/>
-  <text x="1520" y="339" style="font-size:7">4,852,0,0,0</text>
+  <text x="1520" y="342" style="font-size:5px">4,852,0,0,0</text>
   <path class="p4" d="M 1534 337 L 1532 325 L 1502 320 L 1504 331 L 1534 337"/>
-  <text x="1518" y="328" style="font-size:7">4,853,0,0,0</text>
+  <text x="1518" y="330" style="font-size:4px">4,853,0,0,0</text>
   <path class="p4" d="M 1505 342 L 1504 331 L 1474 325 L 1474 335 L 1505 342"/>
-  <text x="1489" y="333" style="font-size:7">4,854,0,0,0</text>
+  <text x="1489" y="335" style="font-size:4px">4,854,0,0,0</text>
   <path class="p4" d="M 1504 331 L 1502 320 L 1473 315 L 1474 325 L 1504 331"/>
-  <text x="1488" y="322" style="font-size:7">4,855,0,0,0</text>
+  <text x="1488" y="324" style="font-size:4px">4,855,0,0,0</text>
   <path class="p4" d="M 1475 356 L 1474 345 L 1443 337 L 1442 347 L 1475 356"/>
-  <text x="1458" y="346" style="font-size:7">4,856,0,0,0</text>
+  <text x="1458" y="349" style="font-size:5px">4,856,0,0,0</text>
   <path class="p4" d="M 1474 345 L 1474 335 L 1443 328 L 1443 337 L 1474 345"/>
-  <text x="1458" y="336" style="font-size:7">4,857,0,0,0</text>
+  <text x="1458" y="339" style="font-size:5px">4,857,0,0,0</text>
   <path class="p4" d="M 1442 347 L 1443 337 L 1411 330 L 1410 339 L 1442 347"/>
-  <text x="1426" y="338" style="font-size:7">4,858,0,0,0</text>
+  <text x="1426" y="341" style="font-size:5px">4,858,0,0,0</text>
   <path class="p4" d="M 1443 337 L 1443 328 L 1413 321 L 1411 330 L 1443 337"/>
-  <text x="1427" y="329" style="font-size:7">4,859,0,0,0</text>
+  <text x="1427" y="331" style="font-size:4px">4,859,0,0,0</text>
   <path class="p4" d="M 1474 335 L 1474 325 L 1444 318 L 1443 328 L 1474 335"/>
-  <text x="1459" y="326" style="font-size:7">4,860,0,0,0</text>
+  <text x="1459" y="328" style="font-size:4px">4,860,0,0,0</text>
   <path class="p4" d="M 1474 325 L 1473 315 L 1445 309 L 1444 318 L 1474 325"/>
-  <text x="1459" y="317" style="font-size:7">4,861,0,0,0</text>
+  <text x="1459" y="319" style="font-size:4px">4,861,0,0,0</text>
   <path class="p4" d="M 1443 328 L 1444 318 L 1414 312 L 1413 321 L 1443 328"/>
-  <text x="1429" y="320" style="font-size:7">4,862,0,0,0</text>
+  <text x="1429" y="322" style="font-size:4px">4,862,0,0,0</text>
   <path class="p4" d="M 1444 318 L 1445 309 L 1416 304 L 1414 312 L 1444 318"/>
-  <text x="1430" y="311" style="font-size:7">4,863,0,0,0</text>
+  <text x="1430" y="313" style="font-size:4px">4,863,0,0,0</text>
   <path class="p4" d="M 1403 375 L 1404 366 L 1370 355 L 1367 364 L 1403 375"/>
-  <text x="1386" y="365" style="font-size:8">4,864,0,0,0</text>
+  <text x="1386" y="368" style="font-size:5px">4,864,0,0,0</text>
   <path class="p4" d="M 1404 366 L 1406 357 L 1372 347 L 1370 355 L 1404 366"/>
-  <text x="1388" y="356" style="font-size:8">4,865,0,0,0</text>
+  <text x="1388" y="359" style="font-size:5px">4,865,0,0,0</text>
   <path class="p4" d="M 1367 364 L 1370 355 L 1336 344 L 1332 352 L 1367 364"/>
-  <text x="1351" y="354" style="font-size:8">4,866,0,0,0</text>
+  <text x="1351" y="356" style="font-size:5px">4,866,0,0,0</text>
   <path class="p4" d="M 1370 355 L 1372 347 L 1339 337 L 1336 344 L 1370 355"/>
-  <text x="1354" y="346" style="font-size:8">4,867,0,0,0</text>
+  <text x="1354" y="348" style="font-size:5px">4,867,0,0,0</text>
   <path class="p4" d="M 1406 357 L 1408 348 L 1375 338 L 1372 347 L 1406 357"/>
-  <text x="1390" y="347" style="font-size:8">4,868,0,0,0</text>
+  <text x="1390" y="350" style="font-size:5px">4,868,0,0,0</text>
   <path class="p4" d="M 1408 348 L 1410 339 L 1378 330 L 1375 338 L 1408 348"/>
-  <text x="1392" y="339" style="font-size:7">4,869,0,0,0</text>
+  <text x="1392" y="341" style="font-size:5px">4,869,0,0,0</text>
   <path class="p4" d="M 1372 347 L 1375 338 L 1343 329 L 1339 337 L 1372 347"/>
-  <text x="1357" y="338" style="font-size:7">4,870,0,0,0</text>
+  <text x="1357" y="340" style="font-size:5px">4,870,0,0,0</text>
   <path class="p4" d="M 1375 338 L 1378 330 L 1346 322 L 1343 329 L 1375 338"/>
-  <text x="1360" y="330" style="font-size:7">4,871,0,0,0</text>
+  <text x="1360" y="332" style="font-size:5px">4,871,0,0,0</text>
   <path class="p4" d="M 1332 352 L 1336 344 L 1302 334 L 1298 341 L 1332 352"/>
-  <text x="1317" y="343" style="font-size:7">4,872,0,0,0</text>
+  <text x="1317" y="345" style="font-size:5px">4,872,0,0,0</text>
   <path class="p4" d="M 1336 344 L 1339 337 L 1307 327 L 1302 334 L 1336 344"/>
-  <text x="1321" y="335" style="font-size:7">4,873,0,0,0</text>
+  <text x="1321" y="338" style="font-size:5px">4,873,0,0,0</text>
   <path class="p4" d="M 1298 341 L 1302 334 L 1270 324 L 1265 330 L 1298 341"/>
-  <text x="1284" y="332" style="font-size:7">4,874,0,0,0</text>
+  <text x="1284" y="334" style="font-size:5px">4,874,0,0,0</text>
   <line x1="1265" y1="330" x2="1270" y2="324"/>
   <path class="p4" d="M 1302 334 L 1307 327 L 1275 318 L 1270 324 L 1302 334"/>
-  <text x="1288" y="325" style="font-size:7">4,875,0,0,0</text>
+  <text x="1288" y="328" style="font-size:5px">4,875,0,0,0</text>
   <line x1="1270" y1="324" x2="1275" y2="318"/>
   <path class="p4" d="M 1339 337 L 1343 329 L 1311 320 L 1307 327 L 1339 337"/>
-  <text x="1325" y="328" style="font-size:7">4,876,0,0,0</text>
+  <text x="1325" y="331" style="font-size:5px">4,876,0,0,0</text>
   <path class="p4" d="M 1343 329 L 1346 322 L 1316 314 L 1311 320 L 1343 329"/>
-  <text x="1329" y="321" style="font-size:7">4,877,0,0,0</text>
+  <text x="1329" y="323" style="font-size:4px">4,877,0,0,0</text>
   <path class="p4" d="M 1307 327 L 1311 320 L 1280 312 L 1275 318 L 1307 327"/>
-  <text x="1293" y="319" style="font-size:7">4,878,0,0,0</text>
+  <text x="1293" y="321" style="font-size:4px">4,878,0,0,0</text>
   <line x1="1275" y1="318" x2="1280" y2="312"/>
   <path class="p4" d="M 1311 320 L 1316 314 L 1285 306 L 1280 312 L 1311 320"/>
-  <text x="1298" y="313" style="font-size:7">4,879,0,0,0</text>
+  <text x="1298" y="315" style="font-size:4px">4,879,0,0,0</text>
   <line x1="1280" y1="312" x2="1285" y2="306"/>
   <path class="p4" d="M 1410 339 L 1411 330 L 1380 322 L 1378 330 L 1410 339"/>
-  <text x="1395" y="330" style="font-size:7">4,880,0,0,0</text>
+  <text x="1395" y="333" style="font-size:5px">4,880,0,0,0</text>
   <path class="p4" d="M 1411 330 L 1413 321 L 1383 314 L 1380 322 L 1411 330"/>
-  <text x="1397" y="322" style="font-size:7">4,881,0,0,0</text>
+  <text x="1397" y="324" style="font-size:4px">4,881,0,0,0</text>
   <path class="p4" d="M 1378 330 L 1380 322 L 1350 315 L 1346 322 L 1378 330"/>
-  <text x="1364" y="322" style="font-size:7">4,882,0,0,0</text>
+  <text x="1364" y="324" style="font-size:4px">4,882,0,0,0</text>
   <path class="p4" d="M 1380 322 L 1383 314 L 1353 308 L 1350 315 L 1380 322"/>
-  <text x="1367" y="315" style="font-size:7">4,883,0,0,0</text>
+  <text x="1367" y="317" style="font-size:4px">4,883,0,0,0</text>
   <path class="p4" d="M 1413 321 L 1414 312 L 1385 306 L 1383 314 L 1413 321"/>
-  <text x="1399" y="313" style="font-size:7">4,884,0,0,0</text>
+  <text x="1399" y="315" style="font-size:4px">4,884,0,0,0</text>
   <path class="p4" d="M 1414 312 L 1416 304 L 1388 299 L 1385 306 L 1414 312"/>
-  <text x="1401" y="305" style="font-size:7">4,885,0,0,0</text>
+  <text x="1401" y="307" style="font-size:4px">4,885,0,0,0</text>
   <path class="p4" d="M 1383 314 L 1385 306 L 1357 301 L 1353 308 L 1383 314"/>
-  <text x="1370" y="307" style="font-size:7">4,886,0,0,0</text>
+  <text x="1370" y="309" style="font-size:4px">4,886,0,0,0</text>
   <path class="p4" d="M 1385 306 L 1388 299 L 1360 294 L 1357 301 L 1385 306"/>
-  <text x="1372" y="300" style="font-size:7">4,887,0,0,0</text>
+  <text x="1372" y="302" style="font-size:4px">4,887,0,0,0</text>
   <path class="p4" d="M 1346 322 L 1350 315 L 1320 307 L 1316 314 L 1346 322"/>
-  <text x="1333" y="314" style="font-size:7">4,888,0,0,0</text>
+  <text x="1333" y="316" style="font-size:4px">4,888,0,0,0</text>
   <path class="p4" d="M 1350 315 L 1353 308 L 1324 301 L 1320 307 L 1350 315"/>
-  <text x="1337" y="308" style="font-size:7">4,889,0,0,0</text>
+  <text x="1337" y="310" style="font-size:4px">4,889,0,0,0</text>
   <path class="p4" d="M 1316 314 L 1320 307 L 1290 300 L 1285 306 L 1316 314"/>
-  <text x="1303" y="307" style="font-size:7">4,890,0,0,0</text>
+  <text x="1303" y="309" style="font-size:4px">4,890,0,0,0</text>
   <line x1="1285" y1="306" x2="1290" y2="300"/>
   <path class="p4" d="M 1320 307 L 1324 301 L 1295 295 L 1290 300 L 1320 307"/>
-  <text x="1307" y="301" style="font-size:7">4,891,0,0,0</text>
+  <text x="1307" y="303" style="font-size:4px">4,891,0,0,0</text>
   <line x1="1290" y1="300" x2="1295" y2="295"/>
   <path class="p4" d="M 1353 308 L 1357 301 L 1328 295 L 1324 301 L 1353 308"/>
-  <text x="1341" y="301" style="font-size:7">4,892,0,0,0</text>
+  <text x="1341" y="303" style="font-size:4px">4,892,0,0,0</text>
   <path class="p4" d="M 1357 301 L 1360 294 L 1332 289 L 1328 295 L 1357 301"/>
-  <text x="1344" y="294" style="font-size:7">4,893,0,0,0</text>
+  <text x="1344" y="296" style="font-size:4px">4,893,0,0,0</text>
   <path class="p4" d="M 1324 301 L 1328 295 L 1300 289 L 1295 295 L 1324 301"/>
-  <text x="1312" y="295" style="font-size:7">4,894,0,0,0</text>
+  <text x="1312" y="297" style="font-size:4px">4,894,0,0,0</text>
   <line x1="1295" y1="295" x2="1300" y2="289"/>
   <path class="p4" d="M 1328 295 L 1332 289 L 1305 283 L 1300 289 L 1328 295"/>
-  <text x="1317" y="289" style="font-size:7">4,895,0,0,0</text>
+  <text x="1317" y="291" style="font-size:4px">4,895,0,0,0</text>
   <line x1="1300" y1="289" x2="1305" y2="283"/>
   <path class="p4" d="M 1532 325 L 1529 314 L 1501 309 L 1502 320 L 1532 325"/>
-  <text x="1516" y="317" style="font-size:7">4,896,0,0,0</text>
+  <text x="1516" y="319" style="font-size:4px">4,896,0,0,0</text>
   <path class="p4" d="M 1529 314 L 1527 303 L 1500 299 L 1501 309 L 1529 314"/>
-  <text x="1514" y="306" style="font-size:7">4,897,0,0,0</text>
+  <text x="1514" y="308" style="font-size:4px">4,897,0,0,0</text>
   <path class="p4" d="M 1502 320 L 1501 309 L 1473 305 L 1473 315 L 1502 320"/>
-  <text x="1487" y="312" style="font-size:7">4,898,0,0,0</text>
+  <text x="1487" y="314" style="font-size:4px">4,898,0,0,0</text>
   <path class="p4" d="M 1501 309 L 1500 299 L 1473 295 L 1473 305 L 1501 309"/>
-  <text x="1486" y="302" style="font-size:7">4,899,0,0,0</text>
+  <text x="1486" y="304" style="font-size:4px">4,899,0,0,0</text>
   <path class="p4" d="M 1527 303 L 1524 292 L 1498 289 L 1500 299 L 1527 303"/>
-  <text x="1512" y="296" style="font-size:7">4,900,0,0,0</text>
+  <text x="1512" y="298" style="font-size:4px">4,900,0,0,0</text>
   <path class="p4" d="M 1524 292 L 1522 282 L 1497 279 L 1498 289 L 1524 292"/>
-  <text x="1510" y="285" style="font-size:6">4,901,0,0,0</text>
+  <text x="1510" y="287" style="font-size:4px">4,901,0,0,0</text>
   <path class="p4" d="M 1500 299 L 1498 289 L 1472 286 L 1473 295 L 1500 299"/>
-  <text x="1486" y="292" style="font-size:7">4,902,0,0,0</text>
+  <text x="1486" y="294" style="font-size:4px">4,902,0,0,0</text>
   <path class="p4" d="M 1498 289 L 1497 279 L 1472 277 L 1472 286 L 1498 289"/>
-  <text x="1485" y="283" style="font-size:6">4,903,0,0,0</text>
+  <text x="1485" y="285" style="font-size:4px">4,903,0,0,0</text>
   <path class="p4" d="M 1473 315 L 1473 305 L 1445 300 L 1445 309 L 1473 315"/>
-  <text x="1459" y="307" style="font-size:7">4,904,0,0,0</text>
+  <text x="1459" y="309" style="font-size:4px">4,904,0,0,0</text>
   <path class="p4" d="M 1473 305 L 1473 295 L 1446 291 L 1445 300 L 1473 305"/>
-  <text x="1459" y="298" style="font-size:7">4,905,0,0,0</text>
+  <text x="1459" y="300" style="font-size:4px">4,905,0,0,0</text>
   <path class="p4" d="M 1445 309 L 1445 300 L 1418 296 L 1416 304 L 1445 309"/>
-  <text x="1431" y="302" style="font-size:7">4,906,0,0,0</text>
+  <text x="1431" y="304" style="font-size:4px">4,906,0,0,0</text>
   <path class="p4" d="M 1445 300 L 1446 291 L 1419 288 L 1418 296 L 1445 300"/>
-  <text x="1432" y="294" style="font-size:7">4,907,0,0,0</text>
+  <text x="1432" y="296" style="font-size:4px">4,907,0,0,0</text>
   <path class="p4" d="M 1473 295 L 1472 286 L 1446 283 L 1446 291 L 1473 295"/>
-  <text x="1459" y="289" style="font-size:7">4,908,0,0,0</text>
+  <text x="1459" y="291" style="font-size:4px">4,908,0,0,0</text>
   <path class="p4" d="M 1472 286 L 1472 277 L 1447 274 L 1446 283 L 1472 286"/>
-  <text x="1459" y="280" style="font-size:6">4,909,0,0,0</text>
+  <text x="1459" y="282" style="font-size:4px">4,909,0,0,0</text>
   <path class="p4" d="M 1446 291 L 1446 283 L 1421 280 L 1419 288 L 1446 291"/>
-  <text x="1433" y="285" style="font-size:7">4,910,0,0,0</text>
+  <text x="1433" y="287" style="font-size:4px">4,910,0,0,0</text>
   <path class="p4" d="M 1446 283 L 1447 274 L 1422 272 L 1421 280 L 1446 283"/>
-  <text x="1434" y="277" style="font-size:6">4,911,0,0,0</text>
+  <text x="1434" y="279" style="font-size:4px">4,911,0,0,0</text>
   <path class="p4" d="M 1522 282 L 1520 271 L 1496 269 L 1497 279 L 1522 282"/>
-  <text x="1509" y="275" style="font-size:6">4,912,0,0,0</text>
+  <text x="1509" y="277" style="font-size:4px">4,912,0,0,0</text>
   <path class="p4" d="M 1520 271 L 1518 261 L 1494 260 L 1496 269 L 1520 271"/>
-  <text x="1507" y="265" style="font-size:6">4,913,0,0,0</text>
+  <text x="1507" y="267" style="font-size:4px">4,913,0,0,0</text>
   <path class="p4" d="M 1497 279 L 1496 269 L 1472 268 L 1472 277 L 1497 279"/>
-  <text x="1484" y="273" style="font-size:6">4,914,0,0,0</text>
+  <text x="1484" y="275" style="font-size:4px">4,914,0,0,0</text>
   <path class="p4" d="M 1496 269 L 1494 260 L 1471 259 L 1472 268 L 1496 269"/>
-  <text x="1483" y="264" style="font-size:6">4,915,0,0,0</text>
+  <text x="1483" y="266" style="font-size:4px">4,915,0,0,0</text>
   <path class="p4" d="M 1518 261 L 1516 251 L 1493 251 L 1494 260 L 1518 261"/>
-  <text x="1505" y="256" style="font-size:6">4,916,0,0,0</text>
+  <text x="1505" y="258" style="font-size:4px">4,916,0,0,0</text>
   <path class="p4" d="M 1516 251 L 1513 241 L 1492 241 L 1493 251 L 1516 251"/>
-  <text x="1504" y="246" style="font-size:6">4,917,0,0,0</text>
+  <text x="1504" y="248" style="font-size:4px">4,917,0,0,0</text>
   <path class="p4" d="M 1494 260 L 1493 251 L 1471 250 L 1471 259 L 1494 260"/>
-  <text x="1482" y="255" style="font-size:6">4,918,0,0,0</text>
+  <text x="1482" y="257" style="font-size:4px">4,918,0,0,0</text>
   <path class="p4" d="M 1493 251 L 1492 241 L 1471 241 L 1471 250 L 1493 251"/>
-  <text x="1482" y="246" style="font-size:6">4,919,0,0,0</text>
+  <text x="1482" y="248" style="font-size:4px">4,919,0,0,0</text>
   <path class="p4" d="M 1472 277 L 1472 268 L 1448 266 L 1447 274 L 1472 277"/>
-  <text x="1459" y="271" style="font-size:6">4,920,0,0,0</text>
+  <text x="1459" y="273" style="font-size:4px">4,920,0,0,0</text>
   <path class="p4" d="M 1472 268 L 1471 259 L 1448 257 L 1448 266 L 1472 268"/>
-  <text x="1460" y="262" style="font-size:6">4,921,0,0,0</text>
+  <text x="1460" y="264" style="font-size:4px">4,921,0,0,0</text>
   <path class="p4" d="M 1447 274 L 1448 266 L 1424 264 L 1422 272 L 1447 274"/>
-  <text x="1435" y="269" style="font-size:6">4,922,0,0,0</text>
+  <text x="1435" y="271" style="font-size:4px">4,922,0,0,0</text>
   <path class="p4" d="M 1448 266 L 1448 257 L 1425 256 L 1424 264 L 1448 266"/>
-  <text x="1436" y="261" style="font-size:6">4,923,0,0,0</text>
+  <text x="1436" y="263" style="font-size:4px">4,923,0,0,0</text>
   <path class="p4" d="M 1471 259 L 1471 250 L 1449 249 L 1448 257 L 1471 259"/>
-  <text x="1460" y="254" style="font-size:6">4,924,0,0,0</text>
+  <text x="1460" y="256" style="font-size:4px">4,924,0,0,0</text>
   <path class="p4" d="M 1471 250 L 1471 241 L 1449 241 L 1449 249 L 1471 250"/>
-  <text x="1460" y="245" style="font-size:6">4,925,0,0,0</text>
+  <text x="1460" y="247" style="font-size:4px">4,925,0,0,0</text>
   <path class="p4" d="M 1448 257 L 1449 249 L 1426 249 L 1425 256 L 1448 257"/>
-  <text x="1437" y="253" style="font-size:6">4,926,0,0,0</text>
+  <text x="1437" y="255" style="font-size:4px">4,926,0,0,0</text>
   <path class="p4" d="M 1449 249 L 1449 241 L 1428 241 L 1426 249 L 1449 249"/>
-  <text x="1438" y="245" style="font-size:6">4,927,0,0,0</text>
+  <text x="1438" y="247" style="font-size:4px">4,927,0,0,0</text>
   <path class="p4" d="M 1416 304 L 1418 296 L 1390 291 L 1388 299 L 1416 304"/>
-  <text x="1403" y="297" style="font-size:7">4,928,0,0,0</text>
+  <text x="1403" y="299" style="font-size:4px">4,928,0,0,0</text>
   <path class="p4" d="M 1418 296 L 1419 288 L 1393 284 L 1390 291 L 1418 296"/>
-  <text x="1405" y="290" style="font-size:7">4,929,0,0,0</text>
+  <text x="1405" y="292" style="font-size:4px">4,929,0,0,0</text>
   <path class="p4" d="M 1388 299 L 1390 291 L 1363 287 L 1360 294 L 1388 299"/>
-  <text x="1375" y="293" style="font-size:7">4,930,0,0,0</text>
+  <text x="1375" y="295" style="font-size:4px">4,930,0,0,0</text>
   <path class="p4" d="M 1390 291 L 1393 284 L 1367 280 L 1363 287 L 1390 291"/>
-  <text x="1378" y="285" style="font-size:7">4,931,0,0,0</text>
+  <text x="1378" y="287" style="font-size:4px">4,931,0,0,0</text>
   <path class="p4" d="M 1419 288 L 1421 280 L 1395 276 L 1393 284 L 1419 288"/>
-  <text x="1407" y="282" style="font-size:6">4,932,0,0,0</text>
+  <text x="1407" y="284" style="font-size:4px">4,932,0,0,0</text>
   <path class="p4" d="M 1421 280 L 1422 272 L 1397 269 L 1395 276 L 1421 280"/>
-  <text x="1409" y="274" style="font-size:6">4,933,0,0,0</text>
+  <text x="1409" y="276" style="font-size:4px">4,933,0,0,0</text>
   <path class="p4" d="M 1393 284 L 1395 276 L 1370 273 L 1367 280 L 1393 284"/>
-  <text x="1381" y="278" style="font-size:6">4,934,0,0,0</text>
+  <text x="1381" y="280" style="font-size:4px">4,934,0,0,0</text>
   <path class="p4" d="M 1395 276 L 1397 269 L 1373 267 L 1370 273 L 1395 276"/>
-  <text x="1384" y="271" style="font-size:6">4,935,0,0,0</text>
+  <text x="1384" y="273" style="font-size:4px">4,935,0,0,0</text>
   <path class="p4" d="M 1360 294 L 1363 287 L 1337 282 L 1332 289 L 1360 294"/>
-  <text x="1348" y="288" style="font-size:7">4,936,0,0,0</text>
+  <text x="1348" y="290" style="font-size:4px">4,936,0,0,0</text>
   <path class="p4" d="M 1363 287 L 1367 280 L 1341 276 L 1337 282 L 1363 287"/>
-  <text x="1352" y="281" style="font-size:7">4,937,0,0,0</text>
+  <text x="1352" y="283" style="font-size:4px">4,937,0,0,0</text>
   <path class="p4" d="M 1332 289 L 1337 282 L 1310 278 L 1305 283 L 1332 289"/>
-  <text x="1321" y="283" style="font-size:7">4,938,0,0,0</text>
+  <text x="1321" y="285" style="font-size:4px">4,938,0,0,0</text>
   <line x1="1305" y1="283" x2="1310" y2="278"/>
   <path class="p4" d="M 1337 282 L 1341 276 L 1315 273 L 1310 278 L 1337 282"/>
-  <text x="1325" y="277" style="font-size:6">4,939,0,0,0</text>
+  <text x="1325" y="279" style="font-size:4px">4,939,0,0,0</text>
   <line x1="1310" y1="278" x2="1315" y2="273"/>
   <path class="p4" d="M 1367 280 L 1370 273 L 1345 270 L 1341 276 L 1367 280"/>
-  <text x="1355" y="275" style="font-size:6">4,940,0,0,0</text>
+  <text x="1355" y="277" style="font-size:4px">4,940,0,0,0</text>
   <path class="p4" d="M 1370 273 L 1373 267 L 1348 264 L 1345 270 L 1370 273"/>
-  <text x="1359" y="269" style="font-size:6">4,941,0,0,0</text>
+  <text x="1359" y="271" style="font-size:4px">4,941,0,0,0</text>
   <path class="p4" d="M 1341 276 L 1345 270 L 1319 267 L 1315 273 L 1341 276"/>
-  <text x="1330" y="272" style="font-size:6">4,942,0,0,0</text>
+  <text x="1330" y="274" style="font-size:4px">4,942,0,0,0</text>
   <line x1="1315" y1="273" x2="1319" y2="267"/>
   <path class="p4" d="M 1345 270 L 1348 264 L 1324 262 L 1319 267 L 1345 270"/>
-  <text x="1334" y="266" style="font-size:6">4,943,0,0,0</text>
+  <text x="1334" y="268" style="font-size:4px">4,943,0,0,0</text>
   <line x1="1319" y1="267" x2="1324" y2="262"/>
   <path class="p4" d="M 1422 272 L 1424 264 L 1400 262 L 1397 269 L 1422 272"/>
-  <text x="1411" y="267" style="font-size:6">4,944,0,0,0</text>
+  <text x="1411" y="269" style="font-size:4px">4,944,0,0,0</text>
   <path class="p4" d="M 1424 264 L 1425 256 L 1402 255 L 1400 262 L 1424 264"/>
-  <text x="1413" y="259" style="font-size:6">4,945,0,0,0</text>
+  <text x="1413" y="261" style="font-size:4px">4,945,0,0,0</text>
   <path class="p4" d="M 1397 269 L 1400 262 L 1376 260 L 1373 267 L 1397 269"/>
-  <text x="1387" y="265" style="font-size:6">4,946,0,0,0</text>
+  <text x="1387" y="267" style="font-size:4px">4,946,0,0,0</text>
   <path class="p4" d="M 1400 262 L 1402 255 L 1379 254 L 1376 260 L 1400 262"/>
-  <text x="1389" y="258" style="font-size:6">4,947,0,0,0</text>
+  <text x="1389" y="260" style="font-size:4px">4,947,0,0,0</text>
   <path class="p4" d="M 1425 256 L 1426 249 L 1404 248 L 1402 255 L 1425 256"/>
-  <text x="1414" y="252" style="font-size:6">4,948,0,0,0</text>
+  <text x="1414" y="254" style="font-size:4px">4,948,0,0,0</text>
   <path class="p4" d="M 1426 249 L 1428 241 L 1406 241 L 1404 248 L 1426 249"/>
-  <text x="1416" y="245" style="font-size:6">4,949,0,0,0</text>
+  <text x="1416" y="247" style="font-size:4px">4,949,0,0,0</text>
   <path class="p4" d="M 1402 255 L 1404 248 L 1382 248 L 1379 254 L 1402 255"/>
-  <text x="1392" y="251" style="font-size:6">4,950,0,0,0</text>
+  <text x="1392" y="253" style="font-size:4px">4,950,0,0,0</text>
   <path class="p4" d="M 1404 248 L 1406 241 L 1385 241 L 1382 248 L 1404 248"/>
-  <text x="1394" y="245" style="font-size:6">4,951,0,0,0</text>
+  <text x="1394" y="247" style="font-size:4px">4,951,0,0,0</text>
   <path class="p4" d="M 1373 267 L 1376 260 L 1352 259 L 1348 264 L 1373 267"/>
-  <text x="1362" y="262" style="font-size:6">4,952,0,0,0</text>
+  <text x="1362" y="264" style="font-size:4px">4,952,0,0,0</text>
   <path class="p4" d="M 1376 260 L 1379 254 L 1356 253 L 1352 259 L 1376 260"/>
-  <text x="1366" y="256" style="font-size:6">4,953,0,0,0</text>
+  <text x="1366" y="258" style="font-size:4px">4,953,0,0,0</text>
   <path class="p4" d="M 1348 264 L 1352 259 L 1329 257 L 1324 262 L 1348 264"/>
-  <text x="1338" y="260" style="font-size:6">4,954,0,0,0</text>
+  <text x="1338" y="262" style="font-size:4px">4,954,0,0,0</text>
   <line x1="1324" y1="262" x2="1329" y2="257"/>
   <path class="p4" d="M 1352 259 L 1356 253 L 1333 252 L 1329 257 L 1352 259"/>
-  <text x="1343" y="255" style="font-size:6">4,955,0,0,0</text>
+  <text x="1343" y="257" style="font-size:4px">4,955,0,0,0</text>
   <line x1="1329" y1="257" x2="1333" y2="252"/>
   <path class="p4" d="M 1379 254 L 1382 248 L 1360 247 L 1356 253 L 1379 254"/>
-  <text x="1369" y="250" style="font-size:6">4,956,0,0,0</text>
+  <text x="1369" y="252" style="font-size:4px">4,956,0,0,0</text>
   <path class="p4" d="M 1382 248 L 1385 241 L 1364 241 L 1360 247 L 1382 248"/>
-  <text x="1373" y="244" style="font-size:6">4,957,0,0,0</text>
+  <text x="1373" y="246" style="font-size:4px">4,957,0,0,0</text>
   <path class="p4" d="M 1356 253 L 1360 247 L 1338 246 L 1333 252 L 1356 253"/>
-  <text x="1347" y="249" style="font-size:6">4,958,0,0,0</text>
+  <text x="1347" y="251" style="font-size:4px">4,958,0,0,0</text>
   <line x1="1333" y1="252" x2="1338" y2="246"/>
   <path class="p4" d="M 1360 247 L 1364 241 L 1342 241 L 1338 246 L 1360 247"/>
-  <text x="1351" y="244" style="font-size:6">4,959,0,0,0</text>
+  <text x="1351" y="246" style="font-size:4px">4,959,0,0,0</text>
   <line x1="1338" y1="246" x2="1342" y2="241"/>
 
  <!-- legend -->
  <rect x="2000" y="96" width="386" height="199"/>
- <text x="2015" y="128" style="text-anchor:start; font-weight:bold; font-size:21">cell label</text>
-  <text x="2024" y="159" style="text-anchor:start; font-style:oblique; font-size:21">level_number,</text>
-  <text x="2024" y="191" style="text-anchor:start; font-style:oblique; font-size:21">cell_index,</text>
-  <text x="2024" y="222" style="text-anchor:start; font-style:oblique; font-size:21">material_id,</text>
-  <text x= "2024" y="254" style="text-anchor:start; font-style:oblique; font-size:21">subdomain_id,</text>
-  <text x= "2024" y="285" style="text-anchor:start; font-style:oblique; font-size:21">level_subdomain_id</text>
-  <text x="2000" y="322" style="text-anchor:start; font-size:21">azimuth: 0°, polar: 60°</text>
+ <text x="2015" y="128" style="text-anchor:start; font-weight:bold; font-size:21px">cell label</text>
+  <text x="2024" y="159" style="text-anchor:start; font-style:oblique; font-size:21px">level_number,</text>
+  <text x="2024" y="191" style="text-anchor:start; font-style:oblique; font-size:21px">cell_index,</text>
+  <text x="2024" y="222" style="text-anchor:start; font-style:oblique; font-size:21px">material_id,</text>
+  <text x= "2024" y="254" style="text-anchor:start; font-style:oblique; font-size:21px">subdomain_id,</text>
+  <text x= "2024" y="285" style="text-anchor:start; font-style:oblique; font-size:21px">level_subdomain_id</text>
+  <text x="2000" y="322" style="text-anchor:start; font-size:21px">azimuth: 0°, polar: 60°</text>
 
  <!-- colorbar -->
- <text x="2000" y="429" style="text-anchor:start; font-weight:bold; font-size:21">level_number</text>
+ <text x="2000" y="429" style="text-anchor:start; font-weight:bold; font-size:21px">level_number</text>
   <rect class="r0" x="2000" y="974" width="30" height="132"/>
-  <text x="2045.00" y="1047.00" style="text-anchor:start; font-size:21; font-weight:bold">0 min</text>
+  <text x="2045.00" y="1047.00" style="text-anchor:start; font-size:21px; font-weight:bold">0 min</text>
   <rect class="r1" x="2000" y="842" width="30" height="132"/>
-  <text x="2045.00" y="915.000" style="text-anchor:start; font-size:21">1</text>
+  <text x="2045.00" y="915.000" style="text-anchor:start; font-size:21px">1</text>
   <rect class="r2" x="2000" y="710" width="30" height="132"/>
-  <text x="2045.00" y="783.000" style="text-anchor:start; font-size:21">2</text>
+  <text x="2045.00" y="783.000" style="text-anchor:start; font-size:21px">2</text>
   <rect class="r3" x="2000" y="578" width="30" height="132"/>
-  <text x="2045.00" y="651.000" style="text-anchor:start; font-size:21">3</text>
+  <text x="2045.00" y="651.000" style="text-anchor:start; font-size:21px">3</text>
   <rect class="r4" x="2000" y="446" width="30" height="132"/>
-  <text x="2045.00" y="519.000" style="text-anchor:start; font-size:21; font-weight:bold">4 max</text>
+  <text x="2045.00" y="519.000" style="text-anchor:start; font-size:21px; font-weight:bold">4 max</text>
 
 </svg>


### PR DESCRIPTION
The font scaling in GridOut::write_svg() was broken since the units were missing. It has been fixed and an additional parameter GridOutFlags::Svg::cell_font_scaling has been introduced for tuning.