### PR TITLE
fix ctest makeopts

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -472,7 +472,8 @@ IF("${_res}" STREQUAL "0")
   # Only run the build stage if configure was successful:
 
   MESSAGE("-- Running CTEST_BUILD()")
-  CTEST_BUILD(TARGET ${MAKEOPTS} NUMBER_ERRORS _res)
+  SET(CTEST_BUILD_FLAGS "${MAKEOPTS}")
+  CTEST_BUILD(NUMBER_ERRORS _res)
 
   IF("${_res}" STREQUAL "0")
     # Only run tests if the build was successful:


### PR DESCRIPTION
The argument after TARGET is the target to build and we abused it to
specify build flags. This fails on windows. With cmake 3.3 there is an
argument FLAGS <flags>, but older versions grab CTEST_BUILD_FLAGS, so
this is where we put the flags now.