### PR TITLE
Deprecate more vector functions.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -95,6 +95,14 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Changed: The function Vector::add() that adds a scalar number to all
+  elements of a vector has been deprecated. The same is true for the
+  Vector::ratio() function, and for the corresponding functions in other
+  vector classes.
+  <br>
+  (Wolfgang Bangerth, Bruno Turcksin, 2015/08/13)
+  </li>
+
   <li> Improved: Some finite elements compute hessians analytically rather than
   by finite differencing. Namely, these are finite elements that are subclasses
   of FEPoly as well as FESystem with those as base elements.

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -821,7 +821,7 @@ namespace parallel
        * Addition of @p s to all components. Note that @p s is a scalar and
        * not a vector.
        */
-      void add (const Number s);
+      void add (const Number s) DEAL_II_DEPRECATED;
 
       /**
        * Simple vector addition, equal to the <tt>operator +=</tt>.
@@ -945,7 +945,7 @@ namespace parallel
        * attempt is made to catch such situations.
        */
       void ratio (const Vector<Number> &a,
-                  const Vector<Number> &b);
+                  const Vector<Number> &b) DEAL_II_DEPRECATED;
       //@}
 
 

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -609,7 +609,7 @@ namespace PETScWrappers
      * Addition of @p s to all components. Note that @p s is a scalar and not
      * a vector.
      */
-    void add (const PetscScalar s);
+    void add (const PetscScalar s) DEAL_II_DEPRECATED;
 
     /**
      * Simple vector addition, equal to the <tt>operator +=</tt>.
@@ -698,7 +698,7 @@ namespace PETScWrappers
      * attempt is made to catch such situations.
      */
     void ratio (const VectorBase &a,
-                const VectorBase &b);
+                const VectorBase &b) DEAL_II_DEPRECATED;
 
     /**
      * Prints the PETSc vector object values using PETSc internal vector

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -690,7 +690,7 @@ namespace TrilinosWrappers
      * Addition of @p s to all components. Note that @p s is a scalar and not
      * a vector.
      */
-    void add (const TrilinosScalar s);
+    void add (const TrilinosScalar s) DEAL_II_DEPRECATED;
 
     /**
      * Simple vector addition, equal to the <tt>operator +=</tt>.
@@ -794,7 +794,7 @@ namespace TrilinosWrappers
      * attempt is made to catch such situations.
      */
     void ratio (const VectorBase &a,
-                const VectorBase &b);
+                const VectorBase &b) DEAL_II_DEPRECATED;
     //@}
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -660,7 +660,7 @@ public:
    *
    * @dealiiOperationIsMultithreaded
    */
-  void add (const Number s);
+  void add (const Number s) DEAL_II_DEPRECATED;
 
   /**
    * Simple vector addition, equal to the <tt>operator +=</tt>.
@@ -811,7 +811,7 @@ public:
    * @dealiiOperationIsMultithreaded
    */
   void ratio (const Vector<Number> &a,
-              const Vector<Number> &b);
+              const Vector<Number> &b) DEAL_II_DEPRECATED;
 
   /**
    * This function does nothing but is there for compatibility with the @p


### PR DESCRIPTION
These are a bit obscure and of questionable value. In particular,
these are functions that can't quite decide whether they would
belong into the VectorWithElementAccess category, or into the
VectorSpaceVector category. Thus, nuke them.