### PR TITLE
Use gold instead of the traditional linker if possible.

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -55,6 +55,11 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
 ENABLE_IF_LINKS(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
 
 #
+# Use the 'gold' linker if possible, given that it's substantially faster.
+#
+ENABLE_IF_SUPPORTED(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")
+
+#
 # Setup various warnings:
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wall")

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -44,6 +44,11 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
 # the deal.II library with it.
 #
 ENABLE_IF_LINKS(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
+
+#
+# Use the 'gold' linker if possible, given that it's substantially faster.
+#
+ENABLE_IF_SUPPORTED(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")
 
 #
 # Set ansi mode:

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -114,14 +114,23 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Improved: When available, deal.II now uses the "gold" linker, a
+  reimplementation of the traditional Unix "ld" linker that is substantially
+  faster. This reduces build and, in particular, test turnaround times.
+  <br>
+  (Wolfgang Bangerth, Matthias Maier, 2015/09/06)
+  </li>
+
   <li> Improved: Allow continuation lines in ParameterHandler.
   <br>
   (Alberto Sartori, 2015/09/04)
+  </li>
 
   <li> Fixed: VectorTools::integrate_difference for VectorTools::Hdiv_seminorm
   was computed incorrectly.
   <br>
   (Timo Heister, 2015/08/31)
+  </li>
 
   <li> Improved: The testsuite now supports multiple comparison files.
   Apart from the main comparison file that ends in
@@ -129,8 +138,8 @@ inconvenience this causes.
   <code>[...].output.[string]</code> are considered for comparison.
   <br>
   (Matthias Maier, 2015/08/29)
-
   </li>
+  
   <li> New: A class BlockLinearOperator has been introduced that extends
   the LinearOperator concept to block structures. A BlockLinearOperator can
   be sliced back to a LinearOperator.


### PR DESCRIPTION
This fixes #1476.