### PR TITLE
Add debug flag when testing for support of C++14.

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -103,6 +103,10 @@ IF(NOT DEFINED DEAL_II_WITH_CXX14 OR DEAL_II_WITH_CXX14)
     MESSAGE(STATUS "Using C++ version flag \"${DEAL_II_CXX_VERSION_FLAG}\"")
     PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
 
+    # Some versions of clang are feature complete but do not have debug
+    # information.
+    PUSH_CMAKE_REQUIRED("-g")
+
     #
     # This test does not guarantee full C++14 support, but virtually every
     # compiler with some C++14 support implements this.


### PR DESCRIPTION
@koecher hit this bug with clang 3.5 when compiling the bundled version of boost: http://stackoverflow.com/questions/24617679/workaround-for-debug-symbol-error-with-auto-member-function This should fix the problem but I don't have a version of clang old enough to test it.