### PR TITLE
Fix path to cmake file.

### DIFF
--- a/tests/sharedtria/CMakeLists.txt
+++ b/tests/sharedtria/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
-INCLUDE(${DEAL_II_SOURCE_DIR}/tests/setup_testsubproject.cmake)
+INCLUDE(../setup_testsubproject.cmake)
 PROJECT(testsuite CXX)
 INCLUDE(${DEAL_II_TARGET_CONFIG})
 DEAL_II_PICKUP_TESTS()


### PR DESCRIPTION
The current path leads to a failure on my system when calling
'ninja setup_tests':

FAILED: cd /node/bangerth/trunk/build/tests/sharedtria && /w/bangerth/share/software/cmake-2.8.12.2/bin/cmake -GNinja -DDEAL_II_DIR=/node/bangerth/trunk/build -UDIFF_DIR -UNUMDIFF_DIR -UTEST_PICKUP_REGEX -UTEST_TIME_LIMIT /node/bangerth/trunk/dealii/tests/sharedtria > /dev/null
CMake Error at CMakeLists.txt:2 (INCLUDE):
  include could not find load file:

    ../tests/setup_testsubproject.cmake


CMake Error at CMakeLists.txt:4 (INCLUDE):
  include called with wrong number of arguments.  Include only takes one
  file.


Fix this by providing the same path as in the tests/distributed
directory.