### PR TITLE
Further fe values cleanups 27

### DIFF
--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -445,29 +445,6 @@ private:
    * @}
    */
 
-  /**
-   * This function and the next allow to generate the transform require by the
-   * virtual transform() in mapping, but unfortunately in C++ one cannot
-   * declare a virtual template function.
-   */
-  template <int rank>
-  void
-  transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-                   VectorSlice<std::vector<Tensor<rank,spacedim> > >        output,
-                   const typename Mapping<dim,spacedim>::InternalDataBase  &internal,
-                   const MappingType                                        mapping_type) const;
-
-
-  /**
-   * See transform_fields() above.
-   */
-  template <int rank>
-  void
-  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > > input,
-                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                       output,
-                               const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
-                               const MappingType                                                          mapping_type) const;
-
 
   /**
    * Reference to the vector of shifts.

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -103,6 +103,7 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              const MappingType type) const;
 
+  // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > >    input,
@@ -110,6 +111,7 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              const MappingType type) const;
 
+  // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
@@ -117,6 +119,7 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              const MappingType type) const;
 
+  // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
@@ -124,58 +127,17 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              const MappingType type) const;
 
+  // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector<Tensor<3, dim> > >     input,
              VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              const MappingType type) const;
-  // for documentation, see the Mapping base class
-
-
-protected:
-  /**
-   * This function and the next ones allow to generate the transform required by the
-   * virtual transform() in mapping, but unfortunately in C++ one cannot
-   * declare a virtual template function.
-   */
-  template < int rank >
-  void
-  transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim>      > > input,
-                   VectorSlice<      std::vector<Tensor<rank,spacedim> > > output,
-                   const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-                   const MappingType type) const;
 
   /**
-   * see doc in transform_fields
+   * @}
    */
-  template < int rank >
-  void
-  transform_gradients(const VectorSlice<const std::vector<Tensor<rank,dim>      > > input,
-                      VectorSlice<      std::vector<Tensor<rank,spacedim> > > output,
-                      const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-                      const MappingType type) const;
-
-  /**
-   * see doc in transform_fields
-   */
-  void
-  transform_hessians(const VectorSlice<const std::vector<Tensor<3,dim> > > input,
-                     VectorSlice<std::vector<Tensor<3,spacedim> > > output,
-                     const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-                     const MappingType mapping_type) const;
-
-  /**
-   * see doc in transform_fields
-   */
-  template < int rank >
-  void
-  transform_differential_forms(
-    const VectorSlice<const std::vector<DerivativeForm<rank, dim, spacedim> > >    input,
-    VectorSlice<std::vector<Tensor<rank+1, spacedim> > > output,
-    const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-    const MappingType type) const;
-
 
   /**
    * @name Interface with FEValues

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -166,6 +166,24 @@ public:
     InternalData(const unsigned int n_shape_functions);
 
     /**
+     * Initialize the object's member variables related to cell data
+     * based on the given arguments.
+     */
+    void
+    initialize (const UpdateFlags      update_flags,
+                const Quadrature<dim> &quadrature,
+                const unsigned int     n_original_q_points);
+
+    /**
+     * Initialize the object's member variables related to cell and
+     * face data based on the given arguments.
+     */
+    void
+    initialize_face (const UpdateFlags      update_flags,
+                     const Quadrature<dim> &quadrature,
+                     const unsigned int     n_original_q_points);
+
+    /**
      * Shape function at quadrature point. Shape functions are in tensor
      * product order, so vertices must be reordered to obtain transformation.
      */
@@ -413,27 +431,6 @@ protected:
    */
   void compute_shapes (const std::vector<Point<dim> > &unit_points,
                        InternalData &data) const;
-
-  /**
-   * Do the computations for the @p get_data functions. Here, the data vectors
-   * of @p InternalData are reinitialized to proper size and shape values are
-   * computed.
-   */
-  void compute_data (const UpdateFlags flags,
-                     const Quadrature<dim> &quadrature,
-                     const unsigned int n_orig_q_points,
-                     InternalData &data) const;
-
-  /**
-   * Do the computations for the @p get_face_data functions. Here, the data
-   * vectors of @p InternalData are reinitialized to proper size and shape
-   * values and derivatives are computed. Furthermore @p unit_tangential
-   * vectors of the face are computed.
-   */
-  void compute_face_data (const UpdateFlags flags,
-                          const Quadrature<dim> &quadrature,
-                          const unsigned int n_orig_q_points,
-                          InternalData &data) const;
 
   /**
    * Compute shape values and/or derivatives.

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -203,21 +203,25 @@ MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::TaskGroup<> tasks;
   tasks += Threads::new_task (std_cxx11::function<void()>
-                              (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_data,
-                                               this,
+                              (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize,
+                                               data,
                                                update_flags,
                                                std_cxx11::cref(quadrature),
-                                               quadrature.size(),
-                                               std_cxx11::ref(*data))));
+                                               quadrature.size())));
   if (!use_mapping_q_on_all_cells)
     tasks += Threads::new_task (std_cxx11::function<void()>
-                                (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_data,
-                                                 this,
+                                (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize,
+                                                 &data->mapping_q1_data,
                                                  update_flags,
                                                  std_cxx11::cref(quadrature),
-                                                 quadrature.size(),
-                                                 std_cxx11::ref(data->mapping_q1_data))));
+                                                 quadrature.size())));
   tasks.join_all ();
+
+  // TODO: parallelize this as well
+  compute_shapes (quadrature.get_points(), *data);
+  if (!use_mapping_q_on_all_cells)
+    compute_shapes (quadrature.get_points(), data->mapping_q1_data);
+
 
   return data;
 }
@@ -235,21 +239,24 @@ MappingQ<dim,spacedim>::get_face_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::TaskGroup<> tasks;
   tasks += Threads::new_task (std_cxx11::function<void()>
-                              (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_face_data,
-                                               this,
+                              (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                                               data,
                                                update_flags,
                                                std_cxx11::cref(q),
-                                               quadrature.size(),
-                                               std_cxx11::ref(*data))));
+                                               quadrature.size())));
   if (!use_mapping_q_on_all_cells)
     tasks += Threads::new_task (std_cxx11::function<void()>
-                                (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_face_data,
-                                                 this,
+                                (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                                                 &data->mapping_q1_data,
                                                  update_flags,
                                                  std_cxx11::cref(q),
-                                                 quadrature.size(),
-                                                 std_cxx11::ref(data->mapping_q1_data))));
+                                                 quadrature.size())));
   tasks.join_all ();
+
+  // TODO: parallelize this as well
+  compute_shapes (q.get_points(), *data);
+  if (!use_mapping_q_on_all_cells)
+    compute_shapes (q.get_points(), data->mapping_q1_data);
 
   return data;
 }
@@ -267,21 +274,25 @@ MappingQ<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::TaskGroup<> tasks;
   tasks += Threads::new_task (std_cxx11::function<void()>
-                              (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_face_data,
-                                               this,
+                              (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                                               data,
                                                update_flags,
                                                std_cxx11::cref(q),
-                                               quadrature.size(),
-                                               std_cxx11::ref(*data))));
+                                               quadrature.size())));
   if (!use_mapping_q_on_all_cells)
     tasks += Threads::new_task (std_cxx11::function<void()>
-                                (std_cxx11::bind(&MappingQ<dim,spacedim>::compute_face_data,
-                                                 this,
+                                (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                                                 &data->mapping_q1_data,
                                                  update_flags,
                                                  std_cxx11::cref(q),
-                                                 quadrature.size(),
-                                                 std_cxx11::ref(data->mapping_q1_data))));
+                                                 quadrature.size())));
   tasks.join_all ();
+
+  // TODO: parallelize this as well
+  compute_shapes (q.get_points(), *data);
+  if (!use_mapping_q_on_all_cells)
+    compute_shapes (q.get_points(), data->mapping_q1_data);
+
 
   return data;
 }

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -68,6 +68,116 @@ MappingQ1<dim,spacedim>::InternalData::memory_consumption () const
 }
 
 
+template <int dim, int spacedim>
+void
+MappingQ1<dim,spacedim>::InternalData::
+initialize (const UpdateFlags      update_flags,
+            const Quadrature<dim> &q,
+            const unsigned int     n_original_q_points)
+{
+  // store the flags in the internal data object so we can access them
+  // in fill_fe_*_values()
+  this->update_each = update_flags;
+
+  const unsigned int n_q_points = q.size();
+
+  // see if we need the (transformation) shape function values
+  // and/or gradients and resize the necessary arrays
+  if (this->update_each & update_quadrature_points)
+    shape_values.resize(n_shape_functions * n_q_points);
+
+  if (this->update_each & (update_covariant_transformation
+                           | update_contravariant_transformation
+                           | update_JxW_values
+                           | update_boundary_forms
+                           | update_normal_vectors
+                           | update_jacobians
+                           | update_jacobian_grads
+                           | update_inverse_jacobians))
+    shape_derivatives.resize(n_shape_functions * n_q_points);
+
+  if (this->update_each & update_covariant_transformation)
+    covariant.resize(n_original_q_points);
+
+  if (this->update_each & update_contravariant_transformation)
+    contravariant.resize(n_original_q_points);
+
+  if (this->update_each & update_volume_elements)
+    volume_elements.resize(n_original_q_points);
+
+  if (this->update_each & update_jacobian_grads)
+    shape_second_derivatives.resize(n_shape_functions * n_q_points);
+}
+
+
+template <int dim, int spacedim>
+void
+MappingQ1<dim,spacedim>::InternalData::
+initialize_face (const UpdateFlags      update_flags,
+                 const Quadrature<dim> &q,
+                 const unsigned int     n_original_q_points)
+{
+  initialize (update_flags, q, n_original_q_points);
+
+  if (dim > 1)
+    {
+      if (this->update_each & update_boundary_forms)
+        {
+          aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
+
+          // Compute tangentials to the
+          // unit cell.
+          const unsigned int nfaces = GeometryInfo<dim>::faces_per_cell;
+          unit_tangentials.resize (nfaces*(dim-1),
+                                   std::vector<Tensor<1,dim> > (n_original_q_points));
+          if (dim==2)
+            {
+              // ensure a counterclockwise
+              // orientation of tangentials
+              static const int tangential_orientation[4]= {-1,1,1,-1};
+              for (unsigned int i=0; i<nfaces; ++i)
+                {
+                  Tensor<1,dim> tang;
+                  tang[1-i/2]=tangential_orientation[i];
+                  std::fill (unit_tangentials[i].begin(),
+                             unit_tangentials[i].end(), tang);
+                }
+            }
+          else if (dim==3)
+            {
+              for (unsigned int i=0; i<nfaces; ++i)
+                {
+                  Tensor<1,dim> tang1, tang2;
+
+                  const unsigned int nd=
+                    GeometryInfo<dim>::unit_normal_direction[i];
+
+                  // first tangential
+                  // vector in direction
+                  // of the (nd+1)%3 axis
+                  // and inverted in case
+                  // of unit inward normal
+                  tang1[(nd+1)%dim]=GeometryInfo<dim>::unit_normal_orientation[i];
+                  // second tangential
+                  // vector in direction
+                  // of the (nd+2)%3 axis
+                  tang2[(nd+2)%dim]=1.;
+
+                  // same unit tangents
+                  // for all quadrature
+                  // points on this face
+                  std::fill (unit_tangentials[i].begin(),
+                             unit_tangentials[i].end(), tang1);
+                  std::fill (unit_tangentials[nfaces+i].begin(),
+                             unit_tangentials[nfaces+i].end(), tang2);
+                }
+            }
+        }
+    }
+}
+
+
+
 
 template<int dim, int spacedim>
 MappingQ1<dim,spacedim>::MappingQ1 ()
@@ -531,51 +641,6 @@ MappingQ1<dim,spacedim>::requires_update_flags (const UpdateFlags in) const
 }
 
 
-template<int dim, int spacedim>
-void
-MappingQ1<dim,spacedim>::compute_data (const UpdateFlags      update_flags,
-                                       const Quadrature<dim> &q,
-                                       const unsigned int     n_original_q_points,
-                                       InternalData          &data) const
-{
-  // store the flags in the internal data object so we can access them
-  // in fill_fe_*_values(). use the transitive hull of the required
-  // flags
-  data.update_each = requires_update_flags(update_flags);
-
-  const unsigned int n_q_points = q.size();
-
-  // see if we need the (transformation) shape function values
-  // and/or gradients and resize the necessary arrays
-  if (data.update_each & update_quadrature_points)
-    data.shape_values.resize(data.n_shape_functions * n_q_points);
-
-  if (data.update_each & (update_covariant_transformation
-                          | update_contravariant_transformation
-                          | update_JxW_values
-                          | update_boundary_forms
-                          | update_normal_vectors
-                          | update_jacobians
-                          | update_jacobian_grads
-                          | update_inverse_jacobians))
-    data.shape_derivatives.resize(data.n_shape_functions * n_q_points);
-
-  if (data.update_each & update_covariant_transformation)
-    data.covariant.resize(n_original_q_points);
-
-  if (data.update_each & update_contravariant_transformation)
-    data.contravariant.resize(n_original_q_points);
-
-  if (data.update_each & update_volume_elements)
-    data.volume_elements.resize(n_original_q_points);
-
-  if (data.update_each & update_jacobian_grads)
-    data.shape_second_derivatives.resize(data.n_shape_functions * n_q_points);
-
-  compute_shapes (q.get_points(), data);
-}
-
-
 
 template<int dim, int spacedim>
 typename MappingQ1<dim,spacedim>::InternalData *
@@ -583,76 +648,10 @@ MappingQ1<dim,spacedim>::get_data (const UpdateFlags update_flags,
                                    const Quadrature<dim> &q) const
 {
   InternalData *data = new InternalData(n_shape_functions);
-  compute_data (update_flags, q, q.size(), *data);
+  data->initialize (requires_update_flags(update_flags), q, q.size());
+  compute_shapes (q.get_points(), *data);
+
   return data;
-}
-
-
-
-template<int dim, int spacedim>
-void
-MappingQ1<dim,spacedim>::compute_face_data (const UpdateFlags update_flags,
-                                            const Quadrature<dim> &q,
-                                            const unsigned int n_original_q_points,
-                                            InternalData &data) const
-{
-  compute_data (update_flags, q, n_original_q_points, data);
-
-  if (dim > 1)
-    {
-      if (data.update_each & update_boundary_forms)
-        {
-          data.aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
-
-          // Compute tangentials to the
-          // unit cell.
-          const unsigned int nfaces = GeometryInfo<dim>::faces_per_cell;
-          data.unit_tangentials.resize (nfaces*(dim-1),
-                                        std::vector<Tensor<1,dim> > (n_original_q_points));
-          if (dim==2)
-            {
-              // ensure a counterclockwise
-              // orientation of tangentials
-              static const int tangential_orientation[4]= {-1,1,1,-1};
-              for (unsigned int i=0; i<nfaces; ++i)
-                {
-                  Tensor<1,dim> tang;
-                  tang[1-i/2]=tangential_orientation[i];
-                  std::fill (data.unit_tangentials[i].begin(),
-                             data.unit_tangentials[i].end(), tang);
-                }
-            }
-          else if (dim==3)
-            {
-              for (unsigned int i=0; i<nfaces; ++i)
-                {
-                  Tensor<1,dim> tang1, tang2;
-
-                  const unsigned int nd=
-                    GeometryInfo<dim>::unit_normal_direction[i];
-
-                  // first tangential
-                  // vector in direction
-                  // of the (nd+1)%3 axis
-                  // and inverted in case
-                  // of unit inward normal
-                  tang1[(nd+1)%dim]=GeometryInfo<dim>::unit_normal_orientation[i];
-                  // second tangential
-                  // vector in direction
-                  // of the (nd+2)%3 axis
-                  tang2[(nd+2)%dim]=1.;
-
-                  // same unit tangents
-                  // for all quadrature
-                  // points on this face
-                  std::fill (data.unit_tangentials[i].begin(),
-                             data.unit_tangentials[i].end(), tang1);
-                  std::fill (data.unit_tangentials[nfaces+i].begin(),
-                             data.unit_tangentials[nfaces+i].end(), tang2);
-                }
-            }
-        }
-    }
 }
 
 
@@ -663,10 +662,11 @@ MappingQ1<dim,spacedim>::get_face_data (const UpdateFlags        update_flags,
                                         const Quadrature<dim-1> &quadrature) const
 {
   InternalData *data = new InternalData(n_shape_functions);
-  compute_face_data (update_flags,
-                     QProjector<dim>::project_to_all_faces(quadrature),
-                     quadrature.size(),
-                     *data);
+  data->initialize_face (requires_update_flags(update_flags),
+                         QProjector<dim>::project_to_all_faces(quadrature),
+                         quadrature.size());
+  compute_shapes (QProjector<dim>::project_to_all_faces(quadrature).get_points(),
+                  *data);
 
   return data;
 }
@@ -679,10 +679,12 @@ MappingQ1<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
                                            const Quadrature<dim-1>& quadrature) const
 {
   InternalData *data = new InternalData(n_shape_functions);
-  compute_face_data (update_flags,
-                     QProjector<dim>::project_to_all_subfaces(quadrature),
-                     quadrature.size(),
-                     *data);
+  data->initialize_face (requires_update_flags(update_flags),
+                         QProjector<dim>::project_to_all_subfaces(quadrature),
+                         quadrature.size());
+  compute_shapes (QProjector<dim>::project_to_all_subfaces(quadrature).get_points(),
+                  *data);
+
 
   return data;
 }

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1298,6 +1298,305 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 
 
+namespace
+{
+  template <int dim, int spacedim, int rank>
+  void
+  transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
+                   VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
+                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                   const MappingType mapping_type)
+  {
+    AssertDimension (input.size(), output.size());
+    Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
+            ExcInternalError());
+    const typename MappingQ1<dim,spacedim>::InternalData
+    &data = static_cast<const typename MappingQ1<dim,spacedim>::InternalData &>(mapping_data);
+
+    switch (mapping_type)
+      {
+      case mapping_contravariant:
+      {
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          output[i] = apply_transformation(data.contravariant[i], input[i]);
+
+        return;
+      }
+
+      case mapping_piola:
+      {
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+        Assert (data.update_each & update_volume_elements,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
+        Assert (rank==1, ExcMessage("Only for rank 1"));
+        if (rank!=1)
+          return;
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          {
+            output[i] = apply_transformation(data.contravariant[i], input[i]);
+            output[i] /= data.volume_elements[i];
+          }
+        return;
+      }
+      //We still allow this operation as in the
+      //reference cell Derivatives are Tensor
+      //rather than DerivativeForm
+      case mapping_covariant:
+      {
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          output[i] = apply_transformation(data.covariant[i], input[i]);
+
+        return;
+      }
+
+      default:
+        Assert(false, ExcNotImplemented());
+      }
+  }
+
+
+  template <int dim, int spacedim, int rank>
+  void
+  transform_gradients(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
+                      VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
+                      const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                      const MappingType mapping_type)
+  {
+    AssertDimension (input.size(), output.size());
+    Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
+            ExcInternalError());
+    const typename MappingQ1<dim,spacedim>::InternalData
+    &data = static_cast<const typename MappingQ1<dim,spacedim>::InternalData &>(mapping_data);
+
+    switch (mapping_type)
+      {
+      case mapping_contravariant_gradient:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+        Assert (rank==2, ExcMessage("Only for rank 2"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          {
+            DerivativeForm<1,spacedim,dim> A =
+              apply_transformation(data.contravariant[i], transpose(input[i]) );
+            output[i] = apply_transformation(data.covariant[i], A.transpose() );
+          }
+
+        return;
+      }
+
+      case mapping_covariant_gradient:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+        Assert (rank==2, ExcMessage("Only for rank 2"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          {
+            DerivativeForm<1,spacedim,dim> A =
+              apply_transformation(data.covariant[i], transpose(input[i]) );
+            output[i] = apply_transformation(data.covariant[i], A.transpose() );
+          }
+
+        return;
+      }
+
+      case mapping_piola_gradient:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+        Assert (data.update_each & update_volume_elements,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
+        Assert (rank==2, ExcMessage("Only for rank 2"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          {
+            DerivativeForm<1,spacedim,dim> A =
+              apply_transformation(data.covariant[i], input[i] );
+            Tensor<2,spacedim> T =
+              apply_transformation(data.contravariant[i], A.transpose() );
+
+            output[i] = transpose(T);
+            output[i] /= data.volume_elements[i];
+          }
+
+        return;
+      }
+
+      default:
+        Assert(false, ExcNotImplemented());
+      }
+  }
+
+
+
+
+  template <int dim, int spacedim>
+  void
+  transform_hessians(const VectorSlice<const std::vector<Tensor<3,dim> > > input,
+                     VectorSlice<std::vector<Tensor<3,spacedim> > > output,
+                     const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                     const MappingType mapping_type)
+  {
+    AssertDimension (input.size(), output.size());
+    Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
+            ExcInternalError());
+    const typename MappingQ1<dim,spacedim>::InternalData
+    &data = static_cast<const typename MappingQ1<dim,spacedim>::InternalData &>(mapping_data);
+
+    switch (mapping_type)
+      {
+      case mapping_contravariant_hessian:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+
+        for (unsigned int q=0; q<output.size(); ++q)
+          for (unsigned int i=0; i<spacedim; ++i)
+            for (unsigned int j=0; j<spacedim; ++j)
+              for (unsigned int k=0; k<spacedim; ++k)
+                {
+                  output[q][i][j][k] =    data.contravariant[q][i][0]
+                                          * data.covariant[q][j][0]
+                                          * data.covariant[q][k][0]
+                                          * input[q][0][0][0];
+                  for (unsigned int I=0; I<dim; ++I)
+                    for (unsigned int J=0; J<dim; ++J)
+                      {
+                        const unsigned int K0 = (0==(I+J))? 1 : 0;
+                        for (unsigned int K=K0; K<dim; ++K)
+                          output[q][i][j][k] +=    data.contravariant[q][i][I]
+                                                   * data.covariant[q][j][J]
+                                                   * data.covariant[q][k][K]
+                                                   * input[q][I][J][K];
+                      }
+
+                }
+        return;
+      }
+
+      case mapping_covariant_hessian:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+
+        for (unsigned int q=0; q<output.size(); ++q)
+          for (unsigned int i=0; i<spacedim; ++i)
+            for (unsigned int j=0; j<spacedim; ++j)
+              for (unsigned int k=0; k<spacedim; ++k)
+                {
+                  output[q][i][j][k] =    data.covariant[q][i][0]
+                                          * data.covariant[q][j][0]
+                                          * data.covariant[q][k][0]
+                                          * input[q][0][0][0];
+                  for (unsigned int I=0; I<dim; ++I)
+                    for (unsigned int J=0; J<dim; ++J)
+                      {
+                        const unsigned int K0 = (0==(I+J))? 1 : 0;
+                        for (unsigned int K=K0; K<dim; ++K)
+                          output[q][i][j][k] +=   data.covariant[q][i][I]
+                                                  * data.covariant[q][j][J]
+                                                  * data.covariant[q][k][K]
+                                                  * input[q][I][J][K];
+                      }
+
+                }
+
+        return;
+      }
+
+      case mapping_piola_hessian:
+      {
+        Assert (data.update_each & update_covariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
+        Assert (data.update_each & update_volume_elements,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
+
+        for (unsigned int q=0; q<output.size(); ++q)
+          for (unsigned int i=0; i<spacedim; ++i)
+            for (unsigned int j=0; j<spacedim; ++j)
+              for (unsigned int k=0; k<spacedim; ++k)
+                {
+                  output[q][i][j][k] =    data.contravariant[q][i][0]
+                                          / data.volume_elements[q]
+                                          * data.covariant[q][j][0]
+                                          * data.covariant[q][k][0]
+                                          * input[q][0][0][0];
+                  for (unsigned int I=0; I<dim; ++I)
+                    for (unsigned int J=0; J<dim; ++J)
+                      {
+                        const unsigned int K0 = (0==(I+J))? 1 : 0;
+                        for (unsigned int K=K0; K<dim; ++K)
+                          output[q][i][j][k] +=    data.contravariant[q][i][I]
+                                                   / data.volume_elements[q]
+                                                   * data.covariant[q][j][J]
+                                                   * data.covariant[q][k][K]
+                                                   * input[q][I][J][K];
+                      }
+
+                }
+
+        return;
+      }
+
+      default:
+        Assert(false, ExcNotImplemented());
+      }
+  }
+
+
+
+
+  template <int dim, int spacedim, int rank>
+  void
+  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >    input,
+                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > > output,
+                               const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                               const MappingType mapping_type)
+  {
+    AssertDimension (input.size(), output.size());
+    Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
+            ExcInternalError());
+    const typename MappingQ1<dim,spacedim>::InternalData
+    &data = static_cast<const typename MappingQ1<dim,spacedim>::InternalData &>(mapping_data);
+
+    switch (mapping_type)
+      {
+      case mapping_covariant:
+      {
+        Assert (data.update_each & update_contravariant_transformation,
+                typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
+
+        for (unsigned int i=0; i<output.size(); ++i)
+          output[i] = apply_transformation(data.covariant[i], input[i]);
+
+        return;
+      }
+      default:
+        Assert(false, ExcNotImplemented());
+      }
+  }
+}
+
+
+
 template<int dim, int spacedim>
 void
 MappingQ1<dim,spacedim>::transform (
@@ -1319,9 +1618,7 @@ MappingQ1<dim,spacedim>::transform (
   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   const MappingType mapping_type) const
 {
-
   transform_differential_forms(input, output, mapping_data, mapping_type);
-
 }
 
 
@@ -1334,7 +1631,6 @@ MappingQ1<dim,spacedim>::transform (
   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
   const MappingType mapping_type) const
 {
-
   switch (mapping_type)
     {
     case mapping_contravariant:
@@ -1349,7 +1645,6 @@ MappingQ1<dim,spacedim>::transform (
     default:
       Assert(false, ExcNotImplemented());
     }
-
 }
 
 
@@ -1395,11 +1690,13 @@ MappingQ1<dim,spacedim>::transform (
               }
       return;
     }
+
     default:
       Assert(false, ExcNotImplemented());
     }
-
 }
+
+
 
 template<int dim, int spacedim>
 void
@@ -1422,302 +1719,6 @@ MappingQ1<dim,spacedim>::transform (
     }
 
 }
-
-template<int dim, int spacedim>
-template < int rank >
-void MappingQ1<dim,spacedim>::transform_fields(
-  const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-  VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
-{
-  AssertDimension (input.size(), output.size());
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
-          ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
-
-  switch (mapping_type)
-    {
-    case mapping_contravariant:
-    {
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        output[i] = apply_transformation(data.contravariant[i], input[i]);
-
-      return;
-    }
-
-    case mapping_piola:
-    {
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_each & update_volume_elements,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
-      Assert (rank==1, ExcMessage("Only for rank 1"));
-      if (rank!=1)
-        return;
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        {
-          output[i] = apply_transformation(data.contravariant[i], input[i]);
-          output[i] /= data.volume_elements[i];
-        }
-      return;
-    }
-    //We still allow this operation as in the
-    //reference cell Derivatives are Tensor
-    //rather than DerivativeForm
-    case mapping_covariant:
-    {
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        output[i] = apply_transformation(data.covariant[i], input[i]);
-
-      return;
-    }
-
-    default:
-      Assert(false, ExcNotImplemented());
-    }
-}
-
-
-template<int dim, int spacedim>
-template < int rank >
-void MappingQ1<dim,spacedim>::transform_gradients(
-  const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-  VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
-{
-  AssertDimension (input.size(), output.size());
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
-          ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
-
-  switch (mapping_type)
-    {
-    case mapping_contravariant_gradient:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (rank==2, ExcMessage("Only for rank 2"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        {
-          DerivativeForm<1,spacedim,dim> A =
-            apply_transformation(data.contravariant[i], transpose(input[i]) );
-          output[i] = apply_transformation(data.covariant[i], A.transpose() );
-        }
-
-      return;
-    }
-
-    case mapping_covariant_gradient:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (rank==2, ExcMessage("Only for rank 2"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        {
-          DerivativeForm<1,spacedim,dim> A =
-            apply_transformation(data.covariant[i], transpose(input[i]) );
-          output[i] = apply_transformation(data.covariant[i], A.transpose() );
-        }
-
-      return;
-    }
-
-    case mapping_piola_gradient:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_each & update_volume_elements,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
-      Assert (rank==2, ExcMessage("Only for rank 2"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        {
-          DerivativeForm<1,spacedim,dim> A =
-            apply_transformation(data.covariant[i], input[i] );
-          Tensor<2,spacedim> T =
-            apply_transformation(data.contravariant[i], A.transpose() );
-
-          output[i] = transpose(T);
-          output[i] /= data.volume_elements[i];
-        }
-
-      return;
-    }
-
-    default:
-      Assert(false, ExcNotImplemented());
-    }
-}
-
-
-
-
-template<int dim, int spacedim>
-void MappingQ1<dim,spacedim>::transform_hessians(
-  const VectorSlice<const std::vector<Tensor<3,dim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
-{
-  AssertDimension (input.size(), output.size());
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
-          ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
-
-  switch (mapping_type)
-    {
-    case mapping_contravariant_hessian:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-
-      for (unsigned int q=0; q<output.size(); ++q)
-        for (unsigned int i=0; i<spacedim; ++i)
-          for (unsigned int j=0; j<spacedim; ++j)
-            for (unsigned int k=0; k<spacedim; ++k)
-              {
-                output[q][i][j][k] =    data.contravariant[q][i][0]
-                                        * data.covariant[q][j][0]
-                                        * data.covariant[q][k][0]
-                                        * input[q][0][0][0];
-                for (unsigned int I=0; I<dim; ++I)
-                  for (unsigned int J=0; J<dim; ++J)
-                    {
-                      const unsigned int K0 = (0==(I+J))? 1 : 0;
-                      for (unsigned int K=K0; K<dim; ++K)
-                        output[q][i][j][k] +=    data.contravariant[q][i][I]
-                                                 * data.covariant[q][j][J]
-                                                 * data.covariant[q][k][K]
-                                                 * input[q][I][J][K];
-                    }
-
-              }
-      return;
-    }
-
-    case mapping_covariant_hessian:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-
-      for (unsigned int q=0; q<output.size(); ++q)
-        for (unsigned int i=0; i<spacedim; ++i)
-          for (unsigned int j=0; j<spacedim; ++j)
-            for (unsigned int k=0; k<spacedim; ++k)
-              {
-                output[q][i][j][k] =    data.covariant[q][i][0]
-                                        * data.covariant[q][j][0]
-                                        * data.covariant[q][k][0]
-                                        * input[q][0][0][0];
-                for (unsigned int I=0; I<dim; ++I)
-                  for (unsigned int J=0; J<dim; ++J)
-                    {
-                      const unsigned int K0 = (0==(I+J))? 1 : 0;
-                      for (unsigned int K=K0; K<dim; ++K)
-                        output[q][i][j][k] +=   data.covariant[q][i][I]
-                                                * data.covariant[q][j][J]
-                                                * data.covariant[q][k][K]
-                                                * input[q][I][J][K];
-                    }
-
-              }
-
-      return;
-    }
-
-    case mapping_piola_hessian:
-    {
-      Assert (data.update_each & update_covariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_contravariant_transformation"));
-      Assert (data.update_each & update_volume_elements,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_volume_elements"));
-
-      for (unsigned int q=0; q<output.size(); ++q)
-        for (unsigned int i=0; i<spacedim; ++i)
-          for (unsigned int j=0; j<spacedim; ++j)
-            for (unsigned int k=0; k<spacedim; ++k)
-              {
-                output[q][i][j][k] =    data.contravariant[q][i][0]
-                                        / data.volume_elements[q]
-                                        * data.covariant[q][j][0]
-                                        * data.covariant[q][k][0]
-                                        * input[q][0][0][0];
-                for (unsigned int I=0; I<dim; ++I)
-                  for (unsigned int J=0; J<dim; ++J)
-                    {
-                      const unsigned int K0 = (0==(I+J))? 1 : 0;
-                      for (unsigned int K=K0; K<dim; ++K)
-                        output[q][i][j][k] +=    data.contravariant[q][i][I]
-                                                 / data.volume_elements[q]
-                                                 * data.covariant[q][j][J]
-                                                 * data.covariant[q][k][K]
-                                                 * input[q][I][J][K];
-                    }
-
-              }
-
-      return;
-    }
-
-    default:
-      Assert(false, ExcNotImplemented());
-    }
-}
-
-
-
-
-template<int dim, int spacedim>
-template < int rank >
-void MappingQ1<dim,spacedim>::transform_differential_forms(
-  const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >    input,
-  VectorSlice<std::vector<Tensor<rank+1, spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
-{
-
-  AssertDimension (input.size(), output.size());
-  Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
-          ExcInternalError());
-  const InternalData &data = static_cast<const InternalData &>(mapping_data);
-
-  switch (mapping_type)
-    {
-    case mapping_covariant:
-    {
-      Assert (data.update_each & update_contravariant_transformation,
-              typename FEValuesBase<dim>::ExcAccessToUninitializedField("update_covariant_transformation"));
-
-      for (unsigned int i=0; i<output.size(); ++i)
-        output[i] = apply_transformation(data.covariant[i], input[i]);
-
-      return;
-    }
-    default:
-      Assert(false, ExcNotImplemented());
-    }
-
-}
-
 
 
 


### PR DESCRIPTION
This simplifies the class structure of two of the mapping classes (in the same way) by moving certain functions out of the private section and into anonymous namespaces in the .cc file.

Passes the testsuite. In reference to #1198.