### PR TITLE
Clean up parallel::Triangulation

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -1079,28 +1079,13 @@ namespace parallel
      * actually be created if we don't have p4est available.
      */
     template <int dim, int spacedim = dim>
-    class Triangulation : public dealii::Triangulation<dim,spacedim>
+    class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
     {
     private:
       /**
        * Constructor.
        */
       Triangulation ();
-
-    public:
-
-      /**
-       * Destructor.
-       */
-      virtual ~Triangulation ();
-
-      /**
-       * Return the subdomain id of those cells that are owned by the current
-       * processor. All cells in the triangulation that do not have this
-       * subdomain id are either owned by another processor or have children
-       * that only exist on other processors.
-       */
-      types::subdomain_id locally_owned_subdomain () const;
 
     };
   }

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2013 by the deal.II authors
+// Copyright (C) 2008 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -56,25 +56,19 @@ namespace parallel
     /**
      * Constructor.
      */
-#ifdef DEAL_II_WITH_MPI
     Triangulation (MPI_Comm mpi_communicator,
                    const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing smooth_grid = (dealii::Triangulation<dim,spacedim>::none),
                    const bool check_for_distorted_cells = false);
-#else
-    Triangulation ();
-#endif
 
     /**
      * Destructor.
      */
     virtual ~Triangulation ();
 
-#ifdef DEAL_II_WITH_MPI
     /**
      * Return MPI communicator used by this triangulation.
      */
     virtual MPI_Comm get_communicator () const;
-#endif
 
     /**
      * Implementation of the same function as in the base class.
@@ -143,14 +137,12 @@ namespace parallel
 
 
   protected:
-#ifdef DEAL_II_WITH_MPI
     /**
      * MPI communicator to be used for the triangulation. We create a unique
      * communicator for this class, which is a duplicate of the one passed
      * to the constructor.
      */
     MPI_Comm mpi_communicator;
-#endif
 
     /**
      * The subdomain id to be used for the current processor.

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4590,37 +4590,11 @@ namespace parallel
   {
     template <int dim, int spacedim>
     Triangulation<dim,spacedim>::Triangulation ()
+      :
+      dealii::parallel::Triangulation<dim,spacedim>(MPI_COMM_SELF)
     {
       Assert (false, ExcNotImplemented());
     }
-
-
-    template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::~Triangulation ()
-    {
-      Assert (false, ExcNotImplemented());
-    }
-
-
-
-    template <int dim, int spacedim>
-    types::subdomain_id
-    Triangulation<dim,spacedim>::locally_owned_subdomain () const
-    {
-      Assert (false, ExcNotImplemented());
-      return 0;
-    }
-
-
-#ifdef DEAL_II_WITH_MPI
-    template <int dim, int spacedim>
-    MPI_Comm
-    Triangulation<dim,spacedim>::get_communicator () const
-    {
-      Assert (false, ExcNotImplemented());
-      return MPI_COMM_WORLD;
-    }
-#endif
   }
 }
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/tria_base.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_boundary.h>
@@ -204,14 +205,12 @@ namespace GridTools
     double global_volume = 0;
 
 #ifdef DEAL_II_WITH_MPI
-    if (const parallel::distributed::Triangulation<dim,spacedim> *p_tria
-        = dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&triangulation))
+    if (const parallel::Triangulation<dim,spacedim> *p_tria
+        = dynamic_cast<const parallel::Triangulation<dim,spacedim>*>(&triangulation))
       global_volume = Utilities::MPI::sum (local_volume, p_tria->get_communicator());
     else
-      global_volume = local_volume;
-#else
-    global_volume = local_volume;
 #endif
+      global_volume = local_volume;
 
     return global_volume;
   }


### PR DESCRIPTION
The old code did not compile grid_tools.cc because parallel::distributed::Triangulation without p4est does not provide the method `get_communicator()` any more. Thus, I enabled the respective method to parallel::Triangulation. We do provide MPI_Comm and MPI_COMM_SELF in the non-MPI case, so it makes the interface cleaner to provide these methods as well (and bail out in the constructor).

Also, the GridTools::volume method works for `parallel::Triangulation`, not only `parallel::distributed::Triangulation` (second patch).