### PR TITLE
Parallelize FEValues construction.

### DIFF
--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3403,20 +3403,27 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
 
   // then get objects into which the FE and the Mapping can store
   // intermediate data used across calls to reinit. we can do this in parallel
+  Threads::Task<typename FiniteElement<dim,spacedim>::InternalDataBase *>
+  fe_get_data = Threads::new_task (&FiniteElement<dim,spacedim>::get_data,
+                                   *this->fe,
+                                   flags,
+                                   *this->mapping,
+                                   quadrature);
   Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase *>
   mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_data,
                                         *this->mapping,
                                         flags,
                                         quadrature);
 
-  this->fe_data.reset (this->fe->get_data(flags, *this->mapping, quadrature));
-  this->mapping_data.reset (mapping_get_data.return_value());
-
   // initialize the base classes
   internal::FEValues::MappingRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, flags);
   internal::FEValues::FiniteElementRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, *this->fe, flags);
 
   this->update_flags = flags;
+
+  // then collect answers from the two task above
+  this->fe_data.reset (fe_get_data.return_value());
+  this->mapping_data.reset (mapping_get_data.return_value());
 }
 
 
@@ -3636,20 +3643,27 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
 
   // then get objects into which the FE and the Mapping can store
   // intermediate data used across calls to reinit. this can be done in parallel
+  Threads::Task<typename FiniteElement<dim,spacedim>::InternalDataBase *>
+  fe_get_data = Threads::new_task (&FiniteElement<dim,spacedim>::get_face_data,
+                                   *this->fe,
+                                   flags,
+                                   *this->mapping,
+                                   this->quadrature);
   Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase *>
   mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_face_data,
                                         *this->mapping,
                                         flags,
                                         this->quadrature);
 
-  this->fe_data.reset (this->fe->get_face_data(flags, *this->mapping, this->quadrature));
-  this->mapping_data.reset (mapping_get_data.return_value());
-
   // initialize the base classes
   internal::FEValues::MappingRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, flags);
   internal::FEValues::FiniteElementRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, *this->fe, flags);
 
   this->update_flags = flags;
+
+  // then collect answers from the two task above
+  this->fe_data.reset (fe_get_data.return_value());
+  this->mapping_data.reset (mapping_get_data.return_value());
 }
 
 
@@ -3786,22 +3800,27 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   // then get objects into which the FE and the Mapping can store
   // intermediate data used across calls to reinit. this can be done
   // in parallel
+  Threads::Task<typename FiniteElement<dim,spacedim>::InternalDataBase *>
+  fe_get_data = Threads::new_task (&FiniteElement<dim,spacedim>::get_subface_data,
+                                   *this->fe,
+                                   flags,
+                                   *this->mapping,
+                                   this->quadrature);
   Threads::Task<typename Mapping<dim,spacedim>::InternalDataBase *>
   mapping_get_data = Threads::new_task (&Mapping<dim,spacedim>::get_subface_data,
                                         *this->mapping,
                                         flags,
                                         this->quadrature);
 
-  this->fe_data.reset (this->fe->get_subface_data(flags,
-                                                  *this->mapping,
-                                                  this->quadrature));
-  this->mapping_data.reset (mapping_get_data.return_value());
-
   // initialize the base classes
   internal::FEValues::MappingRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, flags);
   internal::FEValues::FiniteElementRelatedData<dim,spacedim>::initialize(this->n_quadrature_points, *this->fe, flags);
 
   this->update_flags = flags;
+
+  // then collect answers from the two task above
+  this->fe_data.reset (fe_get_data.return_value());
+  this->mapping_data.reset (mapping_get_data.return_value());
 }
 
 


### PR DESCRIPTION
There are two main operations in this function, namely to call
get_data() on both the mapping and the finite element. Do these
in the background while initializing some other data structures
in the meantime.