### PR TITLE
CMake: Error out on Cygwin platforms and derivatives (MinGW, MinGW-64)

### DIFF
--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -105,6 +105,18 @@ ENDIF()
 #                                                                      #
 ########################################################################
 
+#
+# Put an end to user's suffering from cygwin's defects
+#
+IF( CMAKE_SYSTEM_NAME MATCHES "CYGWIN" OR
+    CMAKE_SYSTEM_NAME MATCHES "Windows" )
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    MESSAGE(FATAL_ERROR
+      "\nCygwin and forks such as MinGW and MinGW-64 are unsupported due to "
+      "multiple unresolved miscompilation issues.\n\n"
+      )
+  ENDIF()
+ENDIF()
 
 IF(CMAKE_SYSTEM_NAME MATCHES "Windows")
 


### PR DESCRIPTION
Let's face it - we do not support those ports of the GNU Compiler
Collection. We have had multiple severe, unresolved miscompilation issues
for years.