### PR TITLE
Remove the deprecated update_support_points flag.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,14 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Removed: The <code>UpdateFlags</code> flag
+  <code>update_support_points</code> has been removed. This flag was deprecated
+  in 2013 and has not done anything in a long time (see the commit message for
+  more information).
+  <br>
+  (David Wells, 2015/09/16)
+  </li>
+
   <li> Cleanup: The two argument variant of cross_product that returned the
   result by reference as first argument has been removed. Use the function
   that directly returns the result instead.

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -199,10 +199,6 @@ enum UpdateFlags
    * Compute the volume element in each quadrature point.
    */
   update_volume_elements = 0x10000,
-  /**
-   * @deprecated This flag has no effect.
-   */
-  update_support_points = 0x20000,
   //! Jacobian at generalized support points
   /**
    * Update the Jacobian of the mapping in generalized support points.
@@ -276,7 +272,6 @@ STREAM &operator << (STREAM &s, UpdateFlags u)
   if (u & update_contravariant_transformation)            s << "contravariant_transformation|";
   if (u & update_transformation_values)                   s << "transformation_values|";
   if (u & update_transformation_gradients)                s << "transformation_gradients|";
-  if (u & update_support_points)                          s << "support_points|";
   if (u & update_support_jacobians)                       s << "support_jacobians|";
   if (u & update_support_inverse_jacobians)               s << "support_inverse_jacobians|";
   if (u & update_jacobian_pushed_forward_grads)           s << "jacobian_pushed_forward_grads|";


### PR DESCRIPTION
This flag was deprecated in 2013 and has not done anything for a long
time. This flag has a rather interesting past:

* Its predecessor, a boolean `update_ansatz_points` (which predates
  `UpdateFlags`) appeared in commit f11068359c42 in April 1998. This
  commit only implemented the option and not any actual functionality.
* Its first actual appearance was in commit e183dbbef3c1 in September
  1998 as a rename of `update_ansatz_points`.
* The implementation of this flag in `FEValues` was removed in commit
  737af606cf92 in March 2001.
* The flag was removed for the first time in commit 0e03535fbf03 in
  September 2001.
* The flag reappeared (with no corresponding functionality) in commit
  cfb5ac8b76df in October 2007.
* The flag was marked as deprecated in commit d2b4ca622a844 in February
  2013.

This should close #917.