### PR TITLE
Restrict template arguments for FEValues::reinit().

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2465,8 +2465,8 @@ public:
    * associated with this object. It is assumed that the finite element used
    * by the given cell is also the one used by this FEValues object.
    */
-  template <class DH, bool level_dof_access>
-  void reinit (const TriaIterator<DoFCellAccessor<DH,level_dof_access> > &cell);
+  template <template <int,int> class DH, bool level_dof_access>
+  void reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>,level_dof_access> > &cell);
 
   /**
    * Reinitialize the gradients, Jacobi determinants, etc for the given cell
@@ -2671,8 +2671,8 @@ public:
    * Reinitialize the gradients, Jacobi determinants, etc for the face with
    * number @p face_no of @p cell and the given finite element.
    */
-  template <class DH, bool level_dof_access>
-  void reinit (const TriaIterator<DoFCellAccessor<DH,level_dof_access> > &cell,
+  template <template <int,int> class DH, bool level_dof_access>
+  void reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>,level_dof_access> > &cell,
                const unsigned int face_no);
 
   /**
@@ -2780,8 +2780,8 @@ public:
    * associated with this object. It is assumed that the finite element used
    * by the given cell is also the one used by this FESubfaceValues object.
    */
-  template <class DH, bool level_dof_access>
-  void reinit (const TriaIterator<DoFCellAccessor<DH,level_dof_access> > &cell,
+  template <template <int,int> class DH, bool level_dof_access>
+  void reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>,level_dof_access> > &cell,
                const unsigned int                    face_no,
                const unsigned int                    subface_no);
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3499,9 +3499,9 @@ void FEValues<dim,spacedim>::reinit (const typename Triangulation<dim,spacedim>:
 
 
 template <int dim, int spacedim>
-template <class DH, bool lda>
+template <template <int,int> class DH, bool lda>
 void
-FEValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &cell)
+FEValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > &cell)
 {
   // assert that the finite elements
   // passed to the constructor and
@@ -3515,7 +3515,7 @@ FEValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &c
   this->maybe_invalidate_previous_present_cell (cell);
   this->check_cell_similarity(cell);
 
-  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
+  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > > >
   (this->present_cell, cell);
 
   // this was the part of the work
@@ -3687,9 +3687,9 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
 
 
 template <int dim, int spacedim>
-template <class DH, bool lda>
+template <template <int,int> class DH, bool lda>
 void
-FEFaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &cell,
+FEFaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > &cell,
                                     const unsigned int face_no)
 {
   // assert that the finite elements
@@ -3706,7 +3706,7 @@ FEFaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> 
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));
 
   this->maybe_invalidate_previous_present_cell (cell);
-  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
+  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > > >
   (this->present_cell, cell);
 
   // this was the part of the work
@@ -3843,8 +3843,8 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
 
 
 template <int dim, int spacedim>
-template <class DH, bool lda>
-void FESubfaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH, lda> > &cell,
+template <template <int,int> class DH, bool lda>
+void FESubfaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > &cell,
                                             const unsigned int         face_no,
                                             const unsigned int         subface_no)
 {
@@ -3879,7 +3879,7 @@ void FESubfaceValues<dim,spacedim>::reinit (const TriaIterator<DoFCellAccessor<D
                       "instead in these cases."));
 
   this->maybe_invalidate_previous_present_cell (cell);
-  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH, lda> > > >
+  reset_pointer_in_place_if_possible<typename FEValuesBase<dim,spacedim>::template CellIterator<TriaIterator<DoFCellAccessor<DH<dim,spacedim>, lda> > > >
   (this->present_cell, cell);
 
   // this was the part of the work


### PR DESCRIPTION
There is a strange failure for the Intel compiler on some of the testcases
where it finds an undefined reference:
```
/local/offloaded/ssd-auto-deal-intel/buildintel15/lib/libdeal_II.g.so.8.4.pre: undefined reference to `void dealii::FEValues<1, 3>::reinit<dealii::DoFHandler<1, 1>, false>(dealii::TriaIterator<dealii::DoFCellAccessor<dealii::DoFHandler<1, 1>, false> > const&)'
/local/offloaded/ssd-auto-deal-intel/buildintel15/lib/libdeal_II.g.so.8.4.pre: undefined reference to `void dealii::FEValues<1, 2>::reinit<dealii::DoFHandler<1, 1>, false>(dealii::TriaIterator<dealii::DoFCellAccessor<dealii::DoFHandler<1, 1>, false> > const&)'
/local/offloaded/ssd-auto-deal-intel/buildintel15/lib/libdeal_II.g.so.8.4.pre: undefined reference to `void dealii::FEValues<2, 3>::reinit<dealii::DoFHandler<2, 2>, false>(dealii::TriaIterator<dealii::DoFCellAccessor<dealii::DoFHandler<2, 2>, false> > const&)'
```
This makes no sense since clearly dim and spacedim need to match between
the FEValues and the iterator. Where it makes the mistake
is unclear to me, but we can restrict arguments for this
function to only allow matching dim/spacedim values.