### PR TITLE
Fix an inconsistency.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -62,6 +62,14 @@ inconvenience this causes.
 
 <ol>
 
+  <li> Fixed: When using FESystem with base elements that require
+  information other than the determinant of the Jacobian (e.g.,
+  elements that require the Jacobian itself), then this information
+  was not passed down to FiniteElement::fill_fe_values of the
+  base element. This is now fixed.
+  <br>
+  (Wolfgang Bangerth, Zhen Tao, 2015/07/17)
+  </li>
 
   <li> New: The parallel::distributed::Triangulation can now be told to
   partition the cells so that the sum of certain weights associated with each

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1180,14 +1180,17 @@ FESystem<dim,spacedim>::compute_fill (
           FEValuesData<dim,spacedim> &
           base_data    = fe_data.get_fe_values_data(base_no);
 
-          // Copy quadrature points. These are required for computing
-          // the determinant in the FEPolyTensor class. The
-          // determinant is one ingredient of the Piola
-          // transformation, which is applied to correctly map the RT
-          // space from the reference element to the global coordinate
-          // system.
-          if (cell_similarity != CellSimilarity::translation)
-            base_data.JxW_values = data.JxW_values;
+          // Copy all of the things that the mapping set in the FEValuesData
+          // that we store here into the corresponding objects we pass down
+          // to the various base elements. some of these arrays may be empty,
+          // in which case copying is cheap
+          base_data.JxW_values        = data.JxW_values;
+          base_data.jacobians         = data.jacobians;
+          base_data.jacobian_grads    = data.jacobian_grads;
+          base_data.inverse_jacobians = data.inverse_jacobians;
+          base_data.quadrature_points = data.quadrature_points;
+          base_data.normal_vectors    = data.normal_vectors;
+          base_data.boundary_forms    = data.boundary_forms;
 
 
           // Make sure that in the case of fill_fe_values the data is only


### PR DESCRIPTION
My understanding is that when FEValues calls the mapping, the mapping puts
its results into the FEValuesData base class of the FEValues object. Then,
FEValues calls FiniteElement::fill_fe_values which uses the mapping data
and its InternalData object to compute shape function information and again
put it into the FEValuesData base class of the FEValues object.

In the case of FESystem, this is a bit more complicated: Here, we don't want
the base elements to put their stuff into the FEValuesData base object 
because the results of *all* base elements will go there (and because,
consequently, array sizes don't match, etc). Thus, FESystem::fill_fe_values
creates an array of scratch FEValuesData objects, passes these to the
base elements that fill them, and the copies back the data from the scratch
objects to its own base element. To make this work, FESystem has to also first
copy everything that's in its own FEValuesData base object to each of the scratch
objects.

This is where the bug lies: Currently, only one of the elements that the mapping
has computed is copied; we need to be consistent and do this with all
mapping related arrays in FEValuesData.