### PR TITLE
correct vector dimension check in step-33.

### DIFF
--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -608,10 +608,7 @@ namespace Step33
 
     if (do_schlieren_plot == true)
       Assert (duh.size() == n_quadrature_points,
-              ExcInternalError())
-      else
-        Assert (duh.size() == 0,
-                ExcInternalError());
+              ExcInternalError());
 
     Assert (computed_quantities.size() == n_quadrature_points,
             ExcInternalError());


### PR DESCRIPTION
The vector `duh` always has correct size. The update flag only effects whether its content is updated or not. The current dimension check will cause problem when `do_schlieren_plot` is false.