### PR TITLE
removed the no longer necessary FiniteElement::differences and ::fd_s…

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -565,15 +565,6 @@ public:
      */
     virtual std::size_t memory_consumption () const;
 
-    /**
-     * Storage for FEValues objects needed to approximate second derivatives.
-     *
-     * The ordering is <i>p+hx</i>, <i>p+hy</i>, <i>p+hz</i>, <i>p-hx</i>,
-     * <i>p-hy</i>, <i>p-hz</i>, where unused entries in lower dimensions are
-     * missing.
-     */
-    std::vector<FEValues<dim,spacedim>*> differences;
-
   private:
     /**
      * Initially set to true, but reset to false when clear_first_cell()
@@ -2183,13 +2174,6 @@ protected:
    * initialized in the constructor of this class.
    */
   const std::vector<unsigned int> n_nonzero_components_table;
-
-  /**
-   * Second derivatives of shapes functions are not computed analytically, but
-   * by finite differences of the gradients. This static variable denotes the
-   * step length to be used for that. It's value is set to 1e-6.
-   */
-  static const double fd_step_length;
 
   /**
    * Return the size of interface constraint matrices. Since this is needed in

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -35,10 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-const double FiniteElement<dim,spacedim>::fd_step_length = 1.0e-6;
-
-
-template <int dim, int spacedim>
 FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
   update_flags(update_default),
   update_once(update_default),
@@ -50,17 +46,7 @@ FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
 
 template <int dim, int spacedim>
 FiniteElement<dim,spacedim>::InternalDataBase::~InternalDataBase ()
-{
-  for (unsigned int i=0; i<differences.size (); ++i)
-    if (differences[i] != 0)
-      {
-        // delete pointer and set it
-        // to zero to avoid
-        // inadvertent use
-        delete differences[i];
-        differences[i] = 0;
-      }
-}
+{}
 
 
 


### PR DESCRIPTION
…tep_length

I missed these in #1544. This is a follow up PR to remove them.