### PR TITLE
disable muparser warnings

### DIFF
--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -20,7 +20,9 @@
 
 
 #ifdef DEAL_II_WITH_MUPARSER
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <muParser.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #else
 
 namespace fparser


### PR DESCRIPTION
suppress -Wnested-anon-types warning with clang 3.6 in muParser.