### PR TITLE
Don't derive FE::InternalDataBase from Mapping::InternalDataBase.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -90,6 +90,12 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: There is now a function MemoryConsumption::memory_consumption()
+  for std_cxx11::unique_ptr arguments.
+  <br>
+  (Wolfgang Bangerth, 2015/08/07)
+  </li>
+
   <li> New: VtkFlags now stores a parameter describing the compression level
   zlib uses when writing compressed output. For small problems, the flag
   ZlibCompressionLevel::best_speed can make the call to write_vtu many times

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 
 #include <string>
 #include <complex>
@@ -355,6 +356,15 @@ namespace MemoryConsumption
   template <typename T>
   inline
   std::size_t memory_consumption (const std_cxx11::shared_ptr<T> &);
+
+  /**
+   * Return the amount of memory used by a std_cxx11::unique_ptr object.
+   *
+   * @note This returns the size of the pointer, not of the object pointed to.
+   */
+  template <typename T>
+  inline
+  std::size_t memory_consumption (const std_cxx11::unique_ptr<T> &);
 }
 
 
@@ -624,6 +634,16 @@ namespace MemoryConsumption
   memory_consumption (const std_cxx11::shared_ptr<T> &)
   {
     return sizeof(std_cxx11::shared_ptr<T>);
+  }
+
+
+
+  template <typename T>
+  inline
+  std::size_t
+  memory_consumption (const std_cxx11::unique_ptr<T> &)
+  {
+    return sizeof(std_cxx11::unique_ptr<T>);
   }
 
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -382,7 +382,7 @@ public:
    *
    * @author Guido Kanschat, 2001; Wolfgang Bangerth, 2015.
    */
-  class InternalDataBase : public Subscriptor
+  class InternalDataBase
   {
   private:
     /**

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -382,9 +382,21 @@ public:
    *
    * @author Guido Kanschat, 2001; Wolfgang Bangerth, 2015.
    */
-  class InternalDataBase : public Mapping<dim,spacedim>::InternalDataBase
+  class InternalDataBase : public Subscriptor
   {
+  private:
+    /**
+     * Copy construction is forbidden.
+     */
+    InternalDataBase (const InternalDataBase &);
+
   public:
+    /**
+     * Constructor. Sets update_flags to @p update_default and @p first_cell
+     * to @p true.
+     */
+    InternalDataBase ();
+
     /**
      * Destructor. Made virtual to allow polymorphism.
      */
@@ -399,6 +411,51 @@ public:
                          const Quadrature<dim>    &quadrature);
 
     /**
+     * Values updated by the constructor or by reinit.
+     */
+    UpdateFlags          update_flags;
+
+    /**
+     * Values computed by constructor.
+     */
+    UpdateFlags          update_once;
+
+    /**
+     * Values updated on each cell by reinit.
+     */
+    UpdateFlags          update_each;
+
+    /**
+     * If <tt>first_cell==true</tt> this function returns @p update_flags,
+     * i.e. <tt>update_once|update_each</tt>. If <tt>first_cell==false</tt> it
+     * returns @p update_each.
+     */
+    UpdateFlags  current_update_flags() const;
+
+    /**
+     * Return whether we are presently initializing data for the first cell.
+     * The value of the field this function is returning is set to @p true in
+     * the constructor, and cleared by the @p FEValues class after the first
+     * cell has been initialized.
+     *
+     * This function is used to determine whether we need to use the @p
+     * update_once flags for computing data, or whether we can use the @p
+     * update_each flags.
+     */
+    bool is_first_cell () const;
+
+    /**
+     * Set the @p first_cell flag to @p false. Used by the @p FEValues class
+     * to indicate that we have already done the work on the first cell.
+     */
+    virtual void clear_first_cell ();
+
+    /**
+     * Return an estimate (in bytes) or the memory consumption of this object.
+     */
+    virtual std::size_t memory_consumption () const;
+
+    /**
      * Storage for FEValues objects needed to approximate second derivatives.
      *
      * The ordering is <i>p+hx</i>, <i>p+hy</i>, <i>p+hz</i>, <i>p-hx</i>,
@@ -406,6 +463,12 @@ public:
      * missing.
      */
     std::vector<FEValues<dim,spacedim>*> differences;
+
+  private:
+    /**
+     * The value returned by @p is_first_cell.
+     */
+    bool first_cell;
   };
 
 public:

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -355,9 +355,7 @@ public:
 
   /**
    * A base class for internal data that derived finite element classes may
-   * wish to store. This class uses the same data fields as
-   * Mapping::InternalDataBase() but adds a field for the computation of
-   * second derivatives.
+   * wish to store.
    *
    * The class is used as follows: Whenever an FEValues (or FEFaceValues or
    * FESubfaceValues) object is initialized, it requests that the finite

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2334,12 +2334,12 @@ protected:
   /**
    * Internal data of mapping.
    */
-  SmartPointer<typename Mapping<dim,spacedim>::InternalDataBase,FEValuesBase<dim,spacedim> > mapping_data;
+  std_cxx11::unique_ptr<typename Mapping<dim,spacedim>::InternalDataBase> mapping_data;
 
   /**
    * Internal data of finite element.
    */
-  SmartPointer<typename FiniteElement<dim,spacedim>::InternalDataBase,FEValuesBase<dim,spacedim> > fe_data;
+  std_cxx11::unique_ptr<typename FiniteElement<dim,spacedim>::InternalDataBase> fe_data;
 
   /**
    * Original update flags handed to the constructor of FEValues.

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -348,11 +348,11 @@ public:
    * modification despite the fact that the surrounding object is
    * marked as <code>const</code>.
    */
-  class InternalDataBase: public Subscriptor
+  class InternalDataBase : public Subscriptor
   {
   private:
     /**
-     * Copy constructor forbidden.
+     * Copy construction is forbidden.
      */
     InternalDataBase (const InternalDataBase &);
 

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -348,7 +348,7 @@ public:
    * modification despite the fact that the surrounding object is
    * marked as <code>const</code>.
    */
-  class InternalDataBase : public Subscriptor
+  class InternalDataBase
   {
   private:
     /**

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -39,6 +39,42 @@ const double FiniteElement<dim,spacedim>::fd_step_length = 1.0e-6;
 
 
 template <int dim, int spacedim>
+FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
+  update_flags(update_default),
+  update_once(update_default),
+  update_each(update_default),
+  first_cell(true)
+{}
+
+
+
+template <int dim, int spacedim>
+FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase ()
+{
+  for (unsigned int i=0; i<differences.size (); ++i)
+    if (differences[i] != 0)
+      {
+        // delete pointer and set it
+        // to zero to avoid
+        // inadvertent use
+        delete differences[i];
+        differences[i] = 0;
+      }
+}
+
+
+
+template <int dim, int spacedim>
+std::size_t
+FiniteElement<dim, spacedim>::InternalDataBase::memory_consumption () const
+{
+  return sizeof(*this);
+}
+
+
+
+
+template <int dim, int spacedim>
 void
 FiniteElement<dim,spacedim>::
 InternalDataBase::initialize_2nd (const FiniteElement<dim,spacedim> *element,
@@ -89,19 +125,39 @@ InternalDataBase::initialize_2nd (const FiniteElement<dim,spacedim> *element,
 
 
 
+template <int dim, int spacedim>
+inline
+UpdateFlags
+FiniteElement<dim,spacedim>::InternalDataBase::current_update_flags () const
+{
+  if (first_cell)
+    {
+      Assert (update_flags==(update_once|update_each),
+              ExcInternalError());
+      return update_flags;
+    }
+  else
+    return update_each;
+}
+
+
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase ()
+inline
+bool
+FiniteElement<dim,spacedim>::InternalDataBase::is_first_cell () const
 {
-  for (unsigned int i=0; i<differences.size (); ++i)
-    if (differences[i] != 0)
-      {
-        // delete pointer and set it
-        // to zero to avoid
-        // inadvertent use
-        delete differences[i];
-        differences[i] = 0;
-      };
+  return first_cell;
+}
+
+
+
+template <int dim, int spacedim>
+inline
+void
+FiniteElement<dim,spacedim>::InternalDataBase::clear_first_cell ()
+{
+  first_cell = false;
 }
 
 


### PR DESCRIPTION
There was no logical reason to do this, and it turns out that the derived classes
actually didn't need any of the fields of the class it was previously derived from (other than the
is_first_cell/clear_first_cell mechanism, see #1305). So break the inheritance
and have these two classes be completely unrelated.

While there, also use unique_ptr rather than SmartPointer to point to such objects
in FEValues -- these pointers are never shared between objects, so ownership is
always clear. Doing so requires the addition of a MemoryConsumption function for
unique_ptr objects, but it allows us to not derive the InternalDataBase objects
from Subscriptor any more.

This fixes #1280. In reference to #1198.