### PR TITLE
fix pragma warnings warnings

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -327,6 +327,7 @@ CHECK_CXX_SOURCE_COMPILES(
   "
   _Pragma(\"GCC diagnostic push\")
   _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunknown-pragmas\\\\\\\"\")
   _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wpragmas\\\\\\\"\")
   int main() { return 0; }
   _Pragma(\"GCC diagnostic pop\")

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -290,6 +290,7 @@
 
 #  define DEAL_II_DISABLE_EXTRA_DIAGNOSTICS                      \
 _Pragma("GCC diagnostic push")                                   \
+_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")          \
 _Pragma("GCC diagnostic ignored \"-Wpragmas\"")                  \
 _Pragma("GCC diagnostic ignored \"-Wextra\"")                    \
 _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")       \


### PR DESCRIPTION
PR #1076 disabled warnings due to disabling unknown warnings with a
pragma. This causes the warning

src.cxx:4:3: error: unknown warning group '-Wpragmas', ignored [-Werror,-Wunknown-pragmas]
  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")

with Clang 3.4.0, which in turn disables disabling warnings. It seems it supports Wunknown-pragmas which is okay to be used with gcc too. Sigh.