### PR TITLE
Update a comment.

### DIFF
--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2014 by the deal.II authors
+// Copyright (C) 1999 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1180,11 +1180,12 @@ FESystem<dim,spacedim>::compute_fill (
           FEValuesData<dim,spacedim> &
           base_data    = fe_data.get_fe_values_data(base_no);
 
-          //TODO: Think about a smarter alternative Copy quadrature
-          // points. These are required for computing the determinant in the
-          // FEPolyTensor class. The determinant is one ingredient of the
-          // Piola transformation, which is applied to correctly map the RT
-          // space from the reference element to the global coordinate system.
+          // Copy quadrature points. These are required for computing
+          // the determinant in the FEPolyTensor class. The
+          // determinant is one ingredient of the Piola
+          // transformation, which is applied to correctly map the RT
+          // space from the reference element to the global coordinate
+          // system.
           if (cell_similarity != CellSimilarity::translation)
             base_data.JxW_values = data.JxW_values;
 


### PR DESCRIPTION
Reformatting has destroyed the formatting of this comment and made it
difficult to see what it actually was supposed to mean. That said, I'm
also not entirely clear what exactly the TODO referred to to begin with,
so remove it.