### PR TITLE
Testsuite: Also adjust location in disctributed_grids and mpi

### DIFF
--- a/tests/distributed_grids/2d_coarse_grid_02.cc
+++ b/tests/distributed_grids/2d_coarse_grid_02.cc
@@ -38,7 +38,7 @@ void test(std::ostream & /*out*/)
 
   GridIn<dim> gi;
   gi.attach_triangulation (tr);
-  std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+  std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
   try
     {
       gi.read_xda (in);

--- a/tests/distributed_grids/2d_coarse_grid_03.cc
+++ b/tests/distributed_grids/2d_coarse_grid_03.cc
@@ -36,7 +36,7 @@ void test(std::ostream & /*out*/)
 
   GridIn<dim> gi;
   gi.attach_triangulation (tr);
-  std::ifstream in (SOURCE_DIR "/../deal.II/grid_in/2d.inp");
+  std::ifstream in (SOURCE_DIR "/../grid/grid_in/2d.inp");
   gi.read_ucd (in);
 
   write_vtk(tr, "1");

--- a/tests/distributed_grids/2d_coarsening_03.cc
+++ b/tests/distributed_grids/2d_coarsening_03.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
     try
       {
         gi.read_xda (in);
@@ -60,7 +60,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
     try
       {
         gi.read_xda (in);

--- a/tests/distributed_grids/2d_refinement_03.cc
+++ b/tests/distributed_grids/2d_refinement_03.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
     try
       {
         gi.read_xda (in);
@@ -60,7 +60,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
     try
       {
         gi.read_xda (in);

--- a/tests/distributed_grids/3d_coarse_grid_02.cc
+++ b/tests/distributed_grids/3d_coarse_grid_02.cc
@@ -61,16 +61,16 @@ int main(int argc, char *argv[])
 
   deallog.push("3d");
 
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/1.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/2.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/3.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/4.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/1.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/2.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/3.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/4.in");
 
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/evil_0.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/evil_1.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/evil_2.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/evil_3.in");
-  test<3> (SOURCE_DIR "/../deal.II/grid_in_3d/evil_4.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/evil_0.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/evil_1.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/evil_2.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/evil_3.in");
+  test<3> (SOURCE_DIR "/../grid/grid_in_3d/evil_4.in");
 
   deallog.pop();
 

--- a/tests/distributed_grids/3d_coarse_grid_06.cc
+++ b/tests/distributed_grids/3d_coarse_grid_06.cc
@@ -36,7 +36,7 @@ void test(std::ostream & /*out*/)
 
   GridIn<dim> gi;
   gi.attach_triangulation (tr);
-  gi.read (SOURCE_DIR "/../deal.II/grid_in_3d_02/747.ucd");
+  gi.read (SOURCE_DIR "/../grid/grid_in_3d_02/747.ucd");
 
   deallog << "Checksum: "
           << tr.get_checksum ()

--- a/tests/distributed_grids/3d_coarsening_03.cc
+++ b/tests/distributed_grids/3d_coarsening_03.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d/4.in");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d/4.in");
     gi.read_xda (in);
 				     //tr.refine_global (1);
   }
@@ -51,7 +51,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d/4.in");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d/4.in");
     gi.read_xda (in);
 				     //tr2.refine_global (1);
   }

--- a/tests/distributed_grids/3d_coarsening_04.cc
+++ b/tests/distributed_grids/3d_coarsening_04.cc
@@ -43,7 +43,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d_02/747.ucd");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d_02/747.ucd");
     gi.read (in);
     //tr.refine_global (1);
   }
@@ -51,7 +51,7 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d_02/747.ucd");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d_02/747.ucd");
     gi.read (in);
     //tr2.refine_global (1);
   }

--- a/tests/distributed_grids/3d_refinement_03.cc
+++ b/tests/distributed_grids/3d_refinement_03.cc
@@ -43,14 +43,14 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d/4.in");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d/4.in");
     gi.read_xda (in);
   }
 
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d/4.in");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d/4.in");
     gi.read_xda (in);
   }
 

--- a/tests/distributed_grids/3d_refinement_08.cc
+++ b/tests/distributed_grids/3d_refinement_08.cc
@@ -43,14 +43,14 @@ void test(std::ostream & /*out*/)
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d_02/747.ucd");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d_02/747.ucd");
     gi.read (in);
   }
 
   {
     GridIn<dim> gi;
     gi.attach_triangulation (tr2);
-    std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_3d_02/747.ucd");
+    std::ifstream in (SOURCE_DIR "/../grid/grid_in_3d_02/747.ucd");
     gi.read (in);
   }
 

--- a/tests/mpi/p4est_2d_coarse_01.cc
+++ b/tests/mpi/p4est_2d_coarse_01.cc
@@ -44,7 +44,7 @@ void test()
       parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
       GridIn<dim> gi;
       gi.attach_triangulation (tr);
-      std::ifstream in (SOURCE_DIR "/../deal.II/grid_in_02/2d.xda");
+      std::ifstream in (SOURCE_DIR "/../grid/grid_in_02/2d.xda");
       try
         {
           gi.read_xda (in);


### PR DESCRIPTION
We have a small number of tests under distributed_grids/ and mpi/ that read
in external grids from deal.II/ (which is now removed).

Update those references to the new location "../grid/grid_in*".