### PR TITLE
Deprecate Epetra_Map constructors in Trilinos::SparseMatrix and add getters for IndexSets

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -64,6 +64,14 @@ inconvenience this causes.
 
 <ol>
 
+  <li> New: IndexSet now can be constructed using Epetra_Map.
+  All constructors of TrilinosWrappers::SparseMatrix which use Epetra_Map
+  were marked deprecated. 
+  <br>
+  (Luca Heltai, 2015/07/25)
+  </li>
+
+
   <li> New: IndexSet now implements iterators.
   <br>
   (Timo Heister, 2015/07/12)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -104,6 +104,14 @@ public:
    */
   explicit IndexSet (const size_type size);
 
+
+#ifdef DEAL_II_WITH_TRILINOS
+  /**
+   * Constructor from a trilinos Epetra_Map.
+   */
+  IndexSet(const Epetra_Map &map);
+#endif
+
   /**
    * Remove all indices from this index set. The index set retains its size,
    * however.
@@ -1198,6 +1206,24 @@ IndexSet::IndexSet (const size_type size)
 
 
 
+
+#ifdef DEAL_II_WITH_TRILINOS
+inline
+IndexSet::IndexSet (const Epetra_Map &map)
+  :
+  is_compressed (true),
+  index_space_size (map.NumGlobalElements()),
+  largest_range (numbers::invalid_unsigned_int)
+{
+  int *map_indices = map.MyGlobalElements();
+  for (int i=0; i<map.NumMyElements(); ++i)
+    add_index((size_type)map_indices[i]);
+  compress();
+}
+#endif
+
+
+
 inline
 void
 IndexSet::clear ()
@@ -1206,6 +1232,7 @@ IndexSet::clear ()
   largest_range = 0;
   is_compressed = true;
 }
+
 
 
 inline

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1215,9 +1215,13 @@ IndexSet::IndexSet (const Epetra_Map &map)
   index_space_size (map.NumGlobalElements()),
   largest_range (numbers::invalid_unsigned_int)
 {
-  int *map_indices = map.MyGlobalElements();
-  for (int i=0; i<map.NumMyElements(); ++i)
-    add_index((size_type)map_indices[i]);
+  const size_type n_indices = map.NumMyElements();
+#ifndef DEAL_II_WITH_64BIT_INDICES
+  unsigned int *indices = (unsigned int *)map.MyGlobalElements();
+#else
+  size_type *indices = (size_type *)map.MyGlobalElements64();
+#endif
+  add_indices(indices, indices+n_indices);
   compress();
 }
 #endif

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -662,7 +662,7 @@ namespace TrilinosWrappers
      * the compress() step).
      */
     SparseMatrix (const Epetra_Map  &parallel_partitioning,
-                  const size_type    n_max_entries_per_row = 0);
+                  const size_type    n_max_entries_per_row = 0) DEAL_II_DEPRECATED;
 
     /**
      * Same as before, but now set a value of nonzeros for each matrix row.
@@ -672,7 +672,7 @@ namespace TrilinosWrappers
      * respective SparseMatrix::reinit call considerably faster.
      */
     SparseMatrix (const Epetra_Map                &parallel_partitioning,
-                  const std::vector<unsigned int> &n_entries_per_row);
+                  const std::vector<unsigned int> &n_entries_per_row) DEAL_II_DEPRECATED;
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -692,7 +692,7 @@ namespace TrilinosWrappers
      */
     SparseMatrix (const Epetra_Map &row_parallel_partitioning,
                   const Epetra_Map &col_parallel_partitioning,
-                  const size_type   n_max_entries_per_row = 0);
+                  const size_type   n_max_entries_per_row = 0) DEAL_II_DEPRECATED;
 
     /**
      * This constructor is similar to the one above, but it now takes two
@@ -710,7 +710,7 @@ namespace TrilinosWrappers
      */
     SparseMatrix (const Epetra_Map                &row_parallel_partitioning,
                   const Epetra_Map                &col_parallel_partitioning,
-                  const std::vector<unsigned int> &n_entries_per_row);
+                  const std::vector<unsigned int> &n_entries_per_row) DEAL_II_DEPRECATED;
 
     /**
      * This function is initializes the Trilinos Epetra matrix according to
@@ -739,7 +739,7 @@ namespace TrilinosWrappers
     template<typename SparsityType>
     void reinit (const Epetra_Map    &parallel_partitioning,
                  const SparsityType  &sparsity_pattern,
-                 const bool          exchange_data = false);
+                 const bool          exchange_data = false) DEAL_II_DEPRECATED;
 
     /**
      * This function is similar to the other initialization function above,
@@ -757,7 +757,7 @@ namespace TrilinosWrappers
     void reinit (const Epetra_Map    &row_parallel_partitioning,
                  const Epetra_Map    &col_parallel_partitioning,
                  const SparsityType  &sparsity_pattern,
-                 const bool          exchange_data = false);
+                 const bool          exchange_data = false) DEAL_II_DEPRECATED;
 
     /**
      * This function initializes the Trilinos matrix using the deal.II sparse
@@ -780,7 +780,7 @@ namespace TrilinosWrappers
                  const ::dealii::SparseMatrix<number> &dealii_sparse_matrix,
                  const double                          drop_tolerance=1e-13,
                  const bool                            copy_values=true,
-                 const ::dealii::SparsityPattern      *use_this_sparsity=0);
+                 const ::dealii::SparsityPattern      *use_this_sparsity=0) DEAL_II_DEPRECATED;
 
     /**
      * This function is similar to the other initialization function with
@@ -801,7 +801,7 @@ namespace TrilinosWrappers
                  const ::dealii::SparseMatrix<number>  &dealii_sparse_matrix,
                  const double                           drop_tolerance=1e-13,
                  const bool                             copy_values=true,
-                 const ::dealii::SparsityPattern      *use_this_sparsity=0);
+                 const ::dealii::SparsityPattern      *use_this_sparsity=0) DEAL_II_DEPRECATED;
 //@}
     /**
      * @name Constructors and initialization using an IndexSet description
@@ -1029,6 +1029,11 @@ namespace TrilinosWrappers
      * returned in case this is called in an MPI-based program.
      */
     size_type memory_consumption () const;
+
+    /**
+     * Return the MPI communicator object in use with this matrix.
+     */
+    MPI_Comm get_mpi_communicator () const;
 
 //@}
     /**
@@ -1664,7 +1669,7 @@ namespace TrilinosWrappers
      * sets the partitioning of the domain space of this matrix, i.e., the
      * partitioning of the vectors this matrix has to be multiplied with.
      */
-    const Epetra_Map &domain_partitioner () const;
+    const Epetra_Map &domain_partitioner ()  const DEAL_II_DEPRECATED;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -1672,14 +1677,14 @@ namespace TrilinosWrappers
      * partitioning of the vectors that are result from matrix-vector
      * products.
      */
-    const Epetra_Map &range_partitioner () const;
+    const Epetra_Map &range_partitioner () const DEAL_II_DEPRECATED;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
      * sets the partitioning of the matrix rows. Equal to the partitioning of
      * the range.
      */
-    const Epetra_Map &row_partitioner () const;
+    const Epetra_Map &row_partitioner () const DEAL_II_DEPRECATED;
 
     /**
      * Return a const reference to the underlying Trilinos Epetra_Map that
@@ -1687,8 +1692,29 @@ namespace TrilinosWrappers
      * equal to the partitioner Epetra_Map for the domain because of overlap
      * in the matrix.
      */
-    const Epetra_Map &col_partitioner () const;
+    const Epetra_Map &col_partitioner () const DEAL_II_DEPRECATED;
 //@}
+
+    /**
+     * @name Partitioners
+     */
+//@{
+
+    /**
+     * Return the partitioning of the domain space of this matrix, i.e., the
+     * partitioning of the vectors this matrix has to be multiplied with.
+     */
+    IndexSet locally_owned_domain_indices() const;
+
+    /**
+     * Return the partitioning of the range space of this matrix, i.e., the
+     * partitioning of the vectors that are result from matrix-vector
+     * products.
+     */
+    IndexSet locally_owned_range_indices() const;
+
+//@}
+
     /**
      * @name Iterators
      */
@@ -2613,6 +2639,24 @@ namespace TrilinosWrappers
   SparseMatrix::range_partitioner () const
   {
     return matrix->RangeMap();
+  }
+
+
+
+  inline
+  IndexSet
+  SparseMatrix::locally_owned_domain_indices () const
+  {
+    return IndexSet(matrix->DomainMap());
+  }
+
+
+
+  inline
+  IndexSet
+  SparseMatrix::locally_owned_range_indices () const
+  {
+    return IndexSet(matrix->RangeMap());
   }
 
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -988,7 +988,7 @@ namespace internal
                                 TrilinosWrappers::MPI::Vector &v,
                                 bool fast)
       {
-        v.reinit(matrix.range_partitioner(), fast);
+        v.reinit(IndexSet(matrix.range_partitioner()), MPI_COMM_WORLD, fast);
       }
 
       template <typename Matrix>
@@ -997,7 +997,7 @@ namespace internal
                                 TrilinosWrappers::MPI::Vector &v,
                                 bool fast)
       {
-        v.reinit(matrix.domain_partitioner(), fast);
+        v.reinit(IndexSet(matrix.domain_partitioner()), MPI_COMM_WORLD, fast);
       }
     };
 
@@ -1015,7 +1015,7 @@ namespace internal
                                 TrilinosWrappers::Vector &v,
                                 bool fast)
       {
-        v.reinit(matrix.range_partitioner(), fast);
+        v.reinit(IndexSet(matrix.range_partitioner()), MPI_COMM_WORLD, fast);
       }
 
       template <typename Matrix>
@@ -1024,7 +1024,7 @@ namespace internal
                                 TrilinosWrappers::Vector &v,
                                 bool fast)
       {
-        v.reinit(matrix.domain_partitioner(), fast);
+        v.reinit(IndexSet(matrix.domain_partitioner()), MPI_COMM_WORLD, fast);
       }
     };
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -988,7 +988,7 @@ namespace internal
                                 TrilinosWrappers::MPI::Vector &v,
                                 bool fast)
       {
-        v.reinit(IndexSet(matrix.range_partitioner()), MPI_COMM_WORLD, fast);
+        v.reinit(matrix.locally_owned_range_indices(), matrix.get_mpi_communicator(), fast);
       }
 
       template <typename Matrix>
@@ -997,7 +997,7 @@ namespace internal
                                 TrilinosWrappers::MPI::Vector &v,
                                 bool fast)
       {
-        v.reinit(IndexSet(matrix.domain_partitioner()), MPI_COMM_WORLD, fast);
+        v.reinit(matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator(), fast);
       }
     };
 
@@ -1015,7 +1015,7 @@ namespace internal
                                 TrilinosWrappers::Vector &v,
                                 bool fast)
       {
-        v.reinit(IndexSet(matrix.range_partitioner()), MPI_COMM_WORLD, fast);
+        v.reinit(matrix.locally_owned_range_indices(), matrix.get_mpi_communicator(), fast);
       }
 
       template <typename Matrix>
@@ -1024,7 +1024,7 @@ namespace internal
                                 TrilinosWrappers::Vector &v,
                                 bool fast)
       {
-        v.reinit(IndexSet(matrix.domain_partitioner()), MPI_COMM_WORLD, fast);
+        v.reinit(matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator(), fast);
       }
     };
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2310,6 +2310,22 @@ namespace TrilinosWrappers
     return ((sizeof(TrilinosScalar)+sizeof(TrilinosWrappers::types::int_type))*
             matrix->NumMyNonzeros() + sizeof(int)*local_size() + static_memory);
   }
+
+  MPI_Comm SparseMatrix::get_mpi_communicator () const
+  {
+
+#ifdef DEAL_II_WITH_MPI
+
+    const Epetra_MpiComm *mpi_comm
+      = dynamic_cast<const Epetra_MpiComm *>(&range_partitioner().Comm());
+    return mpi_comm->Comm();
+#else
+
+    return MPI_COMM_SELF;
+
+#endif
+
+  }
 }
 
 


### PR DESCRIPTION
A lot of constructors in trilinos_vector.h were marked deprecated. This made `LinearOperator` unhappy. I implemented a constructor for `IndexSet` which takes an `Epetra_Map`, and made LinearOperator use this interface. All tests for `LinearOperator` are passing, so I did not add an additional test for this. 

This is necessary at the moment because the `Vector` interfaces using Trilinos objects directly were marked deprecated but Trilinos matrices were not instructed to return index sets instead of Epetra_Maps.

Whilst this PR fixes the warnings (#1029), it also makes it clear that *removing* Trilinos constructors is not, in my opinion, necessary. These *are* wrappers to trilinos objects, and I'm not sure we should be so harsh in marking things deprecated "because PETSc does not have the same interface". 

Of course we should have *a common interface*, but that does not mean that we should throw away the other interface... Comments?