### PR TITLE
Remove Mapping::update_once/each().

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -47,7 +47,17 @@ inconvenience this causes.
   class hierarchy. As part of a general overhaul, the FEValuesData class
   has also been removed.
   <br>
-  (Wolfgang Bangerth, 2015/07/20-2015/08/06)
+  (Wolfgang Bangerth, 2015/07/20-2015/08/13)
+  </li>
+
+  <li> Changed: The functions update_once() and update_each() in the
+  Mapping classes computed information that was, in essence, only of use
+  internally. No external piece of code actually needed to know which
+  pieces of information a mapping could compute once and which they needed
+  to compute on every cell. Consequently, these two functions have been
+  removed and have been replaced by Mapping::requires_update_flags().
+  <br>
+  (Wolfgang Bangerth, 2015/07/20-2015/08/13)
   </li>
 
   <li> Changed: The function DoFRenumbering::random() now produces different

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -419,7 +419,20 @@ public:
     UpdateFlags          update_once;
 
     /**
-     * Values updated on each cell by reinit.
+     * A set of update flags specifying the kind of information that
+     * an implementation of the FiniteElement interface needs to compute on
+     * each cell or face, i.e., in FiniteElement::fill_fe_values() and
+     * friends.
+     *
+     * This set of flags is stored here by implementations of
+     * FiniteElement::get_data(), FiniteElement::get_face_data(), or
+     * FiniteElement::get_subface_data(), and is that subset of the update
+     * flags passed to those functions that require re-computation on
+     * every cell. (The subset of the flags corresponding to
+     * information that can be computed once and for all already at
+     * the time of the call to FiniteElement::get_data() -- or an
+     * implementation of that interface -- need not be stored here
+     * because it has already been taken care of.)
      */
     UpdateFlags          update_each;
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -211,8 +211,13 @@ protected:
                      std::vector<Point<dim> > &normal_vectors) const;
 
 private:
-  virtual UpdateFlags update_once (const UpdateFlags) const;
-  virtual UpdateFlags update_each (const UpdateFlags) const;
+  /**
+   * Implementation of the corresponding function in the base class,
+   * Mapping::requires_update_flags(). See there for more information.
+   */
+  virtual
+  UpdateFlags
+  requires_update_flags (const UpdateFlags update_flags) const;
 
   /**
    * Value to indicate that a given face or subface number is invalid.

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -506,18 +506,12 @@ private:
                           typename MappingFEField<dim, spacedim>::InternalData &data) const;
 
   /**
-   * Reimplemented from Mapping. See the documentation of the base class for
-   * detailed information.
+   * Implementation of the corresponding function in the base class,
+   * Mapping::requires_update_flags(). See there for more information.
    */
-  virtual UpdateFlags
-  update_once (const UpdateFlags in) const;
-
-  /**
-   * Reimplemented from Mapping. See the documentation of the base class for
-   * detailed information.
-   */
-  virtual UpdateFlags
-  update_each (const UpdateFlags in) const;
+  virtual
+  UpdateFlags
+  requires_update_flags (const UpdateFlags update_flags) const;
 
   /**
    * Reimplemented from Mapping. See the documentation of the base class for

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -474,49 +474,14 @@ protected:
 
 
 private:
-  /**
-   * Implementation of the interface in Mapping.
-   *
-   * Description of effects:
-   * <ul>
-   * <li> if @p update_quadrature_points is required, the output will contain
-   * @p update_transformation_values. This computes the values of the
-   * transformation basis polynomials at the unit cell quadrature points.
-   * <li> if any of @p update_covariant_transformation, @p
-   * update_contravariant_transformation, @p update_JxW_values, @p
-   * update_boundary_forms, @p update_normal_vectors is required, the output
-   * will contain @p update_transformation_gradients to compute derivatives of
-   * the transformation basis polynomials.
-   * </ul>
-   */
-  virtual UpdateFlags update_once (const UpdateFlags flags) const;
 
   /**
-   * Implementation of the interface in Mapping.
-   *
-   * Description of effects if @p flags contains:
-   * <ul>
-   * <li> <code>update_quadrature_points</code> is copied to the output to
-   * compute the quadrature points on the real cell.
-   * <li> <code>update_JxW_values</code> is copied and requires @p
-   * update_boundary_forms on faces. The latter, because the surface element
-   * is just the norm of the boundary form.
-   * <li> <code>update_normal_vectors</code> is copied and requires @p
-   * update_boundary_forms. The latter, because the normal vector is the
-   * normalized boundary form.
-   * <li> <code>update_covariant_transformation</code> is copied and requires
-   * @p update_contravariant_transformation, since it is computed as the
-   * inverse of the latter.
-   * <li> <code>update_JxW_values</code> is copied and requires
-   * <code>update_contravariant_transformation</code>, since it is computed as
-   * one over determinant of the latter.
-   * <li> <code>update_boundary_forms</code> is copied and requires
-   * <code>update_contravariant_transformation</code>, since the boundary form
-   * is computed as the contravariant image of the normal vector to the unit
-   * cell.
-   * </ul>
+   * Implementation of the corresponding function in the base class,
+   * Mapping::requires_update_flags(). See there for more information.
    */
-  virtual UpdateFlags update_each (const UpdateFlags flags) const;
+  virtual
+  UpdateFlags
+  requires_update_flags (const UpdateFlags update_flags) const;
 
   /**
    * Implementation of the Mapping::get_data() interface.

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3214,8 +3214,7 @@ FEValuesBase<dim,spacedim>::compute_update_flags (const UpdateFlags update_flags
   UpdateFlags flags = update_flags
                       | fe->update_once (update_flags)
                       | fe->update_each (update_flags);
-  flags |= mapping->update_once (flags)
-           | mapping->update_each (flags);
+  flags |= mapping->requires_update_flags (flags);
 
   return flags;
 }

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -125,43 +125,15 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_shapes_virtual (
 
 template<int dim, int spacedim, class VECTOR, class DH>
 UpdateFlags
-MappingFEField<dim,spacedim,VECTOR,DH>::update_once (const UpdateFlags) const
+MappingFEField<dim,spacedim,VECTOR,DH>::requires_update_flags (const UpdateFlags in) const
 {
-  // nothing here
-  return update_default;
-}
-
-
-
-template<int dim, int spacedim, class VECTOR, class DH>
-UpdateFlags
-MappingFEField<dim,spacedim,VECTOR,DH>::update_each (const UpdateFlags in) const
-{
-  // Select flags of concern for the
-  // transformation.
-  UpdateFlags out = UpdateFlags(in & (update_quadrature_points
-                                      | update_covariant_transformation
-                                      | update_contravariant_transformation
-                                      | update_JxW_values
-                                      | update_boundary_forms
-                                      | update_normal_vectors
-                                      | update_volume_elements
-                                      | update_jacobians
-                                      | update_jacobian_grads
-                                      | update_inverse_jacobians));
-
-  // add flags if the respective
-  // quantities are necessary to
-  // compute what we need. note that
-  // some flags appear in both
-  // conditions and in subsequent
-  // set operations. this leads to
-  // some circular logic. the only
-  // way to treat this is to
-  // iterate. since there are 5
-  // if-clauses in the loop, it will
-  // take at most 4 iterations to
+  // add flags if the respective quantities are necessary to compute
+  // what we need. note that some flags appear in both conditions and
+  // in subsequent set operations. this leads to some circular
+  // logic. the only way to treat this is to iterate. since there are
+  // 5 if-clauses in the loop, it will take at most 4 iterations to
   // converge. do them:
+  UpdateFlags out = in;
   for (unsigned int i=0; i<5; ++i)
     {
       // The following is a little incorrect:
@@ -214,36 +186,38 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_data (const UpdateFlags      upd
                                                       const unsigned int     n_original_q_points,
                                                       InternalData           &data) const
 {
-  data.update_each = update_each(update_flags);
+  // store the flags in the internal data object so we can access them
+  // in fill_fe_*_values(). use the transitive hull of the required
+  // flags
+  data.update_each = requires_update_flags(update_flags);
 
   const unsigned int n_q_points = q.size();
-  const UpdateFlags flags = update_once(update_flags) | update_each(update_flags);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (flags & update_quadrature_points)
+  if (data.update_each & update_quadrature_points)
     data.shape_values.resize(data.n_shape_functions * n_q_points);
 
-  if (flags & (update_covariant_transformation
-               | update_contravariant_transformation
-               | update_JxW_values
-               | update_boundary_forms
-               | update_normal_vectors
-               | update_jacobians
-               | update_jacobian_grads
-               | update_inverse_jacobians))
+  if (data.update_each & (update_covariant_transformation
+                          | update_contravariant_transformation
+                          | update_JxW_values
+                          | update_boundary_forms
+                          | update_normal_vectors
+                          | update_jacobians
+                          | update_jacobian_grads
+                          | update_inverse_jacobians))
     data.shape_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (flags & update_covariant_transformation)
+  if (data.update_each & update_covariant_transformation)
     data.covariant.resize(n_original_q_points);
 
-  if (flags & update_contravariant_transformation)
+  if (data.update_each & update_contravariant_transformation)
     data.contravariant.resize(n_original_q_points);
 
-  if (flags & update_volume_elements)
+  if (data.update_each & update_volume_elements)
     data.volume_elements.resize(n_original_q_points);
 
-  if (flags & update_jacobian_grads)
+  if (data.update_each & update_jacobian_grads)
     data.shape_second_derivatives.resize(data.n_shape_functions * n_q_points);
 
   compute_shapes_virtual (q.get_points(), data);
@@ -261,7 +235,7 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_face_data (const UpdateFlags upd
 
   if (dim > 1)
     {
-      if (update_flags & update_boundary_forms)
+      if (data.update_each & update_boundary_forms)
         {
           data.aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 


### PR DESCRIPTION
These two functions computed something that, in essence, is only important
for the internal implementation of the mapping classes. It should thus
not be part of the public interface of these classes. Consequently,
remove them and replace them by the only thing that is of interest,
namely to compute transitive closure of the set of flags one needs to
compute -- as now done using the requires_update_flags() function.

This addresses one half of #1335 (the Mapping side). In reference to #1198.