### PR TITLE
Testsuite: Bugfix: Fix mpi tests

### DIFF
--- a/cmake/scripts/run_test.cmake
+++ b/cmake/scripts/run_test.cmake
@@ -91,7 +91,21 @@ MESSAGE("===============================   OUTPUT BEGIN  =======================
 
 IF("${_stage}" STREQUAL "PASSED")
   STRING(REGEX REPLACE ".*\\/" "" _test ${TEST})
-  FILE(READ ${BINARY_DIR}/${_test}/diff _diff)
+  #
+  # MPI tests have a special runtime directory so rename:
+  # test.mpirun=X.BUILD -> test.BUILD/mpirun=X
+  #
+  STRING(REGEX REPLACE "\\.(mpirun=[0-9]+)(\\..*)" "\\2/\\1" _test ${_test})
+  #
+  # Also output the diff file if we guessed the location correctly. This is
+  # solely for cosmetic reasons: The diff file is either empty (if
+  # comparison against the main comparison file was successful) or contains
+  # a string explaining which comparison file variant succeeded.
+  #
+  SET(_diff "")
+  IF(EXISTS ${BINARY_DIR}/${_test}/diff)
+    FILE(READ ${BINARY_DIR}/${_test}/diff _diff)
+  ENDIF()
   MESSAGE("${_diff}${TEST}: PASSED.")
 
 ELSE()


### PR DESCRIPTION
MPI test results and diffs are stored at a different location than the
files for ordinary tests. Fix run_test.cmake to take that into account.

Safeguard against possible further changes by checking whether we have
guessed the location correctly prior to reading the diff file. We output
the file contents (which is either empty or explains against which variant
we successfully compared) for informational reasons anyway...