### PR TITLE
Rename the 'fast' parameter to 'skip_initialization'.

### DIFF
--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -481,13 +481,15 @@ public:
   void reset_values ();
 
   /**
-   * Set the dimensions of this object to the sizes given in the argument, and
-   * newly allocate the required memory. If <tt>fast</tt> is set to
-   * <tt>false</tt>, previous content is deleted, otherwise the memory is not
-   * touched.
+   * Set the dimensions of this object to the sizes given in the
+   * argument, and newly allocate the required memory. If
+   * <tt>omit_default_initialization</tt> is set to <tt>false</tt>,
+   * all elements of the table are set to a default constructed object
+   * for the element type. Otherwise the memory is left in an
+   * uninitialized or otherwise undefined state.
    */
   void reinit (const TableIndices<N> &new_size,
-               const bool             fast = false);
+               const bool             omit_default_initialization = false);
 
   /**
    * Size of the table in direction <tt>i</tt>.
@@ -864,7 +866,7 @@ public:
    */
   void reinit (const unsigned int size1,
                const unsigned int size2,
-               const bool         fast = false);
+               const bool         omit_default_initialization = false);
 
   using TableBase<2,T>::reinit;
 
@@ -1525,7 +1527,7 @@ public:
    */
   void reinit (const unsigned int size1,
                const unsigned int size2,
-               const bool         fast = false);
+               const bool         omit_default_initialization = false);
 
   /**
    * Direct access to one element of the table by specifying all indices at
@@ -1881,7 +1883,7 @@ template <int N, typename T>
 inline
 void
 TableBase<N,T>::reinit (const TableIndices<N> &new_sizes,
-                        const bool             fast)
+                        const bool             omit_default_initialization)
 {
   table_size = new_sizes;
 
@@ -1901,9 +1903,9 @@ TableBase<N,T>::reinit (const TableIndices<N> &new_sizes,
     }
 
   // if new size is nonzero: if necessary allocate additional memory, and if
-  // not fast resize, zero out all values)
+  // not fast resize, zero out all values/default initialize them)
   values.resize_fast (new_size);
-  if (!fast)
+  if (!omit_default_initialization)
     values.fill(T());
 }
 
@@ -2253,9 +2255,9 @@ inline
 void
 Table<2,T>::reinit (const unsigned int size1,
                     const unsigned int size2,
-                    const bool         fast)
+                    const bool         omit_default_initialization)
 {
-  this->TableBase<2,T>::reinit (TableIndices<2> (size1, size2),fast);
+  this->TableBase<2,T>::reinit (TableIndices<2> (size1, size2),omit_default_initialization);
 }
 
 
@@ -2402,9 +2404,9 @@ inline
 void
 TransposeTable<T>::reinit (const unsigned int size1,
                            const unsigned int size2,
-                           const bool         fast)
+                           const bool         omit_default_initialization)
 {
-  this->TableBase<2,T>::reinit (TableIndices<2> (size2, size1),fast);
+  this->TableBase<2,T>::reinit (TableIndices<2> (size2, size1), omit_default_initialization);
 }
 
 

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -282,7 +282,7 @@ namespace internal
     populate_linear_operator_functions(
       dealii::BlockLinearOperator<Range, Domain> &op)
     {
-      op.reinit_range_vector = [=](Range &v, bool fast)
+      op.reinit_range_vector = [=](Range &v, bool omit_zeroing_entries)
       {
         const unsigned int m = op.n_block_rows();
 
@@ -291,12 +291,12 @@ namespace internal
 
         // And reinitialize every individual block with reinit_range_vectors:
         for (unsigned int i = 0; i < m; ++i)
-          op.block(i, 0).reinit_range_vector(v.block(i), fast);
+          op.block(i, 0).reinit_range_vector(v.block(i), omit_zeroing_entries);
 
         v.collect_sizes();
       };
 
-      op.reinit_domain_vector = [=](Domain &v, bool fast)
+      op.reinit_domain_vector = [=](Domain &v, bool omit_zeroing_entries)
       {
         const unsigned int n = op.n_block_cols();
 
@@ -305,7 +305,7 @@ namespace internal
 
         // And reinitialize every individual block with reinit_domain_vectors:
         for (unsigned int i = 0; i < n; ++i)
-          op.block(0, i).reinit_domain_vector(v.block(i), fast);
+          op.block(0, i).reinit_domain_vector(v.block(i), omit_zeroing_entries);
 
         v.collect_sizes();
       };
@@ -714,7 +714,7 @@ block_forward_substitution(const BlockLinearOperator<Range, Domain> &block_opera
 
     for (unsigned int i = 1; i < m; ++i)
       {
-        diagonal_inverse.block(i, i).reinit_range_vector(*tmp, /*bool fast=*/ true);
+        diagonal_inverse.block(i, i).reinit_range_vector(*tmp, /*bool omit_zeroing_entries=*/ true);
         *tmp = u.block(i);
         *tmp *= -1.;
         for (unsigned int j = 0; j < i; ++j)
@@ -821,7 +821,7 @@ block_back_substitution(const BlockLinearOperator<Range, Domain> &block_operator
 
     for (int i = m - 2; i >= 0; --i)
       {
-        diagonal_inverse.block(i, i).reinit_range_vector(*tmp, /*bool fast=*/ true);
+        diagonal_inverse.block(i, i).reinit_range_vector(*tmp, /*bool omit_zeroing_entries=*/ true);
         *tmp = u.block(i);
         *tmp *= -1.;
         for (int j = i + 1; j < m; ++j)

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -245,11 +245,11 @@ public:
    * collect_sizes() to update the block system's knowledge of its individual
    * block's sizes.
    *
-   * If <tt>fast==false</tt>, the vector is filled with zeros.
+   * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
    */
   void reinit (const unsigned int n_blocks,
                const size_type block_size = 0,
-               const bool fast = false);
+               const bool omit_zeroing_entries = false);
 
   /**
    * Reinitialize the BlockVector such that it contains
@@ -259,7 +259,7 @@ public:
    * If the number of blocks is the same as before this function was called,
    * all vectors remain the same and reinit() is called for each vector.
    *
-   * If <tt>fast==false</tt>, the vector is filled with zeros.
+   * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
    *
    * Note that you must call this (or the other reinit() functions) function,
    * rather than calling the reinit() functions of an individual block, to
@@ -268,7 +268,7 @@ public:
    * yield unpredictable results since they may be routed to the wrong block.
    */
   void reinit (const std::vector<size_type> &block_sizes,
-               const bool                    fast=false);
+               const bool                    omit_zeroing_entries=false);
 
   /**
    * Reinitialize the BlockVector to reflect the structure found in
@@ -277,17 +277,17 @@ public:
    * If the number of blocks is the same as before this function was called,
    * all vectors remain the same and reinit() is called for each vector.
    *
-   * If <tt>fast==false</tt>, the vector is filled with zeros.
+   * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
    */
   void reinit (const BlockIndices &block_indices,
-               const bool fast=false);
+               const bool omit_zeroing_entries=false);
 
   /**
    * Change the dimension to that of the vector <tt>V</tt>. The same applies
    * as for the other reinit() function.
    *
    * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-   * same as calling <tt>reinit (V.size(), fast)</tt>.
+   * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
    *
    * Note that you must call this (or the other reinit() functions) function,
    * rather than calling the reinit() functions of an individual block, to
@@ -297,7 +297,7 @@ public:
    */
   template <typename Number2>
   void reinit (const BlockVector<Number2> &V,
-               const bool                 fast=false);
+               const bool                 omit_zeroing_entries=false);
 
   /**
    * Multiply each element of this vector by the corresponding element of
@@ -514,18 +514,18 @@ namespace internal
       static
       void reinit_range_vector (const Matrix &matrix,
                                 BlockVector<number> &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.get_row_indices(), fast);
+        v.reinit(matrix.get_row_indices(), omit_zeroing_entries);
       }
 
       template <typename Matrix>
       static
       void reinit_domain_vector(const Matrix &matrix,
                                 BlockVector<number> &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.get_column_indices(), fast);
+        v.reinit(matrix.get_column_indices(), omit_zeroing_entries);
       }
     };
 

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -105,51 +105,51 @@ BlockVector<Number>::BlockVector (const TrilinosWrappers::BlockVector &v)
 template <typename Number>
 void BlockVector<Number>::reinit (const unsigned int n_blocks,
                                   const size_type    block_size,
-                                  const bool         fast)
+                                  const bool         omit_zeroing_entries)
 {
   std::vector<size_type> block_sizes(n_blocks, block_size);
-  reinit(block_sizes, fast);
+  reinit(block_sizes, omit_zeroing_entries);
 }
 
 
 template <typename Number>
 void BlockVector<Number>::reinit (const std::vector<size_type> &block_sizes,
-                                  const bool                    fast)
+                                  const bool                    omit_zeroing_entries)
 {
   this->block_indices.reinit (block_sizes);
   if (this->components.size() != this->n_blocks())
     this->components.resize(this->n_blocks());
 
   for (size_type i=0; i<this->n_blocks(); ++i)
-    this->components[i].reinit(block_sizes[i], fast);
+    this->components[i].reinit(block_sizes[i], omit_zeroing_entries);
 }
 
 
 template <typename Number>
 void BlockVector<Number>::reinit (
   const BlockIndices &n,
-  const bool fast)
+  const bool omit_zeroing_entries)
 {
   this->block_indices = n;
   if (this->components.size() != this->n_blocks())
     this->components.resize(this->n_blocks());
 
   for (size_type i=0; i<this->n_blocks(); ++i)
-    this->components[i].reinit(n.block_size(i), fast);
+    this->components[i].reinit(n.block_size(i), omit_zeroing_entries);
 }
 
 
 template <typename Number>
 template <typename Number2>
 void BlockVector<Number>::reinit (const BlockVector<Number2> &v,
-                                  const bool fast)
+                                  const bool omit_zeroing_entries)
 {
   this->block_indices = v.get_block_indices();
   if (this->components.size() != this->n_blocks())
     this->components.resize(this->n_blocks());
 
   for (size_type i=0; i<this->n_blocks(); ++i)
-    this->block(i).reinit(v.block(i), fast);
+    this->block(i).reinit(v.block(i), omit_zeroing_entries);
 }
 
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -230,7 +230,7 @@ public:
    * initalization is done, i.e., if it is set to false the content of the
    * vector is set to 0.
    */
-  std::function<void(Range &v, bool fast)> reinit_range_vector;
+  std::function<void(Range &v, bool omit_zeroing_entries)> reinit_range_vector;
 
   /**
    * Initializes a vector of the Domain space to be directly usable as the
@@ -239,7 +239,7 @@ public:
    * initalization is done, i.e., if it is set to false the content of the
    * vector is set to 0.
    */
-  std::function<void(Domain &v, bool fast)> reinit_domain_vector;
+  std::function<void(Domain &v, bool omit_zeroing_entries)> reinit_domain_vector;
 
   /**
    * @name In-place vector space operations
@@ -540,7 +540,7 @@ operator*(const LinearOperator<Range, Intermediate> &first_op,
         static GrowingVectorMemory<Intermediate> vector_memory;
 
         Intermediate *i = vector_memory.alloc();
-        second_op.reinit_range_vector(*i, /*bool fast =*/ true);
+        second_op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
         second_op.vmult(*i, u);
         first_op.vmult(v, *i);
         vector_memory.free(i);
@@ -551,7 +551,7 @@ operator*(const LinearOperator<Range, Intermediate> &first_op,
         static GrowingVectorMemory<Intermediate> vector_memory;
 
         Intermediate *i = vector_memory.alloc();
-        second_op.reinit_range_vector(*i, /*bool fast =*/ true);
+        second_op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
         second_op.vmult(*i, u);
         first_op.vmult_add(v, *i);
         vector_memory.free(i);
@@ -562,7 +562,7 @@ operator*(const LinearOperator<Range, Intermediate> &first_op,
         static GrowingVectorMemory<Intermediate> vector_memory;
 
         Intermediate *i = vector_memory.alloc();
-        first_op.reinit_domain_vector(*i, /*bool fast =*/ true);
+        first_op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
         first_op.Tvmult(*i, u);
         second_op.Tvmult(v, *i);
         vector_memory.free(i);
@@ -573,7 +573,7 @@ operator*(const LinearOperator<Range, Intermediate> &first_op,
         static GrowingVectorMemory<Intermediate> vector_memory;
 
         Intermediate *i = vector_memory.alloc();
-        first_op.reinit_domain_vector(*i, /*bool fast =*/ true);
+        first_op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
         first_op.Tvmult(*i, u);
         second_op.Tvmult_add(v, *i);
         vector_memory.free(i);
@@ -641,7 +641,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
 
   return_op.vmult = [op, &solver, &preconditioner](Vector &v, const Vector &u)
   {
-    op.reinit_range_vector(v, /*bool fast =*/ false);
+    op.reinit_range_vector(v, /*bool omit_zeroing_entries =*/ false);
     solver.solve(op, v, u, preconditioner);
   };
 
@@ -651,7 +651,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
     static GrowingVectorMemory<typename Solver::vector_type> vector_memory;
 
     Vector *v2 = vector_memory.alloc();
-    op.reinit_range_vector(*v2, /*bool fast =*/ false);
+    op.reinit_range_vector(*v2, /*bool omit_zeroing_entries =*/ false);
     solver.solve(op, *v2, u, preconditioner);
     v += *v2;
     vector_memory.free(v2);
@@ -660,7 +660,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
   return_op.Tvmult = [op, &solver, &preconditioner]( Vector &v, const
                                                      Vector &u)
   {
-    op.reinit_range_vector(v, /*bool fast =*/ false);
+    op.reinit_range_vector(v, /*bool omit_zeroing_entries =*/ false);
     solver.solve(transpose_operator(op), v, u, preconditioner);
   };
 
@@ -670,7 +670,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
     static GrowingVectorMemory<typename Solver::vector_type> vector_memory;
 
     Vector *v2 = vector_memory.alloc();
-    op.reinit_range_vector(*v2, /*bool fast =*/ false);
+    op.reinit_range_vector(*v2, /*bool omit_zeroing_entries =*/ false);
     solver.solve(transpose_operator(op), *v2, u, preconditioner);
     v += *v2;
     vector_memory.free(v2);
@@ -801,9 +801,9 @@ namespace internal
        */
       template <typename Matrix>
       static
-      void reinit_range_vector (const Matrix &matrix, Vector &v, bool fast)
+      void reinit_range_vector (const Matrix &matrix, Vector &v, bool omit_zeroing_entries)
       {
-        v.reinit(matrix.m(), fast);
+        v.reinit(matrix.m(), omit_zeroing_entries);
       }
 
       /**
@@ -819,9 +819,9 @@ namespace internal
        */
       template <typename Matrix>
       static
-      void reinit_domain_vector (const Matrix &matrix, Vector &v, bool fast)
+      void reinit_domain_vector (const Matrix &matrix, Vector &v, bool omit_zeroing_entries)
       {
-        v.reinit(matrix.n(), fast);
+        v.reinit(matrix.n(), omit_zeroing_entries);
       }
     };
   } /* namespace LinearOperator */
@@ -872,7 +872,7 @@ namespace
     static GrowingVectorMemory<Range> vector_memory;
 
     Range *i = vector_memory.alloc();
-    i->reinit(v, /*bool fast =*/true);
+    i->reinit(v, /*bool omit_zeroing_entries =*/true);
 
     function(*i, u);
 
@@ -1097,14 +1097,14 @@ linear_operator(const OperatorExemplar &operator_exemplar, const Matrix &matrix)
   // creation of a LinearOperator wrapper is respected - further a matrix
   // or an operator_exemplar cannot usually be copied...
 
-  return_op.reinit_range_vector = [&operator_exemplar](Range &v, bool fast)
+  return_op.reinit_range_vector = [&operator_exemplar](Range &v, bool omit_zeroing_entries)
   {
-    internal::LinearOperator::ReinitHelper<Range>::reinit_range_vector(operator_exemplar, v, fast);
+    internal::LinearOperator::ReinitHelper<Range>::reinit_range_vector(operator_exemplar, v, omit_zeroing_entries);
   };
 
-  return_op.reinit_domain_vector = [&operator_exemplar](Domain &v, bool fast)
+  return_op.reinit_domain_vector = [&operator_exemplar](Domain &v, bool omit_zeroing_entries)
   {
-    internal::LinearOperator::ReinitHelper<Domain>::reinit_domain_vector(operator_exemplar, v, fast);
+    internal::LinearOperator::ReinitHelper<Domain>::reinit_domain_vector(operator_exemplar, v, omit_zeroing_entries);
   };
 
   typename std::conditional<

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -170,9 +170,9 @@ public:
       v += u;
     };
 
-    reinit_vector = [&u](Range &v, bool fast)
+    reinit_vector = [&u](Range &v, bool omit_zeroing_entries)
     {
-      v.reinit(u, fast);
+      v.reinit(u, omit_zeroing_entries);
     };
 
     return *this;
@@ -188,7 +188,7 @@ public:
   {
     Range result_vector;
 
-    reinit_vector(result_vector, /*bool fast=*/ true);
+    reinit_vector(result_vector, /*bool omit_zeroing_entries=*/ true);
     apply(result_vector);
 
     return result_vector;
@@ -267,7 +267,7 @@ public:
    * whether a fast initialization is done, i.e., if it is set to false the
    * content of the vector is set to 0.
    */
-  std::function<void(Range &v, bool fast)> reinit_vector;
+  std::function<void(Range &v, bool omit_zeroing_entries)> reinit_vector;
 };
 
 
@@ -532,9 +532,9 @@ PackagedOperation<Range> operator+(const Range &u, const Range &v)
   // ensure to have valid PackagedOperation objects by catching op by value
   // u is caught by reference
 
-  return_comp.reinit_vector = [&u](Range &x, bool fast)
+  return_comp.reinit_vector = [&u](Range &x, bool omit_zeroing_entries)
   {
-    x.reinit(u, fast);
+    x.reinit(u, omit_zeroing_entries);
   };
 
   return_comp.apply = [&u, &v](Range &x)
@@ -577,9 +577,9 @@ PackagedOperation<Range> operator-(const Range &u, const Range &v)
   // ensure to have valid PackagedOperation objects by catching op by value
   // u is catched by reference
 
-  return_comp.reinit_vector = [&u](Range &x, bool fast)
+  return_comp.reinit_vector = [&u](Range &x, bool omit_zeroing_entries)
   {
-    x.reinit(u, fast);
+    x.reinit(u, omit_zeroing_entries);
   };
 
   return_comp.apply = [&u, &v](Range &x)
@@ -753,7 +753,7 @@ operator*(const LinearOperator<Range, Domain> &op,
     static GrowingVectorMemory<Range> vector_memory;
 
     Range *i = vector_memory.alloc();
-    op.reinit_domain_vector(*i, /*bool fast =*/ true);
+    op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.vmult(v, *i);
@@ -766,7 +766,7 @@ operator*(const LinearOperator<Range, Domain> &op,
     static GrowingVectorMemory<Range> vector_memory;
 
     Range *i = vector_memory.alloc();
-    op.reinit_range_vector(*i, /*bool fast =*/ true);
+    op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.vmult_add(v, *i);
@@ -803,7 +803,7 @@ operator*(const PackagedOperation<Range> &comp,
     static GrowingVectorMemory<Range> vector_memory;
 
     Range *i = vector_memory.alloc();
-    op.reinit_range_vector(*i, /*bool fast =*/ true);
+    op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.Tvmult(v, *i);
@@ -816,7 +816,7 @@ operator*(const PackagedOperation<Range> &comp,
     static GrowingVectorMemory<Range> vector_memory;
 
     Range *i = vector_memory.alloc();
-    op.reinit_range_vector(*i, /*bool fast =*/ true);
+    op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.Tvmult_add(v, *i);

--- a/include/deal.II/lac/parallel_block_vector.h
+++ b/include/deal.II/lac/parallel_block_vector.h
@@ -211,11 +211,11 @@ namespace parallel
        * and call collect_sizes() to update the block system's knowledge of
        * its individual block's sizes.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        */
       void reinit (const size_type num_blocks,
                    const size_type block_size = 0,
-                   const bool fast = false);
+                   const bool omit_zeroing_entries = false);
 
       /**
        * Reinitialize the BlockVector such that it contains
@@ -226,7 +226,7 @@ namespace parallel
        * called, all vectors remain the same and reinit() is called for each
        * vector.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        *
        * Note that you must call this (or the other reinit() functions)
        * function, rather than calling the reinit() functions of an individual
@@ -236,14 +236,14 @@ namespace parallel
        * be routed to the wrong block.
        */
       void reinit (const std::vector<size_type> &N,
-                   const bool                    fast=false);
+                   const bool                    omit_zeroing_entries=false);
 
       /**
        * Change the dimension to that of the vector <tt>V</tt>. The same
        * applies as for the other reinit() function.
        *
        * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-       * same as calling <tt>reinit (V.size(), fast)</tt>.
+       * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
        *
        * Note that you must call this (or the other reinit() functions)
        * function, rather than calling the reinit() functions of an individual
@@ -254,7 +254,7 @@ namespace parallel
        */
       template <typename Number2>
       void reinit (const BlockVector<Number2> &V,
-                   const bool                 fast=false);
+                   const bool                 omit_zeroing_entries=false);
 
       /**
        * This function copies the data that has accumulated in the data buffer
@@ -531,24 +531,24 @@ namespace parallel
     inline
     void BlockVector<Number>::reinit (const size_type n_bl,
                                       const size_type bl_sz,
-                                      const bool         fast)
+                                      const bool         omit_zeroing_entries)
     {
       std::vector<size_type> n(n_bl, bl_sz);
-      reinit(n, fast);
+      reinit(n, omit_zeroing_entries);
     }
 
 
     template <typename Number>
     inline
     void BlockVector<Number>::reinit (const std::vector<size_type> &n,
-                                      const bool                    fast)
+                                      const bool                    omit_zeroing_entries)
     {
       this->block_indices.reinit (n);
       if (this->components.size() != this->n_blocks())
         this->components.resize(this->n_blocks());
 
       for (size_type i=0; i<this->n_blocks(); ++i)
-        this->components[i].reinit(n[i], fast);
+        this->components[i].reinit(n[i], omit_zeroing_entries);
     }
 
 
@@ -557,14 +557,14 @@ namespace parallel
     template <typename Number2>
     inline
     void BlockVector<Number>::reinit (const BlockVector<Number2> &v,
-                                      const bool fast)
+                                      const bool omit_zeroing_entries)
     {
       this->block_indices = v.get_block_indices();
       if (this->components.size() != this->n_blocks())
         this->components.resize(this->n_blocks());
 
       for (unsigned int i=0; i<this->n_blocks(); ++i)
-        this->block(i).reinit(v.block(i), fast);
+        this->block(i).reinit(v.block(i), omit_zeroing_entries);
     }
 
 

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -237,20 +237,20 @@ namespace parallel
        * parallel distribution.
        */
       void reinit (const size_type size,
-                   const bool      fast = false);
+                   const bool      omit_zeroing_entries = false);
 
       /**
        * Uses the parallel layout of the input vector @p in_vector and
        * allocates memory for this vector. Recommended initialization function
        * when several vectors with the same layout should be created.
        *
-       * If the flag @p fast is set to false, the memory will be initialized
+       * If the flag @p omit_zeroing_entries is set to false, the memory will be initialized
        * with zero, otherwise the memory will be untouched (and the user must
        * make sure to fill it with reasonable data before using it).
        */
       template <typename Number2>
       void reinit(const Vector<Number2> &in_vector,
-                  const bool             fast = false);
+                  const bool             omit_zeroing_entries = false);
 
       /**
        * Initialize the vector. The local range is specified by @p

--- a/include/deal.II/lac/parallel_vector.templates.h
+++ b/include/deal.II/lac/parallel_vector.templates.h
@@ -77,7 +77,7 @@ namespace parallel
     template <typename Number>
     void
     Vector<Number>::reinit (const size_type size,
-                            const bool      fast)
+                            const bool      omit_zeroing_entries)
     {
       clear_mpi_requests();
       // check whether we need to reallocate
@@ -95,7 +95,7 @@ namespace parallel
       partitioner.reset (new Utilities::MPI::Partitioner (size));
 
       // set entries to zero if so requested
-      if (fast == false)
+      if (omit_zeroing_entries == false)
         this->operator = (Number());
 
       vector_is_ghosted = false;
@@ -107,7 +107,7 @@ namespace parallel
     template <typename Number2>
     void
     Vector<Number>::reinit (const Vector<Number2> &v,
-                            const bool             fast)
+                            const bool             omit_zeroing_entries)
     {
       clear_mpi_requests();
       Assert (v.partitioner.get() != 0, ExcNotInitialized());
@@ -128,7 +128,7 @@ namespace parallel
         Assert (vector_view.size() == partitioner->local_size(),
                 ExcInternalError());
 
-      if (fast == false)
+      if (omit_zeroing_entries == false)
         this->operator= (Number());
 
       if (import_data != 0)

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -158,11 +158,11 @@ namespace PETScWrappers
      * Reinitialize the BlockVector to contain <tt>num_blocks</tt> blocks of
      * size <tt>block_size</tt> each.
      *
-     * If <tt>fast==false</tt>, the vector is filled with zeros.
+     * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
      */
     void reinit (const unsigned int num_blocks,
                  const size_type    block_size,
-                 const bool fast = false);
+                 const bool omit_zeroing_entries = false);
 
     /**
      * Reinitialize the BlockVector such that it contains
@@ -172,7 +172,7 @@ namespace PETScWrappers
      * If the number of blocks is the same as before this function was called,
      * all vectors remain the same and reinit() is called for each vector.
      *
-     * If <tt>fast==false</tt>, the vector is filled with zeros.
+     * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
      *
      * Note that you must call this (or the other reinit() functions)
      * function, rather than calling the reinit() functions of an individual
@@ -182,14 +182,14 @@ namespace PETScWrappers
      * the wrong block.
      */
     void reinit (const std::vector<size_type> &N,
-                 const bool                   fast=false);
+                 const bool                   omit_zeroing_entries=false);
 
     /**
      * Change the dimension to that of the vector <tt>V</tt>. The same applies
      * as for the other reinit() function.
      *
      * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-     * same as calling <tt>reinit (V.size(), fast)</tt>.
+     * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
      *
      * Note that you must call this (or the other reinit() functions)
      * function, rather than calling the reinit() functions of an individual
@@ -199,7 +199,7 @@ namespace PETScWrappers
      * the wrong block.
      */
     void reinit (const BlockVector &V,
-                 const bool         fast=false);
+                 const bool         omit_zeroing_entries=false);
 
     /**
      * Change the number of blocks to <tt>num_blocks</tt>. The individual
@@ -359,10 +359,10 @@ namespace PETScWrappers
   void
   BlockVector::reinit (const unsigned int n_bl,
                        const size_type    bl_sz,
-                       const bool         fast)
+                       const bool         omit_zeroing_entries)
   {
     std::vector<size_type> n(n_bl, bl_sz);
-    reinit(n, fast);
+    reinit(n, omit_zeroing_entries);
   }
 
 
@@ -370,28 +370,28 @@ namespace PETScWrappers
   inline
   void
   BlockVector::reinit (const std::vector<size_type> &n,
-                       const bool                    fast)
+                       const bool                    omit_zeroing_entries)
   {
     block_indices.reinit (n);
     if (this->components.size() != this->n_blocks())
       this->components.resize(this->n_blocks());
 
     for (unsigned int i=0; i<this->n_blocks(); ++i)
-      this->components[i].reinit(n[i], fast);
+      this->components[i].reinit(n[i], omit_zeroing_entries);
   }
 
 
   inline
   void
   BlockVector::reinit (const BlockVector &v,
-                       const bool fast)
+                       const bool omit_zeroing_entries)
   {
     block_indices = v.get_block_indices();
     if (this->components.size() != this->n_blocks())
       this->components.resize(this->n_blocks());
 
     for (unsigned int i=0; i<this->n_blocks(); ++i)
-      block(i).reinit(v.block(i), fast);
+      block(i).reinit(v.block(i), omit_zeroing_entries);
   }
 
 

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -174,13 +174,13 @@ namespace PETScWrappers
        * @p communicator argument denotes which MPI channel each of these
        * blocks shall communicate.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        */
       void reinit (const unsigned int  n_blocks,
                    const MPI_Comm     &communicator,
                    const size_type     block_size,
                    const size_type     local_size,
-                   const bool fast = false);
+                   const bool omit_zeroing_entries = false);
 
       /**
        * Reinitialize the BlockVector such that it contains
@@ -192,7 +192,7 @@ namespace PETScWrappers
        * called, all vectors remain the same and reinit() is called for each
        * vector.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        *
        * Note that you must call this (or the other reinit() functions)
        * function, rather than calling the reinit() functions of an individual
@@ -204,14 +204,14 @@ namespace PETScWrappers
       void reinit (const std::vector<size_type> &block_sizes,
                    const MPI_Comm               &communicator,
                    const std::vector<size_type> &local_sizes,
-                   const bool                    fast=false);
+                   const bool                    omit_zeroing_entries=false);
 
       /**
        * Change the dimension to that of the vector <tt>V</tt>. The same
        * applies as for the other reinit() function.
        *
        * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-       * same as calling <tt>reinit (V.size(), fast)</tt>.
+       * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
        *
        * Note that you must call this (or the other reinit() functions)
        * function, rather than calling the reinit() functions of an individual
@@ -221,7 +221,7 @@ namespace PETScWrappers
        * be routed to the wrong block.
        */
       void reinit (const BlockVector &V,
-                   const bool         fast=false);
+                   const bool         omit_zeroing_entries=false);
 
       /**
        * Reinitialize the BlockVector using IndexSets. See the constructor
@@ -390,12 +390,12 @@ namespace PETScWrappers
                          const MPI_Comm     &communicator,
                          const size_type     block_size,
                          const size_type     local_size,
-                         const bool fast)
+                         const bool omit_zeroing_entries)
     {
       reinit(std::vector<size_type>(n_blocks, block_size),
              communicator,
              std::vector<size_type>(n_blocks, local_size),
-             fast);
+             omit_zeroing_entries);
     }
 
 
@@ -405,7 +405,7 @@ namespace PETScWrappers
     BlockVector::reinit (const std::vector<size_type> &block_sizes,
                          const MPI_Comm               &communicator,
                          const std::vector<size_type> &local_sizes,
-                         const bool                    fast)
+                         const bool                    omit_zeroing_entries)
     {
       this->block_indices.reinit (block_sizes);
       if (this->components.size() != this->n_blocks())
@@ -413,21 +413,21 @@ namespace PETScWrappers
 
       for (unsigned int i=0; i<this->n_blocks(); ++i)
         this->components[i].reinit(communicator, block_sizes[i],
-                                   local_sizes[i], fast);
+                                   local_sizes[i], omit_zeroing_entries);
     }
 
 
     inline
     void
     BlockVector::reinit (const BlockVector &v,
-                         const bool fast)
+                         const bool omit_zeroing_entries)
     {
       this->block_indices = v.get_block_indices();
       if (this->components.size() != this->n_blocks())
         this->components.resize(this->n_blocks());
 
       for (unsigned int i=0; i<this->n_blocks(); ++i)
-        block(i).reinit(v.block(i), fast);
+        block(i).reinit(v.block(i), omit_zeroing_entries);
     }
 
     inline

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -324,13 +324,13 @@ namespace PETScWrappers
        * @p communicator denotes the MPI communicator henceforth to be used
        * for this vector.
        *
-       * If @p fast is false, the vector is filled by zeros. Otherwise, the
+       * If @p omit_zeroing_entries is false, the vector is filled by zeros. Otherwise, the
        * elements are left an unspecified state.
        */
       void reinit (const MPI_Comm  &communicator,
                    const size_type  N,
                    const size_type  local_size,
-                   const bool       fast = false);
+                   const bool       omit_zeroing_entries = false);
 
       /**
        * Change the dimension to that of the vector @p v, and also take over
@@ -338,10 +338,10 @@ namespace PETScWrappers
        * The same applies as for the other @p reinit function.
        *
        * The elements of @p v are not copied, i.e. this function is the same
-       * as calling <tt>reinit(v.size(), v.local_size(), fast)</tt>.
+       * as calling <tt>reinit(v.size(), v.local_size(), omit_zeroing_entries)</tt>.
        */
       void reinit (const Vector &v,
-                   const bool    fast = false);
+                   const bool    omit_zeroing_entries = false);
 
       /**
        * Reinit as a vector without ghost elements. See the constructor with

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -167,21 +167,21 @@ namespace PETScWrappers
      * reduces memory consumption, or if for efficiency the same amount of
      * memory is used for less data.
      *
-     * If @p fast is false, the vector is filled by zeros. Otherwise, the
+     * If @p omit_zeroing_entries is false, the vector is filled by zeros. Otherwise, the
      * elements are left an unspecified state.
      */
     void reinit (const size_type N,
-                 const bool      fast = false);
+                 const bool      omit_zeroing_entries = false);
 
     /**
      * Change the dimension to that of the vector @p v. The same applies as
      * for the other reinit() function.
      *
      * The elements of @p v are not copied, i.e.  this function is the same as
-     * calling <tt>reinit (v.size(), fast)</tt>.
+     * calling <tt>reinit (v.size(), omit_zeroing_entries)</tt>.
      */
     void reinit (const Vector &v,
-                 const bool    fast = false);
+                 const bool    omit_zeroing_entries = false);
 
   protected:
     /**

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -148,36 +148,36 @@ namespace LinearAlgebra
      * Sets the global size of the vector to @p size. The stored elements have
      * their index in [0,size).
      *
-     * If the flag @p fast is set to false, the memory will be initialized
+     * If the flag @p omit_zeroing_entries is set to false, the memory will be initialized
      * with zero, otherwise the memory will be untouched (and the user must
      * make sure to fill it with reasonable data before using it).
      */
     void reinit (const size_type size,
-                 const bool      fast = false);
+                 const bool      omit_zeroing_entries = false);
 
     /**
      * Uses the same IndexSet as the one of the input vector @p in_vector and
      * allocates memory for this vector.
      *
-     * If the flag @p fast is set to false, the memory will be initialized
+     * If the flag @p omit_zeroing_entries is set to false, the memory will be initialized
      * with zero, otherwise the memory will be untouched (and the user must
      * make sure to fill it with reasonable data before using it).
      */
     template <typename Number2>
     void reinit(const ReadWriteVector<Number2> &in_vector,
-                const bool                      fast = false);
+                const bool                      omit_zeroing_entries = false);
 
     /**
      * Initializes the vector. The indices are specified by
      * @p locally_stored_indices.
      *
-     * If the flag @p fast is set to false, the memory will be initialized
+     * If the flag @p omit_zeroing_entries is set to false, the memory will be initialized
      * with zero, otherwise the memory will be untouched (and the user must
      * make sure to fill it with reasonable data before using it).
      * locally_stored_indices.
      */
     void reinit (const IndexSet &locally_stored_indices,
-                 const bool      fast = false);
+                 const bool      omit_zeroing_entries = false);
 
     /**
      * Swap the contents of this vector and the other vector @p v. One could

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -55,7 +55,7 @@ namespace LinearAlgebra
   template <typename Number>
   void
   ReadWriteVector<Number>::reinit (const size_type size,
-                                   const bool      fast)
+                                   const bool      omit_zeroing_entries)
   {
     // check whether we need to reallocate
     resize_val(size);
@@ -63,7 +63,7 @@ namespace LinearAlgebra
     stored_elements = complete_index_set(size);
 
     // set entries to zero if so requested
-    if (fast == false)
+    if (omit_zeroing_entries == false)
       this->operator = (Number());
   }
 
@@ -73,13 +73,13 @@ namespace LinearAlgebra
   template <typename Number2>
   void
   ReadWriteVector<Number>::reinit (const ReadWriteVector<Number2> &v,
-                                   const bool             fast)
+                                   const bool             omit_zeroing_entries)
   {
     resize_val(v.n_elements());
 
     stored_elements = v.get_stored_elements();
 
-    if (fast == false)
+    if (omit_zeroing_entries == false)
       this->operator= (Number());
   }
 
@@ -88,7 +88,7 @@ namespace LinearAlgebra
   template <typename Number>
   void
   ReadWriteVector<Number>::reinit (const IndexSet &locally_stored_indices,
-                                   const bool      fast)
+                                   const bool      omit_zeroing_entries)
   {
     stored_elements = locally_stored_indices;
 
@@ -96,7 +96,7 @@ namespace LinearAlgebra
     resize_val(stored_elements.n_elements());
 
     // initialize to zero
-    if (fast == false)
+    if (omit_zeroing_entries == false)
       this->operator= (Number());
   }
 

--- a/include/deal.II/lac/trilinos_block_vector.h
+++ b/include/deal.II/lac/trilinos_block_vector.h
@@ -198,10 +198,10 @@ namespace TrilinosWrappers
      * on the same Epetra_map is intended. In that case, the same communicator
      * is used for data exchange.
      *
-     * If <tt>fast==false</tt>, the vector is filled with zeros.
+     * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
      */
     void reinit (const std::vector<Epetra_Map> &partitioning,
-                 const bool                     fast = false);
+                 const bool                     omit_zeroing_entries = false);
 
     /**
      * Reinitialize the BlockVector to contain as many blocks as there are
@@ -211,21 +211,21 @@ namespace TrilinosWrappers
      * with a distributed vector based on the same initialization is intended.
      * In that case, the same communicator is used for data exchange.
      *
-     * If <tt>fast==false</tt>, the vector is filled with zeros.
+     * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
      */
     void reinit (const std::vector<IndexSet> &partitioning,
                  const MPI_Comm              &communicator = MPI_COMM_WORLD,
-                 const bool                   fast = false);
+                 const bool                   omit_zeroing_entries = false);
 
     /**
      * Reinitialize the BlockVector to contain as many blocks as there are
      * elements in the first argument, and with the respective sizes. Since no
      * distribution map is given, all vectors are local vectors.
      *
-     * If <tt>fast==false</tt>, the vector is filled with zeros.
+     * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
      */
     void reinit (const std::vector<size_type> &N,
-                 const bool                    fast=false);
+                 const bool                    omit_zeroing_entries=false);
 
     /**
      * Reinitialize the vector in the same way as the given to a distributed
@@ -238,7 +238,7 @@ namespace TrilinosWrappers
      * as for the other reinit() function.
      *
      * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-     * same as calling <tt>reinit (V.size(), fast)</tt>.
+     * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
      *
      * Note that you must call this (or the other reinit() functions)
      * function, rather than calling the reinit() functions of an individual
@@ -248,7 +248,7 @@ namespace TrilinosWrappers
      * the wrong block.
      */
     void reinit (const BlockVector &V,
-                 const bool fast = false);
+                 const bool omit_zeroing_entries = false);
 
     /**
      * Change the number of blocks to <tt>num_blocks</tt>. The individual
@@ -472,18 +472,18 @@ namespace internal
       static
       void reinit_range_vector (const Matrix &matrix,
                                 TrilinosWrappers::BlockVector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.range_partitioner(), fast);
+        v.reinit(matrix.range_partitioner(), omit_zeroing_entries);
       }
 
       template <typename Matrix>
       static
       void reinit_domain_vector(const Matrix &matrix,
                                 TrilinosWrappers::BlockVector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.domain_partitioner(), fast);
+        v.reinit(matrix.domain_partitioner(), omit_zeroing_entries);
       }
     };
 

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -201,23 +201,23 @@ namespace TrilinosWrappers
        * Epetra_Maps given in the input argument, according to the parallel
        * distribution of the individual components described in the maps.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        *
        * This function is deprecated.
        */
       void reinit (const std::vector<Epetra_Map> &parallel_partitioning,
-                   const bool                     fast = false) DEAL_II_DEPRECATED;
+                   const bool                     omit_zeroing_entries = false) DEAL_II_DEPRECATED;
 
       /**
        * Reinitialize the BlockVector to contain as many blocks as there are
        * index sets given in the input argument, according to the parallel
        * distribution of the individual components described in the maps.
        *
-       * If <tt>fast==false</tt>, the vector is filled with zeros.
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with zeros.
        */
       void reinit (const std::vector<IndexSet> &parallel_partitioning,
                    const MPI_Comm              &communicator = MPI_COMM_WORLD,
-                   const bool                   fast = false);
+                   const bool                   omit_zeroing_entries = false);
 
       /**
        * Reinit functionality. This function destroys the old vector content
@@ -247,7 +247,7 @@ namespace TrilinosWrappers
        * applies as for the other reinit() function.
        *
        * The elements of <tt>V</tt> are not copied, i.e.  this function is the
-       * same as calling <tt>reinit (V.size(), fast)</tt>.
+       * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
        *
        * Note that you must call this (or the other reinit() functions)
        * function, rather than calling the reinit() functions of an individual
@@ -257,7 +257,7 @@ namespace TrilinosWrappers
        * be routed to the wrong block.
        */
       void reinit (const BlockVector &V,
-                   const bool fast = false);
+                   const bool omit_zeroing_entries = false);
 
       /**
        * Change the number of blocks to <tt>num_blocks</tt>. The individual
@@ -497,18 +497,18 @@ namespace internal
       static
       void reinit_range_vector (const Matrix &matrix,
                                 TrilinosWrappers::MPI::BlockVector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.range_partitioner(), fast);
+        v.reinit(matrix.range_partitioner(), omit_zeroing_entries);
       }
 
       template <typename Matrix>
       static
       void reinit_domain_vector(const Matrix &matrix,
                                 TrilinosWrappers::MPI::BlockVector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.domain_partitioner(), fast);
+        v.reinit(matrix.domain_partitioner(), omit_zeroing_entries);
       }
     };
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -305,7 +305,7 @@ namespace TrilinosWrappers
       /**
        * Reinit functionality. This function sets the calling vector to the
        * dimension and the parallel distribution of the input vector, but does
-       * not copy the elements in <tt>v</tt>. If <tt>fast</tt> is not
+       * not copy the elements in <tt>v</tt>. If <tt>omit_zeroing_entries</tt> is not
        * <tt>true</tt>, the elements in the vector are initialized with zero,
        * otherwise the content will be left unchanged and the user has to set
        * all elements.
@@ -316,13 +316,13 @@ namespace TrilinosWrappers
        * application of this function is to generate a replication of a whole
        * vector on each machine, when the calling vector is built according to
        * the localized vector class TrilinosWrappers::Vector, and <tt>v</tt>
-       * is a distributed vector. In this case, the variable <tt>fast</tt>
+       * is a distributed vector. In this case, the variable <tt>omit_zeroing_entries</tt>
        * needs to be set to <tt>false</tt>, since it does not make sense to
        * exchange data between differently parallelized vectors without
        * touching the elements.
        */
       void reinit (const VectorBase &v,
-                   const bool        fast = false,
+                   const bool        omit_zeroing_entries = false,
                    const bool        allow_different_maps = false);
 
       /**
@@ -472,7 +472,7 @@ namespace TrilinosWrappers
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       void reinit (const Epetra_Map &parallel_partitioning,
-                   const bool        fast = false) DEAL_II_DEPRECATED;
+                   const bool        omit_zeroing_entries = false) DEAL_II_DEPRECATED;
 
       /**
        * Copy-constructor from deal.II vectors. Sets the dimension to that of
@@ -566,7 +566,7 @@ namespace TrilinosWrappers
       /**
        * Reinit functionality. This function destroys the old vector content
        * and generates a new one based on the input partitioning.  The flag
-       * <tt>fast</tt> determines whether the vector should be filled with
+       * <tt>omit_zeroing_entries</tt> determines whether the vector should be filled with
        * zero (false) or left untouched (true).
        *
        *
@@ -580,7 +580,7 @@ namespace TrilinosWrappers
        */
       void reinit (const IndexSet &parallel_partitioning,
                    const MPI_Comm &communicator = MPI_COMM_WORLD,
-                   const bool      fast = false);
+                   const bool      omit_zeroing_entries = false);
 
       /**
        * Reinit functionality. This function destroys the old vector content
@@ -799,7 +799,7 @@ namespace TrilinosWrappers
      * <tt>n</tt>.
      */
     void reinit (const size_type n,
-                 const bool      fast = false);
+                 const bool      omit_zeroing_entries = false);
 
     /**
      * Initialization with an Epetra_Map. Similar to the call in the other
@@ -807,7 +807,7 @@ namespace TrilinosWrappers
      * is generated. This initialization function is appropriate when the data
      * in the localized vector should be imported from a distributed vector
      * that has been initialized with the same communicator. The variable
-     * <tt>fast</tt> determines whether the vector should be filled with zero
+     * <tt>omit_zeroing_entries</tt> determines whether the vector should be filled with zero
      * or left untouched.
      *
      * Which element of the @p input_map argument are set is in fact ignored,
@@ -815,7 +815,7 @@ namespace TrilinosWrappers
      * this argument.
      */
     void reinit (const Epetra_Map &input_map,
-                 const bool        fast = false);
+                 const bool        omit_zeroing_entries = false);
 
     /**
      * Initialization with an IndexSet. Similar to the call in the other class
@@ -823,7 +823,7 @@ namespace TrilinosWrappers
      * generated. This initialization function is appropriate in case the data
      * in the localized vector should be imported from a distributed vector
      * that has been initialized with the same communicator. The variable
-     * <tt>fast</tt> determines whether the vector should be filled with zero
+     * <tt>omit_zeroing_entries</tt> determines whether the vector should be filled with zero
      * (false) or left untouched (true).
      *
      * Which element of the @p input_map argument are set is in fact ignored,
@@ -832,14 +832,14 @@ namespace TrilinosWrappers
      */
     void reinit (const IndexSet   &input_map,
                  const MPI_Comm   &communicator = MPI_COMM_WORLD,
-                 const bool        fast = false);
+                 const bool        omit_zeroing_entries = false);
 
     /**
      * Reinit function. Takes the information of a Vector and copies
      * everything to the calling vector, now also allowing different maps.
      */
     void reinit (const VectorBase &V,
-                 const bool        fast = false,
+                 const bool        omit_zeroing_entries = false,
                  const bool        allow_different_maps = false);
 
     /**
@@ -986,18 +986,18 @@ namespace internal
       static
       void reinit_range_vector (const Matrix &matrix,
                                 TrilinosWrappers::MPI::Vector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.locally_owned_range_indices(), matrix.get_mpi_communicator(), fast);
+        v.reinit(matrix.locally_owned_range_indices(), matrix.get_mpi_communicator(), omit_zeroing_entries);
       }
 
       template <typename Matrix>
       static
       void reinit_domain_vector(const Matrix &matrix,
                                 TrilinosWrappers::MPI::Vector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator(), fast);
+        v.reinit(matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator(), omit_zeroing_entries);
       }
     };
 
@@ -1013,18 +1013,22 @@ namespace internal
       static
       void reinit_range_vector (const Matrix &matrix,
                                 TrilinosWrappers::Vector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.locally_owned_range_indices(), matrix.get_mpi_communicator(), fast);
+        v.reinit(matrix.locally_owned_range_indices(),
+                 matrix.get_mpi_communicator(),
+                 omit_zeroing_entries);
       }
 
       template <typename Matrix>
       static
       void reinit_domain_vector(const Matrix &matrix,
                                 TrilinosWrappers::Vector &v,
-                                bool fast)
+                                bool omit_zeroing_entries)
       {
-        v.reinit(matrix.locally_owned_domain_indices(), matrix.get_mpi_communicator(), fast);
+        v.reinit(matrix.locally_owned_domain_indices(),
+                 matrix.get_mpi_communicator(),
+                 omit_zeroing_entries);
       }
     };
 

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -264,7 +264,7 @@ namespace TrilinosWrappers
      * input vector.
      */
     void reinit (const VectorBase &v,
-                 const bool        fast = false);
+                 const bool        omit_zeroing_entries = false);
 
     /**
      * Compress the underlying representation of the Trilinos object, i.e.
@@ -1207,12 +1207,12 @@ namespace TrilinosWrappers
   inline
   void
   VectorBase::reinit (const VectorBase &v,
-                      const bool        fast)
+                      const bool        omit_zeroing_entries)
   {
     Assert (vector.get() != 0,
             ExcMessage("Vector has not been constructed properly."));
 
-    if (fast == false ||
+    if (omit_zeroing_entries == false ||
         vector_partitioner().SameAs(v.vector_partitioner())==false)
       vector.reset (new Epetra_FEVector(*v.vector));
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -287,25 +287,25 @@ public:
    * <tt>reinit(N)</tt>. This cited behaviour is analogous to that of the
    * standard library containers.
    *
-   * If @p fast is false, the vector is filled by zeros. Otherwise, the
+   * If @p omit_zeroing_entries is false, the vector is filled by zeros. Otherwise, the
    * elements are left an unspecified state.
    *
    * This function is virtual in order to allow for derived classes to handle
    * memory separately.
    */
   virtual void reinit (const size_type N,
-                       const bool      fast=false);
+                       const bool      omit_zeroing_entries=false);
 
   /**
    * Change the dimension to that of the vector @p V. The same applies as for
    * the other @p reinit function.
    *
    * The elements of @p V are not copied, i.e.  this function is the same as
-   * calling <tt>reinit (V.size(), fast)</tt>.
+   * calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
    */
   template <typename Number2>
   void reinit (const Vector<Number2> &V,
-               const bool            fast=false);
+               const bool            omit_zeroing_entries=false);
 
   /**
    * Swap the contents of this vector and the other vector @p v. One could do
@@ -1074,7 +1074,8 @@ Vector<Number>::~Vector ()
 
 template <typename Number>
 inline
-void Vector<Number>::reinit (const size_type n, const bool fast)
+void Vector<Number>::reinit (const size_type n,
+                             const bool omit_zeroing_entries)
 {
   if (n==0)
     {
@@ -1091,7 +1092,7 @@ void Vector<Number>::reinit (const size_type n, const bool fast)
       allocate();
     };
   vec_size = n;
-  if (fast == false)
+  if (omit_zeroing_entries == false)
     *this = static_cast<Number>(0);
 }
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -725,9 +725,9 @@ Vector<Number>::Vector (const TrilinosWrappers::Vector &v)
 template <typename Number>
 template <typename Number2>
 void Vector<Number>::reinit (const Vector<Number2> &v,
-                             const bool fast)
+                             const bool omit_zeroing_entries)
 {
-  reinit (v.size(), fast);
+  reinit (v.size(), omit_zeroing_entries);
 }
 
 

--- a/include/deal.II/lac/vector_view.h
+++ b/include/deal.II/lac/vector_view.h
@@ -171,9 +171,10 @@ public:
    * have of the original object. Notice that it is your own responsibility to
    * ensure that the memory you are pointing to is big enough.
    *
-   * Similarly to what happens in the base class, if fast is false, then the
-   * entire content of the vector is set to 0, otherwise the content of the
-   * memory is left unchanged.
+   * Similarly to what happens in the base class, if
+   * 'omit_zeroing_entries' is false, then the entire content of the
+   * vector is set to 0, otherwise the content of the memory is left
+   * unchanged.
    *
    * Notice that the following snippet of code may not produce what you
    * expect:
@@ -204,7 +205,7 @@ public:
    * call this reinit function if you really know what you are doing.
    */
   virtual void reinit (const size_type N,
-                       const bool         fast=false);
+                       const bool         omit_zeroing_entries=false);
 
   /**
    * This reinit function is equivalent to constructing a new object with the
@@ -269,11 +270,12 @@ VectorView<Number>::~VectorView()
 
 template<typename Number>
 inline
-void VectorView<Number>::reinit(const size_type N, const bool fast)
+void VectorView<Number>::reinit(const size_type N,
+                                const bool omit_zeroing_entries)
 {
   this->vec_size = N;
   this->max_vec_size = N;
-  if (fast == false)
+  if (omit_zeroing_entries == false)
     Vector<Number>::operator=(static_cast<Number>(0));
 }
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -112,7 +112,7 @@ namespace PETScWrappers
     Vector::reinit (const MPI_Comm  &comm,
                     const size_type  n,
                     const size_type  local_sz,
-                    const bool       fast)
+                    const bool       omit_zeroing_entries)
     {
       communicator = comm;
 
@@ -148,7 +148,7 @@ namespace PETScWrappers
 
       // finally clear the new vector if so
       // desired
-      if (fast == false)
+      if (omit_zeroing_entries == false)
         *this = 0;
     }
 
@@ -156,19 +156,19 @@ namespace PETScWrappers
 
     void
     Vector::reinit (const Vector &v,
-                    const bool    fast)
+                    const bool    omit_zeroing_entries)
     {
       if (v.has_ghost_elements())
         {
           reinit (v.locally_owned_elements(), v.ghost_indices, v.communicator);
-          if (!fast)
+          if (!omit_zeroing_entries)
             {
               int ierr = VecSet(vector, 0.0);
               AssertThrow (ierr == 0, ExcPETScError(ierr));
             }
         }
       else
-        reinit (v.communicator, v.size(), v.local_size(), fast);
+        reinit (v.communicator, v.size(), v.local_size(), omit_zeroing_entries);
     }
 
 

--- a/source/lac/petsc_vector.cc
+++ b/source/lac/petsc_vector.cc
@@ -72,7 +72,7 @@ namespace PETScWrappers
 
   void
   Vector::reinit (const size_type n,
-                  const bool      fast)
+                  const bool      omit_zeroing_entries)
   {
     // only do something if the sizes
     // mismatch
@@ -101,7 +101,7 @@ namespace PETScWrappers
 
     // finally clear the new vector if so
     // desired
-    if (fast == false)
+    if (omit_zeroing_entries == false)
       *this = 0;
   }
 
@@ -109,9 +109,9 @@ namespace PETScWrappers
 
   void
   Vector::reinit (const Vector &v,
-                  const bool    fast)
+                  const bool    omit_zeroing_entries)
   {
-    reinit (v.size(), fast);
+    reinit (v.size(), omit_zeroing_entries);
   }
 
 

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -108,7 +108,7 @@ namespace TrilinosWrappers
 
     void
     BlockVector::reinit (const std::vector<Epetra_Map> &input_maps,
-                         const bool                     fast)
+                         const bool                     omit_zeroing_entries)
     {
       const size_type no_blocks = input_maps.size();
       std::vector<size_type> block_sizes (no_blocks);
@@ -123,7 +123,7 @@ namespace TrilinosWrappers
         components.resize(n_blocks());
 
       for (size_type i=0; i<n_blocks(); ++i)
-        components[i].reinit(input_maps[i], fast);
+        components[i].reinit(input_maps[i], omit_zeroing_entries);
 
       collect_sizes();
     }
@@ -133,7 +133,7 @@ namespace TrilinosWrappers
     void
     BlockVector::reinit (const std::vector<IndexSet> &parallel_partitioning,
                          const MPI_Comm              &communicator,
-                         const bool                   fast)
+                         const bool                   omit_zeroing_entries)
     {
       const size_type no_blocks = parallel_partitioning.size();
       std::vector<size_type> block_sizes (no_blocks);
@@ -148,7 +148,7 @@ namespace TrilinosWrappers
         components.resize(n_blocks());
 
       for (size_type i=0; i<n_blocks(); ++i)
-        components[i].reinit(parallel_partitioning[i], communicator, fast);
+        components[i].reinit(parallel_partitioning[i], communicator, omit_zeroing_entries);
 
       collect_sizes();
     }
@@ -181,14 +181,14 @@ namespace TrilinosWrappers
 
     void
     BlockVector::reinit (const BlockVector &v,
-                         const bool fast)
+                         const bool omit_zeroing_entries)
     {
       block_indices = v.get_block_indices();
       if (components.size() != n_blocks())
         components.resize(n_blocks());
 
       for (size_type i=0; i<n_blocks(); ++i)
-        components[i].reinit(v.block(i), fast, false);
+        components[i].reinit(v.block(i), omit_zeroing_entries, false);
 
       collect_sizes();
     }
@@ -268,7 +268,7 @@ namespace TrilinosWrappers
 
   void
   BlockVector::reinit (const std::vector<Epetra_Map> &input_maps,
-                       const bool                     fast)
+                       const bool                     omit_zeroing_entries)
   {
     size_type no_blocks = input_maps.size();
     std::vector<size_type> block_sizes (no_blocks);
@@ -282,7 +282,7 @@ namespace TrilinosWrappers
       components.resize(n_blocks());
 
     for (size_type i=0; i<n_blocks(); ++i)
-      components[i].reinit(input_maps[i], fast);
+      components[i].reinit(input_maps[i], omit_zeroing_entries);
 
     collect_sizes();
   }
@@ -292,7 +292,7 @@ namespace TrilinosWrappers
   void
   BlockVector::reinit (const std::vector<IndexSet> &partitioning,
                        const MPI_Comm              &communicator,
-                       const bool                   fast)
+                       const bool                   omit_zeroing_entries)
   {
     size_type no_blocks = partitioning.size();
     std::vector<size_type> block_sizes (no_blocks);
@@ -306,7 +306,7 @@ namespace TrilinosWrappers
       components.resize(n_blocks());
 
     for (size_type i=0; i<n_blocks(); ++i)
-      components[i].reinit(partitioning[i], communicator, fast);
+      components[i].reinit(partitioning[i], communicator, omit_zeroing_entries);
 
     collect_sizes();
   }
@@ -315,14 +315,14 @@ namespace TrilinosWrappers
 
   void
   BlockVector::reinit (const std::vector<size_type> &block_sizes,
-                       const bool                    fast)
+                       const bool                    omit_zeroing_entries)
   {
     this->block_indices.reinit (block_sizes);
     if (components.size() != n_blocks())
       components.resize(n_blocks());
 
     for (size_type i=0; i<n_blocks(); ++i)
-      components[i].reinit(block_sizes[i], fast);
+      components[i].reinit(block_sizes[i], omit_zeroing_entries);
 
     collect_sizes();
   }
@@ -360,14 +360,14 @@ namespace TrilinosWrappers
 
   void
   BlockVector::reinit (const BlockVector &v,
-                       const bool         fast)
+                       const bool         omit_zeroing_entries)
   {
     block_indices = v.get_block_indices();
     if (components.size() != n_blocks())
       components.resize(n_blocks());
 
     for (size_type i=0; i<n_blocks(); ++i)
-      components[i].reinit(v.block(i), fast);
+      components[i].reinit(v.block(i), omit_zeroing_entries);
 
     collect_sizes();
   }

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -199,13 +199,13 @@ namespace TrilinosWrappers
 
     void
     Vector::reinit (const Epetra_Map &input_map,
-                    const bool        fast)
+                    const bool        omit_zeroing_entries)
     {
       nonlocal_vector.reset();
 
       if (vector->Map().SameAs(input_map)==false)
         vector.reset (new Epetra_FEVector(input_map));
-      else if (fast == false)
+      else if (omit_zeroing_entries == false)
         {
           const int ierr = vector->PutScalar(0.);
           (void)ierr;
@@ -221,20 +221,20 @@ namespace TrilinosWrappers
     void
     Vector::reinit (const IndexSet &parallel_partitioner,
                     const MPI_Comm &communicator,
-                    const bool      fast)
+                    const bool      omit_zeroing_entries)
     {
       nonlocal_vector.reset();
 
       Epetra_Map map = parallel_partitioner.make_trilinos_map (communicator,
                                                                true);
-      reinit (map, fast);
+      reinit (map, omit_zeroing_entries);
     }
 
 
 
     void
     Vector::reinit (const VectorBase &v,
-                    const bool        fast,
+                    const bool        omit_zeroing_entries,
                     const bool        allow_different_maps)
     {
       nonlocal_vector.reset();
@@ -250,7 +250,7 @@ namespace TrilinosWrappers
               has_ghosts = v.has_ghosts;
               last_action = Zero;
             }
-          else if (fast == false)
+          else if (omit_zeroing_entries == false)
             {
               // old and new vectors
               // have exactly the
@@ -275,9 +275,9 @@ namespace TrilinosWrappers
       // what she is doing.
       else
         {
-          Assert (fast == false,
+          Assert (omit_zeroing_entries == false,
                   ExcMessage ("It is not possible to exchange data with the "
-                              "option fast set, which would not write "
+                              "option 'omit_zeroing_entries' set, which would not write "
                               "elements."));
 
           AssertThrow (size() == v.size(),
@@ -562,7 +562,7 @@ namespace TrilinosWrappers
 
   void
   Vector::reinit (const size_type n,
-                  const bool      fast)
+                  const bool      omit_zeroing_entries)
   {
     if (size() != n)
       {
@@ -570,7 +570,7 @@ namespace TrilinosWrappers
                              Utilities::Trilinos::comm_self());
         vector.reset (new Epetra_FEVector (map));
       }
-    else if (fast == false)
+    else if (omit_zeroing_entries == false)
       {
         int ierr;
         ierr = vector->GlobalAssemble(last_action);
@@ -588,7 +588,7 @@ namespace TrilinosWrappers
 
   void
   Vector::reinit (const Epetra_Map &input_map,
-                  const bool        fast)
+                  const bool        omit_zeroing_entries)
   {
     if (n_global_elements(vector->Map()) != n_global_elements(input_map))
       {
@@ -597,7 +597,7 @@ namespace TrilinosWrappers
                              input_map.Comm());
         vector.reset (new Epetra_FEVector (map));
       }
-    else if (fast == false)
+    else if (omit_zeroing_entries == false)
       {
         int ierr;
         ierr = vector->GlobalAssemble(last_action);
@@ -616,7 +616,7 @@ namespace TrilinosWrappers
   void
   Vector::reinit (const IndexSet &partitioning,
                   const MPI_Comm &communicator,
-                  const bool      fast)
+                  const bool      omit_zeroing_entries)
   {
     if (n_global_elements(vector->Map()) !=
         static_cast<TrilinosWrappers::types::int_type>(partitioning.size()))
@@ -631,7 +631,7 @@ namespace TrilinosWrappers
 #endif
         vector.reset (new Epetra_FEVector(map));
       }
-    else if (fast == false)
+    else if (omit_zeroing_entries == false)
       {
         int ierr;
         ierr = vector->GlobalAssemble(last_action);
@@ -649,7 +649,7 @@ namespace TrilinosWrappers
 
   void
   Vector::reinit (const VectorBase &v,
-                  const bool        fast,
+                  const bool        omit_zeroing_entries,
                   const bool        allow_different_maps)
   {
     // In case we do not allow to
@@ -659,7 +659,7 @@ namespace TrilinosWrappers
     // the vector, initialize our
     // map with the map in v, and
     // generate the vector.
-    (void)fast;
+    (void)omit_zeroing_entries;
     if (allow_different_maps == false)
       {
         if (local_range() != v.local_range())
@@ -695,9 +695,9 @@ namespace TrilinosWrappers
     // the data.
     else
       {
-        Assert (fast == false,
+        Assert (omit_zeroing_entries == false,
                 ExcMessage ("It is not possible to exchange data with the "
-                            "option fast set, which would not write "
+                            "option 'omit_zeroing_entries' set, which would not write "
                             "elements."));
 
         AssertThrow (size() == v.size(),


### PR DESCRIPTION
This addresses something I recall feeling is a poorly named parameter already sometime around 1998:

The various 'reinit' functions have parameters called 'fast'. This patch renames them all to 'skip_initialization'. This is a more accurate representation of what the parameter achieves, and should be easier to understand. The fact that this mode is also 'fast' is sort of a side effect of the semantics the parameter really carries.