### PR TITLE
remove an extra @ref in document of AssertThrow

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -343,7 +343,6 @@ namespace deal_II_exceptions
  * See the <tt>ExceptionBase</tt> class for more information.
  *
  * @note Active in both DEBUG and RELEASE modes
- * @ref ExceptionBase
  * @ingroup Exceptions
  * @author Wolfgang Bangerth, 1997, 1998, Matthias Maier, 2013
  */


### PR DESCRIPTION
That stand alone cross reference is meaningless.