### PR TITLE
Clarify fill fe values arguments

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -39,6 +39,14 @@ inconvenience this causes.
 
 <ol>
 
+  <li> Changed: The signature of the FiniteElement::fill_fe_values(),
+  FiniteElement::fill_fe_face_values(), and FiniteElement::fill_fe_subface_values()
+  functions has been changed, in an effort to clarify which of these contain
+  input information and which contain output information for these functions.
+  <br>
+  (Wolfgang Bangerth, 2015/07/20)
+  </li>
+
 </ol>
 
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -354,19 +354,39 @@ public:
   static const unsigned int space_dimension = spacedim;
 
   /**
-   * Base class for internal data.  Adds data for second derivatives to
-   * Mapping::InternalDataBase()
+   * A base class for internal data that derived finite element classes may
+   * wish to store. This class uses the same data fields as
+   * Mapping::InternalDataBase() but adds a field for the computation of
+   * second derivatives.
    *
-   * For information about the general purpose of this class, see the
-   * documentation of the base class.
+   * The class is used as follows: Whenever an FEValues (or FEFaceValues or
+   * FESubfaceValues) object is initialized, it requests that the finite
+   * element it is associated with creates an object of a class derived from
+   * the current one here. This is done via each derived class's
+   * FiniteElement::get_data() function. This object is then passed to the
+   * FiniteElement::fill_fe_values(), FiniteElement::fill_fe_face_values(),
+   * and FiniteElement::fill_fe_subface_values() functions as a constant
+   * object. The intent of these objects is so that finite element classes
+   * can pre-compute information once at the beginning (in the call to
+   * FiniteElement::get_data() call) that can then be used on each cell
+   * that is subsequently visited. An example for this is the values of
+   * shape functions at the quadrature point of the reference cell,
+   * which remain the same no matter the cell visited, and that can
+   * therefore be computed once at the beginning and reused later on.
    *
-   * @author Guido Kanschat, 2001
+   * Because only derived classes can know what they can pre-compute,
+   * each derived class that wants to store information computed once
+   * at the beginning, needs to derive its own InternalData class from
+   * this class, and return an object of the derived type through its
+   * get_data() function.
+   *
+   * @author Guido Kanschat, 2001; Wolfgang Bangerth, 2015.
    */
   class InternalDataBase : public Mapping<dim,spacedim>::InternalDataBase
   {
   public:
     /**
-     * Destructor. Needed to avoid memory leaks with difference quotients.
+     * Destructor. Made virtual to allow polymorphism.
      */
     virtual ~InternalDataBase ();
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1972,8 +1972,8 @@ protected:
   void compute_2nd (const Mapping<dim,spacedim>                      &mapping,
                     const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
                     const unsigned int                       offset,
-                    typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-                    InternalDataBase                        &fe_internal,
+                    const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
+                    const InternalDataBase                        &fe_internal,
                     FEValuesData<dim,spacedim>                       &data) const;
 
   /**
@@ -2061,8 +2061,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                     &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_internal,
-                  typename Mapping<dim,spacedim>::InternalDataBase          &fe_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase          &fe_internal,
                   FEValuesData<dim,spacedim>                                &data,
                   CellSimilarity::Similarity                           &cell_similarity) const = 0;
 
@@ -2078,8 +2078,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<dim-1>              &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                       typename Mapping<dim,spacedim>::InternalDataBase       &fe_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase       &fe_internal,
                        FEValuesData<dim,spacedim>                    &data) const = 0;
 
   /**
@@ -2095,8 +2095,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>              &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-                          typename Mapping<dim,spacedim>::InternalDataBase &fe_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &fe_internal,
                           FEValuesData<dim,spacedim>                    &data) const = 0;
 
   friend class InternalDataBase;

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2064,7 +2064,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_internal,
                   const typename Mapping<dim,spacedim>::InternalDataBase          &fe_internal,
                   FEValuesData<dim,spacedim>                                &data,
-                  CellSimilarity::Similarity                           &cell_similarity) const = 0;
+                  const CellSimilarity::Similarity                           cell_similarity) const = 0;
 
   /**
    * Fill the fields of FEFaceValues. This function performs all the

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -539,7 +539,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
                   const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
-                  CellSimilarity::Similarity                       &cell_similarity) const;
+                  const CellSimilarity::Similarity                       cell_similarity) const;
 
   /**
    * Implementation of the same function in FiniteElement.

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -536,8 +536,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim> &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                 &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
                   CellSimilarity::Similarity                       &cell_similarity) const;
 
@@ -549,8 +549,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<dim-1>                &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                        FEValuesData<dim,spacedim> &data) const ;
 
   /**
@@ -562,8 +562,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>                &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                           FEValuesData<dim,spacedim> &data) const ;
 
 private:

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -252,6 +252,19 @@ template <int dim, int spacedim> class MappingQ;
  *
  * <td align="center"></td> </tr> </table>
  *
+ *
+ * <h3> Implementation details </h3>
+ *
+ * This element does not have an InternalData class, unlike all other elements,
+ * because the InternalData classes are used to store things that can be computed once
+ * and reused multiple times (such as the values of shape functions
+ * at quadrature points on the reference cell). However, because the
+ * element is not mapped, this element has nothing that could be computed on the
+ * reference cell -- everything needs to be computed on the real cell -- and
+ * consequently there is nothing we'd like to store in such an object. We can thus
+ * simply use the members already provided by FiniteElement::InternalDataBase without
+ * adding anything in a derived class in this class.
+ *
  * @author Guido Kanschat, 2002
  */
 template <int dim, int spacedim=dim>
@@ -594,21 +607,6 @@ private:
    * Pointer to an object representing the polynomial space used here.
    */
   const PolynomialSpace<dim> polynomial_space;
-
-  /**
-   * Fields of cell-independent data.
-   *
-   * For information about the general purpose of this class, see the
-   * documentation of the base class.
-   */
-  class InternalData : public FiniteElement<dim,spacedim>::InternalDataBase
-  {
-  public:
-    // have some scratch arrays
-    std::vector<double> values;
-    std::vector<Tensor<1,dim> > grads;
-    std::vector<Tensor<2,dim> > grad_grads;
-  };
 
   /**
    * Allow access from other dimensions.

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -247,8 +247,8 @@ protected:
   fill_fe_values (const Mapping<1,spacedim>                           &mapping,
                   const typename Triangulation<1,spacedim>::cell_iterator &cell,
                   const Quadrature<1>                                 &quadrature,
-                  typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
-                  typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
+                  const typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
+                  const typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<1,spacedim>                            &data,
                   CellSimilarity::Similarity                       &cell_similarity) const;
 
@@ -257,8 +257,8 @@ protected:
                        const typename Triangulation<1,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<0>                &quadrature,
-                       typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
-                       typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
+                       const typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
+                       const typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
                        FEValuesData<1,spacedim> &data) const ;
 
   virtual void
@@ -267,8 +267,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<0>                &quadrature,
-                          typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
-                          typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
+                          const typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
+                          const typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
                           FEValuesData<1,spacedim> &data) const ;
 
 

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -250,7 +250,7 @@ protected:
                   const typename Mapping<1,spacedim>::InternalDataBase      &mapping_internal,
                   const typename Mapping<1,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<1,spacedim>                            &data,
-                  CellSimilarity::Similarity                       &cell_similarity) const;
+                  const CellSimilarity::Similarity                       cell_similarity) const;
 
   virtual void
   fill_fe_face_values (const Mapping<1,spacedim> &mapping,

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -162,7 +162,7 @@ public:
                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                   const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
                   FEValuesData<dim,spacedim> &data,
-                  CellSimilarity::Similarity &cell_similarity) const;
+                  const CellSimilarity::Similarity cell_similarity) const;
 
   /**
    * Fill the fields of FEFaceValues. This function performs all the

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -159,8 +159,8 @@ public:
   fill_fe_values (const Mapping<dim,spacedim> &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim> &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
                   FEValuesData<dim,spacedim> &data,
                   CellSimilarity::Similarity &cell_similarity) const;
 
@@ -177,8 +177,8 @@ public:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int face,
                        const Quadrature<dim-1> & quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                       typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
                        FEValuesData<dim,spacedim> &data) const;
 
   /**
@@ -195,8 +195,8 @@ public:
                           const unsigned int face,
                           const unsigned int subface,
                           const Quadrature<dim-1> & quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                          typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
                           FEValuesData<dim,spacedim> &data) const;
 
   /**

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -172,8 +172,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim>                           &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                 &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
                   CellSimilarity::Similarity                       &cell_similarity) const;
 
@@ -182,8 +182,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<dim-1>                &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                        FEValuesData<dim,spacedim> &data) const ;
 
   virtual void
@@ -192,8 +192,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>                &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                           FEValuesData<dim,spacedim> &data) const ;
 
 

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -175,7 +175,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
                   const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
-                  CellSimilarity::Similarity                       &cell_similarity) const;
+                  const CellSimilarity::Similarity                       cell_similarity) const;
 
   virtual void
   fill_fe_face_values (const Mapping<dim,spacedim> &mapping,

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -251,8 +251,8 @@ FE_Poly<POLY,dim,spacedim>::fill_fe_values
 (const Mapping<dim,spacedim>                      &mapping,
  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
  const Quadrature<dim>                            &quadrature,
- typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
- typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+ const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+ const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
  FEValuesData<dim,spacedim>                       &data,
  CellSimilarity::Similarity                  &cell_similarity) const
 {
@@ -260,8 +260,8 @@ FE_Poly<POLY,dim,spacedim>::fill_fe_values
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.current_update_flags());
 
@@ -290,16 +290,16 @@ fill_fe_face_values (const Mapping<dim,spacedim>                   &mapping,
                      const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                      const unsigned int                    face,
                      const Quadrature<dim-1>              &quadrature,
-                     typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
-                     typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
+                     const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
+                     const typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
                      FEValuesData<dim,spacedim>                    &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   // offset determines which data set
   // to take (all data sets for all
@@ -405,16 +405,16 @@ FE_Poly<POLY,dim,spacedim>::fill_fe_subface_values (const Mapping<dim,spacedim> 
                                                     const unsigned int                    face,
                                                     const unsigned int                    subface,
                                                     const Quadrature<dim-1>              &quadrature,
-                                                    typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
-                                                    typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
+                                                    const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
+                                                    const typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
                                                     FEValuesData<dim,spacedim>                    &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   // offset determines which data set
   // to take (all data sets for all

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -254,7 +254,7 @@ FE_Poly<POLY,dim,spacedim>::fill_fe_values
  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
  FEValuesData<dim,spacedim>                       &data,
- CellSimilarity::Similarity                  &cell_similarity) const
+ const CellSimilarity::Similarity                  cell_similarity) const
 {
   // convert data object to internal
   // data for this class. fails with

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -160,8 +160,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim>                           &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                 &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                  typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
                   CellSimilarity::Similarity                       &cell_similarity) const;
 
@@ -170,8 +170,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<dim-1>                &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                        FEValuesData<dim,spacedim> &data) const ;
 
   virtual void
@@ -180,8 +180,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>                &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                           FEValuesData<dim,spacedim> &data) const ;
 
 

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -163,7 +163,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
                   const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                   FEValuesData<dim,spacedim>                            &data,
-                  CellSimilarity::Similarity                       &cell_similarity) const;
+                  const CellSimilarity::Similarity                       cell_similarity) const;
 
   virtual void
   fill_fe_face_values (const Mapping<dim,spacedim> &mapping,

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -178,7 +178,7 @@ FE_PolyFace<POLY,dim,spacedim>::fill_fe_values
  const typename Mapping<dim,spacedim>::InternalDataBase &,
  const typename Mapping<dim,spacedim>::InternalDataBase &,
  FEValuesData<dim,spacedim> &,
- CellSimilarity::Similarity &) const
+ const CellSimilarity::Similarity ) const
 {
   // Do nothing, since we do not have
   // values in the interior

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -175,8 +175,8 @@ FE_PolyFace<POLY,dim,spacedim>::fill_fe_values
 (const Mapping<dim,spacedim> &,
  const typename Triangulation<dim,spacedim>::cell_iterator &,
  const Quadrature<dim> &,
- typename Mapping<dim,spacedim>::InternalDataBase &,
- typename Mapping<dim,spacedim>::InternalDataBase &,
+ const typename Mapping<dim,spacedim>::InternalDataBase &,
+ const typename Mapping<dim,spacedim>::InternalDataBase &,
  FEValuesData<dim,spacedim> &,
  CellSimilarity::Similarity &) const
 {
@@ -193,16 +193,16 @@ FE_PolyFace<POLY,dim,spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &,
   const unsigned int face,
   const Quadrature<dim-1>& quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &,
-  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase &,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   FEValuesData<dim,spacedim> &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
 
@@ -257,16 +257,16 @@ FE_PolyFace<POLY,dim,spacedim>::fill_fe_subface_values (
   const unsigned int face,
   const unsigned int subface,
   const Quadrature<dim-1>& quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &,
-  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase &,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   FEValuesData<dim,spacedim> &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
 

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -185,8 +185,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim>                       &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                             &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase  &mapping_internal,
-                  typename Mapping<dim,spacedim>::InternalDataBase  &fe_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_internal,
+                  const typename Mapping<dim,spacedim>::InternalDataBase  &fe_internal,
                   FEValuesData<dim,spacedim>                        &data,
                   CellSimilarity::Similarity                   &cell_similarity) const;
 
@@ -195,8 +195,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                                  face_no,
                        const Quadrature<dim-1>                            &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase   &mapping_internal,
-                       typename Mapping<dim,spacedim>::InternalDataBase   &fe_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase   &mapping_internal,
+                       const typename Mapping<dim,spacedim>::InternalDataBase   &fe_internal,
                        FEValuesData<dim,spacedim> &data) const ;
 
   virtual void
@@ -205,8 +205,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>                &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_internal,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &fe_internal,
                           FEValuesData<dim,spacedim> &data) const ;
 
   /**

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -188,7 +188,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_internal,
                   const typename Mapping<dim,spacedim>::InternalDataBase  &fe_internal,
                   FEValuesData<dim,spacedim>                        &data,
-                  CellSimilarity::Similarity                   &cell_similarity) const;
+                  const CellSimilarity::Similarity                   cell_similarity) const;
 
   virtual void
   fill_fe_face_values (const Mapping<dim,spacedim> &mapping,

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -822,8 +822,8 @@ protected:
   fill_fe_values (const Mapping<dim,spacedim>                      &mapping,
                   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                            &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                  typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
                   FEValuesData<dim,spacedim>                       &data,
                   CellSimilarity::Similarity                  &cell_similarity) const;
 
@@ -838,8 +838,8 @@ protected:
                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                    face_no,
                        const Quadrature<dim-1>              &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &mapping_data,
-                       typename Mapping<dim,spacedim>::InternalDataBase      &fe_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase      &fe_data,
                        FEValuesData<dim,spacedim>                    &data) const;
 
   /**
@@ -854,8 +854,8 @@ protected:
                           const unsigned int                    face_no,
                           const unsigned int                    sub_no,
                           const Quadrature<dim-1>              &quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &mapping_data,
-                          typename Mapping<dim,spacedim>::InternalDataBase      &fe_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase      &fe_data,
                           FEValuesData<dim,spacedim>                    &data) const;
 
 
@@ -875,9 +875,9 @@ protected:
                      const unsigned int                                face_no,
                      const unsigned int                                sub_no,
                      const Quadrature<dim_1>                          &quadrature,
-                     CellSimilarity::Similarity                   cell_similarity,
-                     typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                     typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+                     const CellSimilarity::Similarity                   cell_similarity,
+                     const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                     const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
                      FEValuesData<dim,spacedim>                       &data) const;
 
 private:
@@ -1050,8 +1050,8 @@ private:
     const unsigned int                                sub_no,
     const Quadrature<dim_1>                          &quadrature,
     CellSimilarity::Similarity                   cell_similarity,
-    typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-    typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+    const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+    const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
     const unsigned int                                base_element,
     FEValuesData<dim,spacedim>                       &data) const;
 

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -825,7 +825,7 @@ protected:
                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                   const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
                   FEValuesData<dim,spacedim>                       &data,
-                  CellSimilarity::Similarity                  &cell_similarity) const;
+                  const CellSimilarity::Similarity                  cell_similarity) const;
 
   /**
    * Implementation of the same function in FiniteElement.

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1218,11 +1218,10 @@ FiniteElement<1,2>::compute_2nd (
   const Mapping<1,2> &,
   const Triangulation<1,2>::cell_iterator &,
   const unsigned int,
-  Mapping<1,2>::InternalDataBase &,
-  InternalDataBase &,
+  const Mapping<1,2>::InternalDataBase &,
+  const InternalDataBase &,
   FEValuesData<1,2> &) const
 {
-
   Assert(false, ExcNotImplemented());
 }
 
@@ -1233,11 +1232,10 @@ FiniteElement<1,3>::compute_2nd (
   const Mapping<1,3> &,
   const Triangulation<1,3>::cell_iterator &,
   const unsigned int,
-  Mapping<1,3>::InternalDataBase &,
-  InternalDataBase &,
+  const Mapping<1,3>::InternalDataBase &,
+  const InternalDataBase &,
   FEValuesData<1,3> &) const
 {
-
   Assert(false, ExcNotImplemented());
 }
 
@@ -1249,11 +1247,10 @@ FiniteElement<2,3>::compute_2nd (
   const Mapping<2,3> &,
   const Triangulation<2,3>::cell_iterator &,
   const unsigned int,
-  Mapping<2,3>::InternalDataBase &,
-  InternalDataBase &,
+  const Mapping<2,3>::InternalDataBase &,
+  const InternalDataBase &,
   FEValuesData<2,3> &) const
 {
-
   Assert(false, ExcNotImplemented());
 }
 
@@ -1265,8 +1262,8 @@ FiniteElement<dim,spacedim>::compute_2nd (
   const Mapping<dim,spacedim>                   &mapping,
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int offset,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-  InternalDataBase                     &fe_internal,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
+  const InternalDataBase                     &fe_internal,
   FEValuesData<dim,spacedim>                    &data) const
 {
   Assert ((fe_internal.update_each | fe_internal.update_once)

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -284,7 +284,7 @@ FE_DGPNonparametric<dim,spacedim>::fill_fe_values (
   const typename Mapping<dim,spacedim>::InternalDataBase &,
   const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim> &data,
-  CellSimilarity::Similarity &/*cell_similarity*/) const
+  const CellSimilarity::Similarity /*cell_similarity*/) const
 {
   const UpdateFlags flags(fe_data.current_update_flags());
   Assert (flags & update_quadrature_points, ExcInternalError());

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -281,8 +281,8 @@ FE_DGPNonparametric<dim,spacedim>::fill_fe_values (
   const Mapping<dim,spacedim> &,
   const typename Triangulation<dim,spacedim>::cell_iterator &,
   const Quadrature<dim> &,
-  typename Mapping<dim,spacedim>::InternalDataBase &,
-  typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim> &data,
   CellSimilarity::Similarity &/*cell_similarity*/) const
 {
@@ -321,8 +321,8 @@ FE_DGPNonparametric<dim,spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &,
   const unsigned int,
   const Quadrature<dim-1>&,
-  typename Mapping<dim,spacedim>::InternalDataBase &,
-  typename Mapping<dim,spacedim>::InternalDataBase       &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &fe_data,
   FEValuesData<dim,spacedim>                             &data) const
 {
   const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
@@ -361,8 +361,8 @@ FE_DGPNonparametric<dim,spacedim>::fill_fe_subface_values (
   const unsigned int,
   const unsigned int,
   const Quadrature<dim-1>&,
-  typename Mapping<dim,spacedim>::InternalDataBase &,
-  typename Mapping<dim,spacedim>::InternalDataBase       &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &fe_data,
   FEValuesData<dim,spacedim>                             &data) const
 {
   const UpdateFlags flags(fe_data.update_once | fe_data.update_each);

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -521,8 +521,8 @@ FE_FaceQ<1,spacedim>::fill_fe_values
 (const Mapping<1,spacedim> &,
  const typename Triangulation<1,spacedim>::cell_iterator &,
  const Quadrature<1> &,
- typename Mapping<1,spacedim>::InternalDataBase &,
- typename Mapping<1,spacedim>::InternalDataBase &,
+ const typename Mapping<1,spacedim>::InternalDataBase &,
+ const typename Mapping<1,spacedim>::InternalDataBase &,
  FEValuesData<1,spacedim> &,
  CellSimilarity::Similarity &) const
 {
@@ -538,8 +538,8 @@ FE_FaceQ<1,spacedim>::fill_fe_face_values (
   const typename Triangulation<1,spacedim>::cell_iterator &,
   const unsigned int face,
   const Quadrature<0> &,
-  typename Mapping<1,spacedim>::InternalDataBase &,
-  typename Mapping<1,spacedim>::InternalDataBase &fedata,
+  const typename Mapping<1,spacedim>::InternalDataBase &,
+  const typename Mapping<1,spacedim>::InternalDataBase &fedata,
   FEValuesData<1,spacedim> &data) const
 {
   const UpdateFlags flags(fedata.update_once | fedata.update_each);
@@ -562,11 +562,11 @@ FE_FaceQ<1,spacedim>::fill_fe_subface_values (
   const unsigned int ,
   const unsigned int ,
   const Quadrature<0> &,
-  typename Mapping<1,spacedim>::InternalDataBase &,
-  typename Mapping<1,spacedim>::InternalDataBase &,
+  const typename Mapping<1,spacedim>::InternalDataBase &,
+  const typename Mapping<1,spacedim>::InternalDataBase &,
   FEValuesData<1,spacedim> &) const
 {
-  Assert(false, ExcMessage("Should not fille subface values in 1D"));
+  Assert(false, ExcMessage("There are no sub-face values to fill in 1D!"));
 }
 
 

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -524,7 +524,7 @@ FE_FaceQ<1,spacedim>::fill_fe_values
  const typename Mapping<1,spacedim>::InternalDataBase &,
  const typename Mapping<1,spacedim>::InternalDataBase &,
  FEValuesData<1,spacedim> &,
- CellSimilarity::Similarity &) const
+ const CellSimilarity::Similarity ) const
 {
   // Do nothing, since we do not have values in the interior
 }

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -123,7 +123,7 @@ fill_fe_values (const Mapping<dim,spacedim> & /*mapping*/,
                 const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
                 const typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
                 FEValuesData<dim,spacedim> & /*data*/,
-                CellSimilarity::Similarity & /*cell_similarity*/) const
+                const CellSimilarity::Similarity  /*cell_similarity*/) const
 {
   // leave data fields empty
 }

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -120,8 +120,8 @@ FE_Nothing<dim,spacedim>::
 fill_fe_values (const Mapping<dim,spacedim> & /*mapping*/,
                 const typename Triangulation<dim,spacedim>::cell_iterator & /*cell*/,
                 const Quadrature<dim> & /*quadrature*/,
-                typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
+                const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
+                const typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
                 FEValuesData<dim,spacedim> & /*data*/,
                 CellSimilarity::Similarity & /*cell_similarity*/) const
 {
@@ -137,8 +137,8 @@ fill_fe_face_values (const Mapping<dim,spacedim> & /*mapping*/,
                      const typename Triangulation<dim,spacedim>::cell_iterator & /*cell*/,
                      const unsigned int /*face*/,
                      const Quadrature<dim-1> & /*quadrature*/,
-                     typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                     typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
+                     const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
+                     const typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
                      FEValuesData<dim,spacedim> & /*data*/) const
 {
   // leave data fields empty
@@ -152,8 +152,8 @@ fill_fe_subface_values (const Mapping<dim,spacedim> & /*mapping*/,
                         const unsigned int /*face*/,
                         const unsigned int /*subface*/,
                         const Quadrature<dim-1> & /*quadrature*/,
-                        typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                        typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
+                        const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
+                        const typename Mapping<dim,spacedim>::InternalDataBase & /*fedata*/,
                         FEValuesData<dim,spacedim> & /*data*/) const
 {
   // leave data fields empty

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -33,8 +33,8 @@ FE_Poly<TensorProductPolynomials<1>,1,2>::fill_fe_values
 (const Mapping<1,2>                        &mapping,
  const Triangulation<1,2>::cell_iterator   &cell,
  const Quadrature<1>                       &quadrature,
- Mapping<1,2>::InternalDataBase            &mapping_data,
- Mapping<1,2>::InternalDataBase            &fedata,
+ const Mapping<1,2>::InternalDataBase            &mapping_data,
+ const Mapping<1,2>::InternalDataBase            &fedata,
  FEValuesData<1,2>                         &data,
  CellSimilarity::Similarity           &cell_similarity) const
 {
@@ -42,8 +42,8 @@ FE_Poly<TensorProductPolynomials<1>,1,2>::fill_fe_values
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.current_update_flags());
 
@@ -71,16 +71,16 @@ FE_Poly<TensorProductPolynomials<2>,2,3>::fill_fe_values
 (const Mapping<2,3>                      &mapping,
  const Triangulation<2,3>::cell_iterator &cell,
  const Quadrature<2>                     &quadrature,
- Mapping<2,3>::InternalDataBase          &mapping_data,
- Mapping<2,3>::InternalDataBase          &fedata,
+ const Mapping<2,3>::InternalDataBase          &mapping_data,
+ const Mapping<2,3>::InternalDataBase          &fedata,
  FEValuesData<2,3>                       &data,
  CellSimilarity::Similarity         &cell_similarity) const
 {
 
   // assert that the following dynamics
   // cast is really well-defined.
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.current_update_flags());
 
@@ -107,8 +107,8 @@ FE_Poly<PolynomialSpace<1>,1,2>::fill_fe_values (
   const Mapping<1,2>                      &mapping,
   const Triangulation<1,2>::cell_iterator &cell,
   const Quadrature<1>                     &quadrature,
-  Mapping<1,2>::InternalDataBase          &mapping_data,
-  Mapping<1,2>::InternalDataBase          &fedata,
+  const Mapping<1,2>::InternalDataBase          &mapping_data,
+  const Mapping<1,2>::InternalDataBase          &fedata,
   FEValuesData<1,2>                       &data,
   CellSimilarity::Similarity         &cell_similarity) const
 {
@@ -117,8 +117,8 @@ FE_Poly<PolynomialSpace<1>,1,2>::fill_fe_values (
   // an exception if that is not
   // possible
 
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.current_update_flags());
 
@@ -145,13 +145,13 @@ FE_Poly<PolynomialSpace<2>,2,3>::fill_fe_values
 (const Mapping<2,3>                      &mapping,
  const Triangulation<2,3>::cell_iterator &cell,
  const Quadrature<2>                     &quadrature,
- Mapping<2,3>::InternalDataBase          &mapping_data,
- Mapping<2,3>::InternalDataBase          &fedata,
+ const Mapping<2,3>::InternalDataBase          &mapping_data,
+ const Mapping<2,3>::InternalDataBase          &fedata,
  FEValuesData<2,3>                       &data,
  CellSimilarity::Similarity         &cell_similarity) const
 {
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const UpdateFlags flags(fe_data.current_update_flags());
 

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -36,7 +36,7 @@ FE_Poly<TensorProductPolynomials<1>,1,2>::fill_fe_values
  const Mapping<1,2>::InternalDataBase            &mapping_data,
  const Mapping<1,2>::InternalDataBase            &fedata,
  FEValuesData<1,2>                         &data,
- CellSimilarity::Similarity           &cell_similarity) const
+ const CellSimilarity::Similarity           cell_similarity) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -74,7 +74,7 @@ FE_Poly<TensorProductPolynomials<2>,2,3>::fill_fe_values
  const Mapping<2,3>::InternalDataBase          &mapping_data,
  const Mapping<2,3>::InternalDataBase          &fedata,
  FEValuesData<2,3>                       &data,
- CellSimilarity::Similarity         &cell_similarity) const
+ const CellSimilarity::Similarity         cell_similarity) const
 {
 
   // assert that the following dynamics
@@ -110,7 +110,7 @@ FE_Poly<PolynomialSpace<1>,1,2>::fill_fe_values (
   const Mapping<1,2>::InternalDataBase          &mapping_data,
   const Mapping<1,2>::InternalDataBase          &fedata,
   FEValuesData<1,2>                       &data,
-  CellSimilarity::Similarity         &cell_similarity) const
+  const CellSimilarity::Similarity         cell_similarity) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -148,7 +148,7 @@ FE_Poly<PolynomialSpace<2>,2,3>::fill_fe_values
  const Mapping<2,3>::InternalDataBase          &mapping_data,
  const Mapping<2,3>::InternalDataBase          &fedata,
  FEValuesData<2,3>                       &data,
- CellSimilarity::Similarity         &cell_similarity) const
+ const CellSimilarity::Similarity         cell_similarity) const
 {
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -393,8 +393,8 @@ FE_PolyTensor<POLY,dim,spacedim>::fill_fe_values (
   const Mapping<dim,spacedim>                      &mapping,
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                            &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   FEValuesData<dim,spacedim>                       &data,
   CellSimilarity::Similarity                  &cell_similarity) const
 {
@@ -402,9 +402,9 @@ FE_PolyTensor<POLY,dim,spacedim>::fill_fe_values (
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
           ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const unsigned int n_q_points = quadrature.size();
   const UpdateFlags flags(fe_data.current_update_flags());
@@ -614,17 +614,17 @@ FE_PolyTensor<POLY,dim,spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int                    face,
   const Quadrature<dim-1>              &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
   FEValuesData<dim,spacedim>                    &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
           ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const unsigned int n_q_points = quadrature.size();
   // offset determines which data set
@@ -819,17 +819,17 @@ FE_PolyTensor<POLY,dim,spacedim>::fill_fe_subface_values (
   const unsigned int                    face,
   const unsigned int                    subface,
   const Quadrature<dim-1>              &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase       &fedata,
   FEValuesData<dim,spacedim>                    &data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
           ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const unsigned int n_q_points = quadrature.size();
 

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -396,7 +396,7 @@ FE_PolyTensor<POLY,dim,spacedim>::fill_fe_values (
   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   FEValuesData<dim,spacedim>                       &data,
-  CellSimilarity::Similarity                  &cell_similarity) const
+  const CellSimilarity::Similarity                  cell_similarity) const
 {
   // convert data object to internal
   // data for this class. fails with

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1037,8 +1037,8 @@ FESystem<dim,spacedim>::fill_fe_values (
   const Mapping<dim,spacedim>                      &mapping,
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                            &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim>                       &data,
   CellSimilarity::Similarity                  &cell_similarity) const
 {
@@ -1055,8 +1055,8 @@ FESystem<dim,spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int                    face_no,
   const Quadrature<dim-1>              &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim>                    &data) const
 {
   compute_fill (mapping, cell, face_no, invalid_face_number, quadrature,
@@ -1074,8 +1074,8 @@ FESystem<dim,spacedim>::fill_fe_subface_values (
   const unsigned int                                face_no,
   const unsigned int                                sub_no,
   const Quadrature<dim-1>                          &quadrature,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim>                       &data) const
 {
   compute_fill (mapping, cell, face_no, sub_no, quadrature,
@@ -1094,12 +1094,12 @@ FESystem<dim,spacedim>::compute_fill_one_base (
   const unsigned int                                sub_no,
   const Quadrature<dim_1>                          &quadrature,
   CellSimilarity::Similarity                   cell_similarity,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   const unsigned int                                base_no,
   FEValuesData<dim,spacedim>                       &data) const
 {
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
   const unsigned int n_q_points = quadrature.size();
 
   const FiniteElement<dim,spacedim> &
@@ -1243,9 +1243,9 @@ FESystem<dim,spacedim>::compute_fill (
   const unsigned int                                face_no,
   const unsigned int                                sub_no,
   const Quadrature<dim_1>                          &quadrature,
-  CellSimilarity::Similarity                   cell_similarity,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  typename Mapping<dim,spacedim>::InternalDataBase &fedata,
+  const CellSimilarity::Similarity                   cell_similarity,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &fedata,
   FEValuesData<dim,spacedim>                       &data) const
 {
   const unsigned int n_q_points = quadrature.size();
@@ -1254,8 +1254,8 @@ FESystem<dim,spacedim>::compute_fill (
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&fedata) != 0, ExcInternalError());
-  InternalData &fe_data = static_cast<InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   // Either dim_1==dim
   // (fill_fe_values) or dim_1==dim-1

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1040,7 +1040,7 @@ FESystem<dim,spacedim>::fill_fe_values (
   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   const typename Mapping<dim,spacedim>::InternalDataBase &fe_data,
   FEValuesData<dim,spacedim>                       &data,
-  CellSimilarity::Similarity                  &cell_similarity) const
+  const CellSimilarity::Similarity                  cell_similarity) const
 {
   compute_fill(mapping, cell, invalid_face_number, invalid_face_number,
                quadrature, cell_similarity, mapping_data, fe_data, data);


### PR DESCRIPTION
This is strictly cleanup work.

The idea of the patch is to make it clearer which of the `FiniteElement::fill_fe_*_values()` arguments are input arguments and which are output arguments. The pull request contains 6 commits, only the first three of which are actually of interest.

* 8b4c0d7: Add some documentation about what the intent of the `FiniteElement::InternalDataBase` object is.

* ef05f59: Rewrite one function that used what was logically intended to be an input argument to store scratch data. The scratch arrays are now allocated as needed locally to the function. This may incur a minor slowdown, though I am quite certain that it is not noticeable. This is necessary to mark the argument to the function `const`, as done in 863c8a5.

* fc0dfd0: No longer modify what is intended to be in put argument, but simply carry the updated value through the function. This is necessary to make the input argument `const`, as done in af6702a. The issue is slightly complicated since the argument (of integer type) is actually passed by reference, so the value that we previously modified leaks back to the caller site. On the other hand, the only calling place of this function is in `fe_values.cc:do_reinit()` where it is not used after the call -- so nobody ever observed the modified value.

The fourth and fifth patches mark input arguments as `const` and as is now possible after the above patches. These two patches are pretty mechanical and boring. The last patch is just a changelog.


The pull request does modify the signature of functions. This may be noticeable to users who implement their own elements, but I think the cleanup is worth it.