### PR TITLE
Adjust test output.

### DIFF
--- a/tests/base/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=off.output
@@ -44,7 +44,7 @@ DEAL::Memory consumption -- Sparsity:      928
 DEAL::Memory consumption -- Matrix:        1400
 DEAL::Memory consumption -- Solution:      416
 DEAL::Memory consumption -- Rhs:           416
-DEAL::Memory consumption -- DataOut:       3328
+DEAL::Memory consumption -- DataOut:       3336
 DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
@@ -90,7 +90,7 @@ DEAL::Memory consumption -- Sparsity:      64160
 DEAL::Memory consumption -- Matrix:        120824
 DEAL::Memory consumption -- Solution:      7456
 DEAL::Memory consumption -- Rhs:           7456
-DEAL::Memory consumption -- DataOut:       42788
+DEAL::Memory consumption -- DataOut:       42796
 DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
@@ -136,4 +136,4 @@ DEAL::Memory consumption -- Sparsity:      8321760
 DEAL::Memory consumption -- Matrix:        16383928
 DEAL::Memory consumption -- Solution:      259552
 DEAL::Memory consumption -- Rhs:           259552
-DEAL::Memory consumption -- DataOut:       1159724
+DEAL::Memory consumption -- DataOut:       1159732

--- a/tests/base/memory_consumption_01.with_64bit_indices=on.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=on.output
@@ -44,7 +44,7 @@ DEAL::Memory consumption -- Sparsity:      1752
 DEAL::Memory consumption -- Matrix:        1400
 DEAL::Memory consumption -- Solution:      424
 DEAL::Memory consumption -- Rhs:           424
-DEAL::Memory consumption -- DataOut:       3328
+DEAL::Memory consumption -- DataOut:       3336
 DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
@@ -90,7 +90,7 @@ DEAL::Memory consumption -- Sparsity:      128216
 DEAL::Memory consumption -- Matrix:        120824
 DEAL::Memory consumption -- Solution:      7464
 DEAL::Memory consumption -- Rhs:           7464
-DEAL::Memory consumption -- DataOut:       42788
+DEAL::Memory consumption -- DataOut:       42796
 DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
@@ -136,4 +136,4 @@ DEAL::Memory consumption -- Sparsity:      16643416
 DEAL::Memory consumption -- Matrix:        16383928
 DEAL::Memory consumption -- Solution:      259560
 DEAL::Memory consumption -- Rhs:           259560
-DEAL::Memory consumption -- DataOut:       1159724
+DEAL::Memory consumption -- DataOut:       1159732


### PR DESCRIPTION
Something must have recently increased the memory consumption of a
DataOut object by 8 bytes. I suspect that it was one of the mapping
patches, but since it's only a fixed amount independent of the size
of the mesh, I'm not going to dig very deep into this to find out
what patch and why.