### PR TITLE
Improve the error message for copying and adding sparse matrices with

### DIFF
--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1516,7 +1516,11 @@ public:
   /**
    * Exception
    */
-  DeclException0 (ExcDifferentSparsityPatterns);
+  DeclExceptionMsg (ExcDifferentSparsityPatterns,
+                    "When copying one sparse matrix into another, "
+                    "or when adding one sparse matrix to another, "
+                    "both matrices need to refer to the same "
+                    "sparsity pattern.");
   /**
    * Exception
    */


### PR DESCRIPTION
different sparsity patterns.