### PR TITLE
fix a compiler error with DEAL_II_WITH_MPI not defined

### DIFF
--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -95,7 +95,8 @@ namespace parallel
   namespace shared
   {
     template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::Triangulation ()
+    Triangulation<dim,spacedim>::Triangulation ():
+      dealii::parallel::Triangulation<dim,spacedim>(0)
     {
       Assert (false, ExcNotImplemented());
     }


### PR DESCRIPTION
When DEAL_II_WITH_MPI is not defined, the compiler doesn't find a constructor for the base class with no input arguments and gives a compiler error: "shared_tria.cc:98:49: error: no matching function for call to ‘dealii::parallel::Triangulation<1, 1>::Triangulation()’". This fixes that error.