### PR TITLE
rework set_thread_limit()

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -66,6 +66,13 @@ inconvenience this causes.
 
 <ol>
 
+  <li> New: MultithreadInfo::set_thread_limit() can now be called more than
+  once and the environment variable DEAL_II_NUM_THREADS will be respected
+  even if user code never calls it.
+  <br>
+  (Timo Heister, 2015/07/26)
+  </li>
+
   <li> New: IndexSet now implements iterators.
   <br>
   (Timo Heister, 2015/07/12)

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -84,19 +84,12 @@ public:
    * given, the default from TBB is used (based on the number of cores in the
    * system).
    *
-   * Due to limitations in the way TBB can be controlled, only the first call
-   * to this method will have any effect. In practice, this means that you
-   * need to call this function before you get to any point in your program
-   * where multiple threads may be created. In other words, the correct place
-   * for a call to this function is at the top of your <code>main()</code>
-   * function.
-   *
-   * This routine is called automatically by MPI_InitFinalize. Use the
-   * appropriate argument of the constructor of MPI_InitFinalize if you have
-   * an MPI based code.
+   * This routine is executed automatically with the default argument before
+   * your code in main() is running (using a static constructor). It is also
+   * executed by MPI_InitFinalize. Use the appropriate argument of the
+   * constructor of MPI_InitFinalize if you have an MPI based code.
    */
   static void set_thread_limit (const unsigned int max_threads = numbers::invalid_unsigned_int);
-
 
   /**
    * Returns if the TBB is running using a single thread either because of

--- a/tests/base/task_11.cc
+++ b/tests/base/task_11.cc
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// test calling MultithreadInfo::set_thread_limit() multiple times and the
+// effect for running tasks
+
+#include "../tests.h"
+#include <iomanip>
+#include <fstream>
+#include <unistd.h>
+
+#include <deal.II/base/thread_management.h>
+
+Threads::Mutex mutex;
+unsigned int n_running;
+unsigned int n_max_running;
+
+void a_task ()
+{
+  mutex.acquire();
+  n_running++;
+  n_max_running=std::max(n_max_running, n_running);
+  mutex.release();
+
+  // Sleep some time to make sure all other concurrently running tasks enter
+  // here.
+  sleep (1);
+
+  mutex.acquire();
+  n_running--;
+  mutex.release();
+}
+
+
+void test()
+{
+  Threads::TaskGroup<> tg;
+
+  n_running = 0;
+  n_max_running = 0;
+
+  // force all tasks to wait until we are done starting
+  mutex.acquire();
+
+  for (unsigned int t=0; t<10; ++t)
+    tg += Threads::new_task(a_task);
+
+  // now let the tasks run
+  mutex.release();
+
+  tg.join_all();
+  deallog << "max concurrent running: " << n_max_running
+          << " should be: " << MultithreadInfo::n_threads()
+          << std::endl;
+}
+
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.depth_console(0);
+  deallog.threshold_double(1.e-10);
+
+  const unsigned int n = testing_max_num_threads();
+  
+  // if we have a machine with less than 5 cores fake the output:
+  if (MultithreadInfo::n_threads()<n)
+    {
+      // you should buy more cores, seriously.
+      deallog << "* default thread limit for tests: " << n << std::endl;
+      deallog << "max concurrent running: " << n
+              << " should be: " << n
+              << std::endl;
+    }
+  else if (MultithreadInfo::n_threads()==n)
+    {
+      deallog << "* default thread limit for tests: " << MultithreadInfo::n_threads() << std::endl;
+      test();
+    }
+  else
+    Assert(false, ExcInternalError("did somebody mess with LimitConcurrency in tests.h?"));
+
+  deallog << "* now with thread limit 1:" << std::endl;
+  MultithreadInfo::set_thread_limit(1);
+  test();
+  deallog << "* now with thread limit 2:" << std::endl;
+  MultithreadInfo::set_thread_limit(2);
+  test();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/base/task_11.with_threads=on.output
+++ b/tests/base/task_11.with_threads=on.output
@@ -1,0 +1,8 @@
+
+DEAL::* default thread limit for tests: 5
+DEAL::max concurrent running: 5 should be: 5
+DEAL::* now with thread limit 1:
+DEAL::max concurrent running: 1 should be: 1
+DEAL::* now with thread limit 2:
+DEAL::max concurrent running: 2 should be: 2
+DEAL::OK

--- a/tests/benchmarks/test_poisson/poisson.cc
+++ b/tests/benchmarks/test_poisson/poisson.cc
@@ -204,7 +204,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::System::MPI_InitFinalize mpi_initialization(argc, argv);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
       deallog.depth_console (0);
 
       FE_Q<dimension> fe(element_degree);

--- a/tests/distributed_grids/2d_coarse_grid_01.cc
+++ b/tests/distributed_grids/2d_coarse_grid_01.cc
@@ -67,7 +67,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarse_grid_02.cc
+++ b/tests/distributed_grids/2d_coarse_grid_02.cc
@@ -57,7 +57,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarse_grid_03.cc
+++ b/tests/distributed_grids/2d_coarse_grid_03.cc
@@ -45,7 +45,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarse_grid_04.cc
+++ b/tests/distributed_grids/2d_coarse_grid_04.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarse_grid_x_01.cc
+++ b/tests/distributed_grids/2d_coarse_grid_x_01.cc
@@ -80,7 +80,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarsening_01.cc
+++ b/tests/distributed_grids/2d_coarsening_01.cc
@@ -49,7 +49,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarsening_02.cc
+++ b/tests/distributed_grids/2d_coarsening_02.cc
@@ -119,7 +119,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarsening_03.cc
+++ b/tests/distributed_grids/2d_coarsening_03.cc
@@ -180,7 +180,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_coarsening_05.cc
+++ b/tests/distributed_grids/2d_coarsening_05.cc
@@ -107,7 +107,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_dofhandler_01.cc
+++ b/tests/distributed_grids/2d_dofhandler_01.cc
@@ -75,7 +75,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_01.cc
+++ b/tests/distributed_grids/2d_refinement_01.cc
@@ -47,7 +47,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_02.cc
+++ b/tests/distributed_grids/2d_refinement_02.cc
@@ -108,7 +108,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_03.cc
+++ b/tests/distributed_grids/2d_refinement_03.cc
@@ -138,7 +138,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_04.cc
+++ b/tests/distributed_grids/2d_refinement_04.cc
@@ -76,7 +76,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_05.cc
+++ b/tests/distributed_grids/2d_refinement_05.cc
@@ -98,7 +98,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_06.cc
+++ b/tests/distributed_grids/2d_refinement_06.cc
@@ -71,7 +71,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/2d_refinement_07.cc
+++ b/tests/distributed_grids/2d_refinement_07.cc
@@ -64,7 +64,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
   deal_II_exceptions::disable_abort_on_exception();
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_01.cc
+++ b/tests/distributed_grids/3d_coarse_grid_01.cc
@@ -67,7 +67,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_02.cc
+++ b/tests/distributed_grids/3d_coarse_grid_02.cc
@@ -52,7 +52,7 @@ void test(const char *filename)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_03.cc
+++ b/tests/distributed_grids/3d_coarse_grid_03.cc
@@ -45,7 +45,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_04.cc
+++ b/tests/distributed_grids/3d_coarse_grid_04.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_05.cc
+++ b/tests/distributed_grids/3d_coarse_grid_05.cc
@@ -144,7 +144,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_06.cc
+++ b/tests/distributed_grids/3d_coarse_grid_06.cc
@@ -46,7 +46,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarse_grid_x_01.cc
+++ b/tests/distributed_grids/3d_coarse_grid_x_01.cc
@@ -80,7 +80,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarsening_01.cc
+++ b/tests/distributed_grids/3d_coarsening_01.cc
@@ -49,7 +49,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarsening_02.cc
+++ b/tests/distributed_grids/3d_coarsening_02.cc
@@ -121,7 +121,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarsening_03.cc
+++ b/tests/distributed_grids/3d_coarsening_03.cc
@@ -118,7 +118,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarsening_04.cc
+++ b/tests/distributed_grids/3d_coarsening_04.cc
@@ -119,7 +119,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_coarsening_05.cc
+++ b/tests/distributed_grids/3d_coarsening_05.cc
@@ -108,7 +108,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_refinement_01.cc
+++ b/tests/distributed_grids/3d_refinement_01.cc
@@ -47,7 +47,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_refinement_02.cc
+++ b/tests/distributed_grids/3d_refinement_02.cc
@@ -108,7 +108,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/3d_refinement_03.cc
+++ b/tests/distributed_grids/3d_refinement_03.cc
@@ -98,7 +98,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_04.cc
+++ b/tests/distributed_grids/3d_refinement_04.cc
@@ -77,7 +77,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_05.cc
+++ b/tests/distributed_grids/3d_refinement_05.cc
@@ -100,7 +100,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_06.cc
+++ b/tests/distributed_grids/3d_refinement_06.cc
@@ -86,7 +86,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_07.cc
+++ b/tests/distributed_grids/3d_refinement_07.cc
@@ -60,7 +60,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_08.cc
+++ b/tests/distributed_grids/3d_refinement_08.cc
@@ -97,7 +97,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/3d_refinement_09.cc
+++ b/tests/distributed_grids/3d_refinement_09.cc
@@ -64,7 +64,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
   deal_II_exceptions::disable_abort_on_exception();
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/anisotropic.cc
+++ b/tests/distributed_grids/anisotropic.cc
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
   deal_II_exceptions::disable_abort_on_exception();
 
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/codim_01.cc
+++ b/tests/distributed_grids/codim_01.cc
@@ -46,7 +46,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   initlog();
 

--- a/tests/distributed_grids/count_dofs_per_block_01.cc
+++ b/tests/distributed_grids/count_dofs_per_block_01.cc
@@ -109,7 +109,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/count_dofs_per_component_01.cc
+++ b/tests/distributed_grids/count_dofs_per_component_01.cc
@@ -75,7 +75,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/dof_handler_number_cache.cc
+++ b/tests/distributed_grids/dof_handler_number_cache.cc
@@ -111,7 +111,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/solution_transfer_01.cc
+++ b/tests/distributed_grids/solution_transfer_01.cc
@@ -79,7 +79,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/solution_transfer_02.cc
+++ b/tests/distributed_grids/solution_transfer_02.cc
@@ -116,7 +116,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/solution_transfer_03.cc
+++ b/tests/distributed_grids/solution_transfer_03.cc
@@ -144,7 +144,7 @@ void test(std::ostream & /*out*/)
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 #else
   (void)argc;
   (void)argv;

--- a/tests/distributed_grids/solution_transfer_04.cc
+++ b/tests/distributed_grids/solution_transfer_04.cc
@@ -100,7 +100,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/subdomain_id_01.cc
+++ b/tests/distributed_grids/subdomain_id_01.cc
@@ -63,7 +63,7 @@ int main (int argc, char *argv[])
 {
   deal_II_exceptions::disable_abort_on_exception();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   std::ofstream logfile("output");
   deallog.attach(logfile);
   deallog.depth_console(0);

--- a/tests/distributed_grids/tria_settings_01.cc
+++ b/tests/distributed_grids/tria_settings_01.cc
@@ -85,7 +85,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/distributed_grids/update_number_cache_01.cc
+++ b/tests/distributed_grids/update_number_cache_01.cc
@@ -49,7 +49,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/fe/cell_similarity_11.cc
+++ b/tests/fe/cell_similarity_11.cc
@@ -26,9 +26,7 @@
 // in real space in two locations inside the cell.
 
 // To make sure the cell similarity code is used, only run the program with
-// one thread. For this we need to disable LimitConcurreny in ../tests.h and
-// then set the number of threads to 1 (in main() below):
-#define DEAL_II_TEST_DO_NOT_SET_THREAD_LIMIT
+// one thread.
 
 #include "../tests.h"
 #include <deal.II/base/logstream.h>

--- a/tests/gla/block_mat_01.cc
+++ b/tests/gla/block_mat_01.cc
@@ -90,7 +90,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   {

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -225,7 +225,7 @@ void test_LA_Trilinos ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   {

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -222,7 +222,7 @@ A.reinit(sp);
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   {

--- a/tests/gla/block_vec_01.cc
+++ b/tests/gla/block_vec_01.cc
@@ -82,7 +82,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/block_vec_02.cc
+++ b/tests/gla/block_vec_02.cc
@@ -92,7 +92,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/block_vec_03.cc
+++ b/tests/gla/block_vec_03.cc
@@ -90,7 +90,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/block_vec_04.cc
+++ b/tests/gla/block_vec_04.cc
@@ -87,7 +87,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/extract_subvector_to.cc
+++ b/tests/gla/extract_subvector_to.cc
@@ -66,7 +66,7 @@ void test (Vector &vector)
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     {

--- a/tests/gla/extract_subvector_to_parallel.cc
+++ b/tests/gla/extract_subvector_to_parallel.cc
@@ -72,7 +72,7 @@ void test (Vector &vector)
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   const unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   {

--- a/tests/gla/mat_01.cc
+++ b/tests/gla/mat_01.cc
@@ -86,7 +86,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/mat_02.cc
+++ b/tests/gla/mat_02.cc
@@ -87,7 +87,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/mat_03.cc
+++ b/tests/gla/mat_03.cc
@@ -109,7 +109,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   {

--- a/tests/gla/mat_04.cc
+++ b/tests/gla/mat_04.cc
@@ -151,7 +151,7 @@ void test_trilinos_alternative ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   {

--- a/tests/gla/mat_05.cc
+++ b/tests/gla/mat_05.cc
@@ -119,7 +119,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/mat_06.cc
+++ b/tests/gla/mat_06.cc
@@ -91,7 +91,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_00.cc
+++ b/tests/gla/vec_00.cc
@@ -81,7 +81,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/gla/vec_01.cc
+++ b/tests/gla/vec_01.cc
@@ -86,7 +86,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/gla/vec_02.cc
+++ b/tests/gla/vec_02.cc
@@ -98,7 +98,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/gla/vec_03.cc
+++ b/tests/gla/vec_03.cc
@@ -93,7 +93,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_04.cc
+++ b/tests/gla/vec_04.cc
@@ -95,7 +95,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_05.cc
+++ b/tests/gla/vec_05.cc
@@ -93,7 +93,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_06.cc
+++ b/tests/gla/vec_06.cc
@@ -80,7 +80,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_07.cc
+++ b/tests/gla/vec_07.cc
@@ -74,7 +74,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   {
     deallog.push("PETSc");

--- a/tests/gla/vec_all_zero_01.cc
+++ b/tests/gla/vec_all_zero_01.cc
@@ -66,7 +66,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/grid/cell_id_01.cc
+++ b/tests/grid/cell_id_01.cc
@@ -51,7 +51,7 @@ void check (TRIA &tr)
 
 int main (int argc, char *argv[])
 {
-  // Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  // Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   initlog();
   deal_II_exceptions::disable_abort_on_exception();

--- a/tests/grid/cell_id_02.cc
+++ b/tests/grid/cell_id_02.cc
@@ -63,7 +63,7 @@ void check (TRIA &tr)
 
 int main (int argc, char *argv[])
 {
-  // Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  // Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   initlog();
   deal_II_exceptions::disable_abort_on_exception();

--- a/tests/grid/grid_out_vtk_02.cc
+++ b/tests/grid/grid_out_vtk_02.cc
@@ -102,7 +102,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/integrators/assembler_simple_matrix_03tri.cc
+++ b/tests/integrators/assembler_simple_matrix_03tri.cc
@@ -109,7 +109,7 @@ void test(FiniteElement<dim> &fe)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   initlog();
 
   FE_DGP<2> p0(0);

--- a/tests/lac/linear_operator_04.cc
+++ b/tests/lac/linear_operator_04.cc
@@ -28,7 +28,7 @@ using namespace dealii;
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   initlog();
   deallog << std::setprecision(10);

--- a/tests/lac/matrix_out_02.cc
+++ b/tests/lac/matrix_out_02.cc
@@ -28,7 +28,7 @@
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog << std::fixed;

--- a/tests/lac/matrix_out_03.cc
+++ b/tests/lac/matrix_out_03.cc
@@ -26,7 +26,7 @@
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog << std::fixed;

--- a/tests/matrix_free/matrix_vector_10.cc
+++ b/tests/matrix_free/matrix_vector_10.cc
@@ -198,8 +198,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv,
-                                                         numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/matrix_free/matrix_vector_11.cc
+++ b/tests/matrix_free/matrix_vector_11.cc
@@ -172,8 +172,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv,
-                                                         numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -262,8 +262,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv,
-                                                         numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -264,8 +264,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv,
-                                                         numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -390,7 +390,7 @@ namespace Step48
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -361,7 +361,7 @@ namespace Step48
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/active_cell_index_01.cc
+++ b/tests/mpi/active_cell_index_01.cc
@@ -65,7 +65,7 @@ void check ()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   check<2> ();

--- a/tests/mpi/attach_data_01.cc
+++ b/tests/mpi/attach_data_01.cc
@@ -158,7 +158,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/blockvec_01.cc
+++ b/tests/mpi/blockvec_01.cc
@@ -101,7 +101,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/cell_weights_01.cc
+++ b/tests/mpi/cell_weights_01.cc
@@ -64,7 +64,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_01_back_and_forth_01.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_01.cc
@@ -77,7 +77,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_01_back_and_forth_02.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_02.cc
@@ -73,7 +73,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -64,7 +64,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -96,7 +96,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_04.cc
+++ b/tests/mpi/cell_weights_04.cc
@@ -95,7 +95,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -119,7 +119,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -116,7 +116,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/codim_01.cc
+++ b/tests/mpi/codim_01.cc
@@ -100,7 +100,7 @@ void test(std::ostream & /*out*/)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   MPILogInitAll init;
 

--- a/tests/mpi/collective_01.cc
+++ b/tests/mpi/collective_01.cc
@@ -81,7 +81,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02.cc
+++ b/tests/mpi/collective_02.cc
@@ -57,7 +57,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_array.cc
+++ b/tests/mpi/collective_02_array.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_array_in_place.cc
+++ b/tests/mpi/collective_02_array_in_place.cc
@@ -42,7 +42,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_dealii_vector.cc
+++ b/tests/mpi/collective_02_dealii_vector.cc
@@ -64,7 +64,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_dealii_vector_in_place.cc
+++ b/tests/mpi/collective_02_dealii_vector_in_place.cc
@@ -62,7 +62,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_vector.cc
+++ b/tests/mpi/collective_02_vector.cc
@@ -44,7 +44,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_02_vector_in_place.cc
+++ b/tests/mpi/collective_02_vector_in_place.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_max.cc
+++ b/tests/mpi/collective_max.cc
@@ -57,7 +57,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_max_array.cc
+++ b/tests/mpi/collective_max_array.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_max_array_in_place.cc
+++ b/tests/mpi/collective_max_array_in_place.cc
@@ -42,7 +42,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_max_vector.cc
+++ b/tests/mpi/collective_max_vector.cc
@@ -44,7 +44,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_max_vector_in_place.cc
+++ b/tests/mpi/collective_max_vector_in_place.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_min.cc
+++ b/tests/mpi/collective_min.cc
@@ -57,7 +57,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_min_array.cc
+++ b/tests/mpi/collective_min_array.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_min_array_in_place.cc
+++ b/tests/mpi/collective_min_array_in_place.cc
@@ -42,7 +42,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_min_vector.cc
+++ b/tests/mpi/collective_min_vector.cc
@@ -44,7 +44,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_min_vector_in_place.cc
+++ b/tests/mpi/collective_min_vector_in_place.cc
@@ -43,7 +43,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/collective_tensor.cc
+++ b/tests/mpi/collective_tensor.cc
@@ -96,7 +96,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/communicate_moved_vertices_01.cc
+++ b/tests/mpi/communicate_moved_vertices_01.cc
@@ -107,7 +107,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/communicate_moved_vertices_02.cc
+++ b/tests/mpi/communicate_moved_vertices_02.cc
@@ -103,7 +103,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/compute_mean_value.cc
+++ b/tests/mpi/compute_mean_value.cc
@@ -91,7 +91,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/condense_01.cc
+++ b/tests/mpi/condense_01.cc
@@ -90,7 +90,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/constraint_matrix_condense_01.cc
+++ b/tests/mpi/constraint_matrix_condense_01.cc
@@ -78,7 +78,7 @@ void test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/constraint_matrix_crash_01.cc
+++ b/tests/mpi/constraint_matrix_crash_01.cc
@@ -45,7 +45,7 @@ void test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test();

--- a/tests/mpi/constraint_matrix_set_zero_01.cc
+++ b/tests/mpi/constraint_matrix_set_zero_01.cc
@@ -76,7 +76,7 @@ void test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test();

--- a/tests/mpi/constraint_matrix_set_zero_02.cc
+++ b/tests/mpi/constraint_matrix_set_zero_02.cc
@@ -79,7 +79,7 @@ void test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test();

--- a/tests/mpi/constraint_matrix_trilinos_bug.cc
+++ b/tests/mpi/constraint_matrix_trilinos_bug.cc
@@ -142,7 +142,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/count_dofs_per_block_01.cc
+++ b/tests/mpi/count_dofs_per_block_01.cc
@@ -65,7 +65,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/count_dofs_per_block_02.cc
+++ b/tests/mpi/count_dofs_per_block_02.cc
@@ -108,7 +108,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/count_dofs_per_component_01.cc
+++ b/tests/mpi/count_dofs_per_component_01.cc
@@ -74,7 +74,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/crash_01.cc
+++ b/tests/mpi/crash_01.cc
@@ -60,7 +60,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/crash_02.cc
+++ b/tests/mpi/crash_02.cc
@@ -55,7 +55,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/crash_03.cc
+++ b/tests/mpi/crash_03.cc
@@ -85,7 +85,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/crash_04.cc
+++ b/tests/mpi/crash_04.cc
@@ -111,7 +111,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/crash_05.cc
+++ b/tests/mpi/crash_05.cc
@@ -89,7 +89,7 @@ void test()
 
 int main(int argc, char *argv[])
 {  
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/crash_06.cc
+++ b/tests/mpi/crash_06.cc
@@ -95,7 +95,7 @@ void testit()
 
 int main(int argc, char *argv[])
 {  
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   testit<2>();

--- a/tests/mpi/cuthill_mckee_01.cc
+++ b/tests/mpi/cuthill_mckee_01.cc
@@ -45,7 +45,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));
   if (myid == 0)

--- a/tests/mpi/data_out_hdf5_01.cc
+++ b/tests/mpi/data_out_hdf5_01.cc
@@ -69,7 +69,7 @@ test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   try

--- a/tests/mpi/derivative_approximation_01.cc
+++ b/tests/mpi/derivative_approximation_01.cc
@@ -92,7 +92,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/derivative_approximation_02.cc
+++ b/tests/mpi/derivative_approximation_02.cc
@@ -99,7 +99,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   MPILogInitAll log;
 

--- a/tests/mpi/distort_random_01.cc
+++ b/tests/mpi/distort_random_01.cc
@@ -69,7 +69,7 @@ void test1 (const bool keep_boundary)
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
   {

--- a/tests/mpi/distort_random_02.cc
+++ b/tests/mpi/distort_random_02.cc
@@ -81,7 +81,7 @@ void test1 (const bool keep_boundary)
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
   {

--- a/tests/mpi/distribute_sp_01.cc
+++ b/tests/mpi/distribute_sp_01.cc
@@ -95,7 +95,7 @@ void test_mpi()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/distribute_sp_02.cc
+++ b/tests/mpi/distribute_sp_02.cc
@@ -155,7 +155,7 @@ void test_mpi()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/dof_handler_number_cache.cc
+++ b/tests/mpi/dof_handler_number_cache.cc
@@ -133,7 +133,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/extract_boundary_dofs.cc
+++ b/tests/mpi/extract_boundary_dofs.cc
@@ -59,7 +59,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/extract_constant_modes_01.cc
+++ b/tests/mpi/extract_constant_modes_01.cc
@@ -101,7 +101,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/extract_constant_modes_02.cc
+++ b/tests/mpi/extract_constant_modes_02.cc
@@ -77,7 +77,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/extract_locally_active_dofs.cc
+++ b/tests/mpi/extract_locally_active_dofs.cc
@@ -78,7 +78,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/fe_field_function_01.cc
+++ b/tests/mpi/fe_field_function_01.cc
@@ -119,7 +119,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/find_active_cell_around_point_01.cc
+++ b/tests/mpi/find_active_cell_around_point_01.cc
@@ -80,7 +80,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -189,11 +189,11 @@ namespace Step39
 
 int main(int argc, char *argv[])
 {
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
-  mpi_initlog(true);
-
   using namespace dealii;
   using namespace Step39;
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+  mpi_initlog(true);
 
   try
     {

--- a/tests/mpi/ghost_01.cc
+++ b/tests/mpi/ghost_01.cc
@@ -81,7 +81,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/ghost_02.cc
+++ b/tests/mpi/ghost_02.cc
@@ -96,7 +96,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/ghost_03.cc
+++ b/tests/mpi/ghost_03.cc
@@ -92,7 +92,7 @@ int main (int argc, char **argv)
 {
   deal_II_exceptions::disable_abort_on_exception();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/has_active_dofs_01.cc
+++ b/tests/mpi/has_active_dofs_01.cc
@@ -103,7 +103,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/has_active_dofs_02.cc
+++ b/tests/mpi/has_active_dofs_02.cc
@@ -105,7 +105,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/has_hanging_nodes.cc
+++ b/tests/mpi/has_hanging_nodes.cc
@@ -144,7 +144,7 @@ int main (int argc, char *argv[])
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
    
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   test_int<2>(0,0);
   test_int<2>(2,0);
   test_int<2>(3,1);

--- a/tests/mpi/integrate_difference.cc
+++ b/tests/mpi/integrate_difference.cc
@@ -112,7 +112,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/interpolate_01.cc
+++ b/tests/mpi/interpolate_01.cc
@@ -82,7 +82,7 @@ void test()
 int main(int argc, char *argv[])
 {
 #ifdef DEAL_II_WITH_MPI
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 #else
   (void)argc;
   (void)argv;

--- a/tests/mpi/interpolate_02.cc
+++ b/tests/mpi/interpolate_02.cc
@@ -80,7 +80,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/interpolate_03.cc
+++ b/tests/mpi/interpolate_03.cc
@@ -84,7 +84,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/interpolate_04.cc
+++ b/tests/mpi/interpolate_04.cc
@@ -91,7 +91,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/interpolate_to_different_mesh_01.cc
+++ b/tests/mpi/interpolate_to_different_mesh_01.cc
@@ -191,7 +191,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   test<2>();
 }

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -293,7 +293,7 @@ void seventh_grid()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   deallog.depth_file(0);
   

--- a/tests/mpi/is_locally_owned.cc
+++ b/tests/mpi/is_locally_owned.cc
@@ -84,7 +84,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/make_zero_boundary_values.cc
+++ b/tests/mpi/make_zero_boundary_values.cc
@@ -65,7 +65,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/map_dofs_to_support_points.cc
+++ b/tests/mpi/map_dofs_to_support_points.cc
@@ -80,7 +80,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/mesh_worker_01.cc
+++ b/tests/mpi/mesh_worker_01.cc
@@ -217,7 +217,7 @@ test()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/mesh_worker_02.cc
+++ b/tests/mpi/mesh_worker_02.cc
@@ -183,7 +183,7 @@ test()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/mesh_worker_04.cc
+++ b/tests/mpi/mesh_worker_04.cc
@@ -175,7 +175,7 @@ test()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/mesh_worker_matrix_01.cc
+++ b/tests/mpi/mesh_worker_matrix_01.cc
@@ -275,7 +275,7 @@ test(const FiniteElement<dim> &fe)
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
   FE_DGP<2> p0(0);

--- a/tests/mpi/mg_01.cc
+++ b/tests/mpi/mg_01.cc
@@ -107,7 +107,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/mg_02.cc
+++ b/tests/mpi/mg_02.cc
@@ -111,7 +111,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/mg_03.cc
+++ b/tests/mpi/mg_03.cc
@@ -116,7 +116,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/mg_04.cc
+++ b/tests/mpi/mg_04.cc
@@ -112,7 +112,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/mg_05.cc
+++ b/tests/mpi/mg_05.cc
@@ -154,7 +154,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/mg_06.cc
+++ b/tests/mpi/mg_06.cc
@@ -155,7 +155,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -770,7 +770,7 @@ int main (int argc, char *argv[])
       using namespace dealii;
       using namespace Step22;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)==0)

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -504,14 +504,14 @@ namespace Step50
 // in step-6:
 int main (int argc, char *argv[])
 {
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  using namespace dealii;
+  using namespace Step50;
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   mpi_initlog();
 
   try
     {
-      using namespace dealii;
-      using namespace Step50;
-
       LaplaceProblem<2> laplace_problem(1);
       laplace_problem.run ();
     }

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -498,14 +498,13 @@ namespace Step50
 // in step-6:
 int main (int argc, char *argv[])
 {
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  using namespace dealii;
+  using namespace Step50;
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   mpi_initlog();
 
   try
     {
-      using namespace dealii;
-      using namespace Step50;
-
       LaplaceProblem<2> laplace_problem(1);
       laplace_problem.run ();
     }

--- a/tests/mpi/no_flux_constraints.cc
+++ b/tests/mpi/no_flux_constraints.cc
@@ -170,7 +170,7 @@ void test()
 int main(int argc, char *argv[])
 {
   {
-    Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+    Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
     unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
 

--- a/tests/mpi/no_flux_constraints_02.cc
+++ b/tests/mpi/no_flux_constraints_02.cc
@@ -212,7 +212,7 @@ void test()
 int main(int argc, char *argv[])
 {
   {
-    Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+    Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
     unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
 

--- a/tests/mpi/no_flux_constraints_03.cc
+++ b/tests/mpi/no_flux_constraints_03.cc
@@ -187,7 +187,7 @@ void test()
 int main(int argc, char *argv[])
 {
   {
-    Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+    Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
     unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
 

--- a/tests/mpi/normal_flux_constraints.cc
+++ b/tests/mpi/normal_flux_constraints.cc
@@ -169,7 +169,7 @@ void test()
 int main(int argc, char *argv[])
 {
   {
-    Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+    Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
     unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
 

--- a/tests/mpi/p4est_2d_coarse_01.cc
+++ b/tests/mpi/p4est_2d_coarse_01.cc
@@ -93,7 +93,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_01.cc
@@ -94,7 +94,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_02.cc
@@ -94,7 +94,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_03.cc
@@ -224,7 +224,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -319,7 +319,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_05.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_05.cc
@@ -97,7 +97,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_dofhandler_01.cc
+++ b/tests/mpi/p4est_2d_dofhandler_01.cc
@@ -85,7 +85,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_dofhandler_02.cc
+++ b/tests/mpi/p4est_2d_dofhandler_02.cc
@@ -98,7 +98,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_dofhandler_03.cc
+++ b/tests/mpi/p4est_2d_dofhandler_03.cc
@@ -117,7 +117,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_dofhandler_04.cc
+++ b/tests/mpi/p4est_2d_dofhandler_04.cc
@@ -127,7 +127,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_dofhandler_05.cc
+++ b/tests/mpi/p4est_2d_dofhandler_05.cc
@@ -65,7 +65,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_ghost_01.cc
+++ b/tests/mpi/p4est_2d_ghost_01.cc
@@ -113,7 +113,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_ghost_02.cc
+++ b/tests/mpi/p4est_2d_ghost_02.cc
@@ -115,7 +115,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_refine_01.cc
+++ b/tests/mpi/p4est_2d_refine_01.cc
@@ -79,7 +79,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_refine_02.cc
+++ b/tests/mpi/p4est_2d_refine_02.cc
@@ -90,7 +90,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/p4est_2d_refine_03.cc
+++ b/tests/mpi/p4est_2d_refine_03.cc
@@ -89,7 +89,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_renumber_01.cc
+++ b/tests/mpi/p4est_2d_renumber_01.cc
@@ -118,7 +118,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_renumber_02.cc
+++ b/tests/mpi/p4est_2d_renumber_02.cc
@@ -114,7 +114,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_simple.cc
+++ b/tests/mpi/p4est_2d_simple.cc
@@ -82,7 +82,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_01.cc
@@ -104,7 +104,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_02.cc
@@ -132,7 +132,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -315,7 +315,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_04.cc
@@ -94,7 +94,7 @@ void test ()
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   const unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/p4est_3d_ghost_01.cc
+++ b/tests/mpi/p4est_3d_ghost_01.cc
@@ -124,7 +124,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_refine_01.cc
+++ b/tests/mpi/p4est_3d_refine_01.cc
@@ -118,7 +118,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_refine_02.cc
+++ b/tests/mpi/p4est_3d_refine_02.cc
@@ -79,7 +79,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_refine_03.cc
+++ b/tests/mpi/p4est_3d_refine_03.cc
@@ -76,7 +76,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_refine_04.cc
+++ b/tests/mpi/p4est_3d_refine_04.cc
@@ -116,7 +116,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_data_out_01.cc
+++ b/tests/mpi/p4est_data_out_01.cc
@@ -82,7 +82,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_get_subdomain_association.cc
+++ b/tests/mpi/p4est_get_subdomain_association.cc
@@ -77,7 +77,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_max_refine.cc
+++ b/tests/mpi/p4est_max_refine.cc
@@ -78,7 +78,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_save_01.cc
+++ b/tests/mpi/p4est_save_01.cc
@@ -105,7 +105,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_save_02.cc
+++ b/tests/mpi/p4est_save_02.cc
@@ -160,7 +160,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_save_03.cc
+++ b/tests/mpi/p4est_save_03.cc
@@ -173,7 +173,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_save_04.cc
+++ b/tests/mpi/p4est_save_04.cc
@@ -152,7 +152,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   test<2>();

--- a/tests/mpi/parallel_block_vector_01.cc
+++ b/tests/mpi/parallel_block_vector_01.cc
@@ -234,7 +234,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_block_vector_02.cc
+++ b/tests/mpi/parallel_block_vector_02.cc
@@ -155,7 +155,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_partitioner_01.cc
+++ b/tests/mpi/parallel_partitioner_01.cc
@@ -119,7 +119,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_partitioner_02.cc
+++ b/tests/mpi/parallel_partitioner_02.cc
@@ -92,7 +92,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_partitioner_03.cc
+++ b/tests/mpi/parallel_partitioner_03.cc
@@ -98,7 +98,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_partitioner_04.cc
+++ b/tests/mpi/parallel_partitioner_04.cc
@@ -89,7 +89,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_01.cc
+++ b/tests/mpi/parallel_vector_01.cc
@@ -69,7 +69,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_02.cc
+++ b/tests/mpi/parallel_vector_02.cc
@@ -80,7 +80,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_03.cc
+++ b/tests/mpi/parallel_vector_03.cc
@@ -81,7 +81,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_04.cc
+++ b/tests/mpi/parallel_vector_04.cc
@@ -103,7 +103,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_05.cc
+++ b/tests/mpi/parallel_vector_05.cc
@@ -72,7 +72,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_06.cc
+++ b/tests/mpi/parallel_vector_06.cc
@@ -221,7 +221,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_07.cc
+++ b/tests/mpi/parallel_vector_07.cc
@@ -97,7 +97,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_08.cc
+++ b/tests/mpi/parallel_vector_08.cc
@@ -144,7 +144,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_09.cc
+++ b/tests/mpi/parallel_vector_09.cc
@@ -118,7 +118,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_10.cc
+++ b/tests/mpi/parallel_vector_10.cc
@@ -70,7 +70,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_11.cc
+++ b/tests/mpi/parallel_vector_11.cc
@@ -165,7 +165,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_12.cc
+++ b/tests/mpi/parallel_vector_12.cc
@@ -171,7 +171,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_13.cc
+++ b/tests/mpi/parallel_vector_13.cc
@@ -94,7 +94,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_14.cc
+++ b/tests/mpi/parallel_vector_14.cc
@@ -123,7 +123,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_15.cc
+++ b/tests/mpi/parallel_vector_15.cc
@@ -96,7 +96,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_back_interpolate.cc
+++ b/tests/mpi/parallel_vector_back_interpolate.cc
@@ -77,7 +77,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vector_interpolate.cc
+++ b/tests/mpi/parallel_vector_interpolate.cc
@@ -76,7 +76,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/parallel_vtu_01.cc
+++ b/tests/mpi/parallel_vtu_01.cc
@@ -87,7 +87,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
       using namespace dealii;
       using namespace Step40;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)==0)

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -773,7 +773,7 @@ int main (int argc, char *argv[])
       using namespace dealii;
       using namespace Step22;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)==0)

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -843,7 +843,7 @@ int main (int argc, char *argv[])
       using namespace dealii;
       using namespace Step22;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)==0)

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -238,7 +238,7 @@ int main (int argc, char *argv[])
     {
       using namespace dealii;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       MPILogInitAll log;

--- a/tests/mpi/petsc_01.cc
+++ b/tests/mpi/petsc_01.cc
@@ -83,7 +83,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/petsc_02.cc
+++ b/tests/mpi/petsc_02.cc
@@ -62,7 +62,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/petsc_03.cc
+++ b/tests/mpi/petsc_03.cc
@@ -60,7 +60,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/petsc_bug_ghost_vector_01.cc
+++ b/tests/mpi/petsc_bug_ghost_vector_01.cc
@@ -244,7 +244,7 @@ void test ()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/petsc_distribute_01.cc
+++ b/tests/mpi/petsc_distribute_01.cc
@@ -144,7 +144,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/petsc_distribute_01_block.cc
+++ b/tests/mpi/petsc_distribute_01_block.cc
@@ -178,7 +178,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/petsc_distribute_01_inhomogenous.cc
+++ b/tests/mpi/petsc_distribute_01_inhomogenous.cc
@@ -138,7 +138,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/petsc_locally_owned_elements.cc
+++ b/tests/mpi/petsc_locally_owned_elements.cc
@@ -62,7 +62,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/point_to_point_pattern_01.cc
+++ b/tests/mpi/point_to_point_pattern_01.cc
@@ -108,7 +108,7 @@ void test_mpi()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/point_value_01.cc
+++ b/tests/mpi/point_value_01.cc
@@ -101,7 +101,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   if (myid == 0)

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_01.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_01.cc
@@ -127,7 +127,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_02.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_02.cc
@@ -137,7 +137,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_03.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_03.cc
@@ -116,7 +116,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_04.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_04.cc
@@ -134,7 +134,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_05.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_05.cc
@@ -131,7 +131,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_06.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_06.cc
@@ -150,7 +150,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_07.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_07.cc
@@ -199,7 +199,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_01.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_01.cc
@@ -115,7 +115,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_02.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_02.cc
@@ -116,7 +116,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_03.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_03.cc
@@ -105,7 +105,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_04.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_04.cc
@@ -134,7 +134,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_05.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_05.cc
@@ -131,7 +131,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refine_and_coarsen_fixed_number_06.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_06.cc
@@ -70,7 +70,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/refine_and_coarsen_fixed_number_07.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_07.cc
@@ -108,7 +108,7 @@ void test(const double max_n_cell_ratio)
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refinement_listener_01.cc
+++ b/tests/mpi/refinement_listener_01.cc
@@ -85,7 +85,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/refinement_listener_02.cc
+++ b/tests/mpi/refinement_listener_02.cc
@@ -88,7 +88,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -91,7 +91,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -93,7 +93,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/renumber_z_order_01.cc
+++ b/tests/mpi/renumber_z_order_01.cc
@@ -121,7 +121,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/renumber_z_order_02.cc
+++ b/tests/mpi/renumber_z_order_02.cc
@@ -125,7 +125,7 @@ void test()
 
 int main (int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/repartition_01.cc
+++ b/tests/mpi/repartition_01.cc
@@ -77,7 +77,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   test<2>();
 }

--- a/tests/mpi/repartition_02.cc
+++ b/tests/mpi/repartition_02.cc
@@ -154,7 +154,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   test<2>();
 }

--- a/tests/mpi/repartition_03.cc
+++ b/tests/mpi/repartition_03.cc
@@ -99,7 +99,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   test<2>();
 }

--- a/tests/mpi/simple_mpi_01.cc
+++ b/tests/mpi/simple_mpi_01.cc
@@ -65,7 +65,7 @@ void test_mpi()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     {

--- a/tests/mpi/solution_transfer_01.cc
+++ b/tests/mpi/solution_transfer_01.cc
@@ -102,7 +102,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -693,12 +693,12 @@ namespace Step39
 
 int main(int argc, char *argv[])
 {
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
-  MPILogInitAll log;
-  
   using namespace dealii;
   using namespace Step39;
 
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+  MPILogInitAll log;
+  
   try
     {
       FE_DGQ<2> fe1(2);

--- a/tests/mpi/torus.cc
+++ b/tests/mpi/torus.cc
@@ -66,7 +66,8 @@ DeclException1(ExcMissingCell,
 
 int main(int argc, char *argv[])
 {
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  using namespace dealii;
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)

--- a/tests/mpi/tria_01.cc
+++ b/tests/mpi/tria_01.cc
@@ -75,7 +75,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
 
   deallog.push("2d");

--- a/tests/mpi/tria_copy_triangulation.cc
+++ b/tests/mpi/tria_copy_triangulation.cc
@@ -120,7 +120,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_01.cc
+++ b/tests/mpi/trilinos_01.cc
@@ -86,7 +86,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_02.cc
+++ b/tests/mpi/trilinos_02.cc
@@ -83,7 +83,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_bug_5609.cc
+++ b/tests/mpi/trilinos_bug_5609.cc
@@ -68,7 +68,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_compress_bug.cc
+++ b/tests/mpi/trilinos_compress_bug.cc
@@ -92,7 +92,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_distribute_01.cc
+++ b/tests/mpi/trilinos_distribute_01.cc
@@ -149,7 +149,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_distribute_01_block.cc
+++ b/tests/mpi/trilinos_distribute_01_block.cc
@@ -182,7 +182,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_distribute_01_inhomogenous.cc
+++ b/tests/mpi/trilinos_distribute_01_inhomogenous.cc
@@ -143,7 +143,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_distribute_03.cc
+++ b/tests/mpi/trilinos_distribute_03.cc
@@ -57,7 +57,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_distribute_04.cc
+++ b/tests/mpi/trilinos_distribute_04.cc
@@ -119,7 +119,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_ghost_01.cc
+++ b/tests/mpi/trilinos_ghost_01.cc
@@ -77,7 +77,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_ghost_02.cc
+++ b/tests/mpi/trilinos_ghost_02.cc
@@ -68,7 +68,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_ghost_03.cc
+++ b/tests/mpi/trilinos_ghost_03.cc
@@ -84,7 +84,7 @@ int main (int argc, char **argv)
 {
   deal_II_exceptions::disable_abort_on_exception();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_ghost_03_linfty.cc
+++ b/tests/mpi/trilinos_ghost_03_linfty.cc
@@ -83,7 +83,7 @@ int main (int argc, char **argv)
 {
   deal_II_exceptions::disable_abort_on_exception();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_ghost_05.cc
+++ b/tests/mpi/trilinos_ghost_05.cc
@@ -82,7 +82,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_locally_owned_elements_01.cc
+++ b/tests/mpi/trilinos_locally_owned_elements_01.cc
@@ -66,7 +66,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 

--- a/tests/mpi/trilinos_matvec_01.cc
+++ b/tests/mpi/trilinos_matvec_01.cc
@@ -121,7 +121,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_matvec_02.cc
+++ b/tests/mpi/trilinos_matvec_02.cc
@@ -121,7 +121,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_matvec_03.cc
+++ b/tests/mpi/trilinos_matvec_03.cc
@@ -143,7 +143,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_sadd_01.cc
+++ b/tests/mpi/trilinos_sadd_01.cc
@@ -84,7 +84,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_sadd_02.cc
+++ b/tests/mpi/trilinos_sadd_02.cc
@@ -97,7 +97,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_sadd_03.cc
+++ b/tests/mpi/trilinos_sadd_03.cc
@@ -142,7 +142,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_sparse_matrix_01.cc
+++ b/tests/mpi/trilinos_sparse_matrix_01.cc
@@ -116,7 +116,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_sparse_matrix_02.cc
+++ b/tests/mpi/trilinos_sparse_matrix_02.cc
@@ -115,7 +115,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   MPILogInitAll log;
   test();
 }

--- a/tests/mpi/trilinos_sparse_matrix_03.cc
+++ b/tests/mpi/trilinos_sparse_matrix_03.cc
@@ -208,7 +208,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_sparse_matrix_04.cc
+++ b/tests/mpi/trilinos_sparse_matrix_04.cc
@@ -119,7 +119,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_sparse_matrix_05.cc
+++ b/tests/mpi/trilinos_sparse_matrix_05.cc
@@ -124,7 +124,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_sparse_matrix_mmult_01.cc
+++ b/tests/mpi/trilinos_sparse_matrix_mmult_01.cc
@@ -148,7 +148,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/mpi/trilinos_sparse_matrix_print_01.cc
+++ b/tests/mpi/trilinos_sparse_matrix_print_01.cc
@@ -83,7 +83,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);

--- a/tests/mpi/trilinos_vector_ghosts_01.cc
+++ b/tests/mpi/trilinos_vector_ghosts_01.cc
@@ -66,12 +66,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-#ifdef DEAL_II_WITH_MPI
-  MPI_Init (&argc,&argv);
-#else
-  (void)argc;
-  (void)argv;
-#endif
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
@@ -87,8 +82,4 @@ int main(int argc, char *argv[])
     }
   else
     test();
-
-#ifdef DEAL_II_WITH_MPI
-  MPI_Finalize();
-#endif
 }

--- a/tests/mpi/trilinos_vector_reinit.cc
+++ b/tests/mpi/trilinos_vector_reinit.cc
@@ -61,7 +61,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/petsc/01.cc
+++ b/tests/petsc/01.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/02.cc
+++ b/tests/petsc/02.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/04.cc
+++ b/tests/petsc/04.cc
@@ -42,7 +42,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/05.cc
+++ b/tests/petsc/05.cc
@@ -57,7 +57,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/06.cc
+++ b/tests/petsc/06.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/07.cc
+++ b/tests/petsc/07.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/08.cc
+++ b/tests/petsc/08.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/09.cc
+++ b/tests/petsc/09.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/10.cc
+++ b/tests/petsc/10.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix m (5,5,3);
         test (m);

--- a/tests/petsc/11.cc
+++ b/tests/petsc/11.cc
@@ -47,7 +47,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/12.cc
+++ b/tests/petsc/12.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/13.cc
+++ b/tests/petsc/13.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/17.cc
+++ b/tests/petsc/17.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/18.cc
+++ b/tests/petsc/18.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/19.cc
+++ b/tests/petsc/19.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/20.cc
+++ b/tests/petsc/20.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/21.cc
+++ b/tests/petsc/21.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/22.cc
+++ b/tests/petsc/22.cc
@@ -55,7 +55,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/23.cc
+++ b/tests/petsc/23.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/24.cc
+++ b/tests/petsc/24.cc
@@ -55,7 +55,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/25.cc
+++ b/tests/petsc/25.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/26.cc
+++ b/tests/petsc/26.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/27.cc
+++ b/tests/petsc/27.cc
@@ -57,7 +57,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/28.cc
+++ b/tests/petsc/28.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/29.cc
+++ b/tests/petsc/29.cc
@@ -44,7 +44,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/30.cc
+++ b/tests/petsc/30.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/31.cc
+++ b/tests/petsc/31.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/32.cc
+++ b/tests/petsc/32.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/33.cc
+++ b/tests/petsc/33.cc
@@ -55,7 +55,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/34.cc
+++ b/tests/petsc/34.cc
@@ -55,7 +55,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/35.cc
+++ b/tests/petsc/35.cc
@@ -71,7 +71,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/36.cc
+++ b/tests/petsc/36.cc
@@ -71,7 +71,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/37.cc
+++ b/tests/petsc/37.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/38.cc
+++ b/tests/petsc/38.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/39.cc
+++ b/tests/petsc/39.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/40.cc
+++ b/tests/petsc/40.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/41.cc
+++ b/tests/petsc/41.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/42.cc
+++ b/tests/petsc/42.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/43.cc
+++ b/tests/petsc/43.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/44.cc
+++ b/tests/petsc/44.cc
@@ -67,7 +67,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/45.cc
+++ b/tests/petsc/45.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/46.cc
+++ b/tests/petsc/46.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/47.cc
+++ b/tests/petsc/47.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/48.cc
+++ b/tests/petsc/48.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/49.cc
+++ b/tests/petsc/49.cc
@@ -56,7 +56,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/50.cc
+++ b/tests/petsc/50.cc
@@ -72,7 +72,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/51.cc
+++ b/tests/petsc/51.cc
@@ -56,7 +56,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/52.cc
+++ b/tests/petsc/52.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         typedef PETScWrappers::SparseMatrix::size_type size_type;
 

--- a/tests/petsc/55.cc
+++ b/tests/petsc/55.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/56.cc
+++ b/tests/petsc/56.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/57.cc
+++ b/tests/petsc/57.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/58.cc
+++ b/tests/petsc/58.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/59.cc
+++ b/tests/petsc/59.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/60.cc
+++ b/tests/petsc/60.cc
@@ -64,7 +64,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/61.cc
+++ b/tests/petsc/61.cc
@@ -69,7 +69,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         test (v);

--- a/tests/petsc/62.cc
+++ b/tests/petsc/62.cc
@@ -50,7 +50,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (100,100,5);
         test (v);

--- a/tests/petsc/63.cc
+++ b/tests/petsc/63.cc
@@ -48,7 +48,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (100,100,5);
         test (v);

--- a/tests/petsc/64.cc
+++ b/tests/petsc/64.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         const unsigned int n_dofs=420;
         // check

--- a/tests/petsc/65.cc
+++ b/tests/petsc/65.cc
@@ -47,7 +47,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/66.cc
+++ b/tests/petsc/66.cc
@@ -104,7 +104,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (14,14,3);
         test (v);

--- a/tests/petsc/67.cc
+++ b/tests/petsc/67.cc
@@ -112,7 +112,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (14,14,3);
         test (v);

--- a/tests/petsc/68.cc
+++ b/tests/petsc/68.cc
@@ -108,7 +108,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (14,14,3);
         test (v);

--- a/tests/petsc/69.cc
+++ b/tests/petsc/69.cc
@@ -116,7 +116,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::SparseMatrix v (14,14,3);
         test (v);

--- a/tests/petsc/block_vector_iterator_01.cc
+++ b/tests/petsc/block_vector_iterator_01.cc
@@ -87,7 +87,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/block_vector_iterator_02.cc
+++ b/tests/petsc/block_vector_iterator_02.cc
@@ -81,7 +81,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/block_vector_iterator_03.cc
+++ b/tests/petsc/block_vector_iterator_03.cc
@@ -332,7 +332,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/copy_to_dealvec.cc
+++ b/tests/petsc/copy_to_dealvec.cc
@@ -98,7 +98,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/petsc/copy_to_dealvec_block.cc
+++ b/tests/petsc/copy_to_dealvec_block.cc
@@ -117,7 +117,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-10);
 

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/full_matrix_00.cc
+++ b/tests/petsc/full_matrix_00.cc
@@ -86,7 +86,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         // Standard intialiser...
         PETScWrappers::FullMatrix m (3,3);

--- a/tests/petsc/full_matrix_01.cc
+++ b/tests/petsc/full_matrix_01.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_02.cc
+++ b/tests/petsc/full_matrix_02.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_04.cc
+++ b/tests/petsc/full_matrix_04.cc
@@ -42,7 +42,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_05.cc
+++ b/tests/petsc/full_matrix_05.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_06.cc
+++ b/tests/petsc/full_matrix_06.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_07.cc
+++ b/tests/petsc/full_matrix_07.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_08.cc
+++ b/tests/petsc/full_matrix_08.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_09.cc
+++ b/tests/petsc/full_matrix_09.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_10.cc
+++ b/tests/petsc/full_matrix_10.cc
@@ -65,7 +65,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::FullMatrix m (5,5);
         test (m);

--- a/tests/petsc/full_matrix_iterator_01.cc
+++ b/tests/petsc/full_matrix_iterator_01.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/full_matrix_vector_01.cc
+++ b/tests/petsc/full_matrix_vector_01.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/full_matrix_vector_02.cc
+++ b/tests/petsc/full_matrix_vector_02.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/full_matrix_vector_03.cc
+++ b/tests/petsc/full_matrix_vector_03.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/full_matrix_vector_04.cc
+++ b/tests/petsc/full_matrix_vector_04.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/full_matrix_vector_05.cc
+++ b/tests/petsc/full_matrix_vector_05.cc
@@ -74,7 +74,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/full_matrix_vector_06.cc
+++ b/tests/petsc/full_matrix_vector_06.cc
@@ -66,7 +66,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (30);
         test (v);

--- a/tests/petsc/full_matrix_vector_07.cc
+++ b/tests/petsc/full_matrix_vector_07.cc
@@ -76,7 +76,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/parallel_sparse_matrix_01.cc
+++ b/tests/petsc/parallel_sparse_matrix_01.cc
@@ -127,7 +127,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       test ();
 
     }

--- a/tests/petsc/slowness_01.cc
+++ b/tests/petsc/slowness_01.cc
@@ -115,7 +115,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/slowness_02.cc
+++ b/tests/petsc/slowness_02.cc
@@ -86,7 +86,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/slowness_03.cc
+++ b/tests/petsc/slowness_03.cc
@@ -89,7 +89,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/slowness_04.cc
+++ b/tests/petsc/slowness_04.cc
@@ -120,7 +120,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     SolverControl control(100, 1.e-3);
 

--- a/tests/petsc/sparse_direct_mumps.cc
+++ b/tests/petsc/sparse_direct_mumps.cc
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   {
     const unsigned int size = 32;
     unsigned int dim = (size-1)*(size-1);

--- a/tests/petsc/sparse_matrix_01.cc
+++ b/tests/petsc/sparse_matrix_01.cc
@@ -76,7 +76,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
   test ();
 
 }

--- a/tests/petsc/sparse_matrix_02.cc
+++ b/tests/petsc/sparse_matrix_02.cc
@@ -70,7 +70,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
 

--- a/tests/petsc/sparse_matrix_iterator_01.cc
+++ b/tests/petsc/sparse_matrix_iterator_01.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         test ();
       }

--- a/tests/petsc/sparse_matrix_vector_01.cc
+++ b/tests/petsc/sparse_matrix_vector_01.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/sparse_matrix_vector_02.cc
+++ b/tests/petsc/sparse_matrix_vector_02.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/sparse_matrix_vector_03.cc
+++ b/tests/petsc/sparse_matrix_vector_03.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/sparse_matrix_vector_04.cc
+++ b/tests/petsc/sparse_matrix_vector_04.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/sparse_matrix_vector_05.cc
+++ b/tests/petsc/sparse_matrix_vector_05.cc
@@ -74,7 +74,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/sparse_matrix_vector_06.cc
+++ b/tests/petsc/sparse_matrix_vector_06.cc
@@ -66,7 +66,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (30);
         test (v);

--- a/tests/petsc/sparse_matrix_vector_07.cc
+++ b/tests/petsc/sparse_matrix_vector_07.cc
@@ -76,7 +76,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_assign_01.cc
+++ b/tests/petsc/vector_assign_01.cc
@@ -58,7 +58,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_assign_02.cc
+++ b/tests/petsc/vector_assign_02.cc
@@ -57,7 +57,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_equality_1.cc
+++ b/tests/petsc/vector_equality_1.cc
@@ -53,7 +53,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_equality_2.cc
+++ b/tests/petsc/vector_equality_2.cc
@@ -55,7 +55,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_equality_3.cc
+++ b/tests/petsc/vector_equality_3.cc
@@ -53,7 +53,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_equality_4.cc
+++ b/tests/petsc/vector_equality_4.cc
@@ -55,7 +55,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (100);
         PETScWrappers::Vector w (100);

--- a/tests/petsc/vector_print.cc
+++ b/tests/petsc/vector_print.cc
@@ -34,7 +34,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         PETScWrappers::Vector v (5);
         for (unsigned int i=0; i<v.size(); ++i)

--- a/tests/petsc/vector_wrap_01.cc
+++ b/tests/petsc/vector_wrap_01.cc
@@ -55,7 +55,7 @@ int main (int argc, char **argv)
 
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       Vec vpetsc;
       int ierr = VecCreateSeq (PETSC_COMM_SELF, 100, &vpetsc);
       AssertThrow (ierr == 0, ExcPETScError(ierr));

--- a/tests/quick_tests/p4est.cc
+++ b/tests/quick_tests/p4est.cc
@@ -74,7 +74,7 @@ void test()
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
   test<2>();
   test<3>();

--- a/tests/quick_tests/step-petsc.cc
+++ b/tests/quick_tests/step-petsc.cc
@@ -181,7 +181,7 @@ int main (int argc, char **argv)
 {
   try
     {
-      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         deallog.depth_console (0);
         LaplaceProblem problem;

--- a/tests/quick_tests/step-slepc.cc
+++ b/tests/quick_tests/step-slepc.cc
@@ -201,7 +201,7 @@ int main (int argc, char **argv)
 {
   try
     {
-      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       {
         deallog.depth_console (0);
         LaplaceEigenspectrumProblem problem;

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -190,21 +190,19 @@ std::string unify_pretty_function (const std::string &text)
  * each of them runs 64 threads, then we get astronomical loads.
  * Limit concurrency to a fixed (small) number of threads, independent
  * of the core count.
- *
- * Note that we can't do this if we run in MPI mode because then
- * MPI_InitFinalize already calls this function. Since every test
- * calls MPI_InitFinalize itself, we can't adjust the thread count
- * for this here.
  */
-#if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_TEST_DO_NOT_SET_THREAD_LIMIT)
+inline unsigned int testing_max_num_threads()
+{
+    return 5;
+}
+
 struct LimitConcurrency
 {
   LimitConcurrency ()
   {
-    MultithreadInfo::set_thread_limit (5);
+    MultithreadInfo::set_thread_limit (testing_max_num_threads());
   }
 } limit_concurrency;
-#endif
 
 
 

--- a/tests/trilinos/01.cc
+++ b/tests/trilinos/01.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/02.cc
+++ b/tests/trilinos/02.cc
@@ -66,7 +66,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/03a.cc
+++ b/tests/trilinos/03a.cc
@@ -70,7 +70,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/03b.cc
+++ b/tests/trilinos/03b.cc
@@ -77,7 +77,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/04.cc
+++ b/tests/trilinos/04.cc
@@ -41,7 +41,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/05.cc
+++ b/tests/trilinos/05.cc
@@ -56,7 +56,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/06.cc
+++ b/tests/trilinos/06.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/07.cc
+++ b/tests/trilinos/07.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/08.cc
+++ b/tests/trilinos/08.cc
@@ -57,7 +57,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/09.cc
+++ b/tests/trilinos/09.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/10.cc
+++ b/tests/trilinos/10.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/11.cc
+++ b/tests/trilinos/11.cc
@@ -46,7 +46,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/12.cc
+++ b/tests/trilinos/12.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/13.cc
+++ b/tests/trilinos/13.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/14.cc
+++ b/tests/trilinos/14.cc
@@ -78,7 +78,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/15.cc
+++ b/tests/trilinos/15.cc
@@ -77,7 +77,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/16.cc
+++ b/tests/trilinos/16.cc
@@ -78,7 +78,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/17.cc
+++ b/tests/trilinos/17.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/18.cc
+++ b/tests/trilinos/18.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/19.cc
+++ b/tests/trilinos/19.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/20.cc
+++ b/tests/trilinos/20.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/21.cc
+++ b/tests/trilinos/21.cc
@@ -60,7 +60,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/22.cc
+++ b/tests/trilinos/22.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/23.cc
+++ b/tests/trilinos/23.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/24.cc
+++ b/tests/trilinos/24.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/25.cc
+++ b/tests/trilinos/25.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/26.cc
+++ b/tests/trilinos/26.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/27.cc
+++ b/tests/trilinos/27.cc
@@ -56,7 +56,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/28.cc
+++ b/tests/trilinos/28.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/29.cc
+++ b/tests/trilinos/29.cc
@@ -43,7 +43,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/30.cc
+++ b/tests/trilinos/30.cc
@@ -51,7 +51,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/31.cc
+++ b/tests/trilinos/31.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/32.cc
+++ b/tests/trilinos/32.cc
@@ -53,7 +53,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/33.cc
+++ b/tests/trilinos/33.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/34.cc
+++ b/tests/trilinos/34.cc
@@ -54,7 +54,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/35.cc
+++ b/tests/trilinos/35.cc
@@ -70,7 +70,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/36.cc
+++ b/tests/trilinos/36.cc
@@ -70,7 +70,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/37.cc
+++ b/tests/trilinos/37.cc
@@ -50,7 +50,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/38.cc
+++ b/tests/trilinos/38.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/39.cc
+++ b/tests/trilinos/39.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/40.cc
+++ b/tests/trilinos/40.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/41.cc
+++ b/tests/trilinos/41.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/42.cc
+++ b/tests/trilinos/42.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/43.cc
+++ b/tests/trilinos/43.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/44.cc
+++ b/tests/trilinos/44.cc
@@ -66,7 +66,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/45.cc
+++ b/tests/trilinos/45.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/46.cc
+++ b/tests/trilinos/46.cc
@@ -58,7 +58,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/47.cc
+++ b/tests/trilinos/47.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/48.cc
+++ b/tests/trilinos/48.cc
@@ -64,7 +64,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/49.cc
+++ b/tests/trilinos/49.cc
@@ -55,7 +55,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/49a.cc
+++ b/tests/trilinos/49a.cc
@@ -69,7 +69,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/49b.cc
+++ b/tests/trilinos/49b.cc
@@ -69,7 +69,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/50.cc
+++ b/tests/trilinos/50.cc
@@ -71,7 +71,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/51.cc
+++ b/tests/trilinos/51.cc
@@ -56,7 +56,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/52.cc
+++ b/tests/trilinos/52.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/53.cc
+++ b/tests/trilinos/53.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/54.cc
+++ b/tests/trilinos/54.cc
@@ -62,7 +62,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/55.cc
+++ b/tests/trilinos/55.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/56.cc
+++ b/tests/trilinos/56.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/57.cc
+++ b/tests/trilinos/57.cc
@@ -59,7 +59,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/58.cc
+++ b/tests/trilinos/58.cc
@@ -61,7 +61,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/59.cc
+++ b/tests/trilinos/59.cc
@@ -64,7 +64,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/60.cc
+++ b/tests/trilinos/60.cc
@@ -63,7 +63,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/61.cc
+++ b/tests/trilinos/61.cc
@@ -68,7 +68,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/62.cc
+++ b/tests/trilinos/62.cc
@@ -49,7 +49,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/63.cc
+++ b/tests/trilinos/63.cc
@@ -47,7 +47,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/64.cc
+++ b/tests/trilinos/64.cc
@@ -52,7 +52,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/65.cc
+++ b/tests/trilinos/65.cc
@@ -47,7 +47,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/66.cc
+++ b/tests/trilinos/66.cc
@@ -103,7 +103,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/67.cc
+++ b/tests/trilinos/67.cc
@@ -109,7 +109,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/68.cc
+++ b/tests/trilinos/68.cc
@@ -107,7 +107,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/69.cc
+++ b/tests/trilinos/69.cc
@@ -113,7 +113,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/70.cc
+++ b/tests/trilinos/70.cc
@@ -31,7 +31,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   if (typeid(TrilinosScalar)==typeid(double))

--- a/tests/trilinos/add_matrices_01.cc
+++ b/tests/trilinos/add_matrices_01.cc
@@ -99,7 +99,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/add_matrices_02.cc
+++ b/tests/trilinos/add_matrices_02.cc
@@ -91,7 +91,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/add_matrices_03.cc
+++ b/tests/trilinos/add_matrices_03.cc
@@ -94,7 +94,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/add_matrices_04.cc
+++ b/tests/trilinos/add_matrices_04.cc
@@ -68,7 +68,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/add_matrices_05.cc
+++ b/tests/trilinos/add_matrices_05.cc
@@ -73,7 +73,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/add_matrices_06.cc
+++ b/tests/trilinos/add_matrices_06.cc
@@ -86,7 +86,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/assemble_matrix_parallel_01.cc
+++ b/tests/trilinos/assemble_matrix_parallel_01.cc
@@ -437,7 +437,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_02.cc
+++ b/tests/trilinos/assemble_matrix_parallel_02.cc
@@ -439,7 +439,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_03.cc
+++ b/tests/trilinos/assemble_matrix_parallel_03.cc
@@ -445,7 +445,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -465,7 +465,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_05.cc
+++ b/tests/trilinos/assemble_matrix_parallel_05.cc
@@ -441,7 +441,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -466,7 +466,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -450,7 +450,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize init(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     deallog.push("2d");

--- a/tests/trilinos/block_sparse_matrix_add_01.cc
+++ b/tests/trilinos/block_sparse_matrix_add_01.cc
@@ -134,7 +134,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/block_sparse_matrix_set_01.cc
+++ b/tests/trilinos/block_sparse_matrix_set_01.cc
@@ -135,7 +135,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/block_sparse_matrix_vector_01.cc
+++ b/tests/trilinos/block_sparse_matrix_vector_01.cc
@@ -95,7 +95,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_sparse_matrix_vector_02.cc
+++ b/tests/trilinos/block_sparse_matrix_vector_02.cc
@@ -89,7 +89,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_sparse_matrix_vector_03.cc
+++ b/tests/trilinos/block_sparse_matrix_vector_03.cc
@@ -89,7 +89,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_sparse_matrix_vector_04.cc
+++ b/tests/trilinos/block_sparse_matrix_vector_04.cc
@@ -81,7 +81,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_vector_iterator_01.cc
+++ b/tests/trilinos/block_vector_iterator_01.cc
@@ -90,7 +90,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_vector_iterator_02.cc
+++ b/tests/trilinos/block_vector_iterator_02.cc
@@ -84,7 +84,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_vector_iterator_03.cc
+++ b/tests/trilinos/block_vector_iterator_03.cc
@@ -331,7 +331,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/block_vector_move_operations.cc
+++ b/tests/trilinos/block_vector_move_operations.cc
@@ -33,7 +33,7 @@ int main (int argc, char **argv)
 {
   initlog();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     std::vector<IndexSet> local_owned(5);

--- a/tests/trilinos/copy_to_dealvec.cc
+++ b/tests/trilinos/copy_to_dealvec.cc
@@ -99,7 +99,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/trilinos/copy_to_dealvec_block.cc
+++ b/tests/trilinos/copy_to_dealvec_block.cc
@@ -115,7 +115,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   deallog.push(Utilities::int_to_string(myid));

--- a/tests/trilinos/deal_solver_01.cc
+++ b/tests/trilinos/deal_solver_01.cc
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/deal_solver_02.cc
+++ b/tests/trilinos/deal_solver_02.cc
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/deal_solver_04.cc
+++ b/tests/trilinos/deal_solver_04.cc
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/deal_solver_05.cc
+++ b/tests/trilinos/deal_solver_05.cc
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/direct_solver.cc
+++ b/tests/trilinos/direct_solver.cc
@@ -297,7 +297,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/mg_transfer_prebuilt_01.cc
+++ b/tests/trilinos/mg_transfer_prebuilt_01.cc
@@ -142,7 +142,7 @@ void check_simple(const FiniteElement<dim> &fe)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog << std::setprecision(6);

--- a/tests/trilinos/parallel_sparse_matrix_01.cc
+++ b/tests/trilinos/parallel_sparse_matrix_01.cc
@@ -111,7 +111,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/precondition_amg_dgp.cc
+++ b/tests/trilinos/precondition_amg_dgp.cc
@@ -218,7 +218,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/precondition_amg_smoother.cc
+++ b/tests/trilinos/precondition_amg_smoother.cc
@@ -266,7 +266,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/precondition_muelu_dgp.cc
+++ b/tests/trilinos/precondition_muelu_dgp.cc
@@ -221,7 +221,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/precondition_muelu_q_iso_q1.cc
+++ b/tests/trilinos/precondition_muelu_q_iso_q1.cc
@@ -324,7 +324,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/precondition_muelu_smoother.cc
+++ b/tests/trilinos/precondition_muelu_smoother.cc
@@ -266,7 +266,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/precondition_q_iso_q1.cc
+++ b/tests/trilinos/precondition_q_iso_q1.cc
@@ -320,7 +320,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/slowness_01.cc
+++ b/tests/trilinos/slowness_01.cc
@@ -114,7 +114,7 @@ int main (int argc,char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/slowness_02.cc
+++ b/tests/trilinos/slowness_02.cc
@@ -85,7 +85,7 @@ int main (int argc,char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/slowness_03.cc
+++ b/tests/trilinos/slowness_03.cc
@@ -87,7 +87,7 @@ int main (int argc,char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/slowness_04.cc
+++ b/tests/trilinos/slowness_04.cc
@@ -118,7 +118,7 @@ int main (int argc,char **argv)
   deallog.attach(logfile);
   deallog.depth_console(0);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/solver_03.cc
+++ b/tests/trilinos/solver_03.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/solver_05.cc
+++ b/tests/trilinos/solver_05.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   {

--- a/tests/trilinos/solver_07.cc
+++ b/tests/trilinos/solver_07.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     SolverControl control(200, 1.e-3);

--- a/tests/trilinos/sparse_matrix_01.cc
+++ b/tests/trilinos/sparse_matrix_01.cc
@@ -37,7 +37,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   IndexSet row_partitioning (3);
   IndexSet col_partitioning (4);

--- a/tests/trilinos/sparse_matrix_02.cc
+++ b/tests/trilinos/sparse_matrix_02.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_03.cc
+++ b/tests/trilinos/sparse_matrix_03.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_04.cc
+++ b/tests/trilinos/sparse_matrix_04.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_05.cc
+++ b/tests/trilinos/sparse_matrix_05.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_07.cc
+++ b/tests/trilinos/sparse_matrix_07.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_07_rectangle.cc
+++ b/tests/trilinos/sparse_matrix_07_rectangle.cc
@@ -29,7 +29,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_add_01.cc
+++ b/tests/trilinos/sparse_matrix_add_01.cc
@@ -94,7 +94,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/sparse_matrix_add_02.cc
+++ b/tests/trilinos/sparse_matrix_add_02.cc
@@ -94,7 +94,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/sparse_matrix_copy_from_01.cc
+++ b/tests/trilinos/sparse_matrix_copy_from_01.cc
@@ -28,7 +28,7 @@
 
 int main (int argc,char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   deallog.attach(logfile);

--- a/tests/trilinos/sparse_matrix_iterator.cc
+++ b/tests/trilinos/sparse_matrix_iterator.cc
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
   deallog.attach(logfile);
   deallog.depth_console (0);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   TrilinosWrappers::SparsityPattern pattern(4,5,2);
   pattern.add(0,2);

--- a/tests/trilinos/sparse_matrix_iterator_01.cc
+++ b/tests/trilinos/sparse_matrix_iterator_01.cc
@@ -50,7 +50,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_set_01.cc
+++ b/tests/trilinos/sparse_matrix_set_01.cc
@@ -90,7 +90,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/sparse_matrix_set_02.cc
+++ b/tests/trilinos/sparse_matrix_set_02.cc
@@ -91,7 +91,7 @@ int main (int argc,char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/sparse_matrix_vector_01.cc
+++ b/tests/trilinos/sparse_matrix_vector_01.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_02.cc
+++ b/tests/trilinos/sparse_matrix_vector_02.cc
@@ -67,7 +67,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_03.cc
+++ b/tests/trilinos/sparse_matrix_vector_03.cc
@@ -70,7 +70,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_04.cc
+++ b/tests/trilinos/sparse_matrix_vector_04.cc
@@ -69,7 +69,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_05.cc
+++ b/tests/trilinos/sparse_matrix_vector_05.cc
@@ -73,7 +73,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_06.cc
+++ b/tests/trilinos/sparse_matrix_vector_06.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_07.cc
+++ b/tests/trilinos/sparse_matrix_vector_07.cc
@@ -75,7 +75,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_08.cc
+++ b/tests/trilinos/sparse_matrix_vector_08.cc
@@ -73,7 +73,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_09.cc
+++ b/tests/trilinos/sparse_matrix_vector_09.cc
@@ -73,7 +73,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_10.cc
+++ b/tests/trilinos/sparse_matrix_vector_10.cc
@@ -74,7 +74,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparse_matrix_vector_11.cc
+++ b/tests/trilinos/sparse_matrix_vector_11.cc
@@ -73,7 +73,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/sparsity_pattern_01.cc
+++ b/tests/trilinos/sparsity_pattern_01.cc
@@ -22,7 +22,7 @@
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   std::ofstream logfile("output");
   logfile.setf(std::ios::fixed);
   deallog << std::setprecision(3);

--- a/tests/trilinos/sparsity_pattern_02.cc
+++ b/tests/trilinos/sparsity_pattern_02.cc
@@ -22,7 +22,7 @@
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
   std::ofstream logfile("output");
   logfile.setf(std::ios::fixed);
   deallog << std::setprecision(3);

--- a/tests/trilinos/sparsity_pattern_03.cc
+++ b/tests/trilinos/sparsity_pattern_03.cc
@@ -22,7 +22,7 @@
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   std::ofstream logfile("output");
   logfile.setf(std::ios::fixed);

--- a/tests/trilinos/trilinos_64_bit_crash_01.cc
+++ b/tests/trilinos/trilinos_64_bit_crash_01.cc
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   deallog << "32bit" << std::endl;
   test<int>();

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_01.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_01.cc
@@ -54,7 +54,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_02.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_02.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_03.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_03.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_04.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_04.cc
@@ -64,7 +64,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_05.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_05.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_06.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_06.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_07.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_07.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_08.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_08.cc
@@ -71,7 +71,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_09.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_09.cc
@@ -55,7 +55,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_10.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_10.cc
@@ -57,7 +57,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_11.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_11.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_12.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_12.cc
@@ -65,7 +65,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparsity_pattern_01.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_01.cc
@@ -76,7 +76,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   try
     {

--- a/tests/trilinos/trilinos_sparsity_pattern_02.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_02.cc
@@ -152,7 +152,7 @@ int main (int argc, char *argv[])
       using namespace dealii;
       using namespace Step22;
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
       deallog.depth_console (0);
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)==0)

--- a/tests/trilinos/vector_assign_01.cc
+++ b/tests/trilinos/vector_assign_01.cc
@@ -57,7 +57,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_assign_02.cc
+++ b/tests/trilinos/vector_assign_02.cc
@@ -56,7 +56,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_equality_1.cc
+++ b/tests/trilinos/vector_equality_1.cc
@@ -52,7 +52,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_equality_2.cc
+++ b/tests/trilinos/vector_equality_2.cc
@@ -54,7 +54,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_equality_3.cc
+++ b/tests/trilinos/vector_equality_3.cc
@@ -52,7 +52,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_equality_4.cc
+++ b/tests/trilinos/vector_equality_4.cc
@@ -54,7 +54,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try

--- a/tests/trilinos/vector_move_operations.cc
+++ b/tests/trilinos/vector_move_operations.cc
@@ -28,7 +28,7 @@ int main (int argc, char **argv)
 {
   initlog();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
   {
     IndexSet local_owned(10);

--- a/tests/trilinos/vector_swap_01.cc
+++ b/tests/trilinos/vector_swap_01.cc
@@ -72,7 +72,7 @@ int main (int argc, char **argv)
   deallog.depth_console(0);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, numbers::invalid_unsigned_int);
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
 
   try


### PR DESCRIPTION
- allow calling set_thread_limit() more than once by reinitializing the
TBB task_scheduler
- always call set_thread_limit() using static initialization before any
user code (and thus TBB usage) happens
- as a result DEAL_II_NUM_THREADS will now always be respected even if
users never call set_thread_limit() themselves
- test suite: always enforce a maximum of 5 threads (instead of only if
not configured with MPI)
- add test for changing the thread limit

this supersedes #1196 