### PR TITLE
Fix a bug where SolutionTransfer is not instantiated for BlockVector

### DIFF
--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(_src
   solution_transfer.cc
   solution_transfer_inst2.cc
   solution_transfer_inst3.cc
+  solution_transfer_inst4.cc
   time_dependent.cc
   vector_tools_boundary.cc
   vector_tools_constraints.cc

--- a/source/numerics/solution_transfer_inst4.cc
+++ b/source/numerics/solution_transfer_inst4.cc
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2013 - 2014 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// This file compiles the last quarter of the instantiations from solution_transfer.cc
+// to reduce the compilation unit (and memory consumption)
+
+#define SPLIT_INSTANTIATIONS_INDEX 3
+#include "solution_transfer.cc"


### PR DESCRIPTION
Fix a bug introduced in  d353ca5d59a0d300d9bec27ed4abf509604129d1 SolutionTransfer was not instantiated for BlockVector when using hp::DoFHandler