### PR TITLE
Fix Hdiv_seminorm computation

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -114,6 +114,11 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: VectorTools::integrate_difference for VectorTools::Hdiv_seminorm
+  was computed incorrectly.
+  <br>
+  (Timo Heister, 2015/08/31)
+
   <li> Improved: The testsuite now supports multiple comparison files.
   Apart from the main comparison file that ends in
   <code>[...].output</code> all files of the form

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6218,6 +6218,8 @@ namespace VectorTools
         }
 
       double diff = 0;
+
+      // First work on function values:
       switch (norm)
         {
         case mean:
@@ -6245,7 +6247,7 @@ namespace VectorTools
               diff += sum * fe_values.JxW(q);
             }
 
-          // Compute the root only, if no derivative values are added later
+          // Compute the root only if no derivative values are added later
           if (!(update_flags & update_gradients))
             diff = std::pow(diff, 1./exponent);
           break;
@@ -6275,8 +6277,10 @@ namespace VectorTools
           break;
 
         case H1_seminorm:
+        case Hdiv_seminorm:
         case W1p_seminorm:
         case W1infty_seminorm:
+          // function values are not used for these norms
           break;
 
         default:
@@ -6284,6 +6288,7 @@ namespace VectorTools
           break;
         }
 
+      // Now compute terms depending on derivatives:
       switch (norm)
         {
         case W1p_seminorm:

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6329,9 +6329,8 @@ namespace VectorTools
               // take the trace of the derivatives, square it, multiply it
               // with the weight function
               for (unsigned int k=0; k<dim; ++k)
-                sum += (data.psi_grads[q][k][k] * data.psi_grads[q][k][k]) *
-                       data.weight_vectors[q](k);
-              diff += sum * fe_values.JxW(q);
+                sum += data.psi_grads[q][k][k] * data.weight_vectors[q](k);
+              diff += sum * sum * fe_values.JxW(q);
             }
           diff = std::sqrt(diff);
           break;

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6326,10 +6326,9 @@ namespace VectorTools
                                   "with at least 'dim' components. In that case, this function "
                                   "will take the divergence of the first 'dim' components."));
               double sum = 0;
-              // take the trace of the derivatives, square it, multiply it
-              // with the weight function
+              // take the trace of the derivatives scaled by the weight and square it
               for (unsigned int k=0; k<dim; ++k)
-                sum += data.psi_grads[q][k][k] * data.weight_vectors[q](k);
+                sum += data.psi_grads[q][k][k] * std::sqrt(data.weight_vectors[q](k));
               diff += sum * sum * fe_values.JxW(q);
             }
           diff = std::sqrt(diff);

--- a/tests/vector_tools/CMakeLists.txt
+++ b/tests/vector_tools/CMakeLists.txt
@@ -1,0 +1,4 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+INCLUDE(../setup_testsubproject.cmake)
+PROJECT(testsuite CXX)
+DEAL_II_PICKUP_TESTS()

--- a/tests/vector_tools/integrate_difference_01.cc
+++ b/tests/vector_tools/integrate_difference_01.cc
@@ -96,7 +96,10 @@ void test()
   deallog << "L2_norm:" << std::endl;
   // sqrt(\int_\Omega f^2) = sqrt(\int (x+y)^2+(x^2+y^2)^2)
   test<dim>(VectorTools::L2_norm, std::sqrt(161.0/90.0));
-  
+  deallog << "H1_seminorm:" << std::endl;
+  // sqrt( sum | d/dxi f |_0^2 ) = sqrt( sum \int   )
+  test<dim>(VectorTools::H1_seminorm, std::sqrt(14.0/3.0));
+
   deallog << "OK" << std::endl;
 }
 

--- a/tests/vector_tools/integrate_difference_01.cc
+++ b/tests/vector_tools/integrate_difference_01.cc
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2014 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test integrate_difference
+
+#include "../tests.h"
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+using namespace dealii;
+
+
+// x+y(+z), x^2+y^2 (, z+xy)
+// div = 1+2y (+1)
+template <int dim>
+class Ref : public Function<dim>
+{
+  public:
+    Ref()
+		    :Function<dim>(dim)
+      {}
+    
+    double value (const Point<dim> &p, const unsigned int c) const
+      {
+	if (c==0)
+	  return p[0]+p[1]+((dim==3)?p[2]:0.0);
+	if (c==1)
+	  return p[0]*p[0]+p[1]*p[1];
+	if (c==2)
+	  return p[2]+p[0]*p[1];
+      }    
+};
+
+
+
+template <int dim>
+void test(VectorTools::NormType norm, double value)
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+
+  FESystem<dim> fe(FE_Q<dim>(4),dim);
+  DoFHandler<dim> dofh(tria);
+  dofh.distribute_dofs(fe);
+
+  Vector<double> solution (dofh.n_dofs ());
+  VectorTools::interpolate(dofh, Ref<dim>(), solution);
+  
+  Vector<double> cellwise_errors (tria.n_active_cells());
+  VectorTools::integrate_difference (dofh,
+				     solution,
+				     ZeroFunction<dim>(dim),
+				     cellwise_errors,
+				     QGauss<dim>(5),
+				     norm);
+  
+  const double error = cellwise_errors.l2_norm();
+
+  const double difference = std::abs(error-value);
+  deallog << "computed: " << error
+	  << " expected: " << value
+	  << " difference: " << difference
+	  << std::endl;
+  Assert(difference<1e-10, ExcMessage("Error in integrate_difference"));
+}
+
+template <int dim>
+void test()
+{
+  deallog << "Hdiv_seminorm:" << std::endl;
+  // sqrt(\int (div f)^2 = sqrt(\int (1+2y)^2)
+  test<dim>(VectorTools::Hdiv_seminorm, std::sqrt(13.0/3.0));
+  deallog << "L2_norm:" << std::endl;
+  // sqrt(\int_\Omega f^2) = sqrt(\int (x+y)^2+(x^2+y^2)^2)
+  test<dim>(VectorTools::L2_norm, std::sqrt(161.0/90.0));
+  
+  deallog << "OK" << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  initlog();
+  test<2>();
+
+}

--- a/tests/vector_tools/integrate_difference_01.output
+++ b/tests/vector_tools/integrate_difference_01.output
@@ -1,0 +1,6 @@
+
+DEAL::Hdiv_seminorm:
+DEAL::computed: 2.08167 expected: 2.08167 difference: 4.44089e-16
+DEAL::L2_norm:
+DEAL::computed: 1.33749 expected: 1.33749 difference: 2.22045e-16
+DEAL::OK


### PR DESCRIPTION
- remove ExcNotImplemented
- fix wrong computation:
| u |_Hdiv
= || div u ||_L2
= sqrt( \int_\Omega (div u)^2 )
= sqrt( \int_\Omega (sum d/dx_i u_i)^2 )
and not
sqrt( \int_\Omega (sum (d/dx_i u_i)^2) ) (old implementation).
- add test