### PR TITLE
Unbreak compilation.

### DIFF
--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -218,9 +218,9 @@ MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
   tasks.join_all ();
 
   // TODO: parallelize this as well
-  compute_shapes (quadrature.get_points(), *data);
+  this->compute_shapes (quadrature.get_points(), *data);
   if (!use_mapping_q_on_all_cells)
-    compute_shapes (quadrature.get_points(), data->mapping_q1_data);
+    this->compute_shapes (quadrature.get_points(), data->mapping_q1_data);
 
 
   return data;
@@ -254,9 +254,9 @@ MappingQ<dim,spacedim>::get_face_data (const UpdateFlags update_flags,
   tasks.join_all ();
 
   // TODO: parallelize this as well
-  compute_shapes (q.get_points(), *data);
+  this->compute_shapes (q.get_points(), *data);
   if (!use_mapping_q_on_all_cells)
-    compute_shapes (q.get_points(), data->mapping_q1_data);
+    this->compute_shapes (q.get_points(), data->mapping_q1_data);
 
   return data;
 }
@@ -289,9 +289,9 @@ MappingQ<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
   tasks.join_all ();
 
   // TODO: parallelize this as well
-  compute_shapes (q.get_points(), *data);
+  this->compute_shapes (q.get_points(), *data);
   if (!use_mapping_q_on_all_cells)
-    compute_shapes (q.get_points(), data->mapping_q1_data);
+    this->compute_shapes (q.get_points(), data->mapping_q1_data);
 
 
   return data;


### PR DESCRIPTION
Apparently for some compilers we need to say this-> here, whereas
it works on my system :-(

This should fix recent compile failures that were introduced by
#1425. I guess it's also related to #1198 then.