### PR TITLE
Break dependency of MappingQ from MappingQGeneric.

### DIFF
--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -33,13 +33,10 @@ DEAL_II_NAMESPACE_OPEN
  * class chooses them such that the discretized boundary is globally
  * continuously differentiable.
  *
- * To use this class, make sure that the Boundary::@p get_normals_at_vertices
+ * To use this class, make sure that the Boundary::get_normals_at_vertices()
  * function is implemented for the user's boundary object.
  *
- * For more information about the <tt>spacedim</tt> template parameter check
- * the documentation of FiniteElement or the one of Triangulation.
- *
- * @author Wolfgang Bangerth, 2001
+ * @author Wolfgang Bangerth, 2001, 2015
  */
 template<int dim, int spacedim=dim>
 class MappingC1 : public MappingQ<dim,spacedim>
@@ -59,37 +56,53 @@ public:
   Mapping<dim,spacedim> *clone () const;
 
 protected:
-  /**
-   * For <tt>dim=2,3</tt>. Append the support points of all shape functions
-   * located on bounding lines to the vector @p a. Points located on the line
-   * but on vertices are not included.
-   *
-   * Needed by the <tt>compute_support_points_simple(laplace)</tt> functions.
-   * For <tt>dim=1</tt> this function is empty.
-   *
-   * This function chooses the respective points not such that they are
-   * interpolating the boundary (as does the base class), but rather such that
-   * the resulting cubic mapping is a continuous one.
-   */
-  virtual void
-  add_line_support_points (const typename Triangulation<dim>::cell_iterator &cell,
-                           std::vector<Point<dim> > &a) const;
 
   /**
-   * For <tt>dim=3</tt>. Append the support points of all shape functions
-   * located on bounding faces (quads in 3d) to the vector @p a. Points
-   * located on the line but on vertices are not included.
-   *
-   * Needed by the @p compute_support_points_laplace function. For
-   * <tt>dim=1</tt> and 2 this function is empty.
-   *
-   * This function chooses the respective points not such that they are
-   * interpolating the boundary (as does the base class), but rather such that
-   * the resulting cubic mapping is a continuous one.
+   * A class derived from MappingQGeneric that provides the generic
+   * mapping with support points on boundary objects so that the
+   * corresponding Q3 mapping ends up being C1.
    */
-  virtual void
-  add_quad_support_points(const typename Triangulation<dim>::cell_iterator &cell,
-                          std::vector<Point<dim> > &a) const;
+  class MappingC1Generic : public MappingQGeneric<dim,spacedim>
+  {
+  public:
+
+    /**
+     * Constructor.
+     */
+    MappingC1Generic ();
+
+    /**
+     * For <tt>dim=2,3</tt>. Append the support points of all shape functions
+     * located on bounding lines to the vector @p a. Points located on the line
+     * but on vertices are not included.
+     *
+     * Needed by the <tt>compute_support_points_simple(laplace)</tt> functions.
+     * For <tt>dim=1</tt> this function is empty.
+     *
+     * This function chooses the respective points not such that they are
+     * interpolating the boundary (as does the base class), but rather such that
+     * the resulting cubic mapping is a continuous one.
+     */
+    virtual void
+    add_line_support_points (const typename Triangulation<dim>::cell_iterator &cell,
+                             std::vector<Point<dim> > &a) const;
+
+    /**
+     * For <tt>dim=3</tt>. Append the support points of all shape functions
+     * located on bounding faces (quads in 3d) to the vector @p a. Points
+     * located on the line but on vertices are not included.
+     *
+     * Needed by the @p compute_support_points_laplace function. For
+     * <tt>dim=1</tt> and 2 this function is empty.
+     *
+     * This function chooses the respective points not such that they are
+     * interpolating the boundary (as does the base class), but rather such that
+     * the resulting cubic mapping is a continuous one.
+     */
+    virtual void
+    add_quad_support_points(const typename Triangulation<dim>::cell_iterator &cell,
+                            std::vector<Point<dim> > &a) const;
+  };
 };
 
 /*@}*/
@@ -98,17 +111,17 @@ protected:
 
 #ifndef DOXYGEN
 
-template <> void MappingC1<1>::add_line_support_points (
+template <> void MappingC1<1>::MappingC1Generic::add_line_support_points (
   const Triangulation<1>::cell_iterator &,
   std::vector<Point<1> > &) const;
-template <> void MappingC1<2>::add_line_support_points (
+template <> void MappingC1<2>::MappingC1Generic::add_line_support_points (
   const Triangulation<2>::cell_iterator &cell,
   std::vector<Point<2> > &a) const;
 
-template <> void MappingC1<1>::add_quad_support_points (
+template <> void MappingC1<1>::MappingC1Generic::add_quad_support_points (
   const Triangulation<1>::cell_iterator &,
   std::vector<Point<1> > &) const;
-template <> void MappingC1<2>::add_quad_support_points (
+template <> void MappingC1<2>::MappingC1Generic::add_quad_support_points (
   const Triangulation<2>::cell_iterator &,
   std::vector<Point<2> > &) const;
 

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -211,13 +211,46 @@ private:
   mutable Threads::Mutex fe_values_mutex;
 
   /**
-   * Compute the positions of the support points in the current configuration.
-   * See the documentation of MappingQGeneric::compute_mapping_support_points()
-   * for more information.
+   * A class derived from MappingQGeneric that provides the generic
+   * mapping with support points on boundary objects so that the
+   * corresponding Q3 mapping ends up being C1.
    */
-  virtual
-  std::vector<Point<spacedim> >
-  compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+  class MappingQEulerianGeneric : public MappingQGeneric<dim,spacedim>
+  {
+  public:
+
+    /**
+     * Constructor.
+     */
+    MappingQEulerianGeneric (const unsigned int degree,
+                             const MappingQEulerian<dim,VECTOR,spacedim> &mapping_q_eulerian);
+
+    /**
+     * Return the mapped vertices of the cell. For the current class, this function does
+     * not use the support points from the geometry of the current cell but
+     * instead evaluates an externally given displacement field in addition to
+     * the geometry of the cell.
+     */
+    virtual
+    std_cxx11::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
+    get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+
+    /**
+     * Compute the positions of the support points in the current configuration.
+     * See the documentation of MappingQGeneric::compute_mapping_support_points()
+     * for more information.
+     */
+    virtual
+    std::vector<Point<spacedim> >
+    compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
+
+  private:
+    /**
+     * Reference to the surrounding object off of which we live.
+     */
+    const MappingQEulerian<dim,VECTOR,spacedim> &mapping_q_eulerian;
+  };
+
 };
 
 /*@}*/

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -176,41 +176,6 @@ protected:
 private:
 
   /**
-   * Special quadrature rule used to define the support points in the
-   * reference configuration.
-   */
-
-  class SupportQuadrature : public Quadrature<dim>
-  {
-  public:
-    /**
-     * Constructor, with an argument defining the desired polynomial degree.
-     */
-
-    SupportQuadrature (const unsigned int map_degree);
-
-  };
-
-  /**
-   * A member variable holding the quadrature points in the right order.
-   */
-  const SupportQuadrature support_quadrature;
-
-  /**
-   * FEValues object used to query the the given finite element field at the
-   * support points in the reference configuration.
-   *
-   * The variable is marked as mutable since we have to call FEValues::reinit
-   * from compute_mapping_support_points, a function that is 'const'.
-   */
-  mutable FEValues<dim,spacedim> fe_values;
-
-  /**
-   * A variable to guard access to the fe_values variable.
-   */
-  mutable Threads::Mutex fe_values_mutex;
-
-  /**
    * A class derived from MappingQGeneric that provides the generic
    * mapping with support points on boundary objects so that the
    * corresponding Q3 mapping ends up being C1.
@@ -249,6 +214,42 @@ private:
      * Reference to the surrounding object off of which we live.
      */
     const MappingQEulerian<dim,VECTOR,spacedim> &mapping_q_eulerian;
+
+
+    /**
+     * Special quadrature rule used to define the support points in the
+     * reference configuration.
+     */
+
+    class SupportQuadrature : public Quadrature<dim>
+    {
+    public:
+      /**
+       * Constructor, with an argument defining the desired polynomial degree.
+       */
+
+      SupportQuadrature (const unsigned int map_degree);
+
+    };
+
+    /**
+     * A member variable holding the quadrature points in the right order.
+     */
+    const SupportQuadrature support_quadrature;
+
+    /**
+     * FEValues object used to query the the given finite element field at the
+     * support points in the reference configuration.
+     *
+     * The variable is marked as mutable since we have to call FEValues::reinit
+     * from compute_mapping_support_points, a function that is 'const'.
+     */
+    mutable FEValues<dim,spacedim> fe_values;
+
+    /**
+     * A variable to guard access to the fe_values variable.
+     */
+    mutable Threads::Mutex fe_values_mutex;
   };
 
 };

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -24,19 +24,34 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
+MappingC1<dim,spacedim>::MappingC1Generic::MappingC1Generic ()
+  :
+  MappingQGeneric<dim,spacedim> (3)
+{}
+
+
+
+template <int dim, int spacedim>
 MappingC1<dim,spacedim>::MappingC1 ()
   :
   MappingQ<dim,spacedim> (3)
 {
   Assert (dim > 1, ExcImpossibleInDim(dim));
+
+  // replace the mapping_qp objects of the base class by something
+  // that knows about generating data points based on the geometry
+  //
+  // we only need to replace the Qp mapping because that's the one that's
+  // used on boundary cells where it matters
+  this->qp_mapping.reset (new MappingC1<dim,spacedim>::MappingC1Generic());
 }
 
 
 
 template <>
 void
-MappingC1<1>::add_line_support_points (const Triangulation<1>::cell_iterator &,
-                                       std::vector<Point<1> > &) const
+MappingC1<1>::MappingC1Generic::add_line_support_points (const Triangulation<1>::cell_iterator &,
+                                                         std::vector<Point<1> > &) const
 {
   const unsigned int dim = 1;
   (void)dim;
@@ -47,8 +62,8 @@ MappingC1<1>::add_line_support_points (const Triangulation<1>::cell_iterator &,
 
 template <>
 void
-MappingC1<2>::add_line_support_points (const Triangulation<2>::cell_iterator &cell,
-                                       std::vector<Point<2> > &a) const
+MappingC1<2>::MappingC1Generic::add_line_support_points (const Triangulation<2>::cell_iterator &cell,
+                                                         std::vector<Point<2> > &a) const
 {
   const unsigned int dim = 2;
   std::vector<Point<dim> > line_points (2);
@@ -139,16 +154,16 @@ MappingC1<2>::add_line_support_points (const Triangulation<2>::cell_iterator &ce
           static const StraightBoundary<dim> straight_boundary;
           straight_boundary.get_intermediate_points_on_line (line, line_points);
           a.insert (a.end(), line_points.begin(), line_points.end());
-        };
-    };
+        }
+    }
 }
 
 
 
 template<int dim, int spacedim>
 void
-MappingC1<dim,spacedim>::add_line_support_points (const typename Triangulation<dim>::cell_iterator &,
-                                                  std::vector<Point<dim> > &) const
+MappingC1<dim,spacedim>::MappingC1Generic::add_line_support_points (const typename Triangulation<dim>::cell_iterator &,
+    std::vector<Point<dim> > &) const
 {
   Assert (false, ExcNotImplemented());
 }
@@ -157,8 +172,8 @@ MappingC1<dim,spacedim>::add_line_support_points (const typename Triangulation<d
 
 template <>
 void
-MappingC1<1>::add_quad_support_points (const Triangulation<1>::cell_iterator &,
-                                       std::vector<Point<1> > &) const
+MappingC1<1>::MappingC1Generic::add_quad_support_points (const Triangulation<1>::cell_iterator &,
+                                                         std::vector<Point<1> > &) const
 {
   const unsigned int dim = 1;
   (void)dim;
@@ -169,8 +184,8 @@ MappingC1<1>::add_quad_support_points (const Triangulation<1>::cell_iterator &,
 
 template <>
 void
-MappingC1<2>::add_quad_support_points (const Triangulation<2>::cell_iterator &,
-                                       std::vector<Point<2> > &) const
+MappingC1<2>::MappingC1Generic::add_quad_support_points (const Triangulation<2>::cell_iterator &,
+                                                         std::vector<Point<2> > &) const
 {
   const unsigned int dim = 2;
   (void)dim;
@@ -181,8 +196,8 @@ MappingC1<2>::add_quad_support_points (const Triangulation<2>::cell_iterator &,
 
 template<int dim, int spacedim>
 void
-MappingC1<dim,spacedim>::add_quad_support_points (const typename Triangulation<dim>::cell_iterator &,
-                                                  std::vector<Point<dim> > &) const
+MappingC1<dim,spacedim>::MappingC1Generic::add_quad_support_points (const typename Triangulation<dim>::cell_iterator &,
+    std::vector<Point<dim> > &) const
 {
   Assert (false, ExcNotImplemented());
 }

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -1160,7 +1160,10 @@ MappingQGeneric<dim,spacedim>::MappingQGeneric (const unsigned int p)
   fe_q(dim == 3 ? new FE_Q<dim>(this->polynomial_degree) : 0),
   support_point_weights_on_quad (compute_support_point_weights_on_quad<dim>(this->polynomial_degree)),
   support_point_weights_on_hex (compute_support_point_weights_on_hex<dim>(this->polynomial_degree))
-{}
+{
+  Assert (p >= 1, ExcMessage ("It only makes sense to create polynomial mappings "
+                              "with a polynomial degree greater or equal to one."));
+}
 
 
 


### PR DESCRIPTION
As discussed in #1732, MappingQ doesn't have the is-a property with
regard to MappingQGeneric. Nor does it have it with regard to its previous
base class, MappingQ1, and this was already fixed previously (#1429). Rather, what
it should be is a has-a relationship with regard to both the MappingQGeneric
(used on cells on the boundary) and MappingQ1 (used for interior cells).

This patch implements this. The part of the patch for MappingQ itself is
relatively straightforward: have it store pointers to both Q1 and Qp
mappings, and where it currently dispatches to the base class
MappingQGeneric, just dispatch to the Qp object instead. We can
then break the inheritance from  MappingQ
to MappingQGeneric, at the cost of reimplementing a couple of
trivial functions of the Mapping interface that were previously
provided by the MappingQGeneric class.

The bigger problems appear in the MappingQEulerian and
MappingC1 classes which previously overloaded functions
declared in MappingQGeneric and that are now no longer
available to the MappingQGeneric object we now keep a
pointer to, rather than have as base class. This is
worked around by having both MappingQEulerian and
MappingC1 declare their own internal classes derived
from MappingQGeneric that provide the now missing
functions.

This fixes #1732. In reference to #1198.