### PR TITLE
Attempt to fix non-C++11 code path

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2493,7 +2493,7 @@ MatrixFree<dim,Number>::cell_loop
                             const std::pair<unsigned int,
                             unsigned int> &)>
   function = std_cxx11::bind<void>(function_pointer,
-                                   std_cxx11::cref(*owning_class),
+                                   owning_class,
                                    std_cxx11::_1,
                                    std_cxx11::_2,
                                    std_cxx11::_3,
@@ -2525,7 +2525,7 @@ MatrixFree<dim,Number>::cell_loop
                             const std::pair<unsigned int,
                             unsigned int> &)>
   function = std_cxx11::bind<void>(function_pointer,
-                                   std_cxx11::ref(*owning_class),
+                                   owning_class,
                                    std_cxx11::_1,
                                    std_cxx11::_2,
                                    std_cxx11::_3,


### PR DESCRIPTION
I can't reproduce the bug reported in http://cdash.kyomu.43-1.org/testDetails.php?test=20689718&build=11991 on my machines (it seems that gcc-4.9 and bundled boost work fine), so please check this patch on the offending system before merging.