### PR TITLE
Fix another aspect of #1343.

### DIFF
--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -20,6 +20,7 @@
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/fe/fe.h>
 #include <deal.II/base/derivative_form.h>
+#include <deal.II/base/quadrature.h>
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This is another necessary fix for #1343, adding a missing #include.
It fixes 23 more tests that currently fail.