### PR TITLE
CMake: Avoid running CXX11 Thread support test

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -217,32 +217,13 @@ IF(NOT DEFINED DEAL_II_WITH_CXX11 OR DEAL_II_WITH_CXX11)
       "
       DEAL_II_HAVE_CXX11_SHARED_PTR)
 
-    #
-    # On some systems with gcc 4.5.0, we can compile the code
-    # below but it will throw an exception when run. So test
-    # that as well.
-    #
-    IF(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
-      PUSH_CMAKE_REQUIRED("-pthread")
-      # 
-      # On Ubuntu 14.04, the code below won't run without the flag 
-      # -Wl,-no-as-needed. However, deal.II will work fine without 
-      # the flag.
-      #
-      PUSH_CMAKE_REQUIRED("-Wl,-no-as-needed")
-      CHECK_CXX_SOURCE_RUNS(
-        "
-        #include <thread>
-        void f(int){}
-        int main(){ std::thread t(f,1); t.join(); return 0; }
-        "
-        DEAL_II_HAVE_CXX11_THREAD)
-      RESET_CMAKE_REQUIRED()
-      PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
-    ELSE()
-      # Just export it ;-)
-      SET(DEAL_II_HAVE_CXX11_THREAD TRUE CACHE BOOL "")
-    ENDIF()
+    CHECK_CXX_SOURCE_COMPILES(
+      "
+      #include <thread>
+      void f(int){}
+      int main(){ std::thread t(f,1); t.join(); return 0; }
+      "
+      DEAL_II_HAVE_CXX11_THREAD)
 
     CHECK_CXX_SOURCE_COMPILES(
       "

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -63,9 +63,9 @@
   platforms:
 </p>
 <ul>
-  <li>GNU/Linux: GCC version 4.1 or later; Clang version 3.0 or later;
-  ICC versions 13* or 14*</li>
-  <li>Mac OS X: GCC version 4.1 or later; Clang version 3.0 or later.
+  <li>GNU/Linux: GCC version 4.6 or later; Clang version 3.3 or later;
+  ICC versions 15 or later</li>
+  <li>Mac OS X: GCC version 4.6 or later; Clang version 3.3 or later.
     Please see the <a href="https://github.com/dealii/dealii/wiki/MacOSX"
     target="_top">deal.II Wiki</a> for installation instructions.</li>
   <li>Windows: Currently, Windows is not supported officially.


### PR DESCRIPTION
We have had multiple problems with running this test so far. The latests is
pull request #1524, the attempted fix opens another problem #1535.

Given the fact that the test tries to detect a problem with gcc-4.5, just
check for successful compilation.

Closes #1535 