### PR TITLE
Make mapping internal data const

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -667,7 +667,8 @@ private:
 
   /**
    * Prepare internal data structures and fill in values independent of the
-   * cell.
+   * cell. See the documentation of Mapping::InternalDataBase for more
+   * information on the purpose of this function.
    */
   virtual InternalDataBase *
   get_data (const UpdateFlags,
@@ -675,7 +676,9 @@ private:
 
   /**
    * Prepare internal data structure for transformation of faces and fill in
-   * values independent of the cell.
+   * values independent of the cell. See the documentation of
+   * Mapping::InternalDataBase for more
+   * information on the purpose of this function.
    */
   virtual InternalDataBase *
   get_face_data (const UpdateFlags flags,
@@ -683,7 +686,9 @@ private:
 
   /**
    * Prepare internal data structure for transformation of children of faces
-   * and fill in values independent of the cell.
+   * and fill in values independent of the cell. See the documentation
+   * of Mapping::InternalDataBase for more
+   * information on the purpose of this function.
    */
   virtual InternalDataBase *
   get_subface_data (const UpdateFlags flags,

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -321,12 +321,6 @@ public:
     virtual std::size_t memory_consumption () const;
 
     /**
-     * The determinant of the Jacobian in each quadrature point. Filled if
-     * #update_volume_elements.
-     */
-    mutable std::vector<double> volume_elements;
-
-    /**
      * The positions of the mapped (generalized) support points.
      */
     std::vector<Point<spacedim> > support_point_values;

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -47,16 +47,32 @@ template <int dim, int spacedim> class FESubfaceValues;
  */
 enum MappingType
 {
-/// No mapping
+  /**
+   * No mapping, i.e., shape functions are not mapped from a reference cell
+   * but instead are defined right on the real-space cell.
+   */
   mapping_none = 0x0000,
-/// Covariant mapping (see Mapping::transform() for details)
+
+  /**
+   * Covariant mapping (see Mapping::transform() for details).
+   */
   mapping_covariant = 0x0001,
-/// Contravariant mapping (see Mapping::transform() for details)
+
+  /**
+   * Contravariant mapping (see Mapping::transform() for details).
+   */
   mapping_contravariant = 0x0002,
-/// Mapping of the gradient of a covariant vector field (see Mapping::transform() for details)
+
+  /**
+   * Mapping of the gradient of a covariant vector field (see Mapping::transform() for details).
+   */
   mapping_covariant_gradient = 0x0003,
-/// Mapping of the gradient of a contravariant vector field (see Mapping::transform() for details)
+
+  /**
+   * Mapping of the gradient of a contravariant vector field (see Mapping::transform() for details).
+   */
   mapping_contravariant_gradient = 0x0004,
+
   /**
    * The Piola transform usually used for Hdiv elements. Piola transform is
    * the standard transformation of vector valued elements in H<sup>div</sup>.
@@ -64,22 +80,30 @@ enum MappingType
    * volume element.
    */
   mapping_piola = 0x0100,
+
   /**
-   * transformation for the gradient of a vector field corresponding to a
+   * Transformation for the gradient of a vector field corresponding to a
    * mapping_piola transformation (see Mapping::transform() for details).
    */
-
   mapping_piola_gradient = 0x0101,
-/// The mapping used for Nedelec elements
+
   /**
-   * curl-conforming elements are mapped as covariant vectors. Nevertheless,
+   * The mapping used for Nedelec elements.
+   *
+   * Curl-conforming elements are mapped as covariant vectors. Nevertheless,
    * we introduce a separate mapping type, such that we can use the same flag
    * for the vector and its gradient (see Mapping::transform() for details).
    */
   mapping_nedelec = 0x0200,
-/// The mapping used for Raviart-Thomas elements
+
+  /**
+   * The mapping used for Raviart-Thomas elements.
+   */
   mapping_raviart_thomas = 0x0300,
-/// The mapping used for BDM elements
+
+  /**
+   * The mapping used for BDM elements.
+   */
   mapping_bdm = mapping_raviart_thomas
 };
 

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -324,7 +324,7 @@ public:
      * The determinant of the Jacobian in each quadrature point. Filled if
      * #update_volume_elements.
      */
-    std::vector<double> volume_elements;
+    mutable std::vector<double> volume_elements;
 
     /**
      * The positions of the mapped (generalized) support points.
@@ -644,15 +644,14 @@ private:
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                         &quadrature,
-                  InternalDataBase                              &internal,
+                  const InternalDataBase                              &internal,
                   std::vector<Point<spacedim> >                 &quadrature_points,
                   std::vector<double>                           &JxW_values,
                   std::vector<DerivativeForm<1,dim,spacedim>  > &jacobians,
                   std::vector<DerivativeForm<2,dim,spacedim>  > &jacobian_grads,
                   std::vector<DerivativeForm<1,spacedim,dim>  > &inverse_jacobians,
                   std::vector<Point<spacedim> >                 &cell_normal_vectors,
-                  const CellSimilarity::Similarity                    cell_similarity
-                 ) const=0;
+                  const CellSimilarity::Similarity                    cell_similarity) const=0;
 
 
 
@@ -670,7 +669,7 @@ private:
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                            face_no,
                        const Quadrature<dim-1>                      &quadrature,
-                       InternalDataBase                             &internal,
+                       const InternalDataBase                             &internal,
                        std::vector<Point<spacedim> >                &quadrature_points,
                        std::vector<double>                          &JxW_values,
                        std::vector<Tensor<1,spacedim> >             &boundary_form,
@@ -686,7 +685,7 @@ private:
                           const unsigned int                face_no,
                           const unsigned int                sub_no,
                           const Quadrature<dim-1>          &quadrature,
-                          InternalDataBase                 &internal,
+                          const InternalDataBase                 &internal,
                           std::vector<Point<spacedim> >    &quadrature_points,
                           std::vector<double>              &JxW_values,
                           std::vector<Tensor<1,spacedim> > &boundary_form,

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -73,7 +73,7 @@ public:
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                             &quadrature,
-                  typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+                  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
                   std::vector<Point<spacedim> >                     &quadrature_points,
                   std::vector<double>                               &JxW_values,
                   std::vector<DerivativeForm<1,dim,spacedim> >      &jacobians,
@@ -87,7 +87,7 @@ public:
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int               face_no,
                        const Quadrature<dim-1>&         quadrature,
-                       typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+                       const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
                        std::vector<Point<dim> >        &quadrature_points,
                        std::vector<double>             &JxW_values,
                        std::vector<Tensor<1,dim> >     &boundary_form,
@@ -99,7 +99,7 @@ public:
                           const unsigned int              face_no,
                           const unsigned int              sub_no,
                           const Quadrature<dim-1>&        quadrature,
-                          typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+                          const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
                           std::vector<Point<dim> >        &quadrature_points,
                           std::vector<double>             &JxW_values,
                           std::vector<Tensor<1,dim> >     &boundary_form,
@@ -160,6 +160,13 @@ public:
 protected:
   /**
    * Storage for internal data of the scaling.
+   *
+   * This includes data that is computed once when the object is created
+   * (in get_data()) as well as data the class wants to store from between
+   * the call to fill_fe_values(), fill_fe_face_values(), or
+   * fill_fe_subface_values() until possible later calls from the finite
+   * element to functions such as transform(). The latter class of
+   * member variables are marked as 'mutable'.
    */
   class InternalData : public Mapping<dim, spacedim>::InternalDataBase
   {
@@ -178,12 +185,12 @@ protected:
      * Length of the cell in different coordinate directions,
      * <i>h<sub>x</sub></i>, <i>h<sub>y</sub></i>, <i>h<sub>z</sub></i>.
      */
-    Tensor<1,dim> length;
+    mutable Tensor<1,dim> length;
 
     /**
      * The volume element
      */
-    double volume_element;
+    mutable double volume_element;
 
     /**
      * Vector of all quadrature points. Especially, all points on all faces.
@@ -198,7 +205,7 @@ protected:
                      const unsigned int face_no,
                      const unsigned int sub_no,
                      const CellSimilarity::Similarity cell_similarity,
-                     InternalData &data,
+                     const InternalData &data,
                      std::vector<Point<dim> > &quadrature_points,
                      std::vector<Point<dim> > &normal_vectors) const;
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -159,7 +159,8 @@ public:
 
 protected:
   /**
-   * Storage for internal data of the scaling.
+   * Storage for internal data of the mapping. See Mapping::InternalDataBase
+   * for an extensive description.
    *
    * This includes data that is computed once when the object is created
    * (in get_data()) as well as data the class wants to store from between

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -340,13 +340,13 @@ public:
     /**
      * Storage for the indices of the local degrees of freedom.
      */
-    std::vector<types::global_dof_index> local_dof_indices;
+    mutable std::vector<types::global_dof_index> local_dof_indices;
 
 
     /**
      * Storage for local degrees of freedom.
      */
-    std::vector<double> local_dof_values;
+    mutable std::vector<double> local_dof_values;
   };
 
 
@@ -528,7 +528,7 @@ private:
    * Update internal degrees of freedom.
    */
   void update_internal_dofs(const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                            typename MappingFEField<dim, spacedim>::InternalData &data) const;
+                            const typename MappingFEField<dim, spacedim>::InternalData &data) const;
 
   /**
    * Reimplemented from Mapping. See the documentation of the base class for

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -289,6 +289,12 @@ public:
     mutable std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
 
     /**
+     * The determinant of the Jacobian in each quadrature point. Filled if
+     * #update_volume_elements.
+     */
+    mutable std::vector<double> volume_elements;
+
+    /**
      * Unit tangential vectors. Used for the computation of boundary forms and
      * normal vectors.
      *

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -208,8 +208,8 @@ public:
      * Shape function at quadrature point. Shape functions are in tensor
      * product order, so vertices must be reordered to obtain transformation.
      */
-    double shape (const unsigned int qpoint,
-                  const unsigned int shape_nr) const;
+    const double &shape (const unsigned int qpoint,
+                         const unsigned int shape_nr) const;
 
     /**
      * Shape function at quadrature point. See above.
@@ -220,8 +220,8 @@ public:
     /**
      * Gradient of shape function in quadrature point. See above.
      */
-    Tensor<1,dim> derivative (const unsigned int qpoint,
-                              const unsigned int shape_nr) const;
+    const Tensor<1,dim> &derivative (const unsigned int qpoint,
+                                     const unsigned int shape_nr) const;
 
     /**
      * Gradient of shape function in quadrature point. See above.
@@ -277,7 +277,7 @@ public:
      *
      * Computed on each cell.
      */
-    std::vector<DerivativeForm<1,dim, spacedim > >  covariant;
+    mutable std::vector<DerivativeForm<1,dim, spacedim > >  covariant;
 
     /**
      * Tensors of contravariant transformation at each of the quadrature
@@ -286,7 +286,7 @@ public:
      *
      * Computed on each cell.
      */
-    std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
+    mutable std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
 
     /**
      * Unit tangential vectors. Used for the computation of boundary forms and
@@ -306,7 +306,7 @@ public:
     /**
      * Auxiliary vectors for internal use.
      */
-    std::vector<std::vector<Tensor<1,spacedim> > > aux;
+    mutable std::vector<std::vector<Tensor<1,spacedim> > > aux;
 
     /**
      * Number of shape functions. If this is a Q1 mapping, then it is simply
@@ -390,7 +390,7 @@ public:
                      const unsigned int      npts,
                      const typename QProjector<dim>::DataSetDescriptor data_set,
                      const CellSimilarity::Similarity cell_similarity,
-                     InternalData           &data,
+                     const InternalData           &data,
                      std::vector<Point<spacedim> > &quadrature_points) const;
 
 
@@ -403,7 +403,7 @@ public:
                           const unsigned int      npts,
                           const typename QProjector<dim>::DataSetDescriptor data_set,
                           const std::vector<double>   &weights,
-                          InternalData           &mapping_data,
+                          const InternalData           &mapping_data,
                           std::vector<Point<spacedim> >    &quadrature_points,
                           std::vector<double>         &JxW_values,
                           std::vector<Tensor<1,spacedim> > &boundary_form,
@@ -428,7 +428,7 @@ protected:
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                                     &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
                   typename std::vector<Point<spacedim> >                    &quadrature_points,
                   std::vector<double>                                       &JxW_values,
                   std::vector<DerivativeForm<1,dim,spacedim> >       &jacobians,
@@ -444,7 +444,7 @@ protected:
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int face_no,
                        const Quadrature<dim-1>& quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                        typename std::vector<Point<spacedim> >        &quadrature_points,
                        std::vector<double>             &JxW_values,
                        std::vector<Tensor<1,spacedim> >             &exterior_forms,
@@ -460,7 +460,7 @@ protected:
                           const unsigned int face_no,
                           const unsigned int sub_no,
                           const Quadrature<dim-1>& quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                           typename std::vector<Point<spacedim> >        &quadrature_points,
                           std::vector<double>             &JxW_values,
                           std::vector<Tensor<1,spacedim> > &exterior_forms,
@@ -627,7 +627,7 @@ private:
 
 template<int dim, int spacedim, class DH, class VECTOR>
 inline
-double
+const double &
 MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::shape (const unsigned int qpoint,
     const unsigned int shape_nr) const
 {
@@ -654,7 +654,7 @@ MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::shape (const unsigned int 
 
 template<int dim, int spacedim, class DH, class VECTOR>
 inline
-Tensor<1,dim>
+const Tensor<1,dim> &
 MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::derivative (const unsigned int qpoint,
     const unsigned int shape_nr) const
 {

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -232,8 +232,8 @@ public:
     /**
      * Second derivative of shape function in quadrature point. See above.
      */
-    Tensor<2,dim> second_derivative (const unsigned int qpoint,
-                                     const unsigned int shape_nr) const;
+    const Tensor<2,dim> &second_derivative (const unsigned int qpoint,
+                                            const unsigned int shape_nr) const;
 
     /**
      * Second derivative of shape function in quadrature point. See above.
@@ -681,7 +681,7 @@ MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::derivative (const unsigned
 
 template <int dim, int spacedim, class DH, class VECTOR>
 inline
-Tensor<2,dim>
+const Tensor<2,dim> &
 MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::second_derivative (const unsigned int qpoint,
     const unsigned int shape_nr) const
 {

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -151,7 +151,19 @@ public:
   Mapping<dim,spacedim> *clone () const;
 
   /**
-   * Storage for internal data of Q_degree transformation.
+   * Storage for internal data of this mapping. See Mapping::InternalDataBase
+   * for an extensive description.
+   *
+   * This includes data that is computed once when the object is created
+   * (in get_data()) as well as data the class wants to store from between
+   * the call to fill_fe_values(), fill_fe_face_values(), or
+   * fill_fe_subface_values() until possible later calls from the finite
+   * element to functions such as transform(). The latter class of
+   * member variables are marked as 'mutable'.
+   *
+   * The current class uses essentially the same fields for storage
+   * as the MappingQ1 class. Consequently, it inherits from
+   * MappingQ1::InternalData, rather than from Mapping::InternalDataBase.
    */
   class InternalData : public MappingQ1<dim,spacedim>::InternalData
   {
@@ -176,7 +188,8 @@ public:
     mutable bool use_mapping_q1_on_current_cell;
 
     /**
-     * On interior cells @p MappingQ1 is used.
+     * A structure to store the corresponding information for the pure
+     * $Q_1$ mapping that is, by default, used on all interior cells.
      */
     typename MappingQ1<dim,spacedim>::InternalData mapping_q1_data;
   };

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -173,7 +173,7 @@ public:
      * If this flag is @p true we are on an interior cell and the @p
      * mapping_q1_data is used.
      */
-    bool use_mapping_q1_on_current_cell;
+    mutable bool use_mapping_q1_on_current_cell;
 
     /**
      * On interior cells @p MappingQ1 is used.
@@ -189,7 +189,7 @@ protected:
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                            &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                   typename std::vector<Point<spacedim> >           &quadrature_points,
                   std::vector<double>                              &JxW_values,
                   std::vector<DerivativeForm<1,dim,spacedim> >     &jacobians,
@@ -205,7 +205,7 @@ protected:
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                           face_no,
                        const Quadrature<dim-1>&                     quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                        typename std::vector<Point<spacedim> >       &quadrature_points,
                        std::vector<double>                          &JxW_values,
                        typename std::vector<Tensor<1,spacedim> >    &exterior_form,
@@ -221,7 +221,7 @@ protected:
                           const unsigned int                           face_no,
                           const unsigned int                           sub_no,
                           const Quadrature<dim-1>&                     quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                           typename std::vector<Point<spacedim> >       &quadrature_points,
                           std::vector<double>                          &JxW_values,
                           typename std::vector<Tensor<1,spacedim> >    &exterior_form,

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -153,7 +153,15 @@ public:
   Mapping<dim,spacedim> *clone () const;
 
   /**
-   * Storage for internal data of d-linear transformation.
+   * Storage for internal data of d-linear mappings. See Mapping::InternalDataBase
+   * for an extensive description.
+   *
+   * This includes data that is computed once when the object is created
+   * (in get_data()) as well as data the class wants to store from between
+   * the call to fill_fe_values(), fill_fe_face_values(), or
+   * fill_fe_subface_values() until possible later calls from the finite
+   * element to functions such as transform(). The latter class of
+   * member variables are marked as 'mutable'.
    */
   class InternalData : public Mapping<dim,spacedim>::InternalDataBase
   {
@@ -228,6 +236,37 @@ public:
     std::vector<Tensor<2,dim> > shape_second_derivatives;
 
     /**
+     * Unit tangential vectors. Used for the computation of boundary forms and
+     * normal vectors.
+     *
+     * This vector has (dim-1)GeometryInfo::faces_per_cell entries. The first
+     * GeometryInfo::faces_per_cell contain the vectors in the first
+     * tangential direction for each face; the second set of
+     * GeometryInfo::faces_per_cell entries contain the vectors in the second
+     * tangential direction (only in 3d, since there we have 2 tangential
+     * directions per face), etc.
+     *
+     * Filled once.
+     */
+    std::vector<std::vector<Tensor<1,dim> > > unit_tangentials;
+
+    /**
+     * Default value of this flag is @p true. If <tt>*this</tt> is an object
+     * of a derived class, this flag is set to @p false. (This is, for example,
+     * the case for MappingQ, which derives MappingQ::InternalData from the
+     * current MappingQ1::InternalData.)
+     */
+    bool is_mapping_q1_data;
+
+    /**
+     * Number of shape functions. If this is a Q1 mapping, then it is simply
+     * the number of vertices per cell. However, since also derived classes
+     * use this class (e.g. the Mapping_Q() class), the number of shape
+     * functions may also be different.
+     */
+    unsigned int n_shape_functions;
+
+    /**
      * Tensors of covariant transformation at each of the quadrature points.
      * The matrix stored is the Jacobian * G^{-1}, where G = Jacobian^{t} *
      * Jacobian, is the first fundamental form of the map; if dim=spacedim
@@ -246,21 +285,6 @@ public:
      * Computed on each cell.
      */
     mutable std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
-
-    /**
-     * Unit tangential vectors. Used for the computation of boundary forms and
-     * normal vectors.
-     *
-     * This vector has (dim-1)GeometryInfo::faces_per_cell entries. The first
-     * GeometryInfo::faces_per_cell contain the vectors in the first
-     * tangential direction for each face; the second set of
-     * GeometryInfo::faces_per_cell entries contain the vectors in the second
-     * tangential direction (only in 3d, since there we have 2 tangential
-     * directions per face), etc.
-     *
-     * Filled once.
-     */
-    std::vector<std::vector<Tensor<1,dim> > > unit_tangentials;
 
     /**
      * Auxiliary vectors for internal use.
@@ -283,20 +307,6 @@ public:
      * #update_volume_elements.
      */
     mutable std::vector<double> volume_elements;
-
-    /**
-     * Default value of this flag is @p true. If <tt>*this</tt> is an object
-     * of a derived class, this flag is set to @p false.
-     */
-    bool is_mapping_q1_data;
-
-    /**
-     * Number of shape functions. If this is a Q1 mapping, then it is simply
-     * the number of vertices per cell. However, since also derived classes
-     * use this class (e.g. the Mapping_Q() class), the number of shape
-     * functions may also be different.
-     */
-    unsigned int n_shape_functions;
   };
 
   /**

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -167,8 +167,8 @@ public:
      * Shape function at quadrature point. Shape functions are in tensor
      * product order, so vertices must be reordered to obtain transformation.
      */
-    double shape (const unsigned int qpoint,
-                  const unsigned int shape_nr) const;
+    const double &shape (const unsigned int qpoint,
+                         const unsigned int shape_nr) const;
 
     /**
      * Shape function at quadrature point. See above.
@@ -179,8 +179,8 @@ public:
     /**
      * Gradient of shape function in quadrature point. See above.
      */
-    Tensor<1,dim> derivative (const unsigned int qpoint,
-                              const unsigned int shape_nr) const;
+    const Tensor<1,dim> &derivative (const unsigned int qpoint,
+                                     const unsigned int shape_nr) const;
 
     /**
      * Gradient of shape function in quadrature point. See above.
@@ -191,8 +191,8 @@ public:
     /**
      * Second derivative of shape function in quadrature point. See above.
      */
-    Tensor<2,dim> second_derivative (const unsigned int qpoint,
-                                     const unsigned int shape_nr) const;
+    const Tensor<2,dim> &second_derivative (const unsigned int qpoint,
+                                            const unsigned int shape_nr) const;
 
     /**
      * Second derivative of shape function in quadrature point. See above.
@@ -236,7 +236,7 @@ public:
      *
      * Computed on each cell.
      */
-    std::vector<DerivativeForm<1,dim, spacedim > >  covariant;
+    mutable std::vector<DerivativeForm<1,dim, spacedim > >  covariant;
 
     /**
      * Tensors of contravariant transformation at each of the quadrature
@@ -245,7 +245,7 @@ public:
      *
      * Computed on each cell.
      */
-    std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
+    mutable std::vector< DerivativeForm<1,dim,spacedim> > contravariant;
 
     /**
      * Unit tangential vectors. Used for the computation of boundary forms and
@@ -265,18 +265,18 @@ public:
     /**
      * Auxiliary vectors for internal use.
      */
-    std::vector<std::vector<Tensor<1,spacedim> > > aux;
+    mutable std::vector<std::vector<Tensor<1,spacedim> > > aux;
 
     /**
      * Stores the support points of the mapping shape functions on the @p
      * cell_of_current_support_points.
      */
-    std::vector<Point<spacedim> > mapping_support_points;
+    mutable std::vector<Point<spacedim> > mapping_support_points;
 
     /**
      * Stores the cell of which the @p mapping_support_points are stored.
      */
-    typename Triangulation<dim,spacedim>::cell_iterator cell_of_current_support_points;
+    mutable typename Triangulation<dim,spacedim>::cell_iterator cell_of_current_support_points;
 
     /**
      * Default value of this flag is @p true. If <tt>*this</tt> is an object
@@ -308,7 +308,7 @@ public:
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                   const Quadrature<dim>                        &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                   typename std::vector<Point<spacedim> >       &quadrature_points,
                   std::vector<double>                          &JxW_values,
                   std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
@@ -324,7 +324,7 @@ public:
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                            face_no,
                        const Quadrature<dim-1>                      &quadrature,
-                       typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                        typename std::vector<Point<spacedim> >       &quadrature_points,
                        std::vector<double>                          &JxW_values,
                        typename std::vector<Tensor<1,spacedim> >    &boundary_form,
@@ -340,7 +340,7 @@ public:
                           const unsigned int                           face_no,
                           const unsigned int                           sub_no,
                           const Quadrature<dim-1>&                     quadrature,
-                          typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                           typename std::vector<Point<spacedim> >       &quadrature_points,
                           std::vector<double>                          &JxW_values,
                           typename std::vector<Tensor<1,spacedim> >    &boundary_form,
@@ -386,7 +386,7 @@ public:
                      const unsigned int      npts,
                      const DataSetDescriptor data_set,
                      const CellSimilarity::Similarity cell_similarity,
-                     InternalData           &data,
+                     const InternalData           &data,
                      std::vector<Point<spacedim> > &quadrature_points) const;
 
   /**
@@ -398,7 +398,7 @@ public:
                           const unsigned int                npts,
                           const DataSetDescriptor           data_set,
                           const std::vector<double>        &weights,
-                          InternalData                     &mapping_data,
+                          const InternalData                     &mapping_data,
                           std::vector<Point<spacedim> >    &quadrature_points,
                           std::vector<double>              &JxW_values,
                           std::vector<Tensor<1,spacedim> > &boundary_form,
@@ -633,7 +633,7 @@ struct StaticMappingQ1
 
 template<int dim, int spacedim>
 inline
-double
+const double &
 MappingQ1<dim,spacedim>::InternalData::shape (const unsigned int qpoint,
                                               const unsigned int shape_nr) const
 {
@@ -660,7 +660,7 @@ MappingQ1<dim,spacedim>::InternalData::shape (const unsigned int qpoint,
 
 template<int dim, int spacedim>
 inline
-Tensor<1,dim>
+const Tensor<1,dim> &
 MappingQ1<dim,spacedim>::InternalData::derivative (const unsigned int qpoint,
                                                    const unsigned int shape_nr) const
 {
@@ -687,7 +687,7 @@ MappingQ1<dim,spacedim>::InternalData::derivative (const unsigned int qpoint,
 
 template <int dim, int spacedim>
 inline
-Tensor<2,dim>
+const Tensor<2,dim> &
 MappingQ1<dim,spacedim>::InternalData::second_derivative (const unsigned int qpoint,
                                                           const unsigned int shape_nr) const
 {

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -279,6 +279,12 @@ public:
     mutable typename Triangulation<dim,spacedim>::cell_iterator cell_of_current_support_points;
 
     /**
+     * The determinant of the Jacobian in each quadrature point. Filled if
+     * #update_volume_elements.
+     */
+    mutable std::vector<double> volume_elements;
+
+    /**
      * Default value of this flag is @p true. If <tt>*this</tt> is an object
      * of a derived class, this flag is set to @p false.
      */

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -136,7 +136,7 @@ MappingCartesian<dim, spacedim>::compute_fill (const typename Triangulation<dim,
                                                const unsigned int        face_no,
                                                const unsigned int        sub_no,
                                                const CellSimilarity::Similarity cell_similarity,
-                                               InternalData             &data,
+                                               const InternalData             &data,
                                                std::vector<Point<dim> > &quadrature_points,
                                                std::vector<Point<dim> > &normal_vectors) const
 {
@@ -319,7 +319,7 @@ CellSimilarity::Similarity
 MappingCartesian<dim, spacedim>::
 fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const Quadrature<dim> &q,
-                typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                 std::vector<Point<spacedim> > &quadrature_points,
                 std::vector<double> &JxW_values,
                 std::vector< DerivativeForm<1,dim,spacedim> > &jacobians,
@@ -332,8 +332,8 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0, ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0, ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   std::vector<Point<dim> > dummy;
 
@@ -398,7 +398,7 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int             face_no,
   const Quadrature<dim-1>       &q,
-  typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   std::vector<Point<dim> >      &quadrature_points,
   std::vector<double>           &JxW_values,
   std::vector<Tensor<1,dim> >   &boundary_forms,
@@ -410,9 +410,9 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values (
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   compute_fill (cell, face_no, invalid_face_number,
                 CellSimilarity::none,
@@ -471,7 +471,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values (
   const unsigned int             face_no,
   const unsigned int             sub_no,
   const Quadrature<dim-1>       &q,
-  typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
   std::vector<Point<dim> >      &quadrature_points,
   std::vector<double>           &JxW_values,
   std::vector<Tensor<1,dim> >   &boundary_forms,
@@ -483,8 +483,8 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values (
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0, ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0, ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   compute_fill (cell, face_no, sub_no, CellSimilarity::none,
                 data,

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -60,6 +60,7 @@ template<int dim, int spacedim, class VECTOR, class DH>
 std::size_t
 MappingFEField<dim,spacedim,VECTOR,DH>::InternalData::memory_consumption () const
 {
+  Assert (false, ExcNotImplemented());
   return 0;
 }
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1223,7 +1223,7 @@ template<int dim, int spacedim, class VECTOR, class DH>
 void
 MappingFEField<dim,spacedim,VECTOR,DH>::update_internal_dofs (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  typename MappingFEField<dim, spacedim>::InternalData &data) const
+  const typename MappingFEField<dim, spacedim>::InternalData &data) const
 {
   Assert(euler_dof_handler != 0, ExcMessage("euler_dof_handler is empty"));
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -376,7 +376,7 @@ CellSimilarity::Similarity
 MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                                     &q,
-  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
   std::vector<Point<spacedim> >                             &quadrature_points,
   std::vector<double>                                       &JxW_values,
   std::vector<DerivativeForm<1,dim,spacedim>   >          &jacobians,
@@ -387,8 +387,8 @@ MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_values (
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0, ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0, ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   const unsigned int n_q_points=q.size();
   const  CellSimilarity::Similarity updated_cell_similarity
@@ -554,7 +554,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int       face_no,
   const Quadrature<dim-1> &q,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   std::vector<Point<spacedim> >     &quadrature_points,
   std::vector<double>          &JxW_values,
   std::vector<Tensor<1,spacedim> >             &exterior_forms,
@@ -564,9 +564,9 @@ MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_face_values (
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   const unsigned int n_q_points=q.size();
   this->compute_fill_face (cell, face_no, numbers::invalid_unsigned_int,
@@ -591,7 +591,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_subface_values (const typename T
     const unsigned int       face_no,
     const unsigned int       sub_no,
     const Quadrature<dim-1> &q,
-    typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+    const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
     std::vector<Point<spacedim> >     &quadrature_points,
     std::vector<double>          &JxW_values,
     std::vector<Tensor<1,spacedim> > &exterior_forms,
@@ -601,9 +601,9 @@ MappingFEField<dim,spacedim,VECTOR,DH>::fill_fe_subface_values (const typename T
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   const unsigned int n_q_points=q.size();
   this->compute_fill_face (cell, face_no, sub_no,
@@ -967,7 +967,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_fill (
   const unsigned int  n_q_points,
   const typename QProjector<dim>::DataSetDescriptor  data_set,
   const CellSimilarity::Similarity cell_similarity,
-  InternalData  &data,
+  const InternalData  &data,
   std::vector<Point<spacedim> > &quadrature_points) const
 {
   const UpdateFlags update_flags(data.current_update_flags());
@@ -1064,7 +1064,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_fill_face (
   const unsigned int      n_q_points,//npts
   const typename QProjector<dim>::DataSetDescriptor data_set,
   const std::vector<double>   &weights,
-  InternalData           &data,
+  const InternalData           &data,
   std::vector<Point<spacedim> >    &quadrature_points,
   std::vector<double>         &JxW_values,
   std::vector<Tensor<1,spacedim> > &boundary_forms,

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -250,7 +250,7 @@ CellSimilarity::Similarity
 MappingQ<dim,spacedim>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                                     &q,
-  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
   std::vector<Point<spacedim> >                             &quadrature_points,
   std::vector<double>                                       &JxW_values,
   std::vector<DerivativeForm<1,dim,spacedim>   >    &jacobians,
@@ -261,8 +261,8 @@ MappingQ<dim,spacedim>::fill_fe_values (
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0, ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0, ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   // check whether this cell needs the full mapping or can be treated by a
   // reduced Q1 mapping, e.g. if the cell is in the interior of the domain
@@ -271,7 +271,7 @@ MappingQ<dim,spacedim>::fill_fe_values (
 
   // depending on this result, use this or the other data object for the
   // mapping.
-  typename MappingQ1<dim,spacedim>::InternalData *
+  const typename MappingQ1<dim,spacedim>::InternalData *
   p_data = (data.use_mapping_q1_on_current_cell
             ?
             &data.mapping_q1_data
@@ -309,7 +309,7 @@ MappingQ<dim,spacedim>::fill_fe_face_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const unsigned int                face_no,
   const Quadrature<dim-1>          &q,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   std::vector<Point<spacedim> >    &quadrature_points,
   std::vector<double>              &JxW_values,
   std::vector<Tensor<1,spacedim> > &exterior_forms,
@@ -319,9 +319,9 @@ MappingQ<dim,spacedim>::fill_fe_face_values (
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   // check whether this cell needs the full mapping or can be treated by a
   // reduced Q1 mapping, e.g. if the cell is entirely in the interior of the
@@ -334,11 +334,12 @@ MappingQ<dim,spacedim>::fill_fe_face_values (
 
   // depending on this result, use this or the other data object for the
   // mapping
-  typename MappingQ1<dim,spacedim>::InternalData *p_data=0;
-  if (data.use_mapping_q1_on_current_cell)
-    p_data=&data.mapping_q1_data;
-  else
-    p_data=&data;
+  const typename MappingQ1<dim,spacedim>::InternalData *p_data
+    = (data.use_mapping_q1_on_current_cell
+       ?
+       &data.mapping_q1_data
+       :
+       &data);
 
   const unsigned int n_q_points=q.size();
   this->compute_fill_face (cell, face_no, numbers::invalid_unsigned_int,
@@ -363,7 +364,7 @@ MappingQ<dim,spacedim>::fill_fe_subface_values (const typename Triangulation<dim
                                                 const unsigned int       face_no,
                                                 const unsigned int       sub_no,
                                                 const Quadrature<dim-1> &q,
-                                                typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                                                const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                                                 std::vector<Point<spacedim> >     &quadrature_points,
                                                 std::vector<double>          &JxW_values,
                                                 std::vector<Tensor<1,spacedim> >  &exterior_forms,
@@ -373,9 +374,9 @@ MappingQ<dim,spacedim>::fill_fe_subface_values (const typename Triangulation<dim
 {
   // convert data object to internal data for this class. fails with an
   // exception if that is not possible
-  Assert (dynamic_cast<InternalData *> (&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *> (&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &> (mapping_data);
+  const InternalData &data = static_cast<const InternalData &> (mapping_data);
 
   // check whether this cell needs the full mapping or can be treated by a
   // reduced Q1 mapping, e.g. if the cell is entirely in the interior of the
@@ -388,11 +389,12 @@ MappingQ<dim,spacedim>::fill_fe_subface_values (const typename Triangulation<dim
 
   // depending on this result, use this or the other data object for the
   // mapping
-  typename MappingQ1<dim,spacedim>::InternalData *p_data=0;
-  if (data.use_mapping_q1_on_current_cell)
-    p_data=&data.mapping_q1_data;
-  else
-    p_data=&data;
+  const typename MappingQ1<dim,spacedim>::InternalData *p_data
+    = (data.use_mapping_q1_on_current_cell
+       ?
+       &data.mapping_q1_data
+       :
+       &data);
 
   const unsigned int n_q_points=q.size();
   this->compute_fill_face (cell, face_no, sub_no,

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -608,7 +608,7 @@ MappingQ1<dim,spacedim>::compute_fill (const typename Triangulation<dim,spacedim
                                        const unsigned int  n_q_points,
                                        const DataSetDescriptor  data_set,
                                        const CellSimilarity::Similarity cell_similarity,
-                                       InternalData  &data,
+                                       const InternalData  &data,
                                        std::vector<Point<spacedim> > &quadrature_points) const
 {
   const UpdateFlags update_flags(data.current_update_flags());
@@ -736,7 +736,7 @@ CellSimilarity::Similarity
 MappingQ1<dim,spacedim>::fill_fe_values (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Quadrature<dim>                        &q,
-  typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   std::vector<Point<spacedim> >                &quadrature_points,
   std::vector<double>                          &JxW_values,
   std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
@@ -746,9 +746,9 @@ MappingQ1<dim,spacedim>::fill_fe_values (
   const CellSimilarity::Similarity                   cell_similarity) const
 {
   // ensure that the following static_cast is really correct:
-  Assert (dynamic_cast<InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
   const unsigned int n_q_points=q.size();
 
@@ -926,7 +926,7 @@ namespace internal
                        const unsigned int               subface_no,
                        const unsigned int               n_q_points,
                        const std::vector<double>        &weights,
-                       typename dealii::MappingQ1<dim,spacedim>::InternalData &data,
+                       const typename dealii::MappingQ1<dim,spacedim>::InternalData &data,
                        std::vector<double>              &JxW_values,
                        std::vector<Tensor<1,spacedim> > &boundary_forms,
                        std::vector<Point<spacedim> >    &normal_vectors,
@@ -1071,7 +1071,7 @@ MappingQ1<dim,spacedim>::compute_fill_face (
   const unsigned int               n_q_points,
   const DataSetDescriptor          data_set,
   const std::vector<double>        &weights,
-  InternalData                     &data,
+  const InternalData                     &data,
   std::vector<Point<spacedim> >    &quadrature_points,
   std::vector<double>              &JxW_values,
   std::vector<Tensor<1,spacedim> > &boundary_forms,
@@ -1095,7 +1095,7 @@ MappingQ1<dim,spacedim>::
 fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                      const unsigned int                               face_no,
                      const Quadrature<dim-1>                          &q,
-                     typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                     const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                      std::vector<Point<spacedim> >                    &quadrature_points,
                      std::vector<double>                              &JxW_values,
                      std::vector<Tensor<1,spacedim> >                 &boundary_forms,
@@ -1105,9 +1105,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
 {
   // ensure that the following cast
   // is really correct:
-  Assert (dynamic_cast<InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
   const unsigned int n_q_points = q.size();
 
@@ -1137,7 +1137,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                         const unsigned int       face_no,
                         const unsigned int       sub_no,
                         const Quadrature<dim-1> &q,
-                        typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                        const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
                         std::vector<Point<spacedim> >     &quadrature_points,
                         std::vector<double>               &JxW_values,
                         std::vector<Tensor<1,spacedim> >  &boundary_forms,
@@ -1147,9 +1147,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 {
   // ensure that the following cast
   // is really correct:
-  Assert (dynamic_cast<InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
           ExcInternalError());
-  InternalData &data = static_cast<InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
 
   const unsigned int n_q_points = q.size();
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -61,6 +61,7 @@ MappingQ1<dim,spacedim>::InternalData::memory_consumption () const
           MemoryConsumption::memory_consumption (aux) +
           MemoryConsumption::memory_consumption (mapping_support_points) +
           MemoryConsumption::memory_consumption (cell_of_current_support_points) +
+          MemoryConsumption::memory_consumption (volume_elements) +
           MemoryConsumption::memory_consumption (is_mapping_q1_data) +
           MemoryConsumption::memory_consumption (n_shape_functions));
 }


### PR DESCRIPTION
This is meant for discussion for now. I would need to update the documentation and clean up a couple of corners.

The idea here is that in the interface between FEValues and Mappings, I conceptually think of the `InternalData` object in the following way:

* It is created by `Mapping::get_data()` to store information that is computed once but used many times.
* `FEValues` passes this object back to the mapping in `FEValues::do_reinit` when calling `Mapping::fill_fe_values`.
* `Mapping::fill_fe_values` uses this to compute mapping-related information using the once-computed data in `InternalData` and stores the output in the `FEValuesData` object.

In this view, the `InternalData` object passed to `Mapping::fill_fe_values` can be `const`, and this patch implements this: It simply makes the `InternalData` argument of `Mapping::fill_fe_*_values` `const`.


Now, here is the problem: some of the mappings also use the `InternalData` object for two other purposes:

* Scratch space for computations inside `Mapping*::fill_fe_values`.
* To store information that is computed in `Mapping*::fill_fe_values` and that is later used in `Mapping*::transform`.

To make this possible, I have marked all those member variable of the various `Mapping*::InternalData` class that are used in this way, as `mutable`. This allows this kind of use. If we decide to go down this road, I will clearly document in each case where this is done what the intent of the `mutable` marking is, and document essentially the whole discussion above in the documentation of the `Mapping::InternalDataBase` class and the affected derived classes.

What do you all think?