### PR TITLE
Use print_svg in step 2

### DIFF
--- a/examples/step-2/doc/results.dox
+++ b/examples/step-2/doc/results.dox
@@ -1,33 +1,7 @@
 <h1>Results</h1>
 
 The program has, after having been run, produced two sparsity
-patterns. We can visualize them using <a
-href="http://www.gnuplot.info/">GNUPLOT</a> (one of the simpler visualization
-programs; maybe not the easiest to use since it is command line driven, but
-also universally available on all Linux and other Unix-like systems):
-@code
-examples/\step-2> gnuplot
-
-        G N U P L O T
-        Version 3.7 patchlevel 3
-        last modified Thu Dec 12 13:00:00 GMT 2002
-        System: Linux 2.6.11.4-21.10-default
-
-        Copyright(C) 1986 - 1993, 1998 - 2002
-        Thomas Williams, Colin Kelley and many others
-
-        Type `help` to access the on-line reference manual
-        The gnuplot FAQ is available from
-        http://www.gnuplot.info/gnuplot-faq.html
-
-        Send comments and requests for help to <info-gnuplot@dartmouth.edu>
-        Send bugs, suggestions and mods to <bug-gnuplot@dartmouth.edu>
-
-
-Terminal type set to 'x11'
-gnuplot> set style data points
-gnuplot> plot "sparsity_pattern.1"
-@endcode
+patterns. We can visualize them by opening the <code>.svg</code> files in a web browser.
 
 The results then look like this (every point denotes an entry which
 might be nonzero; of course the fact whether the entry actually is
@@ -38,11 +12,11 @@ equation):
 <TABLE WIDTH="60%" ALIGN="center">
   <tr>
     <td ALIGN="center">
-      <img src="http://www.dealii.org/images/steps/developer/step-2.sparsity-1.png" alt="">
+      <img src="http://www.dealii.org/images/steps/developer/step-2.sparsity-1.svg" alt="">
     </td>
 
     <td ALIGN="center">
-      <img src="http://www.dealii.org/images/steps/developer/step-2.sparsity-2.png" alt="">
+      <img src="http://www.dealii.org/images/steps/developer/step-2.sparsity-2.svg" alt="">
     </td>
   </tr>
 </table>
@@ -76,3 +50,31 @@ i.e. the matrix clusters more around the diagonal.
 Another idea of experiments would be to try other renumbering
 strategies than Cuthill-McKee from the DoFRenumbering namespace and see how
 they affect the sparsity pattern.
+
+You can also visualize the output using <a
+href="http://www.gnuplot.info/">GNUPLOT</a> (one of the simpler visualization
+programs; maybe not the easiest to use since it is command line driven, but
+also universally available on all Linux and other Unix-like systems) by changing from <code>print_svg()</code> to <code>print_gnuplot()</code> in <code>distribute_dofs()</code> and <code>renumber_dofs()</code>:
+@code
+examples/\step-2> gnuplot
+
+        G N U P L O T
+        Version 3.7 patchlevel 3
+        last modified Thu Dec 12 13:00:00 GMT 2002
+        System: Linux 2.6.11.4-21.10-default
+
+        Copyright(C) 1986 - 1993, 1998 - 2002
+        Thomas Williams, Colin Kelley and many others
+
+        Type `help` to access the on-line reference manual
+        The gnuplot FAQ is available from
+        http://www.gnuplot.info/gnuplot-faq.html
+
+        Send comments and requests for help to <info-gnuplot@dartmouth.edu>
+        Send bugs, suggestions and mods to <bug-gnuplot@dartmouth.edu>
+
+
+Terminal type set to 'x11'
+gnuplot> set style data points
+gnuplot> plot "sparsity_pattern.1"
+@endcode

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -64,7 +64,7 @@ using namespace dealii;
 // @sect3{Mesh generation}
 
 // This is the function that produced the circular grid in the previous step-1
-// example program. The sole difference is that it returns the grid it
+// example program with fewer refinements steps. The sole difference is that it returns the grid it
 // produces via its argument.
 //
 // The details of what the function does are explained in step-1. The only
@@ -85,13 +85,13 @@ void make_grid (Triangulation<2> &triangulation)
                outer_radius = 1.0;
   GridGenerator::hyper_shell (triangulation,
                               center, inner_radius, outer_radius,
-                              10);
+                              5 );
 
   static const SphericalManifold<2> manifold_description(center);
   triangulation.set_all_manifold_ids(0);
   triangulation.set_manifold (0, manifold_description);
 
-  for (unsigned int step=0; step<5; ++step)
+  for (unsigned int step=0; step<3; ++step)
     {
       Triangulation<2>::active_cell_iterator
       cell = triangulation.begin_active(),
@@ -216,11 +216,11 @@ void distribute_dofs (DoFHandler<2> &dof_handler)
   sparsity_pattern.copy_from (dynamic_sparsity_pattern);
 
   // With this, we can now write the results to a file:
-  std::ofstream out ("sparsity_pattern.1");
-  sparsity_pattern.print_gnuplot (out);
-  // The result is in GNUPLOT format, where in each line of the output file,
-  // the coordinates of one nonzero entry are listed. The output will be shown
-  // below.
+  std::ofstream out ("sparsity_pattern1.svg");
+  sparsity_pattern.print_svg (out);
+  // The result is stored in an <code>.svg</code> file, where each nonzero entry in the
+  // matrix corresponds with a red square in the image. The output will be
+  // shown below.
   //
   // If you look at it, you will note that the sparsity pattern is
   // symmetric. This should not come as a surprise, since we have not given
@@ -272,8 +272,8 @@ void renumber_dofs (DoFHandler<2> &dof_handler)
   SparsityPattern sparsity_pattern;
   sparsity_pattern.copy_from (dynamic_sparsity_pattern);
 
-  std::ofstream out ("sparsity_pattern.2");
-  sparsity_pattern.print_gnuplot (out);
+  std::ofstream out ("sparsity_pattern2.svg");
+  sparsity_pattern.print_svg (out);
 }
 
 // Again, the output is shown below. Note that the nonzero entries are


### PR DESCRIPTION
Changed step 2 to output sparsity pattern using .svg file instead of GNU plot and changed documentation to reflect this change. Reasons for this change are nicer output and it is easier to look at than GNU plot.

