### PR TITLE
Further fe values cleanups 33

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -450,9 +450,19 @@ protected:
   const FE_Q<dim> feq;
 
   /**
-   * Pointer to a Q1 mapping to be used on interior cells unless
+   * Pointer to a Q1 mapping. This mapping is used on interior cells unless
    * use_mapping_q_on_all_cells was set in the call to the
-   * constructor.
+   * constructor. The mapping is also used on any cell in the
+   * transform_real_to_unit_cell() to compute a cheap initial
+   * guess for the position of the point before we employ the
+   * more expensive Newton iteration using the full mapping.
+   *
+   * @note MappingQEulerian resets this pointer to an object of type
+   *   MappingQ1Eulerian to ensure that the Q1 mapping also knows
+   *   about the proper shifts and transformations of the Eulerian
+   *   displacements. This also means that we really need to store
+   *   our own Q1 mapping here, rather than simply resorting to
+   *   StaticMappingQ1::mapping.
    */
   std_cxx11::unique_ptr<const MappingQ1<dim,spacedim> > q1_mapping;
 

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -62,15 +62,24 @@ public:
    *
    * The second argument determines whether the higher order mapping should
    * also be used on interior cells. If its value is <code>false</code> (the
-   * default), the a lower-order mapping is used in the interior. This is
+   * default), then a lower order mapping is used in the interior. This is
    * sufficient for most cases where higher order mappings are only used to
    * better approximate the boundary. In that case, cells bounded by straight
    * lines are acceptable in the interior. However, there are cases where one
    * would also like to use a higher order mapping in the interior. The
    * MappingQEulerian class is one such case.
+   *
+   * The value of @p use_mapping_q_on_all_cells is ignore if @p dim is not
+   * equal to @p spacedim, i.e., if we are considering meshes on surfaces
+   * embedded into higher dimensional spaces.
    */
   MappingQ (const unsigned int polynomial_degree,
             const bool use_mapping_q_on_all_cells = false);
+
+  /**
+   * Copy constructor.
+   */
+  MappingQ (const MappingQ<dim,spacedim> &mapping);
 
   /**
    * Transforms the point @p p on the unit cell to the point @p p_real on the
@@ -277,13 +286,13 @@ protected:
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
 
@@ -440,6 +449,12 @@ protected:
    */
   const FE_Q<dim> feq;
 
+  /**
+   * Pointer to a Q1 mapping to be used on interior cells unless
+   * use_mapping_q_on_all_cells was set in the call to the
+   * constructor.
+   */
+  std_cxx11::unique_ptr<const MappingQ1<dim,spacedim> > q1_mapping;
 
   /*
    * The default line support points. These are used when computing

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -69,7 +69,7 @@ public:
    * would also like to use a higher order mapping in the interior. The
    * MappingQEulerian class is one such case.
    *
-   * The value of @p use_mapping_q_on_all_cells is ignore if @p dim is not
+   * The value of @p use_mapping_q_on_all_cells is ignored if @p dim is not
    * equal to @p spacedim, i.e., if we are considering meshes on surfaces
    * embedded into higher dimensional spaces.
    */

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -71,12 +71,6 @@ public:
 
   // for documentation, see the Mapping base class
   virtual
-  Point<spacedim>
-  transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                               const Point<dim>                                 &p) const;
-
-  // for documentation, see the Mapping base class
-  virtual
   Point<dim>
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                const Point<spacedim>                            &p) const;
@@ -145,25 +139,6 @@ protected:
   Point<dim>
   transform_real_to_unit_cell_initial_guess (const std::vector<Point<spacedim> > &vertex,
                                              const Point<spacedim>                            &p) const;
-
-
-  /**
-   * Transforms a point @p p on the unit cell to the point @p p_real on the
-   * real cell @p cell and returns @p p_real.
-   *
-   * This function is called by @p transform_unit_to_real_cell and multiple
-   * times (through the Newton iteration) by @p
-   * transform_real_to_unit_cell_internal.
-   *
-   * Takes a reference to an @p InternalData that must already include the
-   * shape values at point @p p and the mapping support points of the cell.
-   *
-   * This @p InternalData argument avoids multiple computations of the shape
-   * values at point @p p and especially multiple computations of the mapping
-   * support points.
-   */
-  Point<spacedim>
-  transform_unit_to_real_cell_internal (const InternalData &mdata) const;
 
   /**
    * Transforms the point @p p on the real cell to the corresponding point on

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -469,24 +469,6 @@ protected:
                                   std::vector<Point<spacedim> > &a) const = 0;
 
   /**
-   * Transforms a point @p p on the unit cell to the point @p p_real on the
-   * real cell @p cell and returns @p p_real.
-   *
-   * This function is called by @p transform_unit_to_real_cell and multiple
-   * times (through the Newton iteration) by @p
-   * transform_real_to_unit_cell_internal.
-   *
-   * Takes a reference to an @p InternalData that must already include the
-   * shape values at point @p p and the mapping support points of the cell.
-   *
-   * This @p InternalData argument avoids multiple computations of the shape
-   * values at point @p p and especially multiple computations of the mapping
-   * support points.
-   */
-  Point<spacedim>
-  transform_unit_to_real_cell_internal (const InternalData &mdata) const;
-
-  /**
    * Make MappingQ a friend since it needs to call the
    * fill_fe_values() functions on its MappingQ1 sub-object.
    */

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -29,6 +29,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+template <int,int> class MappingQ;
+
+
 /*!@addtogroup mapping */
 /*@{*/
 
@@ -374,7 +377,6 @@ public:
     mutable std::vector<double> volume_elements;
   };
 
-protected:
 
   // documentation can be found in Mapping::requires_update_flags()
   virtual
@@ -389,13 +391,13 @@ protected:
 
   // documentation can be found in Mapping::get_face_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_face_data (const UpdateFlags flags,
                  const Quadrature<dim-1>& quadrature) const;
 
   // documentation can be found in Mapping::get_subface_data()
   virtual
-  typename Mapping<dim,spacedim>::InternalDataBase *
+  InternalData *
   get_subface_data (const UpdateFlags flags,
                     const Quadrature<dim-1>& quadrature) const;
 
@@ -429,6 +431,7 @@ protected:
    * @}
    */
 
+protected:
 
   /**
    * The degree of the polynomials used as shape functions for the mapping
@@ -450,6 +453,12 @@ protected:
   void
   compute_mapping_support_points (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                   std::vector<Point<spacedim> > &a) const = 0;
+
+  /**
+   * Make MappingQ a friend since it needs to call the
+   * fill_fe_values() functions on its MappingQ1 sub-object.
+   */
+  template <int, int> friend class MappingQ;
 };
 
 

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -78,6 +78,20 @@ public:
   virtual
   bool preserves_vertex_locations () const;
 
+  /**
+   * @name Mapping points between reference and real cells
+   * @{
+   */
+
+  // for documentation, see the Mapping base class
+  virtual
+  Point<spacedim>
+  transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
+                               const Point<dim>                                 &p) const;
+
+  /**
+   * @}
+   */
 
   /**
    * @name Functions to transform tensors from reference to real coordinates
@@ -453,6 +467,24 @@ protected:
   void
   compute_mapping_support_points (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                   std::vector<Point<spacedim> > &a) const = 0;
+
+  /**
+   * Transforms a point @p p on the unit cell to the point @p p_real on the
+   * real cell @p cell and returns @p p_real.
+   *
+   * This function is called by @p transform_unit_to_real_cell and multiple
+   * times (through the Newton iteration) by @p
+   * transform_real_to_unit_cell_internal.
+   *
+   * Takes a reference to an @p InternalData that must already include the
+   * shape values at point @p p and the mapping support points of the cell.
+   *
+   * This @p InternalData argument avoids multiple computations of the shape
+   * values at point @p p and especially multiple computations of the mapping
+   * support points.
+   */
+  Point<spacedim>
+  transform_unit_to_real_cell_internal (const InternalData &mdata) const;
 
   /**
    * Make MappingQ a friend since it needs to call the

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -193,7 +193,7 @@ template<int dim, int spacedim>
 Mapping<dim, spacedim> *
 MappingC1<dim,spacedim>::clone () const
 {
-  return new MappingC1<dim,spacedim>(*this);
+  return new MappingC1<dim,spacedim>();
 }
 
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -63,8 +63,17 @@ MappingQ<dim,spacedim>::MappingQ (const unsigned int degree,
           ((dim==2) ?
            4+4*(degree-1) :
            8+12*(degree-1)+6*(degree-1)*(degree-1))),
-  use_mapping_q_on_all_cells (use_mapping_q_on_all_cells
-                              || (dim != spacedim)),
+
+  // see whether we want to use *this* mapping objects on *all* cells,
+  // or defer to an explicit Q1 mapping on interior cells. if
+  // degree==1, then we are already that Q1 mapping, so we don't need
+  // it; if dim!=spacedim, there is also no need for anything because
+  // we're most likely on a curved manifold
+  use_mapping_q_on_all_cells (degree==1
+                              ||
+                              use_mapping_q_on_all_cells
+                              ||
+                              (dim != spacedim)),
   feq(degree),
   q1_mapping (this->use_mapping_q_on_all_cells
               ?
@@ -1028,7 +1037,7 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
   try
     {
       initial_p_unit
-        = MappingQ1<dim,spacedim>::transform_real_to_unit_cell(cell, p);
+        = StaticMappingQ1<dim,spacedim>::mapping.transform_real_to_unit_cell(cell, p);
     }
   catch (const typename Mapping<dim,spacedim>::ExcTransformationFailed &)
     {

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -46,7 +46,7 @@ template<int dim, int spacedim>
 std::size_t
 MappingQ<dim,spacedim>::InternalData::memory_consumption () const
 {
-  return (MappingQ1<dim,spacedim>::InternalData::memory_consumption () +
+  return (MappingQGeneric<dim,spacedim>::InternalData::memory_consumption () +
           MemoryConsumption::memory_consumption (use_mapping_q1_on_current_cell) +
           MemoryConsumption::memory_consumption (mapping_q1_data));
 }
@@ -128,7 +128,7 @@ MappingQ<dim,spacedim>::get_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::Task<>
   task = Threads::new_task (std_cxx11::function<void()>
-                            (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize,
+                            (std_cxx11::bind(&MappingQGeneric<dim,spacedim>::InternalData::initialize,
                                              data,
                                              update_flags,
                                              std_cxx11::cref(quadrature),
@@ -153,7 +153,7 @@ MappingQ<dim,spacedim>::get_face_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::Task<>
   task = Threads::new_task (std_cxx11::function<void()>
-                            (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                            (std_cxx11::bind(&MappingQGeneric<dim,spacedim>::InternalData::initialize_face,
                                              data,
                                              update_flags,
                                              std_cxx11::cref(q),
@@ -178,7 +178,7 @@ MappingQ<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
   // fill the data of both the Q_p and the Q_1 objects in parallel
   Threads::Task<>
   task = Threads::new_task (std_cxx11::function<void()>
-                            (std_cxx11::bind(&MappingQ1<dim,spacedim>::InternalData::initialize_face,
+                            (std_cxx11::bind(&MappingQGeneric<dim,spacedim>::InternalData::initialize_face,
                                              data,
                                              update_flags,
                                              std_cxx11::cref(q),
@@ -237,11 +237,11 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                 *data.mapping_q1_data,
                                 output_data);
   else
-    MappingQ1<dim,spacedim>::fill_fe_values(cell,
-                                            updated_cell_similarity,
-                                            quadrature,
-                                            data,
-                                            output_data);
+    MappingQGeneric<dim,spacedim>::fill_fe_values(cell,
+                                                  updated_cell_similarity,
+                                                  quadrature,
+                                                  data,
+                                                  output_data);
 
   return updated_cell_similarity;
 }
@@ -281,11 +281,11 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                                      *data.mapping_q1_data,
                                      output_data);
   else
-    MappingQ1<dim,spacedim>::fill_fe_face_values(cell,
-                                                 face_no,
-                                                 quadrature,
-                                                 data,
-                                                 output_data);
+    MappingQGeneric<dim,spacedim>::fill_fe_face_values(cell,
+                                                       face_no,
+                                                       quadrature,
+                                                       data,
+                                                       output_data);
 }
 
 
@@ -324,12 +324,12 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
                                         *data.mapping_q1_data,
                                         output_data);
   else
-    MappingQ1<dim,spacedim>::fill_fe_subface_values(cell,
-                                                    face_no,
-                                                    subface_no,
-                                                    quadrature,
-                                                    data,
-                                                    output_data);
+    MappingQGeneric<dim,spacedim>::fill_fe_subface_values(cell,
+                                                          face_no,
+                                                          subface_no,
+                                                          quadrature,
+                                                          data,
+                                                          output_data);
 }
 
 
@@ -871,7 +871,7 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
            VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *> (&mapping_data)
+  Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *> (&mapping_data)
            != 0),
           ExcInternalError());
 
@@ -882,7 +882,7 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
       return q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
 
   // otherwise just stick with what we already had
-  MappingQ1<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
+  MappingQGeneric<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
 }
 
 
@@ -896,7 +896,7 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim> 
            VectorSlice<std::vector<Tensor<2,spacedim> > >                             output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *> (&mapping_data)
+  Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *> (&mapping_data)
            != 0),
           ExcInternalError());
 
@@ -907,7 +907,7 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim> 
       return q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
 
   // otherwise just stick with what we already had
-  MappingQ1<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
+  MappingQGeneric<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
 }
 
 
@@ -919,7 +919,7 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
            VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *> (&mapping_data)
+  Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *> (&mapping_data)
            != 0),
           ExcInternalError());
 
@@ -930,7 +930,7 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
       return q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
 
   // otherwise just stick with what we already had
-  MappingQ1<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
+  MappingQGeneric<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
 }
 
 
@@ -944,7 +944,7 @@ transform (const VectorSlice<const std::vector<DerivativeForm<2, dim ,spacedim> 
            VectorSlice<std::vector<Tensor<3,spacedim> > >                             output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *> (&mapping_data)
+  Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *> (&mapping_data)
            != 0),
           ExcInternalError());
 
@@ -955,7 +955,7 @@ transform (const VectorSlice<const std::vector<DerivativeForm<2, dim ,spacedim> 
       return q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
 
   // otherwise just stick with what we already had
-  MappingQ1<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
+  MappingQGeneric<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
 }
 
 
@@ -967,7 +967,7 @@ transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
            VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
 {
   AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ1<dim,spacedim>::InternalData *> (&mapping_data)
+  Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *> (&mapping_data)
            != 0),
           ExcInternalError());
 
@@ -978,7 +978,7 @@ transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
       return q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
 
   // otherwise just stick with what we already had
-  MappingQ1<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
+  MappingQGeneric<dim,spacedim>::transform(input, mapping_type, mapping_data, output);
 }
 
 
@@ -988,29 +988,23 @@ MappingQ<dim,spacedim>::
 transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                              const Point<dim>                                 &p) const
 {
-  // Use the get_data function to create an InternalData with data vectors of
-  // the right size and transformation shape values already computed at point
-  // p.
-  const Quadrature<dim> point_quadrature(p);
-  std_cxx11::unique_ptr<InternalData> mdata (get_data(update_quadrature_points,
-                                                      point_quadrature));
+  // first see, whether we want to use a linear or a higher order
+  // mapping, then either use our own facilities or that of the Q1
+  // mapping we store
+  if (use_mapping_q_on_all_cells || cell->has_boundary_lines())
+    {
+      const Quadrature<dim> point_quadrature(p);
+      std_cxx11::unique_ptr<InternalData> mdata (get_data(update_quadrature_points,
+                                                          point_quadrature));
 
-  mdata->use_mapping_q1_on_current_cell = !(use_mapping_q_on_all_cells ||
-                                            cell->has_boundary_lines());
+      compute_mapping_support_points(cell, mdata->mapping_support_points);
 
-  typename MappingQ1<dim,spacedim>::InternalData
-  *p_data = (mdata->use_mapping_q1_on_current_cell ?
-             mdata->mapping_q1_data.get() :
-             &*mdata);
-
-  compute_mapping_support_points(cell, p_data->mapping_support_points);
-  // If this should be Q1, ignore all other support points.
-  if (p_data->shape_values.size()<p_data->mapping_support_points.size())
-    p_data->mapping_support_points.resize
-    (GeometryInfo<dim>::vertices_per_cell);
-
-
-  return this->transform_unit_to_real_cell_internal(*p_data);
+      return this->transform_unit_to_real_cell_internal(*mdata);
+    }
+  else
+    {
+      return q1_mapping->transform_unit_to_real_cell (cell, p);
+    }
 }
 
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -205,60 +205,6 @@ MappingQ1<dim,spacedim>::compute_mapping_support_points(
 
 
 
-
-template<int dim, int spacedim>
-Point<spacedim>
-MappingQ1<dim,spacedim>::transform_unit_to_real_cell (
-  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  const Point<dim> &p) const
-{
-  const Quadrature<dim> point_quadrature(p);
-
-  //TODO: Use get_data() here once MappingQ is no longer derived from
-  //MappingQ1. this doesn't currently work because we here really need
-  //a Q1 InternalData, but MappingQGeneric produces one with the
-  //polynomial degree of the MappingQ
-  std_cxx11::unique_ptr<InternalData> mdata (new InternalData(1));
-  mdata->initialize (this->requires_update_flags (update_quadrature_points),
-                     point_quadrature, 1);
-
-  // compute the mapping support
-  // points
-  compute_mapping_support_points(cell, mdata->mapping_support_points);
-
-  // Mapping support points can be
-  // bigger than necessary. If this
-  // is the case, force them to be
-  // Q1.
-  if (mdata->mapping_support_points.size() > mdata->shape_values.size())
-    mdata->mapping_support_points.resize
-    (GeometryInfo<dim>::vertices_per_cell);
-
-
-  return transform_unit_to_real_cell_internal(*mdata);
-}
-
-
-
-template<int dim, int spacedim>
-Point<spacedim>
-MappingQ1<dim,spacedim>::
-transform_unit_to_real_cell_internal (const InternalData &data) const
-{
-  AssertDimension (data.shape_values.size(),
-                   data.mapping_support_points.size());
-
-  // use now the InternalData to
-  // compute the point in real space.
-  Point<spacedim> p_real;
-  for (unsigned int i=0; i<data.mapping_support_points.size(); ++i)
-    p_real += data.mapping_support_points[i] * data.shape(0,i);
-
-  return p_real;
-}
-
-
-
 /* For an explanation of the  KA and Kb
    arrays see the comments in the declaration of
    transform_real_to_unit_cell_initial_guess */

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -219,7 +219,8 @@ MappingQ1<dim,spacedim>::transform_unit_to_real_cell (
   //a Q1 InternalData, but MappingQGeneric produces one with the
   //polynomial degree of the MappingQ
   std_cxx11::unique_ptr<InternalData> mdata (new InternalData(1));
-  mdata->initialize (this->requires_update_flags (update_quadrature_points | update_jacobians), point_quadrature, 1);
+  mdata->initialize (this->requires_update_flags (update_quadrature_points),
+                     point_quadrature, 1);
 
   // compute the mapping support
   // points
@@ -244,9 +245,8 @@ Point<spacedim>
 MappingQ1<dim,spacedim>::
 transform_unit_to_real_cell_internal (const InternalData &data) const
 {
-  const unsigned int n_mapping_points=data.mapping_support_points.size();
-  (void)n_mapping_points;
-  AssertDimension (data.shape_values.size(), n_mapping_points);
+  AssertDimension (data.shape_values.size(),
+                   data.mapping_support_points.size());
 
   // use now the InternalData to
   // compute the point in real space.

--- a/source/fe/mapping_q_eulerian.inst.in
+++ b/source/fe/mapping_q_eulerian.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -18,6 +18,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
   {
 #if deal_II_dimension <= deal_II_space_dimension 	
     template class MappingQEulerian<deal_II_dimension, Vector<double>, deal_II_space_dimension>;
+    template class MappingQEulerian<deal_II_dimension, Vector<float>,  deal_II_space_dimension>;
 #  ifdef DEAL_II_WITH_PETSC
     template class MappingQEulerian<deal_II_dimension,
 				    PETScWrappers::Vector, deal_II_space_dimension>;

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -791,20 +791,28 @@ MappingQGeneric<dim,spacedim>::
 transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                              const Point<dim> &p) const
 {
-  //TODO: This function is inefficient -- it might as well evaluate
-  //the shape functions directly, rather than first building the
-  //InternalData object and then working with it
+  // set up the polynomial space
+  const QGaussLobatto<1> line_support_points (polynomial_degree + 1);
+  const TensorProductPolynomials<dim>
+  tensor_pols (Polynomials::generate_complete_Lagrange_basis(line_support_points.get_points()));
+  Assert (tensor_pols.n() == Utilities::fixed_power<dim>(polynomial_degree+1),
+          ExcInternalError());
 
-  const Quadrature<dim> point_quadrature(p);
-  std_cxx11::unique_ptr<InternalData> mdata (new InternalData(polynomial_degree));
-  mdata->initialize (this->requires_update_flags(update_quadrature_points),
-                     point_quadrature,
-                     1);
+  // then also construct the mapping from lexicographic to the Qp shape function numbering
+  const std::vector<unsigned int>
+  renumber (FETools::
+            lexicographic_to_hierarchic_numbering (
+              FiniteElementData<dim> (get_dpo_vector<dim>(polynomial_degree), 1,
+                                      polynomial_degree)));
 
-  // compute the mapping support
-  // points
-  compute_mapping_support_points(cell, mdata->mapping_support_points);
-  return transform_unit_to_real_cell_internal(*mdata);
+  std::vector<Point<spacedim> > support_points (tensor_pols.n());
+  compute_mapping_support_points(cell, support_points);
+
+  Point<spacedim> mapped_point;
+  for (unsigned int i=0; i<tensor_pols.n(); ++i)
+    mapped_point += support_points[renumber[i]] * tensor_pols.compute_value (i, p);
+
+  return mapped_point;
 }
 
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -859,7 +859,7 @@ MappingQGeneric<dim,spacedim>::get_data (const UpdateFlags update_flags,
 
 
 template<int dim, int spacedim>
-typename Mapping<dim,spacedim>::InternalDataBase *
+typename MappingQGeneric<dim,spacedim>::InternalData *
 MappingQGeneric<dim,spacedim>::get_face_data (const UpdateFlags        update_flags,
                                               const Quadrature<dim-1> &quadrature) const
 {
@@ -874,7 +874,7 @@ MappingQGeneric<dim,spacedim>::get_face_data (const UpdateFlags        update_fl
 
 
 template<int dim, int spacedim>
-typename Mapping<dim,spacedim>::InternalDataBase *
+typename MappingQGeneric<dim,spacedim>::InternalData *
 MappingQGeneric<dim,spacedim>::get_subface_data (const UpdateFlags update_flags,
                                                  const Quadrature<dim-1>& quadrature) const
 {

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -818,25 +818,6 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
 
 
 template<int dim, int spacedim>
-Point<spacedim>
-MappingQGeneric<dim,spacedim>::
-transform_unit_to_real_cell_internal (const InternalData &data) const
-{
-  AssertDimension (data.shape_values.size(),
-                   data.mapping_support_points.size());
-
-  // use now the InternalData to
-  // compute the point in real space.
-  Point<spacedim> p_real;
-  for (unsigned int i=0; i<data.mapping_support_points.size(); ++i)
-    p_real += data.mapping_support_points[i] * data.shape(0,i);
-
-  return p_real;
-}
-
-
-
-template<int dim, int spacedim>
 UpdateFlags
 MappingQGeneric<dim,spacedim>::requires_update_flags (const UpdateFlags in) const
 {


### PR DESCRIPTION
This continues my quest to separate `MappingQ` from `MappingQ1`, see #1429. Specifically, I give `MappingQ` a `MappingQ1` member, establishing the has-a relationship. I also move some of the functions from `MappingQ1` into `MappingQGeneric` and redirect some of the calls from `MappingQ` to the latter rather than the former.

I'm not quite there yet with breaking the inheritance, but this is getting us pretty close.

In reference to #1198.