### PR TITLE
GridTools::integrate_difference: Generalize template signature

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -257,14 +257,14 @@ inconvenience this causes.
   - FunctionTime
   - Function
   - TensorFunction
-
   <br>
-  <em>Classes with fixed interface that now fully support complex number
-  types (pure template classes without explicit instantiations in the
-  library):</em>
+  <em>Classes and functions with fixed interface that now fully support
+  complex number types (without explicit instantiations in the library -
+  make sure to include the correct header):</em>
   - LinearOperator
   - PackagedOperation
   - Tensor
+  - GridTools::integrate_difference
   <br>
   (Matthias Maier, 2015/08/25 - XXX)
   </li>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -1898,57 +1898,57 @@ namespace VectorTools
    * the documentation of the namespace, OutVector only Vector<double> and
    * Vector<float>.
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  void integrate_difference (const Mapping<dim,spacedim>    &mapping,
-                             const DoFHandler<dim,spacedim> &dof,
-                             const InVector                 &fe_function,
-                             const Function<spacedim,double>       &exact_solution,
-                             OutVector                      &difference,
-                             const Quadrature<dim>          &q,
-                             const NormType                 &norm,
-                             const Function<spacedim,double>       *weight = 0,
+  template <int dim, class InVector, class OutVector, int spacedim, class Number>
+  void integrate_difference (const Mapping<dim,spacedim>      &mapping,
+                             const DoFHandler<dim,spacedim>   &dof,
+                             const InVector                   &fe_function,
+                             const Function<spacedim, Number> &exact_solution,
+                             OutVector                        &difference,
+                             const Quadrature<dim>            &q,
+                             const NormType                   &norm,
+                             const Function<spacedim, Number> *weight = 0,
                              const double exponent = 2.);
 
   /**
    * Calls the integrate_difference() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  void integrate_difference (const DoFHandler<dim,spacedim> &dof,
-                             const InVector                 &fe_function,
-                             const Function<spacedim,double>       &exact_solution,
-                             OutVector                      &difference,
-                             const Quadrature<dim>          &q,
-                             const NormType                 &norm,
-                             const Function<spacedim,double>       *weight = 0,
+  template <int dim, class InVector, class OutVector, int spacedim, class Number>
+  void integrate_difference (const DoFHandler<dim,spacedim>   &dof,
+                             const InVector                   &fe_function,
+                             const Function<spacedim, Number> &exact_solution,
+                             OutVector                        &difference,
+                             const Quadrature<dim>            &q,
+                             const NormType                   &norm,
+                             const Function<spacedim, Number> *weight = 0,
                              const double exponent = 2.);
 
   /**
    * Same as above for hp.
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
+  template <int dim, class InVector, class OutVector, int spacedim, class Number>
   void integrate_difference (const hp::MappingCollection<dim,spacedim> &mapping,
                              const hp::DoFHandler<dim,spacedim>        &dof,
                              const InVector                            &fe_function,
-                             const Function<spacedim,double>                  &exact_solution,
+                             const Function<spacedim, Number>          &exact_solution,
                              OutVector                                 &difference,
                              const hp::QCollection<dim>                &q,
                              const NormType                            &norm,
-                             const Function<spacedim,double>                  *weight = 0,
+                             const Function<spacedim, Number>          *weight = 0,
                              const double exponent = 2.);
 
   /**
    * Calls the integrate_difference() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
+  template <int dim, class InVector, class OutVector, int spacedim, class Number>
   void integrate_difference (const hp::DoFHandler<dim,spacedim> &dof,
                              const InVector                     &fe_function,
-                             const Function<spacedim,double>           &exact_solution,
+                             const Function<spacedim, Number>   &exact_solution,
                              OutVector                          &difference,
                              const hp::QCollection<dim>         &q,
                              const NormType                     &norm,
-                             const Function<spacedim,double>           *weight = 0,
+                             const Function<spacedim, Number>   *weight = 0,
                              const double exponent = 2.);
 
   /**

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2015 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -20,95 +20,95 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
     namespace VectorTools \{
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension, double>
         (const Mapping<deal_II_dimension, deal_II_space_dimension>&,
          const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<float>&,
          const Quadrature<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension, double>
         (const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<float>&,
          const Quadrature<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension >
+        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension, double>
         (const Mapping<deal_II_dimension, deal_II_space_dimension>&,
          const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<double>&,
          const Quadrature<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension >
+        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension, double>
         (const DoFHandler<deal_II_dimension, deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<double>&,
          const Quadrature<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension, double>
         (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
          const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<double>&,
          const hp::QCollection<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<double>, deal_II_space_dimension, double>
         (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<double>&,
          const hp::QCollection<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension, double>
         (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>&,
          const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<float>&,
          const hp::QCollection<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       template
-        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension>
+        void integrate_difference<deal_II_dimension, VEC, Vector<float>, deal_II_space_dimension, double>
         (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>&,
          const VEC&,
-         const Function<deal_II_space_dimension>&,
+         const Function<deal_II_space_dimension, double>&,
          Vector<float>&,
          const hp::QCollection<deal_II_dimension>&,
          const NormType&,
-         const Function<deal_II_space_dimension>*,
+         const Function<deal_II_space_dimension, double>*,
          const double);
 
       \}


### PR DESCRIPTION
This commit introduces an additional template parameter for the number type
of the dealii::Function objects.

This makes GridTools::integrate_difference to be usable with vectors and
functions and complex numbers (by including vector_tools.templates.h).


Yes, no default instantiations for complex variants - the number of total
instantiations for all combinations of serial vectors and number types is well
beyond 4000.