### PR TITLE
Also run doxygen on source files.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -95,6 +95,7 @@ SET(_doxygen_input
 
 LIST(APPEND _doxygen_input
   ${CMAKE_SOURCE_DIR}/include/
+  ${CMAKE_SOURCE_DIR}/source/
   ${CMAKE_BINARY_DIR}/include/
   ${CMAKE_SOURCE_DIR}/doc/news/
   ${CMAKE_CURRENT_BINARY_DIR}/tutorial/tutorial.h

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -66,6 +66,14 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: The online documentation of all functions now includes
+  links to the file and line where that function is implemented. Both
+  are clickable to provide immediate access to the source code of a
+  function.
+  <br>
+  (Jason Sheldon, Wolfgang Bangerth, 2015/08/13)
+  </li>
+
   <li> New: FE_Q_Bubbles describes a FiniteElement based on FE_Q 
   enriched by bubble functions.
   <br>


### PR DESCRIPTION
For each function recognized in a .cc file, this yields a nice
'Definition in line 1234 of file abcd.cc' mark with the documentation
of the function, both line and file being clickable so that people can
follow the link and actually see the source code.


This fixes #1303 and follows a suggestion by Jason Sheldon.