### PR TITLE
Fix compilation in c++98/03 mode

### DIFF
--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -1144,8 +1144,13 @@ namespace IteratorFilters
   MaterialIdEqualTo::MaterialIdEqualTo (const types::material_id material_id,
                                         const bool only_locally_owned)
     :
-    material_ids ({material_id}),
-               only_locally_owned (only_locally_owned)
+    // Note: matrial_ids is a const member and has to be populated with a
+    // constructor. Unfortunately, C++98/03 does not allow the use of an
+    // initializer list. Therefore, treat material_id as an array of one
+    // element.
+    // This is well defined according to [expr.add].4 (ISO 14882).
+    material_ids (&material_id, &material_id+1),
+    only_locally_owned (only_locally_owned)
   {}
 
 
@@ -1177,8 +1182,13 @@ namespace IteratorFilters
   ActiveFEIndexEqualTo::ActiveFEIndexEqualTo (const unsigned int active_fe_index,
                                               const bool only_locally_owned)
     :
-    active_fe_indices ({active_fe_index}),
-                    only_locally_owned (only_locally_owned)
+    // Note: active_fe_indices is a const member and has to be populated
+    // with a constructor. Unfortunately, C++98/03 does not allow the use
+    // of an initializer list. Therefore, treat active_fe_index as an array
+    // of one element.
+    // This is well defined according to [expr.add].4 (ISO 14882).
+    active_fe_indices (&active_fe_index, &active_fe_index+1),
+    only_locally_owned (only_locally_owned)
   {}
 
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -94,13 +94,13 @@ for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS
                                    const Point<deal_II_space_dimension> &);
 
   template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>>::type>
+    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
     compute_active_cell_halo_layer (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
                                     const std_cxx11::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, 
-                                                                                                               parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>>::type&)> &);
+                                                                                                               parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type&)> &);
 
   template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>>::type>
+    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
     compute_ghost_cell_halo_layer (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
   template


### PR DESCRIPTION
Closes #1445


Changes:

efee55d (Matthias Maier, 78 seconds ago)
   ">>" for closing brackets is only valid syntax in C++11, and later.

13e804d (Matthias Maier, 8 minutes ago)
   Avoid c++11'ism and fix compilation for C++98/03 mode