### PR TITLE
Minor bugfixes

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <complex>
-
+#include <utility>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -352,7 +352,7 @@ template <typename T, typename U>
 struct ProductType
 {
 #ifdef DEAL_II_WITH_CXX11
-  typedef decltype(T() * U()) type;
+  typedef decltype(std::declval<T>() * std::declval<U>()) type;
 #endif
 };
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1288,7 +1288,7 @@ Tensor<0,dim,typename ProductType<typename EnableIfScalar<OtherNumber>::type, Nu
 operator * (const OtherNumber           factor,
             const Tensor<0,dim,Number> &t)
 {
-  return factor * static_cast<Number>(t);
+  return factor * static_cast<const Number &>(t);
 }
 
 
@@ -1304,7 +1304,7 @@ Tensor<0,dim,typename ProductType<Number, typename EnableIfScalar<OtherNumber>::
 operator * (const Tensor<0,dim,Number> &t,
             const OtherNumber           factor)
 {
-  return static_cast<Number>(t) * factor;
+  return static_cast<const Number &>(t) * factor;
 }
 
 


### PR DESCRIPTION
8016b07 (Matthias Maier, 49 seconds ago)
   Bugfix: Be consistent and cast to  const Number &

1db7463 (Matthias Maier, 2 minutes ago)
   Bugfix: Use declval in decltype expression

   ``` decltype(std::declval<T>() * std::declval<U>())
   ``` is the correct syntax. This does not require that ```T``` and ```U```
   have default constructors...