### PR TITLE
[RFC] Do not set a thread limit in tests in non-MPI mode.

### DIFF
--- a/tests/fe/cell_similarity_11.cc
+++ b/tests/fe/cell_similarity_11.cc
@@ -26,9 +26,7 @@
 // in real space in two locations inside the cell.
 
 // To make sure the cell similarity code is used, only run the program with
-// one thread. For this we need to disable LimitConcurreny in ../tests.h and
-// then set the number of threads to 1 (in main() below):
-#define DEAL_II_TEST_DO_NOT_SET_THREAD_LIMIT
+// one thread.
 
 #include "../tests.h"
 #include <deal.II/base/logstream.h>

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -185,28 +185,6 @@ std::string unify_pretty_function (const std::string &text)
 // ------------------------------ Functions used in initializing subsystems -------------------
 
 
-/*
- * If we run 64 tests at the same time on a 64-core system, and
- * each of them runs 64 threads, then we get astronomical loads.
- * Limit concurrency to a fixed (small) number of threads, independent
- * of the core count.
- *
- * Note that we can't do this if we run in MPI mode because then
- * MPI_InitFinalize already calls this function. Since every test
- * calls MPI_InitFinalize itself, we can't adjust the thread count
- * for this here.
- */
-#if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_TEST_DO_NOT_SET_THREAD_LIMIT)
-struct LimitConcurrency
-{
-  LimitConcurrency ()
-  {
-    MultithreadInfo::set_thread_limit (5);
-  }
-} limit_concurrency;
-#endif
-
-
 
 #ifdef DEAL_II_WITH_PETSC
 #include <petscsys.h>


### PR DESCRIPTION
In d6609be, a temporary fix for
```
Calling set_thread_limit() more than once is not supported!
```
was set for the new cell_similarity_11 test. However, when I ran with serial Trilinos in
http://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=10413
I get 166 failing tests because of that. Before setting DEAL_II_TEST_DO_NOT_SET_THREAD_LIMIT in all those tests, I wonder if we shouldn't remove the LimitConcurrency struct altogether. I realize that it can be valuable but we disable it in MPI mode and the testers seem to do fine. Any reason for keeping it? The alternative would be to make MPI_InitFinalize smarter and only call set_thread_limit in case MultithreadInfo::n_threads() returns invalid_unsigned_int, then we could also apply LimitConcurrency in MPI mode.