### PR TITLE
Clone the base elements of FESystem in parallel.

### DIFF
--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1849,6 +1849,13 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
     if (multiplicities[i]>0)
       this->base_to_block_indices.push_back( multiplicities[i] );
 
+  std::vector<Threads::Task<FiniteElement<dim,spacedim>*> > clone_base_elements;
+
+  for (unsigned int i=0; i<fes.size(); i++)
+    if (multiplicities[i]>0)
+      clone_base_elements.push_back (Threads::new_task (&FiniteElement<dim,spacedim>::clone,
+                                                        *fes[i]));
+
   unsigned int ind=0;
   for (unsigned int i=0; i<fes.size(); i++)
     {
@@ -1856,7 +1863,7 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
         {
           base_elements[ind] =
             std::make_pair (std_cxx11::shared_ptr<const FiniteElement<dim,spacedim> >
-                            (fes[i]->clone()),
+                            (clone_base_elements[ind].return_value()),
                             multiplicities[i]);
           ++ind;
         }


### PR DESCRIPTION
In the constructor of FESystem, we clone the base elements, which requires
constructing new finite element objects -- an expensive task. This patch
does this in parallel for the base elements.