### PR TITLE
Adjust test output.

### DIFF
--- a/tests/sharedtria/dof_01.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/dof_01.with_metis=true.mpirun=3.output
@@ -1,50 +1,50 @@
 
 DEAL:0:2d::n_dofs: 818
 DEAL:0:2d::n_locally_owned_dofs: 289
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:0:2d::n_dofs: 1754
-DEAL:0:2d::n_locally_owned_dofs: 578
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:0:2d::n_locally_owned_dofs: 566
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:0:2d::n_dofs: 3056
-DEAL:0:2d::n_locally_owned_dofs: 1023
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:0:2d::n_locally_owned_dofs: 1018
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:0:3d::n_dofs: 13282
-DEAL:0:3d::n_locally_owned_dofs: 4446
-DEAL:0:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:0:3d::n_locally_owned_dofs: 4428
+DEAL:0:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:0:3d::n_dofs: 41826
-DEAL:0:3d::n_locally_owned_dofs: 13862
-DEAL:0:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:0:3d::n_locally_owned_dofs: 13741
+DEAL:0:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 
 DEAL:1:2d::n_dofs: 818
-DEAL:1:2d::n_locally_owned_dofs: 297
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:1:2d::n_locally_owned_dofs: 232
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:1:2d::n_dofs: 1754
-DEAL:1:2d::n_locally_owned_dofs: 588
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:1:2d::n_locally_owned_dofs: 607
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:1:2d::n_dofs: 3056
-DEAL:1:2d::n_locally_owned_dofs: 1013
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:1:2d::n_locally_owned_dofs: 992
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:1:3d::n_dofs: 13282
-DEAL:1:3d::n_locally_owned_dofs: 4386
-DEAL:1:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:1:3d::n_locally_owned_dofs: 4262
+DEAL:1:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:1:3d::n_dofs: 41826
-DEAL:1:3d::n_locally_owned_dofs: 14131
-DEAL:1:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:1:3d::n_locally_owned_dofs: 14200
+DEAL:1:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 
 
 DEAL:2:2d::n_dofs: 818
-DEAL:2:2d::n_locally_owned_dofs: 232
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:2:2d::n_locally_owned_dofs: 297
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:2:2d::n_dofs: 1754
-DEAL:2:2d::n_locally_owned_dofs: 588
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:2:2d::n_locally_owned_dofs: 581
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:2:2d::n_dofs: 3056
-DEAL:2:2d::n_locally_owned_dofs: 1020
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:2:2d::n_locally_owned_dofs: 1046
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:2:3d::n_dofs: 13282
-DEAL:2:3d::n_locally_owned_dofs: 4450
-DEAL:2:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:2:3d::n_locally_owned_dofs: 4592
+DEAL:2:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:2:3d::n_dofs: 41826
-DEAL:2:3d::n_locally_owned_dofs: 13833
-DEAL:2:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:2:3d::n_locally_owned_dofs: 13885
+DEAL:2:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 

--- a/tests/sharedtria/dof_02.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/dof_02.with_metis=true.mpirun=3.output
@@ -1,50 +1,50 @@
 
 DEAL:0:2d::n_dofs: 818
 DEAL:0:2d::n_locally_owned_dofs: 289
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:0:2d::n_dofs: 1754
-DEAL:0:2d::n_locally_owned_dofs: 578
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:0:2d::n_locally_owned_dofs: 566
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:0:2d::n_dofs: 3056
-DEAL:0:2d::n_locally_owned_dofs: 1023
-DEAL:0:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:0:2d::n_locally_owned_dofs: 1018
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:0:3d::n_dofs: 13282
-DEAL:0:3d::n_locally_owned_dofs: 4446
-DEAL:0:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:0:3d::n_locally_owned_dofs: 4428
+DEAL:0:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:0:3d::n_dofs: 41826
-DEAL:0:3d::n_locally_owned_dofs: 13862
-DEAL:0:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:0:3d::n_locally_owned_dofs: 13741
+DEAL:0:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 
 DEAL:1:2d::n_dofs: 818
-DEAL:1:2d::n_locally_owned_dofs: 297
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:1:2d::n_locally_owned_dofs: 232
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:1:2d::n_dofs: 1754
-DEAL:1:2d::n_locally_owned_dofs: 588
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:1:2d::n_locally_owned_dofs: 607
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:1:2d::n_dofs: 3056
-DEAL:1:2d::n_locally_owned_dofs: 1013
-DEAL:1:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:1:2d::n_locally_owned_dofs: 992
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:1:3d::n_dofs: 13282
-DEAL:1:3d::n_locally_owned_dofs: 4386
-DEAL:1:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:1:3d::n_locally_owned_dofs: 4262
+DEAL:1:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:1:3d::n_dofs: 41826
-DEAL:1:3d::n_locally_owned_dofs: 14131
-DEAL:1:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:1:3d::n_locally_owned_dofs: 14200
+DEAL:1:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 
 
 DEAL:2:2d::n_dofs: 818
-DEAL:2:2d::n_locally_owned_dofs: 232
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 289 297 232  sum: 818
+DEAL:2:2d::n_locally_owned_dofs: 297
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 289 232 297  sum: 818
 DEAL:2:2d::n_dofs: 1754
-DEAL:2:2d::n_locally_owned_dofs: 588
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 578 588 588  sum: 1754
+DEAL:2:2d::n_locally_owned_dofs: 581
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 566 607 581  sum: 1754
 DEAL:2:2d::n_dofs: 3056
-DEAL:2:2d::n_locally_owned_dofs: 1020
-DEAL:2:2d::n_locally_owned_dofs_per_processor: 1023 1013 1020  sum: 3056
+DEAL:2:2d::n_locally_owned_dofs: 1046
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 1018 992 1046  sum: 3056
 DEAL:2:3d::n_dofs: 13282
-DEAL:2:3d::n_locally_owned_dofs: 4450
-DEAL:2:3d::n_locally_owned_dofs_per_processor: 4446 4386 4450  sum: 13282
+DEAL:2:3d::n_locally_owned_dofs: 4592
+DEAL:2:3d::n_locally_owned_dofs_per_processor: 4428 4262 4592  sum: 13282
 DEAL:2:3d::n_dofs: 41826
-DEAL:2:3d::n_locally_owned_dofs: 13833
-DEAL:2:3d::n_locally_owned_dofs_per_processor: 13862 14131 13833  sum: 41826
+DEAL:2:3d::n_locally_owned_dofs: 13885
+DEAL:2:3d::n_locally_owned_dofs_per_processor: 13741 14200 13885  sum: 41826
 

--- a/tests/sharedtria/tria_01.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/tria_01.with_metis=true.mpirun=3.output
@@ -4,26 +4,26 @@ DEAL:0:2d:: locally_owned_subdomain(): 0
  n_levels: 3
  n_global_levels: 3
 
-DEAL:0:2d::subdomains: 0 1 0 1 2 1 2 
+DEAL:0:2d::subdomains: 0 1 0 2 2 1 1 
 DEAL:0:3d:: locally_owned_subdomain(): 0
  n_active_cells: 15
  n_levels: 3
  n_global_levels: 3
 
-DEAL:0:3d::subdomains: 0 2 0 1 0 0 0 2 2 2 2 1 1 1 1 
+DEAL:0:3d::subdomains: 0 2 0 1 0 0 0 2 1 2 2 1 1 2 2 
 
 DEAL:1:2d:: locally_owned_subdomain(): 1
  n_active_cells: 7
  n_levels: 3
  n_global_levels: 3
 
-DEAL:1:2d::subdomains: 0 1 0 1 2 1 2 
+DEAL:1:2d::subdomains: 0 1 0 2 2 1 1 
 DEAL:1:3d:: locally_owned_subdomain(): 1
  n_active_cells: 15
  n_levels: 3
  n_global_levels: 3
 
-DEAL:1:3d::subdomains: 0 2 0 1 0 0 0 2 2 2 2 1 1 1 1 
+DEAL:1:3d::subdomains: 0 2 0 1 0 0 0 2 1 2 2 1 1 2 2 
 
 
 DEAL:2:2d:: locally_owned_subdomain(): 2
@@ -31,11 +31,11 @@ DEAL:2:2d:: locally_owned_subdomain(): 2
  n_levels: 3
  n_global_levels: 3
 
-DEAL:2:2d::subdomains: 0 1 0 1 2 1 2 
+DEAL:2:2d::subdomains: 0 1 0 2 2 1 1 
 DEAL:2:3d:: locally_owned_subdomain(): 2
  n_active_cells: 15
  n_levels: 3
  n_global_levels: 3
 
-DEAL:2:3d::subdomains: 0 2 0 1 0 0 0 2 2 2 2 1 1 1 1 
+DEAL:2:3d::subdomains: 0 2 0 1 0 0 0 2 1 2 2 1 1 2 2 
 


### PR DESCRIPTION
This test seems to provide different results depending on what version
of NETIS is being used. At least this is suggested by the fact that
the results from the official tester are different than the original
results as added by Denis Davydov. Use the values from the official
'tester' machine.

I've looked whether any of the other testers succeed with these
tests, but haven't been able to find any evidence that they
actually run these tests at all. The tests need METIS which
probably not a lot of people have installed. So it may simply
be that nobody but me actually tried to run these tests, and
that that is why they don't show up among the failing
tests for all of the other regression tester machines.