### PR TITLE
Remove fields from Mapping::InternalDataBase.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -416,28 +416,6 @@ public:
      */
     virtual std::size_t memory_consumption () const;
 
-    /**
-     * The positions of the mapped (generalized) support points.
-     */
-    std::vector<Point<spacedim> > support_point_values;
-
-    /*
-     * The Jacobian of the
-     * transformation in the
-     * (generalized) support
-     * points.
-     */
-    std::vector<Tensor<2,spacedim> > support_point_gradients;
-
-    /*
-     * The inverse of the
-     * Jacobian of the
-     * transformation in the
-     * (generalized) support
-     * points.
-     */
-    std::vector<Tensor<2,spacedim> > support_point_inverse_gradients;
-
   private:
     /**
      * Initially set to true, but reset to false when clear_first_cell()
@@ -581,29 +559,6 @@ public:
              VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
              const InternalDataBase &internal,
              const MappingType type) const = 0;
-
-  /**
-   * The transformed (generalized) support point.
-   */
-  const Point<spacedim> &support_point_value(
-    const unsigned int index,
-    const typename Mapping<dim,spacedim>::InternalDataBase &internal) const;
-
-  /**
-   * The Jacobian matrix of the transformation in the (generalized) support
-   * point.
-   */
-  const Tensor<2,spacedim> &support_point_gradient(
-    const unsigned int index,
-    const typename Mapping<dim,spacedim>::InternalDataBase &internal) const;
-
-  /**
-   * The inverse Jacobian matrix of the transformation in the (generalized)
-   * support point.
-   */
-  const Tensor<2,spacedim> &support_point_inverse_gradient(
-    const unsigned int index,
-    const typename Mapping<dim,spacedim>::InternalDataBase &internal) const;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -905,43 +860,6 @@ void
 Mapping<dim,spacedim>::InternalDataBase::clear_first_cell ()
 {
   first_cell = false;
-}
-
-
-
-template <int dim, int spacedim>
-inline
-const Point<spacedim> &
-Mapping<dim,spacedim>::support_point_value(
-  const unsigned int index,
-  const typename Mapping<dim,spacedim>::InternalDataBase &internal) const
-{
-  AssertIndexRange(index, internal.support_point_values.size());
-  return internal.support_point_values[index];
-}
-
-
-template <int dim, int spacedim>
-inline
-const Tensor<2,spacedim> &
-Mapping<dim,spacedim>::support_point_gradient(
-  const unsigned int index,
-  const typename Mapping<dim,spacedim>::InternalDataBase &internal) const
-{
-  AssertIndexRange(index, internal.support_point_gradients.size());
-  return internal.support_point_gradients[index];
-}
-
-
-template <int dim, int spacedim>
-inline
-const Tensor<2,spacedim> &
-Mapping<dim,spacedim>::support_point_inverse_gradient(
-  const unsigned int index,
-  const typename Mapping<dim,spacedim>::InternalDataBase &internal) const
-{
-  AssertIndexRange(index, internal.support_point_inverse_gradients.size());
-  return internal.support_point_inverse_gradients[index];
 }
 
 


### PR DESCRIPTION
It turns out that all of the non-is_first_cell/clear_first_cell() member
variables of Mapping::InternalDataBase are only referenced in Mapping
member functions that are unused throughout the rest of the library.
While they were public, they took an internal object as argument, so
were almost certainly not used anywhere by anyone. Consequently,
zap the fields and the functions that use them.

This fixes #1317 in a magically simple way. Relates to #1198.