### PR TITLE
Specify when Assert* will be active in immediate documentation more explicitly

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -286,6 +286,7 @@ namespace deal_II_exceptions
  *
  * See the <tt>ExceptionBase</tt> class for more information.
  *
+ * @note Active in DEBUG mode only
  * @ingroup Exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
@@ -314,6 +315,7 @@ namespace deal_II_exceptions
  *
  * See the <tt>ExceptionBase</tt> class for more information.
  *
+ * @note Active in DEBUG mode only
  * @ingroup Exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */
@@ -340,6 +342,7 @@ namespace deal_II_exceptions
  *
  * See the <tt>ExceptionBase</tt> class for more information.
  *
+ * @note Active in both DEBUG and RELEASE modes
  * @ref ExceptionBase
  * @ingroup Exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013


### PR DESCRIPTION
The explaining sentences are too long to read. :-]

And the so-called 'run-time' mode is not a verbatim corresponding to deal.II building options 'DEBUG' and 'RELEASE' then it is a little bit confusing.