### PR TITLE
Another non-MPI fix

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -121,7 +121,7 @@ namespace parallel
      * library even if it is disabled.
      *
      * Since the constructor of this class is private, no such objects
-     * can actually be created if we don't have p4est available.
+     * can actually be created if MPI is not available.
      */
     template <int dim, int spacedim = dim>
     class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
@@ -131,13 +131,6 @@ namespace parallel
        * Constructor.
        */
       Triangulation ();
-    public:
-
-      /**
-       * Destructor.
-       */
-      virtual ~Triangulation ();
-
     };
   }
 

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -96,13 +96,8 @@ namespace parallel
   {
     template <int dim, int spacedim>
     Triangulation<dim,spacedim>::Triangulation ()
-    {
-      Assert (false, ExcNotImplemented());
-    }
-
-
-    template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::~Triangulation ()
+      :
+      dealii::parallel::Triangulation<dim,spacedim>(MPI_COMM_SELF)
     {
       Assert (false, ExcNotImplemented());
     }


### PR DESCRIPTION
In my fix of #1473, I was incredibly stupid and forgot to add the file source/distributed/shared_tria.cc (sorry). Besides fixing non-MPI compilation, I also removed the virtual destructor from the non-MPI case of shared tria (it is present through the inheritance from parallel::Triangulation, so why not save a few lines of code).