### PR TITLE
Readd affinity quicktest

### DIFF
--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -80,6 +80,11 @@ FOREACH(_build ${DEAL_II_BUILD_TYPES})
   make_quicktest("step" ${_build} "")
 ENDFOREACH()
 
+# Test whether thread affinity is well behaved
+IF (DEAL_II_WITH_THREADS)
+make_quicktest("affinity" ${_mybuild} "")
+ENDIF()
+
 # Test if MPI is configured correctly
 IF (DEAL_II_WITH_MPI)
   make_quicktest("mpi" ${_mybuild} 2)

--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2013 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/base/multithread_info.h>
+#include <stdio.h>
+
+#if defined(__linux__)
+#include <sched.h>
+#include <sys/sysinfo.h>
+#endif
+
+bool getaffinity(unsigned int &bits_set,unsigned int &mask)
+{
+  bits_set = 0;
+  mask = 0x00;
+  
+#if defined(__linux__)
+  cpu_set_t my_set;
+  CPU_ZERO(&my_set);
+
+  unsigned int len = sizeof(my_set);
+  int   ret = sched_getaffinity(0, len, &my_set);
+
+  if (ret!=0)
+    {
+      printf("sched_getaffinity() failed, return value: %d\n", ret);
+      return false;
+    }
+  for (int i=0;i<CPU_SETSIZE;++i)
+    bits_set += CPU_ISSET(i,&my_set);
+
+  mask = *(int*)(&my_set);
+#else
+  // sadly we don't have an implementation
+  // for mac/windows
+#endif
+  return true;
+}
+
+
+int main ()
+{
+  // we need this, otherwise gcc will not link against deal.II
+  dealii::Triangulation<2> test;
+
+  unsigned int bits_set, mask;
+  if (!getaffinity(bits_set, mask))
+    return 1;
+
+  unsigned int nprocs = dealii::MultithreadInfo::n_cores();
+  unsigned int tbbprocs = dealii::MultithreadInfo::n_threads();
+  printf("aff_ncpus=%d, mask=%08X, nprocs=%d, tbb_threads=%d\n",
+	 bits_set, mask, nprocs, tbbprocs );
+
+  if (bits_set !=0  && bits_set!=nprocs)
+    {
+      printf("Warning: sched_getaffinity() returns that we can only use %d out of %d CPUs.\n",bits_set, nprocs);
+      return 2;
+    }
+  if (nprocs != tbbprocs)
+    {
+      printf("Warning: for some reason TBB only wants to use %d out of %d CPUs.\n",
+	     tbbprocs, nprocs);
+      return 3;
+    }
+  
+  return 0;
+}

--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -13,8 +13,15 @@
 //
 // ---------------------------------------------------------------------
 
+/*
+  Test that OpenMP is not messing with thread affinity, which will stop TBB
+  from creating threads.
+ */
+
+
 #include <deal.II/grid/tria.h>
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/utilities.h>
 #include <stdio.h>
 
 #if defined(__linux__)
@@ -50,6 +57,26 @@ bool getaffinity(unsigned int &bits_set,unsigned int &mask)
   return true;
 }
 
+int get_num_thread_env()
+{
+  const char *penv = getenv ("DEAL_II_NUM_THREADS");
+  if (penv!=NULL)
+    {
+      int max_threads_env = -1;
+      try
+	{
+	  max_threads_env = dealii::Utilities::string_to_int(std::string(penv));
+	}
+      catch (...)
+	{
+	  return -1;
+	}
+      return max_threads_env;
+    }
+
+  return -1;
+}
+
 
 int main ()
 {
@@ -62,13 +89,19 @@ int main ()
 
   unsigned int nprocs = dealii::MultithreadInfo::n_cores();
   unsigned int tbbprocs = dealii::MultithreadInfo::n_threads();
-  printf("aff_ncpus=%d, mask=%08X, nprocs=%d, tbb_threads=%d\n",
-	 bits_set, mask, nprocs, tbbprocs );
+  int env = get_num_thread_env();
+  printf("aff_ncpus=%d, mask=%08X, nprocs=%d, tbb_threads=%d, DEAL_II_NUM_THREADS=%d\n",
+	 bits_set, mask, nprocs, tbbprocs, env );
 
   if (bits_set !=0  && bits_set!=nprocs)
     {
       printf("Warning: sched_getaffinity() returns that we can only use %d out of %d CPUs.\n",bits_set, nprocs);
       return 2;
+    }
+  if (env != -1 && nprocs != tbbprocs)
+    {
+      printf("Warning: number of threads is set to %d in envirnoment using DEAL_II_NUM_THREADS.\n", env);
+      return 0; // do not return an error!
     }
   if (nprocs != tbbprocs)
     {

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -39,7 +39,8 @@ to the mailing list linked at http://www.dealii.org\n"
 The affinity test can fail when you are linking in a library like BLAS
 which uses OpenMP. Even without calling any BLAS functions, OpenMP messes
 with the thread affinity which causes TBB to run single-threaded only. You
-can fix this by exporting OMP_NUM_THREADS=1.\n"
+can fix this by exporting OMP_NUM_THREADS=1. Also see GOMP_CPU_AFFINITY 
+and OMP_PROC_BIND.\n"
         )
     ENDIF()
 

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2015 by the deal.II authors
+## Copyright (C) 2013 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -34,6 +34,15 @@ to the mailing list linked at http://www.dealii.org\n"
     )
 
   FOREACH(test ${ALL_TESTS})  
+    IF (${test} MATCHES "^affinity" AND NOT EXISTS ${test}-OK)
+      MESSAGE("
+The affinity test can fail when you are linking in a library like BLAS
+which uses OpenMP. Even without calling any BLAS functions, OpenMP messes
+with the thread affinity which causes TBB to run single-threaded only. You
+can fix this by exporting OMP_NUM_THREADS=1.\n"
+        )
+    ENDIF()
+
     IF (${test} MATCHES "^step-petsc" AND NOT EXISTS ${test}-OK)
       MESSAGE("
 Additional information about PETSc issues is available


### PR DESCRIPTION
Introduce the quicktest affinity again after we removed it in #1427 based on issue #1351.

Testing with OpenBLAS and OpenMP enabled revealed that we still run into this issue (on my machine only when I set GOMP_CPU_AFFINITY but who knows). To get around issue #1351 I now check the environment variable and don't error out if it is used.