### PR TITLE
Remove an unused variable.

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -168,14 +168,6 @@ public:
     virtual std::size_t memory_consumption () const;
 
     /**
-     * Unit normal vectors. Used for the alternative computation of the normal
-     * vectors. See doc of the @p alternative_normals_computation flag.
-     *
-     * Filled (hardcoded) once in @p get_face_data.
-     */
-    std::vector<std::vector<Point<dim> > > unit_normals;
-
-    /**
      * Flag that is set by the <tt>fill_fe_[[sub]face]_values</tt> function.
      *
      * If this flag is @p true we are on an interior cell and the @p

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -50,7 +50,6 @@ std::size_t
 MappingQ<dim,spacedim>::InternalData::memory_consumption () const
 {
   return (MappingQ1<dim,spacedim>::InternalData::memory_consumption () +
-          MemoryConsumption::memory_consumption (unit_normals) +
           MemoryConsumption::memory_consumption (use_mapping_q1_on_current_cell) +
           MemoryConsumption::memory_consumption (mapping_q1_data));
 }


### PR DESCRIPTION
This must be a left-over from some earlier development.