### PR TITLE
Further fe values cleanups 29: update Mapping::transform()

### DIFF
--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -244,9 +244,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
       if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
-        mapping.transform(fe_data.shape_gradients[k],
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (fe_data.shape_gradients[k],
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
         {
@@ -259,9 +260,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
           correct_untransformed_hessians (fe_data.untransformed_shape_hessians,
                                           mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(fe_data.untransformed_shape_hessians,
-                            output_data.shape_hessians[k],
-                            mapping_internal, mapping_covariant_gradient);
+          mapping.transform (fe_data.untransformed_shape_hessians,
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }
@@ -307,9 +309,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
           output_data.shape_values(k,i) = fe_data.shape_values[k][i+offset];
 
       if (flags & update_gradients)
-        mapping.transform(make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians)
         {
@@ -323,8 +326,12 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
                                          ( fe_data.untransformed_shape_hessians, offset , quadrature.size()),
                                          mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(make_slice(fe_data.untransformed_shape_hessians, offset, quadrature.size()),
-                            output_data.shape_hessians[k], mapping_internal, mapping_covariant_gradient);
+          mapping.transform (make_slice(fe_data.untransformed_shape_hessians,
+                                        offset,
+                                        quadrature.size()),
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }
@@ -370,9 +377,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
           output_data.shape_values(k,i) = fe_data.shape_values[k][i+offset];
 
       if (flags & update_gradients)
-        mapping.transform(make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians)
         {
@@ -383,11 +391,20 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             }
 
           correct_untransformed_hessians(VectorSlice< std::vector<Tensor<2,dim> > >
-                                         ( fe_data.untransformed_shape_hessians, offset , quadrature.size()),
-                                         mapping_data, output_data, quadrature.size(), k);
+                                         (fe_data.untransformed_shape_hessians,
+                                          offset,
+                                          quadrature.size()),
+                                         mapping_data,
+                                         output_data,
+                                         quadrature.size(),
+                                         k);
 
-          mapping.transform(make_slice(fe_data.untransformed_shape_hessians, offset, quadrature.size()),
-                            output_data.shape_hessians[k], mapping_internal, mapping_covariant_gradient);
+          mapping.transform (make_slice(fe_data.untransformed_shape_hessians,
+                                        offset,
+                                        quadrature.size()),
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -907,6 +907,20 @@ public:
    * J(\mathbf x) \hat{\mathbf  u}(\mathbf x).
    * @f]
    * </ul>
+   *
+   * @param[in] input An array (or part of an array) of input objects that should
+   *   be mapped.
+   * @param[in] type The kind of mapping to be applied.
+   * @param[in] internal A pointer to an object of type Mapping::InternalDataBase
+   *   that contains information previously stored by the mapping. The object
+   *   pointed to was created by the get_data(), get_face_data(), or
+   *   get_subface_data() function, and will have been updated as part of a
+   *   call to fill_fe_values(), fill_fe_face_values(), or fill_fe_subface_values()
+   *   for the current cell, before calling the current function. In other words,
+   *   this object also represents with respect to which cell the transformation
+   *   should be applied to.
+   * @param[out] output An array (or part of an array) into which the transformed
+   *   objects should be placed.
    */
   virtual
   void
@@ -939,12 +953,27 @@ public:
    *                        J(\hat{\mathbf  x})^{-1}.
    * @f]
    * </ul>
+   *
    * @note It would have been more reasonable to make this transform a
    * template function with the rank in <code>DerivativeForm@<1, dim,
    * rank@></code>. Unfortunately C++ does not allow templatized virtual
    * functions. This is why we identify <code>DerivativeForm@<1, dim,
    * 1@></code> with a <code>Tensor@<1,dim@></code> when using
    * mapping_covariant() in the function transform() above this one.
+   *
+   * @param[in] input An array (or part of an array) of input objects that should
+   *   be mapped.
+   * @param[in] type The kind of mapping to be applied.
+   * @param[in] internal A pointer to an object of type Mapping::InternalDataBase
+   *   that contains information previously stored by the mapping. The object
+   *   pointed to was created by the get_data(), get_face_data(), or
+   *   get_subface_data() function, and will have been updated as part of a
+   *   call to fill_fe_values(), fill_fe_face_values(), or fill_fe_subface_values()
+   *   for the current cell, before calling the current function. In other words,
+   *   this object also represents with respect to which cell the transformation
+   *   should be applied to.
+   * @param[out] output An array (or part of an array) into which the transformed
+   *   objects should be placed.
    */
   virtual
   void
@@ -984,11 +1013,26 @@ public:
    * J(\hat{\mathbf  x})^{-1}.
    * @f]
    * </ul>
+   *
    * @todo The formulas for mapping_covariant_gradient,
    * mapping_contravariant_gradient and mapping_piola_gradient are only
    * true as stated for linear mappings. If, for example, the mapping is
    * bilinear (or has a higher order polynomial degree) then there is a
    * missing term associated with the derivative of $J$.
+   *
+   * @param[in] input An array (or part of an array) of input objects that should
+   *   be mapped.
+   * @param[in] type The kind of mapping to be applied.
+   * @param[in] internal A pointer to an object of type Mapping::InternalDataBase
+   *   that contains information previously stored by the mapping. The object
+   *   pointed to was created by the get_data(), get_face_data(), or
+   *   get_subface_data() function, and will have been updated as part of a
+   *   call to fill_fe_values(), fill_fe_face_values(), or fill_fe_subface_values()
+   *   for the current cell, before calling the current function. In other words,
+   *   this object also represents with respect to which cell the transformation
+   *   should be applied to.
+   * @param[out] output An array (or part of an array) into which the transformed
+   *   objects should be placed.
    */
   virtual
   void
@@ -1019,6 +1063,20 @@ public:
    *
    * In the case when dim=spacedim the previous formula reduces to
    * @f[J^{\dagger} = J^{-1}@f]
+   *
+   * @param[in] input An array (or part of an array) of input objects that should
+   *   be mapped.
+   * @param[in] type The kind of mapping to be applied.
+   * @param[in] internal A pointer to an object of type Mapping::InternalDataBase
+   *   that contains information previously stored by the mapping. The object
+   *   pointed to was created by the get_data(), get_face_data(), or
+   *   get_subface_data() function, and will have been updated as part of a
+   *   call to fill_fe_values(), fill_fe_face_values(), or fill_fe_subface_values()
+   *   for the current cell, before calling the current function. In other words,
+   *   this object also represents with respect to which cell the transformation
+   *   should be applied to.
+   * @param[out] output An array (or part of an array) into which the transformed
+   *   objects should be placed.
    */
   virtual
   void
@@ -1059,6 +1117,20 @@ public:
    * J_{jJ}(\hat{\mathbf  x})^{-1} J_{kK}(\hat{\mathbf  x})^{-1}.
    * @f]
    * </ul>
+   *
+   * @param[in] input An array (or part of an array) of input objects that should
+   *   be mapped.
+   * @param[in] type The kind of mapping to be applied.
+   * @param[in] internal A pointer to an object of type Mapping::InternalDataBase
+   *   that contains information previously stored by the mapping. The object
+   *   pointed to was created by the get_data(), get_face_data(), or
+   *   get_subface_data() function, and will have been updated as part of a
+   *   call to fill_fe_values(), fill_fe_face_values(), or fill_fe_subface_values()
+   *   for the current cell, before calling the current function. In other words,
+   *   this object also represents with respect to which cell the transformation
+   *   should be applied to.
+   * @param[out] output An array (or part of an array) into which the transformed
+   *   objects should be placed.
    */
   virtual
   void

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -910,10 +910,10 @@ public:
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >        output,
+  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const = 0;
+             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const = 0;
 
 
 
@@ -949,9 +949,9 @@ public:
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<1, dim, spacedim> > > input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const = 0;
+             const MappingType                                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
+             VectorSlice<std::vector<Tensor<2,spacedim> > >                            output) const = 0;
 
 
   /**
@@ -992,10 +992,10 @@ public:
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const = 0;
+             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const = 0;
 
   /**
    * Transform a tensor field from the reference cell to the physical cell.
@@ -1023,9 +1023,9 @@ public:
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const = 0;
+             const MappingType                                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
+             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const = 0;
 
   /**
    * Transform a field of 3-differential forms from the reference cell to the
@@ -1062,10 +1062,10 @@ public:
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >     input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const = 0;
+             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const = 0;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -92,42 +92,44 @@ public:
    */
 
   // for documentation, see the Mapping base class
-  virtual void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-             VectorSlice<std::vector<Tensor<1,spacedim> > > output,
+  virtual
+  void
+  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
-
-  // for documentation, see the Mapping base class
-  virtual void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
+             const MappingType                                                       type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                 &internal,
+             VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const;
+
+  // for documentation, see the Mapping base class
+  virtual
+  void
+  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             const MappingType                                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
+             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >     input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -160,42 +160,42 @@ public:
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-             VectorSlice<std::vector<Tensor<1,spacedim> > > output,
+  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > >    input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > > input,
+             const MappingType                                                        type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                  &internal,
+             VectorSlice<std::vector<Tensor<2,spacedim> > >                           output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             const MappingType                                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
+             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >     input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -114,10 +114,10 @@ public:
    * whether the exception mentioned above has been thrown.
    */
   virtual Point<dim>
-  transform_real_to_unit_cell (
-    const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-    const Point<spacedim>                            &p) const;
+  transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                               const Point<spacedim>                                     &p) const;
 
+  // for documentation, see the base classes
   virtual
   void
   transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
@@ -125,6 +125,7 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
              VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
 
+  // for documentation, see the base classes
   virtual
   void
   transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > > input,
@@ -132,6 +133,7 @@ public:
              const typename Mapping<dim,spacedim>::InternalDataBase                  &internal,
              VectorSlice<std::vector<Tensor<2,spacedim> > >                           output) const;
 
+  // for documentation, see the base classes
   virtual
   void
   transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -118,24 +118,26 @@ public:
     const typename Triangulation<dim,spacedim>::cell_iterator &cell,
     const Point<spacedim>                            &p) const;
 
-  virtual void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-             VectorSlice<std::vector<Tensor<1,spacedim> > > output,
+  virtual
+  void
+  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
-
-  virtual void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > >    input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
 
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > > input,
+             const MappingType                                                        type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                  &internal,
+             VectorSlice<std::vector<Tensor<2,spacedim> > >                           output) const;
+
+  virtual
+  void
+  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
 
   /**
    * Return the degree of the mapping, i.e. the value which was passed to the

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -98,42 +98,42 @@ public:
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-             VectorSlice<std::vector<Tensor<1,spacedim> > > output,
+  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > >    input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
+             const MappingType                                                       type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                 &internal,
+             VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
   transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             const MappingType                                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
+             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >     input,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
+  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+             const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             const MappingType type) const;
+             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
 
   /**
    * @}

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1461,7 +1461,7 @@ FiniteElement<dim,spacedim>::compute_2nd (
         // cell
         for (unsigned int d=0; d<spacedim; ++d)
           {
-            mapping.transform (diff_quot[d], diff_quot2, mapping_internal, mapping_covariant);
+            mapping.transform (diff_quot[d], mapping_covariant, mapping_internal, diff_quot2);
 
             for (unsigned int q=0; q<n_q_points; ++q)
               for (unsigned int d1=0; d1<spacedim; ++d1)

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -56,9 +56,10 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
       if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
-        mapping.transform(fe_data.shape_gradients[k],
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (fe_data.shape_gradients[k],
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
         {
@@ -71,9 +72,10 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
           correct_untransformed_hessians (fe_data.untransformed_shape_hessians,
                                           mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(fe_data.untransformed_shape_hessians,
-                            output_data.shape_hessians[k],
-                            mapping_internal, mapping_covariant_gradient);
+          mapping.transform (fe_data.untransformed_shape_hessians,
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }
@@ -107,9 +109,10 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
       if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
-        mapping.transform(fe_data.shape_gradients[k],
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (fe_data.shape_gradients[k],
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
         {
@@ -122,9 +125,10 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
           correct_untransformed_hessians (fe_data.untransformed_shape_hessians,
                                           mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(fe_data.untransformed_shape_hessians,
-                            output_data.shape_hessians[k],
-                            mapping_internal, mapping_covariant_gradient);
+          mapping.transform (fe_data.untransformed_shape_hessians,
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }
@@ -159,9 +163,10 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
       if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
-        mapping.transform(fe_data.shape_gradients[k],
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (fe_data.shape_gradients[k],
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
         {
@@ -174,9 +179,10 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
           correct_untransformed_hessians (fe_data.untransformed_shape_hessians,
                                           mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(fe_data.untransformed_shape_hessians,
-                            output_data.shape_hessians[k],
-                            mapping_internal, mapping_covariant_gradient);
+          mapping.transform (fe_data.untransformed_shape_hessians,
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }
@@ -207,9 +213,10 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
 
 
       if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
-        mapping.transform(fe_data.shape_gradients[k],
-                          output_data.shape_gradients[k],
-                          mapping_internal, mapping_covariant);
+        mapping.transform (fe_data.shape_gradients[k],
+                           mapping_covariant,
+                           mapping_internal,
+                           output_data.shape_gradients[k]);
 
       if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
         {
@@ -222,9 +229,10 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
           correct_untransformed_hessians (fe_data.untransformed_shape_hessians,
                                           mapping_data, output_data, quadrature.size(), k);
 
-          mapping.transform(fe_data.untransformed_shape_hessians,
-                            output_data.shape_hessians[k],
-                            mapping_internal, mapping_covariant_gradient);
+          mapping.transform (fe_data.untransformed_shape_hessians,
+                             mapping_covariant_gradient,
+                             mapping_internal,
+                             output_data.shape_hessians[k]);
         }
     }
 }

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -328,8 +328,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
 
 
   if ( (flags & update_gradients) && mapping_type != mapping_none )
-    mapping.transform(mapping_data.jacobian_grads, fe_data.transformed_jacobian_grads,
-                      mapping_internal, mapping_covariant_gradient);
+    mapping.transform (mapping_data.jacobian_grads,
+                       mapping_covariant_gradient,
+                       mapping_internal,
+                       fe_data.transformed_jacobian_grads);
 
   for (unsigned int i=0; i<this->dofs_per_cell; ++i)
     {
@@ -361,8 +363,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             case mapping_covariant:
             case mapping_contravariant:
             {
-              mapping.transform(fe_data.shape_values[i],
-                                fe_data.transformed_shape_values, mapping_internal, mapping_type);
+              mapping.transform (fe_data.shape_values[i],
+                                 mapping_type,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_values);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
@@ -374,8 +378,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-              mapping.transform(fe_data.shape_values[i], fe_data.transformed_shape_values,
-                                mapping_internal, mapping_piola);
+              mapping.transform (fe_data.shape_values[i],
+                                 mapping_piola,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_values);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_values(first+d,k)
@@ -385,8 +391,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
 
             case mapping_nedelec:
             {
-              mapping.transform (fe_data.shape_values[i], fe_data.transformed_shape_values,
-                                 mapping_internal, mapping_covariant);
+              mapping.transform (fe_data.shape_values[i],
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_values);
 
               for (unsigned int k = 0; k < n_q_points; ++k)
                 for (unsigned int d = 0; d < dim; ++d)
@@ -414,8 +422,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             {
             case mapping_none:
             {
-              mapping.transform(fe_data.shape_grads[i], fe_data.transformed_shape_grads,
-                                mapping_internal, mapping_covariant);
+              mapping.transform (fe_data.shape_grads[i],
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_grads);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_gradients[first+d][k] = fe_data.transformed_shape_grads[k][d];
@@ -423,8 +433,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             }
             case mapping_covariant:
             {
-              mapping.transform(fe_data.shape_grads[i], fe_data.transformed_shape_grads,
-                                mapping_internal, mapping_covariant_gradient);
+              mapping.transform (fe_data.shape_grads[i],
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -440,8 +452,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             }
             case mapping_contravariant:
             {
-              mapping.transform(fe_data.shape_grads[i], fe_data.transformed_shape_grads,
-                                mapping_internal, mapping_contravariant_gradient);
+              mapping.transform(fe_data.shape_grads[i],
+                                mapping_contravariant_gradient,
+                                mapping_internal,
+                                fe_data.transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -461,8 +475,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
             {
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k] = fe_data.shape_grads[i][k];
-              mapping.transform(fe_data.untransformed_shape_grads, fe_data.transformed_shape_grads,
-                                mapping_internal, mapping_piola_gradient);
+              mapping.transform (fe_data.untransformed_shape_grads,
+                                 mapping_piola_gradient,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -495,8 +511,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k] = fe_data.shape_grads[i][k];
 
-              mapping.transform (fe_data.untransformed_shape_grads,fe_data.transformed_shape_grads,
-                                 mapping_internal, mapping_covariant_gradient);
+              mapping.transform (fe_data.untransformed_shape_grads,
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 fe_data.transformed_shape_grads);
 
 
               for (unsigned int k=0; k<n_q_points; ++k)
@@ -585,10 +603,11 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
     get_face_sign_change_nedelec (cell, this->dofs_per_face, fe_data.sign_change);
 
   if ( (flags & update_gradients) && mapping_type != mapping_none )
-    mapping.transform(mapping_data.jacobian_grads,
-                      VectorSlice< std::vector<Tensor<3,spacedim> > >
-                      (fe_data.transformed_jacobian_grads, offset, n_q_points),
-                      mapping_internal, mapping_covariant_gradient);
+    mapping.transform (mapping_data.jacobian_grads,
+                       mapping_covariant_gradient,
+                       mapping_internal,
+                       VectorSlice< std::vector<Tensor<3,spacedim> > >
+                       (fe_data.transformed_jacobian_grads, offset, n_q_points));
 
   for (unsigned int i=0; i<this->dofs_per_cell; ++i)
     {
@@ -614,8 +633,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             {
               // Use auxiliary vector
               // for transformation
-              mapping.transform(make_slice(fe_data.shape_values[i], offset, n_q_points),
-                                transformed_shape_values, mapping_internal, mapping_type);
+              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+                                 mapping_type,
+                                 mapping_internal,
+                                 transformed_shape_values);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
@@ -627,8 +648,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             case mapping_piola:
             {
 
-              mapping.transform(make_slice(fe_data.shape_values[i], offset, n_q_points),
-                                transformed_shape_values, mapping_internal, mapping_piola);
+              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+                                 mapping_piola,
+                                 mapping_internal,
+                                 transformed_shape_values);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_values(first+d,k)
@@ -639,7 +662,9 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             case mapping_nedelec:
             {
               mapping.transform (make_slice (fe_data.shape_values[i], offset, n_q_points),
-                                 transformed_shape_values, mapping_internal, mapping_covariant);
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 transformed_shape_values);
 
               for (unsigned int k = 0; k < n_q_points; ++k)
                 for (unsigned int d = 0; d < dim; ++d)
@@ -663,8 +688,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             {
             case mapping_none:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_covariant);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 transformed_shape_grads);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_gradients[first+d][k] = transformed_shape_grads[k][d];
@@ -673,8 +700,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
 
             case mapping_covariant:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_covariant_gradient);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -689,8 +718,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             }
             case mapping_contravariant:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_contravariant_gradient);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_contravariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -709,8 +740,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             {
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
-              mapping.transform(make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_piola_gradient);
+              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+                                 mapping_piola_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -745,7 +778,9 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
               mapping.transform (make_slice (fe_data.untransformed_shape_grads, offset, n_q_points),
-                                 transformed_shape_grads, mapping_internal, mapping_covariant_gradient);
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -829,10 +864,11 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
     get_face_sign_change_nedelec (cell, this->dofs_per_face, fe_data.sign_change);
 
   if ( (flags & update_gradients) && mapping_type != mapping_none)
-    mapping.transform(mapping_data.jacobian_grads,
-                      VectorSlice< std::vector<Tensor<3,spacedim> > >
-                      (fe_data.transformed_jacobian_grads, offset, n_q_points),
-                      mapping_internal, mapping_covariant_gradient);
+    mapping.transform (mapping_data.jacobian_grads,
+                       mapping_covariant_gradient,
+                       mapping_internal,
+                       VectorSlice< std::vector<Tensor<3,spacedim> > >
+                       (fe_data.transformed_jacobian_grads, offset, n_q_points));
 
 
   for (unsigned int i=0; i<this->dofs_per_cell; ++i)
@@ -859,8 +895,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             {
               // Use auxiliary vector for
               // transformation
-              mapping.transform(make_slice(fe_data.shape_values[i], offset, n_q_points),
-                                transformed_shape_values, mapping_internal, mapping_type);
+              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+                                 mapping_type,
+                                 mapping_internal,
+                                 transformed_shape_values);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
@@ -871,8 +909,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-              mapping.transform(make_slice(fe_data.shape_values[i], offset, n_q_points),
-                                transformed_shape_values, mapping_internal, mapping_piola);
+              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+                                 mapping_piola,
+                                 mapping_internal,
+                                 transformed_shape_values);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_values(first+d,k)
@@ -882,7 +922,9 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             case mapping_nedelec:
             {
               mapping.transform (make_slice (fe_data.shape_values[i], offset, n_q_points),
-                                 transformed_shape_values, mapping_internal, mapping_covariant);
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 transformed_shape_values);
 
               for (unsigned int k = 0; k < n_q_points; ++k)
                 for (unsigned int d = 0; d < dim; ++d)
@@ -903,8 +945,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             {
             case mapping_none:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_covariant);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_covariant,
+                                 mapping_internal,
+                                 transformed_shape_grads);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_gradients[first+d][k] = transformed_shape_grads[k][d];
@@ -913,8 +957,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
 
             case mapping_covariant:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_covariant_gradient);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -931,8 +977,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
 
             case mapping_contravariant:
             {
-              mapping.transform(make_slice(fe_data.shape_grads[i], offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_contravariant_gradient);
+              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+                                 mapping_contravariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -953,8 +1001,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
-              mapping.transform(make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
-                                transformed_shape_grads, mapping_internal, mapping_piola_gradient);
+              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+                                 mapping_piola_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -987,7 +1037,9 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
               mapping.transform (make_slice (fe_data.untransformed_shape_grads, offset, n_q_points),
-                                 transformed_shape_grads, mapping_internal, mapping_covariant_gradient);
+                                 mapping_covariant_gradient,
+                                 mapping_internal,
+                                 transformed_shape_grads);
 
 
               for (unsigned int k=0; k<n_q_points; ++k)

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3236,7 +3236,7 @@ FEValuesBase<dim,spacedim>::transform (
 {
   VectorSlice<const std::vector<Tensor<1,dim> > > src(original);
   VectorSlice<std::vector<Tensor<1,spacedim> > > dst(transformed);
-  mapping->transform(src, dst, *mapping_data, type);
+  mapping->transform(src, type,*mapping_data, dst);
 }
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -584,11 +584,11 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 template<int dim, int spacedim>
 void
-MappingCartesian<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-  VectorSlice<std::vector<Tensor<1,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingCartesian<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
   Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
@@ -639,11 +639,11 @@ MappingCartesian<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingCartesian<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-  VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingCartesian<dim,spacedim>::
+transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
+           const MappingType                                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                 &mapping_data,
+           VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const
 {
   AssertDimension (input.size(), output.size());
   Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
@@ -740,11 +740,11 @@ MappingCartesian<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingCartesian<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<Tensor<2, dim> > >    input,
-  VectorSlice<std::vector<Tensor<2, spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingCartesian<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<2, spacedim> > >         output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -841,11 +841,11 @@ MappingCartesian<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingCartesian<dim,spacedim>::transform (
-  const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingCartesian<dim,spacedim>::
+transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
+           const MappingType                                                         mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -879,11 +879,11 @@ MappingCartesian<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingCartesian<dim,spacedim>::transform (
-  const VectorSlice<const std::vector< Tensor<3,dim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingCartesian<dim,spacedim>::
+transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
 {
 
   AssertDimension (input.size(), output.size());

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1022,9 +1022,9 @@ namespace internal
                     ExcInternalError());
 
             mapping.transform (data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d],
-                               data.aux[d],
+                               mapping_contravariant,
                                data,
-                               mapping_contravariant);
+                               data.aux[d]);
           }
 
         // if dim==spacedim, we can use the unit tangentials to compute the
@@ -1437,9 +1437,9 @@ namespace
   template<int dim, int spacedim, int rank, class VECTOR, class DH>
   void
   transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-                   VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
-                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                   const MappingType mapping_type)
+                   const MappingType                                        mapping_type,
+                   const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+                   VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData *>(&mapping_data) != 0),
@@ -1499,9 +1499,9 @@ namespace
   template<int dim, int spacedim, int rank, class VECTOR, class DH>
   void
   transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >    input,
-                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > > output,
-                               const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                               const MappingType mapping_type)
+                               const MappingType                                                             mapping_type,
+                               const typename Mapping<dim,spacedim>::InternalDataBase                       &mapping_data,
+                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                          output)
   {
 
     AssertDimension (input.size(), output.size());
@@ -1533,40 +1533,41 @@ namespace
 
 template<int dim, int spacedim, class VECTOR, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::transform (
-  const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-  VectorSlice<std::vector<Tensor<1,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingFEField<dim,spacedim,VECTOR,DH>::
+transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
 
-  transform_fields<dim,spacedim,1,VECTOR,DH>(input, output, mapping_data, mapping_type);
+  transform_fields<dim,spacedim,1,VECTOR,DH>(input, mapping_type, mapping_data, output);
 }
 
 
 
 template<int dim, int spacedim, class VECTOR, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::transform (
-  const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
-  VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingFEField<dim,spacedim,VECTOR,DH>::
+transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
+           const MappingType                                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
+           VectorSlice<std::vector<Tensor<2,spacedim> > >                             output) const
 {
   AssertDimension (input.size(), output.size());
 
-  transform_differential_forms<dim,spacedim,1,VECTOR,DH>(input, output, mapping_data, mapping_type);
-
+  transform_differential_forms<dim,spacedim,1,VECTOR,DH>(input, mapping_type, mapping_data, output);
 }
 
 
+
 template<int dim, int spacedim, class VECTOR, class DH>
-void MappingFEField<dim,spacedim,VECTOR,DH>::transform
-(const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
- VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
- const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
- const MappingType) const
+void
+MappingFEField<dim,spacedim,VECTOR,DH>::
+transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+           const MappingType,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const
 {
   (void)input;
   (void)output;
@@ -1579,11 +1580,12 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform
 
 
 template<int dim, int spacedim, class VECTOR, class DH>
-void MappingFEField<dim,spacedim,VECTOR,DH>::transform (
-  const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+void
+MappingFEField<dim,spacedim,VECTOR,DH>::
+transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
+           const MappingType                                                         mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -1618,18 +1620,22 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform (
               }
       return;
     }
+
     default:
       Assert(false, ExcNotImplemented());
     }
 
 }
 
+
+
 template<int dim, int spacedim, class VECTOR, class DH>
-void MappingFEField<dim,spacedim,VECTOR,DH>::transform (
-  const VectorSlice<const std::vector< Tensor<3,dim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType /*mapping_type*/) const
+void
+MappingFEField<dim,spacedim,VECTOR,DH>::
+transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
+           const MappingType                                     /*mapping_type*/,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
 {
 
   (void)input;
@@ -1640,6 +1646,7 @@ void MappingFEField<dim,spacedim,VECTOR,DH>::transform (
   AssertThrow(false, ExcNotImplemented());
 
 }
+
 
 
 template<int dim, int spacedim, class VECTOR, class DH>

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -995,11 +995,11 @@ add_quad_support_points(const typename Triangulation<dim,spacedim>::cell_iterato
 
 template<int dim, int spacedim>
 void
-MappingQ<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<Tensor<1,dim> > > input,
-  VectorSlice<std::vector<Tensor<1,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
   // The data object may be just a MappingQ1::InternalData, so we have to test
@@ -1020,18 +1020,18 @@ MappingQ<dim,spacedim>::transform (
     }
   // Now, q1_data should have the right tensors in it and we call the base
   // classes transform function
-  MappingQ1<dim,spacedim>::transform(input, output, *q1_data, mapping_type);
+  MappingQ1<dim,spacedim>::transform(input, mapping_type, *q1_data, output);
 }
 
 
 
 template<int dim, int spacedim>
 void
-MappingQ<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
-  VectorSlice<std::vector<Tensor<2,spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ<dim,spacedim>::
+transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
+           const MappingType                                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
+           VectorSlice<std::vector<Tensor<2,spacedim> > >                             output) const
 {
   AssertDimension (input.size(), output.size());
   // The data object may be just a MappingQ1::InternalData, so we have to test
@@ -1052,16 +1052,16 @@ MappingQ<dim,spacedim>::transform (
     }
   // Now, q1_data should have the right tensors in it and we call the base
   // classes transform function
-  MappingQ1<dim,spacedim>::transform(input, output, *q1_data, mapping_type);
+  MappingQ1<dim,spacedim>::transform(input, mapping_type, *q1_data, output);
 }
 
 
 template<int dim, int spacedim>
-void MappingQ<dim,spacedim>::transform
-(const VectorSlice<const std::vector<Tensor<2, dim> > >     input,
- VectorSlice<std::vector<Tensor<2,spacedim> > >             output,
- const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
- const MappingType mapping_type) const
+void MappingQ<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
   // The data object may be just a MappingQ1::InternalData, so we have to test
@@ -1082,7 +1082,7 @@ void MappingQ<dim,spacedim>::transform
     }
   // Now, q1_data should have the right tensors in it and we call the base
   // classes transform function
-  MappingQ1<dim,spacedim>::transform(input, output, *q1_data, mapping_type);
+  MappingQ1<dim,spacedim>::transform(input, mapping_type, *q1_data, output);
 }
 
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -1507,9 +1507,9 @@ namespace internal
                       ExcInternalError());
 
               mapping.transform (data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d],
-                                 data.aux[d],
+                                 mapping_contravariant,
                                  data,
-                                 mapping_contravariant);
+                                 data.aux[d]);
             }
 
           // if dim==spacedim, we can use the unit tangentials to compute the
@@ -1758,9 +1758,9 @@ namespace
   template <int dim, int spacedim, int rank>
   void
   transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-                   VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
-                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                   const MappingType mapping_type)
+                   const MappingType                                        mapping_type,
+                   const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+                   VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -1821,9 +1821,9 @@ namespace
   template <int dim, int spacedim, int rank>
   void
   transform_gradients(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-                      VectorSlice<std::vector<Tensor<rank,spacedim> > > output,
-                      const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                      const MappingType mapping_type)
+                      const MappingType                                        mapping_type,
+                      const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+                      VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -1901,10 +1901,10 @@ namespace
 
   template <int dim, int spacedim>
   void
-  transform_hessians(const VectorSlice<const std::vector<Tensor<3,dim> > > input,
-                     VectorSlice<std::vector<Tensor<3,spacedim> > > output,
+  transform_hessians(const VectorSlice<const std::vector<Tensor<3,dim> > >   input,
+                     const MappingType                                       mapping_type,
                      const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                     const MappingType mapping_type)
+                     VectorSlice<std::vector<Tensor<3,spacedim> > >          output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -2019,12 +2019,12 @@ namespace
 
 
 
-  template <int dim, int spacedim, int rank>
+  template<int dim, int spacedim, int rank>
   void
-  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >    input,
-                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > > output,
-                               const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                               const MappingType mapping_type)
+  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > > input,
+                               const MappingType                                                          mapping_type,
+                               const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
+                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                       output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -2054,48 +2054,48 @@ namespace
 
 template<int dim, int spacedim>
 void
-MappingQ1<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<Tensor<1, dim> > >  input,
-  VectorSlice<std::vector<Tensor<1, spacedim> > >         output,
-  const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-  const MappingType                                       mapping_type) const
+MappingQ1<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<1, dim> > >   input,
+           const MappingType                                        mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+           VectorSlice<std::vector<Tensor<1, spacedim> > >          output) const
 {
-  transform_fields(input, output, mapping_data, mapping_type);
+  transform_fields(input, mapping_type, mapping_data, output);
 }
 
 
 
 template<int dim, int spacedim>
 void
-MappingQ1<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-  VectorSlice<std::vector<Tensor<2, spacedim> > > output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ1<dim,spacedim>::
+transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
+           const MappingType                                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                 &mapping_data,
+           VectorSlice<std::vector<Tensor<2, spacedim> > >                         output) const
 {
-  transform_differential_forms(input, output, mapping_data, mapping_type);
+  transform_differential_forms(input, mapping_type, mapping_data, output);
 }
 
 
 
 template<int dim, int spacedim>
 void
-MappingQ1<dim,spacedim>::transform (
-  const VectorSlice<const std::vector<Tensor<2, dim> > >    input,
-  VectorSlice<std::vector<Tensor<2, spacedim> > >     output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ1<dim,spacedim>::
+transform (const VectorSlice<const std::vector<Tensor<2, dim> > >   input,
+           const MappingType                                        mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+           VectorSlice<std::vector<Tensor<2, spacedim> > >          output) const
 {
   switch (mapping_type)
     {
     case mapping_contravariant:
-      transform_fields(input, output, mapping_data, mapping_type);
+      transform_fields(input, mapping_type, mapping_data, output);
       return;
 
     case mapping_piola_gradient:
     case mapping_contravariant_gradient:
     case mapping_covariant_gradient:
-      transform_gradients(input, output, mapping_data, mapping_type);
+      transform_gradients(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());
@@ -2106,11 +2106,11 @@ MappingQ1<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingQ1<dim,spacedim>::transform (
-  const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ1<dim,spacedim>::
+transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
+           const MappingType                                                         mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -2155,11 +2155,11 @@ MappingQ1<dim,spacedim>::transform (
 
 template<int dim, int spacedim>
 void
-MappingQ1<dim,spacedim>::transform (
-  const VectorSlice<const std::vector< Tensor<3,dim> > > input,
-  VectorSlice<std::vector<Tensor<3,spacedim> > >             output,
-  const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-  const MappingType mapping_type) const
+MappingQ1<dim,spacedim>::
+transform (const VectorSlice<const std::vector< Tensor<3,dim> > >   input,
+           const MappingType                                        mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+           VectorSlice<std::vector<Tensor<3,spacedim> > >           output) const
 {
 
   switch (mapping_type)
@@ -2167,7 +2167,7 @@ MappingQ1<dim,spacedim>::transform (
     case mapping_piola_hessian:
     case mapping_contravariant_hessian:
     case mapping_covariant_hessian:
-      transform_hessians(input, output, mapping_data, mapping_type);
+      transform_hessians(input, mapping_type, mapping_data, output);
       return;
     default:
       Assert(false, ExcNotImplemented());


### PR DESCRIPTION
This updates the order of arguments to Mapping::transform() throughout the mapping classes, and adds documentation to them.

I've decided to keep this change separate from the issue discussed earlier today in #1507 (about the lack of the two new `transform()` functions in `MappingQ`) since that one is actually a bug fix of sorts, whereas here I'm just shuffling arguments. It's not forgotten, though.