### PR TITLE
add -Woverloaded-virtual flag for gnu compiler

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -64,6 +64,7 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wwrite-strings")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wsynth")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wsign-compare")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wswitch")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Woverloaded-virtual")
 
 #
 # Disable Wlong-long that will trigger a lot of warnings when compiling


### PR DESCRIPTION
Add warning about overloaded virtual functions which are shadowed
when only a subset of its signatures are overridden in a derived class.

These warnings seem to be enabled for intel 15 compiler where they caught issue #1527 so they seem to be useful but did not show up on the gnu compiler before this commit.