### PR TITLE
Bugfix: Support complex_overloads.h also in C++11 mode

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -461,6 +461,13 @@ struct ProductType<unsigned int,float>
   typedef float type;
 };
 
+#endif
+
+// Annoyingly, there is no std::complex<T>::operator*(U) for scalars U
+// other than T (not even in C++11, or C++14). We provide our own overloads
+// in base/complex_overloads.h, but in order for them to work, we have to
+// manually specify all products we want to allow:
+
 template <typename T>
 struct ProductType<std::complex<T>,std::complex<T> >
 {
@@ -498,7 +505,6 @@ struct ProductType<std::complex<T>,float>
   typedef std::complex<typename ProductType<T,float>::type> type;
 };
 
-#endif
 
 
 /**


### PR DESCRIPTION
[Wow. This is the first time that I broke something in C++11 mode - I
didn't realize that I was still in C++98 mode when testing...]

Manually specify all products that shall be available in ProductType -
otherwise our overloads cannot be used.