### PR TITLE
Deprecate FEValues::transform().

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -240,6 +240,13 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Changed: FEValues::transform() has been deprecated. The functionality
+  of this function is a (small) subset of what the Mapping classes
+  already provide.
+  <br>
+  (Wolfgang Bangerth, 2015/09/02)
+  </li>
+
   <li> New: introduced hp::FECollection::find_least_face_dominating_fe(const std::set<unsigned int> &fes)
   which aims to find the least dominating finite element w.r.t. those provided
   as fe_indices in @p fes.

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2215,10 +2215,12 @@ public:
   /**
    * Transform a set of vectors, one for each quadrature point. The
    * <tt>mapping</tt> can be any of the ones defined in MappingType.
+   *
+   * @deprecated Use the various Mapping::transform() functions instead.
    */
   void transform (std::vector<Tensor<1,spacedim> > &transformed,
                   const std::vector<Tensor<1,dim> > &original,
-                  MappingType mapping) const;
+                  MappingType mapping) const DEAL_II_DEPRECATED;
 
   //@}
 


### PR DESCRIPTION
I don't see the use of this function given that all the 
transformations from reference to real cell should actually go
through the Mapping classes directly. The function is also not
used anywhere.

Fixes #1509. In reference to #1198.