### PR TITLE
Fix #1343.

### DIFF
--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -248,8 +248,8 @@ protected:
                 const Quadrature<0> &quadrature) const
   {
     // generate a new data object and initialize some fields
-    typename FiniteElement<1, spacedim>::InternalDataBase *data =
-      new typename FiniteElement<1, spacedim>::InternalDataBase;
+    typename FiniteElement<1,spacedim>::InternalDataBase *data =
+      new typename FiniteElement<1,spacedim>::InternalDataBase;
 
     // check what needs to be initialized only once and what on every
     // cell/face/subface we visit

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -113,23 +113,23 @@ protected:
 
     // some scratch arrays
     std::vector<double> values(0);
-    std::vector<Tensor<1, dim - 1> > grads(0);
-    std::vector<Tensor<2, dim - 1> > grad_grads(0);
+    std::vector<Tensor<1,dim-1> > grads(0);
+    std::vector<Tensor<2,dim-1> > grad_grads(0);
 
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
     if (flags & update_values)
       {
-        values.resize(poly_space.n());
-        data->shape_values.resize(poly_space.n(),
-                                  std::vector<double>(n_q_points));
-        for (unsigned int i = 0; i<n_q_points; ++i)
+        values.resize (poly_space.n());
+        data->shape_values.resize (poly_space.n(),
+                                   std::vector<double> (n_q_points));
+        for (unsigned int i=0; i<n_q_points; ++i)
           {
             poly_space.compute(quadrature.point(i),
                                values, grads, grad_grads);
 
-            for (unsigned int k = 0; k<poly_space.n(); ++k)
+            for (unsigned int k=0; k<poly_space.n(); ++k)
               data->shape_values[k][i] = values[k];
           }
       }

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -200,27 +200,38 @@ protected:
     const unsigned int n_q_points = quadrature.size();
 
     // some scratch arrays
-    std::vector<Tensor<1, dim> > values(0);
-    std::vector<Tensor<2, dim> > grads(0);
-    std::vector<Tensor<3, dim> > grad_grads(0);
+    std::vector<Tensor<1,dim> > values(0);
+    std::vector<Tensor<2,dim> > grads(0);
+    std::vector<Tensor<3,dim> > grad_grads(0);
+
+    data->sign_change.resize (this->dofs_per_cell);
 
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
     if (flags & update_values)
       {
-        values.resize(this->dofs_per_cell);
-        data->shape_values.resize(this->dofs_per_cell);
-        for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
-          data->shape_values[i].resize(n_q_points);
+        values.resize (this->dofs_per_cell);
+        data->shape_values.resize (this->dofs_per_cell);
+        for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+          data->shape_values[i].resize (n_q_points);
+        if (mapping_type != mapping_none)
+          data->transformed_shape_values.resize (n_q_points);
       }
 
     if (flags & update_gradients)
       {
-        grads.resize(this->dofs_per_cell);
-        data->shape_grads.resize(this->dofs_per_cell);
-        for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
-          data->shape_grads[i].resize(n_q_points);
+        grads.resize (this->dofs_per_cell);
+        data->shape_grads.resize (this->dofs_per_cell);
+        for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+          data->shape_grads[i].resize (n_q_points);
+        data->transformed_shape_grads.resize (n_q_points);
+        if ( (mapping_type == mapping_raviart_thomas)
+             ||
+             (mapping_type == mapping_piola)
+             ||
+             (mapping_type == mapping_nedelec))
+          data->untransformed_shape_grads.resize(n_q_points);
       }
 
     // if second derivatives through
@@ -229,8 +240,8 @@ protected:
     // that
     if (flags & update_hessians)
       {
-        //      grad_grads.resize (this->dofs_per_cell);
-        data->initialize_2nd(this, mapping, quadrature);
+//      grad_grads.resize (this->dofs_per_cell);
+        data->initialize_2nd (this, mapping, quadrature);
       }
 
     // Compute shape function values
@@ -240,7 +251,7 @@ protected:
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
     if (flags & (update_values | update_gradients))
-      for (unsigned int k = 0; k<n_q_points; ++k)
+      for (unsigned int k=0; k<n_q_points; ++k)
         {
           poly_space.compute(quadrature.point(k),
                              values, grads, grad_grads);
@@ -248,14 +259,14 @@ protected:
           if (flags & update_values)
             {
               if (inverse_node_matrix.n_cols() == 0)
-                for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
+                for (unsigned int i=0; i<this->dofs_per_cell; ++i)
                   data->shape_values[i][k] = values[i];
               else
-                for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
+                for (unsigned int i=0; i<this->dofs_per_cell; ++i)
                   {
-                    Tensor<1, dim> add_values;
-                    for (unsigned int j = 0; j<this->dofs_per_cell; ++j)
-                      add_values += inverse_node_matrix(j, i) * values[j];
+                    Tensor<1,dim> add_values;
+                    for (unsigned int j=0; j<this->dofs_per_cell; ++j)
+                      add_values += inverse_node_matrix(j,i) * values[j];
                     data->shape_values[i][k] = add_values;
                   }
             }
@@ -263,14 +274,14 @@ protected:
           if (flags & update_gradients)
             {
               if (inverse_node_matrix.n_cols() == 0)
-                for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
+                for (unsigned int i=0; i<this->dofs_per_cell; ++i)
                   data->shape_grads[i][k] = grads[i];
               else
-                for (unsigned int i = 0; i<this->dofs_per_cell; ++i)
+                for (unsigned int i=0; i<this->dofs_per_cell; ++i)
                   {
-                    Tensor<2, dim> add_grads;
-                    for (unsigned int j = 0; j<this->dofs_per_cell; ++j)
-                      add_grads += inverse_node_matrix(j, i) * grads[j];
+                    Tensor<2,dim> add_grads;
+                    for (unsigned int j=0; j<this->dofs_per_cell; ++j)
+                      add_grads += inverse_node_matrix(j,i) * grads[j];
                     data->shape_grads[i][k] = add_grads;
                   }
             }


### PR DESCRIPTION
#1343 copied an *old* version of the code in .cc and .templates.h
files into the .h files, thereby undoing a significant portion of
the work of Hamed Maien in #1322. This restores this by using the
correct code and should thereby fix the ~700 testsuite failures that
#1343 introduced.