### PR TITLE
boost variadic template warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -314,6 +314,16 @@ _Pragma("GCC diagnostic pop")
 #endif
 
 
+/**
+ * BOOST can falsely detect cxx11 support and will try to use
+ * variadic templates even when we disable cxx11. This would create
+ * a ton of warnings, so we tell boost to not use them in this case.
+ */
+#ifndef DEAL_II_WITH_CXX11
+#define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+
+
 /***********************************************************************
  * Final inclusions:
  */

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -527,6 +527,10 @@ LogStream::timestamp ()
 #else
   const double time = 0.;
   const unsigned int tick = 100;
+  current_tms.tms_utime = 0;
+  current_tms.tms_stime = 0;
+  current_tms.tms_cutime = 0;
+  current_tms.tms_cstime = 0;
 #endif
   (*this) << "Wall: " << time - reference_time_val
           << " User: " << 1./tick * (current_tms.tms_utime - reference_tms.tms_utime)

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -654,6 +654,7 @@ namespace Utilities
       // Windows does not appear to have posix_memalign. just use the
       // regular malloc in that case
       *memptr = malloc (size);
+      (void)alignment;
       AssertThrow (*memptr != 0, ExcOutOfMemory());
 #endif
     }


### PR DESCRIPTION
Stop BOOST from trying to use variadic templates when we compile without cxx11
support. This only happens rarely (at least with mingw gcc 5 on windows).