### PR TITLE
Tensor<rank,dim,Number -  let outer_product return its result

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1506,6 +1506,30 @@ operator * (const Tensor<rank_1, dim, Number> &src1,
 }
 
 
+/**
+ * The outer product of two tensors of @p rank_1 and @p rank_2: Returns a
+ * tensor of rank $(\text{rank\_1} + \text{rank\_2})$:
+ * @f[
+ *   \text{result}_{i_1,..,i_{r1},j_1,..,j_{r2}}
+ *   = \text{left}_{i_1,..,i_{r1}}\,\text{right}_{j_1,..,j_{r2}.}
+ * @f]
+ *
+ * @relates Tensor
+ * @relates ProductType
+ */
+template <int rank_1, int rank_2, int dim,
+          typename Number, typename OtherNumber>
+inline
+Tensor<rank_1 + rank_2, dim, typename ProductType<Number, OtherNumber>::type>
+outer_product(const Tensor<rank_1, dim, Number> &src1,
+              const Tensor<rank_2, dim, OtherNumber> &src2)
+{
+  typename Tensor<rank_1 + rank_2, dim, typename ProductType<Number, OtherNumber>::type>::tensor_type result;
+  TensorAccessors::contract<0, rank_1, rank_2, dim>(result, src1, src2);
+  return result;
+}
+
+
 //@}
 /**
  * @name To be refactored
@@ -1997,102 +2021,6 @@ contract3 (const Tensor<2,dim,Number> &t1,
         for (unsigned int l=0; l<dim; ++l)
           s += t1[i][j] * t2[i][j][k][l] * t3[k][l];
   return s;
-}
-
-
-/**
- * Form the outer product of two tensors of rank 1 and 1, i.e. <tt>dst[i][j] =
- * src1[i] * src2[j]</tt>.
- *
- * @relates Tensor
- * @author Wolfgang Bangerth, 2000
- */
-template <int dim, typename Number>
-void outer_product (Tensor<2,dim,Number>       &dst,
-                    const Tensor<1,dim,Number> &src1,
-                    const Tensor<1,dim,Number> &src2)
-{
-  for (unsigned int i=0; i<dim; ++i)
-    for (unsigned int j=0; j<dim; ++j)
-      dst[i][j] = src1[i] * src2[j];
-}
-
-
-/**
- * Form the outer product of two tensors of rank 1 and 2, i.e.
- * <tt>dst[i][j][k] = src1[i] * src2[j][k]</tt>.
- *
- * @relates Tensor
- * @author Wolfgang Bangerth, 2000
- */
-template <int dim, typename Number>
-void outer_product (Tensor<3,dim,Number>       &dst,
-                    const Tensor<1,dim,Number> &src1,
-                    const Tensor<2,dim,Number> &src2)
-{
-  for (unsigned int i=0; i<dim; ++i)
-    for (unsigned int j=0; j<dim; ++j)
-      for (unsigned int k=0; k<dim; ++k)
-        dst[i][j][k] = src1[i] * src2[j][k];
-}
-
-
-/**
- * Form the outer product of two tensors of rank 2 and 1, i.e.
- * <tt>dst[i][j][k] = src1[i][j] * src2[k]</tt>.
- *
- * @relates Tensor
- * @author Wolfgang Bangerth, 2000
- */
-template <int dim, typename Number>
-void outer_product (Tensor<3,dim,Number>       &dst,
-                    const Tensor<2,dim,Number> &src1,
-                    const Tensor<1,dim,Number> &src2)
-{
-  for (unsigned int i=0; i<dim; ++i)
-    for (unsigned int j=0; j<dim; ++j)
-      for (unsigned int k=0; k<dim; ++k)
-        dst[i][j][k] = src1[i][j] * src2[k];
-}
-
-
-/**
- * Form the outer product of two tensors of rank 0 and 1, i.e. <tt>dst[i] =
- * src1 * src2[i]</tt>. Of course, this is only a scaling of <tt>src2</tt>,
- * but we consider this an outer product for completeness of these functions
- * and since this is sometimes needed when writing templates that depend on
- * the rank of a tensor, which may sometimes be zero (i.e. a scalar).
- *
- * @relates Tensor
- * @author Wolfgang Bangerth, 2000
- */
-template <int dim, typename Number>
-void outer_product (Tensor<1,dim,Number>       &dst,
-                    const Number                src1,
-                    const Tensor<1,dim,Number> &src2)
-{
-  for (unsigned int i=0; i<dim; ++i)
-    dst[i] = src1 * src2[i];
-}
-
-
-/**
- * Form the outer product of two tensors of rank 1 and 0, i.e. <tt>dst[i] =
- * src1[i] * src2</tt>. Of course, this is only a scaling of <tt>src1</tt>,
- * but we consider this an outer product for completeness of these functions
- * and since this is sometimes needed when writing templates that depend on
- * the rank of a tensor, which may sometimes be zero (i.e. a scalar).
- *
- * @relates Tensor
- * @author Wolfgang Bangerth, 2000
- */
-template <int dim, typename Number>
-void outer_product (Tensor<1,dim,Number>       &dst,
-                    const Tensor<1,dim,Number>  src1,
-                    const Number         src2)
-{
-  for (unsigned int i=0; i<dim; ++i)
-    dst[i] = src1[i] * src2;
 }
 
 

--- a/include/deal.II/base/tensor_deprecated.h
+++ b/include/deal.II/base/tensor_deprecated.h
@@ -29,7 +29,6 @@ DEAL_II_NAMESPACE_OPEN
  */
 //@{
 
-
 /**
  * The cross-product of 2 vectors in 3d.
  *
@@ -43,9 +42,42 @@ cross_product (Tensor<1,dim,Number>       &dst,
                const Tensor<1,dim,Number> &src1,
                const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
 
+/**
+ * Form the outer product of two tensors.
+ *
+ * @deprecated Use the generic version that returns its result instead.
+ * @relates Tensor
+ */
+template <int rank_1, int rank_2, int dim, typename Number>
+void outer_product(Tensor<rank_1 + rank_2, dim, Number> &dst,
+                   const Tensor<rank_1, dim, Number>    &src1,
+                   const Tensor<rank_2, dim, Number>    &src2) DEAL_II_DEPRECATED;
+
+/**
+ * Multiply a Tensor<1,dim,Number> with a Number.
+ *
+ * @deprecated Use operator* instead.
+ * @relates Tensor
+ */
+template <int dim, typename Number>
+void outer_product (Tensor<1,dim,Number>       &dst,
+                    const Number                src1,
+                    const Tensor<1,dim,Number> &src2) DEAL_II_DEPRECATED;
+
+/**
+ * Multiply a Tensor<1,dim,Number> with a Number.
+ *
+ * @deprecated Use operator* instead.
+ * @relates Tensor
+ */
+template <int dim, typename Number>
+void outer_product (Tensor<1,dim,Number>       &dst,
+                    const Tensor<1,dim,Number>  src1,
+                    const Number                src2) DEAL_II_DEPRECATED;
+
+//@}
 
 #ifndef DOXYGEN
-
 
 template <int dim, typename Number>
 inline
@@ -57,9 +89,33 @@ cross_product (Tensor<1,dim,Number>       &dst,
   dst = cross_product(src1, src2);
 }
 
-#endif /* DOXYGEN */
+template <int rank_1, int rank_2, int dim, typename Number>
+void outer_product(Tensor<rank_1 + rank_2, dim, Number> &dst,
+                   const Tensor<rank_1, dim, Number>    &src1,
+                   const Tensor<rank_2, dim, Number>    &src2)
+{
+  TensorAccessors::contract<0, rank_1, rank_2, dim>(dst, src1, src2);
+}
 
-//@}
+template <int dim, typename Number>
+void outer_product (Tensor<1,dim,Number>       &dst,
+                    const Number                src1,
+                    const Tensor<1,dim,Number> &src2)
+{
+  for (unsigned int i=0; i<dim; ++i)
+    dst[i] = src1 * src2[i];
+}
+
+template <int dim, typename Number>
+void outer_product (Tensor<1,dim,Number>       &dst,
+                    const Tensor<1,dim,Number>  src1,
+                    const Number         src2)
+{
+  for (unsigned int i=0; i<dim; ++i)
+    dst[i] = src1[i] * src2;
+}
+
+#endif /* DOXYGEN */
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -804,10 +804,9 @@ namespace internal
         for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_cell; ++i)
           for (unsigned int j=0; j<GeometryInfo<dim>::vertices_per_cell; ++j)
             {
-              Tensor<2,dim> tmp;
-              outer_product (tmp,
-                             GeometryInfo<dim>::d_linear_shape_function_gradient (xi, i),
-                             GeometryInfo<dim>::d_linear_shape_function_gradient (xi, j));
+              Tensor<2, dim> tmp = outer_product(
+                                     GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i),
+                                     GeometryInfo<dim>::d_linear_shape_function_gradient(xi, j));
               H_k += (object->vertex(i) * object->vertex(j)) * tmp;
             }
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -87,7 +87,7 @@ namespace DerivativeApproximation
        * Likewise declare the data type that holds the derivative projected to a
        * certain directions.
        */
-      typedef double        ProjectedDerivative;
+      typedef Tensor<0,dim> ProjectedDerivative;
 
       /**
        * Given an FEValues object initialized to a cell, and a solution vector,
@@ -891,11 +891,7 @@ namespace DerivativeApproximation
                this_midpoint_value);
           projected_finite_difference /= distance;
 
-          typename DerivativeDescription::Derivative projected_derivative_update;
-          outer_product (projected_derivative_update,
-                         y,
-                         projected_finite_difference);
-          projected_derivative += projected_derivative_update;
+          projected_derivative += outer_product(y, projected_finite_difference);
         };
 
       // can we determine an

--- a/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
@@ -113,9 +113,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<2,dim> hessian = fe_face_values[single_component].hessian (i,q);
-                      Tensor<3,dim> hessian_normal_outer_prod;
-
-                      outer_product(hessian_normal_outer_prod, hessian, fe_face_values.normal_vector(q));
+                      Tensor<3, dim> hessian_normal_outer_prod = outer_product(
+                                                                   hessian, fe_face_values.normal_vector(q));
                       boundary_integral += hessian_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<2,dim> hessian = fe_face_values[single_component].hessian (i,q);
-                      Tensor<3,dim> hessian_normal_outer_prod;
-
-                      outer_product(hessian_normal_outer_prod, hessian, fe_face_values.normal_vector(q));
+                      Tensor<3, dim> hessian_normal_outer_prod = outer_product(
+                                                                   hessian, fe_face_values.normal_vector(q));
                       boundary_integral += hessian_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_dgq_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_hessian_divergence_theorem.cc
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<1,dim> gradient = fe_face_values[single_component].gradient (i,q);
-                      Tensor<2,dim> gradient_normal_outer_prod;
-
-                      outer_product(gradient_normal_outer_prod, gradient, fe_face_values.normal_vector(q));
+                      Tensor<2, dim> gradient_normal_outer_prod = outer_product(
+                                                                    gradient, fe_face_values.normal_vector(q));
                       boundary_integral += gradient_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<1,dim> gradient = fe_face_values[single_component].gradient (i,q);
-                      Tensor<2,dim> gradient_normal_outer_prod;
-
-                      outer_product(gradient_normal_outer_prod, gradient, fe_face_values.normal_vector(q));
+                      Tensor<2, dim> gradient_normal_outer_prod = outer_product(
+                                                                    gradient, fe_face_values.normal_vector(q));
                       boundary_integral += gradient_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<2,dim> hessian = fe_face_values[single_component].hessian (i,q);
-                      Tensor<3,dim> hessian_normal_outer_prod;
-
-                      outer_product(hessian_normal_outer_prod, hessian, fe_face_values.normal_vector(q));
+                      Tensor<3, dim> hessian_normal_outer_prod = outer_product(
+                                                                   hessian, fe_face_values.normal_vector(q));
                       boundary_integral += hessian_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_q_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_q_hessian_divergence_theorem.cc
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<1,dim> gradient = fe_face_values[single_component].gradient (i,q);
-                      Tensor<2,dim> gradient_normal_outer_prod;
-
-                      outer_product(gradient_normal_outer_prod, gradient, fe_face_values.normal_vector(q));
+                      Tensor<2, dim> gradient_normal_outer_prod = outer_product(
+                                                                    gradient, fe_face_values.normal_vector(q));
                       boundary_integral += gradient_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
@@ -113,9 +113,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<2,dim> hessian = fe_face_values[single_component].hessian (i,q);
-                      Tensor<3,dim> hessian_normal_outer_prod;
-
-                      outer_product(hessian_normal_outer_prod, hessian, fe_face_values.normal_vector(q));
+                      Tensor<3, dim> hessian_normal_outer_prod = outer_product(
+                                                                   hessian, fe_face_values.normal_vector(q));
                       boundary_integral += hessian_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_rt_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_rt_hessian_divergence_theorem.cc
@@ -106,9 +106,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<1,dim> gradient = fe_face_values[single_component].gradient (i,q);
-                      Tensor<2,dim> gradient_normal_outer_prod;
-
-                      outer_product(gradient_normal_outer_prod, gradient, fe_face_values.normal_vector(q));
+                      Tensor<2, dim> gradient_normal_outer_prod = outer_product(
+                                                                    gradient, fe_face_values.normal_vector(q));
                       boundary_integral += gradient_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }

--- a/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,8 @@ void test (const Triangulation<dim> &tr,
                   for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
                     {
                       Tensor<2,dim> hessian = fe_face_values[single_component].hessian (i,q);
-                      Tensor<3,dim> hessian_normal_outer_prod;
-
-                      outer_product(hessian_normal_outer_prod, hessian, fe_face_values.normal_vector(q));
+                      Tensor<3, dim> hessian_normal_outer_prod = outer_product(
+                                                                   hessian, fe_face_values.normal_vector(q));
                       boundary_integral += hessian_normal_outer_prod * fe_face_values.JxW(q);
                     }
                 }


### PR DESCRIPTION
Furthermore, implement outer_product as a fully templated function, and move
the old signatures to tensor_deprecated.h.