### PR TITLE
avoid test variant error output

### DIFF
--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -77,7 +77,7 @@ diff() {
   # Pick up main comparison file and all variants. A valid variant name is
   # of the form [...].output.[STRING]
   #
-  for file in "${COMPARISON_FILE}" "${COMPARISON_FILE}".*; do
+  for file in "${COMPARISON_FILE}"*; do
     # determine variant name (empty string for main comparison file):
     variant=${file#*.output}
 


### PR DESCRIPTION
If no variant is present, the diff script used to output a line like

numdiff: <bla>/tests/trilinos/precondition_muelu_q_iso_q1.with_trilinos>=11.14.with_64bit_indices=off.output.*: No such file or directory

because a glob in a for statement in bash will return it literally if no
files matches the pattern. This fixes it.