### PR TITLE
Initialize scratch vectors for transformed values and gradients early

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -90,6 +90,13 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Improved: Some finite elements compute hessians analytically rather than
+  by finite differencing. Namely, these are finite elements that are subclasses
+  of FEPoly as well as FESystem with those as base elements.
+  <br>
+  (Maien Hamed, 2015/08/01-2015/08/09)
+  </li>
+
   <li> New: There is now a function Mapping::project_real_point_to_unit_point_on_face()
   that calls Mapping::transform_real_to_unit_cell() and then projects the
   result to a provided face.

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -239,6 +239,14 @@ protected:
      * point.
      */
     std::vector< std::vector< DerivativeForm<1, dim, spacedim> > > shape_grads;
+
+    /**
+     * Scratch arrays for intermediate computations
+     */
+    mutable std::vector<double> sign_change;
+    mutable std::vector<Tensor<1, spacedim> > transformed_shape_values;
+    mutable std::vector<Tensor<2, spacedim > > transformed_shape_grads;
+    mutable std::vector<Tensor<2, dim > > untransformed_shape_grads;
   };
 
   /**


### PR DESCRIPTION
Removed the repeated instantiation of vectors every time data is computed for real cells in fe_poly_tensor.