### PR TITLE
Fix test failures

### DIFF
--- a/source/lac/sparse_matrix.cc
+++ b/source/lac/sparse_matrix.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/lac/sparse_matrix.templates.h>
 #include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/parallel_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/sparse_matrix.inst.in
+++ b/source/lac/sparse_matrix.inst.in
@@ -33,20 +33,20 @@ for (S1, S2 : REAL_SCALARS)
       void SparseMatrix<S1>::copy_from<S2> (const FullMatrix<S2> &);
 
     template void SparseMatrix<S1>::add<S2> (const S1,
-					     const SparseMatrix<S2> &);
+                                             const SparseMatrix<S2> &);
 
     template void SparseMatrix<S1>::add<S2> (const size_type,
-					     const size_type,
-					     const size_type *,
-					     const S2 *,
-					     const bool,
-					     const bool);
+                                             const size_type,
+                                             const size_type *,
+                                             const S2 *,
+                                             const bool,
+                                             const bool);
 
     template void SparseMatrix<S1>::set<S2> (const size_type,
-					     const size_type,
-					     const size_type *,
-					     const S2 *,
-					     const bool);
+                                             const size_type,
+                                             const size_type *,
+                                             const S2 *,
+                                             const bool);
   }
 
 
@@ -59,69 +59,69 @@ for (S1, S2 : REAL_SCALARS)
     template S2
       SparseMatrix<S1>::
       matrix_scalar_product<S2> (const Vector<S2> &,
-				 const Vector<S2> &) const;
+                                 const Vector<S2> &) const;
 
     template S2 SparseMatrix<S1>::
       residual<S2> (Vector<S2> &,
-		    const Vector<S2> &,
-		    const Vector<S2> &) const;
+                    const Vector<S2> &,
+                    const Vector<S2> &) const;
 
     template void SparseMatrix<S1>::
       precondition_SSOR<S2> (Vector<S2> &,
-			     const Vector<S2> &,
-			     const S1,
-			     const std::vector<std::size_t>&) const;
+                             const Vector<S2> &,
+                             const S1,
+                             const std::vector<std::size_t>&) const;
 
     template void SparseMatrix<S1>::
       precondition_SOR<S2> (Vector<S2> &,
-			    const Vector<S2> &,
-			    const S1) const;
+                            const Vector<S2> &,
+                            const S1) const;
 
     template void SparseMatrix<S1>::
       precondition_TSOR<S2> (Vector<S2> &,
-			     const Vector<S2> &,
-			     const S1) const;
+                             const Vector<S2> &,
+                             const S1) const;
 
     template void SparseMatrix<S1>::
       precondition_Jacobi<S2> (Vector<S2> &,
-			       const Vector<S2> &,
-			       const S1) const;
+                               const Vector<S2> &,
+                               const S1) const;
 
     template void SparseMatrix<S1>::
       SOR<S2> (Vector<S2> &,
-	       const S1) const;
+               const S1) const;
     template void SparseMatrix<S1>::
       TSOR<S2> (Vector<S2> &,
-		const S1) const;
+                const S1) const;
     template void SparseMatrix<S1>::
       SSOR<S2> (Vector<S2> &,
-		const S1) const;
+                const S1) const;
     template void SparseMatrix<S1>::
       PSOR<S2> (Vector<S2> &,
-		const std::vector<size_type>&,
-		const std::vector<size_type>&,
-		const S1) const;
+                const std::vector<size_type>&,
+                const std::vector<size_type>&,
+                const S1) const;
     template void SparseMatrix<S1>::
       TPSOR<S2> (Vector<S2> &,
-		 const std::vector<size_type>&,
-		 const std::vector<size_type>&,
-		 const S1) const;
+                 const std::vector<size_type>&,
+                 const std::vector<size_type>&,
+                 const S1) const;
     template void SparseMatrix<S1>::
       Jacobi_step<S2> (Vector<S2> &,
-		       const Vector<S2> &,
-		       const S1) const;
+                       const Vector<S2> &,
+                       const S1) const;
     template void SparseMatrix<S1>::
       SOR_step<S2> (Vector<S2> &,
-		    const Vector<S2> &,
-		    const S1) const;
+                    const Vector<S2> &,
+                    const S1) const;
     template void SparseMatrix<S1>::
       TSOR_step<S2> (Vector<S2> &,
-		     const Vector<S2> &,
-		     const S1) const;
+                     const Vector<S2> &,
+                     const S1) const;
     template void SparseMatrix<S1>::
       SSOR_step<S2> (Vector<S2> &,
-		     const Vector<S2> &,
-		     const S1) const;
+                     const Vector<S2> &,
+                     const S1) const;
   }
 
 for (S1, S2, S3 : REAL_SCALARS;
@@ -137,6 +137,18 @@ for (S1, S2, S3 : REAL_SCALARS;
       Tvmult_add (V1<S2> &, const V2<S3> &) const;
   }
 
+for (S1 : REAL_SCALARS)
+  {
+    template void SparseMatrix<S1>::
+      vmult (parallel::distributed::Vector<S1> &, const parallel::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::
+      Tvmult (parallel::distributed::Vector<S1> &, const parallel::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::
+      vmult_add (parallel::distributed::Vector<S1> &, const parallel::distributed::Vector<S1> &) const;
+    template void SparseMatrix<S1>::
+      Tvmult_add (parallel::distributed::Vector<S1> &, const parallel::distributed::Vector<S1> &) const;
+  }
+
 for (S1, S2, S3: REAL_SCALARS)
   {
     template void SparseMatrix<S1>::
@@ -144,7 +156,7 @@ for (S1, S2, S3: REAL_SCALARS)
              const bool) const;
     template void SparseMatrix<S1>::
       Tmmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-	      const bool) const;
+              const bool) const;
   }
 
 
@@ -167,20 +179,20 @@ for (S1, S2 : COMPLEX_SCALARS)
       void SparseMatrix<S1>::copy_from<S2> (const FullMatrix<S2> &);
 
     template void SparseMatrix<S1>::add<S2> (const S1,
-					     const SparseMatrix<S2> &);
+                                             const SparseMatrix<S2> &);
 
     template void SparseMatrix<S1>::add<S2> (const size_type,
-					     const size_type,
-					     const size_type *,
-					     const S2 *,
-					     const bool,
-					     const bool);
+                                             const size_type,
+                                             const size_type *,
+                                             const S2 *,
+                                             const bool,
+                                             const bool);
 
     template void SparseMatrix<S1>::set<S2> (const size_type,
-					     const size_type,
-					     const size_type *,
-					     const S2 *,
-					     const bool);
+                                             const size_type,
+                                             const size_type *,
+                                             const S2 *,
+                                             const bool);
   }
 
 
@@ -193,69 +205,69 @@ for (S1, S2 : COMPLEX_SCALARS)
     template S2
       SparseMatrix<S1>::
       matrix_scalar_product<S2> (const Vector<S2> &,
-				 const Vector<S2> &) const;
+                                 const Vector<S2> &) const;
 
     template S2 SparseMatrix<S1>::
       residual<S2> (Vector<S2> &,
-		    const Vector<S2> &,
-		    const Vector<S2> &) const;
+                    const Vector<S2> &,
+                    const Vector<S2> &) const;
 
     template void SparseMatrix<S1>::
       precondition_SSOR<S2> (Vector<S2> &,
-			     const Vector<S2> &,
-			     const S1,
-			     const std::vector<std::size_t>&) const;
+                             const Vector<S2> &,
+                             const S1,
+                             const std::vector<std::size_t>&) const;
 
     template void SparseMatrix<S1>::
       precondition_SOR<S2> (Vector<S2> &,
-			    const Vector<S2> &,
-			    const S1) const;
+                            const Vector<S2> &,
+                            const S1) const;
 
     template void SparseMatrix<S1>::
       precondition_TSOR<S2> (Vector<S2> &,
-			     const Vector<S2> &,
-			     const S1) const;
+                             const Vector<S2> &,
+                             const S1) const;
 
     template void SparseMatrix<S1>::
       precondition_Jacobi<S2> (Vector<S2> &,
-			       const Vector<S2> &,
-			       const S1) const;
+                               const Vector<S2> &,
+                               const S1) const;
 
     template void SparseMatrix<S1>::
       SOR<S2> (Vector<S2> &,
-	       const S1) const;
+               const S1) const;
     template void SparseMatrix<S1>::
       TSOR<S2> (Vector<S2> &,
-		const S1) const;
+                const S1) const;
     template void SparseMatrix<S1>::
       SSOR<S2> (Vector<S2> &,
-		const S1) const;
+                const S1) const;
     template void SparseMatrix<S1>::
       PSOR<S2> (Vector<S2> &,
-		const std::vector<size_type>&,
-		const std::vector<size_type>&,
-		const S1) const;
+                const std::vector<size_type>&,
+                const std::vector<size_type>&,
+                const S1) const;
     template void SparseMatrix<S1>::
       TPSOR<S2> (Vector<S2> &,
-		 const std::vector<size_type>&,
-		 const std::vector<size_type>&,
-		 const S1) const;
+                 const std::vector<size_type>&,
+                 const std::vector<size_type>&,
+                 const S1) const;
     template void SparseMatrix<S1>::
       Jacobi_step<S2> (Vector<S2> &,
-		       const Vector<S2> &,
-		       const S1) const;
+                       const Vector<S2> &,
+                       const S1) const;
     template void SparseMatrix<S1>::
       SOR_step<S2> (Vector<S2> &,
-		    const Vector<S2> &,
-		    const S1) const;
+                    const Vector<S2> &,
+                    const S1) const;
     template void SparseMatrix<S1>::
       TSOR_step<S2> (Vector<S2> &,
-		     const Vector<S2> &,
-		     const S1) const;
+                     const Vector<S2> &,
+                     const S1) const;
     template void SparseMatrix<S1>::
       SSOR_step<S2> (Vector<S2> &,
-		     const Vector<S2> &,
-		     const S1) const;
+                     const Vector<S2> &,
+                     const S1) const;
   }
 
 for (S1, S2, S3 : COMPLEX_SCALARS;
@@ -278,5 +290,5 @@ for (S1, S2, S3: COMPLEX_SCALARS)
              const bool) const;
     template void SparseMatrix<S1>::
       Tmmult (SparseMatrix<S2> &, const SparseMatrix<S3> &, const Vector<S1>&,
-	      const bool) const;
+              const bool) const;
   }

--- a/source/lac/sparse_matrix_inst2.cc
+++ b/source/lac/sparse_matrix_inst2.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/lac/sparse_matrix.templates.h>
 #include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/parallel_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/tests/lac/precondition_chebyshev_01.with_lapack=true.output
+++ b/tests/lac/precondition_chebyshev_01.with_lapack=true.output
@@ -1,10 +1,10 @@
 
-DEAL:cg::Starting value 1.00
-DEAL:cg::Convergence step 2 value 0
+DEAL:cg::Starting value 0.95
+DEAL:cg::Convergence step 1 value 0
 DEAL::Exact inverse:     0.84 0.20 0.26 0.20 0.18 0.03 0.05 0.10 0.03 0.06 
 DEAL::Check  vmult orig: 1.09 0.26 0.34 0.26 0.24 0.04 0.06 0.12 0.04 0.07 
 DEAL::Check Tvmult orig: 1.09 0.26 0.34 0.26 0.24 0.04 0.06 0.12 0.04 0.07 
-DEAL:cg::Starting value 1.00
+DEAL:cg::Starting value 0.95
 DEAL:cg::Failure step 8 value 0.00
 DEAL::Check  vmult diag: 0.82 0.26 0.33 0.21 0.15 0.02 0.03 0.09 0.03 0.07 
 DEAL::Check Tvmult diag: 0.82 0.26 0.33 0.21 0.15 0.02 0.03 0.09 0.03 0.07 


### PR DESCRIPTION
This should fix the testcase failures due to #1650. The first commit adjusts output I had forgotten whereas the second adds an instatiation of SparseMatrix::vmult for parallel::distributed::Vector. This is used by MGTransfer in case no Trilinos is available. It does work in that case but of course no MPI is possible with SparseMatrix.