### PR TITLE
Save solution time into tecplot ascii files for animating time depend…

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -841,18 +841,11 @@ namespace DataOutBase
     double solution_time;
 
     /**
-     * A strand is a set of zones that represent the same region of the solution over time.
-     * <tt>strand_id</tt> is an integer value that uniquely identifies each strand.
-     */
-    int strand_id;
-
-    /**
      * Constructor.
      */
     TecplotFlags (const char *tecplot_binary_file_name = NULL,
                   const char *zone_name = NULL,
-                  const double solution_time = -1.0,
-                  const int strand_id = 1);
+                  const double solution_time = -1.0);
 
     /**
      * Return an estimate for the memory consumption, in bytes, of this

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -834,10 +834,25 @@ namespace DataOutBase
     const char *zone_name;
 
     /**
+     * Solution time for each zone in a strand. This value must be non-negative,
+     * otherwise it will not be written to file. Do not assign any value for this
+     * in case of a static zone.
+     */
+    double solution_time;
+
+    /**
+     * A strand is a set of zones that represent the same region of the solution over time.
+     * <tt>strand_id</tt> is an integer value that uniquely identifies each strand.
+     */
+    int strand_id;
+
+    /**
      * Constructor.
      */
     TecplotFlags (const char *tecplot_binary_file_name = NULL,
-                  const char *zone_name = NULL);
+                  const char *zone_name = NULL,
+                  const double solution_time = -1.0,
+                  const int strand_id = 1);
 
     /**
      * Return an estimate for the memory consumption, in bytes, of this

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1978,11 +1978,19 @@ namespace DataOutBase
 
   TecplotFlags::
   TecplotFlags (const char *tecplot_binary_file_name,
-                const char *zone_name)
+                const char *zone_name,
+                const double solution_time,
+                const int strand_id)
     :
     tecplot_binary_file_name(tecplot_binary_file_name),
-    zone_name(zone_name)
-  {}
+    zone_name(zone_name),
+    solution_time (solution_time),
+    strand_id (strand_id)
+
+  {
+    Assert (strand_id >= 1,
+            ExcMessage("For transient data, strand_id must be > 0"));
+  }
 
 
 
@@ -4093,6 +4101,9 @@ namespace DataOutBase
       out << "zone ";
       if (flags.zone_name)
         out << "t=\"" << flags.zone_name << "\" ";
+
+      if (flags.solution_time >= 0.0)
+        out << "strandid=" << flags.strand_id << ", solutiontime=" << flags.solution_time <<", ";
 
       out << "f=feblock, n=" << n_nodes << ", e=" << n_cells
           << ", et=" << tecplot_cell_type[dim] << '\n';

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1979,18 +1979,12 @@ namespace DataOutBase
   TecplotFlags::
   TecplotFlags (const char *tecplot_binary_file_name,
                 const char *zone_name,
-                const double solution_time,
-                const int strand_id)
+                const double solution_time)
     :
     tecplot_binary_file_name(tecplot_binary_file_name),
     zone_name(zone_name),
-    solution_time (solution_time),
-    strand_id (strand_id)
-
-  {
-    Assert (strand_id >= 1,
-            ExcMessage("For transient data, strand_id must be > 0"));
-  }
+    solution_time (solution_time)
+  {}
 
 
 
@@ -4103,7 +4097,7 @@ namespace DataOutBase
         out << "t=\"" << flags.zone_name << "\" ";
 
       if (flags.solution_time >= 0.0)
-        out << "strandid=" << flags.strand_id << ", solutiontime=" << flags.solution_time <<", ";
+        out << "strandid=1, solutiontime=" << flags.solution_time <<", ";
 
       out << "f=feblock, n=" << n_nodes << ", e=" << n_cells
           << ", et=" << tecplot_cell_type[dim] << '\n';


### PR DESCRIPTION
Transient data can be animated in tecplot if we save solution time into the tecplot files. This can be used as

      DataOutBase::TecplotFlags flags(NULL, NULL, solution_time);
      data_out.set_flags (flags);
      data_out.write_tecplot (output);

If you have more strands, the ```strand_id``` must be given as last argument to the ```TecplotFlags``` constructor.