### PR TITLE
Polynomials_bdm Documentation Edit

### DIFF
--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -53,7 +53,7 @@ DEAL_II_NAMESPACE_OPEN
  *   Note: the curl of a scalar function is given by $\text{curl}(f(x,y)) =
  *   \begin{pmatrix} f_{y}(x,y) \\ -f_{x}(x,y) \end{pmatrix}$.
  *
- *   <dd> The shape functions for $k=1$ are
+ *   <dd> The basis used to construct the $BDM_{1}$ shape functions is
  *   @f{align*}
  *     \phi_0 = \begin{pmatrix} 1 \\ 0 \end{pmatrix},
  *     \phi_1 = \begin{pmatrix} -\sqrt{3}+2\sqrt{3}x \\ 0 \end{pmatrix},


### PR DESCRIPTION
  - The documentation suggests that the given functions are the
    the bdm shape functions when in fact they are the basis functions
    used to construct the bdm shape functions. I've reworded the
    documentation to clarify this point.