### PR TITLE
make IndexSet Epetra_Map constr explicit

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -109,7 +109,7 @@ public:
   /**
    * Constructor from a trilinos Epetra_Map.
    */
-  IndexSet(const Epetra_Map &map);
+  explicit IndexSet(const Epetra_Map &map);
 #endif
 
   /**


### PR DESCRIPTION
The new constructor IndexSet(const Epetra_Map &map) was not marked explicit
and caused ambiguous type conversions.