### PR TITLE
Triangulation weights callback

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -159,6 +159,20 @@ inconvenience this causes.
 <a name="general"></a>
 <h3>General</h3>
 <ol>
+  <li> Changed: The functionality to distribute cells across processes
+  according to a vector of cell weights that was passed in a call to
+  <code>parallel::distributed::Triangulation<dim>::repartition()</code>
+  was replaced by a cell-wise signal. This signal is called during
+  <code>execute_coarsening_and_refinement</code> and <code>repartition</code>
+  if any function is connected to it. It allows to connect a function that
+  takes the current cell iterator and a status argument that indicates whether
+  this cell will be refined, coarsened or remains unchanged and returns a
+  cell weight, which will be used to distribute cells across processes in a
+  way that keeps the sum of weights across each individual process
+  approximately equal.
+  <br>
+  (Rene Gassmoeller, 2015/11/02)
+  </li>
 
   <li> New: 2nd derivatives are implemented for polynomials_BDM in 3D.
   <br>

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1407,7 +1407,7 @@ namespace
                       quadrant_overlaps_tree (const_cast<typename internal::p4est::types<dim>::tree *>(&tree),
                                               &p4est_cell)
                       == false))
-      return; //this quadrant and none of it's childs belongs to us.
+      return; //this quadrant and none of its children belongs to us.
 
     bool p4est_has_children = (idx == -1);
 
@@ -1505,7 +1505,7 @@ namespace
                            ptr);
           }
 
-        //mark other childs as invalid, so that unpack only happens once
+        //mark other children as invalid, so that unpack only happens once
         for (unsigned int i=1; i<GeometryInfo<dim>::max_children_per_cell; ++i)
           {
             int child_idx = sc_array_bsearch(const_cast<sc_array_t *>(&tree.quadrants),
@@ -1521,7 +1521,7 @@ namespace
       }
     else
       {
-        //it's children got coarsened into this cell
+        //its children got coarsened into this cell
         typename internal::p4est::types<dim>::quadrant *q;
         q = static_cast<typename internal::p4est::types<dim>::quadrant *> (
               sc_array_index (const_cast<sc_array_t *>(&tree.quadrants), idx)
@@ -1537,6 +1537,86 @@ namespace
                            parallel::distributed::Triangulation<dim,spacedim>::CELL_COARSEN,
                            ptr);
           }
+      }
+  }
+
+  template <int dim, int spacedim>
+  void
+  get_cell_weights_recursively (const typename internal::p4est::types<dim>::tree &tree,
+                                const typename Triangulation<dim,spacedim>::cell_iterator &dealii_cell,
+                                const typename internal::p4est::types<dim>::quadrant &p4est_cell,
+                                const typename Triangulation<dim,spacedim>::Signals &signals,
+                                std::vector<unsigned int> &weight)
+  {
+    const int idx = sc_array_bsearch(const_cast<sc_array_t *>(&tree.quadrants),
+                                     &p4est_cell,
+                                     internal::p4est::functions<dim>::quadrant_compare);
+
+    if (idx == -1 && (internal::p4est::functions<dim>::
+                      quadrant_overlaps_tree (const_cast<typename internal::p4est::types<dim>::tree *>(&tree),
+                                              &p4est_cell)
+                      == false))
+      return; // This quadrant and none of its children belongs to us.
+
+    const bool p4est_has_children = (idx == -1);
+
+    if (p4est_has_children && dealii_cell->has_children())
+      {
+        //recurse further
+        typename internal::p4est::types<dim>::quadrant
+        p4est_child[GeometryInfo<dim>::max_children_per_cell];
+        for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
+          switch (dim)
+            {
+            case 2:
+              P4EST_QUADRANT_INIT(&p4est_child[c]);
+              break;
+            case 3:
+              P8EST_QUADRANT_INIT(&p4est_child[c]);
+              break;
+            default:
+              Assert (false, ExcNotImplemented());
+            }
+
+        internal::p4est::functions<dim>::
+        quadrant_childrenv (&p4est_cell, p4est_child);
+
+        for (unsigned int c=0;
+             c<GeometryInfo<dim>::max_children_per_cell; ++c)
+          {
+            get_cell_weights_recursively<dim,spacedim> (tree,
+                                                        dealii_cell->child(c),
+                                                        p4est_child[c],
+                                                        signals,
+                                                        weight);
+          }
+      }
+    else if (!p4est_has_children && !dealii_cell->has_children())
+      {
+        // This active cell didn't change
+        weight.push_back(1000);
+        weight.back() += signals.cell_weight(dealii_cell,
+                                             parallel::distributed::Triangulation<dim,spacedim>::CELL_PERSIST);
+      }
+    else if (p4est_has_children)
+      {
+        // This cell will be refined
+        unsigned int parent_weight(1000);
+        parent_weight += signals.cell_weight(dealii_cell,
+                                             parallel::distributed::Triangulation<dim,spacedim>::CELL_REFINE);
+
+        for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
+          {
+            // We assign the weight of the parent cell equally to all children
+            weight.push_back(parent_weight);
+          }
+      }
+    else
+      {
+        // This cell's children will be coarsened into this cell
+        weight.push_back(1000);
+        weight.back() += signals.cell_weight(dealii_cell,
+                                             parallel::distributed::Triangulation<dim,spacedim>::CELL_COARSEN);
       }
   }
 
@@ -1559,7 +1639,7 @@ namespace
                       quadrant_overlaps_tree (const_cast<typename internal::p4est::types<dim>::tree *>(&tree),
                                               &p4est_cell)
                       == false))
-      // this quadrant and none of it's children belong to us.
+      // this quadrant and none of its children belong to us.
       return;
 
 
@@ -1955,10 +2035,12 @@ namespace
   class PartitionWeights
   {
   public:
-    PartitionWeights (const parallel::distributed::Triangulation<dim,spacedim> &triangulation,
-                      const std::vector<unsigned int>   &cell_weights,
-                      const std::vector<types::global_dof_index> &p4est_tree_to_coarse_cell_permutation,
-                      const types::subdomain_id                   my_subdomain);
+    /**
+     * This constructor assumes the cell_weights are already sorted in the
+     * order that p4est will encounter the cells, and they do not contain
+     * ghost cells or artificial cells.
+     */
+    PartitionWeights (const std::vector<unsigned int> &cell_weights);
 
     /**
      * A callback function that we pass to the p4est data structures when a
@@ -1976,102 +2058,18 @@ namespace
   private:
     std::vector<unsigned int> cell_weights_list;
     std::vector<unsigned int>::const_iterator current_pointer;
-
-    /**
-     * Recursively go through the cells of the p4est and deal.II triangulation
-     * and collect the partitioning weights.
-     */
-    void
-    build_weight_list (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
-                       const typename internal::p4est::types<dim>::quadrant &p4est_cell,
-                       const types::subdomain_id my_subdomain,
-                       const std::vector<unsigned int> &cell_weights);
   };
 
 
   template <int dim, int spacedim>
   PartitionWeights<dim,spacedim>::
-  PartitionWeights (const parallel::distributed::Triangulation<dim,spacedim>            &triangulation,
-                    const std::vector<unsigned int>              &cell_weights,
-                    const std::vector<types::global_dof_index>   &p4est_tree_to_coarse_cell_permutation,
-                    const types::subdomain_id                    my_subdomain)
+  PartitionWeights (const std::vector<unsigned int> &cell_weights)
+    :
+    cell_weights_list(cell_weights)
   {
-    Assert (cell_weights.size() == triangulation.n_active_cells(), ExcInternalError());
-
-    // build the cell_weights_list as an array over all locally owned
-    // active cells (i.e., a subset of the weights provided by the user, which
-    // are for all active cells), in the order in which p4est will encounter them
-    cell_weights_list.reserve (triangulation.n_locally_owned_active_cells());
-    for (unsigned int c=0; c<triangulation.n_cells(0); ++c)
-      {
-        unsigned int coarse_cell_index =
-          p4est_tree_to_coarse_cell_permutation[c];
-
-        const typename Triangulation<dim,spacedim>::cell_iterator
-        cell (&triangulation, 0, coarse_cell_index);
-
-        typename internal::p4est::types<dim>::quadrant p4est_cell;
-        internal::p4est::functions<dim>::
-        quadrant_set_morton (&p4est_cell,
-                             /*level=*/0,
-                             /*index=*/0);
-        p4est_cell.p.which_tree = c;
-        build_weight_list (cell, p4est_cell, my_subdomain,
-                           cell_weights);
-      }
-
-    // ensure that we built the list right
-    Assert(cell_weights_list.size() == triangulation.n_locally_owned_active_cells(),
-           ExcInternalError());
-
     // set the current pointer to the first element of the list, given that
     // we will walk through it sequentially
     current_pointer  = cell_weights_list.begin();
-  }
-
-
-  template <int dim, int spacedim>
-  void
-  PartitionWeights<dim,spacedim>::
-  build_weight_list (const typename Triangulation<dim,spacedim>::cell_iterator     &cell,
-                     const typename internal::p4est::types<dim>::quadrant &p4est_cell,
-                     const types::subdomain_id my_subdomain,
-                     const std::vector<unsigned int> &cell_weights)
-  {
-    if (!cell->has_children())
-      {
-        if (cell->subdomain_id() == my_subdomain)
-          cell_weights_list.push_back (cell_weights[cell->active_cell_index()]);
-      }
-    else
-      {
-        typename internal::p4est::types<dim>::quadrant
-        p4est_child[GeometryInfo<dim>::max_children_per_cell];
-        for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
-          switch (dim)
-            {
-            case 2:
-              P4EST_QUADRANT_INIT(&p4est_child[c]);
-              break;
-            case 3:
-              P8EST_QUADRANT_INIT(&p4est_child[c]);
-              break;
-            default:
-              Assert (false, ExcNotImplemented());
-            }
-        internal::p4est::functions<dim>::
-        quadrant_childrenv (&p4est_cell,
-                            p4est_child);
-        for (unsigned int c=0;
-             c<GeometryInfo<dim>::max_children_per_cell; ++c)
-          {
-            p4est_child[c].p.which_tree = p4est_cell.p.which_tree;
-            build_weight_list (cell->child(c),
-                               p4est_child[c],
-                               my_subdomain,
-                               cell_weights);
-          }
-      }
   }
 
 
@@ -2097,7 +2095,6 @@ namespace
     // get the weight, increment the pointer, and return the weight
     return *this_object->current_pointer++;
   }
-
 }
 
 
@@ -2761,10 +2758,7 @@ namespace parallel
         // number of CPUs and so everything works without this call, but
         // this command changes the distribution for some reason, so we
         // will leave it in here.
-        dealii::internal::p4est::functions<dim>::
-        partition (parallel_forest,
-                   /* prepare coarsening */ 1,
-                   /* weight_callback */ NULL);
+        repartition();
 
       try
         {
@@ -3572,21 +3566,41 @@ namespace parallel
                 balance_type(P8EST_CONNECT_FULL)),
                /*init_callback=*/NULL);
 
-
       // before repartitioning the mesh let others attach mesh related info
       // (such as SolutionTransfer data) to the p4est
       attach_mesh_data();
 
-      // partition the new mesh between all processors. we cannot
-      // use weights for each cell here because the cells have changed
-      // from the time the user has called execute_c_and_r due to the
-      // mesh refinement and coarsening, and the user has not had time
-      // to attach cell weights yet
       if (!(settings & no_automatic_repartitioning))
-        dealii::internal::p4est::functions<dim>::
-        partition (parallel_forest,
-                   /* prepare coarsening */ 1,
-                   /* weight_callback */ NULL);
+        {
+          // partition the new mesh between all processors. If cell weights have
+          // not been given balance the number of cells.
+          if (this->signals.cell_weight.num_slots() == 0)
+            dealii::internal::p4est::functions<dim>::
+            partition (parallel_forest,
+                       /* prepare coarsening */ 1,
+                       /* weight_callback */ NULL);
+          else
+            {
+              // get cell weights for a weighted repartitioning.
+              const std::vector<unsigned int> cell_weights = get_cell_weights();
+
+              PartitionWeights<dim,spacedim> partition_weights (cell_weights);
+
+              // attach (temporarily) a pointer to the cell weights through p4est's
+              // user_pointer object
+              Assert (parallel_forest->user_pointer == this,
+                      ExcInternalError());
+              parallel_forest->user_pointer = &partition_weights;
+
+              dealii::internal::p4est::functions<dim>::
+              partition (parallel_forest,
+                         /* prepare coarsening */ 1,
+                         /* weight_callback */ &PartitionWeights<dim,spacedim>::cell_weight);
+
+              // reset the user pointer to its previous state
+              parallel_forest->user_pointer = this;
+            }
+        }
 
       // finally copy back from local part of tree to deal.II
       // triangulation. before doing so, make sure there are no refine or
@@ -3618,7 +3632,7 @@ namespace parallel
 
     template <int dim, int spacedim>
     void
-    Triangulation<dim,spacedim>::repartition (const std::vector<unsigned int> &cell_weights)
+    Triangulation<dim,spacedim>::repartition ()
     {
       AssertThrow(settings & no_automatic_repartitioning,
                   ExcMessage("You need to set the 'no_automatic_repartitioning' flag in the "
@@ -3641,7 +3655,7 @@ namespace parallel
       // (such as SolutionTransfer data) to the p4est
       attach_mesh_data();
 
-      if (cell_weights.size() == 0)
+      if (this->signals.cell_weight.num_slots() == 0)
         {
           // no cell weights given -- call p4est's 'partition' without a
           // callback for cell weights
@@ -3652,17 +3666,15 @@ namespace parallel
         }
       else
         {
-          AssertDimension (cell_weights.size(), this->n_active_cells());
+          // get cell weights for a weighted repartitioning.
+          const std::vector<unsigned int> cell_weights = get_cell_weights();
 
-          // copy the cell weights into the order in which p4est will
-          // encounter them, then attach (temporarily) a pointer to
-          // this list through p4est's user_pointer object
+          PartitionWeights<dim,spacedim> partition_weights (cell_weights);
+
+          // attach (temporarily) a pointer to the cell weights through p4est's
+          // user_pointer object
           Assert (parallel_forest->user_pointer == this,
                   ExcInternalError());
-          PartitionWeights<dim,spacedim> partition_weights (*this,
-                                                            cell_weights,
-                                                            p4est_tree_to_coarse_cell_permutation,
-                                                            this->my_subdomain);
           parallel_forest->user_pointer = &partition_weights;
 
           dealii::internal::p4est::functions<dim>::
@@ -4740,6 +4752,57 @@ namespace parallel
                                                      p4est_coarse_cell,
                                                      attached_data_pack_callbacks);
         }
+    }
+
+    template <int dim, int spacedim>
+    std::vector<unsigned int>
+    Triangulation<dim,spacedim>::
+    get_cell_weights()
+    {
+      // Allocate the space for the weights. In fact we do not know yet, how
+      // many cells we own after the refinement (only p4est knows that
+      // at this point). We simply reserve n_active_cells space and if many
+      // more cells are refined than coarsened than additional reallocation
+      // will be done inside get_cell_weights_recursively.
+      std::vector<unsigned int> weights;
+      weights.reserve(this->n_active_cells());
+
+      // Recurse over p4est and Triangulation
+      // to find refined/coarsened/kept
+      // cells. Then append cell_weight.
+      // Note that we need to follow the p4est ordering
+      // instead of the deal.II ordering to get the cell_weights
+      // in the same order p4est will encounter them during repartitioning.
+      for (unsigned int c=0; c<this->n_cells(0); ++c)
+        {
+          // skip coarse cells, that are not ours
+          if (tree_exists_locally<dim,spacedim>(parallel_forest,c) == false)
+            continue;
+
+          const unsigned int coarse_cell_index =
+            p4est_tree_to_coarse_cell_permutation[c];
+
+          const typename Triangulation<dim,spacedim>::cell_iterator
+          dealii_coarse_cell (this, 0, coarse_cell_index);
+
+          typename dealii::internal::p4est::types<dim>::quadrant p4est_coarse_cell;
+          dealii::internal::p4est::functions<dim>::
+          quadrant_set_morton (&p4est_coarse_cell,
+                               /*level=*/0,
+                               /*index=*/0);
+          p4est_coarse_cell.p.which_tree = c;
+
+          const typename dealii::internal::p4est::types<dim>::tree *tree =
+            init_tree(coarse_cell_index);
+
+          get_cell_weights_recursively<dim,spacedim>(*tree,
+                                                     dealii_coarse_cell,
+                                                     p4est_coarse_cell,
+                                                     this->signals,
+                                                     weights);
+        }
+
+      return weights;
     }
 
     template <int dim, int spacedim>

--- a/tests/mpi/cell_weights_01_back_and_forth_01.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_01.cc
@@ -35,6 +35,24 @@
 
 #include <fstream>
 
+unsigned int current_cell_weight;
+
+template <int dim>
+unsigned int
+cell_weight_1(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+              const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  return current_cell_weight++;
+}
+
+template <int dim>
+unsigned int
+cell_weight_2(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+              const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  return 1;
+}
+
 
 template<int dim>
 void test()
@@ -49,20 +67,21 @@ void test()
   GridGenerator::subdivided_hyper_cube(tr, 16);
   tr.refine_global(1);
 
+  current_cell_weight = 1;
+
   // repartition the mesh as described above, first in some arbitrary
   // way, and then with all equal weights
-  {
-    std::vector<unsigned int> weights (tr.n_active_cells());
-    for (unsigned int i=0; i<weights.size(); ++i)
-      weights[i] = i+1;
-    tr.repartition (weights);
-  }
-  {
-    std::vector<unsigned int> weights (tr.n_active_cells());
-    for (unsigned int i=0; i<weights.size(); ++i)
-      weights[i] = 1;
-    tr.repartition (weights);
-  }
+  tr.signals.cell_weight.connect(std::bind(&cell_weight_1<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+  tr.repartition();
+
+  tr.signals.cell_weight.disconnect_all_slots();
+
+  tr.signals.cell_weight.connect(std::bind(&cell_weight_2<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+  tr.repartition();
 
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -34,6 +34,13 @@
 
 #include <fstream>
 
+template <int dim>
+unsigned int
+cell_weight(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+            const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  return 100;
+}
 
 template<int dim>
 void test()
@@ -42,15 +49,14 @@ void test()
   unsigned int numproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               dealii::Triangulation<dim>::none,
-                                               parallel::distributed::Triangulation<dim>::no_automatic_repartitioning);
+                                               dealii::Triangulation<dim>::none);
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
-  tr.refine_global(1);
 
-  // repartition the mesh; attach equal weights to all cells
-  const std::vector<unsigned int> weights (tr.n_active_cells(), 100U);
-  tr.repartition (weights);
+  tr.signals.cell_weight.connect(std::bind(&cell_weight<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+  tr.refine_global(1);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -34,6 +34,21 @@
 
 #include <fstream>
 
+template <int dim>
+unsigned int
+cell_weight(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+            const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  const unsigned int cell_weight = (cell->center()[0] < 0.5
+                                    ||
+                                    cell->center()[1] < 0.5
+                                    ?
+                                    0
+                                    :
+                                    3 * 1000);
+
+  return cell_weight;
+}
 
 template<int dim>
 void test()
@@ -46,21 +61,14 @@ void test()
                                                parallel::distributed::Triangulation<dim>::no_automatic_repartitioning);
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
+
   tr.refine_global(1);
 
-  // repartition the mesh; attach different weights to all cells
-  std::vector<unsigned int> weights (tr.n_active_cells());
-  for (typename Triangulation<dim>::active_cell_iterator
-       cell = tr.begin_active(); cell != tr.end(); ++cell)
-    weights[cell->active_cell_index()]
-      = (cell->center()[0] < 0.5
-         ||
-         cell->center()[1] < 0.5
-         ?
-         1
-         :
-         4);
-  tr.repartition (weights);
+  tr.signals.cell_weight.connect(std::bind(&cell_weight<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+
+  tr.repartition();
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)
@@ -76,13 +84,8 @@ void test()
        cell = tr.begin_active(); cell != tr.end(); ++cell)
     if (cell->is_locally_owned())
       integrated_weights[myid]
-      += (cell->center()[0] < 0.5
-          ||
-          cell->center()[1] < 0.5
-          ?
-          1
-          :
-          4);
+      += 1000 + cell_weight<dim>(cell,parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+
   Utilities::MPI::sum (integrated_weights, MPI_COMM_WORLD, integrated_weights);
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)

--- a/tests/mpi/cell_weights_03.mpirun=5.output
+++ b/tests/mpi/cell_weights_03.mpirun=5.output
@@ -4,18 +4,18 @@ DEAL:2d::processor 1: 356 locally owned active cells
 DEAL:2d::processor 2: 128 locally owned active cells
 DEAL:2d::processor 3: 92 locally owned active cells
 DEAL:2d::processor 4: 88 locally owned active cells
-DEAL:2d::processor 0: 360.000 weight
-DEAL:2d::processor 1: 356.000 weight
-DEAL:2d::processor 2: 356.000 weight
-DEAL:2d::processor 3: 368.000 weight
-DEAL:2d::processor 4: 352.000 weight
+DEAL:2d::processor 0: 360000. weight
+DEAL:2d::processor 1: 356000. weight
+DEAL:2d::processor 2: 356000. weight
+DEAL:2d::processor 3: 368000. weight
+DEAL:2d::processor 4: 352000. weight
 DEAL:3d::processor 0: 11472 locally owned active cells
 DEAL:3d::processor 1: 3480 locally owned active cells
 DEAL:3d::processor 2: 7168 locally owned active cells
 DEAL:3d::processor 3: 7784 locally owned active cells
 DEAL:3d::processor 4: 2864 locally owned active cells
-DEAL:3d::processor 0: 11472.0 weight
-DEAL:3d::processor 1: 11472.0 weight
-DEAL:3d::processor 2: 11464.0 weight
-DEAL:3d::processor 3: 11480.0 weight
-DEAL:3d::processor 4: 11456.0 weight
+DEAL:3d::processor 0: 1.14720e+07 weight
+DEAL:3d::processor 1: 1.14720e+07 weight
+DEAL:3d::processor 2: 1.14640e+07 weight
+DEAL:3d::processor 3: 1.14800e+07 weight
+DEAL:3d::processor 4: 1.14560e+07 weight

--- a/tests/mpi/cell_weights_04.mpirun=5.output
+++ b/tests/mpi/cell_weights_04.mpirun=5.output
@@ -4,18 +4,18 @@ DEAL:2d::processor 1: 52 locally owned active cells
 DEAL:2d::processor 2: 52 locally owned active cells
 DEAL:2d::processor 3: 48 locally owned active cells
 DEAL:2d::processor 4: 52 locally owned active cells
-DEAL:2d::processor 0: 52768.0 weight
-DEAL:2d::processor 1: 52000.0 weight
-DEAL:2d::processor 2: 52000.0 weight
-DEAL:2d::processor 3: 48000.0 weight
-DEAL:2d::processor 4: 52000.0 weight
+DEAL:2d::processor 0: 5.27680e+07 weight
+DEAL:2d::processor 1: 5.20000e+07 weight
+DEAL:2d::processor 2: 5.20000e+07 weight
+DEAL:2d::processor 3: 4.80000e+07 weight
+DEAL:2d::processor 4: 5.20000e+07 weight
 DEAL:3d::processor 0: 13920 locally owned active cells
 DEAL:3d::processor 1: 1640 locally owned active cells
 DEAL:3d::processor 2: 13920 locally owned active cells
 DEAL:3d::processor 3: 1648 locally owned active cells
 DEAL:3d::processor 4: 1640 locally owned active cells
-DEAL:3d::processor 0: 1.64429e+06 weight
-DEAL:3d::processor 1: 1.64000e+06 weight
-DEAL:3d::processor 2: 1.64429e+06 weight
-DEAL:3d::processor 3: 1.64800e+06 weight
-DEAL:3d::processor 4: 1.64000e+06 weight
+DEAL:3d::processor 0: 1.64429e+09 weight
+DEAL:3d::processor 1: 1.64000e+09 weight
+DEAL:3d::processor 2: 1.64429e+09 weight
+DEAL:3d::processor 3: 1.64800e+09 weight
+DEAL:3d::processor 4: 1.64000e+09 weight

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -43,6 +43,26 @@
 
 #include <fstream>
 
+template <int dim>
+unsigned int
+cell_weight(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+            const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  return (
+           // bottom left corner
+           (cell->center()[0] < 1)
+           &&
+           (cell->center()[1] < 1)
+           &&
+           (dim == 3 ?
+            (cell->center()[2] < 1) :
+            true)
+           ?
+           // one cell has more weight than all others together
+           std::pow(16,dim) * 1000
+           :
+           0);
+}
 
 template<int dim>
 void test()
@@ -59,25 +79,11 @@ void test()
 
 
   // repartition the mesh; attach different weights to all cells
-  std::vector<unsigned int> weights (tr.n_active_cells());
-  for (typename Triangulation<dim>::active_cell_iterator
-       cell = tr.begin_active(); cell != tr.end(); ++cell)
-    weights[cell->active_cell_index()]
-      = (
-          // bottom left corner
-          (cell->center()[0] < 1)
-          &&
-          (cell->center()[1] < 1)
-          &&
-          (dim == 3 ?
-           (cell->center()[2] < 1) :
-           true)
-          ?
-          // one cell has more weight than all others together
-          tr.n_global_active_cells()
-          :
-          1);
-  tr.repartition (weights);
+  tr.signals.cell_weight.connect(std::bind(&cell_weight<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+
+  tr.repartition ();
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)
@@ -93,19 +99,7 @@ void test()
        cell = tr.begin_active(); cell != tr.end(); ++cell)
     if (cell->is_locally_owned())
       integrated_weights[myid]
-      += (
-           // bottom left corner
-           (cell->center()[0] < 1)
-           &&
-           (cell->center()[1] < 1)
-           &&
-           (dim == 3 ?
-            (cell->center()[2] < 1) :
-            true)
-           ?
-           tr.n_global_active_cells()
-           :
-           1);
+      += 1000 + cell_weight<dim>(cell,parallel::distributed::Triangulation<dim>::CELL_PERSIST);
   Utilities::MPI::sum (integrated_weights, MPI_COMM_WORLD, integrated_weights);
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)

--- a/tests/mpi/cell_weights_05.mpirun=3.output
+++ b/tests/mpi/cell_weights_05.mpirun=3.output
@@ -1,13 +1,13 @@
 
 DEAL:2d::processor 0: 1 locally owned active cells
-DEAL:2d::processor 1: 84 locally owned active cells
-DEAL:2d::processor 2: 171 locally owned active cells
-DEAL:2d::processor 0: 256.000 weight
-DEAL:2d::processor 1: 84.0000 weight
-DEAL:2d::processor 2: 171.000 weight
+DEAL:2d::processor 1: 85 locally owned active cells
+DEAL:2d::processor 2: 170 locally owned active cells
+DEAL:2d::processor 0: 257000. weight
+DEAL:2d::processor 1: 85000.0 weight
+DEAL:2d::processor 2: 170000. weight
 DEAL:3d::processor 0: 1 locally owned active cells
-DEAL:3d::processor 1: 1364 locally owned active cells
-DEAL:3d::processor 2: 2731 locally owned active cells
-DEAL:3d::processor 0: 4096.00 weight
-DEAL:3d::processor 1: 1364.00 weight
-DEAL:3d::processor 2: 2731.00 weight
+DEAL:3d::processor 1: 1365 locally owned active cells
+DEAL:3d::processor 2: 2730 locally owned active cells
+DEAL:3d::processor 0: 4.09700e+06 weight
+DEAL:3d::processor 1: 1.36500e+06 weight
+DEAL:3d::processor 2: 2.73000e+06 weight

--- a/tests/mpi/cell_weights_05.mpirun=5.output
+++ b/tests/mpi/cell_weights_05.mpirun=5.output
@@ -1,21 +1,21 @@
 
 DEAL:2d::processor 0: 1 locally owned active cells
 DEAL:2d::processor 1: 0 locally owned active cells
-DEAL:2d::processor 2: 50 locally owned active cells
+DEAL:2d::processor 2: 51 locally owned active cells
 DEAL:2d::processor 3: 102 locally owned active cells
-DEAL:2d::processor 4: 103 locally owned active cells
-DEAL:2d::processor 0: 256.000 weight
+DEAL:2d::processor 4: 102 locally owned active cells
+DEAL:2d::processor 0: 257000. weight
 DEAL:2d::processor 1: 0 weight
-DEAL:2d::processor 2: 50.0000 weight
-DEAL:2d::processor 3: 102.000 weight
-DEAL:2d::processor 4: 103.000 weight
+DEAL:2d::processor 2: 51000.0 weight
+DEAL:2d::processor 3: 102000. weight
+DEAL:2d::processor 4: 102000. weight
 DEAL:3d::processor 0: 1 locally owned active cells
 DEAL:3d::processor 1: 0 locally owned active cells
-DEAL:3d::processor 2: 818 locally owned active cells
+DEAL:3d::processor 2: 819 locally owned active cells
 DEAL:3d::processor 3: 1638 locally owned active cells
-DEAL:3d::processor 4: 1639 locally owned active cells
-DEAL:3d::processor 0: 4096.00 weight
+DEAL:3d::processor 4: 1638 locally owned active cells
+DEAL:3d::processor 0: 4.09700e+06 weight
 DEAL:3d::processor 1: 0 weight
-DEAL:3d::processor 2: 818.000 weight
-DEAL:3d::processor 3: 1638.00 weight
-DEAL:3d::processor 4: 1639.00 weight
+DEAL:3d::processor 2: 819000. weight
+DEAL:3d::processor 3: 1.63800e+06 weight
+DEAL:3d::processor 4: 1.63800e+06 weight

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -40,6 +40,28 @@
 
 #include <fstream>
 
+unsigned int n_global_active_cells;
+
+template <int dim>
+unsigned int
+cell_weight(const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+            const typename parallel::distributed::Triangulation<dim>::CellStatus status)
+{
+  return (
+           // bottom left corner
+           (cell->center()[0] < 1)
+           &&
+           (cell->center()[1] < 1)
+           &&
+           (dim == 3 ?
+            (cell->center()[2] < 1) :
+            true)
+           ?
+           // one cell has more weight than all others together
+           n_global_active_cells * 1000
+           :
+           0);
+}
 
 template<int dim>
 void test()
@@ -56,25 +78,11 @@ void test()
   tr.refine_global (1);
 
   // repartition the mesh; attach different weights to all cells
-  std::vector<unsigned int> weights (tr.n_active_cells());
-  for (typename Triangulation<dim>::active_cell_iterator
-       cell = tr.begin_active(); cell != tr.end(); ++cell)
-    weights[cell->active_cell_index()]
-      = (
-          // bottom left corner
-          (cell->center()[0] < 1)
-          &&
-          (cell->center()[1] < 1)
-          &&
-          (dim == 3 ?
-           (cell->center()[2] < 1) :
-           true)
-          ?
-          // one cell has more weight than all others together
-          tr.n_global_active_cells()
-          :
-          1);
-  tr.repartition (weights);
+  n_global_active_cells = tr.n_global_active_cells();
+  tr.signals.cell_weight.connect(std::bind(&cell_weight<dim>,
+                                           std_cxx11::_1,
+                                           std_cxx11::_2));
+  tr.repartition ();
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)
@@ -90,19 +98,7 @@ void test()
        cell = tr.begin_active(); cell != tr.end(); ++cell)
     if (cell->is_locally_owned())
       integrated_weights[myid]
-      += (
-           // bottom left corner
-           (cell->center()[0] < 1)
-           &&
-           (cell->center()[1] < 1)
-           &&
-           (dim == 3 ?
-            (cell->center()[2] < 1) :
-            true)
-           ?
-           tr.n_global_active_cells()
-           :
-           1);
+      += 1000 + cell_weight<dim>(cell,parallel::distributed::Triangulation<dim>::CELL_PERSIST);
   Utilities::MPI::sum (integrated_weights, MPI_COMM_WORLD, integrated_weights);
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     for (unsigned int p=0; p<numproc; ++p)

--- a/tests/mpi/cell_weights_06.mpirun=3.output
+++ b/tests/mpi/cell_weights_06.mpirun=3.output
@@ -1,13 +1,13 @@
 
 DEAL:2d::processor 0: 0 locally owned active cells
-DEAL:2d::processor 1: 84 locally owned active cells
-DEAL:2d::processor 2: 172 locally owned active cells
+DEAL:2d::processor 1: 88 locally owned active cells
+DEAL:2d::processor 2: 168 locally owned active cells
 DEAL:2d::processor 0: 0 weight
-DEAL:2d::processor 1: 339.000 weight
-DEAL:2d::processor 2: 172.000 weight
+DEAL:2d::processor 1: 344000. weight
+DEAL:2d::processor 2: 168000. weight
 DEAL:3d::processor 0: 0 locally owned active cells
 DEAL:3d::processor 1: 1368 locally owned active cells
 DEAL:3d::processor 2: 2728 locally owned active cells
 DEAL:3d::processor 0: 0 weight
-DEAL:3d::processor 1: 5463.00 weight
-DEAL:3d::processor 2: 2728.00 weight
+DEAL:3d::processor 1: 5.46400e+06 weight
+DEAL:3d::processor 2: 2.72800e+06 weight


### PR DESCRIPTION
This is an enhancement that evolved out of a discussion on the ASPECT github page: https://github.com/geodynamics/aspect/pull/617
We would like to be able to assign repartition weights to cells during refinement_and_coarsening, because we want to avoid to transfer our solution and attached data twice (once for the refinement, and once for the repartitioning). It is not possible to simply hand the weights over to ´execute_coarsening_and_refinement`, because we do not know yet, how the refinement will change the mesh. It would be possible however, with a signal that calls a callback_function for every cell, which hands over a cell reference and what will happen to this cell, and returns a weight for this particular cell.

This is work in progress in that not all comments are up to date, and the partitioning in some of my tests look strange, although the general behaviour looks correct. I have 2 questions though, and would like some feedback:
- currently, we only define signals for `Triangulation`, but this new signal is specific for parallel::Triangulation. For now I copied the Signals structure into `parallel::distributed::Triangulation`, but maybe it would be better to start something like a parallel::Triangulation::ParallelSignals?
- There is already a class `PartitionWeights`, which can store and provide the cell weights for p4est. However, this class is designed for taking a list of cells ordered in deal.II ordering and sorting it into p4est order. Because the new approach can not iterate in deal.II order (some cells are not there yet), I already have a list of weights sorted in p4est order. For now I copied PartitionWeights and stripped away the sorting, but of course I could also change PartitionWeights to take an additional parameter that indicates, whether it should do the sorting (maybe with the default set to do the sorting, to keep compatibility?). Would that be preferrable to remove code duplication?