### PR TITLE
Fix markup.

### DIFF
--- a/examples/step-11/doc/intro.dox
+++ b/examples/step-11/doc/intro.dox
@@ -79,11 +79,11 @@ index), then the constraint can also be represented by
   u_{i_0} = \sum_{i\in\partial\Omega_h\backslash i_0} -u_i.
 @f]
 This, luckily, is exactly the form of constraints for which the
-<code>ConstraintMatrix</code> class was designed. Note that we have used this
+ConstraintMatrix class was designed. Note that we have used this
 class in several previous examples for the representation of hanging nodes
 constraints, which also have this form: there, the middle vertex shall have
 the mean of the values of the adjacent vertices. In general, the
-<code>ConstraintMatrix</code> class is designed to handle homogeneous constraints
+ConstraintMatrix class is designed to handle homogeneous constraints
 of the form
 @f[
   CU = 0
@@ -93,7 +93,7 @@ where $C$ denotes a matrix, and $U$ the vector of nodal values.
 In this example, the mean value along the boundary allows just such a
 representation, with $C$ being a matrix with just one row (i.e. there is only
 one constraint). In the implementation, we will create a
-<code>ConstraintMatrix</code> object, add one constraint (i.e. add another row to
+ConstraintMatrix object, add one constraint (i.e. add another row to
 the matrix) referring to the first boundary node $i_0$, and insert the weights
 with which all the other nodes contribute, which in this example happens to be
 just $-1$.

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -2335,7 +2335,7 @@ namespace Step14
     // solutions only to see them qualitatively, we contend ourselves with
     // interpolating the dual solution to the (smaller) primal space. For the
     // interpolation, there is a library function, that takes a
-    // <code>ConstraintMatrix</code> object including the hanging node
+    // ConstraintMatrix object including the hanging node
     // constraints. The rest is standard.
     //
     // There is, however, one work-around worth mentioning: in this function,

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -171,7 +171,7 @@ namespace Step45
 
     // We also incorporate the homogeneous Dirichlet boundary conditions on
     // the upper and lower parts of the boundary (i.e. the ones with boundary
-    // indicator 1) and close the <code>ConstraintMatrix</code> object:
+    // indicator 1) and close the ConstraintMatrix object:
     VectorTools::interpolate_boundary_values (dof_handler, 1,
                                               ZeroFunction<2> (),
                                               constraints);

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -389,7 +389,7 @@ namespace Step51
     // The degrees of freedom corresponding to the skeleton strongly enforce
     // Dirichlet boundary conditions, just as in a continuous Galerkin finite
     // element method.  We can enforce the boundary conditions in an analogous
-    // manner through the use of <code>ConstraintMatrix</code> constructs. In
+    // manner through the use of ConstraintMatrix constructs. In
     // addition, hanging nodes are handled in the same way as for
     // continuous finite elements: For the face elements which
     // only define degrees of freedom on the face, this process sets the


### PR DESCRIPTION
doxygen automatically cross-links class names automatically. No need
to mark them as <code>...</code>.