### PR TITLE
Code cleanup and documentation update for periodic boundary conditions

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1220,13 +1220,13 @@ Article{JK10,
  * conditions</b></dt>
  * <dd>Periodic boundary condition are often used when only part of the physical
  * relevant domain is modeled. One assumes that the solution simply continues
- * periodically with respect to the boundaries that are condiered periodic.
+ * periodically with respect to the boundaries that are considered periodic.
  * In deal.II, support for this is through DoFTools::make_periodicity_constraints()
  * and GridTools::collect_periodic_faces(). As soon as a
  * parallel::distributed::Triangulation is used also
  * parallel::distributed::Triangulation::add_periodicity() has to be called to make
  * sure that all the processes know about relevant parts of the triangulation on both
- * sides of the periodic boundary. A typical process for disctributed triangulations would be:
+ * sides of the periodic boundary. A typical process for distributed triangulations would be:
  * -# Create a mesh
  * -# Gather the periodic faces using GridTools::collect_periodic_faces() (Triangulation)
  * -# Add the periodicity information to the mesh

--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1214,6 +1214,26 @@ Article{JK10,
  *     <td><i>Q<sub>k+1,k</sub> x Q<sub>k,k+1</sub></i></td>
  *     <td>Gauss points on edges(faces) and anisotropic Gauss points in the interior</td></tr>
  * </table>
+ *
+ *
+ * <dt class="glossary">@anchor GlossPeriodicConstraints <b>Periodic boundary
+ * conditions</b></dt>
+ * <dd>Periodic boundary condition are often used when only part of the physical
+ * relevant domain is modeled. One assumes that the solution simply continues
+ * periodically with respect to the boundaries that are condiered periodic.
+ * In deal.II, support for this is through DoFTools::make_periodicity_constraints()
+ * and GridTools::collect_periodic_faces(). As soon as a
+ * parallel::distributed::Triangulation is used also
+ * parallel::distributed::Triangulation::add_periodicity() has to be called to make
+ * sure that all the processes know about relevant parts of the triangulation on both
+ * sides of the periodic boundary. A typical process for disctributed triangulations would be:
+ * -# Create a mesh
+ * -# Gather the periodic faces using GridTools::collect_periodic_faces() (Triangulation)
+ * -# Add the periodicity information to the mesh
+ * using parallel::distributed::Triangulation::add_periodicity()
+ * -# Gather the periodic faces using GridTools::collect_periodic_faces() (DoFHandler)
+ * -# Add periodicity constraints using DoFTools::make_periodicity_constraints()
+ *
  *
  * <dt class="glossary">@anchor GlossPrimitive <b>Primitive finite
  * elements</b></dt>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,7 +38,15 @@ inconvenience this causes.
 </p>
 
 <ol>
-  
+
+  <li> Changed: The parameter @p first_vector_components has been removed
+  from GridTools::collect_periodic_faces(). Instead,
+  DoFTools::make_periodicity_constraints() now accepts a parameter
+  @p first_vector_components in all (supported) variants.
+  <br>
+  (Matthias maier, 2015/08/21)
+  </li>
+
   <li> Changed: FEValues::normal_vector() for historical reasons returned a
   value of type Point, though a normal vector is more adequately described
   as a Tensor@<1,dim@>. Many similar cases were already clarified in deal.II
@@ -100,6 +108,12 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Improved: The interface and documentation for periodic boundary
+  conditions have been restructured. A glossary entry has been written.
+  <br>
+  (Daniel Arndt, Matthias Maier, 2015/08/01-2015/08/21)
+  </li>
+
   <li> New: There is a new documentation module on
   @ref FE_vs_Mapping_vs_FEValues "How Mapping, FiniteElement, and FEValues work together".
   <br>

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -109,7 +109,8 @@ inconvenience this causes.
 
 <ol>
   <li> Improved: The interface and documentation for periodic boundary
-  conditions have been restructured. A glossary entry has been written.
+  conditions have been restructured. A
+  @ref GlossPeriodicConstraints "glossary entry" has been written.
   <br>
   (Daniel Arndt, Matthias Maier, 2015/08/01-2015/08/21)
   </li>

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -896,22 +896,20 @@ namespace DoFTools
    * and any combination of that...
    * @endcode
    *
-   * Optionally a matrix @p matrix along with an std::vector @p
-   * first_vector_components can be specified that describes how DoFs on @p
-   * face_1 should be modified prior to constraining to the DoFs of @p face_2.
-   * Here, two declarations are possible: If the std::vector @p
-   * first_vector_components is non empty the matrix is interpreted as a @p
-   * dim $\times$ @p dim rotation matrix that is applied to all vector valued
-   * blocks listed in @p first_vector_components of the FESystem. If @p
-   * first_vector_components is empty the matrix is interpreted as an
+   * Optionally a matrix @p matrix along with an std::vector
+   * @p first_vector_components can be specified that describes how DoFs on
+   * @p face_1 should be modified prior to constraining to the DoFs of
+   * @p face_2. Here, two declarations are possible: If the std::vector
+   * @p first_vector_components is non empty the matrix is interpreted as a
+   * @p dim $\times$ @p dim rotation matrix that is applied to all vector
+   * valued blocks listed in @p first_vector_components of the FESystem. If
+   * @p first_vector_components is empty the matrix is interpreted as an
    * interpolation matrix with size no_face_dofs $\times$ no_face_dofs.
    *
    * Detailed information can be found in the see
    * @ref GlossPeriodicConstraints "Glossary entry on periodic boundary conditions".
    *
-   * @todo: Reference to soon be written example step and glossary article.
-   *
-   * @author Matthias Maier, 2012, 2014
+   * @author Matthias Maier, 2012 - 2015
    */
   template<typename FaceIterator>
   void
@@ -947,15 +945,16 @@ namespace DoFTools
    * @ref GlossPeriodicConstraints "Glossary entry on periodic boundary conditions"
    * for further information.
    *
-   * @author Daniel Arndt, Matthias Maier, 2013, 2014
+   * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
   template<typename DH>
   void
   make_periodicity_constraints
   (const std::vector<GridTools::PeriodicFacePair<typename DH::cell_iterator> >
-   &periodic_faces,
-   dealii::ConstraintMatrix &constraint_matrix,
-   const ComponentMask      &component_mask = ComponentMask());
+                                   &periodic_faces,
+   dealii::ConstraintMatrix        &constraint_matrix,
+   const ComponentMask             &component_mask = ComponentMask(),
+   const std::vector<unsigned int> &first_vector_components = std::vector<unsigned int>());
 
 
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -933,8 +933,7 @@ namespace DoFTools
    * This is the main high level interface for above low level variant of
    * make_periodicity_constraints(). It takes an std::vector @p periodic_faces
    * as argument and applies above make_periodicity_constraints on each entry.
-   * The std::vector @p periodic_faces can be created by
-   * GridTools::collect_periodic_faces.
+   * @p periodic_faces can be created by GridTools::collect_periodic_faces.
    *
    * @note For DoFHandler objects that are built on a
    * parallel::distributed::Triangulation object

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -950,7 +950,7 @@ namespace DoFTools
   void
   make_periodicity_constraints
   (const std::vector<GridTools::PeriodicFacePair<typename DH::cell_iterator> >
-                                   &periodic_faces,
+   &periodic_faces,
    dealii::ConstraintMatrix        &constraint_matrix,
    const ComponentMask             &component_mask = ComponentMask(),
    const std::vector<unsigned int> &first_vector_components = std::vector<unsigned int>());

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -931,14 +931,15 @@ namespace DoFTools
    * into a ConstraintMatrix @p constraint_matrix.
    *
    * This is the main high level interface for above low level variant of
-   * make_periodicity_constraints(). It takes an std::vector @p periodic_faces
-   * as argument and applies above make_periodicity_constraints on each entry.
-   * @p periodic_faces can be created by GridTools::collect_periodic_faces.
+   * make_periodicity_constraints(). It takes a std::vector @p periodic_faces
+   * as argument and applies above make_periodicity_constraints() on each
+   * entry. @p periodic_faces can be created by
+   * GridTools::collect_periodic_faces.
    *
    * @note For DoFHandler objects that are built on a
    * parallel::distributed::Triangulation object
    * parallel::distributed::Triangulation::add_periodicity has to be called
-   * before.
+   * before calling this function..
    *
    * @see
    * @ref GlossPeriodicConstraints "Glossary entry on periodic boundary conditions"
@@ -975,22 +976,6 @@ namespace DoFTools
    * If this matching is successful it constrains all DoFs associated with the
    * 'first' boundary to the respective DoFs of the 'second' boundary
    * respecting the relative orientation of the two faces.
-   *
-   * This routine only constrains DoFs that are not already constrained. If
-   * this routine encounters a DoF that already is constrained (for instance
-   * by Dirichlet boundary conditions), the old setting of the constraint
-   * (dofs the entry is constrained to, inhomogeneities) is kept and nothing
-   * happens.
-   *
-   * The flags in the last parameter, @p component_mask (see
-   * @ref GlossComponentMask)
-   * denote which components of the finite element space shall be constrained
-   * with periodic boundary conditions. If it is left as specified by the
-   * default value all components are constrained. If it is different from the
-   * default value, it is assumed that the number of entries equals the number
-   * of components in the boundary functions and the finite element, and those
-   * components in the given boundary function will be used for which the
-   * respective flag was set in the component mask.
    *
    * @note: This function is a convenience wrapper. It internally calls
    * GridTools::collect_periodic_faces() with the supplied paramaters and

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -936,24 +936,18 @@ namespace GridTools
     std::bitset<3> orientation;
 
     /**
-     * A matrix that describes how vector valued DoFs of the first face should
-     * be modified prior to constraining to the DoFs of the second face. If
-     * the std::vector first_vector_components is non empty the matrix is
-     * interpreted as a @p dim $\times$ @p dim rotation matrix that is applied
-     * to all vector valued blocks listed in @p first_vector_components of the
-     * FESystem. If @p first_vector_components is empty the matrix is
-     * interpreted as an interpolation matrix with size no_face_dofs $\times$
-     * no_face_dofs. For more details see make_periodicity_constraints() and
-     * the glossary
-     * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
+     * A matrix that describes how vector valued DoFs of the first face
+     * should be modified prior to constraining to the DoFs of the second
+     * face. If the std::vector first_vector_components (supplied as a
+     * parameter to DofTools::make_periodicity_constraints()) is non empty
+     * the matrix is interpreted as a @p dim $\times$ @p dim rotation
+     * matrix that is applied to all vector valued blocks listed in @p
+     * first_vector_components of the FESystem. Alternatively, if @p
+     * first_vector_components is empty the matrix is interpreted as an
+     * interpolation matrix with size no_face_dofs $\times$ no_face_dofs.
+     * For more details see DoFTools::make_periodicity_constraints().
      */
     FullMatrix<double> matrix;
-
-    /**
-     * A vector of unsigned ints pointing to the first components of all
-     * vector valued blocks that should be rotated by matrix.
-     */
-    std::vector<unsigned int> first_vector_components;
   };
 
 
@@ -1047,9 +1041,10 @@ namespace GridTools
 
 
   /**
-   * This function will collect periodic face pairs on the coarsest mesh level
-   * of the given @p container (a Triangulation or DoFHandler) and add them to
-   * the vector @p matched_pairs leaving the original contents intact.
+   * This function will collect periodic face pairs on the coarsest mesh
+   * level of the given @p container (a Triangulation or DoFHandler) and
+   * add them to the vector @p matched_pairs leaving the original contents
+   * intact.
    *
    * Define a 'first' boundary as all boundary faces having boundary_id @p
    * b_id1 and a 'second' boundary consisting of all faces belonging to @p
@@ -1060,25 +1055,28 @@ namespace GridTools
    * orthogonal_equality().
    *
    * The bitset that is returned inside of PeriodicFacePair encodes the
-   * _relative_ orientation of the first face with respect to the second face,
-   * see the documentation of orthogonal_equality() for further details.
+   * _relative_ orientation of the first face with respect to the second
+   * face, see the documentation of orthogonal_equality() for further
+   * details.
    *
    * The @p direction refers to the space direction in which periodicity is
    * enforced.
    *
    * The @p offset is a vector tangential to the faces that is added to the
    * location of vertices of the 'first' boundary when attempting to match
-   * them to the corresponding vertices of the 'second' boundary. This can be
-   * used to implement conditions such as $u(0,y)=u(1,y+1)$.
+   * them to the corresponding vertices of the 'second' boundary. This can
+   * be used to implement conditions such as $u(0,y)=u(1,y+1)$.
    *
-   * Optionally a (dim x dim) rotation matrix @p matrix along with a vector @p
-   * first_vector_components can be specified that describes how vector valued
-   * DoFs of the first face should be modified prior to constraining to the
-   * DoFs of the second face. If @p first_vector_components is non empty the
-   * matrix is interpreted as a rotation matrix that is applied to all vector
-   * valued blocks listed in @p first_vector_components of the FESystem. For
-   * more details see make_periodicity_constraints() and the glossary
-   * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
+   * Optionally a @p matrix can be specified that describes how vector
+   * valued DoFs of the first face should be modified prior to constraining
+   * to the DoFs of the second face. If the matrix has size
+   * $n\_face\_dofs\times n\_face\_dofs$, the periodicity constraints are
+   * applied as $dofs\_2 = matrix\cdot dofs\_1$. If the matrix has size
+   * $dim\times dim$, the matrix is interpreted as a rotation matrix for
+   * vector valued components.
+   * For more details see DoFTools::make_periodicity_constraints(), the
+   * glossary @ref GlossPeriodicConstraints "glossary entry on periodic
+   * conditions" and @ref step_45 "step-45".
    *
    * @tparam Container A type that satisfies the requirements of a mesh
    * container (see
@@ -1090,11 +1088,11 @@ namespace GridTools
    * periodicity algebraically.
    *
    * @note Because elements will be added to @p matched_pairs (and existing
-   * entries will be preserved), it is possible to call this function several
-   * times with different boundary ids to generate a vector with all periodic
-   * pairs.
+   * entries will be preserved), it is possible to call this function
+   * several times with different boundary ids to generate a vector with
+   * all periodic pairs.
    *
-   * @author Daniel Arndt, Matthias Maier, 2013, 2014
+   * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
   template <typename CONTAINER>
   void
@@ -1105,8 +1103,7 @@ namespace GridTools
    const int                                                          direction,
    std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
    const Tensor<1,CONTAINER::space_dimension>                        &offset = dealii::Tensor<1,CONTAINER::space_dimension>(),
-   const FullMatrix<double>                                          &matrix = FullMatrix<double>(),
-   const std::vector<unsigned int>                                   &first_vector_components = std::vector<unsigned int>());
+   const FullMatrix<double>                                          &matrix = FullMatrix<double>());
 
 
   /**
@@ -1150,8 +1147,7 @@ namespace GridTools
    const int                                                          direction,
    std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
    const dealii::Tensor<1,CONTAINER::space_dimension>                &offset = dealii::Tensor<1,CONTAINER::space_dimension>(),
-   const FullMatrix<double>                                          &matrix = FullMatrix<double>(),
-   const std::vector<unsigned int>                                   &first_vector_components = std::vector<unsigned int>());
+   const FullMatrix<double>                                          &matrix = FullMatrix<double>());
 
   /*@}*/
   /**

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -936,17 +936,16 @@ namespace GridTools
     std::bitset<3> orientation;
 
     /**
-     * A matrix that describes how vector valued DoFs of the first face
-     * should be modified prior to constraining to the DoFs of the second
-     * face. If the std::vector first_vector_components (supplied as a
-     * parameter to DofTools::make_periodicity_constraints()) is non empty
-     * the matrix is interpreted as a @p dim $\times$ @p dim rotation
-     * matrix that is applied to all vector valued blocks listed in @p
-     * first_vector_components of the finite element space. Alternatively,
-     * if @p first_vector_components is empty the matrix is interpreted as
-     * an interpolation matrix with size no_face_dofs $\times$
-     * no_face_dofs. For more details see
-     * DoFTools::make_periodicity_constraints() and the glossary
+     * A @p dim $\times$ @p dim rotation matrix that describes how vector
+     * valued DoFs of the first face should be modified prior to
+     * constraining to the DoFs of the second face.
+     *
+     * The rotation matrix is used in
+     * DoFTools::make_periodicity_constriants() by applying the rotation to
+     * all vector valued blocks listed in the parameter
+     * @p first_vector_components of the finite element space.
+     * For more details see DoFTools::make_periodicity_constraints() and
+     * the glossary
      * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
      */
     FullMatrix<double> matrix;
@@ -959,11 +958,11 @@ namespace GridTools
    * @p face1 and @p face2 are considered equal, if a one to one matching
    * between its vertices can be achieved via an orthogonal equality relation.
    *
-   * Hereby, two vertices <tt>v_1</tt> and <tt>v_2</tt> are considered equal,
+   * Here, two vertices <tt>v_1</tt> and <tt>v_2</tt> are considered equal,
    * if $M\cdot v_1 + offset - v_2$ is parallel to the unit vector in unit
    * direction @p direction. If the parameter @p matrix is a reference to a
-   * spacedim x spacedim matrix, $M$ is set to @p matrix, otherwise $M$ is the
-   * identity matrix.
+   * spacedim x spacedim matrix, $M$ is set to @p matrix, otherwise $M$ is
+   * the identity matrix.
    *
    * If the matching was successful, the _relative_ orientation of @p face1
    * with respect to @p face2 is returned in the bitset @p orientation, where
@@ -1069,17 +1068,19 @@ namespace GridTools
    * them to the corresponding vertices of the 'second' boundary. This can
    * be used to implement conditions such as $u(0,y)=u(1,y+1)$.
    *
-   * Optionally, a @p matrix can be specified that describes how vector
-   * valued DoFs of the first face should be modified prior to constraining
-   * to the DoFs of the second face. If the matrix has size
-   * $n\_face\_dofs\times n\_face\_dofs$, the periodicity constraints are
-   * applied as $dofs\_2 = matrix\cdot dofs\_1$. If the matrix has size
-   * $dim\times dim$, the matrix is interpreted as a rotation matrix for
-   * vector valued components.
-   * For more details see DoFTools::make_periodicity_constraints(), the
+   * Optionally, a $dim\times dim$ rotation @p matrix can be specified that
+   * describes how vector valued DoFs of the first face should be modified
+   * prior to constraining to the DoFs of the second face.
+   * The @p matrix is used in two places. First, @p matrix will be supplied
+   * to orthogonal_equality() and used for matching faces: Two vertices
+   * $v_1$ and $v_2$ match if
+   * $\text{matrix}\cdot v_1 + \text{offset} - v_2$
+   * is parallel to the unit vector in unit direction @p direction.
+   * (For more details see DoFTools::make_periodicity_constraints(), the
    * glossary
    * @ref GlossPeriodicConstraints "glossary entry on periodic conditions"
-   * and @ref step_45 "step-45".
+   * and @ref step_45 "step-45"). Second, @p matrix will be stored in the
+   * PeriodicFacePair collection @p matched_pairs for further use.
    *
    * @tparam Container A type that satisfies the requirements of a mesh
    * container (see
@@ -1123,26 +1124,13 @@ namespace GridTools
    * This function will collect periodic face pairs on the coarsest mesh level
    * and add them to @p matched_pairs leaving the original contents intact.
    *
-   * Optionally, a @p matrix can be specified that describes how vector
-   * valued DoFs of the first face should be modified prior to constraining
-   * to the DoFs of the second face. If the matrix has size
-   * $n\_face\_dofs\times n\_face\_dofs$, the periodicity constraints are
-   * applied as $dofs\_2 = matrix\cdot dofs\_1$. If the matrix has size
-   * $dim\times dim$, the matrix is interpreted as a rotation matrix for
-   * vector valued components. For more details see
-   * DoFTools::make_periodicity_constraints(), the glossary
-   * @ref GlossPeriodicConstraints "glossary entry on periodic conditions"
-   * and @ref step_45 "step-45".
-   *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
+   * See above function for further details.
    *
    * @note This version of collect_periodic_face_pairs() will not work on
    * meshes with cells not in
    * @ref GlossFaceOrientation "standard orientation".
    *
-   * @author Daniel Arndt, Matthias Maier, 2013, 2014
+   * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
   template <typename CONTAINER>
   void

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -931,7 +931,7 @@ namespace GridTools
     /**
      * The relative orientation of the first face with respect to the second
      * face as described in orthogonal_equality() and
-     * make_periodicity_constraints() (and stored as a bitset).
+     * DoFTools::make_periodicity_constraints() (and stored as a bitset).
      */
     std::bitset<3> orientation;
 
@@ -945,7 +945,9 @@ namespace GridTools
      * first_vector_components of the FESystem. Alternatively, if @p
      * first_vector_components is empty the matrix is interpreted as an
      * interpolation matrix with size no_face_dofs $\times$ no_face_dofs.
-     * For more details see DoFTools::make_periodicity_constraints().
+     * For more details see DoFTools::make_periodicity_constraints() and
+     * the glossary
+     * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
      */
     FullMatrix<double> matrix;
   };
@@ -1060,14 +1062,14 @@ namespace GridTools
    * details.
    *
    * The @p direction refers to the space direction in which periodicity is
-   * enforced.
+   * enforced. When maching periodic faces this vector component is ignored.
    *
    * The @p offset is a vector tangential to the faces that is added to the
    * location of vertices of the 'first' boundary when attempting to match
    * them to the corresponding vertices of the 'second' boundary. This can
    * be used to implement conditions such as $u(0,y)=u(1,y+1)$.
    *
-   * Optionally a @p matrix can be specified that describes how vector
+   * Optionally, a @p matrix can be specified that describes how vector
    * valued DoFs of the first face should be modified prior to constraining
    * to the DoFs of the second face. If the matrix has size
    * $n\_face\_dofs\times n\_face\_dofs$, the periodicity constraints are
@@ -1075,8 +1077,9 @@ namespace GridTools
    * $dim\times dim$, the matrix is interpreted as a rotation matrix for
    * vector valued components.
    * For more details see DoFTools::make_periodicity_constraints(), the
-   * glossary @ref GlossPeriodicConstraints "glossary entry on periodic
-   * conditions" and @ref step_45 "step-45".
+   * glossary
+   * @ref GlossPeriodicConstraints "glossary entry on periodic conditions"
+   * and @ref step_45 "step-45".
    *
    * @tparam Container A type that satisfies the requirements of a mesh
    * container (see
@@ -1124,9 +1127,11 @@ namespace GridTools
    * first_vector_components can be specified that describes how vector valued
    * DoFs of the first face should be modified prior to constraining to the
    * DoFs of the second face. If @p first_vector_components is non empty the
-   * matrix is interpreted as a rotation matrix that is applied to all vector
-   * valued blocks listed in @p first_vector_components of the FESystem. For
-   * more details see make_periodicity_constraints() and the glossary
+   * matrix is interpreted as a rotation matrix that is applied to all
+   * vector valued blocks listed in @p first_vector_components of the
+   * FESystem. For more details see
+   * DoFTools::make_periodicity_constraints() and the glossary
+   *
    * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
    *
    * @tparam Container A type that satisfies the requirements of a mesh

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -942,11 +942,11 @@ namespace GridTools
      * parameter to DofTools::make_periodicity_constraints()) is non empty
      * the matrix is interpreted as a @p dim $\times$ @p dim rotation
      * matrix that is applied to all vector valued blocks listed in @p
-     * first_vector_components of the FESystem. Alternatively, if @p
-     * first_vector_components is empty the matrix is interpreted as an
-     * interpolation matrix with size no_face_dofs $\times$ no_face_dofs.
-     * For more details see DoFTools::make_periodicity_constraints() and
-     * the glossary
+     * first_vector_components of the finite element space. Alternatively,
+     * if @p first_vector_components is empty the matrix is interpreted as
+     * an interpolation matrix with size no_face_dofs $\times$
+     * no_face_dofs. For more details see
+     * DoFTools::make_periodicity_constraints() and the glossary
      * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
      */
     FullMatrix<double> matrix;
@@ -1123,16 +1123,16 @@ namespace GridTools
    * This function will collect periodic face pairs on the coarsest mesh level
    * and add them to @p matched_pairs leaving the original contents intact.
    *
-   * Optionally a rotation matrix @p matrix along with a vector @p
-   * first_vector_components can be specified that describes how vector valued
-   * DoFs of the first face should be modified prior to constraining to the
-   * DoFs of the second face. If @p first_vector_components is non empty the
-   * matrix is interpreted as a rotation matrix that is applied to all
-   * vector valued blocks listed in @p first_vector_components of the
-   * FESystem. For more details see
-   * DoFTools::make_periodicity_constraints() and the glossary
-   *
-   * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
+   * Optionally, a @p matrix can be specified that describes how vector
+   * valued DoFs of the first face should be modified prior to constraining
+   * to the DoFs of the second face. If the matrix has size
+   * $n\_face\_dofs\times n\_face\_dofs$, the periodicity constraints are
+   * applied as $dofs\_2 = matrix\cdot dofs\_1$. If the matrix has size
+   * $dim\times dim$, the matrix is interpreted as a rotation matrix for
+   * vector valued components. For more details see
+   * DoFTools::make_periodicity_constraints(), the glossary
+   * @ref GlossPeriodicConstraints "glossary entry on periodic conditions"
+   * and @ref step_45 "step-45".
    *
    * @tparam Container A type that satisfies the requirements of a mesh
    * container (see

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2267,9 +2267,10 @@ namespace DoFTools
   void
   make_periodicity_constraints
   (const std::vector<GridTools::PeriodicFacePair<typename DH::cell_iterator> >
-   &periodic_faces,
-   dealii::ConstraintMatrix &constraint_matrix,
-   const ComponentMask      &component_mask)
+                                   &periodic_faces,
+   dealii::ConstraintMatrix        &constraint_matrix,
+   const ComponentMask             &component_mask,
+   const std::vector<unsigned int> &first_vector_components)
   {
     typedef std::vector<GridTools::PeriodicFacePair<typename DH::cell_iterator> >
     FaceVector;
@@ -2300,7 +2301,7 @@ namespace DoFTools
                                      it->orientation[1],
                                      it->orientation[2],
                                      it->matrix,
-                                     it->first_vector_components);
+                                     first_vector_components);
       }
   }
 
@@ -2310,12 +2311,12 @@ namespace DoFTools
 
   template<typename DH>
   void
-  make_periodicity_constraints (const DH                       &dof_handler,
-                                const types::boundary_id       b_id1,
-                                const types::boundary_id       b_id2,
-                                const int                      direction,
-                                dealii::ConstraintMatrix       &constraint_matrix,
-                                const ComponentMask            &component_mask)
+  make_periodicity_constraints (const DH                        &dof_handler,
+                                const types::boundary_id        b_id1,
+                                const types::boundary_id        b_id2,
+                                const int                       direction,
+                                dealii::ConstraintMatrix        &constraint_matrix,
+                                const ComponentMask             &component_mask)
   {
     static const int space_dim = DH::space_dimension;
     (void)space_dim;
@@ -2341,11 +2342,11 @@ namespace DoFTools
 
   template<typename DH>
   void
-  make_periodicity_constraints (const DH                       &dof_handler,
-                                const types::boundary_id       b_id,
-                                const int                      direction,
-                                dealii::ConstraintMatrix       &constraint_matrix,
-                                const ComponentMask            &component_mask)
+  make_periodicity_constraints (const DH                        &dof_handler,
+                                const types::boundary_id         b_id,
+                                const int                        direction,
+                                dealii::ConstraintMatrix        &constraint_matrix,
+                                const ComponentMask             &component_mask)
   {
     static const int dim = DH::dimension;
     static const int space_dim = DH::space_dimension;

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2267,7 +2267,7 @@ namespace DoFTools
   void
   make_periodicity_constraints
   (const std::vector<GridTools::PeriodicFacePair<typename DH::cell_iterator> >
-                                   &periodic_faces,
+   &periodic_faces,
    dealii::ConstraintMatrix        &constraint_matrix,
    const ComponentMask             &component_mask,
    const std::vector<unsigned int> &first_vector_components)

--- a/source/dofs/dof_tools_constraints.inst.in
+++ b/source/dofs/dof_tools_constraints.inst.in
@@ -39,7 +39,8 @@ for (DH : DOFHANDLERS; deal_II_dimension : DIMENSIONS)
   DoFTools::make_periodicity_constraints<DH>
   (const std::vector<GridTools::PeriodicFacePair<DH::cell_iterator> > &,
    dealii::ConstraintMatrix &,
-   const ComponentMask &);
+   const ComponentMask &,
+   const std::vector<unsigned int> &);
 
 
   template

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2702,8 +2702,7 @@ next_cell:
    const int                                        direction,
    std::vector<PeriodicFacePair<CellIterator> >     &matched_pairs,
    const dealii::Tensor<1,CellIterator::AccessorType::space_dimension> &offset,
-   const FullMatrix<double>                         &matrix,
-   const std::vector<unsigned int>                  &first_vector_components)
+   const FullMatrix<double>                         &matrix)
   {
     static const int space_dim = CellIterator::AccessorType::space_dimension;
     (void)space_dim;
@@ -2741,8 +2740,7 @@ next_cell:
                   {cell1, cell2},
                   {face_idx1, face_idx2},
                   orientation,
-                  matrix,
-                  first_vector_components
+                  matrix
                 };
                 matched_pairs.push_back(matched_face);
                 pairs2.erase(it2);
@@ -2768,8 +2766,7 @@ next_cell:
    const int                                  direction,
    std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
    const Tensor<1,CONTAINER::space_dimension> &offset,
-   const FullMatrix<double>                   &matrix,
-   const std::vector<unsigned int>            &first_vector_components)
+   const FullMatrix<double>                   &matrix)
   {
     static const int dim = CONTAINER::dimension;
     static const int space_dim = CONTAINER::space_dimension;
@@ -2810,8 +2807,8 @@ next_cell:
             ExcMessage ("Unmatched faces on periodic boundaries"));
 
     // and call match_periodic_face_pairs that does the actual matching:
-    match_periodic_face_pairs(pairs1, pairs2, direction, matched_pairs,
-                              offset, matrix, first_vector_components);
+    match_periodic_face_pairs(pairs1, pairs2, direction, matched_pairs, offset,
+                              matrix);
   }
 
 
@@ -2824,8 +2821,7 @@ next_cell:
    const int                                  direction,
    std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
    const Tensor<1,CONTAINER::space_dimension> &offset,
-   const FullMatrix<double>                   &matrix,
-   const std::vector<unsigned int>            &first_vector_components)
+   const FullMatrix<double>                   &matrix)
   {
     static const int dim = CONTAINER::dimension;
     static const int space_dim = CONTAINER::space_dimension;
@@ -2873,8 +2869,8 @@ next_cell:
 #endif
 
     // and call match_periodic_face_pairs that does the actual matching:
-    match_periodic_face_pairs(pairs1, pairs2, direction, matched_pairs,
-                              offset, matrix, first_vector_components);
+    match_periodic_face_pairs(pairs1, pairs2, direction, matched_pairs, offset,
+                              matrix);
 
 #ifdef DEBUG
     //check for standard orientation

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -24,7 +24,7 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
   template
     unsigned int
     find_closest_vertex (const X &,
-			 const Point<deal_II_space_dimension> &);
+                         const Point<deal_II_space_dimension> &);
 
   template
     std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
@@ -37,19 +37,19 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
   template
     std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type, Point<deal_II_dimension> >
     find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-				   const X &,
-				   const Point<deal_II_space_dimension> &);
+                                   const X &,
+                                   const Point<deal_II_space_dimension> &);
 
   template
     std::list<std::pair<X::cell_iterator, X::cell_iterator> >
     get_finest_common_cells (const X &mesh_1,
-  			     const X &mesh_2);
+                               const X &mesh_2);
 
 
   template
     bool
     have_same_coarse_mesh (const X &mesh_1,
-			   const X &mesh_2);
+                           const X &mesh_2);
 
   \}
 
@@ -67,33 +67,33 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
   template
     unsigned int
     find_closest_vertex (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-			 const Point<deal_II_space_dimension> &);
+                         const Point<deal_II_space_dimension> &);
 
   template
     std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
     find_cells_adjacent_to_vertex(const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-				  const unsigned int);
+                                  const unsigned int);
   template
     dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type
     find_active_cell_around_point (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-				   const Point<deal_II_space_dimension> &p);
+                                   const Point<deal_II_space_dimension> &p);
 
   template
     std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type, Point<deal_II_dimension> >
     find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-				   const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-				   const Point<deal_II_space_dimension> &);
+                                   const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
+                                   const Point<deal_II_space_dimension> &);
 
   template
     std::list<std::pair<parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator, parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator> >
     get_finest_common_cells (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_1,
-  			     const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
+                               const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
 
 
   template
     bool
     have_same_coarse_mesh (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_1,
-			   const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
+                           const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
 
   \}
 
@@ -107,13 +107,13 @@ for (deal_II_space_dimension : SPACE_DIMENSIONS)
 
     dealii::internal::ActiveCellIterator<deal_II_space_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_space_dimension, deal_II_space_dimension> >::type
     find_active_cell_around_point (const parallel::distributed::Triangulation<deal_II_space_dimension> &,
-				   const Point<deal_II_space_dimension> &p);
+                                   const Point<deal_II_space_dimension> &p);
 
 
     std::pair<dealii::internal::ActiveCellIterator<deal_II_space_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_space_dimension, deal_II_space_dimension> >::type, Point<deal_II_space_dimension> >
     find_active_cell_around_point (const Mapping<deal_II_space_dimension> &,
-				   const parallel::distributed::Triangulation<deal_II_space_dimension> &,
-				   const Point<deal_II_space_dimension> &);
+                                   const parallel::distributed::Triangulation<deal_II_space_dimension> &,
+                                   const Point<deal_II_space_dimension> &);
 }
 
 
@@ -135,28 +135,28 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 
     template
       void delete_unused_vertices (std::vector<Point<deal_II_space_dimension> > &,
-				   std::vector<CellData<deal_II_dimension> > &,
-				   SubCellData &);
+                                   std::vector<CellData<deal_II_dimension> > &,
+                                   SubCellData &);
 
     template
       void delete_duplicated_vertices (std::vector<Point<deal_II_space_dimension> > &,
-				       std::vector<CellData<deal_II_dimension> > &,
-				       SubCellData &,
-				       std::vector<unsigned int> &,
-				       double);
+                                       std::vector<CellData<deal_II_dimension> > &,
+                                       SubCellData &,
+                                       std::vector<unsigned int> &,
+                                       double);
 
     template
       void shift<deal_II_dimension> (const Tensor<1,deal_II_space_dimension> &,
-						Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+                                                Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
     template
       void scale<deal_II_dimension> (const double,
-				     Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+                                     Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
     template
       void distort_random<deal_II_dimension> (const double,
-				     Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-				     const bool);
+                                     Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+                                     const bool);
 
     template
       void get_face_connectivity_of_cells
@@ -175,16 +175,16 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 
     template
       void partition_triangulation (const unsigned int,
-			       Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+                               Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
     template
       void partition_triangulation (const unsigned int,
-				    const SparsityPattern &,
-				    Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+                                    const SparsityPattern &,
+                                    Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
     template
       std::pair<hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>::active_cell_iterator,
-		Point<deal_II_dimension> >
+                Point<deal_II_dimension> >
       find_active_cell_around_point
       (const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension> &,
        const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
@@ -194,7 +194,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 
     template
       void get_subdomain_association (const Triangulation<deal_II_dimension, deal_II_space_dimension>  &,
-				      std::vector<types::subdomain_id> &);
+                                      std::vector<types::subdomain_id> &);
 
     template
     unsigned int count_cells_with_subdomain_association(
@@ -303,8 +303,7 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
                                       const int,
                                       std::vector<PeriodicFacePair<X::cell_iterator> > &,
                                       const Tensor<1,X::space_dimension> &,
-                                      const FullMatrix<double> &,
-                                      const std::vector<unsigned int> &);
+                                      const FullMatrix<double> &);
 
       template
       void collect_periodic_faces<X> (const X &,
@@ -312,8 +311,7 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
                                       const int,
                                       std::vector<PeriodicFacePair<X::cell_iterator> > &,
                                       const Tensor<1,X::space_dimension> &,
-                                      const FullMatrix<double> &,
-                                      const std::vector<unsigned int> &);
+                                      const FullMatrix<double> &);
 
     #endif
 
@@ -336,8 +334,7 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
                                   const int,
                                   std::vector<PeriodicFacePair<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::cell_iterator> > &,
                                   const Tensor<1,parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
-                                  const FullMatrix<double> &,
-                                  const std::vector<unsigned int> &);
+                                  const FullMatrix<double> &);
 
       template
       void
@@ -347,8 +344,7 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
                                   const int,
                                   std::vector<PeriodicFacePair<parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::cell_iterator> > &,
                                   const Tensor<1,parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>::space_dimension> &,
-                                  const FullMatrix<double> &,
-                                  const std::vector<unsigned int> &);
+                                  const FullMatrix<double> &);
      \}
    #endif
 #endif

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -362,12 +362,12 @@ namespace Step22
       std::vector<unsigned int> first_vector_components;
       first_vector_components.push_back(0);
 
-      GridTools::collect_periodic_faces
-      (dof_handler, 2, 3, 1, periodicity_vector, Tensor<1,dim>(),
-       matrix, first_vector_components);
+      GridTools::collect_periodic_faces(
+          dof_handler, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
-      DoFTools::make_periodicity_constraints<DoFHandler<dim> >
-      (periodicity_vector, constraints, fe.component_mask(velocities));
+      DoFTools::make_periodicity_constraints<DoFHandler<dim>>(
+          periodicity_vector, constraints, fe.component_mask(velocities)),
+          first_vector_components;
 #endif
     }
 
@@ -724,9 +724,8 @@ namespace Step22
     std::vector<unsigned int> first_vector_components;
     first_vector_components.push_back(0);
 
-    GridTools::collect_periodic_faces
-    (triangulation, 2, 3, 1, periodicity_vector, Tensor<1,dim>(),
-     matrix, first_vector_components);
+    GridTools::collect_periodic_faces(
+        triangulation, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
     triangulation.add_periodicity(periodicity_vector);
 #endif

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2008 - 2014 by the deal.II authors
+ * Copyright (C) 2008 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -363,12 +363,12 @@ namespace Step22
       std::vector<unsigned int> first_vector_components;
       first_vector_components.push_back(0);
 
-      GridTools::collect_periodic_faces
-      (dof_handler, 2, 3, 1, periodicity_vector, Tensor<1,dim>(),
-       matrix, first_vector_components);
+      GridTools::collect_periodic_faces(
+          dof_handler, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
-      DoFTools::make_periodicity_constraints<DoFHandler<dim> >
-      (periodicity_vector, constraints, fe.component_mask(velocities));
+      DoFTools::make_periodicity_constraints<DoFHandler<dim>>(
+          periodicity_vector, constraints, fe.component_mask(velocities),
+          first_vector_components);
 #endif
     }
 
@@ -727,9 +727,8 @@ namespace Step22
     std::vector<unsigned int> first_vector_components;
     first_vector_components.push_back(0);
 
-    GridTools::collect_periodic_faces
-    (triangulation, 2, 3, 1, periodicity_vector, Tensor<1,dim>(),
-     matrix, first_vector_components);
+    GridTools::collect_periodic_faces(
+        triangulation, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
     triangulation.add_periodicity(periodicity_vector);
 #endif


### PR DESCRIPTION
* Periodic bc: Relocate first_vector_components parameter

   This removes the first_vector_components parameter from
   GridTools::collect_periodic_faces(), as well as, the first_vector_components
   data field from the struct GridTools::PeriodicFacePair. The parameter is no
   added to all varianst of DoFTools::make_periodicity_constraints instead.

   This is an incompatible change made for consistency: A PeriodicFacePair
   should not store first_vector_components and with that information about the
   underlying finite element space.

* Fixup documentation for Periodicity constraints

   Closes #554