### PR TITLE
Speed up higher order derivative computations

### DIFF
--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -685,6 +685,7 @@ namespace internal
 
           if (cell_similarity != CellSimilarity::translation)
             {
+              double tmp[spacedim][spacedim][spacedim];
               for (unsigned int point=0; point<n_q_points; ++point)
                 {
                   const Tensor<2,dim> *second =
@@ -700,25 +701,36 @@ namespace internal
                           for (unsigned int l=0; l<dim; ++l)
                             result[fe_to_real[comp_k]][j][l] += (second[k][j][l]
                                                                  * data.local_dof_values[k]);
-
-                      // pushing forward the derivative coordinates
-                      for (unsigned int i=0; i<spacedim; ++i)
-                        for (unsigned int j=0; j<spacedim; ++j)
-                          for (unsigned int l=0; l<spacedim; ++l)
-                            {
-                              jacobian_pushed_forward_grads[point][i][j][l] = result[i][0][0] *
-                                                                              data.covariant[point][j][0] *
-                                                                              data.covariant[point][l][0];
-                              for (unsigned int jr=0; jr<dim; ++jr)
-                                {
-                                  const unsigned int lr_start = jr==0? 1:0;
-                                  for (unsigned int lr=lr_start; lr<dim; ++lr)
-                                    jacobian_pushed_forward_grads[point][i][j][l] += result[i][jr][lr] *
-                                                                                     data.covariant[point][j][jr] *
-                                                                                     data.covariant[point][l][lr];
-                                }
-                            }
                     }
+
+                  // first push forward the j-components
+                  for (unsigned int i=0; i<spacedim; ++i)
+                    for (unsigned int j=0; j<spacedim; ++j)
+                      for (unsigned int l=0; l<dim; ++l)
+                        {
+                          tmp[i][j][l] = result[i][0][l] *
+                                         data.covariant[point][j][0];
+                          for (unsigned int jr=1; jr<dim; ++jr)
+                            {
+                              tmp[i][j][l] += result[i][jr][l] *
+                                              data.covariant[point][j][jr];
+                            }
+                        }
+
+                  // now, pushing forward the l-components
+                  for (unsigned int i=0; i<spacedim; ++i)
+                    for (unsigned int j=0; j<spacedim; ++j)
+                      for (unsigned int l=0; l<spacedim; ++l)
+                        {
+                          jacobian_pushed_forward_grads[point][i][j][l] = tmp[i][j][0] *
+                                                                          data.covariant[point][l][0];
+                          for (unsigned int lr=1; lr<dim; ++lr)
+                            {
+                              jacobian_pushed_forward_grads[point][i][j][l] += tmp[i][j][lr] *
+                                                                               data.covariant[point][l][lr];
+                            }
+
+                        }
                 }
             }
         }
@@ -801,6 +813,7 @@ namespace internal
 
           if (cell_similarity != CellSimilarity::translation)
             {
+              double tmp[spacedim][spacedim][spacedim][spacedim];
               for (unsigned int point=0; point<n_q_points; ++point)
                 {
                   const Tensor<3,dim> *third =
@@ -819,28 +832,49 @@ namespace internal
                                                                       * data.local_dof_values[k]);
                     }
 
-                  // pushing forward the derivative coordinates
+                  // push forward the j-coordinate
+                  for (unsigned int i=0; i<spacedim; ++i)
+                    for (unsigned int j=0; j<spacedim; ++j)
+                      for (unsigned int l=0; l<dim; ++l)
+                        for (unsigned int m=0; m<dim; ++m)
+                          {
+                            jacobian_pushed_forward_2nd_derivatives[point][i][j][l][m]
+                              = result[i][0][l][m]*
+                                data.covariant[point][j][0];
+                            for (unsigned int jr=1; jr<dim; ++jr)
+                              jacobian_pushed_forward_2nd_derivatives[point][i][j][l][m]
+                              += result[i][jr][l][m]*
+                                 data.covariant[point][j][jr];
+                          }
+
+                  // push forward the l-coordinate
+                  for (unsigned int i=0; i<spacedim; ++i)
+                    for (unsigned int j=0; j<spacedim; ++j)
+                      for (unsigned int l=0; l<spacedim; ++l)
+                        for (unsigned int m=0; m<dim; ++m)
+                          {
+                            tmp[i][j][l][m]
+                              = jacobian_pushed_forward_2nd_derivatives[point][i][j][0][m]*
+                                data.covariant[point][l][0];
+                            for (unsigned int lr=1; lr<dim; ++lr)
+                              tmp[i][j][l][m]
+                              += jacobian_pushed_forward_2nd_derivatives[point][i][j][lr][m]*
+                                 data.covariant[point][l][lr];
+                          }
+
+                  // push forward the m-coordinate
                   for (unsigned int i=0; i<spacedim; ++i)
                     for (unsigned int j=0; j<spacedim; ++j)
                       for (unsigned int l=0; l<spacedim; ++l)
                         for (unsigned int m=0; m<spacedim; ++m)
                           {
                             jacobian_pushed_forward_2nd_derivatives[point][i][j][l][m]
-                              = result[i][0][0][0] *
-                                data.covariant[point][j][0] *
-                                data.covariant[point][l][0] *
+                              = tmp[i][j][l][0]*
                                 data.covariant[point][m][0];
-                            for (unsigned int jr=0; jr<dim; ++jr)
-                              for (unsigned int lr=0; lr<dim; ++lr)
-                                {
-                                  const unsigned int mr_start = (jr+lr==0)? 1:0;
-                                  for (unsigned int mr=mr_start; mr<dim; ++mr)
-                                    jacobian_pushed_forward_2nd_derivatives[point][i][j][l][m]
-                                    += result[i][jr][lr][mr] *
-                                       data.covariant[point][j][jr] *
-                                       data.covariant[point][l][lr]*
-                                       data.covariant[point][m][mr];
-                                }
+                            for (unsigned int mr=1; mr<dim; ++mr)
+                              jacobian_pushed_forward_2nd_derivatives[point][i][j][l][m]
+                              += tmp[i][j][l][mr]*
+                                 data.covariant[point][m][mr];
                           }
                 }
             }
@@ -928,6 +962,7 @@ namespace internal
 
         if (cell_similarity != CellSimilarity::translation)
           {
+            double tmp[spacedim][spacedim][spacedim][spacedim][spacedim];
             for (unsigned int point=0; point<n_q_points; ++point)
               {
                 const Tensor<4,dim> *fourth =
@@ -948,31 +983,66 @@ namespace internal
                                   * data.local_dof_values[k]);
                   }
 
-                // pushing forward the derivative coordinates
+                // push-forward the j-coordinate
+                for (unsigned int i=0; i<spacedim; ++i)
+                  for (unsigned int j=0; j<spacedim; ++j)
+                    for (unsigned int l=0; l<dim; ++l)
+                      for (unsigned int m=0; m<dim; ++m)
+                        for (unsigned int n=0; n<dim; ++n)
+                          {
+                            tmp[i][j][l][m][n] = result[i][0][l][m][n] *
+                                                 data.covariant[point][j][0];
+                            for (unsigned int jr=1; jr<dim; ++jr)
+                              tmp[i][j][l][m][n] += result[i][jr][l][m][n] *
+                                                    data.covariant[point][j][jr];
+                          }
+
+                // push-forward the l-coordinate
+                for (unsigned int i=0; i<spacedim; ++i)
+                  for (unsigned int j=0; j<spacedim; ++j)
+                    for (unsigned int l=0; l<spacedim; ++l)
+                      for (unsigned int m=0; m<dim; ++m)
+                        for (unsigned int n=0; n<dim; ++n)
+                          {
+                            jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
+                              = tmp[i][j][0][m][n] *
+                                data.covariant[point][l][0];
+                            for (unsigned int lr=1; lr<dim; ++lr)
+                              jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
+                              += tmp[i][j][lr][m][n] *
+                                 data.covariant[point][l][lr];
+                          }
+
+                // push-forward the m-coordinate
                 for (unsigned int i=0; i<spacedim; ++i)
                   for (unsigned int j=0; j<spacedim; ++j)
                     for (unsigned int l=0; l<spacedim; ++l)
                       for (unsigned int m=0; m<spacedim; ++m)
                         for (unsigned int n=0; n<dim; ++n)
                           {
-                            jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
-                              = result[i][0][0][0][0] *
-                                data.covariant[point][j][0] *
-                                data.covariant[point][l][0] *
+                            tmp[i][j][l][m][n]
+                              = jacobian_pushed_forward_3rd_derivatives[point][i][j][l][0][n] *
                                 data.covariant[point][m][0];
-                            for (unsigned int jr=0; jr<dim; ++jr)
-                              for (unsigned int lr=0; lr<dim; ++lr)
-                                for (unsigned int mr=0; mr<dim; ++mr)
-                                  {
-                                    const unsigned int nr_start = (jr+lr+mr==0)? 1:0;
-                                    for (unsigned int nr=nr_start; nr<dim; ++nr)
-                                      jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
-                                      += result[i][jr][lr][mr][nr] *
-                                         data.covariant[point][j][jr] *
-                                         data.covariant[point][l][lr]*
-                                         data.covariant[point][m][mr]*
-                                         data.covariant[point][n][nr];
-                                  }
+                            for (unsigned int mr=1; mr<dim; ++mr)
+                              tmp[i][j][l][m][n]
+                              += jacobian_pushed_forward_3rd_derivatives[point][i][j][l][mr][n] *
+                                 data.covariant[point][m][mr];
+                          }
+
+                // push-forward the n-coordinate
+                for (unsigned int i=0; i<spacedim; ++i)
+                  for (unsigned int j=0; j<spacedim; ++j)
+                    for (unsigned int l=0; l<spacedim; ++l)
+                      for (unsigned int m=0; m<spacedim; ++m)
+                        for (unsigned int n=0; n<spacedim; ++n)
+                          {
+                            jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
+                              = tmp[i][j][l][m][0] *
+                                data.covariant[point][n][0];
+                            for (unsigned int nr=1; nr<dim; ++nr)
+                              jacobian_pushed_forward_3rd_derivatives[point][i][j][l][m][n]
+                              += tmp[i][j][l][m][nr] *
+                                 data.covariant[point][n][nr];
                           }
               }
           }

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2286,31 +2286,31 @@ namespace internal
                   // first push forward the j-components
                   for (unsigned int i=0; i<spacedim; ++i)
                     for (unsigned int j=0; j<spacedim; ++j)
-                        for (unsigned int l=0; l<dim; ++l)
-                          {
-                            tmp[i][j][l] = result[i][0][l] *
-                                           data.covariant[point][j][0];
-                            for (unsigned int jr=1; jr<dim; ++jr)
-                              {
-                                tmp[i][j][l] += result[i][jr][l] *
-                                                data.covariant[point][j][jr];
-                              }
-                          }
+                      for (unsigned int l=0; l<dim; ++l)
+                        {
+                          tmp[i][j][l] = result[i][0][l] *
+                                         data.covariant[point][j][0];
+                          for (unsigned int jr=1; jr<dim; ++jr)
+                            {
+                              tmp[i][j][l] += result[i][jr][l] *
+                                              data.covariant[point][j][jr];
+                            }
+                        }
 
                   // now, pushing forward the l-components
                   for (unsigned int i=0; i<spacedim; ++i)
                     for (unsigned int j=0; j<spacedim; ++j)
-                        for (unsigned int l=0; l<spacedim; ++l)
-                          {
-                            jacobian_pushed_forward_grads[point][i][j][l] = tmp[i][j][0] *
-                                                                            data.covariant[point][l][0];
-                            for (unsigned int lr=1; lr<dim; ++lr)
-                              {
-                                jacobian_pushed_forward_grads[point][i][j][l] += tmp[i][j][lr] *
-                                                                                data.covariant[point][l][lr];
-                              }
+                      for (unsigned int l=0; l<spacedim; ++l)
+                        {
+                          jacobian_pushed_forward_grads[point][i][j][l] = tmp[i][j][0] *
+                                                                          data.covariant[point][l][0];
+                          for (unsigned int lr=1; lr<dim; ++lr)
+                            {
+                              jacobian_pushed_forward_grads[point][i][j][l] += tmp[i][j][lr] *
+                                                                               data.covariant[point][l][lr];
+                            }
 
-                          }
+                        }
                 }
             }
         }

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -3206,25 +3206,32 @@ namespace
 
         for (unsigned int q=0; q<output.size(); ++q)
           for (unsigned int i=0; i<spacedim; ++i)
-            for (unsigned int j=0; j<spacedim; ++j)
-              for (unsigned int k=0; k<spacedim; ++k)
+            {
+              double tmp1[dim][dim];
+              for (unsigned int J=0; J<dim; ++J)
+                for (unsigned int K=0; K<dim; ++K)
+                  {
+                    tmp1[J][K] = data.contravariant[q][i][0] * input[q][0][J][K];
+                    for (unsigned int I=1; I<dim; ++I)
+                      tmp1[J][K] += data.contravariant[q][i][I] * input[q][I][J][K];
+                  }
+              for (unsigned int j=0; j<spacedim; ++j)
                 {
-                  output[q][i][j][k] =    data.contravariant[q][i][0]
-                                          * data.covariant[q][j][0]
-                                          * data.covariant[q][k][0]
-                                          * input[q][0][0][0];
-                  for (unsigned int I=0; I<dim; ++I)
-                    for (unsigned int J=0; J<dim; ++J)
-                      {
-                        const unsigned int K0 = (0==(I+J))? 1 : 0;
-                        for (unsigned int K=K0; K<dim; ++K)
-                          output[q][i][j][k] +=    data.contravariant[q][i][I]
-                                                   * data.covariant[q][j][J]
-                                                   * data.covariant[q][k][K]
-                                                   * input[q][I][J][K];
-                      }
-
+                  double tmp2[dim];
+                  for (unsigned int K=0; K<dim; ++K)
+                    {
+                      tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
+                      for (unsigned int J=1; J<dim; ++J)
+                        tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
+                    }
+                  for (unsigned int k=0; k<spacedim; ++k)
+                    {
+                      output[q][i][j][k] = data.covariant[q][k][0] * tmp2[0];
+                      for (unsigned int K=1; K<dim; ++K)
+                        output[q][i][j][k] += data.covariant[q][k][K] * tmp2[K];
+                    }
                 }
+            }
         return;
       }
 
@@ -3235,25 +3242,32 @@ namespace
 
         for (unsigned int q=0; q<output.size(); ++q)
           for (unsigned int i=0; i<spacedim; ++i)
-            for (unsigned int j=0; j<spacedim; ++j)
-              for (unsigned int k=0; k<spacedim; ++k)
+            {
+              double tmp1[dim][dim];
+              for (unsigned int J=0; J<dim; ++J)
+                for (unsigned int K=0; K<dim; ++K)
+                  {
+                    tmp1[J][K] = data.covariant[q][i][0] * input[q][0][J][K];
+                    for (unsigned int I=1; I<dim; ++I)
+                      tmp1[J][K] += data.covariant[q][i][I] * input[q][I][J][K];
+                  }
+              for (unsigned int j=0; j<spacedim; ++j)
                 {
-                  output[q][i][j][k] =    data.covariant[q][i][0]
-                                          * data.covariant[q][j][0]
-                                          * data.covariant[q][k][0]
-                                          * input[q][0][0][0];
-                  for (unsigned int I=0; I<dim; ++I)
-                    for (unsigned int J=0; J<dim; ++J)
-                      {
-                        const unsigned int K0 = (0==(I+J))? 1 : 0;
-                        for (unsigned int K=K0; K<dim; ++K)
-                          output[q][i][j][k] +=   data.covariant[q][i][I]
-                                                  * data.covariant[q][j][J]
-                                                  * data.covariant[q][k][K]
-                                                  * input[q][I][J][K];
-                      }
-
+                  double tmp2[dim];
+                  for (unsigned int K=0; K<dim; ++K)
+                    {
+                      tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
+                      for (unsigned int J=1; J<dim; ++J)
+                        tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
+                    }
+                  for (unsigned int k=0; k<spacedim; ++k)
+                    {
+                      output[q][i][j][k] = data.covariant[q][k][0] * tmp2[0];
+                      for (unsigned int K=1; K<dim; ++K)
+                        output[q][i][j][k] += data.covariant[q][k][K] * tmp2[K];
+                    }
                 }
+            }
 
         return;
       }
@@ -3269,27 +3283,35 @@ namespace
 
         for (unsigned int q=0; q<output.size(); ++q)
           for (unsigned int i=0; i<spacedim; ++i)
-            for (unsigned int j=0; j<spacedim; ++j)
-              for (unsigned int k=0; k<spacedim; ++k)
+            {
+              double factor[dim];
+              for (unsigned int I=0; I<dim; ++I)
+                factor[I] = data.contravariant[q][i][I] / data.volume_elements[q];
+              double tmp1[dim][dim];
+              for (unsigned int J=0; J<dim; ++J)
+                for (unsigned int K=0; K<dim; ++K)
+                  {
+                    tmp1[J][K] = factor[0] * input[q][0][J][K];
+                    for (unsigned int I=1; I<dim; ++I)
+                      tmp1[J][K] += factor[I] * input[q][I][J][K];
+                  }
+              for (unsigned int j=0; j<spacedim; ++j)
                 {
-                  output[q][i][j][k] =    data.contravariant[q][i][0]
-                                          / data.volume_elements[q]
-                                          * data.covariant[q][j][0]
-                                          * data.covariant[q][k][0]
-                                          * input[q][0][0][0];
-                  for (unsigned int I=0; I<dim; ++I)
-                    for (unsigned int J=0; J<dim; ++J)
-                      {
-                        const unsigned int K0 = (0==(I+J))? 1 : 0;
-                        for (unsigned int K=K0; K<dim; ++K)
-                          output[q][i][j][k] +=    data.contravariant[q][i][I]
-                                                   / data.volume_elements[q]
-                                                   * data.covariant[q][j][J]
-                                                   * data.covariant[q][k][K]
-                                                   * input[q][I][J][K];
-                      }
-
+                  double tmp2[dim];
+                  for (unsigned int K=0; K<dim; ++K)
+                    {
+                      tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
+                      for (unsigned int J=1; J<dim; ++J)
+                        tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
+                    }
+                  for (unsigned int k=0; k<spacedim; ++k)
+                    {
+                      output[q][i][j][k] = data.covariant[q][k][0] * tmp2[0];
+                      for (unsigned int K=1; K<dim; ++K)
+                        output[q][i][j][k] += data.covariant[q][k][K] * tmp2[K];
+                    }
                 }
+            }
 
         return;
       }
@@ -3411,21 +3433,21 @@ transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim>
       for (unsigned int q=0; q<output.size(); ++q)
         for (unsigned int i=0; i<spacedim; ++i)
           for (unsigned int j=0; j<spacedim; ++j)
-            for (unsigned int k=0; k<spacedim; ++k)
-              {
-                output[q][i][j][k] = data.covariant[q][j][0]
-                                     * data.covariant[q][k][0]
-                                     * input[q][i][0][0];
-                for (unsigned int J=0; J<dim; ++J)
-                  {
-                    const unsigned int K0 = (0==J)? 1 : 0;
-                    for (unsigned int K=K0; K<dim; ++K)
-                      output[q][i][j][k] += data.covariant[q][j][J]
-                                            * data.covariant[q][k][K]
-                                            * input[q][i][J][K];
-                  }
-
-              }
+            {
+              double tmp[dim];
+              for (unsigned int K=0; K<dim; ++K)
+                {
+                  tmp[K] = data.covariant[q][j][0] * input[q][i][0][K];
+                  for (unsigned int J=1; J<dim; ++J)
+                    tmp[K] += data.covariant[q][j][J] * input[q][i][J][K];
+                }
+              for (unsigned int k=0; k<spacedim; ++k)
+                {
+                  output[q][i][j][k] = data.covariant[q][k][0] * tmp[0];
+                  for (unsigned int K=1; K<dim; ++K)
+                    output[q][i][j][k] += data.covariant[q][k][K] * tmp[K];
+                }
+            }
       return;
     }
 


### PR DESCRIPTION
As realized in #1700 the computation of higher derivatives takes a long time. I have looked at one of the relevant code pieces and found that one can considerably improve the run time by applying the covariant/contravariant mapping to one dimension at a time. The change boils essentially down to replace the product of three or four matrices,
```
A * B * C * D
```
that is done by one single sweep multiplying all elements and expanding all sums (thus involving something like `dim^5` operations) by a series of three matrix multiplications
```
((A * B) * C ) * D
```
that result in something like `3 dim^3` operations. The tests using the divergence theorem pass this patch.

Similar code is also used in the `maybe_update_jacobian_pushed_forward_grads`, `maybe_update_jacobian_pushed_forward_2nd_derivatives`, and `maybe_update_jacobian_pushed_forward_3rd_derivatives` of mapping_q_generic.cc and similarly in mapping_fe_field.cc. I currently lack the time to pull this through for all variants. @maieneuro would you like to have a look? You may push the changes to my branch (or open a new one that includes this code).