### PR TITLE
Fix non-MPI case

### DIFF
--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/base/std_cxx1x/function.h>
@@ -30,10 +31,6 @@
 #include <vector>
 #include <list>
 #include <utility>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
 
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
I forgot to check that the non-MPI case still compiles with #1470, and indeed it does not [1].

[1] http://cdash.kyomu.43-1.org/viewBuildError.php?buildid=11837