### PR TITLE
Revise mapping fill fe values interface

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -43,6 +43,8 @@ inconvenience this causes.
   FiniteElement::fill_fe_face_values(), and FiniteElement::fill_fe_subface_values()
   functions has been changed, in an effort to clarify which of these contain
   input information and which contain output information for these functions.
+  The same has been done for the corresponding functions in the Mapping
+  class hierarchy.
   <br>
   (Wolfgang Bangerth, 2015/07/20)
   </li>

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -283,7 +283,7 @@ public:
    * Ownership of the object created by Mapping::get_data() is then transferred
    * to the FEValues object,
    * but a reference to this object is passed to the mapping object every
-   * time it it is asked to compute information on a concrete cell. This
+   * time it is asked to compute information on a concrete cell. This
    * happens when FEValues::reinit() (or the corresponding classes in
    * FEFaceValues and FESubfaceValues) call Mapping::fill_fe_values()
    * (and similarly via Mapping::fill_fe_face_values() and

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -69,43 +69,43 @@ public:
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
 
+  /**
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
+   */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                             &quadrature,
-                  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
-                  std::vector<Point<spacedim> >                     &quadrature_points,
-                  std::vector<double>                               &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> >      &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim> >      &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
-                  std::vector<Point<spacedim> > &,
-                  const CellSimilarity::Similarity                        cell_similarity) const;
+                  const CellSimilarity::Similarity                           cell_similarity,
+                  const Quadrature<dim>                                     &quadrature,
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
-
+  /**
+   * Compute mapping-related information for a face of a cell.
+   * See the documentation of Mapping::fill_fe_face_values() for
+   * a discussion of purpose and arguments of this function.
+   */
   virtual void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int               face_no,
-                       const Quadrature<dim-1>&         quadrature,
-                       const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
-                       std::vector<Point<dim> >        &quadrature_points,
-                       std::vector<double>             &JxW_values,
-                       std::vector<Tensor<1,dim> >     &boundary_form,
-                       std::vector<Point<spacedim> >   &normal_vectors,
-                       std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                       std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                       const unsigned int                                         face_no,
+                       const Quadrature<dim-1>                                   &quadrature,
+                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                       FEValuesData<dim,spacedim>                                &output_data) const;
+
+  /**
+   * Compute mapping-related information for a child of a face of a cell.
+   * See the documentation of Mapping::fill_fe_subface_values() for
+   * a discussion of purpose and arguments of this function.
+   */
   virtual void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int              face_no,
-                          const unsigned int              sub_no,
-                          const Quadrature<dim-1>&        quadrature,
-                          const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
-                          std::vector<Point<dim> >        &quadrature_points,
-                          std::vector<double>             &JxW_values,
-                          std::vector<Tensor<1,dim> >     &boundary_form,
-                          std::vector<Point<spacedim> >   &normal_vectors,
-                          std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                          std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                          const unsigned int                                         face_no,
+                          const unsigned int                                         subface_no,
+                          const Quadrature<dim-1>                                   &quadrature,
+                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                          FEValuesData<dim,spacedim>                                &output_data) const;
 
   virtual void
   transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -434,52 +434,42 @@ public:
 
 protected:
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
    */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                  const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
-                  typename std::vector<Point<spacedim> >                    &quadrature_points,
-                  std::vector<double>                                       &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> >       &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim> >       &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
-                  std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a face of a cell.
+   * See the documentation of Mapping::fill_fe_face_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int face_no,
-                       const Quadrature<dim-1>& quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                       typename std::vector<Point<spacedim> >        &quadrature_points,
-                       std::vector<double>             &JxW_values,
-                       std::vector<Tensor<1,spacedim> >             &exterior_forms,
-                       std::vector<Point<spacedim> >                &normal_vectors,
-                       std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                       std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                       const unsigned int                                         face_no,
+                       const Quadrature<dim-1>                                   &quadrature,
+                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                       FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a child of a face of a cell.
+   * See the documentation of Mapping::fill_fe_subface_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int face_no,
-                          const unsigned int sub_no,
-                          const Quadrature<dim-1>& quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                          typename std::vector<Point<spacedim> >        &quadrature_points,
-                          std::vector<double>             &JxW_values,
-                          std::vector<Tensor<1,spacedim> > &exterior_forms,
-                          std::vector<Point<spacedim> >    &normal_vectors,
-                          std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                          std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
-
+                          const unsigned int                                         face_no,
+                          const unsigned int                                         subface_no,
+                          const Quadrature<dim-1>                                   &quadrature,
+                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                          FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
    * This function and the next allow to generate the transform require by the

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -196,51 +196,42 @@ public:
 
 protected:
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
    */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                            &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                  typename std::vector<Point<spacedim> >           &quadrature_points,
-                  std::vector<double>                              &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> >     &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim> >     &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim> >     &inverse_jacobians,
-                  std::vector<Point<spacedim> >                    &cell_normal_vectors,
-                  const CellSimilarity::Similarity                       cell_similarity) const;
+                  const CellSimilarity::Similarity                           cell_similarity,
+                  const Quadrature<dim>                                     &quadrature,
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a face of a cell.
+   * See the documentation of Mapping::fill_fe_face_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                           face_no,
-                       const Quadrature<dim-1>&                     quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                       typename std::vector<Point<spacedim> >       &quadrature_points,
-                       std::vector<double>                          &JxW_values,
-                       typename std::vector<Tensor<1,spacedim> >    &exterior_form,
-                       typename std::vector<Point<spacedim> >       &normal_vectors,
-                       std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                       std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                       const unsigned int                                         face_no,
+                       const Quadrature<dim-1>                                   &quadrature,
+                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                       FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a child of a face of a cell.
+   * See the documentation of Mapping::fill_fe_subface_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                           face_no,
-                          const unsigned int                           sub_no,
-                          const Quadrature<dim-1>&                     quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                          typename std::vector<Point<spacedim> >       &quadrature_points,
-                          std::vector<double>                          &JxW_values,
-                          typename std::vector<Tensor<1,spacedim> >    &exterior_form,
-                          typename std::vector<Point<spacedim> >       &normal_vectors,
-                          std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                          std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                          const unsigned int                                         face_no,
+                          const unsigned int                                         subface_no,
+                          const Quadrature<dim-1>                                   &quadrature,
+                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                          FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
    * For <tt>dim=2,3</tt>. Append the support points of all shape functions

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -318,51 +318,42 @@ public:
   DataSetDescriptor;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
    */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                        &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                  typename std::vector<Point<spacedim> >       &quadrature_points,
-                  std::vector<double>                          &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim> > &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians,
-                  std::vector<Point<spacedim> >                &cell_normal_vectors,
-                  const CellSimilarity::Similarity                   cell_similarity) const;
+                  const CellSimilarity::Similarity                           cell_similarity,
+                  const Quadrature<dim>                                     &quadrature,
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a face of a cell.
+   * See the documentation of Mapping::fill_fe_face_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                            face_no,
-                       const Quadrature<dim-1>                      &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                       typename std::vector<Point<spacedim> >       &quadrature_points,
-                       std::vector<double>                          &JxW_values,
-                       typename std::vector<Tensor<1,spacedim> >    &boundary_form,
-                       typename std::vector<Point<spacedim> >       &normal_vectors,
-                       std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                       std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                       const unsigned int                                         face_no,
+                       const Quadrature<dim-1>                                   &quadrature,
+                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                       FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
-   * Implementation of the interface in Mapping.
+   * Compute mapping-related information for a child of a face of a cell.
+   * See the documentation of Mapping::fill_fe_subface_values() for
+   * a discussion of purpose and arguments of this function.
    */
   virtual void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                           face_no,
-                          const unsigned int                           sub_no,
-                          const Quadrature<dim-1>&                     quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                          typename std::vector<Point<spacedim> >       &quadrature_points,
-                          std::vector<double>                          &JxW_values,
-                          typename std::vector<Tensor<1,spacedim> >    &boundary_form,
-                          typename std::vector<Point<spacedim> >       &normal_vectors,
-                          std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                          std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const;
+                          const unsigned int                                         face_no,
+                          const unsigned int                                         subface_no,
+                          const Quadrature<dim-1>                                   &quadrature,
+                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                          FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
    * Compute shape values and/or derivatives.

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -122,21 +122,20 @@ public:
 
 protected:
   /**
-   * Implementation of the interface in MappingQ1. Overrides the function in
-   * the base class, since we cannot use any cell similarity for this class.
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
+   *
+   * This function overrides the function in
+   * the base class since we cannot use any cell similarity for this class.
    */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                  const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
-                  typename std::vector<Point<spacedim> >                    &quadrature_points,
-                  std::vector<double>                                       &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> >       &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim>  >       &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim>  >       &inverse_jacobians,
-                  std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
    * Reference to the vector of shifts.

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -137,21 +137,20 @@ public:
 
 protected:
   /**
-   * Implementation of the interface in MappingQ. Overrides the function in
-   * the base class, since we cannot use any cell similarity for this class.
+   * Compute mapping-related information for a cell.
+   * See the documentation of Mapping::fill_fe_values() for
+   * a discussion of purpose, arguments, and return value of this function.
+   *
+   * This function overrides the function in
+   * the base class since we cannot use any cell similarity for this class.
    */
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                  const CellSimilarity::Similarity                           cell_similarity,
                   const Quadrature<dim>                                     &quadrature,
-                  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
-                  typename std::vector<Point<spacedim> >                    &quadrature_points,
-                  std::vector<double>                                       &JxW_values,
-                  std::vector<DerivativeForm<1,dim,spacedim> >      &jacobians,
-                  std::vector<DerivativeForm<2,dim,spacedim> >      &jacobian_grads,
-                  std::vector<DerivativeForm<1,spacedim,dim> >      &inverse_jacobians,
-                  std::vector<Point<spacedim> >                             &cell_normal_vectors,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  FEValuesData<dim,spacedim>                                &output_data) const;
 
   /**
    * Reference to the vector of shifts.

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3518,15 +3518,10 @@ void FEValues<dim,spacedim>::do_reinit ()
   // it
   this->cell_similarity
     = this->get_mapping().fill_fe_values(*this->present_cell,
+                                         this->cell_similarity,
                                          quadrature,
                                          *this->mapping_data,
-                                         this->quadrature_points,
-                                         this->JxW_values,
-                                         this->jacobians,
-                                         this->jacobian_grads,
-                                         this->inverse_jacobians,
-                                         this->normal_vectors,
-                                         this->cell_similarity);
+                                         *this);
 
   // then call the finite element and, with the data
   // already filled by the mapping, let it compute the
@@ -3722,15 +3717,11 @@ void FEFaceValues<dim,spacedim>::do_reinit (const unsigned int face_no)
   Assert(!(this->update_flags & update_jacobian_grads),
          ExcNotImplemented());
 
-  this->get_mapping().fill_fe_face_values(*this->present_cell, face_no,
+  this->get_mapping().fill_fe_face_values(*this->present_cell,
+                                          face_no,
                                           this->quadrature,
                                           *this->mapping_data,
-                                          this->quadrature_points,
-                                          this->JxW_values,
-                                          this->boundary_forms,
-                                          this->normal_vectors,
-                                          this->jacobians,
-                                          this->inverse_jacobians);
+                                          *this);
 
   this->get_fe().fill_fe_face_values(this->get_mapping(),
                                      *this->present_cell, face_no,
@@ -3958,15 +3949,11 @@ void FESubfaceValues<dim,spacedim>::do_reinit (const unsigned int face_no,
 
   // now ask the mapping and the finite element to do the actual work
   this->get_mapping().fill_fe_subface_values(*this->present_cell,
-                                             face_no, subface_no,
+                                             face_no,
+                                             subface_no,
                                              this->quadrature,
                                              *this->mapping_data,
-                                             this->quadrature_points,
-                                             this->JxW_values,
-                                             this->boundary_forms,
-                                             this->normal_vectors,
-                                             this->jacobians,
-                                             this->inverse_jacobians);
+                                             *this);
 
   this->get_fe().fill_fe_subface_values(this->get_mapping(),
                                         *this->present_cell,

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -734,31 +734,27 @@ MappingQ1<dim,spacedim>::compute_mapping_support_points(
 
 template<int dim, int spacedim>
 CellSimilarity::Similarity
-MappingQ1<dim,spacedim>::fill_fe_values (
-  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  const Quadrature<dim>                        &q,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  std::vector<Point<spacedim> >                &quadrature_points,
-  std::vector<double>                          &JxW_values,
-  std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-  std::vector<DerivativeForm<2,dim,spacedim> > &jacobian_grads,
-  std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians,
-  std::vector<Point<spacedim> >                &normal_vectors,
-  const CellSimilarity::Similarity                   cell_similarity) const
+MappingQ1<dim,spacedim>::
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                const CellSimilarity::Similarity                           cell_similarity,
+                const Quadrature<dim>                                     &quadrature,
+                const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                FEValuesData<dim,spacedim>                                &output_data) const
 {
   // ensure that the following static_cast is really correct:
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&internal_data) != 0,
           ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  const unsigned int n_q_points=q.size();
+  const unsigned int n_q_points=quadrature.size();
 
   compute_fill (cell, n_q_points, DataSetDescriptor::cell (), cell_similarity,
-                data, quadrature_points);
+                data,
+                output_data.quadrature_points);
 
 
   const UpdateFlags update_flags(data.current_update_flags());
-  const std::vector<double> &weights=q.get_weights();
+  const std::vector<double> &weights=quadrature.get_weights();
 
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
@@ -766,11 +762,11 @@ MappingQ1<dim,spacedim>::fill_fe_values (
   if (update_flags & (update_normal_vectors
                       | update_JxW_values))
     {
-      AssertDimension (JxW_values.size(), n_q_points);
+      AssertDimension (output_data.JxW_values.size(), n_q_points);
 
       Assert( !(update_flags & update_normal_vectors ) ||
-              (normal_vectors.size() == n_q_points),
-              ExcDimensionMismatch(normal_vectors.size(), n_q_points));
+              (output_data.normal_vectors.size() == n_q_points),
+              ExcDimensionMismatch(output_data.normal_vectors.size(), n_q_points));
 
 
       if (cell_similarity != CellSimilarity::translation)
@@ -790,7 +786,7 @@ MappingQ1<dim,spacedim>::fill_fe_values (
                                                                 std::sqrt(double(dim))),
                         (typename Mapping<dim,spacedim>::ExcDistortedMappedCell(cell->center(), det, point)));
 
-                JxW_values[point] = weights[point] * det;
+                output_data.JxW_values[point] = weights[point] * det;
               }
             // if dim==spacedim, then there is no cell normal to
             // compute. since this is for FEValues (and not FEFaceValues),
@@ -807,14 +803,14 @@ MappingQ1<dim,spacedim>::fill_fe_values (
                   for (unsigned int j=0; j<dim; ++j)
                     G[i][j] = DX_t[i] * DX_t[j];
 
-                JxW_values[point]
+                output_data.JxW_values[point]
                   = sqrt(determinant(G)) * weights[point];
 
                 if (cell_similarity == CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
                     if (update_flags & update_normal_vectors)
-                      normal_vectors[point] *= -1.;
+                      output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
@@ -826,15 +822,15 @@ MappingQ1<dim,spacedim>::fill_fe_values (
                         Assert( codim==1 , ExcMessage("There is no cell normal in codim 2."));
 
                         if (dim==1)
-                          cross_product(normal_vectors[point],
+                          cross_product(output_data.normal_vectors[point],
                                         -DX_t[0]);
                         else //dim == 2
-                          cross_product(normal_vectors[point],DX_t[0],DX_t[1]);
+                          cross_product(output_data.normal_vectors[point],DX_t[0],DX_t[1]);
 
-                        normal_vectors[point] /= normal_vectors[point].norm();
+                        output_data.normal_vectors[point] /= output_data.normal_vectors[point].norm();
 
                         if (cell->direction_flag() == false)
-                          normal_vectors[point] *= -1.;
+                          output_data.normal_vectors[point] *= -1.;
                       }
 
                   }
@@ -848,23 +844,23 @@ MappingQ1<dim,spacedim>::fill_fe_values (
   // copy values from InternalData to vector given by reference
   if (update_flags & update_jacobians)
     {
-      AssertDimension (jacobians.size(), n_q_points);
+      AssertDimension (output_data.jacobians.size(), n_q_points);
       if (cell_similarity != CellSimilarity::translation)
         for (unsigned int point=0; point<n_q_points; ++point)
-          jacobians[point] = data.contravariant[point];
+          output_data.jacobians[point] = data.contravariant[point];
     }
 
   // calculate values of the derivatives of the Jacobians. do it here, since
   // we only do it for cells, not faces.
   if (update_flags & update_jacobian_grads)
     {
-      AssertDimension (jacobian_grads.size(), n_q_points);
+      AssertDimension (output_data.jacobian_grads.size(), n_q_points);
 
       if (cell_similarity != CellSimilarity::translation)
         {
 
-          std::fill(jacobian_grads.begin(),
-                    jacobian_grads.end(),
+          std::fill(output_data.jacobian_grads.begin(),
+                    output_data.jacobian_grads.end(),
                     DerivativeForm<2,dim,spacedim>());
 
 
@@ -894,17 +890,17 @@ MappingQ1<dim,spacedim>::fill_fe_values (
               for (unsigned int i=0; i<spacedim; ++i)
                 for (unsigned int j=0; j<dim; ++j)
                   for (unsigned int l=0; l<dim; ++l)
-                    jacobian_grads[point][i][j][l] = result[i][j][l];
+                    output_data.jacobian_grads[point][i][j][l] = result[i][j][l];
             }
         }
     }
   // copy values from InternalData to vector given by reference
   if (update_flags & update_inverse_jacobians)
     {
-      AssertDimension (inverse_jacobians.size(), n_q_points);
+      AssertDimension (output_data.inverse_jacobians.size(), n_q_points);
       if (cell_similarity != CellSimilarity::translation)
         for (unsigned int point=0; point<n_q_points; ++point)
-          inverse_jacobians[point] = data.covariant[point].transpose();
+          output_data.inverse_jacobians[point] = data.covariant[point].transpose();
     }
 
   return cell_similarity;
@@ -1094,23 +1090,18 @@ template<int dim, int spacedim>
 void
 MappingQ1<dim,spacedim>::
 fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                     const unsigned int                               face_no,
-                     const Quadrature<dim-1>                          &q,
-                     const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                     std::vector<Point<spacedim> >                    &quadrature_points,
-                     std::vector<double>                              &JxW_values,
-                     std::vector<Tensor<1,spacedim> >                 &boundary_forms,
-                     std::vector<Point<spacedim> >                    &normal_vectors,
-                     std::vector<DerivativeForm<1,dim,spacedim> >     &jacobians,
-                     std::vector<DerivativeForm<1,spacedim,dim> >     &inverse_jacobians) const
+                     const unsigned int                                         face_no,
+                     const Quadrature<dim-1>                                   &quadrature,
+                     const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                     FEValuesData<dim,spacedim>                                &output_data) const
 {
   // ensure that the following cast
   // is really correct:
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&internal_data) != 0,
           ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  const unsigned int n_q_points = q.size();
+  const unsigned int n_q_points = quadrature.size();
 
   compute_fill_face (cell, face_no, numbers::invalid_unsigned_int,
                      n_q_points,
@@ -1119,14 +1110,14 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                                               cell->face_flip(face_no),
                                               cell->face_rotation(face_no),
                                               n_q_points),
-                     q.get_weights(),
+                     quadrature.get_weights(),
                      data,
-                     quadrature_points,
-                     JxW_values,
-                     boundary_forms,
-                     normal_vectors,
-                     jacobians,
-                     inverse_jacobians);
+                     output_data.quadrature_points,
+                     output_data.JxW_values,
+                     output_data.boundary_forms,
+                     output_data.normal_vectors,
+                     output_data.jacobians,
+                     output_data.inverse_jacobians);
 }
 
 
@@ -1135,41 +1126,36 @@ template<int dim, int spacedim>
 void
 MappingQ1<dim,spacedim>::
 fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                        const unsigned int       face_no,
-                        const unsigned int       sub_no,
-                        const Quadrature<dim-1> &q,
-                        const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                        std::vector<Point<spacedim> >     &quadrature_points,
-                        std::vector<double>               &JxW_values,
-                        std::vector<Tensor<1,spacedim> >  &boundary_forms,
-                        std::vector<Point<spacedim> >     &normal_vectors,
-                        std::vector<DerivativeForm<1,dim,spacedim> > &jacobians,
-                        std::vector<DerivativeForm<1,spacedim,dim> > &inverse_jacobians) const
+                        const unsigned int                                         face_no,
+                        const unsigned int                                         subface_no,
+                        const Quadrature<dim-1>                                   &quadrature,
+                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                        FEValuesData<dim,spacedim>                                &output_data) const
 {
   // ensure that the following cast
   // is really correct:
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
+  Assert (dynamic_cast<const InternalData *>(&internal_data) != 0,
           ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+  const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  const unsigned int n_q_points = q.size();
+  const unsigned int n_q_points = quadrature.size();
 
-  compute_fill_face (cell, face_no, sub_no,
+  compute_fill_face (cell, face_no, subface_no,
                      n_q_points,
-                     DataSetDescriptor::subface (face_no, sub_no,
+                     DataSetDescriptor::subface (face_no, subface_no,
                                                  cell->face_orientation(face_no),
                                                  cell->face_flip(face_no),
                                                  cell->face_rotation(face_no),
                                                  n_q_points,
                                                  cell->subface_case(face_no)),
-                     q.get_weights(),
+                     quadrature.get_weights(),
                      data,
-                     quadrature_points,
-                     JxW_values,
-                     boundary_forms,
-                     normal_vectors,
-                     jacobians,
-                     inverse_jacobians);
+                     output_data.quadrature_points,
+                     output_data.JxW_values,
+                     output_data.boundary_forms,
+                     output_data.normal_vectors,
+                     output_data.jacobians,
+                     output_data.inverse_jacobians);
 }
 
 

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -112,26 +112,21 @@ MappingQ1Eulerian<dim, EulerVectorType, spacedim>::clone () const
 
 template<int dim, class EulerVectorType, int spacedim>
 CellSimilarity::Similarity
-MappingQ1Eulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
-  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  const Quadrature<dim>                                     &q,
-  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
-  std::vector<Point<spacedim> >                             &quadrature_points,
-  std::vector<double>                                       &JxW_values,
-  std::vector< DerivativeForm<1,dim,spacedim>   >              &jacobians,
-  std::vector<DerivativeForm<2,dim,spacedim>    >   &jacobian_grads,
-  std::vector<DerivativeForm<1,spacedim,dim>    >   &inverse_jacobians,
-  std::vector<Point<spacedim> >                             &normal_vectors,
-  const CellSimilarity::Similarity) const
+MappingQ1Eulerian<dim,EulerVectorType,spacedim>::
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                const CellSimilarity::Similarity                           ,
+                const Quadrature<dim>                                     &quadrature,
+                const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                FEValuesData<dim,spacedim>                                &output_data) const
 {
   // call the function of the base class, but ignoring
   // any potentially detected cell similarity between
   // the current and the previous cell
-  MappingQ1<dim,spacedim>::fill_fe_values (cell, q, mapping_data,
-                                           quadrature_points, JxW_values, jacobians,
-                                           jacobian_grads, inverse_jacobians,
-                                           normal_vectors,
-                                           CellSimilarity::invalid_next_cell);
+  MappingQ1<dim,spacedim>::fill_fe_values (cell,
+                                           CellSimilarity::invalid_next_cell,
+                                           quadrature,
+                                           internal_data,
+                                           output_data);
   // also return the updated flag since any detected
   // similarity wasn't based on the mapped field, but
   // the original vertices which are meaningless

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -177,26 +177,21 @@ compute_mapping_support_points
 
 template<int dim, class EulerVectorType, int spacedim>
 CellSimilarity::Similarity
-MappingQEulerian<dim,EulerVectorType,spacedim>::fill_fe_values (
-  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  const Quadrature<dim>                                     &q,
-  typename Mapping<dim,spacedim>::InternalDataBase          &mapping_data,
-  std::vector<Point<spacedim> >                             &quadrature_points,
-  std::vector<double>                                       &JxW_values,
-  std::vector<DerivativeForm<1,dim,spacedim> >       &jacobians,
-  std::vector<DerivativeForm<2,dim,spacedim>  >     &jacobian_grads,
-  std::vector<DerivativeForm<1,spacedim,dim>  >     &inverse_jacobians,
-  std::vector<Point<spacedim> >                             &normal_vectors,
-  const CellSimilarity::Similarity                           ) const
+MappingQEulerian<dim,EulerVectorType,spacedim>::
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                const CellSimilarity::Similarity                           ,
+                const Quadrature<dim>                                     &quadrature,
+                const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                FEValuesData<dim,spacedim>                                &output_data) const
 {
   // call the function of the base class, but ignoring
   // any potentially detected cell similarity between
   // the current and the previous cell
-  MappingQ<dim,spacedim>::fill_fe_values (cell, q, mapping_data,
-                                          quadrature_points, JxW_values, jacobians,
-                                          jacobian_grads, inverse_jacobians,
-                                          normal_vectors,
-                                          CellSimilarity::invalid_next_cell);
+  MappingQ<dim,spacedim>::fill_fe_values (cell,
+                                          CellSimilarity::invalid_next_cell,
+                                          quadrature,
+                                          internal_data,
+                                          output_data);
   // also return the updated flag since any detected
   // similarity wasn't based on the mapped field, but
   // the original vertices which are meaningless


### PR DESCRIPTION
This is the first of two real cleanups in the interfaces (everything else before was just preparatory): I change the interfaces of `Mapping::fill_fe_values` and friends to simply take a single reference to the output structure, rather than references to all of the individual arrays we are supposed to fill. I took the opportunity to (i) comprehensively document these functions, and (ii) sort the function arguments in a way that makes more sense.

In several of the mapping classes, the `fill_fe_*_values()` functions defer their work to `compute_fill()` functions that still have the previous style of interfaces. I may change that in a follow-up patch, but since these are internal functions (not part of the public interface) I'll leave that for a separate PR.

The whole patch passes the testsuite (after also applying #1204).

This is again for #1198.
