### PR TITLE
Fix test output.

### DIFF
--- a/tests/grid/grid_in_gmsh_02.output
+++ b/tests/grid/grid_in_gmsh_02.output
@@ -1,0 +1,11 @@
+
+DEAL::  1 active cells
+DEAL::  hash=0
+DEAL::  360 active cells
+DEAL::  hash=189928
+DEAL::  1 active cells
+DEAL::  hash=0
+DEAL::  200 active cells
+DEAL::  hash=137138
+DEAL::  1 active cells
+DEAL::  hash=0


### PR DESCRIPTION
The correct output must have gotten lost in some of the recent moving
around. The current file is empty. This patch simply replaces it with
the correct output.