### PR TITLE
Wrap boost::enable_if_c as std_cxx11::enable_if.

### DIFF
--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -22,10 +22,6 @@
 #include <deal.II/base/std_cxx11/type_traits.h>
 #include <deal.II/base/std_cxx11/unique_ptr.h>
 
-// unfortunately, boost::enable_if_c, not boost::enable_if, is equivalent to
-// std::enable_if
-#include <boost/utility/enable_if.hpp>
-
 #include <string>
 #include <complex>
 #include <vector>
@@ -100,7 +96,7 @@ namespace MemoryConsumption
    */
   template <typename T>
   inline
-  typename boost::enable_if_c<std_cxx11::is_fundamental<T>::value, std::size_t>::type
+  typename std_cxx11::enable_if<std_cxx11::is_fundamental<T>::value, std::size_t>::type
   memory_consumption (const T &t);
 
   /**
@@ -111,7 +107,7 @@ namespace MemoryConsumption
    */
   template <typename T>
   inline
-  typename boost::enable_if_c<!(std_cxx11::is_fundamental<T>::value || std_cxx11::is_pointer<T>::value), std::size_t>::type
+  typename std_cxx11::enable_if<!(std_cxx11::is_fundamental<T>::value || std_cxx11::is_pointer<T>::value), std::size_t>::type
   memory_consumption (const T &t);
 
   /**
@@ -248,7 +244,7 @@ namespace MemoryConsumption
 {
   template <typename T>
   inline
-  typename boost::enable_if_c<std_cxx11::is_fundamental<T>::value, std::size_t>::type
+  typename std_cxx11::enable_if<std_cxx11::is_fundamental<T>::value, std::size_t>::type
   memory_consumption(const T &)
   {
     return sizeof(T);
@@ -380,7 +376,7 @@ namespace MemoryConsumption
 
   template <typename T>
   inline
-  typename boost::enable_if_c<!(std_cxx11::is_fundamental<T>::value || std_cxx11::is_pointer<T>::value), std::size_t>::type
+  typename std_cxx11::enable_if<!(std_cxx11::is_fundamental<T>::value || std_cxx11::is_pointer<T>::value), std::size_t>::type
   memory_consumption (const T &t)
   {
     return t.memory_consumption();

--- a/include/deal.II/base/std_cxx11/type_traits.h
+++ b/include/deal.II/base/std_cxx11/type_traits.h
@@ -32,18 +32,25 @@ namespace std_cxx11
   using std::is_pointer;
   using std::is_standard_layout;
   using std::is_trivial;
+  using std::enable_if;
 }
 DEAL_II_NAMESPACE_CLOSE
 
 #else
 
 #include <boost/type_traits.hpp>
+#include <boost/core/enable_if.hpp>
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx11
 {
   using boost::is_fundamental;
   using boost::is_pod;
   using boost::is_pointer;
+
+  // boost::enable_if_c, *not* boost::enable_if, is equivalent to std::enable_if.
+  template <bool B, class T = void>
+  struct enable_if : public boost::enable_if_c<B, T>
+  {};
 
   // boost does not have is_standard_layout and
   // is_trivial, but those are both a subset of


### PR DESCRIPTION
This is in response to the post merge discussion in #1704. This just cleans things up slightly by using `std_cxx11` instead of `boost`.

@bangerth I had forgotten about that wrapping ~~trick~~ technique (e.g., what was done for `unique_ptr`). 