### PR TITLE
Add vector_type typedef to mimic Solver class

### DIFF
--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -98,6 +98,10 @@ template <class VECTOR = Vector<double> >
 class SolverSelector : public Subscriptor
 {
 public:
+  /**
+   * A typedef for the underlying vector type
+   */
+  typedef VECTOR vector_type;
 
   /**
    * Constructor, filling in default values


### PR DESCRIPTION
This definition is required to use the SolverSelector with
inverse_operator.