### PR TITLE
Simplify Chebyshev preconditioner setup by using signals

### DIFF
--- a/tests/lac/precondition_chebyshev_01.with_lapack=true.output
+++ b/tests/lac/precondition_chebyshev_01.with_lapack=true.output
@@ -1,8 +1,10 @@
 
-
+DEAL:cg::Starting value 1.00
+DEAL:cg::Convergence step 2 value 0
 DEAL::Exact inverse:     0.84 0.20 0.26 0.20 0.18 0.03 0.05 0.10 0.03 0.06 
 DEAL::Check  vmult orig: 1.09 0.26 0.34 0.26 0.24 0.04 0.06 0.12 0.04 0.07 
 DEAL::Check Tvmult orig: 1.09 0.26 0.34 0.26 0.24 0.04 0.06 0.12 0.04 0.07 
-
+DEAL:cg::Starting value 1.00
+DEAL:cg::Failure step 8 value 0.00
 DEAL::Check  vmult diag: 0.82 0.26 0.33 0.21 0.15 0.02 0.03 0.09 0.03 0.07 
 DEAL::Check Tvmult diag: 0.82 0.26 0.33 0.21 0.15 0.02 0.03 0.09 0.03 0.07 

--- a/tests/matrix_free/step-37.with_lapack=true.output
+++ b/tests/matrix_free/step-37.with_lapack=true.output
@@ -1,52 +1,73 @@
 
 DEAL:2d::Cycle 0
 DEAL:2d::Number of degrees of freedom: 81
-
-
-
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Convergence step 3 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0.00110
 DEAL:2d:cg::Starting value 0.132
 DEAL:2d:cg::Convergence step 4 value 0
 DEAL:2d::
 DEAL:2d::Cycle 1
 DEAL:2d::Number of degrees of freedom: 289
-
-
-
-
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Convergence step 3 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0.00110
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0.153
 DEAL:2d:cg::Starting value 0.0677
 DEAL:2d:cg::Convergence step 5 value 0
 DEAL:2d::
 DEAL:2d::Cycle 2
 DEAL:2d::Number of degrees of freedom: 1089
-
-
-
-
-
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Convergence step 3 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0.00110
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 0.153
+DEAL:2d:cg::Starting value 1.00
+DEAL:2d:cg::Failure step 10 value 1.07
 DEAL:2d:cg::Starting value 0.0343
 DEAL:2d:cg::Convergence step 5 value 0
 DEAL:2d::
 DEAL:3d::Cycle 0
 DEAL:3d::Number of degrees of freedom: 125
-
-
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Convergence step 3 value 0
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0
 DEAL:3d:cg::Starting value 0.125
 DEAL:3d:cg::Convergence step 5 value 0
 DEAL:3d::
 DEAL:3d::Cycle 1
 DEAL:3d::Number of degrees of freedom: 729
-
-
-
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Convergence step 3 value 0
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0.000695
 DEAL:3d:cg::Starting value 0.0479
 DEAL:3d:cg::Convergence step 4 value 0
 DEAL:3d::
 DEAL:3d::Cycle 2
 DEAL:3d::Number of degrees of freedom: 4913
-
-
-
-
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Convergence step 3 value 0
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0.000695
+DEAL:3d:cg::Starting value 1.00
+DEAL:3d:cg::Failure step 10 value 0.0952
 DEAL:3d:cg::Starting value 0.0176
 DEAL:3d:cg::Convergence step 4 value 0
 DEAL:3d::


### PR DESCRIPTION
Thanks to #703, we can now directly read off the eigenvalue estimates from CG instead of manually parsing them from the logstream. (The tests output changes because we the logstream output from the eigenvalue estimate with CG remains in the output stream instead of being redirected.)