### PR TITLE
Properly document get_data() and friends.

### DIFF
--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -54,16 +54,19 @@ template <int dim, int spacedim=dim>
 class MappingCartesian : public Mapping<dim,spacedim>
 {
 public:
+  // documentation can be found in Mapping::get_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 
+  // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
+  // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,
@@ -224,10 +227,7 @@ protected:
                      std::vector<Point<dim> > &normal_vectors) const;
 
 private:
-  /**
-   * Implementation of the corresponding function in the base class,
-   * Mapping::requires_update_flags(). See there for more information.
-   */
+  // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
   requires_update_flags (const UpdateFlags update_flags) const;

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -54,6 +54,13 @@ template <int dim, int spacedim=dim>
 class MappingCartesian : public Mapping<dim,spacedim>
 {
 public:
+private:
+
+  /**
+   * @name Interface with FEValues
+   * @{
+   */
+
   // documentation can be found in Mapping::get_data()
   virtual
   typename Mapping<dim, spacedim>::InternalDataBase *
@@ -72,11 +79,7 @@ public:
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
 
-  /**
-   * Compute mapping-related information for a cell.
-   * See the documentation of Mapping::fill_fe_values() for
-   * a discussion of purpose, arguments, and return value of this function.
-   */
+  // documentation can be found in Mapping::fill_fe_values()
   virtual
   CellSimilarity::Similarity
   fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
@@ -85,11 +88,7 @@ public:
                   const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
                   internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
 
-  /**
-   * Compute mapping-related information for a face of a cell.
-   * See the documentation of Mapping::fill_fe_face_values() for
-   * a discussion of purpose and arguments of this function.
-   */
+  // documentation can be found in Mapping::fill_fe_face_values()
   virtual void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                        const unsigned int                                         face_no,
@@ -97,11 +96,7 @@ public:
                        const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
                        internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
 
-  /**
-   * Compute mapping-related information for a child of a face of a cell.
-   * See the documentation of Mapping::fill_fe_subface_values() for
-   * a discussion of purpose and arguments of this function.
-   */
+  // documentation can be found in Mapping::fill_fe_subface_values()
   virtual void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                           const unsigned int                                         face_no,
@@ -109,6 +104,10 @@ public:
                           const Quadrature<dim-1>                                   &quadrature,
                           const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
                           internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+
+  /**
+   * @}
+   */
 
   virtual void
   transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -519,10 +519,7 @@ private:
   compute_shapes_virtual (const std::vector<Point<dim> > &unit_points,
                           typename MappingFEField<dim, spacedim>::InternalData &data) const;
 
-  /**
-   * Implementation of the corresponding function in the base class,
-   * Mapping::requires_update_flags(). See there for more information.
-   */
+  // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
   requires_update_flags (const UpdateFlags update_flags) const;
@@ -547,28 +544,19 @@ private:
                      const unsigned int     n_original_q_points,
                      InternalData           &data) const;
 
-  /**
-   * Reimplemented from Mapping. See the documentation of the base class for
-   * detailed information.
-   */
+  // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 
-  /**
-   * Reimplemented from Mapping. See the documentation of the base class for
-   * detailed information.
-   */
+  // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
-  /**
-   * Reimplemented from Mapping. See the documentation of the base class for
-   * detailed information.
-   */
+  // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -150,88 +150,8 @@ public:
   virtual
   Mapping<dim,spacedim> *clone () const;
 
-  /**
-   * Storage for internal data of this mapping. See Mapping::InternalDataBase
-   * for an extensive description.
-   *
-   * This includes data that is computed once when the object is created
-   * (in get_data()) as well as data the class wants to store from between
-   * the call to fill_fe_values(), fill_fe_face_values(), or
-   * fill_fe_subface_values() until possible later calls from the finite
-   * element to functions such as transform(). The latter class of
-   * member variables are marked as 'mutable'.
-   *
-   * The current class uses essentially the same fields for storage
-   * as the MappingQ1 class. Consequently, it inherits from
-   * MappingQ1::InternalData, rather than from Mapping::InternalDataBase.
-   */
-  class InternalData : public MappingQ1<dim,spacedim>::InternalData
-  {
-  public:
-    /**
-     * Constructor.
-     */
-    InternalData (const unsigned int n_shape_functions);
-
-
-    /**
-     * Return an estimate (in bytes) or the memory consumption of this object.
-     */
-    virtual std::size_t memory_consumption () const;
-
-    /**
-     * Flag that is set by the <tt>fill_fe_[[sub]face]_values</tt> function.
-     *
-     * If this flag is @p true we are on an interior cell and the @p
-     * mapping_q1_data is used.
-     */
-    mutable bool use_mapping_q1_on_current_cell;
-
-    /**
-     * A structure to store the corresponding information for the pure
-     * $Q_1$ mapping that is, by default, used on all interior cells.
-     */
-    typename MappingQ1<dim,spacedim>::InternalData mapping_q1_data;
-  };
 
 protected:
-  /**
-   * Compute mapping-related information for a cell.
-   * See the documentation of Mapping::fill_fe_values() for
-   * a discussion of purpose, arguments, and return value of this function.
-   */
-  virtual
-  CellSimilarity::Similarity
-  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const CellSimilarity::Similarity                           cell_similarity,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
-
-  /**
-   * Compute mapping-related information for a face of a cell.
-   * See the documentation of Mapping::fill_fe_face_values() for
-   * a discussion of purpose and arguments of this function.
-   */
-  virtual void
-  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
-
-  /**
-   * Compute mapping-related information for a child of a face of a cell.
-   * See the documentation of Mapping::fill_fe_subface_values() for
-   * a discussion of purpose and arguments of this function.
-   */
-  virtual void
-  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         subface_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
-                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
 
   /**
    * For <tt>dim=2,3</tt>. Append the support points of all shape functions
@@ -293,6 +213,57 @@ private:
                                          const TriaIterator &iter,
                                          std::vector<Point<spacedim> > &points) const;
 
+  /**
+   * @name Interface with FEValues
+   * @{
+   */
+
+protected:
+
+  /**
+   * Storage for internal data of this mapping. See Mapping::InternalDataBase
+   * for an extensive description.
+   *
+   * This includes data that is computed once when the object is created
+   * (in get_data()) as well as data the class wants to store from between
+   * the call to fill_fe_values(), fill_fe_face_values(), or
+   * fill_fe_subface_values() until possible later calls from the finite
+   * element to functions such as transform(). The latter class of
+   * member variables are marked as 'mutable'.
+   *
+   * The current class uses essentially the same fields for storage
+   * as the MappingQ1 class. Consequently, it inherits from
+   * MappingQ1::InternalData, rather than from Mapping::InternalDataBase.
+   */
+  class InternalData : public MappingQ1<dim,spacedim>::InternalData
+  {
+  public:
+    /**
+     * Constructor.
+     */
+    InternalData (const unsigned int n_shape_functions);
+
+
+    /**
+     * Return an estimate (in bytes) or the memory consumption of this object.
+     */
+    virtual std::size_t memory_consumption () const;
+
+    /**
+     * Flag that is set by the <tt>fill_fe_[[sub]face]_values</tt> function.
+     *
+     * If this flag is @p true we are on an interior cell and the @p
+     * mapping_q1_data is used.
+     */
+    mutable bool use_mapping_q1_on_current_cell;
+
+    /**
+     * A structure to store the corresponding information for the pure
+     * $Q_1$ mapping that is, by default, used on all interior cells.
+     */
+    typename MappingQ1<dim,spacedim>::InternalData mapping_q1_data;
+  };
+
   // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
@@ -310,6 +281,36 @@ private:
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
+
+  // documentation can be found in Mapping::fill_fe_values()
+  virtual
+  CellSimilarity::Similarity
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                  const CellSimilarity::Similarity                           cell_similarity,
+                  const Quadrature<dim>                                     &quadrature,
+                  const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                  internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+
+  // documentation can be found in Mapping::fill_fe_face_values()
+  virtual void
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                       const unsigned int                                         face_no,
+                       const Quadrature<dim-1>                                   &quadrature,
+                       const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                       internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+
+  // documentation can be found in Mapping::fill_fe_subface_values()
+  virtual void
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                          const unsigned int                                         face_no,
+                          const unsigned int                                         subface_no,
+                          const Quadrature<dim-1>                                   &quadrature,
+                          const typename Mapping<dim,spacedim>::InternalDataBase    &internal_data,
+                          internal::FEValues::MappingRelatedData<dim,spacedim>      &output_data) const;
+
+  /**
+   * @}
+   */
 
   /**
    * Compute shape values and/or derivatives.

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -293,27 +293,19 @@ private:
                                          const TriaIterator &iter,
                                          std::vector<Point<spacedim> > &points) const;
 
-
-  /**
-   * Implementation of the Mapping::get_data() interface.
-   *
-   * As allowed by C++ (using a feature called "covariant return
-   * types"), this function returns a pointer to a
-   * MappingQ::InternalData object since these objects are
-   * derived from the Mapping::InternalDataBase class, pointers to
-   * which are returned by the Mapping::get_data() function. This
-   * makes some uses of this function simpler.
-   */
+  // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 
+  // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
+  // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -177,7 +177,8 @@ public:
    * Storage for internal data of d-linear mappings. See Mapping::InternalDataBase
    * for an extensive description.
    *
-   * This includes data that is computed once when the object is created
+   * For the current class MappingQ1, the InternalData class store
+   * data that is computed once when the object is created
    * (in get_data()) as well as data the class wants to store from between
    * the call to fill_fe_values(), fill_fe_face_values(), or
    * fill_fe_subface_values() until possible later calls from the finite
@@ -496,34 +497,24 @@ protected:
 
 private:
 
-  /**
-   * Implementation of the corresponding function in the base class,
-   * Mapping::requires_update_flags(). See there for more information.
-   */
+  // documentation can be found in Mapping::requires_update_flags()
   virtual
   UpdateFlags
   requires_update_flags (const UpdateFlags update_flags) const;
 
-  /**
-   * Implementation of the Mapping::get_data() interface.
-   *
-   * As allowed by C++ (using a feature called "covariant return
-   * types"), this function returns a pointer to a
-   * MappingQ1::InternalData object since these objects are
-   * derived from the Mapping::InternalDataBase class, pointers to
-   * which are returned by the Mapping::get_data() function. This
-   * makes some uses of this function simpler.
-   */
+  // documentation can be found in Mapping::get_data()
   virtual
   InternalData *
   get_data (const UpdateFlags,
             const Quadrature<dim> &quadrature) const;
 
+  // documentation can be found in Mapping::get_face_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
+  // documentation can be found in Mapping::get_subface_data()
   virtual
   typename Mapping<dim,spacedim>::InternalDataBase *
   get_subface_data (const UpdateFlags flags,

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -699,7 +699,7 @@ namespace internal
      */
     template <int dim, int spacedim>
     void
-    maybe_compute_q_points (const typename dealii::MappingQ1<dim,spacedim>::DataSetDescriptor  data_set,
+    maybe_compute_q_points (const typename QProjector<dim>::DataSetDescriptor                 data_set,
                             const typename dealii::MappingQ1<dim,spacedim>::InternalData      &data,
                             std::vector<Point<spacedim> >                                     &quadrature_points)
     {
@@ -731,7 +731,7 @@ namespace internal
     template <int dim, int spacedim>
     void
     maybe_update_Jacobians (const CellSimilarity::Similarity                                   cell_similarity,
-                            const typename dealii::MappingQ1<dim,spacedim>::DataSetDescriptor  data_set,
+                            const typename dealii::QProjector<dim>::DataSetDescriptor          data_set,
                             const typename dealii::MappingQ1<dim,spacedim>::InternalData      &data)
     {
       const UpdateFlags update_flags = data.update_each;
@@ -808,7 +808,7 @@ namespace internal
     template <int dim, int spacedim>
     void
     maybe_update_jacobian_grads (const CellSimilarity::Similarity                                   cell_similarity,
-                                 const typename dealii::MappingQ1<dim,spacedim>::DataSetDescriptor  data_set,
+                                 const typename QProjector<dim>::DataSetDescriptor                  data_set,
                                  const typename dealii::MappingQ1<dim,spacedim>::InternalData      &data,
                                  std::vector<DerivativeForm<2,dim,spacedim> >                      &jacobian_grads)
     {
@@ -1181,7 +1181,7 @@ namespace internal
                             const typename dealii::Triangulation<dim,spacedim>::cell_iterator &cell,
                             const unsigned int                                                 face_no,
                             const unsigned int                                                 subface_no,
-                            const typename dealii::MappingQ1<dim,spacedim>::DataSetDescriptor  data_set,
+                            const typename QProjector<dim>::DataSetDescriptor                  data_set,
                             const Quadrature<dim-1>                                           &quadrature,
                             const typename dealii::MappingQ1<dim,spacedim>::InternalData      &data,
                             internal::FEValues::MappingRelatedData<dim,spacedim>              &output_data)


### PR DESCRIPTION
Also remove the documentation from these functions in derived classes
as doxygen properly copies the documentation from the corresponding
functions in the base class. This makes sure we only have to document
in one place and avoids things getting out of synch.