### PR TITLE
Improve C++14 test for clang

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -132,7 +132,10 @@ IF(NOT DEFINED DEAL_II_WITH_CXX14 OR DEAL_II_WITH_CXX14)
       {
         auto func();
       };
-      int main() {}
+      int main()
+      {
+        foo bar;
+      }
       "
       DEAL_II_HAVE_CXX14_CLANGAUTODEBUG_BUG_OK)
 


### PR DESCRIPTION
It turns out that one needs to create a variable 'foo' to actually provoke the bug, at least on clang 3.5.