### PR TITLE
fix: avoid Epetra_Map in Trilinos interface

### DIFF
--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1974,7 +1974,7 @@ namespace TrilinosWrappers
   TrilinosScalar
   SparseMatrix::matrix_norm_square (const VectorBase &v) const
   {
-    Assert (matrix->RowMap().SameAs(matrix->ColMap()),
+    Assert (matrix->RowMap().SameAs(matrix->DomainMap()),
             ExcNotQuadratic());
 
     VectorBase temp_vector;
@@ -1990,7 +1990,7 @@ namespace TrilinosWrappers
   SparseMatrix::matrix_scalar_product (const VectorBase &u,
                                        const VectorBase &v) const
   {
-    Assert (matrix->RowMap().SameAs(matrix->ColMap()),
+    Assert (matrix->RowMap().SameAs(matrix->DomainMap()),
             ExcNotQuadratic());
 
     VectorBase temp_vector;


### PR DESCRIPTION
use DomainMap instead of ColMap.

This fixes #1213 