### PR TITLE
Remove the is_first_cell/clear_first_cell() mechanism from Mapping.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -475,44 +475,14 @@ public:
     virtual ~InternalDataBase ();
 
     /**
-     * Values updated by the constructor or by reinit.
-     */
-    UpdateFlags          update_flags;
-
-    /**
-     * Values computed by constructor.
-     */
-    UpdateFlags          update_once;
-
-    /**
-     * Values updated on each cell by reinit.
+     * Values updated on each cell by Mapping::fill_fe_values() and friends.
      */
     UpdateFlags          update_each;
-
-    /**
-     * If <tt>first_cell==true</tt> this function returns @p update_flags,
-     * i.e. <tt>update_once|update_each</tt>. If <tt>first_cell==false</tt> it
-     * returns @p update_each.
-     */
-    UpdateFlags  current_update_flags() const;
-
-    /**
-     * Set the @p first_cell flag to @p false. Used by the @p FEValues class
-     * to indicate that we have already done the work on the first cell.
-     */
-    virtual void clear_first_cell ();
 
     /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
     virtual std::size_t memory_consumption () const;
-
-  private:
-    /**
-     * Initially set to true, but reset to false when clear_first_cell()
-     * is called.
-     */
-    bool first_cell;
   };
 
 
@@ -883,38 +853,6 @@ public:
   friend class FESubfaceValues<dim,spacedim>;
 };
 
-
-/* ------------------------- inline functions ------------------------- */
-
-#ifndef DOXYGEN
-
-template <int dim, int spacedim>
-inline
-UpdateFlags
-Mapping<dim,spacedim>::InternalDataBase::current_update_flags () const
-{
-  if (first_cell)
-    {
-      Assert (update_flags==(update_once|update_each),
-              ExcInternalError());
-      return update_flags;
-    }
-  else
-    return update_each;
-}
-
-
-
-template <int dim, int spacedim>
-inline
-void
-Mapping<dim,spacedim>::InternalDataBase::clear_first_cell ()
-{
-  first_cell = false;
-}
-
-
-#endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3528,7 +3528,6 @@ void FEValues<dim,spacedim>::do_reinit ()
                                 this->cell_similarity);
 
   this->fe_data->clear_first_cell ();
-  this->mapping_data->clear_first_cell ();
 }
 
 
@@ -3724,7 +3723,6 @@ void FEFaceValues<dim,spacedim>::do_reinit (const unsigned int face_no)
                                      *this);
 
   this->fe_data->clear_first_cell ();
-  this->mapping_data->clear_first_cell ();
 }
 
 
@@ -3958,7 +3956,6 @@ void FESubfaceValues<dim,spacedim>::do_reinit (const unsigned int face_no,
                                         *this);
 
   this->fe_data->clear_first_cell ();
-  this->mapping_data->clear_first_cell ();
 }
 
 

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -81,10 +81,7 @@ project_real_point_to_unit_point_on_face (
 
 template <int dim, int spacedim>
 Mapping<dim, spacedim>::InternalDataBase::InternalDataBase ():
-  update_flags(update_default),
-  update_once(update_default),
-  update_each(update_default),
-  first_cell(true)
+  update_each(update_default)
 {}
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -86,9 +86,7 @@ MappingCartesian<dim, spacedim>::get_data (const UpdateFlags      update_flags,
 {
   InternalData *data = new InternalData (q);
 
-  data->update_once = update_once(update_flags);
   data->update_each = update_each(update_flags);
-  data->update_flags = data->update_once | data->update_each;
 
   return data;
 }
@@ -103,9 +101,7 @@ MappingCartesian<dim, spacedim>::get_face_data (const UpdateFlags update_flags,
   InternalData *data
     = new InternalData (QProjector<dim>::project_to_all_faces(quadrature));
 
-  data->update_once = update_once(update_flags);
   data->update_each = update_each(update_flags);
-  data->update_flags = data->update_once | data->update_each;
 
   return data;
 }
@@ -120,9 +116,7 @@ MappingCartesian<dim, spacedim>::get_subface_data (const UpdateFlags update_flag
   InternalData *data
     = new InternalData (QProjector<dim>::project_to_all_subfaces(quadrature));
 
-  data->update_once = update_once(update_flags);
   data->update_each = update_each(update_flags);
-  data->update_flags = data->update_once | data->update_each;
 
   return data;
 }
@@ -555,7 +549,7 @@ MappingCartesian<dim,spacedim>::transform (
     {
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -566,7 +560,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_contravariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -576,9 +570,9 @@ MappingCartesian<dim,spacedim>::transform (
     }
     case mapping_piola:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -610,7 +604,7 @@ MappingCartesian<dim,spacedim>::transform (
     {
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -622,7 +616,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_contravariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -634,7 +628,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_covariant_gradient:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -646,7 +640,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_contravariant_gradient:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -658,9 +652,9 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_piola:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -673,9 +667,9 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_piola_gradient:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -712,7 +706,7 @@ MappingCartesian<dim,spacedim>::transform (
     {
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -724,7 +718,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_contravariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -736,7 +730,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_covariant_gradient:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -748,7 +742,7 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_contravariant_gradient:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -760,9 +754,9 @@ MappingCartesian<dim,spacedim>::transform (
 
     case mapping_piola:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -774,9 +768,9 @@ MappingCartesian<dim,spacedim>::transform (
     }
     case mapping_piola_gradient:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
 
       for (unsigned int i=0; i<output.size(); ++i)

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -231,13 +231,10 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_data (const UpdateFlags      upd
                                                       const unsigned int     n_original_q_points,
                                                       InternalData           &data) const
 {
-  const unsigned int n_q_points = q.size();
-
-  data.update_once = update_once(update_flags);
   data.update_each = update_each(update_flags);
-  data.update_flags = data.update_once | data.update_each;
 
-  const UpdateFlags flags(data.update_flags);
+  const unsigned int n_q_points = q.size();
+  const UpdateFlags flags = update_once(update_flags) | update_each(update_flags);
 
   if (flags & update_transformation_values)
     data.shape_values.resize(data.n_shape_functions * n_q_points);
@@ -272,7 +269,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_face_data (const UpdateFlags upd
 
   if (dim > 1)
     {
-      if (data.update_flags & update_boundary_forms)
+      if (update_flags & update_boundary_forms)
         {
           data.aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 
@@ -991,7 +988,7 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform_fields(
     {
     case mapping_contravariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -1002,9 +999,9 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform_fields(
 
     case mapping_piola:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
       Assert (rank==1, ExcMessage("Only for rank 1"));
       for (unsigned int i=0; i<output.size(); ++i)
@@ -1021,7 +1018,7 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform_fields(
     //rather than DerivativeForm
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -1054,7 +1051,7 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform_differential_forms(
     {
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -564,13 +564,10 @@ MappingQ1<dim,spacedim>::compute_data (const UpdateFlags      update_flags,
                                        const unsigned int     n_original_q_points,
                                        InternalData          &data) const
 {
-  const unsigned int n_q_points = q.size();
-
-  data.update_once = update_once(update_flags);
   data.update_each = update_each(update_flags);
-  data.update_flags = data.update_once | data.update_each;
 
-  const UpdateFlags flags(data.update_flags);
+  const unsigned int n_q_points = q.size();
+  const UpdateFlags flags = update_once(update_flags) | update_each(update_flags);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
@@ -627,7 +624,7 @@ MappingQ1<dim,spacedim>::compute_face_data (const UpdateFlags update_flags,
 
   if (dim > 1)
     {
-      if (data.update_flags & update_boundary_forms)
+      if (update_flags & update_boundary_forms)
         {
           data.aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 
@@ -1401,7 +1398,7 @@ void MappingQ1<dim,spacedim>::transform_fields(
     {
     case mapping_contravariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -1412,9 +1409,9 @@ void MappingQ1<dim,spacedim>::transform_fields(
 
     case mapping_piola:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
       Assert (rank==1, ExcMessage("Only for rank 1"));
       if (rank!=1)
@@ -1434,7 +1431,7 @@ void MappingQ1<dim,spacedim>::transform_fields(
     //rather than DerivativeForm
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)
@@ -1466,9 +1463,9 @@ void MappingQ1<dim,spacedim>::transform_gradients(
     {
     case mapping_contravariant_gradient:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
       Assert (rank==2, ExcMessage("Only for rank 2"));
 
@@ -1484,9 +1481,9 @@ void MappingQ1<dim,spacedim>::transform_gradients(
 
     case mapping_covariant_gradient:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
       Assert (rank==2, ExcMessage("Only for rank 2"));
 
@@ -1506,11 +1503,11 @@ void MappingQ1<dim,spacedim>::transform_gradients(
 
     case mapping_piola_gradient:
     {
-      Assert (data.update_flags & update_covariant_transformation,
+      Assert (data.update_each & update_covariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_flags & update_volume_elements,
+      Assert (data.update_each & update_volume_elements,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
       Assert (rank==2, ExcMessage("Only for rank 2"));
 
@@ -1554,7 +1551,7 @@ void MappingQ1<dim,spacedim>::transform_differential_forms(
     {
     case mapping_covariant:
     {
-      Assert (data.update_flags & update_contravariant_transformation,
+      Assert (data.update_each & update_contravariant_transformation,
               typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
 
       for (unsigned int i=0; i<output.size(); ++i)


### PR DESCRIPTION
This truly makes the Mapping::InternalDataBase objects stateless: we no
    longer need to worry about whether we are on the first cell or not.

This patch depends on #1339 to be merged first. It implements the
mapping half of #1305 and makes the mapping half of #1335 possible.

In reference to #1198.