### PR TITLE
Squash warnings.

### DIFF
--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -91,6 +91,107 @@ public:
                std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 };
 
+
+namespace internal
+{
+  namespace PolynomialsRannacherTurek
+  {
+    template <int order, int dim>
+    inline
+    Tensor<order,dim>
+    compute_derivative (const unsigned int,
+                        const Point<dim> &)
+    {
+      Assert (dim == 2, ExcNotImplemented());
+      return Tensor<order,dim>();
+    }
+
+
+    template <int order>
+    inline
+    Tensor<order,2>
+    compute_derivative (const unsigned int i,
+                        const Point<2> &p)
+    {
+      const unsigned int dim = 2;
+
+      Tensor<order,dim> derivative;
+      switch (order)
+        {
+        case 1:
+        {
+          Tensor<1,dim> &grad = *reinterpret_cast<Tensor<1,dim>*>(&derivative);
+          if (i == 0)
+            {
+              grad[0] = -2.5 + 3*p(0);
+              grad[1] = 1.5 - 3*p(1);
+            }
+          else if (i == 1)
+            {
+              grad[0] = -0.5 + 3.0*p(0);
+              grad[1] = 1.5 - 3.0*p(1);
+            }
+          else if (i == 2)
+            {
+              grad[0] = 1.5 - 3.0*p(0);
+              grad[1] = -2.5 + 3.0*p(1);
+            }
+          else if (i == 3)
+            {
+              grad[0] = 1.5 - 3.0*p(0);
+              grad[1] = -0.5 + 3.0*p(1);
+            }
+          else
+            {
+              Assert(false, ExcNotImplemented());
+            }
+          return derivative;
+        }
+        case 2:
+        {
+          Tensor<2,dim> &grad_grad = *reinterpret_cast<Tensor<2,dim>*>(&derivative);
+          if (i == 0)
+            {
+              grad_grad[0][0] = 3;
+              grad_grad[0][1] = 0;
+              grad_grad[1][0] = 0;
+              grad_grad[1][1] = -3;
+            }
+          else if (i == 1)
+            {
+              grad_grad[0][0] = 3;
+              grad_grad[0][1] = 0;
+              grad_grad[1][0] = 0;
+              grad_grad[1][1] = -3;
+            }
+          else if (i == 2)
+            {
+              grad_grad[0][0] = -3;
+              grad_grad[0][1] = 0;
+              grad_grad[1][0] = 0;
+              grad_grad[1][1] = 3;
+            }
+          else if (i == 3)
+            {
+              grad_grad[0][0] = -3;
+              grad_grad[0][1] = 0;
+              grad_grad[1][0] = 0;
+              grad_grad[1][1] = 3;
+            }
+          return derivative;
+        }
+        default:
+        {
+          // higher derivatives are all zero
+          return Tensor<order,dim>();
+        }
+        }
+    }
+  }
+}
+
+
+
 // template functions
 template <int dim>
 template <int order>
@@ -98,78 +199,7 @@ Tensor<order,dim>
 PolynomialsRannacherTurek<dim>::compute_derivative (const unsigned int i,
                                                     const Point<dim> &p) const
 {
-  Assert(dim == 2, ExcNotImplemented());
-  Tensor<order,dim> derivative;
-  switch (order)
-    {
-    case 1:
-    {
-      Tensor<1,dim> &grad = *reinterpret_cast<Tensor<1,dim>*>(&derivative);
-      if (i == 0)
-        {
-          grad[0] = -2.5 + 3*p(0);
-          grad[1] = 1.5 - 3*p(1);
-        }
-      else if (i == 1)
-        {
-          grad[0] = -0.5 + 3.0*p(0);
-          grad[1] = 1.5 - 3.0*p(1);
-        }
-      else if (i == 2)
-        {
-          grad[0] = 1.5 - 3.0*p(0);
-          grad[1] = -2.5 + 3.0*p(1);
-        }
-      else if (i == 3)
-        {
-          grad[0] = 1.5 - 3.0*p(0);
-          grad[1] = -0.5 + 3.0*p(1);
-        }
-      else
-        {
-          Assert(false, ExcNotImplemented());
-        }
-      return derivative;
-    }
-    case 2:
-    {
-      Tensor<2,dim> &grad_grad = *reinterpret_cast<Tensor<2,dim>*>(&derivative);
-      if (i == 0)
-        {
-          grad_grad[0][0] = 3;
-          grad_grad[0][1] = 0;
-          grad_grad[1][0] = 0;
-          grad_grad[1][1] = -3;
-        }
-      else if (i == 1)
-        {
-          grad_grad[0][0] = 3;
-          grad_grad[0][1] = 0;
-          grad_grad[1][0] = 0;
-          grad_grad[1][1] = -3;
-        }
-      else if (i == 2)
-        {
-          grad_grad[0][0] = -3;
-          grad_grad[0][1] = 0;
-          grad_grad[1][0] = 0;
-          grad_grad[1][1] = 3;
-        }
-      else if (i == 3)
-        {
-          grad_grad[0][0] = -3;
-          grad_grad[0][1] = 0;
-          grad_grad[1][0] = 0;
-          grad_grad[1][1] = 3;
-        }
-      return derivative;
-    }
-    default:
-    {
-      // higher derivatives are all zero
-      return Tensor<order,dim>();
-    }
-    }
+  return internal::PolynomialsRannacherTurek::compute_derivative<order> (i, p);
 }
 
 


### PR DESCRIPTION
We previously had warnings about invalid array accesses for dim==1. The
function in question doesn't implement this, but is instantiated anyway.