### PR TITLE
Fix division by zero.

### DIFF
--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -506,10 +506,10 @@ TimerOutput::print_summary () const
           out_stream << i->second.total_cpu_time << "s |";
           out_stream << std::setw(10);
           out_stream << std::setprecision(2);
-          double value = i->second.total_cpu_time/total_cpu_time * 100;
-          if (!numbers::is_finite(value))
-            value = 0.0;
-          out_stream << value << "% |";
+          if (total_cpu_time != 0)
+            out_stream << i->second.total_cpu_time/total_cpu_time * 100 << "% |";
+          else
+            out_stream << 0.0 << "% |";
         }
       out_stream << std::endl
                  << "+---------------------------------+-----------+"


### PR DESCRIPTION
Instead of first dividing by zero and then cleaning up the mess,
simply test whether we're going to divide by zero and do the
right thing based on that test.

I thought for a moment whether to print a dash '-' instead of '0%'
because the result is clearly invalid, but one would have to figure
out the alignment of that dash, and the case is clearly a corner
case that won't happen in practice (because practical cases
don't require *zero* total CPU seconds.

This fixes the last failure due to #965.