### PR TITLE
Constructors of SolverCG from PETSc and Trilinos have different interaces

### DIFF
--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -467,7 +467,12 @@ namespace Step40
 
     SolverControl solver_control (dof_handler.n_dofs(), 1e-12);
 
+#ifdef USE_PETSC_LA
     LA::SolverCG solver(solver_control, mpi_communicator);
+#else
+    LA::SolverCG solver(solver_control);
+#endif
+
     LA::MPI::PreconditionAMG preconditioner;
 
     LA::MPI::PreconditionAMG::AdditionalData data;


### PR DESCRIPTION
```
TrilinosWrappers::SolverCG (SolverControl &cn,
                            const AdditionalData &data=AdditionalData())
```
and
```
PETScWrappers::SolverCG (SolverControl &cn,
                         const MPI_Comm &mpi_communicator=PETSC_COMM_SELF,
                         const AdditionalData &data=AdditionalData())
```

But amazingly the current code works and could be built without warning.
I found no constructor of ```TrilinosWrappers::SolverCG``` or ```TrilinosWrappers::SolverBase ``` takes```MPI_Comm``` as parameter. 
Am I missed some constructors of  ```SolverCG``` class? Or ```MPI_Comm``` is converted to  ```AdditionalData``` implicitly?