### PR TITLE
Fix some erroneous uses of @tparam.

### DIFF
--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -154,10 +154,12 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the order @tparam order derivative of the <tt>i</tt>th
-   * polynomial at unit point <tt>p</tt>.
+   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th polynomial
+   * at unit point <tt>p</tt>.
    *
    * Consider using compute() instead.
+   *
+   * @tparam order The order of the derivative.
    */
   template <int order>
   Tensor<order,dim> compute_derivative (const unsigned int i,

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -52,11 +52,13 @@ public:
    * to populate a TableIndices object upon creation, either completely, or
    * partially.
    *
-   * Index entries that are not set by this 1 - 9 arguments (either
-   * because they are omitted, or because @tparam N is larger than 9) are
-   * set to numbers::invalid_unsigned_int.
+   * Index entries that are not set by these arguments (either because
+   * they are omitted, or because $N > 9$) are set to
+   * numbers::invalid_unsigned_int.
    *
-   * Note that only the first @tparam N arguments are actually used.
+   * Note that only the first <tt>N</tt> arguments are actually used.
+   *
+   * @tparam N The number of indices stored in each object.
    */
   TableIndices (const unsigned int index0,
                 const unsigned int index1 = numbers::invalid_unsigned_int,

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1394,7 +1394,9 @@ operator / (const Tensor<rank,dim,Number> &t,
 
 
 /**
- * Addition of two tensors of general @tparam rank.
+ * Addition of two tensors of general rank.
+ *
+ * @tparam rank The rank of both tensors.
  *
  * @relates Tensor
  */
@@ -1413,7 +1415,9 @@ operator+ (const Tensor<rank,dim,Number> &p, const Tensor<rank,dim,OtherNumber> 
 
 
 /**
- * Subtraction of two tensors of general @tparam rank.
+ * Subtraction of two tensors of general rank.
+ *
+ * @tparam rank The rank of both tensors.
  *
  * @relates Tensor
  */

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -135,7 +135,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the order @tparam order derivative of the <tt>i</tt>th tensor
+   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -145,6 +145,8 @@ public:
    * several times.  Instead use the compute() function, see above, with
    * the size of the appropriate parameter set to n() to get the point value
    * of all tensor polynomials all at once and in a much more efficient way.
+   *
+   * @tparam order The derivative order.
    */
   template <int order>
   Tensor<order,dim> compute_derivative (const unsigned int i,
@@ -288,7 +290,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the order @tparam order derivative of the <tt>i</tt>th tensor
+   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -298,6 +300,8 @@ public:
    * several times.  Instead use the compute() function, see above, with
    * the size of the appropriate parameter set to n() to get the point value
    * of all tensor polynomials all at once and in a much more efficient way.
+   *
+   * @tparam order The derivative order.
    */
   template <int order>
   Tensor<order,dim> compute_derivative (const unsigned int i,

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -96,7 +96,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the order @tparam order derivative of the <tt>i</tt>th tensor
+   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -106,6 +106,8 @@ public:
    * several times.  Instead use the compute() function, see above, with
    * the size of the appropriate parameter set to n() to get the point value
    * of all tensor polynomials all at once and in a much more efficient way.
+   *
+   * @tparam order The derivative order.
    */
   template <int order>
   Tensor<order,dim> compute_derivative (const unsigned int i,


### PR DESCRIPTION
`@tparam`, unlike `@param`, starts a new paragraph where it is used. This caused some strangely formatted documentation, which is now fixed.