### PR TITLE
New class DoFVector

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -77,6 +77,15 @@ inconvenience this causes.
   (Timo Heister, 2015/07/12)
   </li>
 
+  <li> New: Added class DoFVector as a union of a dof handler and a
+  vector describing functions on such a handler. The new class is also
+  used in the new implementation of FEFieldFunction. The function
+  DoFVector::sync() serves to replace reinitializing vector sizes by
+  hand. It is currently implemented for Vector, BlockVector and
+  MGLevelObject thereof.
+  <br>
+  (Guido Kanschat, 2015/07/07)
+  </li>
 </ol>
 
 

--- a/include/deal.II/dofs/dof_vector.h
+++ b/include/deal.II/dofs/dof_vector.h
@@ -1,0 +1,243 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2007 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__dof_vector_h
+#define dealii__dof_vector_h
+
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_memory.h>
+
+DEAL_II_NAMESPACE_OPEN
+/**
+ * An object storing a vector describing a finite element function
+ * together with its DoFHandler and the ConstraintMatrix associated
+ * with the handler.
+ *
+ * Data vectors for finite element discretizations do not make sense
+ * without their DoFHandler. Nevertheless, deal.II has assumed for
+ * decades, that there is a single DoFHandler in a program and that
+ * all vectors refer to it. This class encapsulates both, to begin
+ * with in a minimally intrusive way, giving access to both
+ * structures.
+ *
+ * @todo Ensure that both objects are synchronized, that is, the
+ * DoFHandler is not changes without the vector being resized.
+ */
+template <class DH, class VECTOR=Vector<double> >
+class DoFVector :  public Subscriptor
+{
+public:
+  /// @name Constructors and initialization
+  ///@{
+  /**
+   * Construct an object with a DoFHandler and borrow a vector from
+   * GrowingVectorMemory for its data. This vector is then owned by
+   * this object and released when the object itself expires.
+   */
+  DoFVector (const DH &dh, const ConstraintMatrix &constraints);
+
+  /**
+   * Construct an object with a DoFHandler but without constraints and
+   * borrow a vector from GrowingVectorMemory for its data. This
+   * vector is then owned by this object and released when the object
+   * itself expires.
+   *
+   * @note This constructor uses the ConstraintMatrix
+   * #no_constraints. The created object thus can output vectors in
+   * distributed format, but writing into vectors will most likely
+   * fail without using a constraint matrix from somewhere else.
+   */
+  DoFVector (const DH &dh);
+
+  /**
+   * Construct an object with a DoFHandler and borrow a vector from
+   * GrowingVectorMemory for its data. This vector is not owned by the
+   * object and read-access only.
+   *
+   * @note An object created this way is effectively constant. In
+   * order to avoid obscure access errors to the data vector, it
+   * should also be declared `const`.
+   */
+  DoFVector (const DH &dh, const ConstraintMatrix &constraints, const VECTOR &v);
+
+  /**
+   * Construct an object with a DoFHandler but without constraints and
+   * borrow a vector from GrowingVectorMemory for its data. This
+   * vector is not owned by the object and read-access only.
+   *
+   * @note An object created this way is effectively constant. In
+   * order to avoid access errors to the data vector, it should also
+   * be declared `const`. Also, vectors are expected to be in
+   * distributed format, since the information on constraints is
+   * missing.
+   */
+  DoFVector (const DH &dh, const VECTOR &v);
+
+  /**
+   * Destructor, deleting own data.
+   */
+  ~DoFVector ();
+
+  /**
+   * Modify the vector dimensions to match the current state of the
+   * dof handler.
+   */
+  void sync ();
+
+  ///@}
+
+  /// @name Access to members
+  ///@{
+  /**
+   * Access to the DoFHandler
+   */
+  const DH &dof_handler () const;
+
+  /**
+   * Read-only access to the data vector
+   */
+  const VECTOR &data () const;
+
+  /**
+   * Read-write access to the data vector.
+   *
+   * Read-write access is only possible, if the vector is owned by the
+   * object.
+   */
+  VECTOR &data ();
+  ///@}
+
+private:
+  /**
+   * The pool for allocating the vector.
+   */
+  GrowingVectorMemory<VECTOR> mem;
+
+  /**
+   * Empty constrainty matrix for constructors without one.
+   */
+  ConstraintMatrix no_constraints;
+
+  /**
+   * Pointer to the dof handler.
+   */
+  SmartPointer<const DH, DoFVector<DH, VECTOR> > dh;
+
+  /**
+   * Pointer to the dof handler.
+   */
+  SmartPointer<const ConstraintMatrix, DoFVector<DH, VECTOR> > constraints;
+
+  /**
+   * The actual data vector, if owned by this object.
+   */
+  VECTOR *my_data;
+
+  /**
+   * The data vector if referencing a vector not owned by this object.
+   */
+  SmartPointer<const VECTOR, DoFVector<DH, VECTOR> > other_data;
+};
+
+
+template <class DH, class VECTOR>
+inline
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const ConstraintMatrix &co)
+  : dh(&dh),
+    constraints(&co),
+    my_data(0),
+    other_data(0)
+{
+  my_data = mem.alloc();
+}
+
+
+template <class DH, class VECTOR>
+inline
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh)
+  : dh(&dh),
+    constraints(&no_constraints),
+    my_data(0),
+    other_data(0)
+{
+  my_data = mem.alloc();
+}
+
+
+template <class DH, class VECTOR>
+inline
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const ConstraintMatrix &co, const VECTOR &v)
+  : dh(&dh),
+    constraints(&co),
+    my_data(0),
+    other_data(&v)
+{}
+
+
+template <class DH, class VECTOR>
+inline
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const VECTOR &v)
+  : dh(&dh),
+    constraints(&no_constraints),
+    my_data(0),
+    other_data(&v)
+{}
+
+
+template <class DH, class VECTOR>
+inline
+DoFVector<DH, VECTOR>::~DoFVector ()
+{
+  if (my_data != 0)
+    mem.free(my_data);
+}
+
+
+template <class DH, class VECTOR>
+inline
+const DH &
+DoFVector<DH, VECTOR>::dof_handler () const
+{
+  return *dh;
+}
+
+
+template <class DH, class VECTOR>
+inline
+const VECTOR &
+DoFVector<DH, VECTOR>::data () const
+{
+  if (my_data != 0)
+    return *my_data;
+  Assert(other_data != 0, ExcNotInitialized());
+  return *other_data;
+}
+
+
+template <class DH, class VECTOR>
+inline
+VECTOR &
+DoFVector<DH, VECTOR>::data ()
+{
+  Assert(my_data != 0, ExcNotInitialized());
+  return *my_data;
+}
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/dofs/dof_vector.h
+++ b/include/deal.II/dofs/dof_vector.h
@@ -28,11 +28,14 @@ DEAL_II_NAMESPACE_OPEN
  * with the handler.
  *
  * This class encapsulates a data vector with the finite element space
- * information associated with it, such that every function which is
- * not purely algebraic can assogiate the right finite element
- * function with the data vector. Thus, functions only need a single
- * argument of type DoFVector instead of several arguments with
- * separate information on data and finite element space.  To begin,
+ * information associated with it, such that every operation which
+ * needs function values of a finite element function, namely every
+ * operation which is not purely algebraic can associate the right
+ * finite element space with the data vector. Thus, functions
+ * implementing such operations need only a single argument of type
+ * DoFVector instead of currently at least three arguments with
+ * separate information on data and finite element space (the latter
+ * being contributed by DoFHandler and ConstraintMatrix).  To begin,
  * it is implemented in a minimally intrusive way, giving access to
  * both structures.
  *
@@ -215,13 +218,13 @@ private:
 
   /**
    * The actual data vector, if owned by this object. This pointer
-   * nonzero implies #other_data is zero.
+   * being nonzero implies #other_data is zero.
    */
   VECTOR *my_data;
 
   /**
    * The data vector if referencing a vector not owned by this
-   * object. This pointer nonzero implies #my_data is zero.
+   * object. This pointer being nonzero implies #my_data is zero.
    */
   SmartPointer<const VECTOR, DoFVector<DH, VECTOR> > other_data;
 };

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_vector.h>
 #include <deal.II/fe/mapping_q1.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
@@ -48,6 +49,11 @@ namespace Functions
    * construct a quadrature object for the point (or set of points) where you
    * want to evaluate your finite element function. In order to do so, it
    * needs to find out where the points lie.
+   *
+   * @note This function is not intended for assembling a vector or a
+   * matrix on a cell-by-cell basis. Tailored access through FEValues
+   * or similar is recommended then. In such a case, the base class
+   * DoFVector may be helpful.
    *
    * If you know in advance in which cell your points lie, you can accelerate
    * things a bit, by calling set_active_cell before asking for values or
@@ -162,7 +168,7 @@ namespace Functions
   template <int dim,
             typename DH=DoFHandler<dim>,
             typename VECTOR=Vector<double> >
-  class FEFieldFunction :  public Function<dim>
+  class FEFieldFunction :  public Function<dim>, private DoFVector<DH, VECTOR>
   {
   public:
     /**
@@ -425,16 +431,6 @@ namespace Functions
     typedef
     Threads::ThreadLocalStorage <typename DH::active_cell_iterator >
     cell_hint_t;
-
-    /**
-     * Pointer to the dof handler.
-     */
-    SmartPointer<const DH,FEFieldFunction<dim, DH, VECTOR> > dh;
-
-    /**
-     * A reference to the actual data vector.
-     */
-    const VECTOR &data_vector;
 
     /**
      * A reference to the mapping being used.

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -52,7 +52,7 @@ namespace Functions
    *
    * @note This function is not intended for assembling a vector or a
    * matrix on a cell-by-cell basis. Tailored access through FEValues
-   * or similar is recommended then. In such a case, the base class
+   * or similar is recommended then. In such a case, the class
    * DoFVector may be helpful.
    *
    * If you know in advance in which cell your points lie, you can accelerate

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -63,15 +63,15 @@ namespace Functions
     Assert (values.size() == n_components,
             ExcDimensionMismatch(values.size(), n_components));
     typename DH::active_cell_iterator cell = cell_hint.get();
-    if (cell == this->dof_handler().end())
-      cell = this->dof_handler().begin_active();
+    if (cell == this->get_dof_handler().end())
+      cell = this->get_dof_handler().begin_active();
 
     boost::optional<Point<dim> >
     qp = get_reference_coordinates (cell, p);
     if (!qp)
       {
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
-          = GridTools::find_active_cell_around_point (mapping, this->dof_handler(), p);
+          = GridTools::find_active_cell_around_point (mapping, this->get_dof_handler(), p);
         AssertThrow (my_pair.first->is_locally_owned(),
                      VectorTools::ExcPointNotAvailableHere());
 
@@ -88,7 +88,7 @@ namespace Functions
     fe_v.reinit(cell);
     std::vector< Vector<typename VECTOR::value_type> >
     vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
-    fe_v.get_function_values(this->data(), vvalues);
+    fe_v.get_function_values(this->get_data(), vvalues);
     values = vvalues[0];
   }
 
@@ -115,15 +115,15 @@ namespace Functions
     Assert (gradients.size() == n_components,
             ExcDimensionMismatch(gradients.size(), n_components));
     typename DH::active_cell_iterator cell = cell_hint.get();
-    if (cell == this->dof_handler().end())
-      cell = this->dof_handler().begin_active();
+    if (cell == this->get_dof_handler().end())
+      cell = this->get_dof_handler().begin_active();
 
     boost::optional<Point<dim> >
     qp = get_reference_coordinates (cell, p);
     if (!qp)
       {
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
-          = GridTools::find_active_cell_around_point (mapping, this->dof_handler(), p);
+          = GridTools::find_active_cell_around_point (mapping, this->get_dof_handler(), p);
         AssertThrow (my_pair.first->is_locally_owned(),
                      VectorTools::ExcPointNotAvailableHere());
 
@@ -144,7 +144,7 @@ namespace Functions
     // function wants to return everything in a vector<double>
     std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > > vgrads
     (1,  std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components) );
-    fe_v.get_function_gradients(this->data(), vgrads);
+    fe_v.get_function_gradients(this->get_data(), vgrads);
     gradients = std::vector<Tensor<1,dim> >(vgrads[0].begin(), vgrads[0].end());
   }
 
@@ -172,15 +172,15 @@ namespace Functions
     Assert (values.size() == n_components,
             ExcDimensionMismatch(values.size(), n_components));
     typename DH::active_cell_iterator cell = cell_hint.get();
-    if (cell == this->dof_handler().end())
-      cell = this->dof_handler().begin_active();
+    if (cell == this->get_dof_handler().end())
+      cell = this->get_dof_handler().begin_active();
 
     boost::optional<Point<dim> >
     qp = get_reference_coordinates (cell, p);
     if (!qp)
       {
         const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
-          = GridTools::find_active_cell_around_point (mapping, this->dof_handler(), p);
+          = GridTools::find_active_cell_around_point (mapping, this->get_dof_handler(), p);
         AssertThrow (my_pair.first->is_locally_owned(),
                      VectorTools::ExcPointNotAvailableHere());
 
@@ -197,7 +197,7 @@ namespace Functions
     fe_v.reinit(cell);
     std::vector< Vector<typename VECTOR::value_type> >
     vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
-    fe_v.get_function_laplacians(this->data(), vvalues);
+    fe_v.get_function_laplacians(this->get_data(), vvalues);
     values = vvalues[0];
   }
 
@@ -231,7 +231,7 @@ namespace Functions
 
     unsigned int ncells = compute_point_locations(points, cells, qpoints, maps);
     hp::MappingCollection<dim> mapping_collection (mapping);
-    hp::FECollection<dim> fe_collection (this->dof_handler().get_fe ());
+    hp::FECollection<dim> fe_collection (this->get_dof_handler().get_fe ());
     hp::QCollection<dim> quadrature_collection;
     // Create quadrature collection
     for (unsigned int i=0; i<ncells; ++i)
@@ -252,7 +252,7 @@ namespace Functions
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
         std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
-        fe_v.get_present_fe_values ().get_function_values(this->data(), vvalues);
+        fe_v.get_present_fe_values ().get_function_values(this->get_data(), vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];
       }
@@ -293,7 +293,7 @@ namespace Functions
 
     unsigned int ncells = compute_point_locations(points, cells, qpoints, maps);
     hp::MappingCollection<dim> mapping_collection (mapping);
-    hp::FECollection<dim> fe_collection (this->dof_handler().get_fe ());
+    hp::FECollection<dim> fe_collection (this->get_dof_handler().get_fe ());
     hp::QCollection<dim> quadrature_collection;
     // Create quadrature collection
     for (unsigned int i=0; i<ncells; ++i)
@@ -315,7 +315,7 @@ namespace Functions
         const unsigned int nq = qpoints[i].size();
         std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > >
         vgrads (nq, std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components));
-        fe_v.get_present_fe_values ().get_function_gradients(this->data(), vgrads);
+        fe_v.get_present_fe_values ().get_function_gradients(this->get_data(), vgrads);
         for (unsigned int q=0; q<nq; ++q)
           {
             const unsigned int s = vgrads[q].size();
@@ -358,7 +358,7 @@ namespace Functions
 
     unsigned int ncells = compute_point_locations(points, cells, qpoints, maps);
     hp::MappingCollection<dim> mapping_collection (mapping);
-    hp::FECollection<dim> fe_collection (this->dof_handler().get_fe ());
+    hp::FECollection<dim> fe_collection (this->get_dof_handler().get_fe ());
     hp::QCollection<dim> quadrature_collection;
     // Create quadrature collection
     for (unsigned int i=0; i<ncells; ++i)
@@ -379,7 +379,7 @@ namespace Functions
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
         std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
-        fe_v.get_present_fe_values ().get_function_laplacians(this->data(), vvalues);
+        fe_v.get_present_fe_values ().get_function_laplacians(this->get_data(), vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];
       }
@@ -430,8 +430,8 @@ namespace Functions
 
     // Current quadrature point
     typename DH::active_cell_iterator cell = cell_hint.get();
-    if (cell == this->dof_handler().end())
-      cell = this->dof_handler().begin_active();
+    if (cell == this->get_dof_handler().end())
+      cell = this->get_dof_handler().begin_active();
 
     {
       // see if the point is
@@ -454,7 +454,7 @@ namespace Functions
         {
           const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> >
           my_pair  = GridTools::find_active_cell_around_point
-                     (mapping, this->dof_handler(), points[0]);
+                     (mapping, this->get_dof_handler(), points[0]);
           AssertThrow (my_pair.first->is_locally_owned(),
                        VectorTools::ExcPointNotAvailableHere());
 
@@ -518,7 +518,7 @@ namespace Functions
         if (left_over == true)
           {
             const std::pair<typename dealii::internal::ActiveCellIterator<dim, dim, DH>::type, Point<dim> > my_pair
-              = GridTools::find_active_cell_around_point (mapping, this->dof_handler(), points[first_outside]);
+              = GridTools::find_active_cell_around_point (mapping, this->get_dof_handler(), points[first_outside]);
             AssertThrow (my_pair.first->is_locally_owned(),
                          VectorTools::ExcPointNotAvailableHere());
 

--- a/source/dofs/CMakeLists.txt
+++ b/source/dofs/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(_src
   dof_tools.cc
   dof_tools_constraints.cc
   dof_tools_sparsity.cc
+  dof_vector.cc
   number_cache.cc
   )
 
@@ -43,6 +44,7 @@ SET(_inst
   dof_tools_constraints.inst.in
   dof_tools.inst.in
   dof_tools_sparsity.inst.in
+  dof_vector.inst.in
   )
 
 FILE(GLOB _header

--- a/source/dofs/dof_vector.cc
+++ b/source/dofs/dof_vector.cc
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/dofs/dof_vector.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/base/mg_level_object.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/parallel_vector.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace
+{
+  template <class DH, class VECTOR>
+  void reinit_dof_vector (const DH &, VECTOR &)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+  template <int dim, int spacedim, typename number>
+  void reinit_dof_vector (const DoFHandler<dim, spacedim> &dh,
+                          Vector<number> &v)
+  {
+    v.reinit(dh.n_dofs());
+  }
+
+  template <int dim, int spacedim, typename number>
+  void reinit_dof_vector (const DoFHandler<dim, spacedim> &dh,
+                          MGLevelObject<Vector<number> > &v)
+  {
+    const unsigned int nlev = dh.get_tria().n_levels();
+    v.resize(0, nlev-1);
+    for (unsigned int l=0; l<nlev; ++l)
+      v[l].reinit(dh.n_dofs(l));
+  }
+
+  template <int dim, int spacedim, typename number>
+  void reinit_dof_vector (const DoFHandler<dim, spacedim> &dh,
+                          BlockVector<number> &v)
+  {
+    v.reinit(dh.block_info().global());
+  }
+
+  template <int dim, int spacedim, typename number>
+  void reinit_dof_vector (const DoFHandler<dim, spacedim> &dh,
+                          MGLevelObject<BlockVector<number> > &v)
+  {
+    const unsigned int nlev = dh.get_tria().n_levels();
+    v.resize(0, nlev-1);
+    for (unsigned int l=0; l<nlev; ++l)
+      v[l].reinit(dh.block_info().level(l));
+  }
+
+  template <int dim, int spacedim, typename number>
+  void reinit_dof_vector (const hp::DoFHandler<dim, spacedim> &dh,
+                          Vector<number> &v)
+  {
+    v.reinit(dh.n_dofs());
+  }
+
+}
+
+
+
+template <class DH, class VECTOR>
+inline
+void
+DoFVector<DH, VECTOR>::sync ()
+{
+  reinit_dof_vector(dof_handler(), data());
+}
+
+
+#include "dof_vector.inst"
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/dofs/dof_vector.cc
+++ b/source/dofs/dof_vector.cc
@@ -89,6 +89,7 @@ DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const ConstraintMatrix &co)
     other_data(0)
 {
   my_data = mem.alloc();
+  const_data = my_data;
 }
 
 
@@ -100,7 +101,18 @@ DoFVector<DH, VECTOR>::DoFVector (const DH &dh)
     other_data(0)
 {
   my_data = mem.alloc();
+  const_data = my_data;
 }
+
+
+template <class DH, class VECTOR>
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const ConstraintMatrix &co, VECTOR &v)
+  : dh(&dh),
+    constraints(&co),
+    my_data(0),
+    other_data(&v),
+    const_data(&v)
+{}
 
 
 template <class DH, class VECTOR>
@@ -108,7 +120,18 @@ DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const ConstraintMatrix &co, cons
   : dh(&dh),
     constraints(&co),
     my_data(0),
-    other_data(&v)
+    other_data(0),
+    const_data(&v)
+{}
+
+
+template <class DH, class VECTOR>
+DoFVector<DH, VECTOR>::DoFVector (const DH &dh, VECTOR &v)
+  : dh(&dh),
+    constraints(&no_constraints),
+    my_data(0),
+    other_data(&v),
+    const_data(&v)
 {}
 
 
@@ -117,7 +140,8 @@ DoFVector<DH, VECTOR>::DoFVector (const DH &dh, const VECTOR &v)
   : dh(&dh),
     constraints(&no_constraints),
     my_data(0),
-    other_data(&v)
+    other_data(0),
+    const_data(&v)
 {}
 
 

--- a/source/dofs/dof_vector.inst.in
+++ b/source/dofs/dof_vector.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -13,22 +13,14 @@
 //
 // ---------------------------------------------------------------------
 
-
-
-for (VECTOR : SERIAL_VECTORS)
+for (VEC : SERIAL_VECTORS ; DH : DOFHANDLER_TEMPLATES ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
   {
-    template class VectorMemory<VECTOR>;
-    template class GrowingVectorMemory<VECTOR>;
+#if deal_II_dimension <= deal_II_space_dimension
+    template
+    void DoFVector< DH<deal_II_dimension,deal_II_space_dimension>, VEC>::sync ();
 
-    template class VectorMemory<MGLevelObject<VECTOR> >;
-    template class GrowingVectorMemory<MGLevelObject<VECTOR> >;
-  }
-
- for (SCALAR : COMPLEX_SCALARS)
-  {
-    template class VectorMemory<Vector<SCALAR> >;
-    template class GrowingVectorMemory<Vector<SCALAR> >;
-
-    template class VectorMemory<BlockVector<SCALAR> >;
-    template class GrowingVectorMemory<BlockVector<SCALAR> >;
+    template
+    void DoFVector< DH<deal_II_dimension,deal_II_space_dimension>,
+      MGLevelObject<VEC> >::sync ();
+#endif
   }

--- a/source/dofs/dof_vector.inst.in
+++ b/source/dofs/dof_vector.inst.in
@@ -17,10 +17,9 @@ for (VEC : SERIAL_VECTORS ; DH : DOFHANDLER_TEMPLATES ; deal_II_dimension : DIME
   {
 #if deal_II_dimension <= deal_II_space_dimension
     template
-    void DoFVector< DH<deal_II_dimension,deal_II_space_dimension>, VEC>::sync ();
+    class DoFVector< DH<deal_II_dimension,deal_II_space_dimension>, VEC>;
 
     template
-    void DoFVector< DH<deal_II_dimension,deal_II_space_dimension>,
-      MGLevelObject<VEC> >::sync ();
+    class DoFVector< DH<deal_II_dimension,deal_II_space_dimension>, MGLevelObject<VEC> >;
 #endif
   }

--- a/source/lac/vector_memory.cc
+++ b/source/lac/vector_memory.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/mg_level_object.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/parallel_vector.h>

--- a/tests/deal.II/dof_vector_01.cc
+++ b/tests/deal.II/dof_vector_01.cc
@@ -38,19 +38,19 @@ void test(const DH& dh)
   
   DoFVector<DH, Vector<number> > dv1(dh);
   dv1.sync();
-  Vector<number>& v1 = dv1.data();
+  Vector<number>& v1 = dv1.get_data();
   deallog << "dim " << DH::dimension << " v1: " << v1.size() << std::endl;
   
   const DoFVector<DH, Vector<number> > dv2(dh);
-  const Vector<number>& v2 = dv2.data();
+  const Vector<number>& v2 = dv2.get_data();
   
   Vector<number> w(5);
   const DoFVector<DH, Vector<number> > dv3(dh, w);
-  const Vector<number>& v3 = dv3.data();
+  const Vector<number>& v3 = dv3.get_data();
 
   DoFVector<DH, BlockVector<number> > dvb(dh);
   dvb.sync();
-  BlockVector<number>& vb = dvb.data();
+  BlockVector<number>& vb = dvb.get_data();
   deallog << "dim " << DH::dimension << " vb: " << vb.get_block_indices().to_string() << std::endl;
   
 }
@@ -62,22 +62,22 @@ void test_mg(const DH& dh)
   
   DoFVector<DH, MGLevelObject<Vector<number> > > dv1(dh);
   dv1.sync();
-  MGLevelObject<Vector<number> >& v1 = dv1.data();
+  MGLevelObject<Vector<number> >& v1 = dv1.get_data();
   deallog << "dim " << DH::dimension << " v1: (" << v1.min_level()
 	  << "->" << v1.max_level() << ')' << std::endl;
   for (unsigned int i=v1.min_level(); i <= v1.max_level();++i)
     deallog << " l" << i << ": " << v1[i].size() << std::endl;
   
   const DoFVector<DH, Vector<number> > dv2(dh);
-  const Vector<number>& v2 = dv2.data();
+  const Vector<number>& v2 = dv2.get_data();
   
   Vector<number> w(5);
   const DoFVector<DH, Vector<number> > dv3(dh, w);
-  const Vector<number>& v3 = dv3.data();
+  const Vector<number>& v3 = dv3.get_data();
 
   DoFVector<DH, MGLevelObject<BlockVector<number> > > dvb(dh);
   dvb.sync();
-  MGLevelObject<BlockVector<number> >& vb = dvb.data();
+  MGLevelObject<BlockVector<number> >& vb = dvb.get_data();
   deallog << "dim " << DH::dimension << " vb: (" << vb.min_level()
 	  << "->" << vb.max_level() << ')' << std::endl;
   for (unsigned int i=vb.min_level(); i <= vb.max_level();++i)

--- a/tests/deal.II/dof_vector_01.cc
+++ b/tests/deal.II/dof_vector_01.cc
@@ -39,14 +39,28 @@ void test(const DH& dh)
   DoFVector<DH, Vector<number> > dv1(dh);
   dv1.sync();
   Vector<number>& v1 = dv1.get_data();
-  deallog << "dim " << DH::dimension << " v1: " << v1.size() << std::endl;
-  
-  const DoFVector<DH, Vector<number> > dv2(dh);
-  const Vector<number>& v2 = dv2.get_data();
+  deallog << " dim " << DH::dimension << " v1: " << v1.size() << std::endl;
+  deallog << "dv1 " << (dv1.is_const() ? 'c' : 'm')
+	  << (dv1.is_owner() ? 'o' : 'x')
+	  << std::endl;
   
   Vector<number> w(5);
-  const DoFVector<DH, Vector<number> > dv3(dh, w);
+  const DoFVector<DH, Vector<number> > dv2(dh, w);
+  deallog << "dv2 " << (dv2.is_const() ? 'c' : 'm')
+	  << (dv2.is_owner() ? 'o' : 'x')
+	  << std::endl;
+  DoFVector<DH, Vector<number> > dv3(dh, w);
   const Vector<number>& v3 = dv3.get_data();
+  deallog << "dv3 " << (dv3.is_const() ? 'c' : 'm')
+	  << (dv3.is_owner() ? 'o' : 'x')
+	  << std::endl;
+
+  const Vector<number>& cw = w;
+  DoFVector<DH, Vector<number> > dv4(dh, cw);
+  deallog << "dv4 " << (dv4.is_const() ? 'c' : 'm')
+	  << (dv4.is_owner() ? 'o' : 'x')
+	  << std::endl;
+  
 
   DoFVector<DH, BlockVector<number> > dvb(dh);
   dvb.sync();

--- a/tests/deal.II/dof_vector_01.cc
+++ b/tests/deal.II/dof_vector_01.cc
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test constructor and access of DoFVector as well as sync for Vector
+// and BlockVector
+
+#include "../tests.h"
+#include <deal.II/base/mg_level_object.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/dofs/dof_vector.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+
+template <class DH, typename number>
+void test(const DH& dh)
+{
+  deallog << dh.get_fe().get_name() << std::endl;
+  
+  DoFVector<DH, Vector<number> > dv1(dh);
+  dv1.sync();
+  Vector<number>& v1 = dv1.data();
+  deallog << "dim " << DH::dimension << " v1: " << v1.size() << std::endl;
+  
+  const DoFVector<DH, Vector<number> > dv2(dh);
+  const Vector<number>& v2 = dv2.data();
+  
+  Vector<number> w(5);
+  const DoFVector<DH, Vector<number> > dv3(dh, w);
+  const Vector<number>& v3 = dv3.data();
+
+  DoFVector<DH, BlockVector<number> > dvb(dh);
+  dvb.sync();
+  BlockVector<number>& vb = dvb.data();
+  deallog << "dim " << DH::dimension << " vb: " << vb.get_block_indices().to_string() << std::endl;
+  
+}
+
+template <class DH, typename number>
+void test_mg(const DH& dh)
+{
+  deallog << "MG" << dh.get_fe().get_name() << std::endl;
+  
+  DoFVector<DH, MGLevelObject<Vector<number> > > dv1(dh);
+  dv1.sync();
+  MGLevelObject<Vector<number> >& v1 = dv1.data();
+  deallog << "dim " << DH::dimension << " v1: (" << v1.min_level()
+	  << "->" << v1.max_level() << ')' << std::endl;
+  for (unsigned int i=v1.min_level(); i <= v1.max_level();++i)
+    deallog << " l" << i << ": " << v1[i].size() << std::endl;
+  
+  const DoFVector<DH, Vector<number> > dv2(dh);
+  const Vector<number>& v2 = dv2.data();
+  
+  Vector<number> w(5);
+  const DoFVector<DH, Vector<number> > dv3(dh, w);
+  const Vector<number>& v3 = dv3.data();
+
+  DoFVector<DH, MGLevelObject<BlockVector<number> > > dvb(dh);
+  dvb.sync();
+  MGLevelObject<BlockVector<number> >& vb = dvb.data();
+  deallog << "dim " << DH::dimension << " vb: (" << vb.min_level()
+	  << "->" << vb.max_level() << ')' << std::endl;
+  for (unsigned int i=vb.min_level(); i <= vb.max_level();++i)
+    deallog << " l" << i << ": " << vb[i].get_block_indices().to_string() << std::endl;
+}
+
+template <int dim>
+void test_grid()
+{
+  Triangulation<dim> tr;
+  GridGenerator::hyper_cube(tr);
+  tr.refine_global(1);
+  FE_Q<dim> fe(1);
+  
+  DoFHandler<dim> dh(tr);
+  dh.distribute_dofs(fe);
+  dh.distribute_mg_dofs(fe);
+  
+  test<DoFHandler<dim>, float>(dh);
+  test_mg<DoFHandler<dim>, float>(dh);
+  test<DoFHandler<dim>, double>(dh);
+  test_mg<DoFHandler<dim>, double>(dh);
+
+  FESystem<dim> fes(fe,3);
+  DoFHandler<dim> ds(tr);
+  ds.distribute_dofs(fes);
+  ds.distribute_mg_dofs(fes);
+  
+  test<DoFHandler<dim>, float>(ds);
+  test_mg<DoFHandler<dim>, float>(ds);
+  test<DoFHandler<dim>, double>(ds);
+  test_mg<DoFHandler<dim>, double>(ds);
+}
+
+
+int main ()
+{
+  initlog();
+  test_grid<2>();
+  test_grid<3>();
+  return 0;
+}
+

--- a/tests/deal.II/dof_vector_01.output
+++ b/tests/deal.II/dof_vector_01.output
@@ -1,6 +1,10 @@
 
 DEAL::FE_Q<2>(1)
-DEAL::dim 2 v1: 9
+DEAL:: dim 2 v1: 9
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 2 vb: [1->9|9]
 DEAL::MGFE_Q<2>(1)
 DEAL::dim 2 v1: (0->1)
@@ -10,7 +14,11 @@ DEAL::dim 2 vb: (0->1)
 DEAL:: l0: [1->4|4]
 DEAL:: l1: [1->9|9]
 DEAL::FE_Q<2>(1)
-DEAL::dim 2 v1: 9
+DEAL:: dim 2 v1: 9
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 2 vb: [1->9|9]
 DEAL::MGFE_Q<2>(1)
 DEAL::dim 2 v1: (0->1)
@@ -20,7 +28,11 @@ DEAL::dim 2 vb: (0->1)
 DEAL:: l0: [1->4|4]
 DEAL:: l1: [1->9|9]
 DEAL::FESystem<2>[FE_Q<2>(1)^3]
-DEAL::dim 2 v1: 27
+DEAL:: dim 2 v1: 27
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 2 vb: [3->9,9,9|27]
 DEAL::MGFESystem<2>[FE_Q<2>(1)^3]
 DEAL::dim 2 v1: (0->1)
@@ -30,7 +42,11 @@ DEAL::dim 2 vb: (0->1)
 DEAL:: l0: [3->4,4,4|12]
 DEAL:: l1: [3->9,9,9|27]
 DEAL::FESystem<2>[FE_Q<2>(1)^3]
-DEAL::dim 2 v1: 27
+DEAL:: dim 2 v1: 27
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 2 vb: [3->9,9,9|27]
 DEAL::MGFESystem<2>[FE_Q<2>(1)^3]
 DEAL::dim 2 v1: (0->1)
@@ -40,7 +56,11 @@ DEAL::dim 2 vb: (0->1)
 DEAL:: l0: [3->4,4,4|12]
 DEAL:: l1: [3->9,9,9|27]
 DEAL::FE_Q<3>(1)
-DEAL::dim 3 v1: 27
+DEAL:: dim 3 v1: 27
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 3 vb: [1->27|27]
 DEAL::MGFE_Q<3>(1)
 DEAL::dim 3 v1: (0->1)
@@ -50,7 +70,11 @@ DEAL::dim 3 vb: (0->1)
 DEAL:: l0: [1->8|8]
 DEAL:: l1: [1->27|27]
 DEAL::FE_Q<3>(1)
-DEAL::dim 3 v1: 27
+DEAL:: dim 3 v1: 27
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 3 vb: [1->27|27]
 DEAL::MGFE_Q<3>(1)
 DEAL::dim 3 v1: (0->1)
@@ -60,7 +84,11 @@ DEAL::dim 3 vb: (0->1)
 DEAL:: l0: [1->8|8]
 DEAL:: l1: [1->27|27]
 DEAL::FESystem<3>[FE_Q<3>(1)^3]
-DEAL::dim 3 v1: 81
+DEAL:: dim 3 v1: 81
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 3 vb: [3->27,27,27|81]
 DEAL::MGFESystem<3>[FE_Q<3>(1)^3]
 DEAL::dim 3 v1: (0->1)
@@ -70,7 +98,11 @@ DEAL::dim 3 vb: (0->1)
 DEAL:: l0: [3->8,8,8|24]
 DEAL:: l1: [3->27,27,27|81]
 DEAL::FESystem<3>[FE_Q<3>(1)^3]
-DEAL::dim 3 v1: 81
+DEAL:: dim 3 v1: 81
+DEAL::dv1 mo
+DEAL::dv2 cx
+DEAL::dv3 mx
+DEAL::dv4 cx
 DEAL::dim 3 vb: [3->27,27,27|81]
 DEAL::MGFESystem<3>[FE_Q<3>(1)^3]
 DEAL::dim 3 v1: (0->1)

--- a/tests/deal.II/dof_vector_01.output
+++ b/tests/deal.II/dof_vector_01.output
@@ -1,0 +1,81 @@
+
+DEAL::FE_Q<2>(1)
+DEAL::dim 2 v1: 9
+DEAL::dim 2 vb: [1->9|9]
+DEAL::MGFE_Q<2>(1)
+DEAL::dim 2 v1: (0->1)
+DEAL:: l0: 4
+DEAL:: l1: 9
+DEAL::dim 2 vb: (0->1)
+DEAL:: l0: [1->4|4]
+DEAL:: l1: [1->9|9]
+DEAL::FE_Q<2>(1)
+DEAL::dim 2 v1: 9
+DEAL::dim 2 vb: [1->9|9]
+DEAL::MGFE_Q<2>(1)
+DEAL::dim 2 v1: (0->1)
+DEAL:: l0: 4
+DEAL:: l1: 9
+DEAL::dim 2 vb: (0->1)
+DEAL:: l0: [1->4|4]
+DEAL:: l1: [1->9|9]
+DEAL::FESystem<2>[FE_Q<2>(1)^3]
+DEAL::dim 2 v1: 27
+DEAL::dim 2 vb: [3->9,9,9|27]
+DEAL::MGFESystem<2>[FE_Q<2>(1)^3]
+DEAL::dim 2 v1: (0->1)
+DEAL:: l0: 12
+DEAL:: l1: 27
+DEAL::dim 2 vb: (0->1)
+DEAL:: l0: [3->4,4,4|12]
+DEAL:: l1: [3->9,9,9|27]
+DEAL::FESystem<2>[FE_Q<2>(1)^3]
+DEAL::dim 2 v1: 27
+DEAL::dim 2 vb: [3->9,9,9|27]
+DEAL::MGFESystem<2>[FE_Q<2>(1)^3]
+DEAL::dim 2 v1: (0->1)
+DEAL:: l0: 12
+DEAL:: l1: 27
+DEAL::dim 2 vb: (0->1)
+DEAL:: l0: [3->4,4,4|12]
+DEAL:: l1: [3->9,9,9|27]
+DEAL::FE_Q<3>(1)
+DEAL::dim 3 v1: 27
+DEAL::dim 3 vb: [1->27|27]
+DEAL::MGFE_Q<3>(1)
+DEAL::dim 3 v1: (0->1)
+DEAL:: l0: 8
+DEAL:: l1: 27
+DEAL::dim 3 vb: (0->1)
+DEAL:: l0: [1->8|8]
+DEAL:: l1: [1->27|27]
+DEAL::FE_Q<3>(1)
+DEAL::dim 3 v1: 27
+DEAL::dim 3 vb: [1->27|27]
+DEAL::MGFE_Q<3>(1)
+DEAL::dim 3 v1: (0->1)
+DEAL:: l0: 8
+DEAL:: l1: 27
+DEAL::dim 3 vb: (0->1)
+DEAL:: l0: [1->8|8]
+DEAL:: l1: [1->27|27]
+DEAL::FESystem<3>[FE_Q<3>(1)^3]
+DEAL::dim 3 v1: 81
+DEAL::dim 3 vb: [3->27,27,27|81]
+DEAL::MGFESystem<3>[FE_Q<3>(1)^3]
+DEAL::dim 3 v1: (0->1)
+DEAL:: l0: 24
+DEAL:: l1: 81
+DEAL::dim 3 vb: (0->1)
+DEAL:: l0: [3->8,8,8|24]
+DEAL:: l1: [3->27,27,27|81]
+DEAL::FESystem<3>[FE_Q<3>(1)^3]
+DEAL::dim 3 v1: 81
+DEAL::dim 3 vb: [3->27,27,27|81]
+DEAL::MGFESystem<3>[FE_Q<3>(1)^3]
+DEAL::dim 3 v1: (0->1)
+DEAL:: l0: 24
+DEAL:: l1: 81
+DEAL::dim 3 vb: (0->1)
+DEAL:: l0: [3->8,8,8|24]
+DEAL:: l1: [3->27,27,27|81]


### PR DESCRIPTION
The new class `DoFVector` introduces better coupling between vectors and finite element spaces.

it serves as a base class for `FEFieldFunction`. The function `DoFVector::sync()` serves to replace reinitializing vector sizes by hand. It is currently implemented for `Vector`, `BlockVector` and  `MGLevelObject` thereof.