### PR TITLE
Update header guard symbols to the new style.

### DIFF
--- a/include/deal.II/lac/vector_view.h
+++ b/include/deal.II/lac/vector_view.h
@@ -13,8 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
-#ifndef __dealii__vector_view_h
-#define __dealii__vector_view_h
+#ifndef dealii__vector_view_h
+#define dealii__vector_view_h
 
 
 #include <deal.II/base/config.h>

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -14,8 +14,8 @@
 // ---------------------------------------------------------------------
 
 
-#ifndef __dealii__point_value_history_h
-#define __dealii__point_value_history_h
+#ifndef dealii__point_value_history_h
+#define dealii__point_value_history_h
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/smartpointer.h>
@@ -658,4 +658,4 @@ private:
 
 
 DEAL_II_NAMESPACE_CLOSE
-#endif /* __dealii__point_value_history_h */
+#endif /* dealii__point_value_history_h */


### PR DESCRIPTION
It looks like these got missed because they started with `__dealii` and not `__deal2`.