### PR TITLE
Make the CellSimilarity argument const also in Mapping.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -640,7 +640,8 @@ private:
    * The function above adjusted with the variable cell_normal_vectors for the
    * case of codimension 1
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                         &quadrature,
                   InternalDataBase                              &internal,
@@ -650,7 +651,7 @@ private:
                   std::vector<DerivativeForm<2,dim,spacedim>  > &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim>  > &inverse_jacobians,
                   std::vector<Point<spacedim> >                 &cell_normal_vectors,
-                  CellSimilarity::Similarity                    &cell_similarity
+                  const CellSimilarity::Similarity                    cell_similarity
                  ) const=0;
 
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -69,7 +69,8 @@ public:
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
 
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                             &quadrature,
                   typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
@@ -79,7 +80,7 @@ public:
                   std::vector<DerivativeForm<2,dim,spacedim> >      &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
                   std::vector<Point<spacedim> > &,
-                  CellSimilarity::Similarity                        &cell_similarity) const ;
+                  const CellSimilarity::Similarity                        cell_similarity) const ;
 
 
   virtual void

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -412,7 +412,8 @@ protected:
   /**
    * Implementation of the interface in Mapping.
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                     &quadrature,
                   typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
@@ -422,7 +423,7 @@ protected:
                   std::vector<DerivativeForm<2,dim,spacedim> >       &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
                   std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  CellSimilarity::Similarity                           &cell_similarity) const ;
+                  const CellSimilarity::Similarity                           cell_similarity) const ;
 
   /**
    * Implementation of the interface in Mapping.

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -193,7 +193,8 @@ protected:
   /**
    * Implementation of the interface in Mapping.
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                            &quadrature,
                   typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
@@ -203,7 +204,7 @@ protected:
                   std::vector<DerivativeForm<2,dim,spacedim> >     &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim> >     &inverse_jacobians,
                   std::vector<Point<spacedim> >                    &cell_normal_vectors,
-                  CellSimilarity::Similarity                       &cell_similarity) const ;
+                  const CellSimilarity::Similarity                       cell_similarity) const ;
 
   /**
    * Implementation of the interface in Mapping.

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -304,7 +304,8 @@ public:
   /**
    * Implementation of the interface in Mapping.
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                        &quadrature,
                   typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
@@ -314,7 +315,7 @@ public:
                   std::vector<DerivativeForm<2,dim,spacedim> > &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians,
                   std::vector<Point<spacedim> >                &cell_normal_vectors,
-                  CellSimilarity::Similarity                   &cell_similarity) const;
+                  const CellSimilarity::Similarity                   cell_similarity) const;
 
   /**
    * Implementation of the interface in Mapping.

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -125,7 +125,8 @@ protected:
    * Implementation of the interface in MappingQ1. Overrides the function in
    * the base class, since we cannot use any cell similarity for this class.
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                     &quadrature,
                   typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
@@ -135,7 +136,7 @@ protected:
                   std::vector<DerivativeForm<2,dim,spacedim>  >       &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim>  >       &inverse_jacobians,
                   std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  CellSimilarity::Similarity                           &cell_similarity) const;
+                  const CellSimilarity::Similarity                           cell_similarity) const;
 
   /**
    * Reference to the vector of shifts.

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -140,7 +140,8 @@ protected:
    * Implementation of the interface in MappingQ. Overrides the function in
    * the base class, since we cannot use any cell similarity for this class.
    */
-  virtual void
+  virtual
+  CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                     &quadrature,
                   typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
@@ -150,7 +151,7 @@ protected:
                   std::vector<DerivativeForm<2,dim,spacedim> >      &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
                   std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  CellSimilarity::Similarity                           &cell_similarity) const;
+                  const CellSimilarity::Similarity                           cell_similarity) const;
 
   /**
    * Reference to the vector of shifts.

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3512,17 +3512,26 @@ FEValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &c
 template <int dim, int spacedim>
 void FEValues<dim,spacedim>::do_reinit ()
 {
-  this->get_mapping().fill_fe_values(*this->present_cell,
-                                     quadrature,
-                                     *this->mapping_data,
-                                     this->quadrature_points,
-                                     this->JxW_values,
-                                     this->jacobians,
-                                     this->jacobian_grads,
-                                     this->inverse_jacobians,
-                                     this->normal_vectors,
-                                     this->cell_similarity);
+  // first call the mapping and let it generate the data
+  // specific to the mapping. also let it inspect the
+  // cell similarity flag and, if necessary, update
+  // it
+  this->cell_similarity
+    = this->get_mapping().fill_fe_values(*this->present_cell,
+                                         quadrature,
+                                         *this->mapping_data,
+                                         this->quadrature_points,
+                                         this->JxW_values,
+                                         this->jacobians,
+                                         this->jacobian_grads,
+                                         this->inverse_jacobians,
+                                         this->normal_vectors,
+                                         this->cell_similarity);
 
+  // then call the finite element and, with the data
+  // already filled by the mapping, let it compute the
+  // data for the mapped shape function values, gradients,
+  // etc.
   this->get_fe().fill_fe_values(this->get_mapping(),
                                 *this->present_cell,
                                 quadrature,

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -315,7 +315,7 @@ MappingCartesian<dim, spacedim>::compute_fill (const typename Triangulation<dim,
 
 
 template<int dim, int spacedim>
-void
+CellSimilarity::Similarity
 MappingCartesian<dim, spacedim>::
 fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const Quadrature<dim> &q,
@@ -326,7 +326,7 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 std::vector<DerivativeForm<2,dim,spacedim> >      &jacobian_grads,
                 std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
                 std::vector<Point<spacedim> > &,
-                CellSimilarity::Similarity &cell_similarity) const
+                const CellSimilarity::Similarity cell_similarity) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -386,6 +386,8 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
           for (unsigned int j=0; j<dim; ++j)
             inverse_jacobians[j][j]=1./data.length[j];
         }
+
+  return cell_similarity;
 }
 
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -732,7 +732,7 @@ MappingQ1<dim,spacedim>::compute_mapping_support_points(
 
 
 template<int dim, int spacedim>
-void
+CellSimilarity::Similarity
 MappingQ1<dim,spacedim>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                        &q,
@@ -743,7 +743,7 @@ MappingQ1<dim,spacedim>::fill_fe_values (
   std::vector<DerivativeForm<2,dim,spacedim> > &jacobian_grads,
   std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians,
   std::vector<Point<spacedim> >                &normal_vectors,
-  CellSimilarity::Similarity                   &cell_similarity) const
+  const CellSimilarity::Similarity                   cell_similarity) const
 {
   // ensure that the following static_cast is really correct:
   Assert (dynamic_cast<InternalData *>(&mapping_data) != 0,
@@ -906,6 +906,7 @@ MappingQ1<dim,spacedim>::fill_fe_values (
           inverse_jacobians[point] = data.covariant[point].transpose();
     }
 
+  return cell_similarity;
 }
 
 

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -111,7 +111,7 @@ MappingQ1Eulerian<dim, EulerVectorType, spacedim>::clone () const
 
 
 template<int dim, class EulerVectorType, int spacedim>
-void
+CellSimilarity::Similarity
 MappingQ1Eulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                                     &q,
@@ -122,16 +122,20 @@ MappingQ1Eulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
   std::vector<DerivativeForm<2,dim,spacedim>    >   &jacobian_grads,
   std::vector<DerivativeForm<1,spacedim,dim>    >   &inverse_jacobians,
   std::vector<Point<spacedim> >                             &normal_vectors,
-  CellSimilarity::Similarity                           &cell_similarity) const
+  const CellSimilarity::Similarity) const
 {
-  // disable any previously detected
-  // similarity and then enter the
-  // respective function of the base class.
-  cell_similarity = CellSimilarity::invalid_next_cell;
+  // call the function of the base class, but ignoring
+  // any potentially detected cell similarity between
+  // the current and the previous cell
   MappingQ1<dim,spacedim>::fill_fe_values (cell, q, mapping_data,
                                            quadrature_points, JxW_values, jacobians,
                                            jacobian_grads, inverse_jacobians,
-                                           normal_vectors, cell_similarity);
+                                           normal_vectors,
+                                           CellSimilarity::invalid_next_cell);
+  // also return the updated flag since any detected
+  // similarity wasn't based on the mapped field, but
+  // the original vertices which are meaningless
+  return CellSimilarity::invalid_next_cell;
 }
 
 

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -176,7 +176,7 @@ compute_mapping_support_points
 
 
 template<int dim, class EulerVectorType, int spacedim>
-void
+CellSimilarity::Similarity
 MappingQEulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                                     &q,
@@ -187,15 +187,20 @@ MappingQEulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
   std::vector<DerivativeForm<2,dim,spacedim>  >     &jacobian_grads,
   std::vector<DerivativeForm<1,spacedim,dim>  >     &inverse_jacobians,
   std::vector<Point<spacedim> >                             &normal_vectors,
-  CellSimilarity::Similarity                           &cell_similarity) const
+  const CellSimilarity::Similarity                           ) const
 {
-  // disable any previously detected similarity and hand on to the respective
-  // function of the base class.
-  cell_similarity = CellSimilarity::invalid_next_cell;
+  // call the function of the base class, but ignoring
+  // any potentially detected cell similarity between
+  // the current and the previous cell
   MappingQ<dim,spacedim>::fill_fe_values (cell, q, mapping_data,
                                           quadrature_points, JxW_values, jacobians,
                                           jacobian_grads, inverse_jacobians,
-                                          normal_vectors, cell_similarity);
+                                          normal_vectors,
+                                          CellSimilarity::invalid_next_cell);
+  // also return the updated flag since any detected
+  // similarity wasn't based on the mapped field, but
+  // the original vertices which are meaningless
+  return CellSimilarity::invalid_next_cell;
 }
 
 


### PR DESCRIPTION
Logically, these arguments are intended to be input arguments, so make them
const. Also, don't make them a reference as they are simply integral values.

This patch is similar but slightly more involved than the one commit in #1166 where I wrote this:
........................
fc0dfd0: No longer modify what is intended to be in put argument, but simply carry the updated value through the function. This is necessary to make the input argument const, as done in af6702a. The issue is slightly complicated since the argument (of integer type) is actually passed by reference, so the value that we previously modified leaks back to the caller site. On the other hand, the only calling place of this function is in fe_values.cc:do_reinit() where it is not used after the call -- so nobody ever observed the modified value.
......................
The problem is that here, there are several functions in `MappingQ`, `MappingQEulerian` and `MappingFEField` that change their `cell_similarity` argument to an invalid value. Because it is currently (i.e., before this patch) passed as a non-const reference, the modified value propagates back to the calling site, which next calls `FiniteElement::fill_fe_values`. So, in principle, the changes I've made here can be seen in the finite element. 

The testsuite does not seem to detect any cases where this leads to a problem. To be honest, I don't quite understand whether there can be any ramifications.

@kronbichler : You initially wrote the `CellSimilarity` stuff. Did you intend for the mapping to be able to invalidate a cell similarity flag and for this to propagate to the finite element?

@luca-heltai : You most recently added mappings that do do this. Can you recall whether you were aware that the invalidated value propagates to the calling site?