### PR TITLE
Testsuite: Bugfix, also consider stderr in test output

### DIFF
--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -39,12 +39,12 @@ COMPARISON_FILE="$6"
 run(){
   rm -f failing_output
   rm -f output
+  rm -f stdout
 
   ${RUN_COMMAND} > stdout 2>&1
   RETURN_VALUE=$?
 
-  [ -f output ] || cp stdout output
-  rm -f stdout
+  [ -f output ] || mv stdout output
 
   if [ $RETURN_VALUE -ne 0 ]; then
     mv output failing_output
@@ -53,6 +53,12 @@ run(){
     echo "${TEST_FULL}: RUN failed. ------ Result: `pwd`/failing_output"
     echo "${TEST_FULL}: RUN failed. ------ Partial output:"
     cat failing_output
+    if [ -f stdout ]; then
+      echo ""
+      echo "${TEST_FULL}: RUN failed. ------ Additional output on stdout/stderr:"
+      echo ""
+      cat stdout
+    fi
     exit 1
   fi
 }

--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -40,7 +40,7 @@ run(){
   rm -f failing_output
   rm -f output
 
-  ${RUN_COMMAND} > stdout
+  ${RUN_COMMAND} > stdout 2>&1
   RETURN_VALUE=$?
 
   [ -f output ] || cp stdout output


### PR DESCRIPTION
This pull request consists of two patches:

2f832a7 (Matthias Maier, 7 minutes ago)
   Testsuite: Also output stdout/stderr in case of a regular output file

   Also output everything a script piped to stdout and stderr in case a test
   fails to run.

3e3d77f (Matthias Maier, 3 minutes ago)
   Testsuite: Bugfix, also pipe stderror in run_test.sh

   The run_test.sh script supports two different output options for tests,
   namely to directly write to a file 'output', or to just output on stdout.

   This commit changes the behavior for the latter situation. It reroutes
   stderr to stdout such that all output of a test is actually considered.

   The former case turned out to be a problem with deallog that writes to
   stderr.

   Note: In case of a test writing to output, stderr is still lost.