### PR TITLE
Testsuite: Port subproject configuration portion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,11 +152,7 @@ ADD_SUBDIRECTORY(cmake/config) # has to be included after source
 ADD_SUBDIRECTORY(contrib) # has to be included after source
 ADD_SUBDIRECTORY(examples)
 
-#
-# Do not configure testsuite on Windows targets because posix shell and
-# commands like 'test', '> /dev/null', 'rm', etc. are not available
-#
-IF(DEAL_II_HAVE_TESTS_DIRECTORY AND NOT DEAL_II_MSVC)
+IF(DEAL_II_HAVE_TESTS_DIRECTORY)
   ADD_SUBDIRECTORY(tests)
 ENDIF()
 

--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013 - 2014 by the deal.II authors
+## Copyright (C) 2013 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -128,8 +128,6 @@ FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
 #    test           - run a minimal set of tests
 #
 #    setup_tests    - set up testsuite subprojects
-#    regen_tests    - rerun configure stage in every testsuite subproject
-#    clean_tests    - run the 'clean' target in every testsuite subproject
 #    prune_tests    - remove all testsuite subprojects
 #
 ###\")"

--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -96,9 +96,6 @@ $ make setup_tests
     <p>
       The setup can be fine-tuned using the following commands:
 <pre>
-$ make regen_tests - reruns configure stage in every testsuite subproject
-
-$ make clean_tests - runs the 'clean' target in every testsuite subproject
 
 $ make prune_tests - removes all testsuite subprojects
 </pre>

--- a/doc/users/cmake.html
+++ b/doc/users/cmake.html
@@ -229,8 +229,6 @@ cmake -DDEAL_II_WITH_MPI=ON &lt;...&gt;
 #    test           - run a minimal set of tests
 #
 #    setup_tests    - set up the testsuite subprojects
-#    regen_tests    - rerun configure stage in every testsuite subprojects
-#    clean_tests    - run the 'clean' target in every testsuite subproject
 #    prune_tests    - remove all testsuite subprojects
 #
 ###

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,6 @@
 #
 # We define toplevel targets:
 #    setup_tests    - set up testsuite subprojects
-#    regen_tests    - rerun configure stage in every testsuite subproject
-#    clean_tests    - run the 'clean' target in every testsuite subproject
 #    prune_tests    - remove all testsuite subprojects
 #
 
@@ -63,7 +61,7 @@ ELSE()
 
   IF("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     MESSAGE(FATAL_ERROR "The testsuite cannot be configured in-source. "
-      "Please create a separate build directory"
+      "Please create a separate build directory!"
       )
   ENDIF()
 
@@ -106,21 +104,20 @@ ADD_CUSTOM_TARGET(setup_tests)
 # Remove all tests:
 ADD_CUSTOM_TARGET(prune_tests)
 
-# Regenerate tests (run "make rebuild_cache" in subprojects):
-ADD_CUSTOM_TARGET(regen_tests)
-
-# Regenerate tests (run "make clean" in subprojects):
-ADD_CUSTOM_TARGET(clean_tests)
-
 FOREACH(_category ${_categories})
   SET(_category_dir ${CMAKE_CURRENT_SOURCE_DIR}/${_category})
 
+  FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_category})
+
+  IF(DEAL_II_MSVC)
+    SET(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir})
+  ELSE()
+    SET(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir} > /dev/null)
+  ENDIF()
+
   ADD_CUSTOM_TARGET(setup_tests_${_category}
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-      ${CMAKE_CURRENT_BINARY_DIR}/${_category}
-      COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/${_category} &&
-      ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir}
-      > /dev/null
+    COMMAND ${_command}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_category}
     COMMENT "Processing tests/${_category}"
     )
   ADD_DEPENDENCIES(setup_tests setup_tests_${_category})
@@ -128,26 +125,11 @@ FOREACH(_category ${_categories})
   ADD_CUSTOM_TARGET(prune_tests_${_category}
     COMMAND ${CMAKE_COMMAND} -E remove_directory
       ${CMAKE_CURRENT_BINARY_DIR}/${_category}
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+      ${CMAKE_CURRENT_BINARY_DIR}/${_category}
     COMMENT "Processing tests/${_category}"
     )
   ADD_DEPENDENCIES(prune_tests prune_tests_${_category})
-
-  ADD_CUSTOM_TARGET(regen_tests_${_category}
-    COMMAND
-      test ! -d ${CMAKE_CURRENT_BINARY_DIR}/${_category} || ${CMAKE_COMMAND}
-      --build ${CMAKE_CURRENT_BINARY_DIR}/${_category} --target regenerate
-      > /dev/null
-    COMMENT "Processing tests/${_category}"
-    )
-  ADD_DEPENDENCIES(regen_tests regen_tests_${_category})
-
-  ADD_CUSTOM_TARGET(clean_tests_${_category}
-    COMMAND
-      test ! -d ${CMAKE_CURRENT_BINARY_DIR}/${_category} || ${CMAKE_COMMAND}
-      --build ${CMAKE_CURRENT_BINARY_DIR}/${_category} --target clean
-    COMMENT "Processing tests/${_category}"
-    )
-  ADD_DEPENDENCIES(clean_tests clean_tests_${_category})
 
   FILE(APPEND ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake
     "SUBDIRS(${_category})\n"


### PR DESCRIPTION
This commit rewrites the subproject configuration part to only use CMake script.