### PR TITLE
move changelog entries that went into 8.3

### DIFF
--- a/doc/news/8.2.1-vs-8.3.0.h
+++ b/doc/news/8.2.1-vs-8.3.0.h
@@ -393,6 +393,13 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: IndexSet now can be constructed using Epetra_Map.
+  All constructors of TrilinosWrappers::SparseMatrix which use Epetra_Map
+  were marked deprecated. 
+  <br>
+  (Luca Heltai, 2015/07/25)
+  </li>
+
   <li> New: Added the class Functions::Polynomial for representation of polynomials.
   The new class is derived from the Function class.
   <br>
@@ -548,6 +555,14 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: VectorTools::get_position_vector now works with arbitrary
+  FESystems, provided that the geometrical components are primitive, 
+  and that you provide a component mask to select what components of 
+  the finite element to use for the geometrical interpolation.
+  <br>
+  (Luca Heltai, 2015/07/25)
+  </li>
+
   <li> Fixed: parallel::distributed::refine_and_coarsen_fixed_fraction()
   in rare circumstances decided to not refine any cells at all, even
   if the refinement threshold was nonzero. This is now fixed.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -64,14 +64,6 @@ inconvenience this causes.
 
 <ol>
 
-  <li> New: IndexSet now can be constructed using Epetra_Map.
-  All constructors of TrilinosWrappers::SparseMatrix which use Epetra_Map
-  were marked deprecated. 
-  <br>
-  (Luca Heltai, 2015/07/25)
-  </li>
-
-
   <li> New: IndexSet now implements iterators.
   <br>
   (Timo Heister, 2015/07/12)
@@ -88,13 +80,6 @@ inconvenience this causes.
 
 
 <ol>
-  <li> New: VectorTools::get_position_vector now works with arbitrary
-  FESystems, provided that the geometrical components are primitive, 
-  and that you provide a component mask to select what components of 
-  the finite element to use for the geometrical interpolation.
-  <br>
-  (Luca Heltai, 2015/07/25)
-  </li>
 
   <li> New: FESystem now does some work in parallel if your system
   has multiple processors.


### PR DESCRIPTION
This is needed because of #1201 so wait until that one is merged.