### PR TITLE
Remove an unnecessary #include file.

### DIFF
--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -34,7 +34,6 @@
 #include <numeric>
 #include <algorithm>
 #include <limits>
-#include <iomanip>
 
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
I accidentally left this in #1180 from a debugging session. It
is no longer needed.