### PR TITLE
Remove is_first_cell().

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -431,18 +431,6 @@ public:
     UpdateFlags  current_update_flags() const;
 
     /**
-     * Return whether we are presently initializing data for the first cell.
-     * The value of the field this function is returning is set to @p true in
-     * the constructor, and cleared by the @p FEValues class after the first
-     * cell has been initialized.
-     *
-     * This function is used to determine whether we need to use the @p
-     * update_once flags for computing data, or whether we can use the @p
-     * update_each flags.
-     */
-    bool is_first_cell () const;
-
-    /**
      * Set the @p first_cell flag to @p false. Used by the @p FEValues class
      * to indicate that we have already done the work on the first cell.
      */
@@ -464,7 +452,8 @@ public:
 
   private:
     /**
-     * The value returned by @p is_first_cell.
+     * Initially set to true, but reset to false when clear_first_cell()
+     * is called.
      */
     bool first_cell;
   };

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -391,18 +391,6 @@ public:
     UpdateFlags  current_update_flags() const;
 
     /**
-     * Return whether we are presently initializing data for the first cell.
-     * The value of the field this function is returning is set to @p true in
-     * the constructor, and cleared by the @p FEValues class after the first
-     * cell has been initialized.
-     *
-     * This function is used to determine whether we need to use the @p
-     * update_once flags for computing data, or whether we can use the @p
-     * update_each flags.
-     */
-    bool is_first_cell () const;
-
-    /**
      * Set the @p first_cell flag to @p false. Used by the @p FEValues class
      * to indicate that we have already done the work on the first cell.
      */
@@ -437,7 +425,8 @@ public:
 
   private:
     /**
-     * The value returned by @p is_first_cell.
+     * Initially set to true, but reset to false when clear_first_cell()
+     * is called.
      */
     bool first_cell;
   };
@@ -891,16 +880,6 @@ Mapping<dim,spacedim>::InternalDataBase::current_update_flags () const
     }
   else
     return update_each;
-}
-
-
-
-template <int dim, int spacedim>
-inline
-bool
-Mapping<dim,spacedim>::InternalDataBase::is_first_cell () const
-{
-  return first_cell;
 }
 
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -126,7 +126,6 @@ InternalDataBase::initialize_2nd (const FiniteElement<dim,spacedim> *element,
 
 
 template <int dim, int spacedim>
-inline
 UpdateFlags
 FiniteElement<dim,spacedim>::InternalDataBase::current_update_flags () const
 {
@@ -143,17 +142,6 @@ FiniteElement<dim,spacedim>::InternalDataBase::current_update_flags () const
 
 
 template <int dim, int spacedim>
-inline
-bool
-FiniteElement<dim,spacedim>::InternalDataBase::is_first_cell () const
-{
-  return first_cell;
-}
-
-
-
-template <int dim, int spacedim>
-inline
 void
 FiniteElement<dim,spacedim>::InternalDataBase::clear_first_cell ()
 {


### PR DESCRIPTION
The InternalDataBase::is_first_cell() function is now no longer used
(though the value it returns is still internally used in
current_update_flags()). Remove the function.

This addresses another part of #1305. In reference to #1198.