### PR TITLE
Fix bug in compute_integrid_weights_2

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2736,7 +2736,7 @@ namespace DoFTools
             (locally_owned_dofs, locally_relevant_dofs, communicator);
 #else
             const types::global_dof_index n_fine_dofs = weight_mapping.size();
-            copy_data.global_parameter_representation[i].resize (n_fine_dofs);
+            copy_data.global_parameter_representation[i].reinit (n_fine_dofs);
 #endif
           }
 


### PR DESCRIPTION
I was getting an error from `compute_intergrid_weights_2` when compiling deal.II without MPI.
The `resize` method was invoked on a a `dealii::Vector` object, where I think the author meant `reinit`; `resize` would be appropriate for a `std::vector`.
This was in a code path that is only compiled if you're not using MPI, so it could be easy to miss.

There were, however, some warnings about unused variables.