### PR TITLE
Restrict DoFs that can be used in constraints to those in the IndexSet

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -1086,6 +1086,19 @@ public:
    *
    * @ingroup Exceptions
    */
+  DeclException2 (ExcColumnNotStoredHere,
+                  size_type,
+                  size_type,
+                  << "The index set given to this constraint matrix indicates "
+                  << "constraints using degree of freedom " << arg2
+                  << " should not be stored by this object, but a constraint "
+                  << "for degree of freedom " << arg1 <<" uses it.");
+
+  /**
+   * Exception
+   *
+   * @ingroup Exceptions
+   */
   DeclException2 (ExcIncorrectConstraint,
                   int, int,
                   << "While distributing the constraint for DoF "
@@ -1404,6 +1417,8 @@ ConstraintMatrix::add_entry (const size_type line,
   // exists, since we don't want to enter it twice
   Assert (lines_cache[calculate_line_index(line)] != numbers::invalid_size_type,
           ExcInternalError());
+  Assert (!local_lines.size() || local_lines.is_element(column),
+          ExcColumnNotStoredHere(line, column));
   ConstraintLine *line_ptr = &lines[lines_cache[calculate_line_index(line)]];
   Assert (line_ptr->line == line, ExcInternalError());
   for (ConstraintLine::Entries::const_iterator


### PR DESCRIPTION
So far only DoFs in the IndexSet can be constrained using ConstraintMatrix. However, the DoFs that are used in a constraint are not restricted. This might lead to situations in which a constraint doesn't do what it was supposed to mean. This PR aims to prevent this by only allowing referenced DoFs that are in the IndexSet (that normally corresponds to the locally relevant DoFs).