### PR TITLE
Fix FPE #include.

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -32,7 +32,9 @@
 #include <sstream>
 #include <iomanip>
 
-#include <cfenv>
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+#  include <cfenv>
+#endif
 
 
 // silence extra diagnostics in the testsuite


### PR DESCRIPTION
We only need the #include if we actually use the functions the file
provides. Disable it otherwise to ensure that the tests continue to
run on platforms that don't provide <cfenv>.

This fixes the problem pointed out here:
https://github.com/dealii/dealii/commit/a80532b259c16b9ce1f2f11bcb3b38e40a10b916#commitcomment-12816137 .