### PR TITLE
Avoid using MappingQ1.

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -211,7 +211,7 @@ protected:
    * as the MappingQ1 class. Consequently, it inherits from
    * MappingQ1::InternalData, rather than from Mapping::InternalDataBase.
    */
-  class InternalData : public MappingQ1<dim,spacedim>::InternalData
+  class InternalData : public MappingQGeneric<dim,spacedim>::InternalData
   {
   public:
     /**
@@ -237,7 +237,7 @@ protected:
      * A pointer to a structure to store the information for the pure
      * $Q_1$ mapping that is, by default, used on all interior cells.
      */
-    std_cxx11::unique_ptr<typename MappingQ1<dim,spacedim>::InternalData> mapping_q1_data;
+    std_cxx11::unique_ptr<typename MappingQGeneric<dim,spacedim>::InternalData> mapping_q1_data;
   };
 
 protected:
@@ -313,7 +313,7 @@ protected:
    *   our own Q1 mapping here, rather than simply resorting to
    *   StaticMappingQ1::mapping.
    */
-  std_cxx11::unique_ptr<const MappingQ1<dim,spacedim> > q1_mapping;
+  std_cxx11::unique_ptr<const MappingQGeneric<dim,spacedim> > q1_mapping;
 
   /**
    * Declare other MappingQ classes friends.

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -81,7 +81,7 @@ public:
 template <int dim, int spacedim=dim>
 struct StaticMappingQ1
 {
-  static MappingQ1<dim, spacedim> mapping;
+  static MappingQGeneric<dim, spacedim> mapping;
 };
 
 

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 /*@{*/
 
 /**
- * Eulerian mapping of general unit cells by d-linear shape functions. Each
+ * Eulerian mapping of general unit cells by $d$-linear shape functions. Each
  * cell is thus shifted in space by values given to the mapping through a
  * finite element field.
  *
@@ -83,7 +83,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Michael Stadler, 2001
  */
 template <int dim, class VECTOR = Vector<double>, int spacedim=dim >
-class MappingQ1Eulerian : public MappingQ1<dim,spacedim>
+class MappingQ1Eulerian : public MappingQGeneric<dim,spacedim>
 {
 public:
 

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -106,6 +106,10 @@ public:
    */
   MappingQGeneric (const MappingQGeneric<dim,spacedim> &mapping);
 
+  // for documentation, see the Mapping base class
+  virtual
+  Mapping<dim,spacedim> *clone () const;
+
   /**
    * Return the degree of the mapping, i.e. the value which was passed to the
    * constructor.

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -312,8 +312,7 @@ public:
                const AdditionalData    additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but with mapping @p
-   * MappingQ1.
+   * Initializes the data structures. Same as above, but using a $Q_1$ mapping.
    */
   template <typename DH, typename Quadrature>
   void reinit (const DH               &dof_handler,
@@ -368,8 +367,7 @@ public:
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but with mapping @p
-   * MappingQ1.
+   * Initializes the data structures. Same as above, but  using a $Q_1$ mapping.
    */
   template <typename DH, typename Quadrature>
   void reinit (const std::vector<const DH *>               &dof_handler,
@@ -392,8 +390,7 @@ public:
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but with mapping @p
-   * MappingQ1.
+   * Initializes the data structures. Same as above, but  using a $Q_1$ mapping.
    */
   template <typename DH, typename Quadrature>
   void reinit (const std::vector<const DH *>               &dof_handler,
@@ -1472,7 +1469,6 @@ reinit(const DH               &dof_handler,
        const Quad             &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
-  MappingQ1<dim>                       mapping;
   std::vector<const DH *>               dof_handlers;
   std::vector<const ConstraintMatrix *> constraints;
   std::vector<Quad>          quads;
@@ -1484,7 +1480,7 @@ reinit(const DH               &dof_handler,
   std::vector<IndexSet> locally_owned_sets =
     internal::MatrixFree::extract_locally_owned_index_sets
     (dof_handlers, additional_data.level_mg_handler);
-  reinit(mapping, dof_handlers,constraints, locally_owned_sets, quads,
+  reinit(StaticMappingQ1<dim>::mapping, dof_handlers,constraints, locally_owned_sets, quads,
          additional_data);
 }
 
@@ -1524,11 +1520,10 @@ reinit(const std::vector<const DH *>               &dof_handler,
        const std::vector<Quad>                    &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
-  MappingQ1<dim> mapping;
   std::vector<IndexSet> locally_owned_set =
     internal::MatrixFree::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
-  reinit(mapping, dof_handler,constraint,locally_owned_set,
+  reinit(StaticMappingQ1<dim>::mapping, dof_handler,constraint,locally_owned_set,
          static_cast<const std::vector<Quadrature<1> >&>(quad),
          additional_data);
 }
@@ -1543,13 +1538,12 @@ reinit(const std::vector<const DH *>               &dof_handler,
        const Quad                                 &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
-  MappingQ1<dim> mapping;
   std::vector<Quad> quads;
   quads.push_back(quad);
   std::vector<IndexSet> locally_owned_set =
     internal::MatrixFree::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
-  reinit(mapping, dof_handler,constraint,locally_owned_set, quads,
+  reinit(StaticMappingQ1<dim>::mapping, dof_handler,constraint,locally_owned_set, quads,
          additional_data);
 }
 

--- a/include/deal.II/numerics/derivative_approximation.h
+++ b/include/deal.II/numerics/derivative_approximation.h
@@ -188,7 +188,7 @@ namespace DerivativeApproximation
 
   /**
    * Calls the @p interpolate function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, template <int, int> class DH, class InputVector, int spacedim>
   void
@@ -224,7 +224,7 @@ namespace DerivativeApproximation
 
   /**
    * Calls the @p interpolate function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, template <int, int> class DH, class InputVector, int spacedim>
   void
@@ -260,7 +260,7 @@ namespace DerivativeApproximation
                                 const unsigned int                            component = 0);
 
   /**
-   * Same as above, with <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * Same as above, with <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <class DH, int dim, int spacedim, class InputVector, int order>
   void

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -341,7 +341,7 @@ public:
 
   /**
    * Calls the @p estimate function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <typename InputVector, class DH>
   static void estimate (const DH                &dof,
@@ -385,7 +385,7 @@ public:
 
   /**
    * Calls the @p estimate function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <typename InputVector, class DH>
   static void estimate (const DH                    &dof,
@@ -578,7 +578,7 @@ public:
 
   /**
    * Calls the @p estimate function, see above, with
-   * <tt>mapping=MappingQ1<1>()</tt>.
+   * <tt>mapping=MappingQGeneric1<1>()</tt>.
    */
   template <typename InputVector, class DH>
   static void estimate (const DH   &dof,
@@ -620,7 +620,7 @@ public:
 
   /**
    * Calls the @p estimate function, see above, with
-   * <tt>mapping=MappingQ1<1>()</tt>.
+   * <tt>mapping=MappingQGeneric1<1>()</tt>.
    */
   template <typename InputVector, class DH>
   static void estimate (const DH       &dof,

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -242,7 +242,7 @@ namespace MatrixCreator
 
   /**
    * Calls the create_mass_matrix() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, typename number, int spacedim>
   void create_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
@@ -279,7 +279,7 @@ namespace MatrixCreator
 
   /**
    * Calls the create_mass_matrix() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, typename number, int spacedim>
   void create_mass_matrix (const DoFHandler<dim,spacedim> &dof,
@@ -373,7 +373,7 @@ namespace MatrixCreator
 
   /**
    * Calls the create_boundary_mass_matrix() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_boundary_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
@@ -438,7 +438,7 @@ namespace MatrixCreator
 
   /**
    * Calls the create_laplace_matrix() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_laplace_matrix (const DoFHandler<dim,spacedim> &dof,
@@ -474,7 +474,7 @@ namespace MatrixCreator
 
   /**
    * Calls the create_laplace_matrix() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_laplace_matrix (const DoFHandler<dim,spacedim> &dof,

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -413,7 +413,7 @@ namespace VectorTools
 
   /**
    * Calls the @p interpolate() function above with
-   * <tt>mapping=MappingQ1@<dim>@()</tt>.
+   * <tt>mapping=MappingQGeneric1@<dim>@()</tt>.
    */
   template <class VECTOR, class DH>
   void interpolate (const DH              &dof,
@@ -605,7 +605,7 @@ namespace VectorTools
 
   /**
    * Calls the project() function above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class VECTOR, int spacedim>
   void project (const DoFHandler<dim,spacedim>    &dof,
@@ -741,7 +741,7 @@ namespace VectorTools
 
   /**
    * Calls the other interpolate_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>. The same comments apply as for the
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>. The same comments apply as for the
    * previous function, in particular about the use of the component mask and
    * the requires size of the function object.
    *
@@ -759,7 +759,7 @@ namespace VectorTools
 
   /**
    * Calls the other interpolate_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>. The same comments apply as for the
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>. The same comments apply as for the
    * previous function, in particular about the use of the component mask and
    * the requires size of the function object.
    */
@@ -862,7 +862,7 @@ namespace VectorTools
 
   /**
    * Calls the other interpolate_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>. The same comments apply as for the
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>. The same comments apply as for the
    * previous function, in particular about the use of the component mask and
    * the requires size of the function object.
    *
@@ -882,7 +882,7 @@ namespace VectorTools
 
   /**
    * Calls the other interpolate_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>. The same comments apply as for the
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>. The same comments apply as for the
    * previous function, in particular about the use of the component mask and
    * the requires size of the function object.
    *
@@ -953,7 +953,7 @@ namespace VectorTools
 
   /**
    * Calls the project_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void project_boundary_values (const DoFHandler<dim,spacedim>    &dof,
@@ -975,7 +975,7 @@ namespace VectorTools
 
   /**
    * Calls the project_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void project_boundary_values (const hp::DoFHandler<dim,spacedim>    &dof,
@@ -1032,7 +1032,7 @@ namespace VectorTools
 
   /**
    * Calls the project_boundary_values() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    *
    * @ingroup constraints
    */
@@ -1604,7 +1604,7 @@ namespace VectorTools
 
   /**
    * Calls the create_right_hand_side() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_right_hand_side (const DoFHandler<dim,spacedim> &dof,
@@ -1647,7 +1647,7 @@ namespace VectorTools
 
   /**
    * Calls the create_point_source_vector() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_point_source_vector(const DoFHandler<dim,spacedim> &dof,
@@ -1700,7 +1700,7 @@ namespace VectorTools
 
   /**
    * Calls the create_point_source_vector() function for vector-valued finite
-   * elements, see above, with <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * elements, see above, with <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
   void create_point_source_vector(const DoFHandler<dim,spacedim> &dof,
@@ -1749,7 +1749,7 @@ namespace VectorTools
 
   /**
    * Calls the create_boundary_right_hand_side() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
@@ -1916,7 +1916,7 @@ namespace VectorTools
 
   /**
    * Calls the integrate_difference() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   void integrate_difference (const DoFHandler<dim,spacedim> &dof,
@@ -1944,7 +1944,7 @@ namespace VectorTools
 
   /**
    * Calls the integrate_difference() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   void integrate_difference (const hp::DoFHandler<dim,spacedim> &dof,
@@ -2335,7 +2335,7 @@ namespace VectorTools
 
   /**
    * Calls the other compute_mean_value() function, see above, with
-   * <tt>mapping=MappingQ1@<dim@>()</tt>.
+   * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, int spacedim>
   double compute_mean_value (const DoFHandler<dim,spacedim> &dof,

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------
 // $Id$
 //
-// Copyright (C) 2012 - 2013 by the deal.II authors
+// Copyright (C) 2012 - 2013, 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -53,8 +53,6 @@ namespace FE_Q_Bubbles_Helper
       const unsigned int degree = fe.degree;
 
       // Initialize quadrature formula on fine cells
-      MappingQ1<dim, spacedim> mapping;
-
       std_cxx11::unique_ptr<Quadrature<dim> > q_fine;
       Quadrature<1> q_dummy(std::vector<Point<1> >(1), std::vector<double> (1,1.));
       switch (dim)
@@ -109,7 +107,7 @@ namespace FE_Q_Bubbles_Helper
           DoFHandler<dim, spacedim> dh(tr);
           dh.distribute_dofs(fe);
 
-          FEValues<dim, spacedim> fine (mapping, fe, *q_fine,
+          FEValues<dim, spacedim> fine (StaticMappingQ1<dim,spacedim>::mapping, fe, *q_fine,
                                         update_quadrature_points
                                         | update_JxW_values | update_values);
 

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -785,12 +785,11 @@ namespace FETools
       tria.begin_active()->set_refine_flag (RefinementCase<dim>(ref_case));
       tria.execute_coarsening_and_refinement ();
 
-      MappingQ1<dim,spacedim> mapping;
       const unsigned int degree = fe.degree;
       QGauss<dim> q_fine (degree+1);
       const unsigned int nq = q_fine.size();
 
-      FEValues<dim,spacedim> fine (mapping, fe, q_fine,
+      FEValues<dim,spacedim> fine (fe, q_fine,
                                    update_quadrature_points |
                                    update_JxW_values |
                                    update_values);
@@ -839,7 +838,7 @@ namespace FETools
               q_points_coarse[i](j) = q_points_fine[i](j);
           const Quadrature<dim> q_coarse (q_points_coarse,
                                           fine.get_JxW_values ());
-          FEValues<dim,spacedim> coarse (mapping, fe, q_coarse, update_values);
+          FEValues<dim,spacedim> coarse (fe, q_coarse, update_values);
 
           coarse.reinit (tria.begin (0));
 
@@ -1124,7 +1123,6 @@ namespace FETools
 
     // prepare FEValues, quadrature etc on
     // coarse cell
-    MappingQ1<dim,spacedim> mapping;
     QGauss<dim> q_fine(degree+1);
     const unsigned int nq = q_fine.size();
 
@@ -1135,7 +1133,7 @@ namespace FETools
       Triangulation<dim,spacedim> tr;
       GridGenerator::hyper_cube (tr, 0, 1);
 
-      FEValues<dim,spacedim> coarse (mapping, fe, q_fine,
+      FEValues<dim,spacedim> coarse (fe, q_fine,
                                      update_JxW_values | update_values);
 
       typename Triangulation<dim,spacedim>::cell_iterator coarse_cell
@@ -1193,7 +1191,7 @@ namespace FETools
         tr.begin_active()->set_refine_flag(RefinementCase<dim>(ref_case));
         tr.execute_coarsening_and_refinement();
 
-        FEValues<dim,spacedim> fine (mapping, fe, q_fine,
+        FEValues<dim,spacedim> fine (StaticMappingQ1<dim,spacedim>::mapping, fe, q_fine,
                                      update_quadrature_points | update_JxW_values |
                                      update_values);
 
@@ -1219,7 +1217,7 @@ namespace FETools
                 q_points_coarse[q](j) = q_points_fine[q](j);
             Quadrature<dim> q_coarse (q_points_coarse,
                                       fine.get_JxW_values());
-            FEValues<dim,spacedim> coarse (mapping, fe, q_coarse, update_values);
+            FEValues<dim,spacedim> coarse (StaticMappingQ1<dim,spacedim>::mapping, fe, q_coarse, update_values);
             coarse.reinit(coarse_cell);
 
             // Build RHS

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -70,7 +70,7 @@ MappingQ<dim,spacedim>::MappingQ (const unsigned int degree,
                               (dim != spacedim)),
   // create a Q1 mapping for use on interior cells (if necessary)
   // or to create a good initial guess in transform_real_to_unit_cell()
-  q1_mapping (new MappingQ1<dim,spacedim>())
+  q1_mapping (new MappingQGeneric<dim,spacedim>(1))
 {}
 
 
@@ -82,7 +82,7 @@ MappingQ<dim,spacedim>::MappingQ (const MappingQ<dim,spacedim> &mapping)
   use_mapping_q_on_all_cells (mapping.use_mapping_q_on_all_cells),
   // clone the Q1 mapping for use on interior cells (if necessary)
   // or to create a good initial guess in transform_real_to_unit_cell()
-  q1_mapping (mapping.q1_mapping->clone())
+  q1_mapping (dynamic_cast<MappingQGeneric<dim,spacedim>*>(mapping.q1_mapping->clone()))
 {}
 
 

--- a/source/fe/mapping_q1.cc
+++ b/source/fe/mapping_q1.cc
@@ -59,7 +59,8 @@ MappingQ1<dim,spacedim>::clone () const
 
 
 template<int dim, int spacedim>
-MappingQ1<dim,spacedim> StaticMappingQ1<dim,spacedim>::mapping;
+MappingQGeneric<dim,spacedim>
+StaticMappingQ1<dim,spacedim>::mapping = MappingQGeneric<dim,spacedim>(1);
 
 
 

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -33,6 +33,7 @@ MappingQ1Eulerian<dim, EulerVectorType, spacedim>::
 MappingQ1Eulerian (const EulerVectorType  &euler_transform_vectors,
                    const DoFHandler<dim,spacedim> &shiftmap_dof_handler)
   :
+  MappingQGeneric<dim,spacedim>(1),
   euler_transform_vectors(&euler_transform_vectors),
   shiftmap_dof_handler(&shiftmap_dof_handler)
 {}
@@ -128,11 +129,11 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
   // call the function of the base class, but ignoring
   // any potentially detected cell similarity between
   // the current and the previous cell
-  MappingQ1<dim,spacedim>::fill_fe_values (cell,
-                                           CellSimilarity::invalid_next_cell,
-                                           quadrature,
-                                           internal_data,
-                                           output_data);
+  MappingQGeneric<dim,spacedim>::fill_fe_values (cell,
+                                                 CellSimilarity::invalid_next_cell,
+                                                 quadrature,
+                                                 internal_data,
+                                                 output_data);
   // also return the updated flag since any detected
   // similarity wasn't based on the mapped field, but
   // the original vertices which are meaningless

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -1013,6 +1013,17 @@ MappingQGeneric<dim,spacedim>::MappingQGeneric (const MappingQGeneric<dim,spaced
 
 
 
+
+template<int dim, int spacedim>
+Mapping<dim,spacedim> *
+MappingQGeneric<dim,spacedim>::clone () const
+{
+  return new MappingQGeneric<dim,spacedim>(*this);
+}
+
+
+
+
 template<int dim, int spacedim>
 unsigned int
 MappingQGeneric<dim,spacedim>::get_degree() const

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -668,10 +668,8 @@ namespace GridTools
                      Triangulation<dim> &triangulation,
                      const Function<dim> *coefficient)
   {
-    // first provide everything that is
-    // needed for solving a Laplace
+    // first provide everything that is needed for solving a Laplace
     // equation.
-    MappingQ1<dim> mapping_q1;
     FE_Q<dim> q1(1);
 
     DoFHandler<dim> dof_handler(triangulation);
@@ -690,7 +688,7 @@ namespace GridTools
 
     QGauss<dim> quadrature(4);
 
-    MatrixCreator::create_laplace_matrix(mapping_q1, dof_handler, quadrature, S,coefficient);
+    MatrixCreator::create_laplace_matrix(StaticMappingQ1<dim>::mapping, dof_handler, quadrature, S, coefficient);
 
     // set up the boundary values for
     // the laplace problem
@@ -1337,7 +1335,7 @@ next_cell:
                     best_cell     = std::make_pair(*cell, p_cell);
                   }
               }
-            catch (typename MappingQ1<dim,spacedim>::ExcTransformationFailed &)
+            catch (typename MappingQGeneric<dim,spacedim>::ExcTransformationFailed &)
               {
                 // ok, the transformation
                 // failed presumably
@@ -1463,7 +1461,7 @@ next_cell:
                         best_cell     = std::make_pair(*cell, p_cell);
                       }
                   }
-                catch (typename MappingQ1<dim,spacedim>::ExcTransformationFailed &)
+                catch (typename MappingQGeneric<dim,spacedim>::ExcTransformationFailed &)
                   {
                     // ok, the transformation
                     // failed presumably

--- a/source/hp/mapping_collection.cc
+++ b/source/hp/mapping_collection.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -93,7 +93,7 @@ namespace hp
      * this function is called.
      */
     template<int dim, int spacedim>
-    MappingQ1<dim,spacedim> &
+    MappingQGeneric<dim,spacedim> &
     get_static_mapping_q1()
     {
       static MappingQ1<dim,spacedim> mapping;

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -453,11 +453,12 @@ void DataOutRotation<dim,DH>::build_patches (const unsigned int n_patches_per_ci
     else
       n_postprocessor_outputs[dataset] = 0;
 
-  const MappingQ1<dimension, space_dimension> mapping;
   internal::DataOutRotation::ParallelData<dimension, space_dimension>
   thread_data (n_datasets,
                n_subdivisions, n_patches_per_circle,
-               n_postprocessor_outputs, mapping, this->get_finite_elements(),
+               n_postprocessor_outputs,
+               StaticMappingQ1<dimension,space_dimension>::mapping,
+               this->get_finite_elements(),
                update_flags);
   std::vector<DataOutBase::Patch<dimension+1,space_dimension+1> >
   new_patches (n_patches_per_circle);

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -647,7 +647,7 @@ void PointValueHistory<dim>
       // we now have a point to query,
       // need to know what cell it is in
       Point <dim> requested_location = point->requested_location;
-      typename DoFHandler<dim>::active_cell_iterator cell = GridTools::find_active_cell_around_point (MappingQ1<dim>(), *dof_handler, requested_location).first;
+      typename DoFHandler<dim>::active_cell_iterator cell = GridTools::find_active_cell_around_point (StaticMappingQ1<dim>::mapping, *dof_handler, requested_location).first;
 
 
       fe_values.reinit (cell);
@@ -1139,7 +1139,7 @@ void PointValueHistory<dim>
       // we now have a point to query,
       // need to know what cell it is in
       Point <dim> requested_location = point->requested_location;
-      typename DoFHandler<dim>::active_cell_iterator cell = GridTools::find_active_cell_around_point (MappingQ1<dim>(), *dof_handler, requested_location).first;
+      typename DoFHandler<dim>::active_cell_iterator cell = GridTools::find_active_cell_around_point (StaticMappingQ1<dim>::mapping, *dof_handler, requested_location).first;
       fe_values.reinit (cell);
 
       evaluation_points = fe_values.get_quadrature_points();

--- a/tests/bits/find_cell_10.cc
+++ b/tests/bits/find_cell_10.cc
@@ -86,7 +86,7 @@ void test()
   ePos(1) = 1125.59175030825804242340382189;
 
   MappingQ<2> mapping(1);
-  MappingQ1<2> &mapping2 = StaticMappingQ1< 2 >::mapping;
+  MappingQGeneric<2> &mapping2 = StaticMappingQ1< 2 >::mapping;
   deallog << "1:" << std::endl;
   GridTools::find_active_cell_around_point (mapping, triangulation, ePos);
   deallog << "2:" << std::endl;

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -97,7 +97,7 @@ void test()
   ePos(1) = 1125.59175030825804242340382189;
 
   MappingQ<2> mapping(1);
-  MappingQ1<2> &mapping2 = StaticMappingQ1< 2 >::mapping;
+  MappingQGeneric<2> &mapping2 = StaticMappingQ1< 2 >::mapping;
 
   Triangulation<2>     triangulation;
   create_coarse_grid(triangulation); // first Tria with just one cell


### PR DESCRIPTION
Since MappingQ1 is now just a wrapper around MappingQGeneric(1),
replace uses of the former by the latter in a variety of places.

This addresses in parts #1537.