### PR TITLE
MSVC fix -> add 'dealii::' root namespace explicitely where MSVC fail…

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -892,7 +892,7 @@ inline
 typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 {
-  return internal::TensorSubscriptor::subscript(values, i, internal::int2type<dim>());
+  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
 }
 
 
@@ -901,7 +901,7 @@ inline
 const typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
 {
-  return internal::TensorSubscriptor::subscript(values, i, internal::int2type<dim>());
+  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
 }
 
 


### PR DESCRIPTION
…s to understand ' internal::' without 'dealii::'