### PR TITLE
Check for MPI_SEEK_SET with CMake.

### DIFF
--- a/cmake/configure/configure_1_mpi.cmake
+++ b/cmake/configure/configure_1_mpi.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -17,10 +17,28 @@
 # Configuration for mpi support:
 #
 
+MACRO(FEATURE_MPI_FIND_EXTERNAL var)
+  FIND_PACKAGE(MPI)
+
+  IF(MPI_FOUND)
+    SET(${var} TRUE)
+
+    IF(NOT MPI_HAVE_MPI_SEEK_SET)
+      MESSAGE(STATUS
+        "Could not find a sufficient MPI version: "
+        "Your MPI implementation must define MPI_SEEK_SET.")
+      SET(MPI_ADDITIONAL_ERROR_STRING
+        "Your MPI implementation must define MPI_SEEK_SET.")
+      SET(${var} FALSE)
+    ENDIF()
+  ENDIF()
+ENDMACRO()
+
 MACRO(FEATURE_MPI_ERROR_MESSAGE)
   MESSAGE(FATAL_ERROR "\n"
     "Could not find any suitable mpi library!\n"
-    "Please ensure that an mpi library is installed on your computer\n"
+    ${MPI_ADDITIONAL_ERROR_STRING}
+    "\nPlease ensure that an mpi library is installed on your computer\n"
     "and set CMAKE_CXX_COMPILER to the appropriate mpi wrappers:\n"
     "    $ CXX=\".../mpicxx\" cmake <...>\n"
     "    $ cmake -DCMAKE_CXX_COMPILER=\".../mpicxx\" <...>\n"

--- a/cmake/modules/FindMPI.cmake
+++ b/cmake/modules/FindMPI.cmake
@@ -23,6 +23,7 @@
 #   MPI_LINKER_FLAGS
 #   MPI_VERSION
 #   OMPI_VERSION
+#   MPI_HAVE_MPI_SEEK_SET
 #
 
 #
@@ -86,6 +87,27 @@ IF(NOT MPI_CXX_FOUND AND DEAL_II_WITH_MPI)
 ENDIF()
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 
+#
+# Older versions of MPI may not have MPI_SEEK_SET, which we
+# require. Strangely, unlike MPICH, OpenMPI needs the correct link libraries
+# for this to compile, not *just* the correct include directories.
+#
+
+CLEAR_CMAKE_REQUIRED()
+SET(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS} ${MPI_CXX_LINK_FLAGS})
+SET(CMAKE_REQUIRED_INCLUDES ${MPI_CXX_INCLUDE_PATH})
+SET(CMAKE_REQUIRED_LIBRARIES ${MPI_LIBRARIES})
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  #include <mpi.h>
+  #ifndef MPI_SEEK_SET
+  #  error
+  #endif
+  int main() {}
+  "
+  MPI_HAVE_MPI_SEEK_SET
+  )
+RESET_CMAKE_REQUIRED()
 
 #
 # Manually assemble some version information:
@@ -162,5 +184,6 @@ DEAL_II_PACKAGE_HANDLE(MPI
     MPI_LIB
     MPI_LIBRARY
     MPI_MPI_H
+    MPI_HAVE_MPI_SEEK_SET
   )
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -19,16 +19,7 @@
 #include <deal.II/base/config.h>
 #include <vector>
 
-#if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
-// mpi.h included through deal.II/base/config.h
-
-// Check whether <mpi.h> is a suitable include for us (if MPI_SEEK_SET is not
-// defined, we'll die anyway):
-#  ifndef MPI_SEEK_SET
-#    error "The buildsystem included an insufficient mpi.h header that does not export MPI_SEEK_SET"
-#  endif
-
-#else
+#if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_WITH_PETSC)
 // without MPI, we would still like to use
 // some constructs with MPI data
 // types. Therefore, create some dummies


### PR DESCRIPTION
This check was previously just embedded in a header, which caused some confusing error messages, e.g.,

https://groups.google.com/forum/#!topic/dealii/2wPzS9wAzMM

This PR improves things by performing the check with CMake instead of doing it at compile time.

I tested this with openmpi and mpich, but (knowing how these things usually go) I would appreciate some feedback to make sure this doesn't break the build process somewhere else.