### PR TITLE
Remove unimplemented UpdateFlags flags.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,10 +38,12 @@ inconvenience this causes.
 </p>
 
 <ol>
-  <li> Removed: The <code>UpdateFlags</code> flag
-  <code>update_support_points</code> has been removed. This flag was deprecated
-  in 2013 and has not done anything in a long time (see the commit message for
-  more information).
+  <li> Removed: The <code>UpdateFlags</code> flags
+  <code>update_support_points</code>, <code>update_support_jacobians</code>,
+  and <code>update_support_inverse_jacobians</code> have been removed.
+  <code>update_support_points</code> was deprecated in 2013 and has not done
+  anything in a long time (see the commit message for more information). The
+  other two appeared in 2007 and were never implemented.
   <br>
   (David Wells, 2015/09/16)
   </li>

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -199,16 +199,6 @@ enum UpdateFlags
    * Compute the volume element in each quadrature point.
    */
   update_volume_elements = 0x10000,
-  //! Jacobian at generalized support points
-  /**
-   * Update the Jacobian of the mapping in generalized support points.
-   */
-  update_support_jacobians = 0x40000,
-  //! inverse Jacobian at generalized support points
-  /**
-   * Update the inverse Jacobian of the mapping in generalized support points.
-   */
-  update_support_inverse_jacobians = 0x80000,
   /**
    * Compute the derivatives of the Jacobian of the transformation pushed
    * forward to the real cell coordinates.
@@ -272,8 +262,6 @@ STREAM &operator << (STREAM &s, UpdateFlags u)
   if (u & update_contravariant_transformation)            s << "contravariant_transformation|";
   if (u & update_transformation_values)                   s << "transformation_values|";
   if (u & update_transformation_gradients)                s << "transformation_gradients|";
-  if (u & update_support_jacobians)                       s << "support_jacobians|";
-  if (u & update_support_inverse_jacobians)               s << "support_inverse_jacobians|";
   if (u & update_jacobian_pushed_forward_grads)           s << "jacobian_pushed_forward_grads|";
   if (u & update_jacobian_2nd_derivatives)                s << "jacobian_2nd_derivatives|";
   if (u & update_jacobian_pushed_forward_2nd_derivatives) s << "jacobian_pushed_forward_2nd_derivatives|";


### PR DESCRIPTION
These two flags showed up in commit cfb5ac8b76df in October 2007 but were never actually implemented. Reading through the results of `git log` is always interesting.

My only concern here (relative to the discussion in #1622) is that these flags are now being removed with out ever being marked as deprecated. They never actually did anything, but I feel bad possibly breaking codes without ever issuing deprecation warnings.