### PR TITLE
Minor updates. Ensure proper dependencies.

### DIFF
--- a/doc/doxygen/tutorial/CMakeLists.txt
+++ b/doc/doxygen/tutorial/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II Authors
+## Copyright (C) 2012 - 2015 by the deal.II Authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -15,11 +15,30 @@
 
 
 #
-# Prepare tutorial.h:
+# Define target for the tutorial. It depends on the
+# file tutorial.h built via the next target below, as well
+# as the various files we create from the tutorial 
+# directories below that. These dependencies are added
+# below the respective targets.
+#
+# This file uses the DEAL_II_STEPS variable set in
+# ../CMakeLists.txt.
+#
+
+ADD_CUSTOM_TARGET(tutorial)
+
+#
+# Describe how to build tutorial.h:
 #
 
 file(GLOB DEAL_II_STEPS_BUILDSON
   ${CMAKE_SOURCE_DIR}/examples/step-*/doc/builds-on
+  )
+file(GLOB DEAL_II_STEPS_KIND
+  ${CMAKE_SOURCE_DIR}/examples/step-*/doc/kind
+  )
+file(GLOB DEAL_II_STEPS_TOOLTIP
+  ${CMAKE_SOURCE_DIR}/examples/step-*/doc/tooltip
   )
 
 ADD_CUSTOM_COMMAND(
@@ -33,16 +52,14 @@ ADD_CUSTOM_COMMAND(
   DEPENDS
     ${DEAL_II_STEPS}
     ${DEAL_II_STEPS_BUILDSON}
+    ${DEAL_II_STEPS_KIND}
+    ${DEAL_II_STEPS_TOOLTIP}
     ${CMAKE_CURRENT_SOURCE_DIR}/tutorial.h.in
   )
+ADD_CUSTOM_TARGET(build_tutorial_h
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h)
+ADD_DEPENDENCIES(tutorial build_tutorial_h)
 
-#
-# A target for the preparation of all the stuff happening in here...
-#
-
-ADD_CUSTOM_TARGET(tutorial
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h
-  )
 
 #
 # Prepare the steps for documentation generation


### PR DESCRIPTION
The original purpose of this patch was to simply ensure proper tracking of dependencies: tutorial.h depends on the */doc/kind and */doc/tooltip files in the tutorial directories as well.

I also took the liberty to move the declaration of the top-level target "tutorial" to the top of the file, and then simply add dependencies later on. I thought this might make things more readable, but it turns out that it does not work. The old way, using
```
ADD_CUSTOM_TARGET(tutorial
  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h
 )
```
works, whereas this does not seem to work (this is what's currently in the patch):
```
ADD_CUSTOM_TARGET(tutorial)
ADD_DEPENDENCIES(tutorial ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h)
```
I don't understand why that is so, but it's easy to verify that it doesn't work by deleting `${CMAKE_CURRENT_BINARY_DIR}/tutorial.h` and the calling `make documentation` -- it complains that `tutorial.h` doesn't exist, and doesn't appear to know how to build it.

@tamiko -- any idea why this is so? It's of course simple enough to work around, but I would like the style after the patch proposed here better...