### PR TITLE
Fix a warning in optimized mode.

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2622,8 +2622,8 @@ namespace DoFTools
                                     const unsigned int                                      coarse_component,
                                     const FiniteElement<dim,spacedim>                      &coarse_fe,
                                     const std::vector<types::global_dof_index>             &weight_mapping,
-                                    std::vector<std::map<types::global_dof_index, float> > &weights,
-                                    bool is_called_in_parallel)
+                                    const bool                                              is_called_in_parallel,
+                                    std::vector<std::map<types::global_dof_index, float> > &weights)
       {
         unsigned int pos = 0;
         for (unsigned int local_dof=0; local_dof<copy_data.dofs_per_cell; ++local_dof)
@@ -2667,12 +2667,15 @@ namespace DoFTools
                         weights[wi][wj] = copy_data.global_parameter_representation[pos](i);
                       }
                   }
-                else
-                  // Note that when this function operates with distributed
-                  // fine grid, this assertion is switched off since the
-                  // condition does not necessarily hold
-                  Assert (copy_data.global_parameter_representation[pos](i) == 0 || is_called_in_parallel,
-                          ExcInternalError());
+                else if (!is_called_in_parallel)
+                  {
+                    // Note that when this function operates with distributed
+                    // fine grid, this assertion is switched off since the
+                    // condition does not necessarily hold
+                    Assert (copy_data.global_parameter_representation[pos](i) == 0,
+                            ExcInternalError());
+                  }
+
               ++pos;
             }
 
@@ -2754,8 +2757,8 @@ namespace DoFTools
                                         coarse_component,
                                         std_cxx11::cref(coarse_grid.get_fe()),
                                         std_cxx11::cref(weight_mapping),
-                                        std_cxx11::ref(weights),
-                                        is_called_in_parallel),
+                                        is_called_in_parallel,
+                                        std_cxx11::ref(weights)),
                         scratch,
                         copy_data);
       }


### PR DESCRIPTION
This also reorders function arguments into the standard order.