### PR TITLE
simplify test

### DIFF
--- a/tests/deal.II/nedelec_non_rect_face.cc
+++ b/tests/deal.II/nedelec_non_rect_face.cc
@@ -411,8 +411,7 @@ namespace Maxwell
   template <int dim>
   void MaxwellProblem<dim>::run ()
   {
-
-    unsigned int numcycles=3;
+    unsigned int numcycles=(p_order>1)?2:3;
 
     for (unsigned int cycle=0; cycle<numcycles; ++cycle)
       {

--- a/tests/deal.II/nedelec_non_rect_face.output
+++ b/tests/deal.II/nedelec_non_rect_face.output
@@ -13,4 +13,3 @@ DEAL::p = 2
 cycle cells dofs  L2 Error  H(curl) Error 
 0     1     144  7.1663e-16 1.1556e-15    
 1     8     882  1.0834e-14 1.1559e-14    
-2     64    6084 3.6087e-14 4.1198e-14    


### PR DESCRIPTION
This avoid timeouts on the tester by speeding up the computation by a
factor of about 4.