### PR TITLE
rework unify_pretty_function() in testsuite

### DIFF
--- a/tests/base/thread_validity_06.cc
+++ b/tests/base/thread_validity_06.cc
@@ -44,14 +44,14 @@ struct X
 void execute_ref (const X &x)
 {
   Assert (x.i == 0, ExcInternalError());
-  deallog << __PRETTY_FUNCTION__ << ' ' << x.i << std::endl;
+  deallog << unify_pretty_function(__PRETTY_FUNCTION__) << ' ' << x.i << std::endl;
   deallog << "OK" << std::endl;
 }
 
 void execute_value (X x)
 {
   Assert (x.i > 0, ExcInternalError());
-  deallog << __PRETTY_FUNCTION__ << ' ' << (x.i>0 ? "OK" : "not OK")
+  deallog << unify_pretty_function(__PRETTY_FUNCTION__) << ' ' << (x.i>0 ? "OK" : "not OK")
           << std::endl;
   deallog << "OK" << std::endl;
 }
@@ -85,5 +85,4 @@ int main()
 
   deallog.detach();
   logfile.close();
-  unify_pretty_function ("output");
 }

--- a/tests/base/threads_02.cc
+++ b/tests/base/threads_02.cc
@@ -22,1623 +22,1623 @@ template <int> struct X {};
 struct U {
   virtual ~U () {}
   X<0> foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_0_const ()const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_0_const () const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_0 () {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_1_const (X<1>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_1_const (X<1>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_1_const (X<1>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_1_const (X<1>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_1_const (X<1>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_1_const (X<1>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_1_const (X<1>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_1_const (X<1>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_1_const (X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_1_const (X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_1_const (const X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_1_const (const X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_1_const (X<1>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_1_const (X<1>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_1_const (X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_1_const (X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_1_const (const X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_1_const (const X<1>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_1 (X<1>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_1 (X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_1 (const X<1>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_2_const (X<1>,X<2>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_2_const (X<1>&,X<2>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_2_const (X<1>&,X<2>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_2_const (X<1>,X<2>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_2_const (X<1>&,X<2>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_2_const (X<1>&,X<2>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_2_const (X<1>,X<2>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_2_const (X<1>,X<2>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_2_const (X<1>&,X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_2_const (X<1>&,X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_2_const (const X<1>&,const X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_2_const (const X<1>&,const X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_2_const (X<1>,X<2>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_2_const (X<1>,X<2>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_2_const (X<1>&,X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_2_const (X<1>&,X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_2_const (const X<1>&,const X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_2_const (const X<1>&,const X<2>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_2 (X<1>,X<2>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_2 (X<1>&,X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_2 (const X<1>&,const X<2>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_3_const (X<1>,X<2>,X<3>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_3_const (X<1>&,X<2>&,X<3>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_3_const (X<1>&,X<2>&,X<3>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_3_const (X<1>,X<2>,X<3>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_3_const (X<1>&,X<2>&,X<3>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_3_const (X<1>&,X<2>&,X<3>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_3_const (X<1>,X<2>,X<3>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_3_const (X<1>,X<2>,X<3>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_3_const (X<1>&,X<2>&,X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_3_const (X<1>&,X<2>&,X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_3_const (const X<1>&,const X<2>&,const X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_3_const (const X<1>&,const X<2>&,const X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_3_const (X<1>,X<2>,X<3>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_3_const (X<1>,X<2>,X<3>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_3_const (X<1>&,X<2>&,X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_3_const (X<1>&,X<2>&,X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_3_const (const X<1>&,const X<2>&,const X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_3_const (const X<1>&,const X<2>&,const X<3>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_3 (X<1>,X<2>,X<3>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_3 (X<1>&,X<2>&,X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_3 (const X<1>&,const X<2>&,const X<3>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_4_const (X<1>,X<2>,X<3>,X<4>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_4_const (X<1>,X<2>,X<3>,X<4>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_4_const (X<1>,X<2>,X<3>,X<4>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_4_const (X<1>,X<2>,X<3>,X<4>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_4_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_4_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_4_const (X<1>,X<2>,X<3>,X<4>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_4_const (X<1>,X<2>,X<3>,X<4>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_4_const (X<1>&,X<2>&,X<3>&,X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_4_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_4_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_4 (X<1>,X<2>,X<3>,X<4>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_4 (X<1>&,X<2>&,X<3>&,X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_4 (const X<1>&,const X<2>&,const X<3>&,const X<4>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_5_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_5_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_5_const (X<1>,X<2>,X<3>,X<4>,X<5>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_5_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_5_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_5_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_5 (X<1>,X<2>,X<3>,X<4>,X<5>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_5 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_5 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_6_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_6_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_6_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_6_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_6_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_6_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_6 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_6 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_6 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_7_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_7_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_7_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_7_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_7_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_7_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_7 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_7 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_7 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   const X<0> & const_ref_foo_const_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual const X<0> & virtual_const_ref_foo_const_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&)const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> static_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static X<0> & static_ref_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   static const X<0> & static_const_ref_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> foo_const_ref_8_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   X<0> & ref_foo_const_ref_8_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_8_const (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_8_const (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_8_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_8_const (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) const {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_8 (X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_ref_8 (X<1>&,X<2>&,X<3>&,X<4>&,X<5>&,X<6>&,X<7>&,X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> virtual_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
   virtual X<0> & virtual_ref_foo_const_ref_8 (const X<1>&,const X<2>&,const X<3>&,const X<4>&,const X<5>&,const X<6>&,const X<7>&,const X<8>&) {
-    deallog << __PRETTY_FUNCTION__ << std::endl;
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x; return x;
   }
 };
@@ -2079,6 +2079,5 @@ X<8> x8;
 
   deallog.detach ();
   logfile.close ();
-  unify_pretty_function ("output");
   sort_file_contents ("output");
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -133,6 +133,29 @@ void sort_file_contents (const std::string &filename)
 }
 
 
+/**
+ * Replace all occurrences of @p from in @p input by @p to and return the new
+ * string.
+ * TODO: move this to Utilities.
+ */
+std::string replace(const std::string& input,
+		    const std::string& from,
+		    const std::string& to)
+{
+  if (from.empty())
+    return input;
+
+  std::string out = input;
+  std::string::size_type pos = out.find(from);
+  
+  while (pos != std::string::npos)
+    {
+      out.replace(pos, from.size(), to);
+      pos = out.find(from, pos + to.size());
+    }
+  return out;
+}
+
 
 /*
  * Replace all occurences of ' &' by '& ' from the given file to hopefully be
@@ -141,11 +164,14 @@ void sort_file_contents (const std::string &filename)
  * Also, while GCC prepends the name by "virtual " if the function is virtual,
  * Intel's ICC does not do that, so filter that out as well.
  */
-void unify_pretty_function (const std::string &filename)
+std::string unify_pretty_function (const std::string &text)
 {
-  int error = std::system ((std::string ("sed -i -e 's/ \\&/ \\& /g' -e 's/ & ,/\\&,/g' -e 's/ \\& )/\\&)/g' -e 's/ \\& /\\& /g' -e 's/^DEAL::virtual /DEAL::/g' ") + filename).c_str());
-
-  Assert (error == 0, ExcInternalError());
+  std::string t=text;
+  t=replace(t, " &", "& ");
+  t=replace(t, " & ,", "&,");
+  t=replace(t, " & ", "& ");
+  t=replace(t, "virtual ", "");
+  return t;
 }
 
 


### PR DESCRIPTION
We used to call into sed to do some string replacement in order to
normalize the output of __PRETTY_FUNCTION__. This is crazy and won't
work on MAC OS (sed doesn't accept -e). Do this using string replacement
instead.