### PR TITLE
make AdditionalData ctor explicit

### DIFF
--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -254,6 +254,7 @@ namespace PETScWrappers
       /**
        * Constructor. By default, set the damping parameter to one.
        */
+      explicit
       AdditionalData (const double omega = 1);
 
       /**

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -90,10 +90,11 @@ public:
      * The default is to perform an exact residual computation and breakdown
      * parameter 1e-10.
      */
+    explicit
     AdditionalData(const bool   exact_residual = true,
-                   const double breakdown      = 1.e-10) :
-      exact_residual(exact_residual),
-      breakdown(breakdown)
+                   const double breakdown      = 1.e-10)
+      : exact_residual(exact_residual),
+        breakdown(breakdown)
     {}
     /**
      * Flag for exact computation of residual.

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -141,6 +141,7 @@ public:
      * @deprecated Instead use: connect_coefficients_slot,
      * connect_condition_number_slot, and connect_eigenvalues_slot.
      */
+    explicit
     AdditionalData (const bool log_coefficients,
                     const bool compute_condition_number = false,
                     const bool compute_all_condition_numbers = false,

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -184,6 +184,7 @@ public:
      * left, the residual of the stopping criterion to the default residual,
      * and re-orthogonalization only if necessary.
      */
+    explicit
     AdditionalData (const unsigned int max_n_tmp_vectors = 30,
                     const bool right_preconditioning = false,
                     const bool use_default_residual = true,
@@ -421,6 +422,7 @@ public:
     /**
      * Constructor. By default, set the maximum basis size to 30.
      */
+    explicit
     AdditionalData(const unsigned int max_basis_size = 30,
                    const bool /*use_default_residual*/ = true)
       :

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -90,6 +90,7 @@ public:
      * The default is no exact residual computation and breakdown parameter
      * 1e-16.
      */
+    explicit
     AdditionalData(bool exact_residual = false,
                    double breakdown=1.e-16) :
       exact_residual(exact_residual),

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -69,6 +69,7 @@ public:
     /**
      * Constructor. By default, set the damping parameter to one.
      */
+    explicit
     AdditionalData (const double omega                       = 1,
                     const bool   use_preconditioned_residual = false);
 

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -90,6 +90,7 @@ namespace TrilinosWrappers
        * it is quite inelegant to set a specific option of one solver in the
        * base class for all solvers.
        */
+      explicit
       AdditionalData (const bool         output_solver_details   = false,
                       const unsigned int gmres_restart_parameter = 30);
 
@@ -276,6 +277,7 @@ namespace TrilinosWrappers
       /**
        * Sets the additional data field to the desired output format.
        */
+      explicit
       AdditionalData (const bool output_solver_details = false);
 
       /**
@@ -321,6 +323,7 @@ namespace TrilinosWrappers
       /**
        * Sets the additional data field to the desired output format.
        */
+      explicit
       AdditionalData (const bool output_solver_details = false);
 
       /**
@@ -367,6 +370,7 @@ namespace TrilinosWrappers
        * Constructor. By default, set the number of temporary vectors to 30,
        * i.e. do a restart every 30 iterations.
        */
+      explicit
       AdditionalData (const bool         output_solver_details = false,
                       const unsigned int restart_parameter = 30);
 
@@ -419,6 +423,7 @@ namespace TrilinosWrappers
       /**
        * Sets the additional data field to the desired output format.
        */
+      explicit
       AdditionalData (const bool output_solver_details = false);
 
       /**
@@ -465,6 +470,7 @@ namespace TrilinosWrappers
       /**
        * Sets the additional data field to the desired output format.
        */
+      explicit
       AdditionalData (const bool output_solver_details = false);
 
       /**
@@ -519,6 +525,7 @@ namespace TrilinosWrappers
       /**
        * Sets the additional data field to the desired output format.
        */
+      explicit
       AdditionalData (const bool output_solver_details = false,
                       const std::string &solver_type = "Amesos_Klu");
 


### PR DESCRIPTION
Constructors of AdditionalData in various linear solvers are now marked
explicit. This is to avoid implicit conversions from int. See #1571 for an
example where an MPI communiator (which is an int) is silently converted
because of the default values in AdditionalData.