### PR TITLE
Remove references to MappingQ1.

### DIFF
--- a/tests/aniso/solution_transfer.cc
+++ b/tests/aniso/solution_transfer.cc
@@ -65,7 +65,7 @@ void transfer(std::ostream &out)
   FE_DGQ<dim> fe(1);
   DoFHandler<dim> dof_handler(tria);
   Vector<double> solution;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   DataOut<dim> data_out;
 
   dof_handler.distribute_dofs (fe);

--- a/tests/bits/data_out_curved_cells.cc
+++ b/tests/bits/data_out_curved_cells.cc
@@ -136,7 +136,7 @@ void curved_grid (std::ofstream &out)
   // now provide everything that is
   // needed for solving a Laplace
   // equation.
-  MappingQ1<2> mapping_q1;
+  MappingQGeneric<2> mapping_q1(1);
   FE_Q<2> fe(2);
   DoFHandler<2> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -83,7 +83,7 @@ void test()
   try
     {
       std::pair<typename Triangulation<2>::active_cell_iterator, Point<2> > current_cell =
-        GridTools::find_active_cell_around_point(MappingQ1<2>(), triangulation, test_point);
+        GridTools::find_active_cell_around_point(MappingQGeneric<2>(1), triangulation, test_point);
 
       deallog << "cell: index = " << current_cell.first->index()
               << " level = " << current_cell.first->level() << std::endl;

--- a/tests/bits/find_cell_7.cc
+++ b/tests/bits/find_cell_7.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -71,8 +71,8 @@ void check2 ()
   deallog << inside(tria, p2) << std::endl;
 
   hp::MappingCollection<3> mappings;
-  mappings.push_back (MappingQ1<3>());
-  mappings.push_back (MappingQ1<3>());
+  mappings.push_back (MappingQGeneric<3>(1));
+  mappings.push_back (MappingQGeneric<3>(1));
 
   hp::FECollection<3> fes;
   fes.push_back (FE_Q<3>(1));

--- a/tests/bits/find_cell_alt_4.cc
+++ b/tests/bits/find_cell_alt_4.cc
@@ -34,7 +34,7 @@
 
 void check (Triangulation<3> &tria)
 {
-  MappingQ1<3> map;
+  MappingQGeneric<3> map(1);
 
   Point<3> p (0.75,0,0);
 

--- a/tests/bits/find_cell_alt_5.cc
+++ b/tests/bits/find_cell_alt_5.cc
@@ -34,7 +34,7 @@
 
 void check (Triangulation<3> &tria)
 {
-  MappingQ1<3> map;
+  MappingQGeneric<3> map(1);
   Point<3> p (0.75,0.75,0.75);
 
   std::pair<Triangulation<3>::active_cell_iterator, Point<3> > cell

--- a/tests/bits/find_cell_alt_6.cc
+++ b/tests/bits/find_cell_alt_6.cc
@@ -47,7 +47,7 @@
 void check (Triangulation<2> &tria)
 {
   const std::vector<Point<2> > &v = tria.get_vertices();
-  MappingQ1<2> map;
+  MappingQGeneric<2> map(1);
 
   for (unsigned i=0; i<tria.n_vertices(); i++)
     {

--- a/tests/bits/point_difference_02.cc
+++ b/tests/bits/point_difference_02.cc
@@ -111,7 +111,7 @@ template <int dim>
 void
 check ()
 {
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   Triangulation<dim> tria;
   make_mesh (tria);
 

--- a/tests/bits/point_gradient_02.cc
+++ b/tests/bits/point_gradient_02.cc
@@ -141,7 +141,7 @@ check ()
 
   FE_Q<dim> element(3);
   DoFHandler<dim> dof(tria);
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   dof.distribute_dofs(element);
 
   // test with two different functions: one

--- a/tests/bits/point_gradient_hp_02.cc
+++ b/tests/bits/point_gradient_hp_02.cc
@@ -146,12 +146,12 @@ check ()
   fe.push_back (FE_Q<dim>(5));
 
   hp::MappingCollection<dim> mapping_1;
-  mapping_1.push_back(MappingQ1<dim>());
-  mapping_1.push_back(MappingQ1<dim>());
-  mapping_1.push_back(MappingQ1<dim>());
+  mapping_1.push_back(MappingQGeneric<dim>(1));
+  mapping_1.push_back(MappingQGeneric<dim>(1));
+  mapping_1.push_back(MappingQGeneric<dim>(1));
 
   hp::MappingCollection<dim> mapping_2;
-  mapping_2.push_back(MappingQ1<dim>());
+  mapping_2.push_back(MappingQGeneric<dim>(1));
 
   hp::DoFHandler<dim> dof_handler (tria);
 

--- a/tests/bits/point_value_02.cc
+++ b/tests/bits/point_value_02.cc
@@ -112,7 +112,7 @@ check ()
 
   FE_Q<dim> element(3);
   DoFHandler<dim> dof(tria);
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   dof.distribute_dofs(element);
 
   // test with two different functions: one

--- a/tests/bits/point_value_hp_02.cc
+++ b/tests/bits/point_value_hp_02.cc
@@ -117,12 +117,12 @@ check ()
   fe.push_back (FE_Q<dim>(5));
 
   hp::MappingCollection<dim> mapping_1;
-  mapping_1.push_back(MappingQ1<dim>());
-  mapping_1.push_back(MappingQ1<dim>());
-  mapping_1.push_back(MappingQ1<dim>());
+  mapping_1.push_back(MappingQGeneric<dim>(1));
+  mapping_1.push_back(MappingQGeneric<dim>(1));
+  mapping_1.push_back(MappingQGeneric<dim>(1));
 
   hp::MappingCollection<dim> mapping_2;
-  mapping_2.push_back(MappingQ1<dim>());
+  mapping_2.push_back(MappingQGeneric<dim>(1));
 
   hp::DoFHandler<dim> dof_handler (tria);
 

--- a/tests/bits/solution_transfer.cc
+++ b/tests/bits/solution_transfer.cc
@@ -71,7 +71,7 @@ void transfer(std::ostream &out)
   DoFHandler<dim> dgq_dof_handler(tria);
   Vector<double> q_solution;
   Vector<double> dgq_solution;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   DataOut<dim> q_data_out, dgq_data_out;
   ConstraintMatrix cm;
   cm.close();

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -340,7 +340,7 @@ private:
   void output_results (const unsigned int cycle) const;
 
   Triangulation<dim>   triangulation;
-  const MappingQGeneric<dim> mapping(1);
+  const MappingQGeneric<dim> mapping;
 
   FE_DGQ<dim>          fe;
   DoFHandler<dim>      dof_handler;
@@ -362,7 +362,7 @@ private:
 template <int dim>
 DGMethod<dim>::DGMethod ()
   :
-  mapping (),
+  mapping (1),
   fe (1),
   dof_handler (triangulation),
   quadrature (4),

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -340,7 +340,7 @@ private:
   void output_results (const unsigned int cycle) const;
 
   Triangulation<dim>   triangulation;
-  const MappingQ1<dim> mapping;
+  const MappingQGeneric<dim> mapping(1);
 
   FE_DGQ<dim>          fe;
   DoFHandler<dim>      dof_handler;

--- a/tests/codim_one/mapping_01.cc
+++ b/tests/codim_one/mapping_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// test mapping surfaces in higher dimensions. when we use the MappingQ1
+// test mapping surfaces in higher dimensions. when we use the MappingQGeneric(1)
 // class, each 1d cell in 2d space is mapped to a straight line and so all
 // cell normals should be parallel. likewise, if the four vertices of a 2d
 // cell in 3d space are in a plane, then the cell normal vectors at all
@@ -50,7 +50,7 @@ void test ()
   GridGenerator::extract_boundary_mesh (volume_mesh, boundary_mesh);
 
   QGauss<dim-1> quadrature(2);
-  MappingQ1<dim-1,dim> mapping;
+  MappingQGeneric<dim-1,dim> mapping(1);
   FE_Q<dim-1,dim> fe (1);
 
   FEValues<dim-1,dim> fe_values (mapping, fe, quadrature, update_normal_vectors);

--- a/tests/codim_one/mapping_q1.cc
+++ b/tests/codim_one/mapping_q1.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2014 by the deal.II authors
+// Copyright (C) 2005 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -49,7 +49,7 @@ void test(std::string filename)
   grid_out.write_ucd (tria, logfile);
 
   QTrapez<dim> quad;
-  MappingQ1<dim,spacedim> mapping;
+  MappingQGeneric<dim,spacedim> mapping(1);
   typename Triangulation<dim,spacedim>::active_cell_iterator cell=tria.begin_active(),
                                                              endc=tria.end() ;
   Point<spacedim> real;

--- a/tests/distributed_grids/solution_transfer_02.cc
+++ b/tests/distributed_grids/solution_transfer_02.cc
@@ -63,7 +63,7 @@ template<int dim>
 void test(std::ostream & /*out*/)
 {
   MyFunction<dim> func;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
 
   GridGenerator::hyper_cube(tr);

--- a/tests/distributed_grids/solution_transfer_03.cc
+++ b/tests/distributed_grids/solution_transfer_03.cc
@@ -66,7 +66,7 @@ template<int dim>
 void test(std::ostream & /*out*/)
 {
   MyFunction<dim> func;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
 
   GridGenerator::hyper_cube(tr);

--- a/tests/dofs/interpolate_based_on_material_id_01.cc
+++ b/tests/dofs/interpolate_based_on_material_id_01.cc
@@ -86,7 +86,7 @@ void test ()
       dof_handler.distribute_dofs (fe);
 
       Vector<double> interpolant (dof_handler.n_dofs());
-      VectorTools::interpolate_based_on_material_id (MappingQ1<dim>(),
+      VectorTools::interpolate_based_on_material_id (MappingQGeneric<dim>(1),
                                                      dof_handler,
                                                      functions,
                                                      interpolant);

--- a/tests/fe/abf_01.cc
+++ b/tests/fe/abf_01.cc
@@ -630,7 +630,7 @@ int main (int /*argc*/, char **/*argv*/)
   DoFTools::make_hanging_node_constraints (*dof_handler,
                                            hn_constraints);
   hn_constraints.close ();
-  MappingQ1<2> map_default;
+  MappingQGeneric<2> map_default(1);
   project (map_default, *dof_handler, hn_constraints,
            QGauss<2> (6), ConstantFunction<2>(1., 2),
            solution);

--- a/tests/fe/cell_similarity_01.cc
+++ b/tests/fe/cell_similarity_01.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_Q<dim> fe(1);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/cell_similarity_02.cc
+++ b/tests/fe/cell_similarity_02.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_Q<dim> fe(2);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/cell_similarity_dgp_monomial_01.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_01.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_DGPMonomial<dim> fe(1);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/cell_similarity_dgp_monomial_02.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_02.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_DGPMonomial<dim> fe(2);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_01.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_01.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_DGPNonparametric<dim> fe(1);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_02.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_02.cc
@@ -67,7 +67,7 @@ void test (const Triangulation<dim> &tr)
   FE_DGPNonparametric<dim> fe(2);
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   deallog << "Mapping=Q1" << std::endl;
 
 

--- a/tests/fe/deformed_projection.h
+++ b/tests/fe/deformed_projection.h
@@ -730,7 +730,7 @@ void check (const FiniteElement<2> &fe)
                                                hn_constraints);
       hn_constraints.close ();
 
-      MappingQ1<2> map_default;
+      MappingQGeneric<2> map_default(1);
 
       project (map_default, *dof_handler, hn_constraints,
                QGauss<2> (6), TestMap1<2>(2),

--- a/tests/fe/derivatives.cc
+++ b/tests/fe/derivatives.cc
@@ -81,7 +81,7 @@ plot_derivatives(Mapping<dim> &mapping,
 template<int dim>
 void plot_FE_Q_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
   FE_Q<dim> q1(1);
   plot_derivatives(m, q1, "Q1");
 //  plot_face_shape_functions(m, q1, "Q1");
@@ -112,7 +112,7 @@ void plot_FE_Q_shape_functions()
 template<int dim>
 void plot_FE_DGQ_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
   FE_DGQ<dim> q1(1);
   plot_derivatives(m, q1, "DGQ1");
 //  plot_face_shape_functions(m, q1, "DGQ1");
@@ -164,7 +164,7 @@ main()
 
 
   // FESystem test.
-  MappingQ1<2> m;
+  MappingQGeneric<2> m(1);
   FESystem<2> q2_q3(FE_Q<2>(2), 1,
                     FE_Q<2>(3), 1);
 //  plot_derivatives(m, q2_q3, "Q2_Q3");

--- a/tests/fe/derivatives_bernstein.cc
+++ b/tests/fe/derivatives_bernstein.cc
@@ -81,7 +81,7 @@ plot_derivatives(Mapping<dim> &mapping,
 template<int dim>
 void plot_FE_Bernstein_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
   FE_Bernstein<dim> b1(1);
   plot_derivatives(m, b1, "B1");
 
@@ -121,7 +121,7 @@ int main()
 
 
   // FESystem test.
-  MappingQ1<2> m;
+  MappingQGeneric<2> m(1);
   FESystem<2> q2_q3(FE_Bernstein<2>(2), 1,
                     FE_Bernstein<2>(3), 1);
 //  plot_derivatives(m, q2_q3, "B2_Q3");

--- a/tests/fe/derivatives_face.cc
+++ b/tests/fe/derivatives_face.cc
@@ -74,7 +74,7 @@ plot_derivatives(Mapping<dim> &mapping,
 template<int dim>
 void plot_FE_Q_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 //  FE_Q<dim> q1(1);
 //  plot_derivatives(m, q1, "Q1");
 //  plot_face_shape_functions(m, q1, "Q1");
@@ -90,7 +90,7 @@ void plot_FE_Q_shape_functions()
 template<int dim>
 void plot_FE_DGQ_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
   FE_DGQ<dim> q1(1);
   plot_derivatives(m, q1, "DGQ1");
   FE_DGQ<dim> q2(2);

--- a/tests/fe/fe_face_values_1d.cc
+++ b/tests/fe/fe_face_values_1d.cc
@@ -146,7 +146,7 @@ void mapping_test()
   std::vector<Mapping<dim> *> mapping_ptr;
   std::vector<std::string> mapping_strings;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   std::string mapping_name = "MappingQ1";
 
   Triangulation<dim> tria;

--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -168,7 +168,7 @@ void test(const FiniteElement<dim> &fe, unsigned n_cycles, bool global, const Po
   const QGauss<dim> quadrature (fe.degree+1);
   const unsigned int n_q_points = quadrature.size ();
   MappingQ<dim> mapping(1);
-  //MappingQ1<dim> mapping;
+  //MappingQGeneric<dim> mapping(1);
   std::vector<double> div_v(n_q_points);
   std::vector<typename FEValuesViews::Vector<dim>::curl_type> curl_v(n_q_points);
 

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -280,7 +280,7 @@ void test(const FiniteElement<dim> &fe, unsigned n_cycles, bool global, const Po
   const unsigned int n_q_points = quadrature.size ();
   const unsigned int n_face_q_points = face_quadrature.size ();
   //MappingQ<dim> mapping(2);
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   std::vector<double> div_v(n_q_points);
   std::vector<typename FEValuesViews::Vector<dim>::curl_type> curl_v(n_q_points);
   std::vector<Tensor<3,dim> > hessians(n_q_points);

--- a/tests/fe/fe_tools_test.cc
+++ b/tests/fe/fe_tools_test.cc
@@ -197,7 +197,7 @@ int main ()
   deallog.threshold_double(1.e-10);
 
   Triangulation<2> tria;
-  MappingQ1<2> mapping;
+  MappingQGeneric<2> mapping(1);
 
   make_grid (tria);
 

--- a/tests/fe/fe_values_view_30.cc
+++ b/tests/fe/fe_values_view_30.cc
@@ -107,7 +107,7 @@ void test (const Triangulation<dim> &tr,
 
   VectorFunction<dim> fe_function;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   const QGauss<dim> quadrature(2);
   FEValues<dim> fe_values (mapping, fe, quadrature,

--- a/tests/fe/mapping.cc
+++ b/tests/fe/mapping.cc
@@ -433,7 +433,7 @@ void mapping_test()
   std::vector<std::string> mapping_strings;
 
   MappingCartesian<dim> cart;
-  MappingQ1<dim> q1_old;
+  MappingQGeneric<dim> q1_old(1);
   MappingQ<dim> q1tmp(1);
   MappingQ<dim> q2tmp(2);
   MappingQ<dim> q3tmp(3);

--- a/tests/fe/mapping_project_01.cc
+++ b/tests/fe/mapping_project_01.cc
@@ -37,7 +37,7 @@ void dim2_grid ()
 
   const Point<2> testp (.5, -.5);  //test point
 
-  MappingQ1<2> mapping;
+  MappingQGeneric<2> mapping(1);
 
   deallog<<"Check project for 2D cube from (-1,-1), to (1,1)."<<std::endl;
 
@@ -64,7 +64,7 @@ void dim3_grid ()
 
   const Point<3> testp (.5, -.5, 0);  //test point
 
-  MappingQ1<3> mapping;
+  MappingQGeneric<3> mapping(1);
 
   deallog<<"Check project for 3D cube from (-1,-1,-1) to (1,1,1)."<<std::endl;
 
@@ -94,7 +94,7 @@ void dim3_parallelepiped_grid ()
 
   const Point<3> testp (1, 1, 1);  //test point
 
-  MappingQ1<3> mapping;
+  MappingQGeneric<3> mapping(1);
 
   deallog<<"Check project for 3D parallelepiped with vectors (2, 0, 0), (0, 2, 0), and (0, 1, 2)."<<std::endl;
   Triangulation<3>::active_cell_iterator

--- a/tests/fe/mapping_q_eulerian.cc
+++ b/tests/fe/mapping_q_eulerian.cc
@@ -163,7 +163,7 @@ void MappingTest<dim>::run_test ()
       dof_handler.distribute_dofs (fe);
       displacements.reinit (dof_handler.n_dofs());
 
-      VectorTools::interpolate(MappingQ1<dim>(),dof_handler,
+      VectorTools::interpolate(MappingQGeneric<dim>(1),dof_handler,
                                imposed_displacement,displacements);
 
 
@@ -231,7 +231,7 @@ void MappingTest<dim>::graphical_output ()
   dof_handler.distribute_dofs (fe);
   displacements.reinit (dof_handler.n_dofs());
 
-  VectorTools::interpolate(MappingQ1<dim>(),dof_handler,
+  VectorTools::interpolate(MappingQGeneric<dim>(1),dof_handler,
                            imposed_displacement,displacements);
 
   explicitly_move_mesh();

--- a/tests/fe/mapping_real_to_unit_02.cc
+++ b/tests/fe/mapping_real_to_unit_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2014 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -42,7 +42,7 @@ void test2()
   GridGenerator::hyper_ball (triangulation);
   triangulation.set_boundary (0, boundary_description);
   triangulation.refine_global (1);
-  MappingQ1< dim > mapping;
+  MappingQGeneric<dim> mapping(1);
 
 
   Point<dim> p(-0.27999999999999992, -0.62999999999999989);

--- a/tests/fe/mapping_real_to_unit_q1.cc
+++ b/tests/fe/mapping_real_to_unit_q1.cc
@@ -68,7 +68,7 @@ void test_real_to_unit_cell()
     }
 
 
-  MappingQ1< dim, spacedim > map;
+  MappingQGeneric<dim,spacedim> map(1);
 
   typename Triangulation<dim, spacedim >::active_cell_iterator
   cell = triangulation.begin_active();

--- a/tests/fe/shapes_bernstein.cc
+++ b/tests/fe/shapes_bernstein.cc
@@ -29,7 +29,7 @@
 template<int dim>
 void plot_FE_Bernstein_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Bernstein<dim> b1(1);
   plot_shape_functions(m, b1, "B1");

--- a/tests/fe/shapes_dgp.cc
+++ b/tests/fe/shapes_dgp.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_DGP_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_DGP<dim> p1(1);
   plot_shape_functions(m, p1, "DGP1");

--- a/tests/fe/shapes_dgp_monomial.cc
+++ b/tests/fe/shapes_dgp_monomial.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_DGPMonomial_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_DGPMonomial<dim> p1(1);
   plot_shape_functions(m, p1, "DGPMonomial1");

--- a/tests/fe/shapes_dgp_nonparametric.cc
+++ b/tests/fe/shapes_dgp_nonparametric.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_DGPNonparametric_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_DGPNonparametric<dim> p0(0);
   plot_shape_functions(m, p0, "DGPNonparametric0");

--- a/tests/fe/shapes_dgq.cc
+++ b/tests/fe/shapes_dgq.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_DGQ_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_DGQ<dim> q1(1);
   plot_shape_functions(m, q1, "DGQ1");

--- a/tests/fe/shapes_faceq.cc
+++ b/tests/fe/shapes_faceq.cc
@@ -29,7 +29,7 @@
 template<int dim>
 void plot_FE_FaceQ_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_FaceQ<dim> q0(0);
   FE_FaceQ<dim> q1(1);

--- a/tests/fe/shapes_nedelec.cc
+++ b/tests/fe/shapes_nedelec.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_Nedelec_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
   FE_Nedelec<dim> p0(0);
 //   plot_shape_functions(m, p1, "Nedelec1");
 //   plot_face_shape_functions(m, p1, "Nedelec1");

--- a/tests/fe/shapes_q.cc
+++ b/tests/fe/shapes_q.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_Q_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Q<dim> q1(1);
   plot_shape_functions(m, q1, "Q1");

--- a/tests/fe/shapes_q_bubbles.cc
+++ b/tests/fe/shapes_q_bubbles.cc
@@ -28,7 +28,7 @@
 template<int dim>
 void plot_FE_Q_Bubbles_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Q_Bubbles<dim> q1(1);
   plot_shape_functions(m, q1, "Q1_Bubbles");

--- a/tests/fe/shapes_q_dg0.cc
+++ b/tests/fe/shapes_q_dg0.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_Q_DG0_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Q_DG0<dim> q1(1);
   plot_shape_functions(m, q1, "Q1_DG0");

--- a/tests/fe/shapes_q_hierarchical.cc
+++ b/tests/fe/shapes_q_hierarchical.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_Q_Hierarchical_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Q_Hierarchical<dim> q1(1);
   plot_shape_functions(m, q1, "QHierarchical1");

--- a/tests/fe/shapes_q_iso_q1.cc
+++ b/tests/fe/shapes_q_iso_q1.cc
@@ -27,7 +27,7 @@
 template<int dim>
 void plot_FE_Q_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_Q_iso_Q1<dim> q1(1);
   plot_shape_functions(m, q1, "Q1");

--- a/tests/fe/shapes_system.cc
+++ b/tests/fe/shapes_system.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014 by the deal.II authors
+// Copyright (C) 2013 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,7 +30,7 @@
 template<int dim>
 void plot_FE_System_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
 //   FESystem<dim> p1(FE_Q<dim>(2), 1,
 //                    FE_Q<dim>(dim<3 ? 3 : 2), 2);

--- a/tests/fe/shapes_traceq.cc
+++ b/tests/fe/shapes_traceq.cc
@@ -28,7 +28,7 @@
 template<int dim>
 void plot_FE_TraceQ_shape_functions()
 {
-  MappingQ1<dim> m;
+  MappingQGeneric<dim> m(1);
 
   FE_TraceQ<dim> tq1(1);
   FE_TraceQ<dim> tq2(2);

--- a/tests/hp/project_01_curved_boundary.cc
+++ b/tests/hp/project_01_curved_boundary.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2014 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -93,7 +93,7 @@ void test()
 
   // use an explicit Q1 mapping. this will yield a zero solution
   {
-    VectorTools::project (hp::MappingCollection<dim>(MappingQ1<dim>()),
+    VectorTools::project (hp::MappingCollection<dim>(MappingQGeneric<dim>(1)),
                           dh, cm, hp::QCollection<dim>(QGauss<dim>(3)), F<dim>(),
                           v);
     deallog << v.l2_norm() << std::endl;

--- a/tests/hp/solution_transfer.cc
+++ b/tests/hp/solution_transfer.cc
@@ -80,7 +80,7 @@ void transfer(std::ostream &out)
   hp::DoFHandler<dim> dgq_dof_handler(tria);
   Vector<double> q_solution;
   Vector<double> dgq_solution;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   // refine a few cells
   typename Triangulation<dim>::active_cell_iterator cell=tria.begin_active(),

--- a/tests/hp/solution_transfer_12.cc
+++ b/tests/hp/solution_transfer_12.cc
@@ -80,7 +80,7 @@ void transfer(std::ostream &out)
     }
   hp::DoFHandler<dim> q_dof_handler(tria);
   Vector<double> q_solution;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   // refine a few cells
   typename Triangulation<dim>::active_cell_iterator cell=tria.begin_active(),

--- a/tests/hp/step-12.cc
+++ b/tests/hp/step-12.cc
@@ -366,7 +366,7 @@ private:
 template <int dim>
 DGMethod<dim>::DGMethod ()
   :
-  mapping (MappingQ1<dim>()),
+  mapping (MappingQGeneric<dim>(1)),
   fe (FE_DGQ<dim>(1)),
   dof_handler (triangulation),
   quadrature (QGauss<dim>(4)),

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -113,7 +113,7 @@ void assemble_mg_matrix(DoFHandler<dim> &dof_handler,
 
   mg.set_zero();
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   UpdateFlags update_flags = update_values | update_gradients | update_hessians;

--- a/tests/integrators/cochain_01.cc
+++ b/tests/integrators/cochain_01.cc
@@ -91,7 +91,7 @@ template <int dim>
 void
 test_cochain(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 {
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   // Initialize DofHandler for a
   // block system with local blocks
   DoFHandler<dim> dof(tr);

--- a/tests/integrators/mesh_worker_01.cc
+++ b/tests/integrators/mesh_worker_01.cc
@@ -132,7 +132,7 @@ test_simple(DoFHandler<dim> &mgdofs)
   local.cells = true;
   local.faces = false;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   info_box.initialize_gauss_quadrature(1, 1, 1);

--- a/tests/integrators/mesh_worker_02.cc
+++ b/tests/integrators/mesh_worker_02.cc
@@ -135,7 +135,7 @@ void
 assemble(const DoFHandler<dim> &dof_handler, SparseMatrix<double> &matrix)
 {
   const FiniteElement<dim> &fe = dof_handler.get_fe();
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;
@@ -170,7 +170,7 @@ assemble(const DoFHandler<dim> &dof_handler,
          MGLevelObject<SparseMatrix<double> > dg_down)
 {
   const FiniteElement<dim> &fe = dof_handler.get_fe();
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;

--- a/tests/integrators/mesh_worker_03.cc
+++ b/tests/integrators/mesh_worker_03.cc
@@ -148,7 +148,7 @@ void
 assemble(const DoFHandler<dim> &dof_handler, SparseMatrix<double> &matrix)
 {
   const FiniteElement<dim> &fe = dof_handler.get_fe();
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;
@@ -183,7 +183,7 @@ assemble(const DoFHandler<dim> &dof_handler,
          MGLevelObject<SparseMatrix<double> > dg_down)
 {
   const FiniteElement<dim> &fe = dof_handler.get_fe();
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;

--- a/tests/integrators/mesh_worker_1d_dg.cc
+++ b/tests/integrators/mesh_worker_1d_dg.cc
@@ -65,7 +65,7 @@ namespace Advection
 
   private:
 
-    const MappingQGeneric<dim> mapping(1);
+    const MappingQGeneric<dim> mapping;
 
     void setup_system ();
 
@@ -109,7 +109,7 @@ namespace Advection
   template <int dim>
   AdvectionProblem<dim>::AdvectionProblem ()
     :
-    mapping(),
+    mapping(1),
     wavespeed(1.0),
     dof_handler (triangulation),
     fe (FE_DGQ<dim>(0), 1),// p=0, and solving for a scalar

--- a/tests/integrators/mesh_worker_1d_dg.cc
+++ b/tests/integrators/mesh_worker_1d_dg.cc
@@ -65,7 +65,7 @@ namespace Advection
 
   private:
 
-    const MappingQ1<dim> mapping;
+    const MappingQGeneric<dim> mapping(1);
 
     void setup_system ();
 

--- a/tests/integrators/mesh_worker_matrix_01.cc
+++ b/tests/integrators/mesh_worker_matrix_01.cc
@@ -138,7 +138,7 @@ test_simple(DoFHandler<dim> &dofs, bool faces)
   local.cells = true;
   local.faces = faces;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   info_box.initialize_gauss_quadrature(1, 1, 1);

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -47,7 +47,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FESystem<dim> fe(FE_Q<dim>(2), 1, FE_Q<dim>(1), 1);
   DoFHandler<dim> dof_handler(triangulation);
 

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -47,7 +47,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FESystem<dim> fe(FE_Q<dim>(2), 1, FE_Q<dim>(1), 1, FE_Q<dim>(3), 1);
   DoFHandler<dim> dof_handler(triangulation);
 

--- a/tests/lac/linear_operator_02.cc
+++ b/tests/lac/linear_operator_02.cc
@@ -48,7 +48,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FE_Q<dim> q1(1);
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(q1);

--- a/tests/lac/linear_operator_02a.cc
+++ b/tests/lac/linear_operator_02a.cc
@@ -52,7 +52,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FE_Q<dim> q1(1);
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(q1);

--- a/tests/lac/linear_operator_03.cc
+++ b/tests/lac/linear_operator_03.cc
@@ -56,7 +56,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FESystem<dim> fe(FE_Q<dim>(1), 1, FE_Q<dim>(1), 1);
   DoFHandler<dim> dof_handler(triangulation);
 

--- a/tests/lac/packaged_operation_02.cc
+++ b/tests/lac/packaged_operation_02.cc
@@ -67,7 +67,7 @@ int main()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global(2);
 
-  MappingQ1<dim> mapping_q1;
+  MappingQGeneric<dim> mapping_q1(1);
   FE_Q<dim> q1(1);
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(q1);

--- a/tests/mpi/derivative_approximation_01.cc
+++ b/tests/mpi/derivative_approximation_01.cc
@@ -77,7 +77,7 @@ void test()
   TrilinosWrappers::MPI::Vector vec_rel ( locally_relevant_set);
   vec_rel = vec;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   Vector<float> indicators(tr.n_active_cells());
   DerivativeApproximation::approximate_gradient  (mapping,
                                                   dofh,

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -75,7 +75,7 @@ namespace Step39
     void setup_system ();
 
     parallel::distributed::Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>           dof_handler;
 
@@ -96,7 +96,7 @@ namespace Step39
     triangulation (MPI_COMM_WORLD,Triangulation<dim>::
                    limit_level_difference_at_vertices,
                    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy),
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation)
   {

--- a/tests/mpi/map_dofs_to_support_points.cc
+++ b/tests/mpi/map_dofs_to_support_points.cc
@@ -42,7 +42,7 @@ void test()
   dofh.distribute_dofs (fe);
 
   std::map<types::global_dof_index, Point<dim> > points;
-  DoFTools::map_dofs_to_support_points (MappingQ1<dim>(),
+  DoFTools::map_dofs_to_support_points (MappingQGeneric<dim>(1),
                                         dofh,
                                         points);
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)

--- a/tests/mpi/mesh_worker_matrix_01.cc
+++ b/tests/mpi/mesh_worker_matrix_01.cc
@@ -139,7 +139,7 @@ test_simple(DoFHandler<dim> &dofs, bool faces)
   local.cells = true;
   local.faces = faces;
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   MeshWorker::IntegrationInfoBox<dim> info_box;
   info_box.initialize_gauss_quadrature(1, 1, 1);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2008 - 2014 by the deal.II authors
+ * Copyright (C) 2008 - 2015 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -201,7 +201,7 @@ void check
   unsigned int n_local_constraints =0 ;
 
   std::map<types::global_dof_index, Point<dim> > support_points;
-  DoFTools::map_dofs_to_support_points (MappingQ1<dim>(), dof_handler, support_points);
+  DoFTools::map_dofs_to_support_points (MappingQGeneric<dim>(1), dof_handler, support_points);
   IndexSet constraints_lines = constraints.get_local_lines();
 
   for (unsigned int i=0; i<constraints_lines.n_elements(); ++i)

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -365,7 +365,7 @@ namespace Step39
     void output_results (const unsigned int cycle) const;
 
     parallel::distributed::Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>           dof_handler;
 
@@ -389,7 +389,7 @@ namespace Step39
     triangulation (MPI_COMM_WORLD,Triangulation<dim>::
                    limit_level_difference_at_vertices,
                    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy),
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation),
     estimates(1)

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -188,7 +188,7 @@ private:
   void refine_local ();
 
   Triangulation<dim>   triangulation;
-  const MappingQ1<dim> mapping;
+  const MappingQGeneric<dim> mapping(1);
   FESystem<dim>        fe;
   DoFHandler<dim>    mg_dof_handler_renumbered;
 

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -188,7 +188,7 @@ private:
   void refine_local ();
 
   Triangulation<dim>   triangulation;
-  const MappingQGeneric<dim> mapping(1);
+  const MappingQGeneric<dim> mapping;
   FESystem<dim>        fe;
   DoFHandler<dim>    mg_dof_handler_renumbered;
 
@@ -202,6 +202,7 @@ private:
 template <int dim>
 LaplaceProblem<dim>::LaplaceProblem (const unsigned int deg) :
   triangulation (Triangulation<dim>::limit_level_difference_at_vertices),
+  mapping(1),
   fe (FE_Q<dim> (deg),3),
   mg_dof_handler_renumbered (triangulation),
   degree(deg)

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -227,7 +227,7 @@ private:
   void refine_local ();
 
   Triangulation<dim>   triangulation;
-  const MappingQ1<dim>      mapping;
+  const MappingQGeneric<dim>      mapping;
   FESystem<dim>            fe;
   DoFHandler<dim>    mg_dof_handler;
   DoFHandler<dim>    mg_dof_handler_renumbered;
@@ -242,6 +242,7 @@ private:
 template <int dim>
 LaplaceProblem<dim>::LaplaceProblem (const unsigned int deg) :
   triangulation (Triangulation<dim>::limit_level_difference_at_vertices),
+  mapping(1),
   fe (FE_Q<dim> (deg),3),
   mg_dof_handler (triangulation),
   mg_dof_handler_renumbered (triangulation),

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -245,7 +245,7 @@ void LaplaceProblem<dim>::setup_system ()
   typename FunctionMap<dim>::type      dirichlet_boundary;
   ZeroFunction<dim>                    homogeneous_dirichlet_bc (1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values (mapping,
                                             mg_dof_handler,
                                             dirichlet_boundary,
@@ -346,7 +346,7 @@ void LaplaceProblem<dim>::assemble_multigrid (const bool &use_mw)
     {
       mg_matrices = 0.;
 
-      MappingQ1<dim> mapping;
+      MappingQGeneric<dim> mapping(1);
       MeshWorker::IntegrationInfoBox<dim> info_box;
       UpdateFlags update_flags = update_values | update_gradients | update_hessians;
       info_box.add_update_flags_all(update_flags);

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -246,7 +246,7 @@ void LaplaceProblem<dim>::setup_system ()
   typename FunctionMap<dim>::type      dirichlet_boundary;
   ZeroFunction<dim>                    homogeneous_dirichlet_bc (1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values (mapping,
                                             mg_dof_handler,
                                             dirichlet_boundary,
@@ -347,7 +347,7 @@ void LaplaceProblem<dim>::assemble_multigrid (const bool &use_mw)
     {
       mg_matrices = 0.;
 
-      MappingQ1<dim> mapping;
+      MappingQGeneric<dim> mapping(1);
       MeshWorker::IntegrationInfoBox<dim> info_box;
       UpdateFlags update_flags = update_values | update_gradients | update_hessians;
       info_box.add_update_flags_all(update_flags);

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -183,7 +183,7 @@ void LaplaceProblem<dim>::setup_system ()
   typename FunctionMap<dim>::type      dirichlet_boundary;
   ZeroFunction<dim>                    homogeneous_dirichlet_bc (1);
   dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   VectorTools::interpolate_boundary_values (mapping,
                                             mg_dof_handler,
                                             dirichlet_boundary,

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -356,7 +356,7 @@ namespace Step39
     void output_results (const unsigned int cycle) const;
 
     Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>           dof_handler;
 
@@ -379,7 +379,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation),
     estimates(1)

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -357,7 +357,7 @@ namespace Step39
     void output_results (const unsigned int cycle) const;
 
     Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>         dof_handler;
     MGConstrainedDoFs mg_constraints;
@@ -381,7 +381,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation),
     estimates(1)

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -362,7 +362,7 @@ namespace Step39
     void output_results (const unsigned int cycle) const;
 
     Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>           dof_handler;
 
@@ -385,7 +385,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation),
     estimates(1)

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -357,7 +357,7 @@ namespace Step39
     void output_results (const unsigned int cycle) const;
 
     Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
+    const MappingQGeneric<dim>      mapping;
     const FiniteElement<dim> &fe;
     DoFHandler<dim>           dof_handler;
 
@@ -379,7 +379,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
-    mapping(),
+    mapping(1),
     fe(fe),
     dof_handler(triangulation),
     estimates(1)

--- a/tests/numerics/derivative_approximation_2.cc
+++ b/tests/numerics/derivative_approximation_2.cc
@@ -151,7 +151,7 @@ void derivatives()
   FE_DGQ<dim> fe(2);
   DoFHandler<dim> dof_handler(tria);
   Vector<double> solution;
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   QMidpoint<dim> q_midpoint;
   FEValues<dim> fe_values(mapping, fe, q_midpoint, update_q_points);
 

--- a/tests/numerics/derivatives.cc
+++ b/tests/numerics/derivatives.cc
@@ -174,7 +174,7 @@ void loop ()
 
   std::vector<Mapping<dim>*> maps;
 //  maps.push_back (new MappingCartesian<dim>);
-  maps.push_back (new MappingQ1<dim>);
+  maps.push_back (new MappingQGeneric<dim>(1));
   maps.push_back (new MappingQ<dim>(2));
 
   std::vector<FiniteElement<dim>*> elements;

--- a/tests/numerics/project_01_curved_boundary.cc
+++ b/tests/numerics/project_01_curved_boundary.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2014 by the deal.II authors
+// Copyright (C) 2006 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -91,7 +91,7 @@ void test()
 
   // use an explicit Q1 mapping. this will yield a zero solution
   {
-    VectorTools::project (MappingQ1<dim>(),
+    VectorTools::project (MappingQGeneric<dim>(1),
                           dh, cm, QGauss<dim>(3), F<dim>(),
                           v);
     deallog << v.l2_norm() << std::endl;

--- a/tests/numerics/project_boundary_rt_01.cc
+++ b/tests/numerics/project_boundary_rt_01.cc
@@ -132,7 +132,7 @@ void test_projection (const Triangulation<dim> &tr,
   dof.distribute_dofs(fe);
 
   QGauss<dim-1> quadrature(degree+2);
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
 
   TestFunction<dim> f(degree-1);
   std::map<types::global_dof_index, double> boundary_constraints;

--- a/tests/trilinos/precondition_amg_dgp.cc
+++ b/tests/trilinos/precondition_amg_dgp.cc
@@ -149,7 +149,7 @@ void Step4<dim>::setup_system ()
   solution.reinit (dof_handler.n_dofs());
   system_rhs.reinit (dof_handler.n_dofs());
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   MeshWorker::IntegrationInfoBox<dim> info_box;
   UpdateFlags update_flags = update_values | update_gradients;
   info_box.add_update_flags_all(update_flags);

--- a/tests/trilinos/precondition_muelu_dgp.cc
+++ b/tests/trilinos/precondition_muelu_dgp.cc
@@ -149,7 +149,7 @@ void Step4<dim>::setup_system ()
   solution.reinit (dof_handler.n_dofs());
   system_rhs.reinit (dof_handler.n_dofs());
 
-  MappingQ1<dim> mapping;
+  MappingQGeneric<dim> mapping(1);
   MeshWorker::IntegrationInfoBox<dim> info_box;
   UpdateFlags update_flags = update_values | update_gradients;
   info_box.add_update_flags_all(update_flags);


### PR DESCRIPTION
Use MappingQGeneric instead. The first commit is completely scripted
and boring. The second one required a little bit (but not very much)
work by hand. The patch is almost certainly incredibly boring to 
look at. It passes the testsuite.

In reference to #1198 and #1537.