### PR TITLE
fix step-51 and tests with Solver*::AdditionalData changes

### DIFF
--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -974,7 +974,7 @@ namespace Step51
   {
     SolverControl solver_control (system_matrix.m()*10,
                                   1e-11*system_rhs.l2_norm());
-    SolverBicgstab<> solver (solver_control, false);
+    SolverBicgstab<> solver (solver_control);
     solver.solve (system_matrix, solution, system_rhs,
                   PreconditionIdentity());
 

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -763,7 +763,7 @@ namespace Step51
     // sensitive
     std::ostringstream stream;
     deallog.attach(stream);
-    SolverBicgstab<> solver (solver_control, false);
+    SolverBicgstab<> solver (solver_control);
     solver.solve (system_matrix, solution, system_rhs,
                   PreconditionIdentity());
     deallog.attach(logfile);

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -761,7 +761,7 @@ namespace Step51
                                   1e-12*system_rhs.l2_norm());
     std::ostringstream stream;
     deallog.attach(stream);
-    SolverBicgstab<> solver (solver_control, false);
+    SolverBicgstab<> solver (solver_control);
     solver.solve (system_matrix, solution, system_rhs,
                   PreconditionIdentity());
     deallog.attach(logfile);

--- a/tests/lac/solver.cc
+++ b/tests/lac/solver.cc
@@ -80,9 +80,10 @@ int main()
   SolverControl control(100, 1.e-3);
   SolverControl verbose_control(100, 1.e-3, true);
   SolverCG<> cg(control, mem);
-  SolverGMRES<> gmres(control, mem, 8);
-  SolverGMRES<>::AdditionalData data(8, true);
-  SolverGMRES<> gmresright(control, mem, data);
+  SolverGMRES<>::AdditionalData data1(8);
+  SolverGMRES<> gmres(control, mem, data1);
+  SolverGMRES<>::AdditionalData data2(8, true);
+  SolverGMRES<> gmresright(control, mem, data2);
   SolverMinRes<> minres(control, mem);
   SolverBicgstab<> bicgstab(control, mem);
   SolverRichardson<> rich(control, mem);

--- a/tests/lac/solver_monitor.cc
+++ b/tests/lac/solver_monitor.cc
@@ -91,7 +91,9 @@ int main()
   cg.connect (&monitor_norm);
   cg.connect (&monitor_mean);
 
-  SolverGMRES<> gmres(control, mem, 8);
+  SolverGMRES<> gmres(control,
+                      mem,
+                      SolverGMRES<>::AdditionalData(/*max_vecs=*/ 8));
   gmres.connect (&monitor_norm);
   gmres.connect (&monitor_mean);
 

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -54,8 +54,8 @@ check_vmult_quadratic(std::vector<double> &residuals,
   GrowingVectorMemory<> mem;
 
   SolverControl control(10, 1.e-13, false);
-  SolverRichardson<> rich(control, mem, .01);
-  SolverRichardson<> prich(control, mem, 1.);
+  SolverRichardson<> rich(control, mem, SolverRichardson<>::AdditionalData(/*omega=*/.01));
+  SolverRichardson<> prich(control, mem, SolverRichardson<>::AdditionalData(/*omega=*/1.));
 
   const types::global_dof_index block_size = (types::global_dof_index) std::sqrt(A.n()+.3);
   const unsigned int n_blocks = A.n()/block_size;
@@ -130,8 +130,8 @@ check_vmult_quadratic(std::vector<double> &residuals,
   GrowingVectorMemory<> mem;
 
   SolverControl control(10, 1.e-13, false);
-  SolverRichardson<> rich(control, mem, .01);
-  SolverRichardson<> prich(control, mem, 1.);
+  SolverRichardson<> rich(control, mem, SolverRichardson<>::AdditionalData(/*omega=*/.01));
+  SolverRichardson<> prich(control, mem, SolverRichardson<>::AdditionalData(/*omega=*/1.));
   PreconditionIdentity identity;
   PreconditionJacobi<BlockSparseMatrix<double> > jacobi;
   jacobi.initialize(A, .5);

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -206,7 +206,7 @@ void SeventhProblem<dim>::solve ()
   LA::MPI::Vector
   completely_distributed_solution (locally_owned_dofs, mpi_communicator);
   SolverControl solver_control (dof_handler.n_dofs(), 1e-12);
-  TrilinosWrappers::SolverCG solver(solver_control, mpi_communicator);
+  TrilinosWrappers::SolverCG solver(solver_control);
   TrilinosWrappers::PreconditionAMG preconditioner;
   TrilinosWrappers::PreconditionAMG::AdditionalData data;
   preconditioner.initialize(system_matrix, data);

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -96,7 +96,8 @@ int main(int argc, char **argv)
     u.compress (VectorOperation::insert);
 
     GrowingVectorMemory<TrilinosWrappers::Vector> mem;
-    SolverRichardson<TrilinosWrappers::Vector> solver(control,mem,0.1);
+    SolverRichardson<TrilinosWrappers::Vector>::AdditionalData data (/*omega=*/0.1);
+    SolverRichardson<TrilinosWrappers::Vector> solver(control, mem, data);
     PreconditionIdentity preconditioner;
     check_solve (solver, control, A,u,f, preconditioner);
   }


### PR DESCRIPTION
PR #1572 disabled implicit conversion to Solver*::AdditionalData. This commit
fixes tests and step-51 that broke because of that.