### PR TITLE
CMake: Refactor DEAL_II_HAVE_FP_EXCEPTIONS

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -424,13 +424,17 @@ ENDIF()
 # "-std=c++11" and "-std=c++14" but do not support
 # 'std::is_trivially_copyable', so check for support in C++11 or newer.
 #
-IF(DEAL_II_HAVE_CXX11)
+IF(DEAL_II_WITH_CXX11)
+  PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
   CHECK_CXX_SOURCE_COMPILES(
     "
   #include <type_traits>
   int main(){ std::is_trivially_copyable<int> bob; }
   "
     DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE)
+  RESET_CMAKE_REQUIRED()
+ELSE()
+  SET(DEAL_II_HAVE_CXX11_IS_TRIVIALLY_COPYABLE FALSE)
 ENDIF()
 
 CHECK_CXX_SOURCE_COMPILES(
@@ -466,7 +470,7 @@ CHECK_CXX_SOURCE_COMPILES(
 
 
 #
-# Check that we can use feenableexcept. Sets DEAL_II_HAVE_FP_EXCEPTIONS
+# Check that we can use feenableexcept through the C++11 header file cfenv:
 #
 # The test is a bit more complicated because we also check that no garbage
 # exception is thrown if we convert -std::numeric_limits<double>::max to a
@@ -475,46 +479,53 @@ CHECK_CXX_SOURCE_COMPILES(
 # - Timo Heister, 2015
 #
 
-IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
-  CHECK_CXX_SOURCE_RUNS(
-    "
-    #include <fenv.h>
-    #include <limits>
-    #include <sstream>
+# This test requires C++11
+IF(DEAL_II_WITH_CXX11)
+  PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
+  IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
+    CHECK_CXX_SOURCE_RUNS(
+      "
+      #include <cfenv>
+      #include <limits>
+      #include <sstream>
 
-    int main()
-    {
-      feenableexcept(FE_DIVBYZERO|FE_INVALID);
-      std::ostringstream description;
-      const double lower_bound = -std::numeric_limits<double>::max();
+      int main()
+      {
+        feenableexcept(FE_DIVBYZERO|FE_INVALID);
+        std::ostringstream description;
+        const double lower_bound = -std::numeric_limits<double>::max();
 
-      description << lower_bound;
+        description << lower_bound;
 
-      return 0;
-    }
-    "
-     DEAL_II_HAVE_FP_EXCEPTIONS)
+        return 0;
+      }
+      "
+       DEAL_II_HAVE_FP_EXCEPTIONS)
+  ELSE()
+    #
+    # If we are not allowed to do platform introspection, just test whether
+    # we can compile above code.
+    #
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <cfenv>
+      #include <limits>
+      #include <sstream>
+
+      int main()
+      {
+        feenableexcept(FE_DIVBYZERO|FE_INVALID);
+        std::ostringstream description;
+        const double lower_bound = -std::numeric_limits<double>::max();
+
+        description << lower_bound;
+
+        return 0;
+      }
+      "
+       DEAL_II_HAVE_FP_EXCEPTIONS)
+  ENDIF()
+  RESET_CMAKE_REQUIRED()
 ELSE()
-  #
-  # If we are not allowed to do platform introspection, just test whether
-  # we can compile above code.
-  #
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    #include <fenv.h>
-    #include <limits>
-    #include <sstream>
-
-    int main()
-    {
-      feenableexcept(FE_DIVBYZERO|FE_INVALID);
-      std::ostringstream description;
-      const double lower_bound = -std::numeric_limits<double>::max();
-
-      description << lower_bound;
-
-      return 0;
-    }
-    "
-     DEAL_II_HAVE_FP_EXCEPTIONS)
+  SET(DEAL_II_HAVE_FP_EXCEPTIONS FALSE)
 ENDIF()

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -25,6 +25,7 @@
 #   DEAL_II_HAVE_ISNAN
 #   DEAL_II_HAVE_UNDERSCORE_ISNAN
 #   DEAL_II_HAVE_ISFINITE
+#   DEAL_II_HAVE_FP_EXCEPTIONS
 #
 
 
@@ -463,3 +464,57 @@ CHECK_CXX_SOURCE_COMPILES(
   "
   DEAL_II_HAVE_ISFINITE)
 
+
+#
+# Check that we can use feenableexcept. Sets DEAL_II_HAVE_FP_EXCEPTIONS
+#
+# The test is a bit more complicated because we also check that no garbage
+# exception is thrown if we convert -std::numeric_limits<double>::max to a
+# string. This sadly happens with some compiler support libraries :-(
+#
+# - Timo Heister, 2015
+#
+
+IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
+  CHECK_CXX_SOURCE_RUNS(
+    "
+    #include <fenv.h>
+    #include <limits>
+    #include <sstream>
+
+    int main()
+    {
+      feenableexcept(FE_DIVBYZERO|FE_INVALID);
+      std::ostringstream description;
+      const double lower_bound = -std::numeric_limits<double>::max();
+
+      description << lower_bound;
+
+      return 0;
+    }
+    "
+     DEAL_II_HAVE_FP_EXCEPTIONS)
+ELSE()
+  #
+  # If we are not allowed to do platform introspection, just test whether
+  # we can compile above code.
+  #
+  CHECK_CXX_SOURCE_COMPILES(
+    "
+    #include <fenv.h>
+    #include <limits>
+    #include <sstream>
+
+    int main()
+    {
+      feenableexcept(FE_DIVBYZERO|FE_INVALID);
+      std::ostringstream description;
+      const double lower_bound = -std::numeric_limits<double>::max();
+
+      description << lower_bound;
+
+      return 0;
+    }
+    "
+     DEAL_II_HAVE_FP_EXCEPTIONS)
+ENDIF()

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -19,7 +19,6 @@
 #   DEAL_II_HAVE_GETHOSTNAME
 #   DEAL_II_HAVE_GETPID
 #   DEAL_II_HAVE_JN
-#   DEAL_II_HAVE_FP_EXCEPTIONS
 #   DEAL_II_HAVE_SYS_RESOURCE_H
 #   DEAL_II_HAVE_SYS_TIME_H
 #   DEAL_II_HAVE_SYS_TIMES_H
@@ -67,46 +66,6 @@ IF(NOT m_LIBRARY MATCHES "-NOTFOUND")
   ENDIF()
 ENDIF()
 
-
-#
-# Check that we can use feenableexcept. Sets DEAL_II_HAVE_FP_EXCEPTIONS
-#
-# The test is a bit more complicated because we also check that no garbage
-# exception is thrown if we convert -std::numeric_limits<double>::max to a
-# string. This sadly happens with some compiler support libraries :-(
-
-INCLUDE (CheckCXXSourceRuns)
-
-CHECK_CXX_SOURCE_RUNS("
-  #include <fenv.h>
-  #include <limits>
-  #include <sstream>
-
-  int main()
-  {
-    feenableexcept(FE_DIVBYZERO|FE_INVALID);
-    std::ostringstream description;
-    const double lower_bound = -std::numeric_limits<double>::max();  
-
-    description << lower_bound;
-
-    return 0;
-  }
-  " 
-  _HAVE_FP_EXCEPTIONS)
-
-
-SET(DEAL_II_HAVE_FP_EXCEPTIONS ON CACHE BOOL "If ON, floating point exception are raised in debug mode when running the testsuite.")
-
-IF (DEAL_II_HAVE_FP_EXCEPTIONS)
-  IF(_HAVE_FP_EXCEPTIONS)
-    MESSAGE(STATUS "Checking for Floating Point Exception macros -- Success")
-    # nothing to set here -- DEAL_II_HAVE_FP_EXCEPTIONS is already ON
-  ELSE()
-    MESSAGE(STATUS "Checking for Floating Point Exception macros -- Failed")
-    SET(DEAL_II_HAVE_FP_EXCEPTIONS OFF CACHE BOOL "" FORCE)
-  ENDIF()
-ENDIF()
 
 
 ########################################################################

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -111,6 +111,7 @@
 #cmakedefine DEAL_II_HAVE_STD_ISNAN
 #cmakedefine DEAL_II_HAVE_UNDERSCORE_ISNAN
 #cmakedefine DEAL_II_HAVE_ISFINITE
+#cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 
 
 /***********************************************************************
@@ -128,7 +129,6 @@
 #cmakedefine DEAL_II_HAVE_GETPID
 #cmakedefine DEAL_II_HAVE_TIMES
 #cmakedefine DEAL_II_HAVE_JN
-#cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 
 #cmakedefine DEAL_II_MSVC
 


### PR DESCRIPTION
- this is a language feature, not a platform feature, so move it to
   check_01_cxx_features.cmake

- A test that _runs_ code *_must_* be guarded with
   DEAL_II_ALLOW_PLATFORM_INTROSPECTION

- Demote DEAL_II_HAVE_FP_EXCEPTIONS to an ordinary variable. Naming
   convetion: Variables starting with "DEAL_II_HAVE" must be ordinary
   variables, or internal, cached variables.

   Note: It is not necessary to promote DEAL_II_HAVE_FP_EXCEPTIONS to cache
   in order to override it with -DDEAL_II_HAVE_FP_EXCEPTIONS...

- Bugfix: Test for <cfenv> header instead of <fenv.h>
   We include the C++11 version <cfenv> in the testuite.
   This fixes the testsuite for use in C++98/03 mode.

- Silently, fix another test as well.