### PR TITLE
Improve error messages about ghosted vectors.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1000,6 +1000,10 @@ namespace StandardExceptions
                     "You are trying an operation on a vector that is only "
                     "allowed if the vector has no ghost elements, but the "
                     "vector you are operating on does have ghost elements. "
+                    "Specifically, vectors with ghost elements are read-only "
+                    "and cannot appear in operations that write into these "
+                    "vectors."
+                    "\n\n"
                     "See the glossary entry on 'Ghosted vectors' for more "
                     "information.");
 

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -703,7 +703,7 @@ namespace internal
                                        const internal::bool2type<false>     /*is_block_vector*/)
     {
       Assert(!vec.has_ghost_elements(),
-             TrilinosWrappers::VectorBase::ExcGhostsPresent());
+             ExcGhostsPresent());
 #ifdef DEAL_II_WITH_MPI
       const Epetra_MpiComm *mpi_comm
         = dynamic_cast<const Epetra_MpiComm *>(&vec.trilinos_vector().Comm());

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -871,11 +871,6 @@ namespace TrilinosWrappers
     /**
      * Exception
      */
-    DeclException0 (ExcGhostsPresent);
-
-    /**
-     * Exception
-     */
     DeclException0 (ExcDifferentParallelPartitioning);
 
     /**


### PR DESCRIPTION
The TrilinosWrappers::VectorBase class declared its own version of
ExcGhostsPresent that hid the class we already declare globally in
exceptions.h, and thereby led to a situation where we output less
information than is available. This also led to some confusion as
evidenced by a recent mail on the mailing list.

Fix this by removing the extraneous class. Also augment the error
message of the existing class.

In reference to #610.