### PR TITLE
Adjust the precision of the output of a test.

### DIFF
--- a/tests/base/quadrature_chebyshev.cc
+++ b/tests/base/quadrature_chebyshev.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -79,7 +79,8 @@ int main()
   deallog.attach(logfile);
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
-
+  deallog << std::setprecision(8);
+  
   deallog.push("1d Gauss-Chebyshev\n");
   deallog.pop();
   check_quadrature<QGaussChebyshev<1>,1>(&exact_monomials[0]);

--- a/tests/base/quadrature_chebyshev.output
+++ b/tests/base/quadrature_chebyshev.output
@@ -1,100 +1,100 @@
 
 DEAL::Quadrature order: 1 is exact for polynomials of degree: 0
 DEAL::Quadrature order: 1 is exact for polynomials of degree: 1
-DEAL::error: 0.392699
-DEAL::error: 0.589049
-DEAL::error: 0.662680
-DEAL::error: 0.674952
-DEAL::error: 0.659612
-DEAL::error: 0.633534
-DEAL::error: 0.604676
-DEAL::error: 0.576537
-DEAL::error: 0.550471
-DEAL::error: 0.526845
-DEAL::error: 0.505596
-DEAL::error: 0.486504
-DEAL::error: 0.469307
-DEAL::error: 0.453753
-DEAL::error: 0.439618
-DEAL::error: 0.426710
-DEAL::error: 0.414869
-DEAL::error: 0.403957
-DEAL::error: 0.393861
-DEAL::error: 0.384484
-DEAL::error: 0.375747
-DEAL::error: 0.367579
-DEAL::error: 0.359921
-DEAL::error: 0.352723
-DEAL::error: 0.345940
-DEAL::error: 0.339533
-DEAL::error: 0.333470
-DEAL::error: 0.327721
-DEAL::error: 0.322259
-DEAL::error: 0.317061
+DEAL::error: 0.39269908
+DEAL::error: 0.58904862
+DEAL::error: 0.66267970
+DEAL::error: 0.67495155
+DEAL::error: 0.65961174
+DEAL::error: 0.63353407
+DEAL::error: 0.60467605
+DEAL::error: 0.57653709
+DEAL::error: 0.55047140
+DEAL::error: 0.52684450
+DEAL::error: 0.50559572
+DEAL::error: 0.48650373
+DEAL::error: 0.46930665
+DEAL::error: 0.45375258
+DEAL::error: 0.43961775
+DEAL::error: 0.42671037
+DEAL::error: 0.41486863
+DEAL::error: 0.40395671
+DEAL::error: 0.39386064
+DEAL::error: 0.38448443
+DEAL::error: 0.37574686
+DEAL::error: 0.36757881
+DEAL::error: 0.35992110
+DEAL::error: 0.35272276
+DEAL::error: 0.34593968
+DEAL::error: 0.33953341
+DEAL::error: 0.33347033
+DEAL::error: 0.32772084
+DEAL::error: 0.32225883
+DEAL::error: 0.31706111
 Quadrature order: 2 is exact for polynomials of degree: 0
 Quadrature order: 2 is exact for polynomials of degree: 1
 Quadrature order: 2 is exact for polynomials of degree: 2
 Quadrature order: 2 is exact for polynomials of degree: 3
-error: 0.0245437
-error: 0.0613592
-error: 0.101243
-error: 0.139592
-error: 0.174394
-error: 0.204930
-error: 0.231116
-error: 0.253173
-error: 0.271460
-error: 0.286385
-error: 0.298359
-error: 0.307772
-error: 0.314982
-error: 0.320310
-error: 0.324042
-error: 0.326427
-error: 0.327683
-error: 0.327997
-error: 0.327531
-error: 0.326424
-error: 0.324793
-error: 0.322739
-error: 0.320347
-error: 0.317689
-error: 0.314825
-error: 0.311806
-error: 0.308674
-error: 0.305466
+error: 0.024543693
+error: 0.061359232
+error: 0.10124273
+error: 0.13959225
+error: 0.17439444
+error: 0.20493025
+error: 0.23111578
+error: 0.25317274
+error: 0.27145992
+error: 0.28638515
+error: 0.29835917
+error: 0.30777198
+error: 0.31498162
+error: 0.32030984
+error: 0.32404161
+error: 0.32642676
+error: 0.32768257
+error: 0.32799686
+error: 0.32753117
+error: 0.32642388
+error: 0.32479304
+error: 0.32273902
+error: 0.32034692
+error: 0.31768861
+error: 0.31482461
+error: 0.31180573
+error: 0.30867443
+error: 0.30546610
 Quadrature order: 3 is exact for polynomials of degree: 0
 Quadrature order: 3 is exact for polynomials of degree: 1
 Quadrature order: 3 is exact for polynomials of degree: 2
 Quadrature order: 3 is exact for polynomials of degree: 3
 Quadrature order: 3 is exact for polynomials of degree: 4
 Quadrature order: 3 is exact for polynomials of degree: 5
-error: 0.00153398
-error: 0.00536893
-error: 0.0115049
-error: 0.0195583
-error: 0.0290318
-error: 0.0394491
-error: 0.0504068
-error: 0.0615852
-error: 0.0727416
-error: 0.0836970
-error: 0.0943235
-error: 0.104533
-error: 0.114266
-error: 0.123487
-error: 0.132177
-error: 0.140329
-error: 0.147947
-error: 0.155038
-error: 0.161618
-error: 0.167703
-error: 0.173314
-error: 0.178472
-error: 0.183198
-error: 0.187514
-error: 0.191445
-error: 0.195010
+error: 0.0015339808
+error: 0.0053689328
+error: 0.011504856
+error: 0.019558255
+error: 0.029031785
+error: 0.039449072
+error: 0.050406773
+error: 0.061585247
+error: 0.072741600
+error: 0.083696996
+error: 0.094323516
+error: 0.10453263
+error: 0.11426578
+error: 0.12348697
+error: 0.13217708
+error: 0.14032948
+error: 0.14794676
+error: 0.15503821
+error: 0.16161791
+error: 0.16770332
+error: 0.17331416
+error: 0.17847159
+error: 0.18319760
+error: 0.18751448
+error: 0.19144451
+error: 0.19500968
 Quadrature order: 4 is exact for polynomials of degree: 0
 Quadrature order: 4 is exact for polynomials of degree: 1
 Quadrature order: 4 is exact for polynomials of degree: 2
@@ -103,30 +103,30 @@ Quadrature order: 4 is exact for polynomials of degree: 4
 Quadrature order: 4 is exact for polynomials of degree: 5
 Quadrature order: 4 is exact for polynomials of degree: 6
 Quadrature order: 4 is exact for polynomials of degree: 7
-error: 9.58738e-05
-error: 0.000431432
-error: 0.00113850
-error: 0.00230696
-error: 0.00397951
-error: 0.00615877
-error: 0.00881824
-error: 0.0119128
-error: 0.0153874
-error: 0.0191830
-error: 0.0232409
-error: 0.0275055
-error: 0.0319257
-error: 0.0364556
-error: 0.0410548
-error: 0.0456881
-error: 0.0503251
-error: 0.0549402
-error: 0.0595116
-error: 0.0640213
-error: 0.0684542
-error: 0.0727982
-error: 0.0770434
-error: 0.0811819
+error: 9.5873799e-05
+error: 0.00043143210
+error: 0.0011385014
+error: 0.0023069633
+error: 0.0039795117
+error: 0.0061587681
+error: 0.0088182361
+error: 0.011912835
+error: 0.015387410
+error: 0.019182960
+error: 0.023240852
+error: 0.027505462
+error: 0.031925685
+error: 0.036455634
+error: 0.041054835
+error: 0.045688085
+error: 0.050325122
+error: 0.054940201
+error: 0.059511627
+error: 0.064021291
+error: 0.068454231
+error: 0.072798217
+error: 0.077043387
+error: 0.081181919
 Quadrature order: 5 is exact for polynomials of degree: 0
 Quadrature order: 5 is exact for polynomials of degree: 1
 Quadrature order: 5 is exact for polynomials of degree: 2
@@ -137,28 +137,28 @@ Quadrature order: 5 is exact for polynomials of degree: 6
 Quadrature order: 5 is exact for polynomials of degree: 7
 Quadrature order: 5 is exact for polynomials of degree: 8
 Quadrature order: 5 is exact for polynomials of degree: 9
-error: 5.99211e-06
-error: 3.29566e-05
-error: 0.000103364
-error: 0.000243430
-error: 0.000479252
-error: 0.000833898
-error: 0.00132568
-error: 0.00196748
-error: 0.00276677
-error: 0.00372614
-error: 0.00484398
-error: 0.00611534
-error: 0.00753270
-error: 0.00908665
-error: 0.0107665
-error: 0.0125609
-error: 0.0144582
-error: 0.0164464
-error: 0.0185142
-error: 0.0206503
-error: 0.0228443
-error: 0.0250860
+error: 5.9921125e-06
+error: 3.2956618e-05
+error: 0.00010336394
+error: 0.00024342957
+error: 0.00047925196
+error: 0.00083389842
+error: 0.0013256847
+error: 0.0019674844
+error: 0.0027667749
+error: 0.0037261356
+error: 0.0048439762
+error: 0.0061153423
+error: 0.0075327001
+error: 0.0090866477
+error: 0.010766529
+error: 0.012560944
+error: 0.014458155
+error: 0.016446410
+error: 0.018514179
+error: 0.020650336
+error: 0.022844280
+error: 0.025086015
 Quadrature order: 6 is exact for polynomials of degree: 0
 Quadrature order: 6 is exact for polynomials of degree: 1
 Quadrature order: 6 is exact for polynomials of degree: 2
@@ -171,26 +171,26 @@ Quadrature order: 6 is exact for polynomials of degree: 8
 Quadrature order: 6 is exact for polynomials of degree: 9
 Quadrature order: 6 is exact for polynomials of degree: 10
 Quadrature order: 6 is exact for polynomials of degree: 11
-error: 3.74507e-07
-error: 2.43430e-06
-error: 8.84773e-06
-error: 2.37578e-05
-error: 5.26065e-05
-error: 0.000101766
-error: 0.000178091
-error: 0.000288475
-error: 0.000439474
-error: 0.000637015
-error: 0.000886200
-error: 0.00119119
-error: 0.00155517
-error: 0.00198033
-error: 0.00246797
-error: 0.00301852
-error: 0.00363165
-error: 0.00430640
-error: 0.00504122
-error: 0.00583412
+error: 3.7450703e-07
+error: 2.4342957e-06
+error: 8.8477285e-06
+error: 2.3757790e-05
+error: 5.2606534e-05
+error: 0.00010176643
+error: 0.00017809126
+error: 0.00028847501
+error: 0.00043947365
+error: 0.00063701483
+error: 0.00088620005
+error: 0.0011911910
+error: 0.0015551660
+error: 0.0019803309
+error: 0.0024679688
+error: 0.0030185157
+error: 0.0036316516
+error: 0.0043063989
+error: 0.0050412208
+error: 0.0058341175
 Quadrature order: 7 is exact for polynomials of degree: 0
 Quadrature order: 7 is exact for polynomials of degree: 1
 Quadrature order: 7 is exact for polynomials of degree: 2
@@ -205,24 +205,24 @@ Quadrature order: 7 is exact for polynomials of degree: 10
 Quadrature order: 7 is exact for polynomials of degree: 11
 Quadrature order: 7 is exact for polynomials of degree: 12
 Quadrature order: 7 is exact for polynomials of degree: 13
-error: 2.34067e-08
-error: 1.75550e-07
-error: 7.25607e-07
-error: 2.18853e-06
-error: 5.38582e-06
-error: 1.14734e-05
-error: 2.19345e-05
-error: 3.85421e-05
-error: 6.33000e-05
-error: 9.83716e-05
-error: 0.000146004
-error: 0.000208456
-error: 0.000287930
-error: 0.000386517
-error: 0.000506154
-error: 0.000648583
-error: 0.000815335
-error: 0.00100771
+error: 2.3406690e-08
+error: 1.7555017e-07
+error: 7.2560737e-07
+error: 2.1885254e-06
+error: 5.3858243e-06
+error: 1.1473438e-05
+error: 2.1934514e-05
+error: 3.8542074e-05
+error: 6.3300003e-05
+error: 9.8371627e-05
+error: 0.00014600420
+error: 0.00020845589
+error: 0.00028792969
+error: 0.00038651725
+error: 0.00050615354
+error: 0.00064858280
+error: 0.00081533491
+error: 0.0010077113
 Quadrature order: 8 is exact for polynomials of degree: 0
 Quadrature order: 8 is exact for polynomials of degree: 1
 Quadrature order: 8 is exact for polynomials of degree: 2
@@ -239,22 +239,22 @@ Quadrature order: 8 is exact for polynomials of degree: 12
 Quadrature order: 8 is exact for polynomials of degree: 13
 Quadrature order: 8 is exact for polynomials of degree: 14
 Quadrature order: 8 is exact for polynomials of degree: 15
-error: 1.46292e-09
-error: 1.24348e-08
-error: 5.76024e-08
-error: 1.92831e-07
-error: 5.22250e-07
-error: 1.21529e-06
-error: 2.52120e-06
-error: 4.77919e-06
-error: 8.42332e-06
-error: 1.39818e-05
-error: 2.20713e-05
-error: 3.33869e-05
-error: 4.86892e-05
-error: 6.87891e-05
-error: 9.45316e-05
-error: 0.000126780
+error: 1.4629181e-09
+error: 1.2434804e-08
+error: 5.7602399e-08
+error: 1.9283089e-07
+error: 5.2225033e-07
+error: 1.2152906e-06
+error: 2.5211950e-06
+error: 4.7791884e-06
+error: 8.4233195e-06
+error: 1.3981797e-05
+error: 2.2071266e-05
+error: 3.3386872e-05
+error: 4.8689189e-05
+error: 6.8789085e-05
+error: 9.4531584e-05
+error: 0.00012677959
 Quadrature order: 9 is exact for polynomials of degree: 0
 Quadrature order: 9 is exact for polynomials of degree: 1
 Quadrature order: 9 is exact for polynomials of degree: 2
@@ -274,19 +274,19 @@ Quadrature order: 9 is exact for polynomials of degree: 15
 Quadrature order: 9 is exact for polynomials of degree: 16
 Quadrature order: 9 is exact for polynomials of degree: 17
 error: 0
-error: 8.68607e-10
-error: 4.45733e-09
-error: 1.64007e-08
-error: 4.84845e-08
-error: 1.22394e-07
-error: 2.73929e-07
-error: 5.57414e-07
-error: 1.04990e-06
-error: 1.85483e-06
-error: 3.10482e-06
-error: 4.96350e-06
-error: 7.62622e-06
-error: 1.13196e-05
+error: 8.6860725e-10
+error: 4.4573282e-09
+error: 1.6400683e-08
+error: 4.8484519e-08
+error: 1.2239385e-07
+error: 2.7392909e-07
+error: 5.5741384e-07
+error: 1.0499016e-06
+error: 1.8548262e-06
+error: 3.1048178e-06
+error: 4.9635047e-06
+error: 7.6262182e-06
+error: 1.1319606e-05
 Quadrature order: 10 is exact for polynomials of degree: 0
 Quadrature order: 10 is exact for polynomials of degree: 1
 Quadrature order: 10 is exact for polynomials of degree: 2
@@ -309,16 +309,16 @@ Quadrature order: 10 is exact for polynomials of degree: 18
 Quadrature order: 10 is exact for polynomials of degree: 19
 error: 0
 error: 0
-error: 3.37871e-10
-error: 1.35541e-09
-error: 4.34348e-09
-error: 1.18239e-08
-error: 2.84031e-08
-error: 6.17703e-08
-error: 1.23862e-07
-error: 2.32137e-07
-error: 4.10882e-07
-error: 6.92494e-07
+error: 3.3787121e-10
+error: 1.3554135e-09
+error: 4.3434845e-09
+error: 1.1823930e-08
+error: 2.8403136e-08
+error: 6.1770346e-08
+error: 1.2386241e-07
+error: 2.3213670e-07
+error: 4.1088196e-07
+error: 6.9249357e-07
 Quadrature order: 11 is exact for polynomials of degree: 0
 Quadrature order: 11 is exact for polynomials of degree: 1
 Quadrature order: 11 is exact for polynomials of degree: 2
@@ -344,13 +344,13 @@ Quadrature order: 11 is exact for polynomials of degree: 21
 error: 0
 error: 0
 error: 0
-error: 1.09379e-10
-error: 3.77701e-10
-error: 1.10304e-09
-error: 2.83114e-09
-error: 6.55445e-09
-error: 1.39440e-08
-error: 2.76394e-08
+error: 1.0937938e-10
+error: 3.7770106e-10
+error: 1.1030416e-09
+error: 2.8311406e-09
+error: 6.5544477e-09
+error: 1.3943958e-08
+error: 2.7639438e-08
 Quadrature order: 12 is exact for polynomials of degree: 0
 Quadrature order: 12 is exact for polynomials of degree: 1
 Quadrature order: 12 is exact for polynomials of degree: 2
@@ -381,8 +381,8 @@ error: 0
 error: 0
 error: 0
 error: 0
-error: 2.72838e-10
-error: 6.70047e-10
+error: 2.7283785e-10
+error: 6.7004710e-10
 Quadrature order: 13 is exact for polynomials of degree: 0
 Quadrature order: 13 is exact for polynomials of degree: 1
 Quadrature order: 13 is exact for polynomials of degree: 2
@@ -544,101 +544,101 @@ Quadrature order: 17 is exact for polynomials of degree: 29
 Quadrature order: 17 is exact for polynomials of degree: 30
 Quadrature order: 17 is exact for polynomials of degree: 31
 Quadrature order: 1 is exact for polynomials of degree: 0
-error: 1.57080
-error: 1.96350
-error: 2.15984
-error: 2.28256
-error: 2.36847
-error: 2.43289
-error: 2.48351
-error: 2.52464
-error: 2.55892
-error: 2.58805
-error: 2.61321
-error: 2.63523
-error: 2.65471
-error: 2.67209
-error: 2.68774
-error: 2.70193
-error: 2.71486
-error: 2.72671
-error: 2.73763
-error: 2.74773
-error: 2.75711
-error: 2.76585
-error: 2.77401
-error: 2.78167
-error: 2.78887
-error: 2.79565
-error: 2.80206
-error: 2.80812
-error: 2.81387
-error: 2.81933
-error: 2.82453
+error: 1.5707963
+error: 1.9634954
+error: 2.1598449
+error: 2.2825634
+error: 2.3684663
+error: 2.4328935
+error: 2.4835149
+error: 2.5246448
+error: 2.5589196
+error: 2.5880533
+error: 2.6132142
+error: 2.6352299
+error: 2.6547054
+error: 2.6720943
+error: 2.6877442
+error: 2.7019270
+error: 2.7148583
+error: 2.7267120
+error: 2.7376300
+error: 2.7477290
+error: 2.7571067
+error: 2.7658450
+error: 2.7740135
+error: 2.7816714
+error: 2.7888698
+error: 2.7956529
+error: 2.8020592
+error: 2.8081223
+error: 2.8138718
+error: 2.8193338
+error: 2.8245315
 Quadrature order: 2 is exact for polynomials of degree: 0
 Quadrature order: 2 is exact for polynomials of degree: 1
 Quadrature order: 2 is exact for polynomials of degree: 2
-error: 0.0981748
-error: 0.196350
-error: 0.276117
-error: 0.339010
-error: 0.389248
-error: 0.430282
-error: 0.464533
-error: 0.493660
-error: 0.518820
-error: 0.540835
-error: 0.560310
-error: 0.577699
-error: 0.593349
-error: 0.607532
-error: 0.620463
-error: 0.632317
-error: 0.643235
-error: 0.653334
-error: 0.662712
-error: 0.671450
-error: 0.679618
-error: 0.687276
-error: 0.694475
-error: 0.701258
-error: 0.707664
-error: 0.713727
-error: 0.719477
-error: 0.724939
-error: 0.730136
+error: 0.098174770
+error: 0.19634954
+error: 0.27611654
+error: 0.33900975
+error: 0.38924762
+error: 0.43028161
+error: 0.46453253
+error: 0.49366018
+error: 0.51881957
+error: 0.54083496
+error: 0.56031036
+error: 0.57769916
+error: 0.59334910
+error: 0.60753187
+error: 0.62046321
+error: 0.63231694
+error: 0.64323485
+error: 0.65333392
+error: 0.66271163
+error: 0.67144994
+error: 0.67961837
+error: 0.68727627
+error: 0.69447469
+error: 0.70125783
+error: 0.70766412
+error: 0.71372721
+error: 0.71947670
+error: 0.72493872
+error: 0.73013644
 Quadrature order: 3 is exact for polynomials of degree: 0
 Quadrature order: 3 is exact for polynomials of degree: 1
 Quadrature order: 3 is exact for polynomials of degree: 2
 Quadrature order: 3 is exact for polynomials of degree: 3
 Quadrature order: 3 is exact for polynomials of degree: 4
-error: 0.00613592
-error: 0.0184078
-error: 0.0348981
-error: 0.0536893
-error: 0.0733435
-error: 0.0929077
-error: 0.111805
-error: 0.129722
-error: 0.146514
-error: 0.162147
-error: 0.176647
-error: 0.190078
-error: 0.202517
-error: 0.214048
-error: 0.224755
-error: 0.234716
-error: 0.244004
-error: 0.252683
-error: 0.260813
-error: 0.268445
-error: 0.275627
-error: 0.282399
-error: 0.288799
-error: 0.294857
-error: 0.300603
-error: 0.306063
-error: 0.311260
+error: 0.0061359232
+error: 0.018407769
+error: 0.034898063
+error: 0.053689328
+error: 0.073343456
+error: 0.092907704
+error: 0.11180533
+error: 0.12972174
+error: 0.14651417
+error: 0.16214691
+error: 0.17664749
+error: 0.19007798
+error: 0.20251695
+error: 0.21404842
+error: 0.22475541
+error: 0.23471643
+error: 0.24400378
+error: 0.25268295
+error: 0.26081267
+error: 0.26844524
+error: 0.27562708
+error: 0.28239936
+error: 0.28879855
+error: 0.29485700
+error: 0.30060345
+error: 0.30606347
+error: 0.31125989
 Quadrature order: 4 is exact for polynomials of degree: 0
 Quadrature order: 4 is exact for polynomials of degree: 1
 Quadrature order: 4 is exact for polynomials of degree: 2
@@ -646,31 +646,31 @@ Quadrature order: 4 is exact for polynomials of degree: 3
 Quadrature order: 4 is exact for polynomials of degree: 4
 Quadrature order: 4 is exact for polynomials of degree: 5
 Quadrature order: 4 is exact for polynomials of degree: 6
-error: 0.000383495
-error: 0.00153398
-error: 0.00366717
-error: 0.00683101
-error: 0.0109581
-error: 0.0159180
-error: 0.0215557
-error: 0.0277145
-error: 0.0342496
-error: 0.0410338
-error: 0.0479596
-error: 0.0549384
-error: 0.0618992
-error: 0.0687861
-error: 0.0755563
-error: 0.0821780
-error: 0.0886283
-error: 0.0948915
-error: 0.100958
-error: 0.106822
-error: 0.112482
-error: 0.117940
-error: 0.123198
-error: 0.128261
-error: 0.133134
+error: 0.00038349520
+error: 0.0015339808
+error: 0.0036671728
+error: 0.0068310082
+error: 0.010958076
+error: 0.015918047
+error: 0.021555688
+error: 0.027714480
+error: 0.034249575
+error: 0.041033822
+error: 0.047959620
+error: 0.054938444
+error: 0.061899198
+error: 0.068786072
+error: 0.075556301
+error: 0.082178012
+error: 0.088628296
+error: 0.094891502
+error: 0.10095779
+error: 0.10682192
+error: 0.11248221
+error: 0.11793975
+error: 0.12319768
+error: 0.12826067
+error: 0.13313449
 Quadrature order: 5 is exact for polynomials of degree: 0
 Quadrature order: 5 is exact for polynomials of degree: 1
 Quadrature order: 5 is exact for polynomials of degree: 2
@@ -680,29 +680,29 @@ Quadrature order: 5 is exact for polynomials of degree: 5
 Quadrature order: 5 is exact for polynomials of degree: 6
 Quadrature order: 5 is exact for polynomials of degree: 7
 Quadrature order: 5 is exact for polynomials of degree: 8
-error: 2.39684e-05
-error: 0.000119842
-error: 0.000346044
-error: 0.000758002
-error: 0.00139972
-error: 0.00230041
-error: 0.00347458
-error: 0.00492397
-error: 0.00664026
-error: 0.00860774
-error: 0.0108058
-error: 0.0132108
-error: 0.0157980
-error: 0.0185421
-error: 0.0214187
-error: 0.0244044
-error: 0.0274776
-error: 0.0306184
-error: 0.0338085
-error: 0.0370317
-error: 0.0402736
-error: 0.0435213
-error: 0.0467638
+error: 2.3968450e-05
+error: 0.00011984225
+error: 0.00034604449
+error: 0.00075800223
+error: 0.0013997200
+error: 0.0023004094
+error: 0.0034745767
+error: 0.0049239716
+error: 0.0066402598
+error: 0.0086077442
+error: 0.010805794
+error: 0.013210849
+error: 0.015797984
+error: 0.018542080
+error: 0.021418652
+error: 0.024404417
+error: 0.027477649
+error: 0.030618380
+error: 0.033808491
+error: 0.037031710
+error: 0.040273572
+error: 0.043521324
+error: 0.046763821
 Quadrature order: 6 is exact for polynomials of degree: 0
 Quadrature order: 6 is exact for polynomials of degree: 1
 Quadrature order: 6 is exact for polynomials of degree: 2
@@ -714,27 +714,27 @@ Quadrature order: 6 is exact for polynomials of degree: 7
 Quadrature order: 6 is exact for polynomials of degree: 8
 Quadrature order: 6 is exact for polynomials of degree: 9
 Quadrature order: 6 is exact for polynomials of degree: 10
-error: 1.49803e-06
-error: 8.98817e-06
-error: 3.04287e-05
-error: 7.66803e-05
-error: 0.000160365
-error: 0.000294597
-error: 0.000491871
-error: 0.000763248
-error: 0.00111784
-error: 0.00156257
-error: 0.00210215
-error: 0.00273916
-error: 0.00347431
-error: 0.00430661
-error: 0.00523373
-error: 0.00625219
-error: 0.00735763
-error: 0.00854507
-error: 0.00980903
-error: 0.0111438
-error: 0.0125434
+error: 1.4980281e-06
+error: 8.9881687e-06
+error: 3.0428696e-05
+error: 7.6680314e-05
+error: 0.00016036508
+error: 0.00029459659
+error: 0.00049187109
+error: 0.00076324825
+error: 0.0011178407
+error: 0.0015625730
+error: 0.0021021490
+error: 0.0027391638
+error: 0.0034743070
+error: 0.0043066135
+error: 0.0052337318
+error: 0.0062521880
+error: 0.0073576331
+error: 0.0085450656
+error: 0.0098090265
+error: 0.011143766
+error: 0.012543382
 Quadrature order: 7 is exact for polynomials of degree: 0
 Quadrature order: 7 is exact for polynomials of degree: 1
 Quadrature order: 7 is exact for polynomials of degree: 2
@@ -748,25 +748,25 @@ Quadrature order: 7 is exact for polynomials of degree: 9
 Quadrature order: 7 is exact for polynomials of degree: 10
 Quadrature order: 7 is exact for polynomials of degree: 11
 Quadrature order: 7 is exact for polynomials of degree: 12
-error: 9.36268e-08
-error: 6.55387e-07
-error: 2.54548e-06
-error: 7.25607e-06
-error: 1.69611e-05
-error: 3.44693e-05
-error: 6.31039e-05
-error: 0.000106539
-error: 0.000168622
-error: 0.000253200
-error: 0.000363975
-error: 0.000504378
-error: 0.000677482
-error: 0.000885938
-error: 0.00113194
-error: 0.00141723
-error: 0.00174307
-error: 0.00211028
-error: 0.00251928
+error: 9.3626758e-08
+error: 6.5538730e-07
+error: 2.5454775e-06
+error: 7.2560737e-06
+error: 1.6961072e-05
+error: 3.4469276e-05
+error: 6.3103909e-05
+error: 0.00010653907
+error: 0.00016862157
+error: 0.00025320001
+error: 0.00036397502
+error: 0.00050437816
+error: 0.00067748163
+error: 0.00088593752
+error: 0.0011319434
+error: 0.0014172299
+error: 0.0017430663
+error: 0.0021102786
+error: 0.0025192783
 Quadrature order: 8 is exact for polynomials of degree: 0
 Quadrature order: 8 is exact for polynomials of degree: 1
 Quadrature order: 8 is exact for polynomials of degree: 2
@@ -782,23 +782,23 @@ Quadrature order: 8 is exact for polynomials of degree: 11
 Quadrature order: 8 is exact for polynomials of degree: 12
 Quadrature order: 8 is exact for polynomials of degree: 13
 Quadrature order: 8 is exact for polynomials of degree: 14
-error: 5.85167e-09
-error: 4.68134e-08
-error: 2.05174e-07
-error: 6.52827e-07
-error: 1.68727e-06
-error: 3.76020e-06
-error: 7.49429e-06
-error: 1.36865e-05
-error: 2.32985e-05
-error: 3.74370e-05
-error: 5.73254e-05
-error: 8.42721e-05
-error: 0.000119636
-error: 0.000164794
-error: 0.000221108
-error: 0.000289897
-error: 0.000372415
+error: 5.8516728e-09
+error: 4.6813379e-08
+error: 2.0517426e-07
+error: 6.5282719e-07
+error: 1.6872703e-06
+error: 3.7602023e-06
+error: 7.4942922e-06
+error: 1.3686487e-05
+error: 2.3298543e-05
+error: 3.7436975e-05
+error: 5.7325369e-05
+error: 8.4272105e-05
+error: 0.00011963629
+error: 0.00016479418
+error: 0.00022110777
+error: 0.00028989686
+error: 0.00037241505
 Quadrature order: 9 is exact for polynomials of degree: 0
 Quadrature order: 9 is exact for polynomials of degree: 1
 Quadrature order: 9 is exact for polynomials of degree: 2
@@ -816,21 +816,21 @@ Quadrature order: 9 is exact for polynomials of degree: 13
 Quadrature order: 9 is exact for polynomials of degree: 14
 Quadrature order: 9 is exact for polynomials of degree: 15
 Quadrature order: 9 is exact for polynomials of degree: 16
-error: 3.65729e-10
-error: 3.29157e-09
-error: 1.60692e-08
-error: 5.64595e-08
-error: 1.59907e-07
-error: 3.87876e-07
-error: 8.36358e-07
-error: 1.64357e-06
-error: 2.99610e-06
-error: 5.13285e-06
-error: 8.34672e-06
-error: 1.29838e-05
-error: 1.94404e-05
-error: 2.81583e-05
-error: 3.96186e-05
+error: 3.6572933e-10
+error: 3.2915654e-09
+error: 1.6069241e-08
+error: 5.6459494e-08
+error: 1.5990666e-07
+error: 3.8787616e-07
+error: 8.3635796e-07
+error: 1.6435745e-06
+error: 2.9960994e-06
+error: 5.1328525e-06
+error: 8.3467181e-06
+error: 1.2983784e-05
+error: 1.9440393e-05
+error: 2.8158344e-05
+error: 3.9618622e-05
 Quadrature order: 10 is exact for polynomials of degree: 0
 Quadrature order: 10 is exact for polynomials of degree: 1
 Quadrature order: 10 is exact for polynomials of degree: 2
@@ -851,18 +851,18 @@ Quadrature order: 10 is exact for polynomials of degree: 16
 Quadrature order: 10 is exact for polynomials of degree: 17
 Quadrature order: 10 is exact for polynomials of degree: 18
 error: 0
-error: 2.28582e-10
-error: 1.23005e-09
-error: 4.73020e-09
-error: 1.45707e-08
-error: 3.82227e-08
-error: 8.86795e-08
-error: 1.86649e-07
-error: 3.62901e-07
-error: 6.60600e-07
-error: 1.13747e-06
-error: 1.86765e-06
-error: 2.94310e-06
+error: 2.2858155e-10
+error: 1.2300518e-09
+error: 4.7301976e-09
+error: 1.4570697e-08
+error: 3.8222664e-08
+error: 8.8679476e-08
+error: 1.8664918e-07
+error: 3.6290079e-07
+error: 6.6059954e-07
+error: 1.1374698e-06
+error: 1.8676453e-06
+error: 2.9430977e-06
 Quadrature order: 11 is exact for polynomials of degree: 0
 Quadrature order: 11 is exact for polynomials of degree: 1
 Quadrature order: 11 is exact for polynomials of degree: 2
@@ -887,14 +887,14 @@ Quadrature order: 11 is exact for polynomials of degree: 20
 error: 0
 error: 0
 error: 0
-error: 3.86087e-10
-error: 1.28521e-09
-error: 3.62593e-09
-error: 9.00818e-09
-error: 2.02224e-08
-error: 4.17846e-08
-error: 8.05651e-08
-error: 1.46489e-07
+error: 3.8608716e-10
+error: 1.2852094e-09
+error: 3.6259320e-09
+error: 9.0081752e-09
+error: 2.0222434e-08
+error: 4.1784606e-08
+error: 8.0565090e-08
+error: 1.4648902e-07
 Quadrature order: 12 is exact for polynomials of degree: 0
 Quadrature order: 12 is exact for polynomials of degree: 1
 Quadrature order: 12 is exact for polynomials of degree: 2
@@ -922,11 +922,11 @@ error: 0
 error: 0
 error: 0
 error: 0
-error: 1.10304e-10
-error: 3.33076e-10
-error: 8.82330e-10
-error: 2.10475e-09
-error: 4.60657e-09
+error: 1.1030450e-10
+error: 3.3307565e-10
+error: 8.8232980e-10
+error: 2.1047486e-09
+error: 4.6065733e-09
 Quadrature order: 13 is exact for polynomials of degree: 0
 Quadrature order: 13 is exact for polynomials of degree: 1
 Quadrature order: 13 is exact for polynomials of degree: 2
@@ -1088,101 +1088,101 @@ Quadrature order: 17 is exact for polynomials of degree: 29
 Quadrature order: 17 is exact for polynomials of degree: 30
 Quadrature order: 17 is exact for polynomials of degree: 31
 Quadrature order: 1 is exact for polynomials of degree 0
-error: 1.57080
-error: 1.17810
-error: 0.981748
-error: 0.859029
-error: 0.773126
-error: 0.708699
-error: 0.658078
-error: 0.616948
-error: 0.582673
-error: 0.553539
-error: 0.528378
-error: 0.506363
-error: 0.486887
-error: 0.469498
-error: 0.453848
-error: 0.439666
-error: 0.426734
-error: 0.414881
-error: 0.403963
-error: 0.393864
-error: 0.384486
-error: 0.375748
-error: 0.367579
-error: 0.359921
-error: 0.352723
-error: 0.345940
-error: 0.339533
-error: 0.333470
-error: 0.327721
-error: 0.322259
-error: 0.317061
+error: 1.5707963
+error: 1.1780972
+error: 0.98174770
+error: 0.85902924
+error: 0.77312632
+error: 0.70869912
+error: 0.65807776
+error: 0.61694790
+error: 0.58267301
+error: 0.55353936
+error: 0.52837848
+error: 0.50636271
+error: 0.48688722
+error: 0.46949840
+error: 0.45384845
+error: 0.43966568
+error: 0.42673434
+error: 0.41488061
+error: 0.40396270
+error: 0.39386363
+error: 0.38448593
+error: 0.37574761
+error: 0.36757918
+error: 0.35992128
+error: 0.35272286
+error: 0.34593973
+error: 0.33953343
+error: 0.33347034
+error: 0.32772085
+error: 0.32225883
+error: 0.31706111
 Quadrature order: 2 is exact for polynomials of degree 0
 Quadrature order: 2 is exact for polynomials of degree 1
 Quadrature order: 2 is exact for polynomials of degree 2
-error: 0.0981748
-error: 0.196350
-error: 0.276117
-error: 0.335942
-error: 0.378510
-error: 0.407272
-error: 0.425416
-error: 0.435597
-error: 0.439921
-error: 0.440020
-error: 0.437130
-error: 0.432181
-error: 0.425860
-error: 0.418674
-error: 0.410991
-error: 0.403073
-error: 0.395107
-error: 0.387222
-error: 0.379505
-error: 0.372012
-error: 0.364777
-error: 0.357820
-error: 0.351147
-error: 0.344758
-error: 0.338647
-error: 0.332805
-error: 0.327222
-error: 0.321885
-error: 0.316781
+error: 0.098174770
+error: 0.19634954
+error: 0.27611654
+error: 0.33594179
+error: 0.37850976
+error: 0.40727190
+error: 0.42541602
+error: 0.43559661
+error: 0.43992142
+error: 0.44001992
+error: 0.43713013
+error: 0.43218057
+error: 0.42586008
+error: 0.41867441
+error: 0.41099088
+error: 0.40307302
+error: 0.39510700
+error: 0.38722186
+error: 0.37950460
+error: 0.37201161
+error: 0.36477719
+error: 0.35781979
+error: 0.35114673
+error: 0.34475763
+error: 0.33864687
+error: 0.33280541
+error: 0.32722215
+error: 0.32188481
+error: 0.31678060
 Quadrature order: 3 is exact for polynomials of degree 0
 Quadrature order: 3 is exact for polynomials of degree 1
 Quadrature order: 3 is exact for polynomials of degree 2
 Quadrature order: 3 is exact for polynomials of degree 3
 Quadrature order: 3 is exact for polynomials of degree 4
-error: 0.00613592
-error: 0.0184078
-error: 0.0348981
-error: 0.0536893
-error: 0.0733435
-error: 0.0928957
-error: 0.111739
-error: 0.129515
-error: 0.146027
-error: 0.161188
-error: 0.174980
-error: 0.187427
-error: 0.198582
-error: 0.208515
-error: 0.217303
-error: 0.225028
-error: 0.231773
-error: 0.237618
-error: 0.242639
-error: 0.246912
-error: 0.250505
-error: 0.253483
-error: 0.255905
-error: 0.257828
-error: 0.259302
-error: 0.260373
-error: 0.261085
+error: 0.0061359232
+error: 0.018407769
+error: 0.034898063
+error: 0.053689328
+error: 0.073343456
+error: 0.092895719
+error: 0.11173941
+error: 0.12951502
+error: 0.14602731
+error: 0.16118841
+error: 0.17497969
+error: 0.18742661
+error: 0.19858198
+error: 0.20851487
+error: 0.21730314
+error: 0.22502847
+error: 0.23177309
+error: 0.23761755
+error: 0.24263937
+error: 0.24691216
+error: 0.25050515
+error: 0.25348294
+error: 0.25590549
+error: 0.25782815
+error: 0.25930185
+error: 0.26037326
+error: 0.26108509
 Quadrature order: 4 is exact for polynomials of degree 0
 Quadrature order: 4 is exact for polynomials of degree 1
 Quadrature order: 4 is exact for polynomials of degree 2
@@ -1190,31 +1190,31 @@ Quadrature order: 4 is exact for polynomials of degree 3
 Quadrature order: 4 is exact for polynomials of degree 4
 Quadrature order: 4 is exact for polynomials of degree 5
 Quadrature order: 4 is exact for polynomials of degree 6
-error: 0.000383495
-error: 0.00153398
-error: 0.00366717
-error: 0.00683101
-error: 0.0109581
-error: 0.0159180
-error: 0.0215557
-error: 0.0277144
-error: 0.0342492
-error: 0.0410324
-error: 0.0479552
-error: 0.0549277
-error: 0.0618763
-error: 0.0687422
-error: 0.0754792
-error: 0.0820514
-error: 0.0884316
-error: 0.0945995
-error: 0.100541
-error: 0.106246
-error: 0.111709
-error: 0.116927
-error: 0.121901
-error: 0.126630
-error: 0.131119
+error: 0.00038349520
+error: 0.0015339808
+error: 0.0036671728
+error: 0.0068310082
+error: 0.010958076
+error: 0.015918047
+error: 0.021555688
+error: 0.027714433
+error: 0.034249224
+error: 0.041032371
+error: 0.047955243
+error: 0.054927672
+error: 0.061876251
+error: 0.068742203
+error: 0.075479217
+error: 0.082051412
+error: 0.088431553
+error: 0.094599494
+error: 0.10054088
+error: 0.10624606
+error: 0.11170918
+error: 0.11692744
+error: 0.12190051
+error: 0.12663000
+error: 0.13111907
 Quadrature order: 5 is exact for polynomials of degree 0
 Quadrature order: 5 is exact for polynomials of degree 1
 Quadrature order: 5 is exact for polynomials of degree 2
@@ -1224,29 +1224,29 @@ Quadrature order: 5 is exact for polynomials of degree 5
 Quadrature order: 5 is exact for polynomials of degree 6
 Quadrature order: 5 is exact for polynomials of degree 7
 Quadrature order: 5 is exact for polynomials of degree 8
-error: 2.39684e-05
-error: 0.000119842
-error: 0.000346044
-error: 0.000758002
-error: 0.00139972
-error: 0.00230041
-error: 0.00347458
-error: 0.00492397
-error: 0.00664026
-error: 0.00860774
-error: 0.0108058
-error: 0.0132108
-error: 0.0157980
-error: 0.0185420
-error: 0.0214184
-error: 0.0244039
-error: 0.0274765
-error: 0.0306163
-error: 0.0338048
-error: 0.0370255
-error: 0.0402636
-error: 0.0435061
-error: 0.0467412
+error: 2.3968450e-05
+error: 0.00011984225
+error: 0.00034604449
+error: 0.00075800223
+error: 0.0013997200
+error: 0.0023004094
+error: 0.0034745767
+error: 0.0049239716
+error: 0.0066402598
+error: 0.0086077441
+error: 0.010805792
+error: 0.013210840
+error: 0.015797951
+error: 0.018541983
+error: 0.021418408
+error: 0.024403869
+error: 0.027476534
+error: 0.030616281
+error: 0.033804781
+error: 0.037025501
+error: 0.040263645
+error: 0.043506071
+error: 0.046741182
 Quadrature order: 6 is exact for polynomials of degree 0
 Quadrature order: 6 is exact for polynomials of degree 1
 Quadrature order: 6 is exact for polynomials of degree 2
@@ -1258,27 +1258,27 @@ Quadrature order: 6 is exact for polynomials of degree 7
 Quadrature order: 6 is exact for polynomials of degree 8
 Quadrature order: 6 is exact for polynomials of degree 9
 Quadrature order: 6 is exact for polynomials of degree 10
-error: 1.49803e-06
-error: 8.98817e-06
-error: 3.04287e-05
-error: 7.66803e-05
-error: 0.000160365
-error: 0.000294597
-error: 0.000491871
-error: 0.000763248
-error: 0.00111784
-error: 0.00156257
-error: 0.00210215
-error: 0.00273916
-error: 0.00347431
-error: 0.00430661
-error: 0.00523373
-error: 0.00625219
-error: 0.00735763
-error: 0.00854506
-error: 0.00980901
-error: 0.0111437
-error: 0.0125433
+error: 1.4980281e-06
+error: 8.9881687e-06
+error: 3.0428696e-05
+error: 7.6680314e-05
+error: 0.00016036508
+error: 0.00029459659
+error: 0.00049187109
+error: 0.00076324825
+error: 0.0011178407
+error: 0.0015625730
+error: 0.0021021490
+error: 0.0027391638
+error: 0.0034743070
+error: 0.0043066135
+error: 0.0052337316
+error: 0.0062521872
+error: 0.0073576309
+error: 0.0085450599
+error: 0.0098090134
+error: 0.011143738
+error: 0.012543326
 Quadrature order: 7 is exact for polynomials of degree 0
 Quadrature order: 7 is exact for polynomials of degree 1
 Quadrature order: 7 is exact for polynomials of degree 2
@@ -1292,25 +1292,25 @@ Quadrature order: 7 is exact for polynomials of degree 9
 Quadrature order: 7 is exact for polynomials of degree 10
 Quadrature order: 7 is exact for polynomials of degree 11
 Quadrature order: 7 is exact for polynomials of degree 12
-error: 9.36268e-08
-error: 6.55387e-07
-error: 2.54548e-06
-error: 7.25607e-06
-error: 1.69611e-05
-error: 3.44693e-05
-error: 6.31039e-05
-error: 0.000106539
-error: 0.000168622
-error: 0.000253200
-error: 0.000363975
-error: 0.000504378
-error: 0.000677482
-error: 0.000885938
-error: 0.00113194
-error: 0.00141723
-error: 0.00174307
-error: 0.00211028
-error: 0.00251928
+error: 9.3626757e-08
+error: 6.5538730e-07
+error: 2.5454775e-06
+error: 7.2560737e-06
+error: 1.6961072e-05
+error: 3.4469276e-05
+error: 6.3103909e-05
+error: 0.00010653907
+error: 0.00016862157
+error: 0.00025320001
+error: 0.00036397502
+error: 0.00050437816
+error: 0.00067748163
+error: 0.00088593752
+error: 0.0011319434
+error: 0.0014172299
+error: 0.0017430663
+error: 0.0021102786
+error: 0.0025192783
 Quadrature order: 8 is exact for polynomials of degree 0
 Quadrature order: 8 is exact for polynomials of degree 1
 Quadrature order: 8 is exact for polynomials of degree 2
@@ -1326,23 +1326,23 @@ Quadrature order: 8 is exact for polynomials of degree 11
 Quadrature order: 8 is exact for polynomials of degree 12
 Quadrature order: 8 is exact for polynomials of degree 13
 Quadrature order: 8 is exact for polynomials of degree 14
-error: 5.85167e-09
-error: 4.68134e-08
-error: 2.05174e-07
-error: 6.52827e-07
-error: 1.68727e-06
-error: 3.76020e-06
-error: 7.49429e-06
-error: 1.36865e-05
-error: 2.32985e-05
-error: 3.74370e-05
-error: 5.73254e-05
-error: 8.42721e-05
-error: 0.000119636
-error: 0.000164794
-error: 0.000221108
-error: 0.000289897
-error: 0.000372415
+error: 5.8516723e-09
+error: 4.6813378e-08
+error: 2.0517426e-07
+error: 6.5282719e-07
+error: 1.6872703e-06
+error: 3.7602023e-06
+error: 7.4942922e-06
+error: 1.3686487e-05
+error: 2.3298543e-05
+error: 3.7436975e-05
+error: 5.7325369e-05
+error: 8.4272105e-05
+error: 0.00011963629
+error: 0.00016479418
+error: 0.00022110777
+error: 0.00028989686
+error: 0.00037241505
 Quadrature order: 9 is exact for polynomials of degree 0
 Quadrature order: 9 is exact for polynomials of degree 1
 Quadrature order: 9 is exact for polynomials of degree 2
@@ -1360,21 +1360,21 @@ Quadrature order: 9 is exact for polynomials of degree 13
 Quadrature order: 9 is exact for polynomials of degree 14
 Quadrature order: 9 is exact for polynomials of degree 15
 Quadrature order: 9 is exact for polynomials of degree 16
-error: 3.65729e-10
-error: 3.29157e-09
-error: 1.60692e-08
-error: 5.64595e-08
-error: 1.59907e-07
-error: 3.87876e-07
-error: 8.36358e-07
-error: 1.64357e-06
-error: 2.99610e-06
-error: 5.13285e-06
-error: 8.34672e-06
-error: 1.29838e-05
-error: 1.94404e-05
-error: 2.81583e-05
-error: 3.96186e-05
+error: 3.6572939e-10
+error: 3.2915656e-09
+error: 1.6069241e-08
+error: 5.6459494e-08
+error: 1.5990666e-07
+error: 3.8787616e-07
+error: 8.3635796e-07
+error: 1.6435745e-06
+error: 2.9960994e-06
+error: 5.1328525e-06
+error: 8.3467181e-06
+error: 1.2983784e-05
+error: 1.9440393e-05
+error: 2.8158344e-05
+error: 3.9618622e-05
 Quadrature order: 10 is exact for polynomials of degree 0
 Quadrature order: 10 is exact for polynomials of degree 1
 Quadrature order: 10 is exact for polynomials of degree 2
@@ -1395,18 +1395,18 @@ Quadrature order: 10 is exact for polynomials of degree 16
 Quadrature order: 10 is exact for polynomials of degree 17
 Quadrature order: 10 is exact for polynomials of degree 18
 error: 0
-error: 2.28581e-10
-error: 1.23005e-09
-error: 4.73020e-09
-error: 1.45707e-08
-error: 3.82227e-08
-error: 8.86795e-08
-error: 1.86649e-07
-error: 3.62901e-07
-error: 6.60600e-07
-error: 1.13747e-06
-error: 1.86765e-06
-error: 2.94310e-06
+error: 2.2858127e-10
+error: 1.2300517e-09
+error: 4.7301973e-09
+error: 1.4570696e-08
+error: 3.8222664e-08
+error: 8.8679475e-08
+error: 1.8664918e-07
+error: 3.6290079e-07
+error: 6.6059954e-07
+error: 1.1374698e-06
+error: 1.8676453e-06
+error: 2.9430977e-06
 Quadrature order: 11 is exact for polynomials of degree 0
 Quadrature order: 11 is exact for polynomials of degree 1
 Quadrature order: 11 is exact for polynomials of degree 2
@@ -1431,14 +1431,14 @@ Quadrature order: 11 is exact for polynomials of degree 20
 error: 0
 error: 0
 error: 0
-error: 3.86088e-10
-error: 1.28521e-09
-error: 3.62593e-09
-error: 9.00818e-09
-error: 2.02224e-08
-error: 4.17846e-08
-error: 8.05651e-08
-error: 1.46489e-07
+error: 3.8608805e-10
+error: 1.2852103e-09
+error: 3.6259328e-09
+error: 9.0081760e-09
+error: 2.0222435e-08
+error: 4.1784607e-08
+error: 8.0565091e-08
+error: 1.4648902e-07
 Quadrature order: 12 is exact for polynomials of degree 0
 Quadrature order: 12 is exact for polynomials of degree 1
 Quadrature order: 12 is exact for polynomials of degree 2
@@ -1466,11 +1466,11 @@ error: 0
 error: 0
 error: 0
 error: 0
-error: 1.10305e-10
-error: 3.33076e-10
-error: 8.82330e-10
-error: 2.10475e-09
-error: 4.60657e-09
+error: 1.1030477e-10
+error: 3.3307590e-10
+error: 8.8233015e-10
+error: 2.1047490e-09
+error: 4.6065738e-09
 Quadrature order: 13 is exact for polynomials of degree 0
 Quadrature order: 13 is exact for polynomials of degree 1
 Quadrature order: 13 is exact for polynomials of degree 2
@@ -1633,100 +1633,100 @@ Quadrature order: 17 is exact for polynomials of degree 30
 Quadrature order: 17 is exact for polynomials of degree 31
 Quadrature order: 2 is exact for polynomials of degree: 0
 Quadrature order: 2 is exact for polynomials of degree: 1
-error: 0.392699
-error: 0.589049
-error: 0.711767
-error: 0.797670
-error: 0.862097
-error: 0.912719
-error: 0.953848
-error: 0.988123
-error: 1.01726
-error: 1.04242
-error: 1.06443
-error: 1.08391
-error: 1.10130
-error: 1.11695
-error: 1.13113
-error: 1.14406
-error: 1.15592
-error: 1.16683
-error: 1.17693
-error: 1.18631
-error: 1.19505
-error: 1.20322
-error: 1.21088
-error: 1.21807
-error: 1.22486
-error: 1.23126
-error: 1.23733
-error: 1.24308
-error: 1.24854
-error: 1.25374
+error: 0.39269908
+error: 0.58904862
+error: 0.71176709
+error: 0.79767001
+error: 0.86209720
+error: 0.91271857
+error: 0.95384843
+error: 0.98812331
+error: 1.0172570
+error: 1.0424178
+error: 1.0644336
+error: 1.0839091
+error: 1.1012979
+error: 1.1169479
+error: 1.1311306
+error: 1.1440620
+error: 1.1559157
+error: 1.1668336
+error: 1.1769327
+error: 1.1863104
+error: 1.1950487
+error: 1.2032171
+error: 1.2108750
+error: 1.2180735
+error: 1.2248566
+error: 1.2312629
+error: 1.2373260
+error: 1.2430755
+error: 1.2485375
+error: 1.2537352
 Quadrature order: 3 is exact for polynomials of degree: 0
 Quadrature order: 3 is exact for polynomials of degree: 1
 Quadrature order: 3 is exact for polynomials of degree: 2
 Quadrature order: 3 is exact for polynomials of degree: 3
-error: 0.0245437
-error: 0.0613592
-error: 0.101243
-error: 0.139592
-error: 0.174586
-error: 0.205793
-error: 0.233393
-error: 0.257787
-error: 0.279419
-error: 0.298703
-error: 0.315996
-error: 0.331598
-error: 0.345756
-error: 0.358676
-error: 0.370524
-error: 0.381438
-error: 0.391536
-error: 0.400913
-error: 0.409651
-error: 0.417819
-error: 0.425477
-error: 0.432675
-error: 0.439458
-error: 0.445865
-error: 0.451928
-error: 0.457677
-error: 0.463139
-error: 0.468337
+error: 0.024543693
+error: 0.061359232
+error: 0.10124273
+error: 0.13959225
+error: 0.17458619
+error: 0.20579311
+error: 0.23339278
+error: 0.25778667
+error: 0.27941894
+error: 0.29870269
+error: 0.31599564
+error: 0.33159765
+error: 0.34575645
+error: 0.35867581
+error: 0.37052355
+error: 0.38143846
+error: 0.39153603
+error: 0.40091299
+error: 0.40965093
+error: 0.41781917
+error: 0.42547697
+error: 0.43267535
+error: 0.43945846
+error: 0.44586474
+error: 0.45192783
+error: 0.45767732
+error: 0.46313933
+error: 0.46833705
 Quadrature order: 4 is exact for polynomials of degree: 0
 error: 0
 Quadrature order: 4 is exact for polynomials of degree: 2
 Quadrature order: 4 is exact for polynomials of degree: 3
 Quadrature order: 4 is exact for polynomials of degree: 4
 Quadrature order: 4 is exact for polynomials of degree: 5
-error: 0.00153398
-error: 0.00536893
-error: 0.0115049
-error: 0.0195583
-error: 0.0290318
-error: 0.0394491
-error: 0.0504075
-error: 0.0615901
-error: 0.0727593
-error: 0.0837445
-error: 0.0944287
-error: 0.104736
-error: 0.114622
-error: 0.124064
-error: 0.133056
-error: 0.141604
-error: 0.149719
-error: 0.157421
-error: 0.164728
-error: 0.171664
-error: 0.178250
-error: 0.184509
-error: 0.190461
-error: 0.196127
-error: 0.201527
-error: 0.206678
+error: 0.0015339808
+error: 0.0053689328
+error: 0.011504856
+error: 0.019558255
+error: 0.029031785
+error: 0.039449072
+error: 0.050407522
+error: 0.061590115
+error: 0.072759296
+error: 0.083744511
+error: 0.094428729
+error: 0.10473616
+error: 0.11462196
+error: 0.12406392
+error: 0.13305603
+error: 0.14160351
+error: 0.14971916
+error: 0.15742059
+error: 0.16472824
+error: 0.17166398
+error: 0.17825010
+error: 0.18450863
+error: 0.19046090
+error: 0.19612727
+error: 0.20152695
+error: 0.20667792
 Quadrature order: 5 is exact for polynomials of degree: 0
 Quadrature order: 5 is exact for polynomials of degree: 1
 Quadrature order: 5 is exact for polynomials of degree: 2
@@ -1735,30 +1735,30 @@ Quadrature order: 5 is exact for polynomials of degree: 4
 Quadrature order: 5 is exact for polynomials of degree: 5
 Quadrature order: 5 is exact for polynomials of degree: 6
 Quadrature order: 5 is exact for polynomials of degree: 7
-error: 9.58738e-05
-error: 0.000431432
-error: 0.00113850
-error: 0.00230696
-error: 0.00397951
-error: 0.00615877
-error: 0.00881824
-error: 0.0119128
-error: 0.0153874
-error: 0.0191830
-error: 0.0232410
-error: 0.0275058
-error: 0.0319267
-error: 0.0364581
-error: 0.0410599
-error: 0.0456976
-error: 0.0503420
-error: 0.0549682
-error: 0.0595558
-error: 0.0640881
-error: 0.0685516
-error: 0.0729358
-error: 0.0772325
-error: 0.0814355
+error: 9.5873799e-05
+error: 0.00043143210
+error: 0.0011385014
+error: 0.0023069633
+error: 0.0039795117
+error: 0.0061587681
+error: 0.0088182361
+error: 0.011912835
+error: 0.015387413
+error: 0.019182985
+error: 0.023240967
+error: 0.027505848
+error: 0.031926729
+error: 0.036458064
+error: 0.041059877
+error: 0.045697643
+error: 0.050341969
+error: 0.054968165
+error: 0.059555770
+error: 0.064088065
+error: 0.068551609
+error: 0.072935795
+error: 0.077232450
+error: 0.081435478
 Quadrature order: 6 is exact for polynomials of degree: 0
 Quadrature order: 6 is exact for polynomials of degree: 1
 Quadrature order: 6 is exact for polynomials of degree: 2
@@ -1769,28 +1769,28 @@ Quadrature order: 6 is exact for polynomials of degree: 6
 Quadrature order: 6 is exact for polynomials of degree: 7
 Quadrature order: 6 is exact for polynomials of degree: 8
 Quadrature order: 6 is exact for polynomials of degree: 9
-error: 5.99211e-06
-error: 3.29566e-05
-error: 0.000103364
-error: 0.000243430
-error: 0.000479252
-error: 0.000833898
-error: 0.00132568
-error: 0.00196748
-error: 0.00276677
-error: 0.00372614
-error: 0.00484398
-error: 0.00611534
-error: 0.00753270
-error: 0.00908665
-error: 0.0107665
-error: 0.0125610
-error: 0.0144582
-error: 0.0164465
-error: 0.0185144
-error: 0.0206508
-error: 0.0228451
-error: 0.0250874
+error: 5.9921125e-06
+error: 3.2956618e-05
+error: 0.00010336394
+error: 0.00024342957
+error: 0.00047925196
+error: 0.00083389842
+error: 0.0013256847
+error: 0.0019674844
+error: 0.0027667749
+error: 0.0037261356
+error: 0.0048439762
+error: 0.0061153425
+error: 0.0075327008
+error: 0.0090866505
+error: 0.010766538
+error: 0.012560968
+error: 0.014458212
+error: 0.016446533
+error: 0.018514427
+error: 0.020650800
+error: 0.022845102
+error: 0.025087400
 Quadrature order: 7 is exact for polynomials of degree: 0
 Quadrature order: 7 is exact for polynomials of degree: 1
 Quadrature order: 7 is exact for polynomials of degree: 2
@@ -1803,26 +1803,26 @@ Quadrature order: 7 is exact for polynomials of degree: 8
 Quadrature order: 7 is exact for polynomials of degree: 9
 Quadrature order: 7 is exact for polynomials of degree: 10
 Quadrature order: 7 is exact for polynomials of degree: 11
-error: 3.74507e-07
-error: 2.43430e-06
-error: 8.84773e-06
-error: 2.37578e-05
-error: 5.26065e-05
-error: 0.000101766
-error: 0.000178091
-error: 0.000288475
-error: 0.000439474
-error: 0.000637015
-error: 0.000886200
-error: 0.00119119
-error: 0.00155517
-error: 0.00198033
-error: 0.00246797
-error: 0.00301852
-error: 0.00363165
-error: 0.00430640
-error: 0.00504122
-error: 0.00583412
+error: 3.7450703e-07
+error: 2.4342957e-06
+error: 8.8477285e-06
+error: 2.3757790e-05
+error: 5.2606534e-05
+error: 0.00010176643
+error: 0.00017809126
+error: 0.00028847501
+error: 0.00043947365
+error: 0.00063701483
+error: 0.00088620005
+error: 0.0011911910
+error: 0.0015551660
+error: 0.0019803309
+error: 0.0024679688
+error: 0.0030185157
+error: 0.0036316517
+error: 0.0043063991
+error: 0.0050412213
+error: 0.0058341188
 Quadrature order: 8 is exact for polynomials of degree: 0
 Quadrature order: 8 is exact for polynomials of degree: 1
 Quadrature order: 8 is exact for polynomials of degree: 2
@@ -1837,24 +1837,24 @@ Quadrature order: 8 is exact for polynomials of degree: 10
 Quadrature order: 8 is exact for polynomials of degree: 11
 Quadrature order: 8 is exact for polynomials of degree: 12
 Quadrature order: 8 is exact for polynomials of degree: 13
-error: 2.34067e-08
-error: 1.75550e-07
-error: 7.25607e-07
-error: 2.18853e-06
-error: 5.38582e-06
-error: 1.14734e-05
-error: 2.19345e-05
-error: 3.85421e-05
-error: 6.33000e-05
-error: 9.83716e-05
-error: 0.000146004
-error: 0.000208456
-error: 0.000287930
-error: 0.000386517
-error: 0.000506154
-error: 0.000648583
-error: 0.000815335
-error: 0.00100771
+error: 2.3406689e-08
+error: 1.7555017e-07
+error: 7.2560737e-07
+error: 2.1885254e-06
+error: 5.3858243e-06
+error: 1.1473438e-05
+error: 2.1934514e-05
+error: 3.8542074e-05
+error: 6.3300003e-05
+error: 9.8371627e-05
+error: 0.00014600420
+error: 0.00020845589
+error: 0.00028792969
+error: 0.00038651725
+error: 0.00050615354
+error: 0.00064858280
+error: 0.00081533491
+error: 0.0010077113
 Quadrature order: 9 is exact for polynomials of degree: 0
 Quadrature order: 9 is exact for polynomials of degree: 1
 Quadrature order: 9 is exact for polynomials of degree: 2
@@ -1871,22 +1871,22 @@ Quadrature order: 9 is exact for polynomials of degree: 12
 Quadrature order: 9 is exact for polynomials of degree: 13
 Quadrature order: 9 is exact for polynomials of degree: 14
 Quadrature order: 9 is exact for polynomials of degree: 15
-error: 1.46292e-09
-error: 1.24348e-08
-error: 5.76024e-08
-error: 1.92831e-07
-error: 5.22250e-07
-error: 1.21529e-06
-error: 2.52120e-06
-error: 4.77919e-06
-error: 8.42332e-06
-error: 1.39818e-05
-error: 2.20713e-05
-error: 3.33869e-05
-error: 4.86892e-05
-error: 6.87891e-05
-error: 9.45316e-05
-error: 0.000126780
+error: 1.4629177e-09
+error: 1.2434803e-08
+error: 5.7602399e-08
+error: 1.9283089e-07
+error: 5.2225032e-07
+error: 1.2152906e-06
+error: 2.5211950e-06
+error: 4.7791884e-06
+error: 8.4233195e-06
+error: 1.3981797e-05
+error: 2.2071266e-05
+error: 3.3386872e-05
+error: 4.8689189e-05
+error: 6.8789085e-05
+error: 9.4531584e-05
+error: 0.00012677959
 Quadrature order: 10 is exact for polynomials of degree: 0
 Quadrature order: 10 is exact for polynomials of degree: 1
 Quadrature order: 10 is exact for polynomials of degree: 2
@@ -1906,19 +1906,19 @@ Quadrature order: 10 is exact for polynomials of degree: 15
 Quadrature order: 10 is exact for polynomials of degree: 16
 Quadrature order: 10 is exact for polynomials of degree: 17
 error: 0
-error: 8.68607e-10
-error: 4.45733e-09
-error: 1.64007e-08
-error: 4.84845e-08
-error: 1.22394e-07
-error: 2.73929e-07
-error: 5.57414e-07
-error: 1.04990e-06
-error: 1.85483e-06
-error: 3.10482e-06
-error: 4.96350e-06
-error: 7.62622e-06
-error: 1.13196e-05
+error: 8.6860678e-10
+error: 4.4573277e-09
+error: 1.6400682e-08
+error: 4.8484519e-08
+error: 1.2239385e-07
+error: 2.7392909e-07
+error: 5.5741384e-07
+error: 1.0499016e-06
+error: 1.8548262e-06
+error: 3.1048178e-06
+error: 4.9635047e-06
+error: 7.6262182e-06
+error: 1.1319606e-05
 Quadrature order: 11 is exact for polynomials of degree: 0
 Quadrature order: 11 is exact for polynomials of degree: 1
 Quadrature order: 11 is exact for polynomials of degree: 2
@@ -1941,16 +1941,16 @@ Quadrature order: 11 is exact for polynomials of degree: 18
 Quadrature order: 11 is exact for polynomials of degree: 19
 error: 0
 error: 0
-error: 3.37871e-10
-error: 1.35541e-09
-error: 4.34348e-09
-error: 1.18239e-08
-error: 2.84031e-08
-error: 6.17703e-08
-error: 1.23862e-07
-error: 2.32137e-07
-error: 4.10882e-07
-error: 6.92494e-07
+error: 3.3787132e-10
+error: 1.3554138e-09
+error: 4.3434846e-09
+error: 1.1823930e-08
+error: 2.8403136e-08
+error: 6.1770347e-08
+error: 1.2386241e-07
+error: 2.3213670e-07
+error: 4.1088196e-07
+error: 6.9249357e-07
 Quadrature order: 12 is exact for polynomials of degree: 0
 Quadrature order: 12 is exact for polynomials of degree: 1
 Quadrature order: 12 is exact for polynomials of degree: 2
@@ -1976,13 +1976,13 @@ Quadrature order: 12 is exact for polynomials of degree: 21
 error: 0
 error: 0
 error: 0
-error: 1.09380e-10
-error: 3.77701e-10
-error: 1.10304e-09
-error: 2.83114e-09
-error: 6.55445e-09
-error: 1.39440e-08
-error: 2.76394e-08
+error: 1.0937976e-10
+error: 3.7770152e-10
+error: 1.1030422e-09
+error: 2.8311411e-09
+error: 6.5544482e-09
+error: 1.3943958e-08
+error: 2.7639439e-08
 Quadrature order: 13 is exact for polynomials of degree: 0
 Quadrature order: 13 is exact for polynomials of degree: 1
 Quadrature order: 13 is exact for polynomials of degree: 2
@@ -2013,8 +2013,8 @@ error: 0
 error: 0
 error: 0
 error: 0
-error: 2.72838e-10
-error: 6.70047e-10
+error: 2.7283759e-10
+error: 6.7004682e-10
 Quadrature order: 14 is exact for polynomials of degree: 0
 Quadrature order: 14 is exact for polynomials of degree: 1
 Quadrature order: 14 is exact for polynomials of degree: 2
@@ -2111,7 +2111,7 @@ Quadrature order: 16 is exact for polynomials of degree: 28
 Quadrature order: 16 is exact for polynomials of degree: 29
 Quadrature order: 16 is exact for polynomials of degree: 30
 Quadrature order: 16 is exact for polynomials of degree: 31
-error: 0
+Quadrature order: 17 is exact for polynomials of degree: 0
 Quadrature order: 17 is exact for polynomials of degree: 1
 Quadrature order: 17 is exact for polynomials of degree: 2
 Quadrature order: 17 is exact for polynomials of degree: 3


### PR DESCRIPTION
The current precision is 6 digits, which means that we round to 6 digits and
renders the absolute tolerance of 1e-6 meaningless when using numdiff. In
other words, in cases where we round differently to 6 digits on different
machines, numdiff will complain because it wants to compare exactly 6 digits.

Fix this by outputting 8 digits. Rounding differences will then show up
in the 8th digit, and numdiff will know how to ignore this.