### PR TITLE
More precise error message

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3606,7 +3606,7 @@ namespace parallel
     Triangulation<dim,spacedim>::repartition (const std::vector<unsigned int> &cell_weights)
     {
       AssertThrow(settings & no_automatic_repartitioning,
-                  ExcMessage("You need to set the 'no_automatic_repartition' flag in the "
+                  ExcMessage("You need to set the 'no_automatic_repartitioning' flag in the "
                              "constructor when creating this parallel::distributed::Triangulation "
                              "object if you want to call repartition() manually."));
 


### PR DESCRIPTION
Following the error message I tried to set the `no_automatic_repartition` flag, which produced a new error message. Just a minor fix to save people a few seconds.