### PR TITLE
configuration fixes

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -324,6 +324,17 @@ IF(NOT DEFINED DEAL_II_WITH_CXX11 OR DEAL_II_WITH_CXX11)
   ENDIF()
 ENDIF()
 
+
+#
+# Finally disable cxx14 if cxx11 detection failed for whatever reason. This
+# can happen if any of our compile checks above fails, for example threading
+# support.
+# 
+IF (DEAL_II_HAVE_CXX14 AND NOT DEAL_II_HAVE_CXX11)
+  MESSAGE(STATUS "Disabling CXX14 support because CXX11 detection failed.")
+  SET(DEAL_II_HAVE_CXX14 FALSE)
+ENDIF()
+
 #
 # Set up a configuration options for C++11 and C++14 support:
 #

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -89,6 +89,12 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # TODO: MM: Check whether this is still necessary...
   #
   STRIP_FLAG(DEAL_II_LINKER_FLAGS "-rdynamic")
+
+  #
+  # At least on Clang 5.0.0 the template depth is set to 128, which is too low
+  # to compile parts of the library. Fix this by setting a large value.
+  #
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-ftemplate-depth=1024")  
 ENDIF()
 
 


### PR DESCRIPTION
- disable cxx14 if cxx11 fails
- set template depth on MAC OS