### PR TITLE
Fix type mismatch in block vector

### DIFF
--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -303,8 +303,8 @@ BlockIndices::global_to_local (const size_type i) const
   while (i < start_indices[block])
     --block;
 
-  return std::pair<size_type,size_type>(block,
-                                        i-start_indices[block]);
+  return std::pair<unsigned int,size_type>(block,
+                                           i-start_indices[block]);
 }
 
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -2170,7 +2170,7 @@ inline
 typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::operator() (const size_type i) const
 {
-  const std::pair<size_type,size_type> local_index
+  const std::pair<unsigned int,size_type> local_index
     = block_indices.global_to_local (i);
   return components[local_index.first](local_index.second);
 }
@@ -2182,7 +2182,7 @@ inline
 typename BlockVectorBase<VectorType>::reference
 BlockVectorBase<VectorType>::operator() (const size_type i)
 {
-  const std::pair<size_type,size_type> local_index
+  const std::pair<unsigned int,size_type> local_index
     = block_indices.global_to_local (i);
   return components[local_index.first](local_index.second);
 }


### PR DESCRIPTION
This is something that confused me while debugging Aspect/PR617
The number of blocks in a block vector is stored as an unsigned int, but in these cases it is interpreted to be of type size_type (which might be long long). 
It is not a particularly important fix, more a cleanup, but maybe it is still worth merging?