### PR TITLE
Bugfix: Add a missing space in a build test target

### DIFF
--- a/tests/build_tests/CMakeLists.txt
+++ b/tests/build_tests/CMakeLists.txt
@@ -132,7 +132,7 @@ FOREACH(_step_full ${_steps})
       ADD_CUSTOM_COMMAND(OUTPUT ${_step_dir}/build_output
         COMMAND test ! -f ${_step_dir}/configure_output
           || (rm -f ${_step_dir}/failing_build_output
-              &&${CMAKE_COMMAND} --build ${_step_dir} --target all
+              && ${CMAKE_COMMAND} --build ${_step_dir} --target all
               > ${_step_dir}/build_output 2>&1)
           || (mv ${_step_dir}/build_output
                  ${_step_dir}/failing_build_output


### PR DESCRIPTION
Maybe this fixes the build tests for [1]

[1] http://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=13878