### PR TITLE
Class names as template arguments

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -295,8 +295,8 @@ public:
    * Vector, BlockVector, but also std::vector@<bool@>, std::vector@<int@>,
    * and std::vector@<double@>.
    */
-  template <typename Vector>
-  void fill_binary_vector (Vector &vector) const;
+  template <typename VectorType>
+  void fill_binary_vector (VectorType &vector) const;
 
   /**
    * Outputs a text representation of this IndexSet to the given stream. Used

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -65,14 +65,14 @@ namespace parallel
        *
        * The same is true for the fraction of cells that is coarsened.
        */
-      template <int dim, class Vector, int spacedim>
+      template <int dim, class VectorType, int spacedim>
       void
-      refine_and_coarsen_fixed_number (
-        parallel::distributed::Triangulation<dim,spacedim> &tria,
-        const Vector                &criteria,
-        const double                 top_fraction_of_cells,
-        const double                 bottom_fraction_of_cells,
-        const unsigned int           max_n_cells = std::numeric_limits<unsigned int>::max());
+      refine_and_coarsen_fixed_number
+      (parallel::distributed::Triangulation<dim,spacedim> &tria,
+       const VectorType                                   &criteria,
+       const double                                       top_fraction_of_cells,
+       const double                                       bottom_fraction_of_cells,
+       const unsigned int                                 max_n_cells = std::numeric_limits<unsigned int>::max());
 
       /**
        * Like dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but
@@ -94,13 +94,13 @@ namespace parallel
        *
        * The same is true for the fraction of cells that is coarsened.
        */
-      template <int dim, class Vector, int spacedim>
+      template <int dim, class VectorType, int spacedim>
       void
-      refine_and_coarsen_fixed_fraction (
-        parallel::distributed::Triangulation<dim,spacedim> &tria,
-        const Vector                &criteria,
-        const double                top_fraction_of_error,
-        const double                bottom_fraction_of_error);
+      refine_and_coarsen_fixed_fraction
+      (parallel::distributed::Triangulation<dim,spacedim> &tria,
+       const VectorType                                   &criteria,
+       const double                                       top_fraction_of_error,
+       const double                                       bottom_fraction_of_error);
     }
   }
 }

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -395,10 +395,10 @@ namespace DoFTools
    *
    * @ingroup constraints
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_sparsity_pattern (const DH               &dof,
-                         SparsityPattern        &sparsity_pattern,
+                         SP                     &sparsity_pattern,
                          const ConstraintMatrix &constraints = ConstraintMatrix(),
                          const bool              keep_constrained_dofs = true,
                          const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id);
@@ -484,11 +484,11 @@ namespace DoFTools
    *
    * @ingroup constraints
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_sparsity_pattern (const DH                 &dof,
                          const Table<2, Coupling> &coupling,
-                         SparsityPattern          &sparsity_pattern,
+                         SP                       &sparsity_pattern,
                          const ConstraintMatrix   &constraints = ConstraintMatrix(),
                          const bool                keep_constrained_dofs = true,
                          const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id);
@@ -513,11 +513,11 @@ namespace DoFTools
    * whereas the ones that correspond to columns come from the second
    * DoFHandler.
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_sparsity_pattern (const DH        &dof_row,
                          const DH        &dof_col,
-                         SparsityPattern &sparsity);
+                         SP              &sparsity);
 
   /**
    * Create the sparsity pattern for boundary matrices. See the general
@@ -529,11 +529,11 @@ namespace DoFTools
    * class that satisfies similar requirements. It is assumed that the size of
    * the sparsity pattern is already correct.
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_boundary_sparsity_pattern (const DH                        &dof,
                                   const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                  SparsityPattern                 &sparsity_pattern);
+                                  SP                              &sparsity_pattern);
 
   /**
    * Write the sparsity structure of the matrix composed of the basis
@@ -551,12 +551,12 @@ namespace DoFTools
    *
    * For the type of the sparsity pattern, the same holds as said above.
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_boundary_sparsity_pattern (const DH &dof,
                                   const typename FunctionMap<DH::space_dimension>::type &boundary_ids,
                                   const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                  SparsityPattern    &sparsity);
+                                  SP                 &sparsity);
 
   /**
    * Generate sparsity pattern for fluxes, i.e. formulations of the discrete
@@ -566,10 +566,10 @@ namespace DoFTools
    * neighboring elements, the normal couplings and these extra matrix entries
    * are considered.
    */
-  template<class DH, class SparsityPattern>
+  template<class DH, class SP>
   void
-  make_flux_sparsity_pattern (const DH        &dof_handler,
-                              SparsityPattern &sparsity_pattern);
+  make_flux_sparsity_pattern (const DH &dof_handler,
+                              SP       &sparsity_pattern);
 
   /**
    * This function does the same as the other with the same name, but it gets
@@ -578,10 +578,10 @@ namespace DoFTools
    *
    * @ingroup constraints
    */
-  template<class DH, class SparsityPattern>
+  template<class DH, class SP>
   void
   make_flux_sparsity_pattern (const DH        &dof_handler,
-                              SparsityPattern &sparsity_pattern,
+                              SP              &sparsity_pattern,
                               const ConstraintMatrix   &constraints,
                               const bool                keep_constrained_dofs = true,
                               const types::subdomain_id  subdomain_id = numbers::invalid_unsigned_int);
@@ -597,10 +597,10 @@ namespace DoFTools
    *
    * @todo Not implemented for hp::DoFHandler.
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_flux_sparsity_pattern (const DH                &dof,
-                              SparsityPattern         &sparsity,
+                              SP                      &sparsity,
                               const Table<2,Coupling> &int_mask,
                               const Table<2,Coupling> &flux_mask);
 

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -146,14 +146,14 @@ namespace GridRefinement
    * indicator. The default value of this argument is to impose no limit on
    * the number of cells.
    */
-  template <int dim, class Vector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  refine_and_coarsen_fixed_number (
-    Triangulation<dim,spacedim> &tria,
-    const Vector                &criteria,
-    const double                top_fraction_of_cells,
-    const double                bottom_fraction_of_cells,
-    const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
+  refine_and_coarsen_fixed_number
+  (Triangulation<dim,spacedim> &tria,
+   const VectorType            &criteria,
+   const double                top_fraction_of_cells,
+   const double                bottom_fraction_of_cells,
+   const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
 
   /**
    * This function provides a refinement strategy controlling the reduction of
@@ -207,14 +207,14 @@ namespace GridRefinement
    * indicator. The default value of this argument is to impose no limit on
    * the number of cells.
    */
-  template <int dim, class Vector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  refine_and_coarsen_fixed_fraction (
-    Triangulation<dim,spacedim> &tria,
-    const Vector                &criteria,
-    const double                top_fraction,
-    const double                bottom_fraction,
-    const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
+  refine_and_coarsen_fixed_fraction
+  (Triangulation<dim,spacedim> &tria,
+   const VectorType            &criteria,
+   const double                top_fraction,
+   const double                bottom_fraction,
+   const unsigned int          max_n_cells = std::numeric_limits<unsigned int>::max());
 
 
 
@@ -290,11 +290,11 @@ namespace GridRefinement
    * thesis, University of Heidelberg, 2005. See in particular Section 4.3,
    * pp. 42-43.
    */
-  template <int dim, class Vector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   refine_and_coarsen_optimize (Triangulation<dim,spacedim> &tria,
-                               const Vector                &criteria,
-                               const unsigned int           order=2);
+                               const VectorType            &criteria,
+                               const unsigned int          order=2);
 
   /**
    * Flag all mesh cells for which the value in @p criteria exceeds @p
@@ -310,11 +310,11 @@ namespace GridRefinement
    * This function does not implement a refinement strategy, it is more a
    * helper function for the actual strategies.
    */
-  template <int dim, class Vector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void refine (Triangulation<dim,spacedim> &tria,
-               const Vector                &criteria,
+               const VectorType            &criteria,
                const double                threshold,
-               const unsigned int max_to_mark = numbers::invalid_unsigned_int);
+               const unsigned int          max_to_mark = numbers::invalid_unsigned_int);
 
   /**
    * Flag all mesh cells for which the value in @p criteria is less than @p
@@ -330,9 +330,9 @@ namespace GridRefinement
    * This function does not implement a refinement strategy, it is more a
    * helper function for the actual strategies.
    */
-  template <int dim, class Vector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void coarsen (Triangulation<dim,spacedim> &tria,
-                const Vector                &criteria,
+                const VectorType            &criteria,
                 const double                threshold);
 
   /**

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -56,7 +56,7 @@ namespace internal
      *
      * @author Wolfgang Bangerth, 2003
      */
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     class FEValuesBase
     {
     public:
@@ -64,16 +64,16 @@ namespace internal
        * Constructor. Set the fields of this class to the values indicated by
        * the parameters to the constructor.
        */
-      FEValuesBase (const dealii::hp::MappingCollection<dim,FEValues::space_dimension> &mapping_collection,
-                    const dealii::hp::FECollection<dim,FEValues::space_dimension>      &fe_collection,
+      FEValuesBase (const dealii::hp::MappingCollection<dim,FEValuesType::space_dimension> &mapping_collection,
+                    const dealii::hp::FECollection<dim,FEValuesType::space_dimension>      &fe_collection,
                     const dealii::hp::QCollection<q_dim>     &q_collection,
-                    const UpdateFlags             update_flags);
+                    const dealii::UpdateFlags             update_flags);
       /**
        * Constructor. This constructor is equivalent to the other one except
        * that it makes the object use a $Q_1$ mapping (i.e., an object of
        * type MappingQGeneric(1)) implicitly.
        */
-      FEValuesBase (const dealii::hp::FECollection<dim,FEValues::space_dimension> &fe_collection,
+      FEValuesBase (const dealii::hp::FECollection<dim,FEValuesType::space_dimension> &fe_collection,
                     const dealii::hp::QCollection<q_dim> &q_collection,
                     const UpdateFlags         update_flags);
 
@@ -81,13 +81,13 @@ namespace internal
        * Get a reference to the collection of finite element objects used
        * here.
        */
-      const dealii::hp::FECollection<dim,FEValues::space_dimension> &
+      const dealii::hp::FECollection<dim,FEValuesType::space_dimension> &
       get_fe_collection () const;
 
       /**
        * Get a reference to the collection of mapping objects used here.
        */
-      const dealii::hp::MappingCollection<dim,FEValues::space_dimension> &
+      const dealii::hp::MappingCollection<dim,FEValuesType::space_dimension> &
       get_mapping_collection () const;
 
       /**
@@ -107,7 +107,7 @@ namespace internal
        * you called the @p reinit function of the <tt>hp::FE*Values</tt> class
        * the last time.
        */
-      const FEValues &get_present_fe_values () const;
+      const FEValuesType &get_present_fe_values () const;
 
     protected:
 
@@ -118,7 +118,7 @@ namespace internal
        * The function returns a writable reference so that derived classes can
        * also reinit() the selected FEValues object.
        */
-      FEValues &
+      FEValuesType &
       select_fe_values (const unsigned int fe_index,
                         const unsigned int mapping_index,
                         const unsigned int q_index);
@@ -127,14 +127,14 @@ namespace internal
       /**
        * A pointer to the collection of finite elements to be used.
        */
-      const SmartPointer<const dealii::hp::FECollection<dim,FEValues::space_dimension>,
-            FEValuesBase<dim,q_dim,FEValues> > fe_collection;
+      const SmartPointer<const dealii::hp::FECollection<dim,FEValuesType::space_dimension>,
+            FEValuesBase<dim,q_dim,FEValuesType> > fe_collection;
 
       /**
        * A pointer to the collection of mappings to be used.
        */
-      const SmartPointer<const dealii::hp::MappingCollection<dim, FEValues::space_dimension>,
-            FEValuesBase<dim,q_dim,FEValues> > mapping_collection;
+      const SmartPointer<const dealii::hp::MappingCollection<dim, FEValuesType::space_dimension>,
+            FEValuesBase<dim,q_dim,FEValuesType> > mapping_collection;
 
       /**
        * Copy of the quadrature collection object provided to the constructor.
@@ -153,7 +153,7 @@ namespace internal
        * Initially, all entries have zero pointers, and we will allocate them
        * lazily as needed in select_fe_values().
        */
-      dealii::Table<3,std_cxx11::shared_ptr<FEValues> > fe_values_table;
+      dealii::Table<3,std_cxx11::shared_ptr<FEValuesType> > fe_values_table;
 
       /**
        * Set of indices pointing at the fe_values object selected last time
@@ -595,50 +595,50 @@ namespace internal
 {
   namespace hp
   {
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     inline
-    const FEValues &
-    FEValuesBase<dim,q_dim,FEValues>::get_present_fe_values () const
+    const FEValuesType &
+    FEValuesBase<dim,q_dim,FEValuesType>::get_present_fe_values () const
     {
       return *fe_values_table(present_fe_values_index);
     }
 
 
 
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     inline
-    const dealii::hp::FECollection<dim,FEValues::space_dimension> &
-    FEValuesBase<dim,q_dim,FEValues>::get_fe_collection () const
+    const dealii::hp::FECollection<dim,FEValuesType::space_dimension> &
+    FEValuesBase<dim,q_dim,FEValuesType>::get_fe_collection () const
     {
       return *fe_collection;
     }
 
 
 
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     inline
-    const dealii::hp::MappingCollection<dim,FEValues::space_dimension> &
-    FEValuesBase<dim,q_dim,FEValues>::get_mapping_collection () const
+    const dealii::hp::MappingCollection<dim,FEValuesType::space_dimension> &
+    FEValuesBase<dim,q_dim,FEValuesType>::get_mapping_collection () const
     {
       return *mapping_collection;
     }
 
 
 
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     inline
     const dealii::hp::QCollection<q_dim> &
-    FEValuesBase<dim,q_dim,FEValues>::get_quadrature_collection () const
+    FEValuesBase<dim,q_dim,FEValuesType>::get_quadrature_collection () const
     {
       return q_collection;
     }
 
 
 
-    template <int dim, int q_dim, class FEValues>
+    template <int dim, int q_dim, class FEValuesType>
     inline
     dealii::UpdateFlags
-    FEValuesBase<dim,q_dim,FEValues>::get_update_flags () const
+    FEValuesBase<dim,q_dim,FEValuesType>::get_update_flags () const
     {
       return update_flags;
     }

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -35,9 +35,9 @@ class BlockLinearOperator;
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockMatrix>
+          typename BlockMatrixType>
 BlockLinearOperator<Range, Domain>
-block_operator(const BlockMatrix &matrix);
+block_operator(const BlockMatrixType &matrix);
 
 template <size_t m, size_t n,
           typename Range = BlockVector<double>,
@@ -66,9 +66,9 @@ block_diagonal_operator(const LinearOperator<typename Range::BlockType, typename
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range,
-          typename BlockMatrix>
+          typename BlockMatrixType>
 BlockLinearOperator<Range, Domain>
-block_diagonal_operator(const BlockMatrix &block_matrix);
+block_diagonal_operator(const BlockMatrixType &block_matrix);
 
 template <typename Range = BlockVector<double>,
           typename Domain = Range>
@@ -388,9 +388,9 @@ namespace internal
  */
 template <typename Range,
           typename Domain,
-          typename BlockMatrix>
+          typename BlockMatrixType>
 BlockLinearOperator<Range, Domain>
-block_operator(const BlockMatrix &block_matrix)
+block_operator(const BlockMatrixType &block_matrix)
 {
   typedef typename BlockLinearOperator<Range, Domain>::BlockType BlockType;
 
@@ -502,9 +502,9 @@ block_operator(const std::array<std::array<LinearOperator<typename Range::BlockT
  */
 template <typename Range,
           typename Domain,
-          typename BlockMatrix>
+          typename BlockMatrixType>
 BlockLinearOperator<Range, Domain>
-block_diagonal_operator(const BlockMatrix &block_matrix)
+block_diagonal_operator(const BlockMatrixType &block_matrix)
 {
   typedef typename BlockLinearOperator<Range, Domain>::BlockType BlockType;
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -53,7 +53,7 @@ namespace BlockMatrixIterators
    * Base class for block matrix accessors, implementing the stepping through
    * a matrix.
    */
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   class AccessorBase
   {
   public:
@@ -65,7 +65,7 @@ namespace BlockMatrixIterators
     /**
      * Typedef the value type of the matrix we point into.
      */
-    typedef typename BlockMatrix::value_type value_type;
+    typedef typename BlockMatrixType::value_type value_type;
 
     /**
      * Initialize data fields to default values.
@@ -105,17 +105,17 @@ namespace BlockMatrixIterators
   /**
    * Accessor classes in block matrices.
    */
-  template <class BlockMatrix, bool ConstNess>
+  template <class BlockMatrixType, bool Constness>
   class Accessor;
 
 
   /**
    * Block matrix accessor for non const matrices.
    */
-  template <class BlockMatrix>
-  class Accessor<BlockMatrix, false>
+  template <class BlockMatrixType>
+  class Accessor<BlockMatrixType, false>
     :
-    public AccessorBase<BlockMatrix>
+    public AccessorBase<BlockMatrixType>
   {
   public:
     /**
@@ -126,12 +126,12 @@ namespace BlockMatrixIterators
     /**
      * Type of the matrix used in this accessor.
      */
-    typedef BlockMatrix MatrixType;
+    typedef BlockMatrixType MatrixType;
 
     /**
      * Typedef the value type of the matrix we point into.
      */
-    typedef typename BlockMatrix::value_type value_type;
+    typedef typename BlockMatrixType::value_type value_type;
 
     /**
      * Constructor. Since we use accessors only for read access, a const
@@ -141,7 +141,7 @@ namespace BlockMatrixIterators
      * create the end pointer if @p row equals the total number of rows in the
      * matrix.
      */
-    Accessor (BlockMatrix *m,
+    Accessor (BlockMatrixType *m,
               const size_type row,
               const size_type col);
 
@@ -169,12 +169,12 @@ namespace BlockMatrixIterators
     /**
      * The matrix accessed.
      */
-    BlockMatrix *matrix;
+    BlockMatrixType *matrix;
 
     /**
      * Iterator of the underlying matrix class.
      */
-    typename BlockMatrix::BlockType::iterator base_iterator;
+    typename BlockMatrixType::BlockType::iterator base_iterator;
 
     /**
      * Move ahead one element.
@@ -187,17 +187,17 @@ namespace BlockMatrixIterators
     bool operator == (const Accessor &a) const;
 
     template <typename> friend class MatrixIterator;
-    friend class Accessor<BlockMatrix, true>;
+    friend class Accessor<BlockMatrixType, true>;
   };
 
   /**
    * Block matrix accessor for constant matrices, implementing the stepping
    * through a matrix.
    */
-  template <class BlockMatrix>
-  class Accessor<BlockMatrix, true>
+  template <class BlockMatrixType>
+  class Accessor<BlockMatrixType, true>
     :
-    public AccessorBase<BlockMatrix>
+    public AccessorBase<BlockMatrixType>
   {
   public:
     /**
@@ -208,12 +208,12 @@ namespace BlockMatrixIterators
     /**
      * Type of the matrix used in this accessor.
      */
-    typedef const BlockMatrix MatrixType;
+    typedef const BlockMatrixType MatrixType;
 
     /**
      * Typedef the value type of the matrix we point into.
      */
-    typedef typename BlockMatrix::value_type value_type;
+    typedef typename BlockMatrixType::value_type value_type;
 
     /**
      * Constructor. Since we use accessors only for read access, a const
@@ -223,14 +223,14 @@ namespace BlockMatrixIterators
      * create the end pointer if @p row equals the total number of rows in the
      * matrix.
      */
-    Accessor (const BlockMatrix *m,
+    Accessor (const BlockMatrixType *m,
               const size_type row,
               const size_type col);
 
     /**
      * Initialize const accessor from non const accessor.
      */
-    Accessor(const Accessor<BlockMatrix, false> &);
+    Accessor(const Accessor<BlockMatrixType, false> &);
 
     /**
      * Row number of the element represented by this object.
@@ -250,12 +250,12 @@ namespace BlockMatrixIterators
     /**
      * The matrix accessed.
      */
-    const BlockMatrix *matrix;
+    const BlockMatrixType *matrix;
 
     /**
      * Iterator of the underlying matrix class.
      */
-    typename BlockMatrix::BlockType::const_iterator base_iterator;
+    typename BlockMatrixType::BlockType::const_iterator base_iterator;
 
     /**
      * Move ahead one element.
@@ -1040,19 +1040,19 @@ private:
 
 namespace BlockMatrixIterators
 {
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  AccessorBase<BlockMatrix>::AccessorBase()
+  AccessorBase<BlockMatrixType>::AccessorBase()
     :
     row_block(0),
     col_block(0)
   {}
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   unsigned int
-  AccessorBase<BlockMatrix>::block_row() const
+  AccessorBase<BlockMatrixType>::block_row() const
   {
     Assert (row_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1061,10 +1061,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   unsigned int
-  AccessorBase<BlockMatrix>::block_column() const
+  AccessorBase<BlockMatrixType>::block_column() const
   {
     Assert (col_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1073,12 +1073,12 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  Accessor<BlockMatrix, true>::Accessor (
-    const BlockMatrix  *matrix,
-    const size_type     row,
-    const size_type     col)
+  Accessor<BlockMatrixType, true>::Accessor (
+    const BlockMatrixType  *matrix,
+    const size_type        row,
+    const size_type        col)
     :
     matrix(matrix),
     base_iterator(matrix->block(0,0).begin())
@@ -1126,9 +1126,9 @@ namespace BlockMatrixIterators
   }
 
 
-//   template <class BlockMatrix>
+//   template <class BlockMatrixType>
 //   inline
-//   Accessor<BlockMatrix, true>::Accessor (const Accessor<BlockMatrix, true>& other)
+//   Accessor<BlockMatrixType, true>::Accessor (const Accessor<BlockMatrixType, true>& other)
 //                :
 //                matrix(other.matrix),
 //                base_iterator(other.base_iterator)
@@ -1138,9 +1138,9 @@ namespace BlockMatrixIterators
 //   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  Accessor<BlockMatrix, true>::Accessor (const Accessor<BlockMatrix, false> &other)
+  Accessor<BlockMatrixType, true>::Accessor (const Accessor<BlockMatrixType, false> &other)
     :
     matrix(other.matrix),
     base_iterator(other.base_iterator)
@@ -1150,10 +1150,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, true>::size_type
-  Accessor<BlockMatrix, true>::row() const
+  typename Accessor<BlockMatrixType, true>::size_type
+  Accessor<BlockMatrixType, true>::row() const
   {
     Assert (this->row_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1163,10 +1163,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, true>::size_type
-  Accessor<BlockMatrix, true>::column() const
+  typename Accessor<BlockMatrixType, true>::size_type
+  Accessor<BlockMatrixType, true>::column() const
   {
     Assert (this->col_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1176,10 +1176,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, true>::value_type
-  Accessor<BlockMatrix, true>::value () const
+  typename Accessor<BlockMatrixType, true>::value_type
+  Accessor<BlockMatrixType, true>::value () const
   {
     Assert (this->row_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1191,10 +1191,10 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   void
-  Accessor<BlockMatrix, true>::advance ()
+  Accessor<BlockMatrixType, true>::advance ()
   {
     Assert (this->row_block != numbers::invalid_unsigned_int,
             ExcIteratorPastEnd());
@@ -1257,10 +1257,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   bool
-  Accessor<BlockMatrix, true>::operator == (const Accessor &a) const
+  Accessor<BlockMatrixType, true>::operator == (const Accessor &a) const
   {
     if (matrix != a.matrix)
       return false;
@@ -1283,12 +1283,12 @@ namespace BlockMatrixIterators
 //----------------------------------------------------------------------//
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  Accessor<BlockMatrix, false>::Accessor (
-    BlockMatrix  *matrix,
-    const size_type row,
-    const size_type col)
+  Accessor<BlockMatrixType, false>::Accessor (
+    BlockMatrixType  *matrix,
+    const size_type  row,
+    const size_type  col)
     :
     matrix(matrix),
     base_iterator(matrix->block(0,0).begin())
@@ -1335,10 +1335,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, false>::size_type
-  Accessor<BlockMatrix, false>::row() const
+  typename Accessor<BlockMatrixType, false>::size_type
+  Accessor<BlockMatrixType, false>::row() const
   {
     Assert (this->row_block != numbers::invalid_size_type,
             ExcIteratorPastEnd());
@@ -1348,10 +1348,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, false>::size_type
-  Accessor<BlockMatrix, false>::column() const
+  typename Accessor<BlockMatrixType, false>::size_type
+  Accessor<BlockMatrixType, false>::column() const
   {
     Assert (this->col_block != numbers::invalid_size_type,
             ExcIteratorPastEnd());
@@ -1361,10 +1361,10 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
-  typename Accessor<BlockMatrix, false>::value_type
-  Accessor<BlockMatrix, false>::value () const
+  typename Accessor<BlockMatrixType, false>::value_type
+  Accessor<BlockMatrixType, false>::value () const
   {
     Assert (this->row_block != numbers::invalid_size_type,
             ExcIteratorPastEnd());
@@ -1376,10 +1376,10 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   void
-  Accessor<BlockMatrix, false>::set_value (typename Accessor<BlockMatrix, false>::value_type newval) const
+  Accessor<BlockMatrixType, false>::set_value (typename Accessor<BlockMatrixType, false>::value_type newval) const
   {
     Assert (this->row_block != numbers::invalid_size_type,
             ExcIteratorPastEnd());
@@ -1391,10 +1391,10 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   void
-  Accessor<BlockMatrix, false>::advance ()
+  Accessor<BlockMatrixType, false>::advance ()
   {
     Assert (this->row_block != numbers::invalid_size_type,
             ExcIteratorPastEnd());
@@ -1458,10 +1458,10 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrix>
+  template <class BlockMatrixType>
   inline
   bool
-  Accessor<BlockMatrix, false>::operator == (const Accessor &a) const
+  Accessor<BlockMatrixType, false>::operator == (const Accessor &a) const
   {
     if (matrix != a.matrix)
       return false;

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -79,7 +79,7 @@ namespace TrilinosWrappers
  * @ref GlossBlockLA "Block (linear algebra)"
  * @author Wolfgang Bangerth, 2000, 2001
  */
-template <class SparsityPatternBase>
+template <class SP>
 class BlockSparsityPatternBase : public Subscriptor
 {
 public:
@@ -160,7 +160,7 @@ public:
   /**
    * Access the block with the given coordinates.
    */
-  SparsityPatternBase &
+  SP &
   block (const size_type row,
          const size_type column);
 
@@ -169,7 +169,7 @@ public:
    * Access the block with the given coordinates. Version for constant
    * objects.
    */
-  const SparsityPatternBase &
+  const SP &
   block (const size_type row,
          const size_type column) const;
 
@@ -338,7 +338,7 @@ protected:
   /**
    * Array of sparsity patterns.
    */
-  Table<2,SmartPointer<SparsityPatternBase, BlockSparsityPatternBase<SparsityPatternBase> > > sub_objects;
+  Table<2,SmartPointer<SP, BlockSparsityPatternBase<SP> > > sub_objects;
 
   /**
    * Object storing and managing the transformation of row indices to indices
@@ -749,11 +749,11 @@ namespace TrilinosWrappers
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
-SparsityPatternBase &
-BlockSparsityPatternBase<SparsityPatternBase>::block (const size_type row,
-                                                      const size_type column)
+SP &
+BlockSparsityPatternBase<SP>::block (const size_type row,
+                                     const size_type column)
 {
   Assert (row<rows, ExcIndexRange(row,0,rows));
   Assert (column<columns, ExcIndexRange(column,0,columns));
@@ -762,11 +762,11 @@ BlockSparsityPatternBase<SparsityPatternBase>::block (const size_type row,
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
-const SparsityPatternBase &
-BlockSparsityPatternBase<SparsityPatternBase>::block (const size_type row,
-                                                      const size_type column) const
+const SP &
+BlockSparsityPatternBase<SP>::block (const size_type row,
+                                     const size_type column) const
 {
   Assert (row<rows, ExcIndexRange(row,0,rows));
   Assert (column<columns, ExcIndexRange(column,0,columns));
@@ -775,31 +775,31 @@ BlockSparsityPatternBase<SparsityPatternBase>::block (const size_type row,
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
 const BlockIndices &
-BlockSparsityPatternBase<SparsityPatternBase>::get_row_indices () const
+BlockSparsityPatternBase<SP>::get_row_indices () const
 {
   return row_indices;
 }
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
 const BlockIndices &
-BlockSparsityPatternBase<SparsityPatternBase>::get_column_indices () const
+BlockSparsityPatternBase<SP>::get_column_indices () const
 {
   return column_indices;
 }
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
 void
-BlockSparsityPatternBase<SparsityPatternBase>::add (const size_type i,
-                                                    const size_type j)
+BlockSparsityPatternBase<SP>::add (const size_type i,
+                                   const size_type j)
 {
   // if you get an error here, are
   // you sure you called
@@ -813,13 +813,13 @@ BlockSparsityPatternBase<SparsityPatternBase>::add (const size_type i,
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 template <typename ForwardIterator>
 void
-BlockSparsityPatternBase<SparsityPatternBase>::add_entries (const size_type row,
-                                                            ForwardIterator begin,
-                                                            ForwardIterator end,
-                                                            const bool      indices_are_sorted)
+BlockSparsityPatternBase<SP>::add_entries (const size_type row,
+                                           ForwardIterator begin,
+                                           ForwardIterator end,
+                                           const bool      indices_are_sorted)
 {
   // Resize scratch arrays
   if (block_column_indices.size() < this->n_block_cols())
@@ -900,11 +900,11 @@ BlockSparsityPatternBase<SparsityPatternBase>::add_entries (const size_type row,
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
 bool
-BlockSparsityPatternBase<SparsityPatternBase>::exists (const size_type i,
-                                                       const size_type j) const
+BlockSparsityPatternBase<SP>::exists (const size_type i,
+                                      const size_type j) const
 {
   // if you get an error here, are
   // you sure you called
@@ -918,10 +918,10 @@ BlockSparsityPatternBase<SparsityPatternBase>::exists (const size_type i,
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
 unsigned int
-BlockSparsityPatternBase<SparsityPatternBase>::
+BlockSparsityPatternBase<SP>::
 row_length (const size_type row) const
 {
   const std::pair<size_type , size_type>
@@ -937,20 +937,20 @@ row_length (const size_type row) const
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
-typename BlockSparsityPatternBase<SparsityPatternBase>::size_type
-BlockSparsityPatternBase<SparsityPatternBase>::n_block_cols () const
+typename BlockSparsityPatternBase<SP>::size_type
+BlockSparsityPatternBase<SP>::n_block_cols () const
 {
   return columns;
 }
 
 
 
-template <class SparsityPatternBase>
+template <class SP>
 inline
-typename BlockSparsityPatternBase<SparsityPatternBase>::size_type
-BlockSparsityPatternBase<SparsityPatternBase>::n_block_rows () const
+typename BlockSparsityPatternBase<SP>::size_type
+BlockSparsityPatternBase<SP>::n_block_rows () const
 {
   return rows;
 }

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -292,32 +292,32 @@ public:
    * used, which gets the partitioning information builtin into the
    * DoFHandler.
    */
-  template <typename DH, typename Quadrature>
+  template <typename DH, typename QuadratureType>
   void reinit (const Mapping<dim>     &mapping,
                const DH               &dof_handler,
                const ConstraintMatrix &constraint,
                const IndexSet         &locally_owned_dofs,
-               const Quadrature       &quad,
+               const QuadratureType   &quad,
                const AdditionalData    additional_data = AdditionalData());
 
   /**
    * Initializes the data structures. Same as above, but with index set stored
    * in the DoFHandler for describing the locally owned degrees of freedom.
    */
-  template <typename DH, typename Quadrature>
+  template <typename DH, typename QuadratureType>
   void reinit (const Mapping<dim>     &mapping,
                const DH               &dof_handler,
                const ConstraintMatrix &constraint,
-               const Quadrature       &quad,
+               const QuadratureType   &quad,
                const AdditionalData    additional_data = AdditionalData());
 
   /**
    * Initializes the data structures. Same as above, but using a $Q_1$ mapping.
    */
-  template <typename DH, typename Quadrature>
+  template <typename DH, typename QuadratureType>
   void reinit (const DH               &dof_handler,
                const ConstraintMatrix &constraint,
-               const Quadrature       &quad,
+               const QuadratureType   &quad,
                const AdditionalData    additional_data = AdditionalData());
 
   /**
@@ -346,12 +346,12 @@ public:
    * used, which gets the partitioning information from the DoFHandler. This
    * is the most general initialization function.
    */
-  template <typename DH, typename Quadrature>
-  void reinit (const Mapping<dim>                         &mapping,
+  template <typename DH, typename QuadratureType>
+  void reinit (const Mapping<dim>                          &mapping,
                const std::vector<const DH *>               &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
-               const std::vector<IndexSet>                &locally_owned_set,
-               const std::vector<Quadrature>              &quad,
+               const std::vector<IndexSet>                 &locally_owned_set,
+               const std::vector<QuadratureType>           &quad,
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
@@ -359,20 +359,20 @@ public:
    * description of the locally owned range of degrees of freedom is taken
    * from the DoFHandler.
    */
-  template <typename DH, typename Quadrature>
-  void reinit (const Mapping<dim>                         &mapping,
+  template <typename DH, typename QuadratureType>
+  void reinit (const Mapping<dim>                          &mapping,
                const std::vector<const DH *>               &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
-               const std::vector<Quadrature>              &quad,
+               const std::vector<QuadratureType>           &quad,
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
    * Initializes the data structures. Same as above, but  using a $Q_1$ mapping.
    */
-  template <typename DH, typename Quadrature>
+  template <typename DH, typename QuadratureType>
   void reinit (const std::vector<const DH *>               &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
-               const std::vector<Quadrature>              &quad,
+               const std::vector<QuadratureType>           &quad,
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
@@ -382,20 +382,20 @@ public:
    * as might be necessary when several components in a vector-valued problem
    * are integrated together based on the same quadrature formula.
    */
-  template <typename DH, typename Quadrature>
-  void reinit (const Mapping<dim>                         &mapping,
+  template <typename DH, typename QuadratureType>
+  void reinit (const Mapping<dim>                          &mapping,
                const std::vector<const DH *>               &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
-               const Quadrature                           &quad,
+               const QuadratureType                        &quad,
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
    * Initializes the data structures. Same as above, but  using a $Q_1$ mapping.
    */
-  template <typename DH, typename Quadrature>
+  template <typename DH, typename QuadratureType>
   void reinit (const std::vector<const DH *>               &dof_handler,
                const std::vector<const ConstraintMatrix *> &constraint,
-               const Quadrature                           &quad,
+               const QuadratureType                        &quad,
                const AdditionalData                        additional_data = AdditionalData());
 
   /**
@@ -1462,16 +1462,16 @@ namespace internal
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const DH               &dof_handler,
-       const ConstraintMatrix &constraints_in,
-       const Quad             &quad,
+reinit(const DH                                              &dof_handler,
+       const ConstraintMatrix                                &constraints_in,
+       const QuadratureType                                  &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<const DH *>               dof_handlers;
   std::vector<const ConstraintMatrix *> constraints;
-  std::vector<Quad>          quads;
+  std::vector<QuadratureType>           quads;
 
   dof_handlers.push_back(&dof_handler);
   constraints.push_back (&constraints_in);
@@ -1487,17 +1487,17 @@ reinit(const DH               &dof_handler,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const Mapping<dim>     &mapping,
-       const DH               &dof_handler,
-       const ConstraintMatrix &constraints_in,
-       const Quad             &quad,
+reinit(const Mapping<dim>                                    &mapping,
+       const DH                                              &dof_handler,
+       const ConstraintMatrix                                &constraints_in,
+       const QuadratureType                                  &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<const DH *>               dof_handlers;
   std::vector<const ConstraintMatrix *> constraints;
-  std::vector<Quad>          quads;
+  std::vector<QuadratureType>           quads;
 
   dof_handlers.push_back(&dof_handler);
   constraints.push_back (&constraints_in);
@@ -1513,11 +1513,11 @@ reinit(const Mapping<dim>     &mapping,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
 reinit(const std::vector<const DH *>               &dof_handler,
        const std::vector<const ConstraintMatrix *> &constraint,
-       const std::vector<Quad>                    &quad,
+       const std::vector<QuadratureType>           &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
@@ -1531,14 +1531,14 @@ reinit(const std::vector<const DH *>               &dof_handler,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const std::vector<const DH *>               &dof_handler,
-       const std::vector<const ConstraintMatrix *> &constraint,
-       const Quad                                 &quad,
+reinit(const std::vector<const DH *>                         &dof_handler,
+       const std::vector<const ConstraintMatrix *>           &constraint,
+       const QuadratureType                                  &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
-  std::vector<Quad> quads;
+  std::vector<QuadratureType> quads;
   quads.push_back(quad);
   std::vector<IndexSet> locally_owned_set =
     internal::MatrixFree::extract_locally_owned_index_sets
@@ -1550,15 +1550,15 @@ reinit(const std::vector<const DH *>               &dof_handler,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const Mapping<dim>                         &mapping,
-       const std::vector<const DH *>               &dof_handler,
-       const std::vector<const ConstraintMatrix *> &constraint,
-       const Quad                                 &quad,
+reinit(const Mapping<dim>                                    &mapping,
+       const std::vector<const DH *>                         &dof_handler,
+       const std::vector<const ConstraintMatrix *>           &constraint,
+       const QuadratureType                                  &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
-  std::vector<Quad> quads;
+  std::vector<QuadratureType> quads;
   quads.push_back(quad);
   std::vector<IndexSet> locally_owned_set =
     internal::MatrixFree::extract_locally_owned_index_sets
@@ -1570,12 +1570,12 @@ reinit(const Mapping<dim>                         &mapping,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const Mapping<dim>                         &mapping,
-       const std::vector<const DH *>  &dof_handler,
-       const std::vector<const ConstraintMatrix *> &constraint,
-       const std::vector<Quad>              &quad,
+reinit(const Mapping<dim>                                   &mapping,
+       const std::vector<const DH *>                        &dof_handler,
+       const std::vector<const ConstraintMatrix *>          &constraint,
+       const std::vector<QuadratureType>                    &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   std::vector<IndexSet> locally_owned_set =
@@ -1588,13 +1588,13 @@ reinit(const Mapping<dim>                         &mapping,
 
 
 template <int dim, typename Number>
-template <typename DH, typename Quad>
+template <typename DH, typename QuadratureType>
 void MatrixFree<dim,Number>::
-reinit(const Mapping<dim>                         &mapping,
-       const std::vector<const DH *>               &dof_handler,
-       const std::vector<const ConstraintMatrix *> &constraint,
-       const std::vector<IndexSet>                &locally_owned_set,
-       const std::vector<Quad>                    &quad,
+reinit(const Mapping<dim>                                    &mapping,
+       const std::vector<const DH *>                         &dof_handler,
+       const std::vector<const ConstraintMatrix *>           &constraint,
+       const std::vector<IndexSet>                           &locally_owned_set,
+       const std::vector<QuadratureType>                     &quad,
        const typename MatrixFree<dim,Number>::AdditionalData additional_data)
 {
   // find out whether we use a hp Quadrature or a standard quadrature

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -81,11 +81,11 @@ namespace MGTools
    * There is no need to consider hanging nodes here, since only one level is
    * considered.
    */
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_sparsity_pattern (const DH &dof_handler,
-                         SparsityPattern         &sparsity,
-                         const unsigned int       level);
+  make_sparsity_pattern (const DH           &dof_handler,
+                         SP                 &sparsity,
+                         const unsigned int level);
 
   /**
    * Make a sparsity pattern including fluxes of discontinuous Galerkin
@@ -95,11 +95,11 @@ namespace MGTools
    * and
    * @ref DoFTools
    */
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
   make_flux_sparsity_pattern (const DoFHandler<dim,spacedim> &dof_handler,
-                              SparsityPattern         &sparsity,
-                              const unsigned int       level);
+                              SP                             &sparsity,
+                              const unsigned int             level);
 
   /**
    * Create sparsity pattern for the fluxes at refinement edges. The matrix
@@ -107,11 +107,11 @@ namespace MGTools
    *
    * make_flux_sparsity_pattern()
    */
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
   make_flux_sparsity_pattern_edge (const DoFHandler<dim,spacedim> &dof_handler,
-                                   SparsityPattern         &sparsity,
-                                   const unsigned int       level);
+                                   SP                             &sparsity,
+                                   const unsigned int             level);
   /**
    * This function does the same as the other with the same name, but it gets
    * two additional coefficient matrices. A matrix entry will only be
@@ -121,11 +121,11 @@ namespace MGTools
    * There is one matrix for couplings in a cell and one for the couplings
    * occurring in fluxes.
    */
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern (const DoFHandler<dim,spacedim> &dof,
-                              SparsityPattern       &sparsity,
-                              const unsigned int level,
+  make_flux_sparsity_pattern (const DoFHandler<dim,spacedim>    &dof,
+                              SP                                &sparsity,
+                              const unsigned int                level,
                               const Table<2,DoFTools::Coupling> &int_mask,
                               const Table<2,DoFTools::Coupling> &flux_mask);
 
@@ -137,11 +137,11 @@ namespace MGTools
    *
    * make_flux_sparsity_pattern()
    */
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern_edge (const DoFHandler<dim,spacedim> &dof_handler,
-                                   SparsityPattern         &sparsity,
-                                   const unsigned int       level,
+  make_flux_sparsity_pattern_edge (const DoFHandler<dim,spacedim>    &dof_handler,
+                                   SP                                &sparsity,
+                                   const unsigned int                level,
                                    const Table<2,DoFTools::Coupling> &flux_mask);
 
   /**

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -1963,12 +1963,12 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  void point_difference (const DoFHandler<dim,spacedim> &dof,
-                         const InVector                 &fe_function,
-                         const Function<spacedim,double>       &exact_solution,
-                         Vector<double>                 &difference,
-                         const Point<spacedim>          &point);
+  template <int dim, class VectorType, int spacedim>
+  void point_difference (const DoFHandler<dim,spacedim>  &dof,
+                         const VectorType                &fe_function,
+                         const Function<spacedim,double> &exact_solution,
+                         Vector<double>                  &difference,
+                         const Point<spacedim>           &point);
 
   /**
    * Point error evaluation. Find the first cell containing the given point
@@ -1982,13 +1982,13 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  void point_difference (const Mapping<dim, spacedim>   &mapping,
-                         const DoFHandler<dim,spacedim> &dof,
-                         const InVector                 &fe_function,
-                         const Function<spacedim,double>       &exact_solution,
-                         Vector<double>                 &difference,
-                         const Point<spacedim>          &point);
+  template <int dim, class VectorType, int spacedim>
+  void point_difference (const Mapping<dim, spacedim>    &mapping,
+                         const DoFHandler<dim,spacedim>  &dof,
+                         const VectorType                &fe_function,
+                         const Function<spacedim,double> &exact_solution,
+                         Vector<double>                  &difference,
+                         const Point<spacedim>           &point);
 
   /**
    * Evaluate a possibly vector-valued finite element function defined by the
@@ -2001,10 +2001,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const DoFHandler<dim,spacedim> &dof,
-               const InVector                 &fe_function,
+               const VectorType               &fe_function,
                const Point<spacedim>          &point,
                Vector<double>                 &value);
 
@@ -2014,10 +2014,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector                     &fe_function,
+               const VectorType                   &fe_function,
                const Point<spacedim>              &point,
                Vector<double>                     &value);
 
@@ -2036,10 +2036,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const DoFHandler<dim,spacedim> &dof,
-               const InVector                 &fe_function,
+               const VectorType               &fe_function,
                const Point<spacedim>          &point);
 
   /**
@@ -2048,10 +2048,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector                     &fe_function,
+               const VectorType                   &fe_function,
                const Point<spacedim>              &point);
 
   /**
@@ -2065,11 +2065,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
-               const InVector                 &fe_function,
+               const VectorType               &fe_function,
                const Point<spacedim>          &point,
                Vector<double>                 &value);
 
@@ -2079,11 +2079,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const hp::MappingCollection<dim, spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>         &dof,
-               const InVector                             &fe_function,
+               const VectorType                           &fe_function,
                const Point<spacedim>                      &point,
                Vector<double>                             &value);
 
@@ -2098,11 +2098,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const Mapping<dim,spacedim>    &mapping,
                const DoFHandler<dim,spacedim> &dof,
-               const InVector                 &fe_function,
+               const VectorType               &fe_function,
                const Point<spacedim>          &point);
 
   /**
@@ -2111,11 +2111,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const hp::MappingCollection<dim,spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>        &dof,
-               const InVector                            &fe_function,
+               const VectorType                          &fe_function,
                const Point<spacedim>                     &point);
 
   /**
@@ -2129,12 +2129,12 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_gradient (const DoFHandler<dim,spacedim>    &dof,
-                  const InVector                    &fe_function,
+                  const VectorType                  &fe_function,
                   const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &value);
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &value);
 
   /**
    * Same as above for hp.
@@ -2142,12 +2142,12 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector                     &fe_function,
+                  const VectorType                   &fe_function,
                   const Point<spacedim>              &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> >  &value);
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -2160,10 +2160,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
-                  const InVector                 &fe_function,
+                  const VectorType               &fe_function,
                   const Point<spacedim>          &point);
 
   /**
@@ -2172,10 +2172,10 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector                     &fe_function,
+                  const VectorType                   &fe_function,
                   const Point<spacedim>              &point);
 
   /**
@@ -2189,13 +2189,13 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_gradient (const Mapping<dim, spacedim>      &mapping,
                   const DoFHandler<dim,spacedim>    &dof,
-                  const InVector                    &fe_function,
+                  const VectorType                  &fe_function,
                   const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &value);
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &value);
 
   /**
    * Same as above for hp.
@@ -2203,13 +2203,13 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>         &dof,
-                  const InVector                             &fe_function,
+                  const VectorType                           &fe_function,
                   const Point<spacedim>                      &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> >          &value);
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -2222,11 +2222,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const Mapping<dim,spacedim>    &mapping,
                   const DoFHandler<dim,spacedim> &dof,
-                  const InVector                 &fe_function,
+                  const VectorType               &fe_function,
                   const Point<spacedim>          &point);
 
   /**
@@ -2235,11 +2235,11 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::MappingCollection<dim,spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>        &dof,
-                  const InVector                            &fe_function,
+                  const VectorType                          &fe_function,
                   const Point<spacedim>                     &point);
 
   //@}
@@ -2321,22 +2321,22 @@ namespace VectorTools
    * Lagrangian elements. For all other elements, you will need to compute the
    * mean value and subtract it right inside the evaluation routine.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double compute_mean_value (const Mapping<dim, spacedim>   &mapping,
                              const DoFHandler<dim,spacedim> &dof,
                              const Quadrature<dim>          &quadrature,
-                             const InVector                 &v,
-                             const unsigned int              component);
+                             const VectorType               &v,
+                             const unsigned int             component);
 
   /**
    * Calls the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double compute_mean_value (const DoFHandler<dim,spacedim> &dof,
                              const Quadrature<dim>          &quadrature,
-                             const InVector                 &v,
-                             const unsigned int              component);
+                             const VectorType               &v,
+                             const unsigned int             component);
   //@}
   /**
    * Geometrical interpolation

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6541,13 +6541,13 @@ namespace VectorTools
 
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_difference (const DoFHandler<dim,spacedim> &dof,
-                    const InVector        &fe_function,
-                    const Function<spacedim>   &exact_function,
-                    Vector<double>        &difference,
-                    const Point<spacedim>      &point)
+                    const VectorType               &fe_function,
+                    const Function<spacedim>       &exact_function,
+                    Vector<double>                 &difference,
+                    const Point<spacedim>          &point)
   {
     point_difference(StaticMappingQ1<dim>::mapping,
                      dof,
@@ -6558,16 +6558,16 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_difference (const Mapping<dim, spacedim>    &mapping,
+  point_difference (const Mapping<dim, spacedim>   &mapping,
                     const DoFHandler<dim,spacedim> &dof,
-                    const InVector        &fe_function,
-                    const Function<spacedim>   &exact_function,
-                    Vector<double>        &difference,
-                    const Point<spacedim>      &point)
+                    const VectorType               &fe_function,
+                    const Function<spacedim>       &exact_function,
+                    Vector<double>                 &difference,
+                    const Point<spacedim>          &point)
   {
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     const FiniteElement<dim> &fe = dof.get_fe();
 
     Assert(difference.size() == fe.n_components(),
@@ -6604,12 +6604,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point,
-               Vector<double>        &value)
+               const VectorType               &fe_function,
+               const Point<spacedim>          &point,
+               Vector<double>                 &value)
   {
 
     point_value (StaticMappingQ1<dim,spacedim>::mapping,
@@ -6620,12 +6620,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point,
-               Vector<double>        &value)
+               const VectorType                   &fe_function,
+               const Point<spacedim>              &point,
+               Vector<double>                     &value)
   {
     point_value(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
                 dof,
@@ -6635,11 +6635,11 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point)
+               const VectorType               &fe_function,
+               const Point<spacedim>          &point)
   {
     return point_value (StaticMappingQ1<dim,spacedim>::mapping,
                         dof,
@@ -6648,11 +6648,11 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point)
+               const VectorType                   &fe_function,
+               const Point<spacedim>              &point)
   {
     return point_value(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
                        dof,
@@ -6661,15 +6661,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_value (const Mapping<dim, spacedim>    &mapping,
+  point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point,
-               Vector<double>        &value)
+               const VectorType               &fe_function,
+               const Point<spacedim>          &point,
+               Vector<double>                 &value)
   {
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     const FiniteElement<dim> &fe = dof.get_fe();
 
     Assert(value.size() == fe.n_components(),
@@ -6702,15 +6702,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_value (const hp::MappingCollection<dim, spacedim>    &mapping,
-               const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point,
-               Vector<double>        &value)
+  point_value (const hp::MappingCollection<dim, spacedim> &mapping,
+               const hp::DoFHandler<dim,spacedim>         &dof,
+               const VectorType                           &fe_function,
+               const Point<spacedim>                      &point,
+               Vector<double>                             &value)
   {
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     const hp::FECollection<dim, spacedim> &fe = dof.get_fe();
 
     Assert(value.size() == fe.n_components(),
@@ -6742,12 +6742,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
-  point_value (const Mapping<dim, spacedim>    &mapping,
+  point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point)
+               const VectorType               &fe_function,
+               const Point<spacedim>          &point)
   {
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
@@ -6759,12 +6759,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
-  point_value (const hp::MappingCollection<dim, spacedim>    &mapping,
-               const hp::DoFHandler<dim,spacedim> &dof,
-               const InVector        &fe_function,
-               const Point<spacedim>      &point)
+  point_value (const hp::MappingCollection<dim, spacedim> &mapping,
+               const hp::DoFHandler<dim,spacedim>         &dof,
+               const VectorType                           &fe_function,
+               const Point<spacedim>                      &point)
   {
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
@@ -6777,12 +6777,12 @@ namespace VectorTools
 
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_gradient (const DoFHandler<dim,spacedim>    &dof,
-                  const InVector                    &fe_function,
-                  const Point<spacedim>             &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradients)
+  point_gradient (const DoFHandler<dim,spacedim> &dof,
+                  const VectorType               &fe_function,
+                  const Point<spacedim>          &point,
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &gradients)
   {
 
     point_gradient (StaticMappingQ1<dim,spacedim>::mapping,
@@ -6793,12 +6793,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradients)
+                  const VectorType                   &fe_function,
+                  const Point<spacedim>              &point,
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &gradients)
   {
     point_gradient(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
                    dof,
@@ -6808,11 +6808,11 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point)
+                  const VectorType               &fe_function,
+                  const Point<spacedim>          &point)
   {
     return point_gradient (StaticMappingQ1<dim,spacedim>::mapping,
                            dof,
@@ -6821,11 +6821,11 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point)
+                  const VectorType                   &fe_function,
+                  const Point<spacedim>              &point)
   {
     return point_gradient(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
                           dof,
@@ -6834,13 +6834,13 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_gradient (const Mapping<dim, spacedim>    &mapping,
+  point_gradient (const Mapping<dim, spacedim>   &mapping,
                   const DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradient)
+                  const VectorType               &fe_function,
+                  const Point<spacedim>          &point,
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &gradient)
   {
     const FiniteElement<dim> &fe = dof.get_fe();
 
@@ -6867,7 +6867,7 @@ namespace VectorTools
 
     // then use this to get the gradients of
     // the given fe_function at this point
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     std::vector<std::vector<Tensor<1, dim, Number> > >
     u_gradient(1, std::vector<Tensor<1, dim, Number> > (fe.n_components()));
     fe_values.get_function_gradients(fe_function, u_gradient);
@@ -6876,15 +6876,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   void
-  point_gradient (const hp::MappingCollection<dim, spacedim>    &mapping,
-                  const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point,
-                  std::vector<Tensor<1, spacedim, typename InVector::value_type> > &gradient)
+  point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
+                  const hp::DoFHandler<dim,spacedim>         &dof,
+                  const VectorType                           &fe_function,
+                  const Point<spacedim>                      &point,
+                  std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &gradient)
   {
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     const hp::FECollection<dim, spacedim> &fe = dof.get_fe();
 
     Assert(gradient.size() == fe.n_components(),
@@ -6915,17 +6915,17 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
-  point_gradient (const Mapping<dim, spacedim>    &mapping,
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
+  point_gradient (const Mapping<dim, spacedim>   &mapping,
                   const DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point)
+                  const VectorType               &fe_function,
+                  const Point<spacedim>          &point)
   {
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
-    std::vector<Tensor<1, dim, typename InVector::value_type> > gradient(1);
+    std::vector<Tensor<1, dim, typename VectorType::value_type> > gradient(1);
     point_gradient (mapping, dof, fe_function, point, gradient);
 
     return gradient[0];
@@ -6933,17 +6933,17 @@ namespace VectorTools
 
 
 
-  template <int dim, class InVector, int spacedim>
-  Tensor<1, spacedim, typename InVector::value_type>
-  point_gradient (const hp::MappingCollection<dim, spacedim>    &mapping,
-                  const hp::DoFHandler<dim,spacedim> &dof,
-                  const InVector        &fe_function,
-                  const Point<spacedim>      &point)
+  template <int dim, class VectorType, int spacedim>
+  Tensor<1, spacedim, typename VectorType::value_type>
+  point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
+                  const hp::DoFHandler<dim,spacedim>         &dof,
+                  const VectorType                           &fe_function,
+                  const Point<spacedim>                      &point)
   {
     Assert(dof.get_fe().n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
-    std::vector<Tensor<1, dim, typename InVector::value_type> > gradient(1);
+    std::vector<Tensor<1, dim, typename VectorType::value_type> > gradient(1);
     point_gradient (mapping, dof, fe_function, point, gradient);
 
     return gradient[0];
@@ -7020,15 +7020,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
-  compute_mean_value (const Mapping<dim, spacedim>    &mapping,
+  compute_mean_value (const Mapping<dim, spacedim>   &mapping,
                       const DoFHandler<dim,spacedim> &dof,
-                      const Quadrature<dim> &quadrature,
-                      const InVector        &v,
-                      const unsigned int     component)
+                      const Quadrature<dim>          &quadrature,
+                      const VectorType               &v,
+                      const unsigned int             component)
   {
-    typedef typename InVector::value_type Number;
+    typedef typename VectorType::value_type Number;
     Assert (v.size() == dof.n_dofs(),
             ExcDimensionMismatch (v.size(), dof.n_dofs()));
     Assert (component < dof.get_fe().n_components(),
@@ -7087,20 +7087,20 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, int spacedim>
+  template <int dim, class VectorType, int spacedim>
   double
   compute_mean_value (const DoFHandler<dim,spacedim> &dof,
-                      const Quadrature<dim> &quadrature,
-                      const InVector        &v,
-                      const unsigned int     component)
+                      const Quadrature<dim>          &quadrature,
+                      const VectorType               &v,
+                      const unsigned int             component)
   {
     return compute_mean_value(StaticMappingQ1<dim,spacedim>::mapping, dof, quadrature, v, component);
   }
 
 
   template<class DH, class VECTOR>
-  void get_position_vector(const DH &dh,
-                           VECTOR &vector,
+  void get_position_vector(const DH            &dh,
+                           VECTOR              &vector,
                            const ComponentMask &mask)
   {
     AssertDimension(vector.size(), dh.n_dofs());

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -623,7 +623,7 @@ namespace VectorTools
     Assert(u2.size()==dof2.n_dofs(),
            ExcDimensionMismatch(u2.size(),dof2.n_dofs()));
 
-    dealii::Vector<typename Vector::value_type> cache;
+    Vector<typename VectorType::value_type> cache;
 
     // Looping over the finest common
     // mesh, this means that source and
@@ -780,7 +780,7 @@ namespace VectorTools
         constraints_and_b_v_are_compatible(constraints, boundary_values);
 
       // set up mass matrix and right hand side
-      dealii::Vector<double> vec (dof.n_dofs());
+      Vector<double> vec (dof.n_dofs());
       SparsityPattern sparsity;
       {
         DynamicSparsityPattern dsp (dof.n_dofs(), dof.n_dofs());
@@ -790,7 +790,7 @@ namespace VectorTools
         sparsity.copy_from (dsp);
       }
       SparseMatrix<double> mass_matrix (sparsity);
-      dealii::Vector<double> tmp (mass_matrix.n());
+      Vector<double> tmp (mass_matrix.n());
 
       // If the constraint matrix does not conflict with the given boundary
       // values (i.e., it either does not contain boundary values or it contains
@@ -1721,7 +1721,7 @@ namespace VectorTools
               // of the number of
               // components of the
               // function
-              dealii::Vector<double> function_values (fe.n_components());
+              Vector<double> function_values (fe.n_components());
               if (fe.n_components() == 1)
                 function_values(0)
                   = boundary_function.value (cell->vertex(direction));
@@ -1793,7 +1793,7 @@ namespace VectorTools
       // points. have two arrays for scalar and vector functions to use the
       // more efficient one respectively
       std::vector<double>          dof_values_scalar;
-      std::vector<dealii::Vector<double> > dof_values_system;
+      std::vector<Vector<double> > dof_values_system;
       dof_values_scalar.reserve (DoFTools::max_dofs_per_face (dof));
       dof_values_system.reserve (DoFTools::max_dofs_per_face (dof));
 
@@ -1906,7 +1906,7 @@ namespace VectorTools
                       // allocating temporary if possible
                       if (dof_values_system.size() < fe.dofs_per_face)
                         dof_values_system.resize (fe.dofs_per_face,
-                                                  dealii::Vector<double>(fe.n_components()));
+                                                  Vector<double>(fe.n_components()));
                       else
                         dof_values_system.resize (fe.dofs_per_face);
 
@@ -6028,17 +6028,17 @@ namespace VectorTools
       void resize_vectors (const unsigned int n_q_points,
                            const unsigned int n_components);
 
-      std::vector<dealii::Vector<Number> > function_values;
+      std::vector<Vector<Number> > function_values;
       std::vector<std::vector<Tensor<1,spacedim,Number> > > function_grads;
       std::vector<double> weight_values;
-      std::vector<dealii::Vector<double> > weight_vectors;
+      std::vector<Vector<double> > weight_vectors;
 
-      std::vector<dealii::Vector<Number> > psi_values;
+      std::vector<Vector<Number> > psi_values;
       std::vector<std::vector<Tensor<1,spacedim,Number> > > psi_grads;
       std::vector<Number> psi_scalar;
 
       std::vector<double>         tmp_values;
-      std::vector<dealii::Vector<double> > tmp_vector_values;
+      std::vector<Vector<double> > tmp_vector_values;
       std::vector<Tensor<1,spacedim> > tmp_gradients;
       std::vector<std::vector<Tensor<1,spacedim> > > tmp_vector_gradients;
 
@@ -6071,23 +6071,23 @@ namespace VectorTools
                                                         const unsigned int n_components)
     {
       function_values.resize (n_q_points,
-                              dealii::Vector<Number>(n_components));
+                              Vector<Number>(n_components));
       function_grads.resize (n_q_points,
                              std::vector<Tensor<1,spacedim,Number> >(n_components));
 
       weight_values.resize (n_q_points);
       weight_vectors.resize (n_q_points,
-                             dealii::Vector<double>(n_components));
+                             Vector<double>(n_components));
 
       psi_values.resize (n_q_points,
-                         dealii::Vector<Number>(n_components));
+                         Vector<Number>(n_components));
       psi_grads.resize (n_q_points,
                         std::vector<Tensor<1,spacedim,Number> >(n_components));
       psi_scalar.resize (n_q_points);
 
       tmp_values.resize (n_q_points);
       tmp_vector_values.resize (n_q_points,
-                                dealii::Vector<double>(n_components));
+                                Vector<double>(n_components));
       tmp_gradients.resize (n_q_points);
       tmp_vector_gradients.resize (n_q_points,
                                    std::vector<Tensor<1,spacedim> >(n_components));

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -543,12 +543,12 @@ namespace VectorTools
 
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class Vector>
+            class VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
-                                 const Vector            &u1,
+                                 const VectorType        &u1,
                                  const DH<dim, spacedim> &dof2,
-                                 Vector                  &u2)
+                                 VectorType              &u2)
   {
     Assert(GridTools::have_same_coarse_mesh(dof1, dof2),
            ExcMessage ("The two containers must represent triangulations that "
@@ -567,13 +567,13 @@ namespace VectorTools
 
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class Vector>
+            class VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
-                                 const Vector            &u1,
+                                 const VectorType        &u1,
                                  const DH<dim, spacedim> &dof2,
                                  const ConstraintMatrix  &constraints,
-                                 Vector                  &u2)
+                                 VectorType              &u2)
   {
     Assert(GridTools::have_same_coarse_mesh(dof1, dof2),
            ExcMessage ("The two containers must represent triangulations that "
@@ -607,12 +607,12 @@ namespace VectorTools
 
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class Vector>
+            class VectorType>
   void
   interpolate_to_different_mesh (const InterGridMap<DH<dim, spacedim> > &intergridmap,
-                                 const Vector                           &u1,
+                                 const VectorType                       &u1,
                                  const ConstraintMatrix                 &constraints,
-                                 Vector                                 &u2)
+                                 VectorType                             &u2)
   {
     const DH<dim, spacedim> &dof1 = intergridmap.get_source_grid();
     const DH<dim, spacedim> &dof2 = intergridmap.get_destination_grid();
@@ -750,7 +750,7 @@ namespace VectorTools
      * Generic implementation of the project() function
      */
     template <int dim, int spacedim,
-              class Vector,
+              class VectorType,
               template <int,int> class DH,
               template <int,int> class M_or_MC,
               template <int> class Q_or_QC>
@@ -759,7 +759,7 @@ namespace VectorTools
                      const ConstraintMatrix   &constraints,
                      const Q_or_QC<dim>       &quadrature,
                      const Function<spacedim> &function,
-                     Vector                   &vec_result,
+                     VectorType               &vec_result,
                      const bool                enforce_zero_boundary,
                      const Q_or_QC<dim-1>  &q_boundary,
                      const bool                project_to_boundary_first)

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -149,11 +149,11 @@ namespace
    * or not), extract those that pertain to
    * locally owned cells.
    */
-  template <int dim, int spacedim, class Vector>
+  template <int dim, int spacedim, typename VectorType>
   void
   get_locally_owned_indicators (const parallel::distributed::Triangulation<dim,spacedim> &tria,
-                                const Vector &criteria,
-                                dealii::Vector<typename Vector::value_type> &locally_owned_indicators)
+                                const VectorType &criteria,
+                                dealii::Vector<typename VectorType::value_type> &locally_owned_indicators)
   {
     Assert (locally_owned_indicators.size() == tria.n_locally_owned_active_cells(),
             ExcInternalError());
@@ -222,12 +222,12 @@ namespace
    * locally own as appropriate for
    * coarsening or refinement.
    */
-  template <int dim, int spacedim, class Vector>
+  template <int dim, int spacedim, typename VectorType>
   void
   mark_cells (parallel::distributed::Triangulation<dim,spacedim> &tria,
-              const Vector &criteria,
-              const double top_threshold,
-              const double bottom_threshold)
+              const VectorType                                   &criteria,
+              const double                                        top_threshold,
+              const double                                        bottom_threshold)
   {
     dealii::GridRefinement::refine (tria, criteria, top_threshold);
     dealii::GridRefinement::coarsen (tria, criteria, bottom_threshold);
@@ -451,14 +451,14 @@ namespace parallel
   {
     namespace GridRefinement
     {
-      template <int dim, class Vector, int spacedim>
+      template <int dim, typename VectorType, int spacedim>
       void
-      refine_and_coarsen_fixed_number (
-        parallel::distributed::Triangulation<dim,spacedim> &tria,
-        const Vector                &criteria,
-        const double                 top_fraction_of_cells,
-        const double                 bottom_fraction_of_cells,
-        const unsigned int           max_n_cells)
+      refine_and_coarsen_fixed_number
+      (parallel::distributed::Triangulation<dim,spacedim> &tria,
+       const VectorType                                   &criteria,
+       const double                                        top_fraction_of_cells,
+       const double                                        bottom_fraction_of_cells,
+       const unsigned int                                  max_n_cells)
       {
         Assert (criteria.size() == tria.n_active_cells(),
                 ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
@@ -482,7 +482,7 @@ namespace parallel
         // vector of indicators the
         // ones that correspond to
         // cells that we locally own
-        dealii::Vector<typename Vector::value_type>
+        dealii::Vector<typename VectorType::value_type>
         locally_owned_indicators (tria.n_locally_owned_active_cells());
         get_locally_owned_indicators (tria,
                                       criteria,
@@ -496,7 +496,7 @@ namespace parallel
         // need it here, but it's a
         // collective communication
         // call
-        const std::pair<typename Vector::value_type,typename Vector::value_type> global_min_and_max
+        const std::pair<typename VectorType::value_type,typename VectorType::value_type> global_min_and_max
           = compute_global_min_and_max_at_root (locally_owned_indicators,
                                                 mpi_communicator);
 
@@ -538,13 +538,13 @@ namespace parallel
       }
 
 
-      template <int dim, class Vector, int spacedim>
+      template <int dim, typename VectorType, int spacedim>
       void
-      refine_and_coarsen_fixed_fraction (
-        parallel::distributed::Triangulation<dim,spacedim> &tria,
-        const Vector                &criteria,
-        const double                top_fraction_of_error,
-        const double                bottom_fraction_of_error)
+      refine_and_coarsen_fixed_fraction
+      (parallel::distributed::Triangulation<dim,spacedim> &tria,
+       const VectorType                                   &criteria,
+       const double                                        top_fraction_of_error,
+       const double                                        bottom_fraction_of_error)
       {
         Assert (criteria.size() == tria.n_active_cells(),
                 ExcDimensionMismatch (criteria.size(), tria.n_active_cells()));
@@ -561,7 +561,7 @@ namespace parallel
         // vector of indicators the
         // ones that correspond to
         // cells that we locally own
-        dealii::Vector<typename Vector::value_type>
+        dealii::Vector<typename VectorType::value_type>
         locally_owned_indicators (tria.n_locally_owned_active_cells());
         get_locally_owned_indicators (tria,
                                       criteria,

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -153,7 +153,7 @@ namespace
   void
   get_locally_owned_indicators (const parallel::distributed::Triangulation<dim,spacedim> &tria,
                                 const VectorType &criteria,
-                                dealii::Vector<typename VectorType::value_type> &locally_owned_indicators)
+                                Vector<typename VectorType::value_type> &locally_owned_indicators)
   {
     Assert (locally_owned_indicators.size() == tria.n_locally_owned_active_cells(),
             ExcInternalError());
@@ -482,7 +482,7 @@ namespace parallel
         // vector of indicators the
         // ones that correspond to
         // cells that we locally own
-        dealii::Vector<typename VectorType::value_type>
+        Vector<typename VectorType::value_type>
         locally_owned_indicators (tria.n_locally_owned_active_cells());
         get_locally_owned_indicators (tria,
                                       criteria,
@@ -561,7 +561,7 @@ namespace parallel
         // vector of indicators the
         // ones that correspond to
         // cells that we locally own
-        dealii::Vector<typename VectorType::value_type>
+        Vector<typename VectorType::value_type>
         locally_owned_indicators (tria.n_locally_owned_active_cells());
         get_locally_owned_indicators (tria,
                                       criteria,

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -50,13 +50,13 @@ DEAL_II_NAMESPACE_OPEN
 namespace DoFTools
 {
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_sparsity_pattern (const DH               &dof,
-                         SparsityPattern        &sparsity,
-                         const ConstraintMatrix &constraints,
-                         const bool              keep_constrained_dofs,
-                         const types::subdomain_id subdomain_id)
+  make_sparsity_pattern (const DH                  &dof,
+                         SP                        &sparsity,
+                         const ConstraintMatrix    &constraints,
+                         const bool                 keep_constrained_dofs,
+                         const types::subdomain_id  subdomain_id)
   {
     const types::global_dof_index n_dofs = dof.n_dofs();
     (void)n_dofs;
@@ -109,14 +109,14 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_sparsity_pattern (const DH                &dof,
-                         const Table<2,Coupling> &couplings,
-                         SparsityPattern         &sparsity,
-                         const ConstraintMatrix  &constraints,
-                         const bool               keep_constrained_dofs,
-                         const types::subdomain_id subdomain_id)
+  make_sparsity_pattern (const DH                  &dof,
+                         const Table<2,Coupling>   &couplings,
+                         SP                        &sparsity,
+                         const ConstraintMatrix    &constraints,
+                         const bool                 keep_constrained_dofs,
+                         const types::subdomain_id  subdomain_id)
   {
     const types::global_dof_index n_dofs = dof.n_dofs();
     (void)n_dofs;
@@ -224,12 +224,11 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_sparsity_pattern (
-    const DH        &dof_row,
-    const DH        &dof_col,
-    SparsityPattern &sparsity)
+  make_sparsity_pattern (const DH &dof_row,
+                         const DH &dof_col,
+                         SP       &sparsity)
   {
     const types::global_dof_index n_dofs_row = dof_row.n_dofs();
     const types::global_dof_index n_dofs_col = dof_col.n_dofs();
@@ -328,12 +327,12 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_boundary_sparsity_pattern (
-    const DH                        &dof,
-    const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-    SparsityPattern                 &sparsity)
+  make_boundary_sparsity_pattern
+  (const DH                                   &dof,
+   const std::vector<types::global_dof_index> &dof_to_boundary_mapping,
+   SP                                         &sparsity)
   {
     if (DH::dimension == 1)
       {
@@ -342,10 +341,10 @@ namespace DoFTools
         typename DH::FunctionMap boundary_ids;
         boundary_ids[0] = 0;
         boundary_ids[1] = 0;
-        make_boundary_sparsity_pattern<DH, SparsityPattern> (dof,
-                                                             boundary_ids,
-                                                             dof_to_boundary_mapping,
-                                                             sparsity);
+        make_boundary_sparsity_pattern<DH, SP> (dof,
+                                                boundary_ids,
+                                                dof_to_boundary_mapping,
+                                                sparsity);
         return;
       }
 
@@ -397,12 +396,12 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
-  void make_boundary_sparsity_pattern (
-    const DH                                        &dof,
-    const typename FunctionMap<DH::space_dimension>::type &boundary_ids,
-    const std::vector<types::global_dof_index>                 &dof_to_boundary_mapping,
-    SparsityPattern                                 &sparsity)
+  template <class DH, class SP>
+  void make_boundary_sparsity_pattern
+  (const DH                                              &dof,
+   const typename FunctionMap<DH::space_dimension>::type &boundary_ids,
+   const std::vector<types::global_dof_index>            &dof_to_boundary_mapping,
+   SP                                                    &sparsity)
   {
     if (DH::dimension == 1)
       {
@@ -485,13 +484,13 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_flux_sparsity_pattern (const DH                  &dof,
-                              SparsityPattern           &sparsity,
+                              SP                        &sparsity,
                               const ConstraintMatrix    &constraints,
-                              const bool                keep_constrained_dofs,
-                              const types::subdomain_id subdomain_id)
+                              const bool                 keep_constrained_dofs,
+                              const types::subdomain_id  subdomain_id)
 
   // TODO: QA: reduce the indentation level of this method..., Maier 2012
 
@@ -635,10 +634,10 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
-  make_flux_sparsity_pattern (const DH        &dof,
-                              SparsityPattern &sparsity)
+  make_flux_sparsity_pattern (const DH &dof,
+                              SP       &sparsity)
   {
     ConstraintMatrix constraints;
     make_flux_sparsity_pattern (dof, sparsity, constraints);
@@ -711,10 +710,10 @@ namespace DoFTools
 
       // implementation of the same function in namespace DoFTools for
       // non-hp DoFHandlers
-      template <class DH, class SparsityPattern>
+      template <class DH, class SP>
       void
       make_flux_sparsity_pattern (const DH                &dof,
-                                  SparsityPattern         &sparsity,
+                                  SP                      &sparsity,
                                   const Table<2,Coupling> &int_mask,
                                   const Table<2,Coupling> &flux_mask)
       {
@@ -943,12 +942,12 @@ namespace DoFTools
 
       // implementation of the same function in namespace DoFTools for
       // non-hp DoFHandlers
-      template <int dim, int spacedim, class SparsityPattern>
+      template <int dim, int spacedim, class SP>
       void
       make_flux_sparsity_pattern (const dealii::hp::DoFHandler<dim,spacedim> &dof,
-                                  SparsityPattern                           &sparsity,
-                                  const Table<2,Coupling> &int_mask,
-                                  const Table<2,Coupling> &flux_mask)
+                                  SP                                         &sparsity,
+                                  const Table<2,Coupling>                    &int_mask,
+                                  const Table<2,Coupling>                    &flux_mask)
       {
         // while the implementation above is quite optimized and caches a
         // lot of data (see e.g. the int/flux_dof_mask tables), this is no
@@ -1132,10 +1131,10 @@ namespace DoFTools
 
 
 
-  template <class DH, class SparsityPattern>
+  template <class DH, class SP>
   void
   make_flux_sparsity_pattern (const DH                &dof,
-                              SparsityPattern         &sparsity,
+                              SP                      &sparsity,
                               const Table<2,Coupling> &int_mask,
                               const Table<2,Coupling> &flux_mask)
   {

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -385,7 +385,7 @@ GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tr
 
   if (refine_cells || coarsen_cells)
     {
-      dealii::Vector<typename VectorType::value_type> tmp (criteria);
+      Vector<typename VectorType::value_type> tmp (criteria);
       if (refine_cells)
         {
           std::nth_element (tmp.begin(), tmp.begin()+refine_cells,
@@ -426,7 +426,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   // error, which is what we have to sum
   // up and compare with
   // @p{fraction_of_error*total_error}.
-  dealii::Vector<typename VectorType::value_type> tmp;
+  Vector<typename VectorType::value_type> tmp;
   tmp = criteria;
   const double total_error = tmp.l1_norm();
 
@@ -435,7 +435,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   std::sort (tmp.begin(), tmp.end(), std::greater<double>());
 
   // compute thresholds
-  typename dealii::Vector<typename VectorType::value_type>::const_iterator
+  typename Vector<typename VectorType::value_type>::const_iterator
   pp=tmp.begin();
   for (double sum=0;
        (sum<top_fraction*total_error) && (pp!=(tmp.end()-1));
@@ -444,7 +444,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   double top_threshold = ( pp != tmp.begin () ?
                            (*pp+*(pp-1))/2 :
                            *pp );
-  typename dealii::Vector<typename VectorType::value_type>::const_iterator
+  typename Vector<typename VectorType::value_type>::const_iterator
   qq=(tmp.end()-1);
   for (double sum=0;
        (sum<bottom_fraction*total_error) && (qq!=tmp.begin());

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -118,30 +118,30 @@ namespace
   } /* namespace internal */
 
 
-  template <typename Vector>
-  typename constraint_and_return_value<!IsBlockVector<Vector>::value,
-           typename Vector::value_type>::type
-           min_element (const Vector &criteria)
+  template <typename VectorType>
+  typename constraint_and_return_value<!IsBlockVector<VectorType>::value,
+           typename VectorType::value_type>::type
+           min_element (const VectorType &criteria)
   {
     return internal::min_element (criteria);
   }
 
 
-  template <typename Vector>
-  typename constraint_and_return_value<!IsBlockVector<Vector>::value,
-           typename Vector::value_type>::type
-           max_element (const Vector &criteria)
+  template <typename VectorType>
+  typename constraint_and_return_value<!IsBlockVector<VectorType>::value,
+           typename VectorType::value_type>::type
+           max_element (const VectorType &criteria)
   {
     return internal::max_element (criteria);
   }
 
 
-  template <typename Vector>
-  typename constraint_and_return_value<IsBlockVector<Vector>::value,
-           typename Vector::value_type>::type
-           min_element (const Vector &criteria)
+  template <typename VectorType>
+  typename constraint_and_return_value<IsBlockVector<VectorType>::value,
+           typename VectorType::value_type>::type
+           min_element (const VectorType &criteria)
   {
-    typename Vector::value_type t = internal::min_element(criteria.block(0));
+    typename VectorType::value_type t = internal::min_element(criteria.block(0));
     for (unsigned int b=1; b<criteria.n_blocks(); ++b)
       t = std::min (t, internal::min_element(criteria.block(b)));
 
@@ -149,12 +149,12 @@ namespace
   }
 
 
-  template <typename Vector>
-  typename constraint_and_return_value<IsBlockVector<Vector>::value,
-           typename Vector::value_type>::type
-           max_element (const Vector &criteria)
+  template <typename VectorType>
+  typename constraint_and_return_value<IsBlockVector<VectorType>::value,
+           typename VectorType::value_type>::type
+           max_element (const VectorType &criteria)
   {
-    typename Vector::value_type t = internal::max_element(criteria.block(0));
+    typename VectorType::value_type t = internal::max_element(criteria.block(0));
     for (unsigned int b=1; b<criteria.n_blocks(); ++b)
       t = std::max (t, internal::max_element(criteria.block(b)));
 
@@ -172,14 +172,14 @@ namespace
    * library version and is needed in @p refine_and_coarsen_optimize.
    */
 
-  template <class Vector>
-  void qsort_index (const Vector              &a,
+  template <class VectorType>
+  void qsort_index (const VectorType          &a,
                     std::vector<unsigned int> &ind,
                     int                        l,
                     int                        r)
   {
     int i,j;
-    typename Vector::value_type v;
+    typename VectorType::value_type v;
 
     if (r<=l)
       return;
@@ -214,9 +214,9 @@ namespace
 
 
 
-template <int dim, class Vector, int spacedim>
+template <int dim, class VectorType, int spacedim>
 void GridRefinement::refine (Triangulation<dim,spacedim> &tria,
-                             const Vector       &criteria,
+                             const VectorType   &criteria,
                              const double        threshold,
                              const unsigned int max_to_mark)
 {
@@ -261,10 +261,10 @@ void GridRefinement::refine (Triangulation<dim,spacedim> &tria,
 
 
 
-template <int dim, class Vector, int spacedim>
+template <int dim, class VectorType, int spacedim>
 void GridRefinement::coarsen (Triangulation<dim,spacedim> &tria,
-                              const Vector       &criteria,
-                              const double        threshold)
+                              const VectorType            &criteria,
+                              const double                 threshold)
 {
   Assert (criteria.size() == tria.n_active_cells(),
           ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));
@@ -359,13 +359,13 @@ GridRefinement::adjust_refine_and_coarsen_number_fraction (const unsigned int  c
   return (adjusted_fractions);
 }
 
-template <int dim, class Vector, int spacedim>
+template <int dim, class VectorType, int spacedim>
 void
 GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tria,
-                                                 const Vector       &criteria,
-                                                 const double        top_fraction,
-                                                 const double        bottom_fraction,
-                                                 const unsigned int  max_n_cells)
+                                                 const VectorType            &criteria,
+                                                 const double                 top_fraction,
+                                                 const double                 bottom_fraction,
+                                                 const unsigned int           max_n_cells)
 {
   // correct number of cells is
   // checked in @p{refine}
@@ -385,7 +385,7 @@ GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tr
 
   if (refine_cells || coarsen_cells)
     {
-      dealii::Vector<typename Vector::value_type> tmp (criteria);
+      dealii::Vector<typename VectorType::value_type> tmp (criteria);
       if (refine_cells)
         {
           std::nth_element (tmp.begin(), tmp.begin()+refine_cells,
@@ -407,10 +407,10 @@ GridRefinement::refine_and_coarsen_fixed_number (Triangulation<dim,spacedim> &tr
 
 
 
-template <int dim, class Vector, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 void
 GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &tria,
-                                                   const Vector       &criteria,
+                                                   const VectorType   &criteria,
                                                    const double        top_fraction,
                                                    const double        bottom_fraction,
                                                    const unsigned int  max_n_cells)
@@ -426,7 +426,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   // error, which is what we have to sum
   // up and compare with
   // @p{fraction_of_error*total_error}.
-  dealii::Vector<typename Vector::value_type> tmp;
+  dealii::Vector<typename VectorType::value_type> tmp;
   tmp = criteria;
   const double total_error = tmp.l1_norm();
 
@@ -435,7 +435,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   std::sort (tmp.begin(), tmp.end(), std::greater<double>());
 
   // compute thresholds
-  typename dealii::Vector<typename Vector::value_type>::const_iterator
+  typename dealii::Vector<typename VectorType::value_type>::const_iterator
   pp=tmp.begin();
   for (double sum=0;
        (sum<top_fraction*total_error) && (pp!=(tmp.end()-1));
@@ -444,7 +444,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
   double top_threshold = ( pp != tmp.begin () ?
                            (*pp+*(pp-1))/2 :
                            *pp );
-  typename dealii::Vector<typename Vector::value_type>::const_iterator
+  typename dealii::Vector<typename VectorType::value_type>::const_iterator
   qq=(tmp.end()-1);
   for (double sum=0;
        (sum<bottom_fraction*total_error) && (qq!=tmp.begin());
@@ -537,11 +537,11 @@ GridRefinement::refine_and_coarsen_fixed_fraction (Triangulation<dim,spacedim> &
 
 
 
-template <int dim, class Vector, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 void
 GridRefinement::refine_and_coarsen_optimize (Triangulation<dim,spacedim> &tria,
-                                             const Vector       &criteria,
-                                             const unsigned int  order)
+                                             const VectorType            &criteria,
+                                             const unsigned int           order)
 {
   Assert (criteria.size() == tria.n_active_cells(),
           ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));
@@ -586,4 +586,3 @@ GridRefinement::refine_and_coarsen_optimize (Triangulation<dim,spacedim> &tria,
 #include "grid_refinement.inst"
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -25,12 +25,12 @@ namespace internal
   {
 // -------------------------- FEValuesBase -------------------------
 
-    template <int dim, int q_dim, class FEValues>
-    FEValuesBase<dim,q_dim,FEValues>::
-    FEValuesBase (const dealii::hp::MappingCollection<dim,FEValues::space_dimension> &mapping_collection,
-                  const dealii::hp::FECollection<dim,FEValues::space_dimension>      &fe_collection,
-                  const dealii::hp::QCollection<q_dim>     &q_collection,
-                  const UpdateFlags                   update_flags)
+    template <int dim, int q_dim, class FEValuesType>
+    FEValuesBase<dim,q_dim,FEValuesType>::FEValuesBase
+    (const dealii::hp::MappingCollection<dim,FEValuesType::space_dimension> &mapping_collection,
+     const dealii::hp::FECollection<dim,FEValuesType::space_dimension>      &fe_collection,
+     const dealii::hp::QCollection<q_dim>                                   &q_collection,
+     const UpdateFlags                                                       update_flags)
       :
       fe_collection (&fe_collection),
       mapping_collection (&mapping_collection),
@@ -45,14 +45,14 @@ namespace internal
     {}
 
 
-    template <int dim, int q_dim, class FEValues>
-    FEValuesBase<dim,q_dim,FEValues>::
-    FEValuesBase (const dealii::hp::FECollection<dim,FEValues::space_dimension>      &fe_collection,
-                  const dealii::hp::QCollection<q_dim> &q_collection,
-                  const UpdateFlags         update_flags)
+    template <int dim, int q_dim, class FEValuesType>
+    FEValuesBase<dim,q_dim,FEValuesType>::FEValuesBase
+    (const dealii::hp::FECollection<dim,FEValuesType::space_dimension> &fe_collection,
+     const dealii::hp::QCollection<q_dim>                              &q_collection,
+     const UpdateFlags                                                  update_flags)
       :
       fe_collection (&fe_collection),
-      mapping_collection (&dealii::hp::StaticMappingQ1<dim,FEValues::space_dimension>::
+      mapping_collection (&dealii::hp::StaticMappingQ1<dim,FEValuesType::space_dimension>::
                           mapping_collection),
       q_collection (q_collection),
       fe_values_table (fe_collection.size(),
@@ -66,12 +66,12 @@ namespace internal
 
 
 
-    template <int dim, int q_dim, class FEValues>
-    FEValues &
-    FEValuesBase<dim,q_dim,FEValues>::
-    select_fe_values (const unsigned int fe_index,
-                      const unsigned int mapping_index,
-                      const unsigned int q_index)
+    template <int dim, int q_dim, class FEValuesType>
+    FEValuesType &
+    FEValuesBase<dim,q_dim,FEValuesType>::select_fe_values
+    (const unsigned int fe_index,
+     const unsigned int mapping_index,
+     const unsigned int q_index)
     {
       Assert (fe_index < fe_collection->size(),
               ExcIndexRange (fe_index, 0, fe_collection->size()));
@@ -94,11 +94,11 @@ namespace internal
       if (fe_values_table(present_fe_values_index).get() == 0)
         fe_values_table(present_fe_values_index)
           =
-            std_cxx11::shared_ptr<FEValues>
-            (new FEValues ((*mapping_collection)[mapping_index],
-                           (*fe_collection)[fe_index],
-                           q_collection[q_index],
-                           update_flags));
+            std_cxx11::shared_ptr<FEValuesType>
+            (new FEValuesType ((*mapping_collection)[mapping_index],
+                               (*fe_collection)[fe_index],
+                               q_collection[q_index],
+                               update_flags));
 
       // now there definitely is one!
       return *fe_values_table(present_fe_values_index);

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -535,11 +535,10 @@ namespace MGTools
 
 
 
-  template <class DH, class SparsityPattern>
-  void make_sparsity_pattern (
-    const DH &dof,
-    SparsityPattern         &sparsity,
-    const unsigned int       level)
+  template <class DH, class SP>
+  void make_sparsity_pattern (const DH           &dof,
+                              SP                 &sparsity,
+                              const unsigned int  level)
   {
     const types::global_dof_index n_dofs = dof.n_dofs(level);
     (void)n_dofs;
@@ -568,12 +567,11 @@ namespace MGTools
 
 
 
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern (
-    const DoFHandler<dim,spacedim> &dof,
-    SparsityPattern       &sparsity,
-    const unsigned int level)
+  make_flux_sparsity_pattern (const DoFHandler<dim,spacedim> &dof,
+                              SP                             &sparsity,
+                              const unsigned int              level)
   {
     const types::global_dof_index n_dofs = dof.n_dofs(level);
     (void)n_dofs;
@@ -637,12 +635,11 @@ namespace MGTools
 
 
 
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern_edge (
-    const DoFHandler<dim,spacedim> &dof,
-    SparsityPattern       &sparsity,
-    const unsigned int level)
+  make_flux_sparsity_pattern_edge (const DoFHandler<dim,spacedim> &dof,
+                                   SP                             &sparsity,
+                                   const unsigned int              level)
   {
     Assert ((level>=1) && (level<dof.get_tria().n_global_levels()),
             ExcIndexRange(level, 1, dof.get_tria().n_global_levels()));
@@ -700,14 +697,13 @@ namespace MGTools
 
 
 
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern (
-    const DoFHandler<dim,spacedim> &dof,
-    SparsityPattern       &sparsity,
-    const unsigned int level,
-    const Table<2,DoFTools::Coupling> &int_mask,
-    const Table<2,DoFTools::Coupling> &flux_mask)
+  make_flux_sparsity_pattern (const DoFHandler<dim,spacedim>    &dof,
+                              SP                                &sparsity,
+                              const unsigned int                 level,
+                              const Table<2,DoFTools::Coupling> &int_mask,
+                              const Table<2,DoFTools::Coupling> &flux_mask)
   {
     const FiniteElement<dim> &fe = dof.get_fe();
     const types::global_dof_index n_dofs = dof.n_dofs(level);
@@ -881,13 +877,12 @@ namespace MGTools
 
 
 
-  template <int dim, class SparsityPattern, int spacedim>
+  template <int dim, class SP, int spacedim>
   void
-  make_flux_sparsity_pattern_edge (
-    const DoFHandler<dim,spacedim> &dof,
-    SparsityPattern       &sparsity,
-    const unsigned int level,
-    const Table<2,DoFTools::Coupling> &flux_mask)
+  make_flux_sparsity_pattern_edge (const DoFHandler<dim,spacedim>    &dof,
+                                   SP                                &sparsity,
+                                   const unsigned int                 level,
+                                   const Table<2,DoFTools::Coupling> &flux_mask)
   {
     const FiniteElement<dim> &fe = dof.get_fe();
     const unsigned int n_comp = fe.n_components();

--- a/tests/gla/extract_subvector_to.cc
+++ b/tests/gla/extract_subvector_to.cc
@@ -29,8 +29,8 @@
 #include <vector>
 
 
-template <class Vector>
-void test (Vector &vector)
+template <typename VectorType>
+void test (VectorType &vector)
 {
   const unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
@@ -38,19 +38,19 @@ void test (Vector &vector)
     vector(i) = i;
 
   // select every other element
-  std::vector<typename Vector::size_type> indices;
+  std::vector<typename VectorType::size_type> indices;
   for (unsigned int j=0; j<vector.size()/2; ++j)
     indices.push_back (2*j);
 
   // do the extraction with the function that takes indices, then
   // assert correctness
-  std::vector<typename Vector::value_type> values1 (indices.size());
+  std::vector<typename VectorType::value_type> values1 (indices.size());
   vector.extract_subvector_to (indices, values1);
   for (unsigned int j=0; j<vector.size()/2; ++j)
     AssertThrow (values1[j] == 2*j, ExcInternalError());
 
   // do the same with the version of the function that takes iterators
-  std::vector<typename Vector::value_type> values2 (indices.size());
+  std::vector<typename VectorType::value_type> values2 (indices.size());
   vector.extract_subvector_to (indices.begin(),
                                indices.end(),
                                values2.begin());

--- a/tests/gla/extract_subvector_to_parallel.cc
+++ b/tests/gla/extract_subvector_to_parallel.cc
@@ -28,8 +28,8 @@
 #include <vector>
 
 
-template <class Vector>
-void set (Vector &vector)
+template <typename VectorType>
+void set (VectorType &vector)
 {
   for (unsigned int i=0; i<vector.size(); ++i)
     if (vector.locally_owned_elements().is_element(i))
@@ -38,25 +38,25 @@ void set (Vector &vector)
 }
 
 
-template <class Vector>
-void test (Vector &vector)
+template <typename VectorType>
+void test (VectorType &vector)
 {
   const unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   // select every other element
-  std::vector<typename Vector::size_type> indices;
+  std::vector<typename VectorType::size_type> indices;
   for (unsigned int j=0; j<vector.size()/2; ++j)
     indices.push_back (2*j);
 
   // do the extraction with the function that takes indices, then
   // assert correctness
-  std::vector<typename Vector::value_type> values1 (indices.size());
+  std::vector<typename VectorType::value_type> values1 (indices.size());
   vector.extract_subvector_to (indices, values1);
   for (unsigned int j=0; j<vector.size()/2; ++j)
     AssertThrow (values1[j] == 2*j, ExcInternalError());
 
   // do the same with the version of the function that takes iterators
-  std::vector<typename Vector::value_type> values2 (indices.size());
+  std::vector<typename VectorType::value_type> values2 (indices.size());
   vector.extract_subvector_to (indices.begin(),
                                indices.end(),
                                values2.begin());

--- a/tests/lac/block_matrices_04.cc
+++ b/tests/lac/block_matrices_04.cc
@@ -54,7 +54,7 @@
 #include <fstream>
 
 
-template <class Vector, class Matrix, class Sparsity>
+template <typename VectorType, class Matrix, class Sparsity>
 class LaplaceProblem
 {
 public:
@@ -64,7 +64,7 @@ public:
   void reinit_sparsity ();
   void reinit_vectors ();
 
-  Vector       solution;
+  VectorType solution;
 
 private:
   void make_grid_and_dofs ();
@@ -73,19 +73,19 @@ private:
 
   const unsigned int n_blocks;
 
-  Triangulation<2>     triangulation;
-  FE_Q<2>              fe;
-  DoFHandler<2>        dof_handler;
+  Triangulation<2>   triangulation;
+  FE_Q<2>            fe;
+  DoFHandler<2>      dof_handler;
 
-  Sparsity      sparsity_pattern;
-  Matrix        system_matrix;
+  Sparsity           sparsity_pattern;
+  Matrix             system_matrix;
 
-  Vector       system_rhs;
+  VectorType         system_rhs;
 };
 
 
-template <class Vector, class Matrix, class Sparsity>
-LaplaceProblem<Vector,Matrix,Sparsity>::LaplaceProblem (const unsigned int n_blocks) :
+template <typename VectorType, class Matrix, class Sparsity>
+LaplaceProblem<VectorType,Matrix,Sparsity>::LaplaceProblem (const unsigned int n_blocks) :
   n_blocks (n_blocks),
   fe(1),
   dof_handler (triangulation)
@@ -113,8 +113,8 @@ LaplaceProblem<Vector<float>,SparseMatrix<float>,SparsityPattern>::LaplaceProble
 
 
 
-template <class Vector, class Matrix, class Sparsity>
-void LaplaceProblem<Vector,Matrix,Sparsity>::make_grid_and_dofs ()
+template <typename VectorType, class Matrix, class Sparsity>
+void LaplaceProblem<VectorType,Matrix,Sparsity>::make_grid_and_dofs ()
 {
   GridGenerator::hyper_cube (triangulation, -1, 1);
   triangulation.refine_global (3);
@@ -256,8 +256,8 @@ void LaplaceProblem<BlockVector<double>,BlockSparseMatrix<double>,BlockSparsityP
 
 
 
-template <class Vector, class Matrix, class Sparsity>
-void LaplaceProblem<Vector,Matrix,Sparsity>::assemble_system ()
+template <typename VectorType, class Matrix, class Sparsity>
+void LaplaceProblem<VectorType,Matrix,Sparsity>::assemble_system ()
 {
   QGauss<2>  quadrature_formula(2);
   FEValues<2> fe_values (fe, quadrature_formula,
@@ -320,12 +320,12 @@ void LaplaceProblem<Vector,Matrix,Sparsity>::assemble_system ()
 }
 
 
-template <class Vector, class Matrix, class Sparsity>
-void LaplaceProblem<Vector,Matrix,Sparsity>::solve ()
+template <typename VectorType, class Matrix, class Sparsity>
+void LaplaceProblem<VectorType,Matrix,Sparsity>::solve ()
 {
-  SolverControl           solver_control (1000, 1e-12, false, false);
-  PrimitiveVectorMemory<Vector> vector_memory;
-  SolverCG<Vector>        cg (solver_control, vector_memory);
+  SolverControl                     solver_control (1000, 1e-12, false, false);
+  PrimitiveVectorMemory<VectorType> vector_memory;
+  SolverCG<VectorType>              cg (solver_control, vector_memory);
 
   PreconditionJacobi<Matrix> preconditioner;
   preconditioner.initialize (system_matrix, 0.8);
@@ -335,8 +335,8 @@ void LaplaceProblem<Vector,Matrix,Sparsity>::solve ()
 }
 
 
-template <class Vector, class Matrix, class Sparsity>
-void LaplaceProblem<Vector,Matrix,Sparsity>::run ()
+template <typename VectorType, class Matrix, class Sparsity>
+void LaplaceProblem<VectorType,Matrix,Sparsity>::run ()
 {
   make_grid_and_dofs ();
   assemble_system ();
@@ -344,7 +344,7 @@ void LaplaceProblem<Vector,Matrix,Sparsity>::run ()
 
   for (unsigned int i=0; i<solution.size(); ++i)
     deallog
-    //<< typeid(Vector).name ()
+    //<< typeid(VectorType).name ()
     //<< ' '
     //<< typeid(Matrix).name ()
     //<< '-'

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -31,10 +31,13 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -48,10 +51,13 @@ check_solve( SOLVER &solver, const MATRIX &A,
     }
 }
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_Tsolve(SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_Tsolve (SOLVER             &solver,
+              const MATRIX       &A,
+              VectorType         &u,
+              VectorType         &f,
+              const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -136,4 +142,3 @@ int main()
         }
     }
 }
-


### PR DESCRIPTION
This (mostly, perhaps completely) addresses #638, and also includes some small dependent followup patches.

I am not sure if we have a consensus on how to name these things. I picked `VectorType`, `QuadratureType`, etc., but these are easy to change to `VECTOR` or `QUADRATURE`. Should we vote on this? I have a slight preference towards `VectorType` but I think `VECTOR` is okay too.