### PR TITLE
input parameter description for start_step() of TimeStepControl

### DIFF
--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -143,7 +143,7 @@ namespace Algorithms
      * @param[in] step The size of the first step, which may be overwritten by
      *   the time stepping strategy.
      */
-    void start_step (double step);
+    void start_step (const double step);
 
     /**
      * Set size of the maximum step size.
@@ -252,7 +252,7 @@ namespace Algorithms
 
 
   inline void
-  TimestepControl::start_step (double t)
+  TimestepControl::start_step (const double t)
   {
     start_step_val = t;
   }

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -139,8 +139,11 @@ namespace Algorithms
     /**
      * Set size of the first step. This may be overwritten by the time
      * stepping strategy.
+     *
+     * @param[in] step The size of the first step, which may be overwritten by
+     *   the time stepping strategy.
      */
-    void start_step (double);
+    void start_step (double step);
 
     /**
      * Set size of the maximum step size.


### PR DESCRIPTION
Added doxygen 'param' description and 'const' specifier for input parameter of start_step() of TimeStepControl.