### PR TITLE
CMake: Drop /.../include/scotch from include dirs

### DIFF
--- a/cmake/modules/FindPETSC.cmake
+++ b/cmake/modules/FindPETSC.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -156,7 +156,11 @@ IF(NOT PETSC_PETSCVARIABLES MATCHES "-NOTFOUND")
 
   SET(_petsc_includes)
   FOREACH(_token ${_external_includes})
-    IF(_token MATCHES "^-I")
+    #
+    # workaround: Do not pull in scotch include directory. It clashes with
+    # our use of the metis headers...
+    #
+    IF(_token MATCHES "^-I" AND NOT _token MATCHES "scotch$")
       STRING(REGEX REPLACE "^-I" "" _token "${_token}")
       LIST(APPEND _petsc_includes ${_token})
     ENDIF()

--- a/cmake/modules/FindTRILINOS.cmake
+++ b/cmake/modules/FindTRILINOS.cmake
@@ -150,12 +150,30 @@ IF(EXISTS ${SACADO_CMATH_HPP})
 ENDIF()
 
 #
-# *Boy* Sanitize the include paths given by TrilinosConfig.cmake...
+# *Boy* Sanitize variables that are exported by TrilinosConfig.cmake...
 #
+# Especially deduplicate stuff...
+#
+REMOVE_DUPLICATES(Trilinos_LIBRARIES REVERSE)
+REMOVE_DUPLICATES(Trilinos_TPL_LIBRARIES REVERSE)
+
+REMOVE_DUPLICATES(Trilinos_INCLUDE_DIRS)
 STRING(REGEX REPLACE
   "(lib64|lib)\\/cmake\\/Trilinos\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/" ""
   Trilinos_INCLUDE_DIRS "${Trilinos_INCLUDE_DIRS}"
   )
+
+REMOVE_DUPLICATES(Trilinos_TPL_INCLUDE_DIRS)
+
+#
+# workaround: Do not pull in scotch include directory. It clashes with
+# our use of the metis headers...
+#
+FOREACH(_item ${Trilinos_TPL_INCLUDE_DIRS})
+  IF("${_item}" MATCHES "scotch$")
+    LIST(REMOVE_ITEM Trilinos_TPL_INCLUDE_DIRS ${_item})
+  ENDIF()
+ENDFOREACH()
 
 #
 # We'd like to have the full library names but the Trilinos package only


### PR DESCRIPTION
scotch has the very unfortunate bad habit of containing a header file

 /usr/include/scotch/metis.h

If above directory is in our list of include directories, we will
accidentally pick up this header instead of /usr/include/metis.h

I assume it is safe to drop /usr/include/scotch/, this should be only
internally used in Trilinos and PETSc...

Further, deduplicate library and include directory lists for Trilinos. *wow*

Changes:

d738a41 (Matthias Maier, 67 seconds ago)
   CMake: FindTRILINOS.cmake: Drop /.../include/scotch from include dirs


68b0e07 (Matthias Maier, 4 minutes ago)
   CMake: FindPETSC.cmake: Drop /.../include/scotch from include dirs