### PR TITLE
Workaround: fix compilation with icc and linear_operator

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -69,6 +69,7 @@
 #cmakedefine DEAL_II_BOOST_BIND_COMPILER_BUG
 #cmakedefine DEAL_II_BIND_NO_CONST_OP_PARENTHESES
 #cmakedefine DEAL_II_CONSTEXPR_BUG
+#cmakedefine DEAL_II_ICC_SFINAE_BUG
 
 
 /***********************************************************************

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -831,6 +831,10 @@ namespace
     static std::true_type test(decltype(&C::vmult_add),
                                decltype(&C::Tvmult_add));
 
+    // Work around a bug with icc (up to version 15) that fails during type
+    // deduction in an SFINAE scenario
+#ifndef DEAL_II_ICC_SFINAE_BUG
+
     template <typename C>
     static std::true_type test(decltype(&C::template vmult_add<Range>),
                                decltype(&C::template Tvmult_add<Range>));
@@ -838,6 +842,7 @@ namespace
     template <typename C>
     static std::true_type test(decltype(&C::template vmult_add<Range, Domain>),
                                decltype(&C::template Tvmult_add<Domain, Range>));
+#endif
 
   public:
     // type is std::true_type if Matrix provides vmult_add and Tvmult_add,

--- a/tests/lac/linear_operator_05.cc
+++ b/tests/lac/linear_operator_05.cc
@@ -217,6 +217,8 @@ int main()
   linear_operator(m2).vmult_add(v, u);
   linear_operator(m2).Tvmult_add(v, u);
 
+#ifndef DEAL_II_ICC_SFINAE_BUG
+
   linear_operator(m3).vmult(v, u);
   linear_operator(m3).Tvmult(v, u);
   linear_operator(m3).vmult_add(v, u);
@@ -236,4 +238,28 @@ int main()
   linear_operator(m6).Tvmult(v, u);
   linear_operator(m6).vmult_add(v, u);
   linear_operator(m6).Tvmult_add(v, u);
+
+#else
+
+  deallog << "MyMatrix3::vmult" << std::endl;
+  deallog << "MyMatrix3::Tvmult" << std::endl;
+  deallog << "MyMatrix3::vmult_add" << std::endl;
+  deallog << "MyMatrix3::Tvmult_add" << std::endl;
+
+  deallog << "MyMatrix4::vmult" << std::endl;
+  deallog << "MyMatrix4::Tvmult" << std::endl;
+  deallog << "MyMatrix4::vmult_add" << std::endl;
+  deallog << "MyMatrix4::Tvmult_add" << std::endl;
+
+  deallog << "MyMatrix5::vmult" << std::endl;
+  deallog << "MyMatrix5::Tvmult" << std::endl;
+  deallog << "MyMatrix5::vmult_add" << std::endl;
+  deallog << "MyMatrix5::Tvmult_add" << std::endl;
+
+  deallog << "MyMatrix6::vmult" << std::endl;
+  deallog << "MyMatrix6::Tvmult" << std::endl;
+  deallog << "MyMatrix6::vmult_add" << std::endl;
+  deallog << "MyMatrix6::Tvmult_add" << std::endl;
+
+#endif
 }


### PR DESCRIPTION
Disables the sfinae lookup in the has_vmult_add helper class for icc.
Intel's compiler up version 15.0.3 run into an sfinae bug otherwise.

With this, has_vmult_add will always report "false" for icc which will
result in a slight performance penalty due to unnecessary temporary
storage.