### PR TITLE
Fix a doxygen issue with quoted italics.

### DIFF
--- a/doc/doxygen/headers/update_flags.h
+++ b/doc/doxygen/headers/update_flags.h
@@ -88,9 +88,9 @@
  * producing a <i>set of flags</i> amounts to setting multiple bits
  * in an integer, which is facilitated using the operation
  * <code>update_gradients | update_JxW_values</code> (in other words, and
- * maybe slightly confusingly so, the operation "this operation <i>and</i> that
- * operation" is represented by the expression "single-bit-in-an-integer-for-this-operation
- * <i>binary-or</i> single-bit-in-an-integer-for-that-operation"). To
+ * maybe slightly confusingly so, the operation @"this operation <i>and</i> that
+ * operation@" is represented by the expression @"single-bit-in-an-integer-for-this-operation
+ * <i>binary-or</i> single-bit-in-an-integer-for-that-operation@"). To
  * make operations cheaper, FEValues and the mapping and finite element objects
  * it depends on really only compute those pieces of information that you
  * have specified in the update flags (plus some information necessary to

--- a/doc/news/8.1.0-vs-8.2.0.h
+++ b/doc/news/8.1.0-vs-8.2.0.h
@@ -50,14 +50,14 @@ inconvenience this causes.
 
   <li> Removed: The constructor of the Utilities::MPI::MPI_InitFinalize
   class used to interpret a last argument equal to numbers::invalid_unsigned_int
-  as "<i>create as many threads as there are processor cores on the current
-  system</i>" for each MPI process. If there were multiple MPI processes on a
+  as @"<i>create as many threads as there are processor cores on the current
+  system</i>@" for each MPI process. If there were multiple MPI processes on a
   given node, this would lead to (sometimes massive) overallocation of resources
   because <i>every</i> MPI process would create as many threads as there are cores.
   This has now been changed: an argument equal to numbers::invalid_unsigned_int
-  is now interpreted as "<i>subdivide the available cores between all MPI
+  is now interpreted as @"<i>subdivide the available cores between all MPI
   processes running on the current system and let each process create as many
-  threads as cores were allocated to it</i>".
+  threads as cores were allocated to it</i>@".
   <br>
   (Wolfgang Bangerth, 2014/09/16)
   </li>


### PR DESCRIPTION
Under certain circumstances Doxygen treats text surrounded by double quotes as a verbatim environment, e.g., doxygen will convert 
```
<i>
```

into 

```
&lt;i%gt;
```
which is not what we want when italicising text.

I also changed the email address associated with my commits; hopefully github won't freak out.