### PR TITLE
Tensor<1,dim,Number> - let the cross_product functions return its result

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,10 +38,20 @@ inconvenience this causes.
 </p>
 
 <ol>
-  <li> Changed: All doxygen-generated pages now contain a link to the
-  tutorial in their top-level menus.
+  <li> Cleanup: The two argument variant of cross_product that returned the
+  result by reference as first argument has been removed. Use the function
+  that directly returns the result instead.
   <br>
-  (Wolfgang Bangerth, 2015/09/13)
+  (Matthias Maier, 2015/09/14)
+  </li>
+
+  <li> Cleanup: The following functions in tensor.h have been deprecated:
+  <br>
+  - The three argument variant of cross_product that returns the result by
+    reference as first argument. Use the function that directly returns the
+    result instead.
+  <br>
+  (Matthias Maier, 2015/09/14 - XXX)
   </li>
 
   <li> Removed: Tensor<rank,dim,Number> as well as Point<dim,Number> no
@@ -293,6 +303,12 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Changed: All doxygen-generated pages now contain a link to the
+  tutorial in their top-level menus.
+  <br>
+  (Wolfgang Bangerth, 2015/09/13)
+  </li>
+
   <li>Cleanup: Constructors of AdditionalData in various linear solvers are now marked
   explicit. This avoid bugs with implicit conversions like the one fixed in step-40.
   <br>

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -2167,51 +2167,57 @@ Number determinant (const Tensor<1,1,Number> &t)
 
 
 /**
- * Cross-product in 2d. This is just a rotation by 90 degrees clockwise to
- * compute the outer normal from a tangential vector. This function is defined
- * for all space dimensions to allow for dimension independent programming
- * (e.g. within switches over the space dimension), but may only be called if
- * the actual dimension of the arguments is two (e.g. from the <tt>dim==2</tt>
- * case in the switch).
+ * Returns the cross-product in 2d. This is just a rotation by 90 degrees
+ * clockwise to compute the outer normal from a tangential vector. This
+ * function is defined for all space dimensions to allow for dimension
+ * independent programming (e.g. within switches over the space dimension),
+ * but may only be called if the actual dimension of the arguments is two
+ * (e.g. from the <tt>dim==2</tt> case in the switch).
  *
  * @relates Tensor
  * @author Guido Kanschat, 2001
  */
 template <int dim, typename Number>
 inline
-void
-cross_product (Tensor<1,dim,Number>       &dst,
-               const Tensor<1,dim,Number> &src)
+Tensor<1,dim,Number>
+cross_product (const Tensor<1,dim,Number> &src)
 {
   Assert (dim==2, ExcInternalError());
 
-  dst[0] = src[1];
-  dst[1] = -src[0];
+  Tensor<1, dim, Number> result;
+
+  result[0] = src[1];
+  result[1] = -src[0];
+
+  return result;
 }
 
 
 /**
- * Cross-product of 2 vectors in 3d. This function is defined for all space
- * dimensions to allow for dimension independent programming (e.g. within
- * switches over the space dimension), but may only be called if the actual
- * dimension of the arguments is three (e.g. from the <tt>dim==3</tt> case in
- * the switch).
+ * Returns the cross-product of 2 vectors in 3d. This function is defined
+ * for all space dimensions to allow for dimension independent programming
+ * (e.g. within switches over the space dimension), but may only be called
+ * if the actual dimension of the arguments is three (e.g. from the
+ * <tt>dim==3</tt> case in the switch).
  *
  * @relates Tensor
  * @author Guido Kanschat, 2001
  */
 template <int dim, typename Number>
 inline
-void
-cross_product (Tensor<1,dim,Number>       &dst,
-               const Tensor<1,dim,Number> &src1,
+Tensor<1,dim,Number>
+cross_product (const Tensor<1,dim,Number> &src1,
                const Tensor<1,dim,Number> &src2)
 {
   Assert (dim==3, ExcInternalError());
 
-  dst[0] = src1[1]*src2[2] - src1[2]*src2[1];
-  dst[1] = src1[2]*src2[0] - src1[0]*src2[2];
-  dst[2] = src1[0]*src2[1] - src1[1]*src2[0];
+  Tensor<1, dim, Number> result;
+
+  result[0] = src1[1]*src2[2] - src1[2]*src2[1];
+  result[1] = src1[2]*src2[0] - src1[0]*src2[2];
+  result[2] = src1[0]*src2[1] - src1[1]*src2[0];
+
+  return result;
 }
 
 
@@ -2535,5 +2541,8 @@ linfty_norm (const Tensor<2,dim,Number> &t)
 //@}
 
 DEAL_II_NAMESPACE_CLOSE
+
+// include deprecated non-member functions operating on Tensor
+#include <deal.II/base/tensor_deprecated.h>
 
 #endif

--- a/include/deal.II/base/tensor_deprecated.h
+++ b/include/deal.II/base/tensor_deprecated.h
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__tensor_deprecated_h
+#define dealii__tensor_deprecated_h
+
+#include <deal.II/base/tensor.h>
+
+
+/* --------- Deprecated non-member functions operating on tensors. ---------- */
+
+DEAL_II_NAMESPACE_OPEN
+
+//@}
+/**
+ * @name Deprecated Tensor operations
+ */
+//@{
+
+
+/**
+ * The cross-product of 2 vectors in 3d.
+ *
+ * @deprecated Use the cross_product function that returns the value.
+ * @relates Tensor
+ */
+template <int dim, typename Number>
+inline
+void
+cross_product (Tensor<1,dim,Number>       &dst,
+               const Tensor<1,dim,Number> &src1,
+               const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
+
+
+#ifndef DOXYGEN
+
+
+template <int dim, typename Number>
+inline
+void
+cross_product (Tensor<1,dim,Number>       &dst,
+               const Tensor<1,dim,Number> &src1,
+               const Tensor<1,dim,Number> &src2)
+{
+  dst = cross_product(src1, src2);
+}
+
+#endif /* DOXYGEN */
+
+//@}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2875,8 +2875,8 @@ namespace VectorTools
 
           // now compute the
           // two normals
-          cross_product (orthonormals[0], vector, tmp);
-          cross_product (orthonormals[1], vector, orthonormals[0]);
+          orthonormals[0] = cross_product (vector, tmp);
+          orthonormals[1] = cross_product (vector, orthonormals[0]);
 
           break;
         }
@@ -4343,9 +4343,9 @@ namespace VectorTools
           // associated with this face. We also must include the residuals from the
           // shape funcations associated with edges.
           Tensor<1, dim> tmp;
-          Tensor<1, dim> cross_product_i,
-                 cross_product_j,
-                 cross_product_rhs;
+          Tensor<1, dim> cross_product_i;
+          Tensor<1, dim> cross_product_j;
+          Tensor<1, dim> cross_product_rhs;
 
           // Loop to construct face linear system.
           for (unsigned int q_point = 0;
@@ -4394,33 +4394,25 @@ namespace VectorTools
                   const unsigned int j_face_idx = associated_face_dof_to_face_dof[j];
                   const unsigned int cell_j = fe.face_to_cell_index (j_face_idx, face);
 
-                  cross_product(cross_product_j,
-                                normal_vector,
-                                fe_face_values[vec].value(cell_j, q_point));
+                  cross_product_j =
+                    cross_product(normal_vector,
+                                  fe_face_values[vec].value(cell_j, q_point));
 
                   for (unsigned int i = 0; i < associated_face_dofs; ++i)
                     {
                       const unsigned int i_face_idx = associated_face_dof_to_face_dof[i];
                       const unsigned int cell_i = fe.face_to_cell_index (i_face_idx, face);
-                      cross_product(cross_product_i,
-                                    normal_vector,
-                                    fe_face_values[vec].value(cell_i, q_point));
+                      cross_product_i =
+                        cross_product(normal_vector,
+                                      fe_face_values[vec].value(cell_i, q_point));
 
-                      face_matrix(i,j)
-                      += fe_face_values.JxW (q_point)
-                         *cross_product_i
-                         *cross_product_j;
-
+                      face_matrix(i, j) += fe_face_values.JxW(q_point) *
+                                           cross_product_i * cross_product_j;
                     }
                   // compute rhs
-                  cross_product(cross_product_rhs,
-                                normal_vector,
-                                tmp);
-                  face_rhs(j)
-                  += fe_face_values.JxW (q_point)
-                     *cross_product_rhs
-                     *cross_product_j;
-
+                  cross_product_rhs = cross_product(normal_vector, tmp);
+                  face_rhs(j) += fe_face_values.JxW(q_point) *
+                                 cross_product_rhs * cross_product_j;
                 }
             }
 
@@ -5727,7 +5719,7 @@ namespace VectorTools
                     // we get here only for dim==3, but at least one isn't
                     // quite smart enough to notice this and warns when
                     // compiling the function in 2d
-                    cross_product (tangent, normals[0], normals[dim-2]);
+                    tangent = cross_product (normals[0], normals[dim-2]);
                     break;
                   default:
                     Assert (false, ExcNotImplemented());

--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -1820,10 +1820,7 @@ namespace internal
     Tensor<1,3>
     wedge_product (const Tensor<1,3> (&derivative)[2])
     {
-      Tensor<1,3> result;
-      cross_product (result, derivative[0], derivative[1]);
-
-      return result;
+      result cross_product (derivative[0], derivative[1]);
     }
 
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1043,10 +1043,11 @@ namespace internal
                                                       -1 : +1);
                   break;
                 case 2:
-                  cross_product (output_data.boundary_forms[i], data.aux[0][i]);
+                  output_data.boundary_forms[i] = cross_product(data.aux[0][i]);
                   break;
                 case 3:
-                  cross_product (output_data.boundary_forms[i], data.aux[0][i], data.aux[1][i]);
+                  output_data.boundary_forms[i] =
+                    cross_product(data.aux[0][i], data.aux[1][i]);
                   break;
                 default:
                   Assert(false, ExcNotImplemented());
@@ -1075,17 +1076,17 @@ namespace internal
 
                 if (dim==2)
                   {
-                    Tensor<1,spacedim> cell_normal;
                     const DerivativeForm<1,spacedim,dim> DX_t =
                       data.contravariant[point].transpose();
-                    cross_product(cell_normal,DX_t[0],DX_t[1]);
+
+                    Tensor<1, spacedim> cell_normal =
+                      cross_product(DX_t[0], DX_t[1]);
                     cell_normal /= cell_normal.norm();
 
                     // then compute the face normal from the face tangent
                     // and the cell normal:
-                    cross_product (output_data.boundary_forms[point],
-                                   data.aux[0][point], cell_normal);
-
+                    output_data.boundary_forms[point] =
+                      cross_product(data.aux[0][point], cell_normal);
                   }
 
               }
@@ -1291,9 +1292,11 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                 ExcMessage("There is no cell normal in codim 2."));
 
                         if (dim==1)
-                          cross_product(output_data.normal_vectors[point], -DX_t[0]);
+                          output_data.normal_vectors[point] =
+                            cross_product(-DX_t[0]);
                         else //dim == 2
-                          cross_product(output_data.normal_vectors[point],DX_t[0],DX_t[1]);
+                          output_data.normal_vectors[point] =
+                            cross_product(DX_t[0], DX_t[1]);
 
                         output_data.normal_vectors[point] /= output_data.normal_vectors[point].norm();
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -1501,10 +1501,11 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                         Assert( codim==1 , ExcMessage("There is no cell normal in codim 2."));
 
                         if (dim==1)
-                          cross_product(output_data.normal_vectors[point],
-                                        -DX_t[0]);
+                          output_data.normal_vectors[point] =
+                            cross_product(-DX_t[0]);
                         else //dim == 2
-                          cross_product(output_data.normal_vectors[point],DX_t[0],DX_t[1]);
+                          output_data.normal_vectors[point] =
+                            cross_product(DX_t[0], DX_t[1]);
 
                         output_data.normal_vectors[point] /= output_data.normal_vectors[point].norm();
 
@@ -1644,10 +1645,12 @@ namespace internal
                                                         -1 : +1);
                     break;
                   case 2:
-                    cross_product (output_data.boundary_forms[i], data.aux[0][i]);
+                    output_data.boundary_forms[i] =
+                      cross_product(data.aux[0][i]);
                     break;
                   case 3:
-                    cross_product (output_data.boundary_forms[i], data.aux[0][i], data.aux[1][i]);
+                    output_data.boundary_forms[i] =
+                      cross_product(data.aux[0][i], data.aux[1][i]);
                     break;
                   default:
                     Assert(false, ExcNotImplemented());
@@ -1675,16 +1678,17 @@ namespace internal
 
                   if (dim==2)
                     {
-                      Tensor<1,spacedim> cell_normal;
                       const DerivativeForm<1,spacedim,dim> DX_t =
                         data.contravariant[point].transpose();
-                      cross_product(cell_normal,DX_t[0],DX_t[1]);
+
+                      Tensor<1, spacedim> cell_normal =
+                        cross_product(DX_t[0], DX_t[1]);
                       cell_normal /= cell_normal.norm();
 
                       // then compute the face normal from the face tangent
                       // and the cell normal:
-                      cross_product (output_data.boundary_forms[point],
-                                     data.aux[0][point], cell_normal);
+                      output_data.boundary_forms[point] =
+                        cross_product(data.aux[0][point], cell_normal);
                     }
                 }
             }

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -981,8 +981,7 @@ namespace
     const Tensor<1,3> v01 = accessor.vertex(1) - accessor.vertex(0);
     const Tensor<1,3> v02 = accessor.vertex(2) - accessor.vertex(0);
 
-    Tensor<1,3> normal;
-    cross_product(normal, v01, v02);
+    Tensor<1,3> normal = cross_product(v01, v02);
 
     const Tensor<1,3> v03 = accessor.vertex(3) - accessor.vertex(0);
 
@@ -1004,8 +1003,7 @@ namespace
     // the face is planar. then its area is 1/2 of the norm of the
     // cross product of the two diagonals
     const Tensor<1,3> v12 = accessor.vertex(2) - accessor.vertex(1);
-    Tensor<1,3> twice_area;
-    cross_product(twice_area, v03, v12);
+    Tensor<1,3> twice_area = cross_product(v03, v12);
     return 0.5 * twice_area.norm();
   }
 

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -491,8 +491,7 @@ namespace internal
     Tensor<1,2>
     normalized_alternating_product (const Tensor<1,2> (&basis_vectors)[1])
     {
-      Tensor<1,2> tmp;
-      cross_product (tmp, basis_vectors[0]);
+      Tensor<1,2> tmp = cross_product (basis_vectors[0]);
       return tmp/tmp.norm();
     }
 
@@ -513,8 +512,7 @@ namespace internal
     Tensor<1,3>
     normalized_alternating_product (const Tensor<1,3> (&basis_vectors)[2])
     {
-      Tensor<1,3> tmp;
-      cross_product (tmp, basis_vectors[0], basis_vectors[1]);
+      Tensor<1,3> tmp = cross_product (basis_vectors[0], basis_vectors[1]);
       return tmp/tmp.norm();
     }
 
@@ -689,11 +687,8 @@ get_normals_at_vertices (const Triangulation<3>::face_iterator &face,
   { {1,2},{3,0},{0,3},{2,1}};
   for (unsigned int vertex=0; vertex<vertices_per_face; ++vertex)
     {
-      // first define the two tangent
-      // vectors at the vertex by
-      // using the two lines
-      // radiating away from this
-      // vertex
+      // first define the two tangent vectors at the vertex by using the
+      // two lines radiating away from this vertex
       const Tensor<1,3> tangents[2]
         = { face->vertex(neighboring_vertices[vertex][0])
             - face->vertex(vertex),
@@ -701,13 +696,9 @@ get_normals_at_vertices (const Triangulation<3>::face_iterator &face,
             - face->vertex(vertex)
           };
 
-      // then compute the normal by
-      // taking the cross
-      // product. since the normal is
-      // not required to be
-      // normalized, no problem here
-      cross_product (face_vertex_normals[vertex],
-                     tangents[0], tangents[1]);
+      // then compute the normal by taking the cross product. since the
+      // normal is not required to be normalized, no problem here
+      face_vertex_normals[vertex] = cross_product(tangents[0], tangents[1]);
     };
 }
 

--- a/tests/base/tensor.cc
+++ b/tests/base/tensor.cc
@@ -75,18 +75,17 @@ int main ()
       e1[0] = 1.;
       e2[1] = 1.;
       e3[2] = 1.;
-      Tensor<1,3> result;
-      cross_product(result,e1,e2);
+      Tensor<1,3> result = cross_product(e1, e2);
       deallog << '\t' << result[0]
               << '\t' << result[1]
               << '\t' << result[2] << std::endl;
 
-      cross_product(result,e2,e3);
+      result = cross_product(e2, e3);
       deallog << '\t' << result[0]
               << '\t' << result[1] << '\t'
               << result[2] << std::endl;
 
-      cross_product(result,e3,e1);
+      result = cross_product(e3, e1);
       deallog << '\t' << result[0]
               << '\t' << result[1]
               << '\t' << result[2] << std::endl;

--- a/tests/base/tensor_complex.cc
+++ b/tests/base/tensor_complex.cc
@@ -96,18 +96,17 @@ int main ()
       e1[0] = 1.;
       e2[1] = 1.;
       e3[2] = 1.;
-      Tensor<1,3,std::complex<double> > result;
-      cross_product(result,e1,e2);
+      Tensor<1,3,std::complex<double> > result = cross_product(e1, e2);
       deallog << '\t' << result[0]
               << '\t' << result[1]
               << '\t' << result[2] << std::endl;
 
-      cross_product(result,e2,e3);
+      result = cross_product(e2, e3);
       deallog << '\t' << result[0]
               << '\t' << result[1] << '\t'
               << result[2] << std::endl;
 
-      cross_product(result,e3,e1);
+      result = cross_product(e3, e1);
       deallog << '\t' << result[0]
               << '\t' << result[1]
               << '\t' << result[2] << std::endl;

--- a/tests/base/tensor_float.cc
+++ b/tests/base/tensor_float.cc
@@ -80,18 +80,17 @@ int main ()
       e1[0] = 1.;
       e2[1] = 1.;
       e3[2] = 1.;
-      Tensor<1,3,float> result;
-      cross_product(result,e1,e2);
+      Tensor<1,3,float> result = cross_product(e1, e2);
       deallog << '\t' << static_cast<double>(result[0])
               << '\t' << static_cast<double>(result[1])
               << '\t' << static_cast<double>(result[2]) << std::endl;
 
-      cross_product(result,e2,e3);
+      result = cross_product(e2, e3);
       deallog << '\t' << static_cast<double>(result[0])
               << '\t' << static_cast<double>(result[1]) << '\t'
               << static_cast<double>(result[2]) << std::endl;
 
-      cross_product(result,e3,e1);
+      result = cross_product(e3, e1);
       deallog << '\t' << static_cast<double>(result[0])
               << '\t' << static_cast<double>(result[1])
               << '\t' << static_cast<double>(result[2]) << std::endl;

--- a/tests/codim_one/bem_integration.cc
+++ b/tests/codim_one/bem_integration.cc
@@ -154,11 +154,9 @@ LaplaceKernelIntegration<dim>::term_S (const Tensor<1,3> &r,
                                        const Tensor<1,3> &n,
                                        const double &rn_c)
 {
-  Point<3> ra1, ra2, a12;
-
-  cross_product(ra1,r,a1);
-  cross_product(ra2,r,a2);
-  cross_product(a12,a1,a2);
+  Tensor<1, 3> ra1 = cross_product(r, a1);
+  Tensor<1, 3> ra2 = cross_product(r, a2);
+  Tensor<1, 3> a12 = cross_product(a1, a2);
 
   double integral =
     -1./2./numbers::PI
@@ -178,11 +176,9 @@ LaplaceKernelIntegration<dim>::term_D (const Tensor<1,3> &r,
                                        const Tensor<1,3> &a1,
                                        const Tensor<1,3> &a2)
 {
-  Point<3> ra1, ra2, a12;
-
-  cross_product(ra1,r,a1);
-  cross_product(ra2,r,a2);
-  cross_product(a12,a1,a2);
+  Tensor<1, 3> ra1 = cross_product(r, a1);
+  Tensor<1, 3> ra2 = cross_product(r, a2);
+  Tensor<1, 3> a12 = cross_product(a1, a2);
 
   double integral = 1./2./numbers::PI
                     *atan2( ra1*ra2, (r.norm()* (r*a12)));


### PR DESCRIPTION
Unfortunately, this is an incompatbile change because the old signature
```
void cross_product(Tensor<1, dim> &dst, const Tensor<1, dim> &src);
```
cannot be kept. It clashes with the new signature
```
Tensor<1, dim>
cross_product(const Tensor<1, dim> &src1, const Tensor<1, dim> &src2);
```

Nevertheless, I consider this a very important change. All other function and
operators just return the result. The cross product should do the same.