### PR TITLE
VectorTools::interpolate_to_different_mesh

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -672,6 +672,8 @@ namespace VectorTools
         cell2->set_dof_values_by_interpolation(cache, u2);
       }
 
+    // finish the work on parallel vectors
+    u2.compress (VectorOperation::insert);
     // Apply hanging node constraints.
     constraints.distribute(u2);
   }


### PR DESCRIPTION
small fix: insert a <code>compress</code> before calling <code>constraints.distribute</code> needed especially for PETSc vectors, otherwise they are in a wrong state!