### PR TITLE
Avoid Intel 15 bug in SymmetricTensor

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1900,7 +1900,7 @@ namespace internal
 
           case 2:
           {
-            static const TableIndices<2> table[3] =
+            const TableIndices<2> table[3] =
             {
               TableIndices<2> (0,0),
               TableIndices<2> (1,1),
@@ -1911,7 +1911,7 @@ namespace internal
 
           case 3:
           {
-            static const TableIndices<2> table[6] =
+            const TableIndices<2> table[6] =
             {
               TableIndices<2> (0,0),
               TableIndices<2> (1,1),


### PR DESCRIPTION
This should fix broken behavior in deal.II/fe_values_view_{23|24|25} with
Intel 15.0.3, where the compiler sometimes forgets to initialize the static
fields.