### PR TITLE
make SparseMatrixEZ can accept new zero entry

### DIFF
--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -429,12 +429,23 @@ public:
    */
 //@{
   /**
-   * Set the element <tt>(i,j)</tt> to @p value. Allocates the entry, if it
-   * does not exist and @p value is non-zero. If <tt>value</tt> is not a
-   * finite number an exception is thrown.
+   * Set the element <tt>(i,j)</tt> to @p value.
+   *
+   * If <tt>value</tt> is not a finite number an exception is thrown.
+   *
+   * The optional parameter <tt>elide_zero_values</tt> can be used to specify
+   * whether zero values should be added anyway or these should be filtered
+   * away and only non-zero data is added. The default value is <tt>true</tt>,
+   * i.e., zero values won't be added into the matrix.
+   *
+   * If anyway a new element will be inserted and it does not exist,
+   * allocates the entry.
+   *
+   * @note You may need to insert some zero elements to keep a
+   * symmetric sparsity pattern for the matrix.
    */
   void set (const size_type i, const size_type j,
-            const number value);
+            const number value, const bool elide_zero_values = true);
 
   /**
    * Add @p value to the element <tt>(i,j)</tt>. Allocates the entry if it
@@ -518,11 +529,16 @@ public:
    * The source matrix may be a matrix of arbitrary type, as long as its data
    * type is convertible to the data type of this matrix.
    *
+   * The optional parameter <tt>elide_zero_values</tt> can be used to specify
+   * whether zero values should be added anyway or these should be filtered
+   * away and only non-zero data is added. The default value is <tt>true</tt>,
+   * i.e., zero values won't be added into the matrix.
+   *
    * The function returns a reference to @p this.
    */
   template <class MATRIX>
   SparseMatrixEZ<number> &
-  copy_from (const MATRIX &source);
+  copy_from (const MATRIX &source, const bool elide_zero_values = true);
 
   /**
    * Add @p matrix scaled by @p factor to this matrix.
@@ -1195,15 +1211,15 @@ template <typename number>
 inline
 void SparseMatrixEZ<number>::set (const size_type i,
                                   const size_type j,
-                                  const number value)
+                                  const number value,
+                                  const bool elide_zero_values)
 {
-
   AssertIsFinite(value);
 
   Assert (i<m(), ExcIndexRange(i,0,m()));
   Assert (j<n(), ExcIndexRange(j,0,n()));
 
-  if (value == 0.)
+  if (elide_zero_values && value == 0.)
     {
       Entry *entry = locate(i,j);
       if (entry != 0)
@@ -1371,7 +1387,7 @@ template<typename number>
 template <class MATRIX>
 inline
 SparseMatrixEZ<number> &
-SparseMatrixEZ<number>::copy_from (const MATRIX &M)
+SparseMatrixEZ<number>::copy_from (const MATRIX &M, const bool elide_zero_values)
 {
   reinit(M.m(), M.n());
 
@@ -1383,8 +1399,7 @@ SparseMatrixEZ<number>::copy_from (const MATRIX &M)
       const typename MATRIX::const_iterator end_row = M.end(row);
       for (typename MATRIX::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
-        if (entry->value() != 0)
-          set(row, entry->column(), entry->value());
+        set(row, entry->column(), entry->value(), elide_zero_values);
     }
 
   return *this;

--- a/tests/lac/sparse_matrix_ez_00.cc
+++ b/tests/lac/sparse_matrix_ez_00.cc
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test SparseMatrixEZ class's behavior on inserting zero entry and the
+// elide_zero_values flag.
+
+#include "../tests.h"
+#include <deal.II/lac/sparse_matrix_ez.h>
+
+#define NUMBER double
+
+int main(int argc, char *argv[])
+{
+  SparseMatrixEZ<NUMBER> m_ez(5,5,3);
+
+  std::ofstream logfile("output");
+  // Not use because SparseMatrixEZ has no interface with LogStream either with
+  // function .print() or operator <<
+
+  // Initialize the matrix
+  m_ez.set(0,0,1);
+
+  m_ez.set(1,0,2);
+  m_ez.set(1,1,3);
+
+  // The third row is filled to default length
+  m_ez.set(2,0,7);
+  m_ez.set(2,1,6.18);
+  m_ez.set(2,2,3.14);
+
+  // Put a non-zero at end of forth row's default length
+  m_ez.set(3,2,2.718);
+
+  // Fifth row is left empty
+
+  //------------------------
+
+  logfile << "The initial matrix:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(0,1,0.0);
+  logfile << "Ignore a zero entry insertion:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(1,0,0.0);
+  logfile << "Set existing entry (1,0) to zero:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(1,2,0.0, /*elide_zero_values=*/false);
+  logfile << "Insert new zero to (1,2):" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(2,4,0.0, /*elide_zero_values=*/false);
+  logfile << "Insert new zero to (2,4), out of range of default row length:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(2,1,0.0, /*elide_zero_values=*/false);
+  logfile << "Set existing entry (2,1) to zero with elide_zero_values=false:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(3,0,1.414, /*elide_zero_values=*/false);
+  logfile << "Insert a non-zero entry at (3,0) with elide_zero_values=false:" << std::endl;
+  m_ez.print(logfile);
+
+  m_ez.set(4,4,0.0, /*elide_zero_values=*/false);
+  logfile << "Insert new zero entry to an empty row with elide_zero_values=false:" << std::endl;
+  m_ez.print(logfile);
+
+  {
+    SparseMatrixEZ<NUMBER> m_ez_cpoier(5,5,2);
+    m_ez_cpoier.copy_from(m_ez);
+    logfile << "Copy the matrix and drop all zeros:" << std::endl;
+    m_ez_cpoier.print(logfile);
+  }
+  {
+    SparseMatrixEZ<NUMBER> m_ez_cpoier(5,5,2);
+    m_ez_cpoier.copy_from(m_ez, /*elide_zero_values=*/false);
+    logfile << "Copy the matrix and keep all zeros:" << std::endl;
+    m_ez_cpoier.print(logfile);
+  }
+
+  logfile.close();
+  return (0);
+}

--- a/tests/lac/sparse_matrix_ez_00.output
+++ b/tests/lac/sparse_matrix_ez_00.output
@@ -1,0 +1,95 @@
+The initial matrix:
+0	0	1
+1	0	2
+1	1	3
+2	0	7
+2	1	6.18
+2	2	3.14
+3	2	2.718
+Ignore a zero entry insertion:
+0	0	1
+1	0	2
+1	1	3
+2	0	7
+2	1	6.18
+2	2	3.14
+3	2	2.718
+Set existing entry (1,0) to zero:
+0	0	1
+1	0	0
+1	1	3
+2	0	7
+2	1	6.18
+2	2	3.14
+3	2	2.718
+Insert new zero to (1,2):
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	6.18
+2	2	3.14
+3	2	2.718
+Insert new zero to (2,4), out of range of default row length:
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	6.18
+2	2	3.14
+2	4	0
+3	2	2.718
+Set existing entry (2,1) to zero with elide_zero_values=false:
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	0
+2	2	3.14
+2	4	0
+3	2	2.718
+Insert a non-zero entry at (3,0) with elide_zero_values=false:
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	0
+2	2	3.14
+2	4	0
+3	0	1.414
+3	2	2.718
+Insert new zero entry to an empty row with elide_zero_values=false:
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	0
+2	2	3.14
+2	4	0
+3	0	1.414
+3	2	2.718
+4	4	0
+Copy the matrix and drop all zeros:
+0	0	1
+1	1	3
+2	0	7
+2	2	3.14
+3	0	1.414
+3	2	2.718
+Copy the matrix and keep all zeros:
+0	0	1
+1	0	0
+1	1	3
+1	2	0
+2	0	7
+2	1	0
+2	2	3.14
+2	4	0
+3	0	1.414
+3	2	2.718
+4	4	0


### PR DESCRIPTION
Sometimes, it is necessary to insert some zero entries to keep a symmetric sparsity pattern.