### PR TITLE
Access to  Epetra_Operator in Trilinos preconditioner wrapper

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -153,6 +153,14 @@ namespace TrilinosWrappers
                          const dealii::parallel::distributed::Vector<double> &src) const;
 
     /**
+     * Return a reference to the underlaying Trilinos Epetra_Operator.
+     * So you can use the preconditioner with unwrapped Trilinos solver.
+     *
+     * Calling this function from an uninitialized object will cause an exception.
+     */
+    Epetra_Operator &trilinos_operator() const;
+
+    /**
      * Exception.
      */
     DeclException1 (ExcNonMatchingMaps,
@@ -1951,6 +1959,14 @@ namespace TrilinosWrappers
     const int ierr = preconditioner->ApplyInverse (tril_src, tril_dst);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
     preconditioner->SetUseTranspose(false);
+  }
+
+  inline
+  Epetra_Operator &
+  PreconditionBase::trilinos_operator () const
+  {
+    AssertThrow (preconditioner, ExcMessage("Trying to dereference a null pointer."));
+    return (*preconditioner);
   }
 
 #endif


### PR DESCRIPTION
Enable using wrapped preconditioner with unwrapped solver.

Because lots of AztecOO solver options is not wrapped. People may need to use unwrapped solver directly.