### PR TITLE
Add erfc function to FunctionParser.

### DIFF
--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/function_parser.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/lac/vector.h>
+#include <cmath>
 
 
 #ifdef DEAL_II_WITH_MUPARSER
@@ -170,6 +171,11 @@ namespace internal
   {
     return std::pow(a, b);
   }
+
+  double mu_erfc(double value)
+  {
+    return erfc(value);
+  }
 }
 
 
@@ -208,6 +214,7 @@ void FunctionParser<dim>:: init_muparser() const
       fp.get()[component].DefineFun("sec", internal::mu_sec, true);
       fp.get()[component].DefineFun("log", internal::mu_log, true);
       fp.get()[component].DefineFun("pow", internal::mu_pow, true);
+      fp.get()[component].DefineFun("erfc", internal::mu_erfc, true);
 
       try
         {
@@ -257,7 +264,8 @@ void FunctionParser<dim>:: init_muparser() const
             "csc",
             "floor",
             "sec",
-            "pow"
+            "pow",
+            "erfc"
           };
           for (unsigned int f=0; f<sizeof(function_names)/sizeof(function_names[0]); ++f)
             {

--- a/tests/base/function_parser_08.cc
+++ b/tests/base/function_parser_08.cc
@@ -1,0 +1,87 @@
+#include "../tests.h"
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/point.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/base/function_parser.h>
+
+// simple function parser test for erfc functionality.
+
+void test1()
+{
+  // set up problem:
+  std::string variables = "x,y";
+  std::string expression = "erfc(x)+erfc(y)";
+  std::map<std::string,double> constants;
+
+  // FunctionParser with 2 variables and 1 component:
+  FunctionParser<2> fp(1);
+  fp.initialize(variables,
+                expression,
+                constants);
+
+  // Point at which we want to evaluate the function
+  Point<2> point(0.1, -0.7);
+
+  // evaluate the expression at 'point':
+  double result = fp.value(point);
+
+  deallog << "Function '" << expression << "'"
+          << " @ " << point
+          << " is " << result << std::endl;
+}
+
+
+void test2()
+{
+  // Define some constants that will be used by the function parser
+  std::map<std::string,double> constants;
+  constants["pi"] = numbers::PI;
+
+  // Define the variables that will be used inside the expressions
+  std::string variables = "x,y,z";
+
+  // Define the expressions of the individual components of a
+  // vector valued function with two components:
+  std::vector<std::string> expressions(2);
+  expressions[0] = "erfc(pi*z)";
+  expressions[1] = "sin(2*pi*y)*erfc(x^2)";
+
+  // function parser with 3 variables and 2 components
+  FunctionParser<3> vector_function(2);
+
+  // And populate it with the newly created objects.
+  vector_function.initialize(variables,
+                             expressions,
+                             constants);
+
+  // Point at which we want to evaluate the function
+  Point<3> point(0.0, 1.0, 1.0);
+
+  // This Vector will store the result
+  Vector<double> result(2);
+
+  // Fill 'result' by evaluating the function
+  vector_function.vector_value(point, result);
+
+  // We can also only evaluate the 2nd component:
+  double c = vector_function.value(point, 1);
+
+  Assert(c == result[1], ExcInternalError());
+
+  // Output the evaluated function
+  deallog << "Function '" << expressions[0] << "," << expressions[1] << "'"
+          << " @ " << point
+          << " is " << result << std::endl;
+}
+
+
+int main()
+{
+  initlog();
+
+  test1();
+  test2();
+}

--- a/tests/base/function_parser_08.with_muparser=true.output
+++ b/tests/base/function_parser_08.with_muparser=true.output
@@ -1,0 +1,4 @@
+
+DEAL::Function 'erfc(x)+erfc(y)' @ 0.100000 -0.700000 is 2.56534
+DEAL::Function 'erfc(pi*z),sin(2*pi*y)*erfc(x^2)' @ 0.00000 1.00000 1.00000 is 8.87615e-06 -2.44929e-16 
+DEAL::


### PR DESCRIPTION
It came up in an Aspect model earlier that it would be useful to have erfc available to the FunctionParser. I don't know of a more modular way to do it than to add it to the builtin functions.