### PR TITLE
Add missing includes to fix compilation after #1371

### DIFF
--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -25,6 +25,7 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/multigrid/mg_tools.h>
 #include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/distributed/tria.h>
 
 #include <algorithm>
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7072,12 +7072,12 @@ namespace VectorTools
             }
         }
 
-#ifdef DEAL_II_WITH_P4EST
+#ifdef DEAL_II_WITH_MPI
     // if this was a distributed DoFHandler, we need to do the reduction
     // over the entire domain
-    if (const parallel::distributed::Triangulation<dim,spacedim> *
-        p_d_triangulation
-        = dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim> *>(&dof.get_tria()))
+    if (const parallel::Triangulation<dim,spacedim> *
+        p_triangulation
+        = dynamic_cast<const parallel::Triangulation<dim,spacedim> *>(&dof.get_tria()))
       {
         // The type used to store the elements of the global vector may be a
         // real or a complex number. Do the global reduction always with real
@@ -7090,7 +7090,7 @@ namespace VectorTools
 
         MPI_Allreduce (&my_values, &global_values, 3, MPI_DOUBLE,
                        MPI_SUM,
-                       p_d_triangulation->get_communicator());
+                       p_triangulation->get_communicator());
 
         set_possibly_complex_number(global_values[0], global_values[1],
                                     mean);

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -14,8 +14,8 @@
 //
 // ---------------------------------------------------------------------
 
-
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/sparsity_tools.h>
@@ -24,7 +24,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/grid_tools.h>
-#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 
 
 #include <algorithm>

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -25,6 +25,8 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/fe/fe.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
 
 #include <set>
 #include <algorithm>

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -25,6 +25,8 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler_policy.h>
 #include <deal.II/fe/fe.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
 
 #include <set>
 #include <algorithm>

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -39,6 +39,8 @@
 
 #include <deal.II/multigrid/mg_tools.h>
 
+#include <deal.II/distributed/tria.h>
+
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/cuthill_mckee_ordering.hpp>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -37,6 +37,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/hp/fe_values.h>
 #include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
 
 
 #include <algorithm>
@@ -1494,12 +1495,12 @@ namespace DoFTools
             ExcInternalError());
 
     // reduce information from all CPUs
-#if defined(DEAL_II_WITH_P4EST) && defined(DEAL_II_WITH_MPI)
+#ifdef DEAL_II_WITH_MPI
     const unsigned int dim = DH::dimension;
     const unsigned int spacedim = DH::space_dimension;
 
-    if (const parallel::distributed::Triangulation<dim,spacedim> *tria
-        = (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
+    if (const parallel::Triangulation<dim,spacedim> *tria
+        = (dynamic_cast<const parallel::Triangulation<dim,spacedim>*>
            (&dof_handler.get_tria())))
       {
         std::vector<types::global_dof_index> local_dof_count = dofs_per_component;
@@ -1573,12 +1574,11 @@ namespace DoFTools
           += std::count(dofs_by_block.begin(), dofs_by_block.end(),
                         block);
 
-#ifdef DEAL_II_WITH_P4EST
 #ifdef DEAL_II_WITH_MPI
         // if we are working on a parallel mesh, we now need to collect
         // this information from all processors
-        if (const parallel::distributed::Triangulation<DH::dimension,DH::space_dimension> *tria
-            = (dynamic_cast<const parallel::distributed::Triangulation<DH::dimension,DH::space_dimension>*>
+        if (const parallel::Triangulation<DH::dimension,DH::space_dimension> *tria
+            = (dynamic_cast<const parallel::Triangulation<DH::dimension,DH::space_dimension>*>
                (&dof_handler.get_tria())))
           {
             std::vector<types::global_dof_index> local_dof_count = dofs_per_block;
@@ -1587,7 +1587,6 @@ namespace DoFTools
                             DEAL_II_DOF_INDEX_MPI_TYPE,
                             MPI_SUM, tria->get_communicator());
           }
-#endif
 #endif
       }
   }

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -26,6 +26,8 @@
 #include <deal.II/grid/tria_levels.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/fe/fe.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
 
 #include <set>
 #include <algorithm>

--- a/source/numerics/error_estimator.cc
+++ b/source/numerics/error_estimator.cc
@@ -37,6 +37,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/hp/mapping_collection.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/distributed/tria.h>
 
 #include <deal.II/base/std_cxx11/bind.h>
 

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -37,6 +37,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/hp/mapping_collection.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/distributed/tria.h>
 
 #include <deal.II/base/std_cxx11/bind.h>
 


### PR DESCRIPTION
The patch #1371 removes the includes of distributed/tria.h and distributed/shared_tria.h from tria_accessor.templates.h and thus, the generic deal.II compilation. I consider this a good thing (even though I should have paid attention to that when merging #1371), so to compile deal.II we need to add includes in the relevant files where we do upcasting to a distributed triangulation.