### PR TITLE
eliminate two compiler warnings

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -72,7 +72,7 @@ namespace parallel
 
   template <int dim, int spacedim>
   void
-  Triangulation<dim,spacedim>::copy_triangulation (const dealii::Triangulation<dim, spacedim> &old_tria)
+  Triangulation<dim,spacedim>::copy_triangulation (const dealii::Triangulation<dim, spacedim> &)
   {
     Assert (false, ExcNotImplemented());
   }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1006,9 +1006,10 @@ namespace internal
       {
 
 #ifndef DEAL_II_WITH_MPI
+        (void)new_numbers;
         (void)dof_handler;
+        (void)number_cache;
         Assert (false, ExcNotImplemented());
-
 #else
         std::vector<types::global_dof_index> global_gathered_numbers (dof_handler.n_dofs (), 0);
         // as we call DoFRenumbering::subdomain_wise (dof_handler) from distribute_dofs(),


### PR DESCRIPTION
Depending on configuration, the compiler warned about unused parameters. This is fixed now.