### PR TITLE
Remove apple gcc 3 compatability

### DIFF
--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2277,11 +2277,6 @@ neighbor_child_on_subface (const unsigned int face,
 
 
 
-// Remark: The explicit instantiations for "TriaAccessor" were moved
-// to the top of this source file. The reason is a slightly buggy version
-// of the Apple gcc v.3.3.
-// For more information, see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=24331
-
 // explicit instantiations
 #include "tria_accessor.inst"
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2281,4 +2281,3 @@ neighbor_child_on_subface (const unsigned int face,
 #include "tria_accessor.inst"
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/grid/tria_accessor.inst.in
+++ b/source/grid/tria_accessor.inst.in
@@ -62,7 +62,7 @@ for (deal_II_dimension : DIMENSIONS)
 
     template class TriaAccessor<1,deal_II_dimension,2>;
     template class TriaAccessor<1,deal_II_dimension,3>;
-    
+
 
 #endif
 #if deal_II_dimension == 2
@@ -91,5 +91,3 @@ for (deal_II_dimension : DIMENSIONS)
 
 #endif
   }
-
-    

--- a/source/grid/tria_accessor.inst.in
+++ b/source/grid/tria_accessor.inst.in
@@ -17,10 +17,6 @@
 
 for (deal_II_dimension : DIMENSIONS)
   {
-// Remark: The explicit instantiations for "TriaAccessor" were moved
-// to the top of this source file. The reason is a slightly buggy version
-// of the Apple gcc v.3.3.
-// For more information, see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=24331
     template class TriaAccessorBase<1,deal_II_dimension>;
 #if deal_II_dimension >= 2
     template class TriaAccessorBase<2,deal_II_dimension>;

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -321,29 +321,6 @@ BlockSparsityPatternBase<SparsityPatternBase>::print_gnuplot(std::ostream &out) 
 
 
 
-
-// Remark: The following explicit instantiations needed to be moved to
-// this place here to work around a problem with gcc3.3 on Apple MacOSX.
-// The reason is that some of the functions instantiated here are used
-// further down; if they are not explicitly instantiated here, then the
-// compiler will do an implicit instantiation and give it internal linkage
-// (despite the later explicit instantiation that should make sure it
-// gets external linkage). To make sure the functions have external
-// linkage, we need to place the explicit instantiation before the first
-// use.
-//
-// For more information, see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=24331
-// +++++++++++++
-
-
-template class BlockSparsityPatternBase<SparsityPattern>;
-template class BlockSparsityPatternBase<DynamicSparsityPattern>;
-#ifdef DEAL_II_WITH_TRILINOS
-template class BlockSparsityPatternBase<TrilinosWrappers::SparsityPattern>;
-#endif
-
-
-
 BlockSparsityPattern::BlockSparsityPattern ()
 {}
 
@@ -709,9 +686,10 @@ namespace TrilinosWrappers
 
 #endif
 
-// Remark: The explicit instantiations for "BlockSparsityPatternBase" were moved
-// to the top of this source file. The reason is a slightly buggy version
-// of the Apple gcc v.3.3.
-// For more information, see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=24331
+template class BlockSparsityPatternBase<SparsityPattern>;
+template class BlockSparsityPatternBase<DynamicSparsityPattern>;
+#ifdef DEAL_II_WITH_TRILINOS
+template class BlockSparsityPatternBase<TrilinosWrappers::SparsityPattern>;
+#endif
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This is another (I think the third) PR in the 'remove references to old GCC versions' category.