### PR TITLE
fix compilation error in compute_ghost_cell_halo_layer

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1577,8 +1577,11 @@ next_cell:
   std::vector<typename Container::active_cell_iterator>
   compute_ghost_cell_halo_layer (const Container &container)
   {
+    std_cxx11::function<bool (const typename Container::active_cell_iterator &)> predicate
+      = IteratorFilters::LocallyOwnedCell();
+
     const std::vector<typename Container::active_cell_iterator>
-    active_halo_layer = compute_active_cell_halo_layer (container, IteratorFilters::LocallyOwnedCell());
+    active_halo_layer = compute_active_cell_halo_layer (container, predicate);
 
     // Check that we never return locally owned or artificial cells
     // What is left should only be the ghost cells


### PR DESCRIPTION
Fix the following compilation error on my machine (gcc 4.6.3)
```
/ssd/deal-git/source/grid/grid_tools.cc:1581:103: error: no matching
function for call to ‘compute_active_cell_halo_layer(const
dealii::Triangulation<1, 1>&,
dealii::IteratorFilters::LocallyOwnedCell)’
/ssd/deal-git/source/grid/grid_tools.cc:1581:103: note: candidate is:
/ssd/deal-git/source/grid/grid_tools.cc:1540:3: note: template<class
Container> std::vector<typename Container::active_cell_iterator>
dealii::GridTools::compute_active_cell_halo_layer(const Container&,
const std::function<bool(const typename
Container::active_cell_iterator&)>&)
```