### PR TITLE
Simplify code.

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -298,8 +298,18 @@ private:
                                          std::vector<Point<spacedim> > &points) const;
 
 
+  /**
+   * Implementation of the Mapping::get_data() interface.
+   *
+   * As allowed by C++ (using a feature called "covariant return
+   * types"), this function returns a pointer to a
+   * MappingQ::InternalData object since these objects are
+   * derived from the Mapping::InternalDataBase class, pointers to
+   * which are returned by the Mapping::get_data() function. This
+   * makes some uses of this function simpler.
+   */
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -538,8 +538,18 @@ private:
    */
   virtual UpdateFlags update_each (const UpdateFlags flags) const;
 
+  /**
+   * Implementation of the Mapping::get_data() interface.
+   *
+   * As allowed by C++ (using a feature called "covariant return
+   * types"), this function returns a pointer to a
+   * MappingQ1::InternalData object since these objects are
+   * derived from the Mapping::InternalDataBase class, pointers to
+   * which are returned by the Mapping::get_data() function. This
+   * makes some uses of this function simpler.
+   */
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -194,7 +194,7 @@ MappingQ<dim,spacedim>::compute_shapes_virtual (const std::vector<Point<dim> > &
 
 
 template<int dim, int spacedim>
-typename Mapping<dim,spacedim>::InternalDataBase *
+typename MappingQ<dim,spacedim>::InternalData *
 MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                   const Quadrature<dim> &quadrature) const
 {
@@ -1044,9 +1044,8 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
   // the right size and transformation shape values already computed at point
   // p.
   const Quadrature<dim> point_quadrature(p);
-  std_cxx11::unique_ptr<InternalData>
-  mdata (dynamic_cast<InternalData *> (
-           get_data(update_transformation_values, point_quadrature)));
+  std_cxx11::unique_ptr<InternalData> mdata (get_data(update_transformation_values,
+                                                      point_quadrature));
 
   mdata->use_mapping_q1_on_current_cell = !(use_mapping_q_on_all_cells ||
                                             cell->has_boundary_lines());
@@ -1130,9 +1129,8 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
       UpdateFlags update_flags = update_transformation_values|update_transformation_gradients;
       if (spacedim>dim)
         update_flags |= update_jacobian_grads;
-      std_cxx11::unique_ptr<InternalData>
-      mdata (dynamic_cast<InternalData *> (
-               get_data(update_flags,point_quadrature)));
+      std_cxx11::unique_ptr<InternalData> mdata (get_data(update_flags,
+                                                          point_quadrature));
 
       mdata->use_mapping_q1_on_current_cell = false;
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -491,7 +491,7 @@ MappingQ1<dim,spacedim>::compute_data (const UpdateFlags      update_flags,
 
 
 template<int dim, int spacedim>
-typename Mapping<dim,spacedim>::InternalDataBase *
+typename MappingQ1<dim,spacedim>::InternalData *
 MappingQ1<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                    const Quadrature<dim> &q) const
 {
@@ -1427,16 +1427,13 @@ MappingQ1<dim,spacedim>::transform_unit_to_real_cell (
   const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   const Point<dim> &p) const
 {
-  // Use the get_data function to
-  // create an InternalData with data
-  // vectors of the right size and
-  // transformation shape values
-  // already computed at point p.
+  // Use the get_data function to create an InternalData with data
+  // vectors of the right size and transformation shape values already
+  // computed at point p.
   const Quadrature<dim> point_quadrature(p);
 
-  std_cxx11::unique_ptr<InternalData>
-  mdata (dynamic_cast<InternalData *> (
-           get_data(update_transformation_values, point_quadrature)));
+  std_cxx11::unique_ptr<InternalData> mdata (get_data(update_transformation_values,
+                                                      point_quadrature));
 
   // compute the mapping support
   // points
@@ -1670,9 +1667,8 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
       if (spacedim>dim)
         update_flags |= update_jacobian_grads;
 
-      std_cxx11::unique_ptr<InternalData>
-      mdata(dynamic_cast<InternalData *> (
-              MappingQ1<dim,spacedim>::get_data(update_flags, point_quadrature)));
+      std_cxx11::unique_ptr<InternalData> mdata(get_data(update_flags,
+                                                         point_quadrature));
 
       compute_mapping_support_points (cell, mdata->mapping_support_points);
       // The support points have to be at


### PR DESCRIPTION
There are a couple of places where we call a get_data() function
that returns a pointer to a base class when we know that the actual
data type is a pointer to derived class. We need to cast right back
to the derived class.

This can be avoided by using covariant return types where the get_data()
function returns a pointer to derived right away.