### PR TITLE
made CMAKE_BUILD_TYPE=DEAL_II_BUILD_TYPE as default for external libraries

### DIFF
--- a/cmake/macros/macro_deal_ii_initialize_cached_variables.cmake
+++ b/cmake/macros/macro_deal_ii_initialize_cached_variables.cmake
@@ -37,17 +37,10 @@ MACRO(DEAL_II_INITIALIZE_CACHED_VARIABLES)
   ENDIF()
 
   #
-  # Set build type according to available libraries
+  # Set build type according to build type of deal.II
   #
-  IF(DEAL_II_BUILD_TYPE MATCHES "Debug")
-    SET(CMAKE_BUILD_TYPE "Debug" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
-      )
-  ELSE()
-    SET(CMAKE_BUILD_TYPE "Release" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
-      )
-  ENDIF()
+  SET(CMAKE_BUILD_TYPE ${DEAL_II_BUILD_TYPE} CACHE STRING
+    "Choose the type of build, options are: Debug, Release, DebugRelease")
 
   #
   # Reset build type if unsupported, i.e. if it is not (case insensitively
@@ -57,11 +50,6 @@ MACRO(DEAL_II_INITIALIZE_CACHED_VARIABLES)
 
   IF(NOT "${_cmake_build_type}" MATCHES "^(debug|release|debugrelease)$")
 
-    IF("${DEAL_II_BUILD_TYPE}" STREQUAL "DebugRelease")
-      SET(_new_build_type "Debug")
-    ELSE()
-      SET(_new_build_type "${DEAL_II_BUILD_TYPE}")
-    ENDIF()
 
     MESSAGE(
 "###
@@ -71,12 +59,12 @@ MACRO(DEAL_II_INITIALIZE_CACHED_VARIABLES)
 #  CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\" unsupported by current installation!
 #  deal.II was built with CMAKE_BUILD_TYPE \"${DEAL_II_BUILD_TYPE}\".
 #
-#  CMAKE_BUILD_TYPE is forced to \"${_new_build_type}\".
+#  CMAKE_BUILD_TYPE is forced to \"${DEAL_II_BUILD_TYPE}\".
 #
 ###"
       )
-    SET(CMAKE_BUILD_TYPE "${_new_build_type}" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
+    SET(CMAKE_BUILD_TYPE ${DEAL_II_BUILD_TYPE} CACHE STRING
+      "Choose the type of build, options are: Debug, Release, DebugRelease"
       FORCE
       )
 

--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -37,6 +37,15 @@
 
 MACRO(DEAL_II_INVOKE_AUTOPILOT)
 
+  # Set CMAKE_BUILD_TYPE=Debug if both 
+  # Debug and Release mode are given
+  IF("${CMAKE_BUILD_TYPE}" STREQUAL "DebugRelease")
+    SET(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+      "Choose the type of build, options are: Debug, Release"
+      FORCE)
+  ENDIF()
+
+
   # Generator specific values:
   IF(CMAKE_GENERATOR MATCHES "Ninja")
     SET(_make_command "$ ninja")


### PR DESCRIPTION
deal.II is built in both optimized and debug versions by default, i.e. `CMAKE_BUILD_TYPE=DebugRelease`.

when an external library based on deal.II is built the `CMAKE_BUILD_TYPE` was set to `Debug` if deal.II was built with either `DebugRelease` or `Debug`. 

Thi patch makes `CMAKE_BUILD_TYPE=${DEAL_II_BUILD_TYPE}` by default   