### PR TITLE
Fix several Tensor<rank,dim,Number> related bugs:

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1994,6 +1994,72 @@ SymmetricTensor<rank,dim,Number>::serialize(Archive &ar, const unsigned int)
 
 /* ----------------- Non-member functions operating on tensors. ------------ */
 
+
+/**
+ * Addition of a SymmetricTensor and a general Tensor of equal rank. The
+ * result is a general Tensor.
+ *
+ * @relates SymmetricTensor
+ */
+template <int rank, int dim, typename Number, typename OtherNumber>
+inline
+Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
+operator+(const SymmetricTensor<rank, dim, Number> &left,
+          const Tensor<rank, dim, OtherNumber> &right)
+{
+  return Tensor<rank, dim, Number>(left) + right;
+}
+
+
+/**
+ * Addition of a general Tensor with a SymmetricTensor of equal rank. The
+ * result is a general Tensor.
+ *
+ * @relates SymmetricTensor
+ */
+template <int rank, int dim, typename Number, typename OtherNumber>
+inline
+Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
+operator+(const Tensor<rank, dim, Number> &left,
+          const SymmetricTensor<rank, dim, OtherNumber> &right)
+{
+  return left + Tensor<rank, dim, OtherNumber>(right);
+}
+
+
+/**
+ * Subtraction of a SymmetricTensor and a general Tensor of equal rank. The
+ * result is a general Tensor.
+ *
+ * @relates SymmetricTensor
+ */
+template <int rank, int dim, typename Number, typename OtherNumber>
+inline
+Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
+operator-(const SymmetricTensor<rank, dim, Number> &left,
+          const Tensor<rank, dim, OtherNumber> &right)
+{
+  return Tensor<rank, dim, Number>(left) - right;
+}
+
+
+/**
+ * Subtraction of a general Tensor with a SymmetricTensor of equal rank.
+ * The result is a general Tensor.
+ *
+ * @relates SymmetricTensor
+ */
+template <int rank, int dim, typename Number, typename OtherNumber>
+inline
+Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
+operator-(const Tensor<rank, dim, Number> &left,
+          const SymmetricTensor<rank, dim, OtherNumber> &right)
+{
+  return left - Tensor<rank, dim, OtherNumber>(right);
+}
+
+
+
 /**
  * Compute the determinant of a tensor or rank 2. The determinant is also
  * commonly referred to as the third invariant of rank-2 tensors.

--- a/tests/base/tensor_accessors_02.cc
+++ b/tests/base/tensor_accessors_02.cc
@@ -78,7 +78,7 @@ int main()
 
     // via std::array:
 #ifdef DEAL_II_WITH_CXX11
-    std::array<unsigned int, 5> temp {2, 1, 0, 2, 1};
+    std::array<unsigned int, 5> temp {{2, 1, 0, 2, 1}};
     deallog << TensorAccessors::extract<5>(foo, temp) << std::endl;
 #else
     deallog << 42. << std::endl;

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -107,8 +107,10 @@ int main()
   auto op_b10 = linear_operator(a.block(1, 0));
   auto op_b11 = linear_operator(a.block(1, 1));
 
-  std::array<std::array<decltype(op_b00), 2>, 2> temp{
-      {op_b00, op_b01, op_b10, op_b11}};
+  std::array<std::array<decltype(op_b00), 2>, 2> temp
+  {
+    {op_b00, op_b01, op_b10, op_b11}
+  };
   auto op_b = block_operator<2, 2, BlockVector<double>>(temp);
 
   {
@@ -184,8 +186,10 @@ int main()
 
   // And finally complicated block structures:
 
-  std::array<std::array<decltype(op_b00), 3>, 3> temp2{
-      {op_b00, op_b01, op_b00, op_b10, op_b11, op_b10, op_b10, op_b11, op_b10}};
+  std::array<std::array<decltype(op_b00), 3>, 3> temp2
+  {
+    {op_b00, op_b01, op_b00, op_b10, op_b11, op_b10, op_b10, op_b11, op_b10}
+  };
   auto op_upp_x_upu = block_operator<3, 3, BlockVector<double>>(temp2);
 
   op_upp_x_upu.reinit_domain_vector(u, false);
@@ -203,12 +207,16 @@ int main()
   op_upp_x_upu.vmult_add(v, u);
   PRINTME("v", v);
 
-  std::array<std::array<decltype(op_b01), 1>, 3> temp3{
-      {op_b01, op_b11, op_b11}};
+  std::array<std::array<decltype(op_b01), 1>, 3> temp3
+  {
+    {op_b01, op_b11, op_b11}
+  };
   auto op_upp_x_p = block_operator<3, 1, BlockVector<double>>(temp3);
 
-  std::array<std::array<decltype(op_b01), 3>, 1> temp4{
-      {op_b00, op_b01, op_b00}};
+  std::array<std::array<decltype(op_b01), 3>, 1> temp4
+  {
+    {op_b00, op_b01, op_b00}
+  };
   auto op_u_x_upu = block_operator<1, 3, BlockVector<double>>(temp4);
 
   auto op_long = op_u_x_upu * transpose_operator(op_upp_x_upu) * op_upp_x_p;

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -107,9 +107,8 @@ int main()
   auto op_b10 = linear_operator(a.block(1, 0));
   auto op_b11 = linear_operator(a.block(1, 1));
 
-  std::array<std::array<decltype(op_b00), 2>, 2> temp {op_b00, op_b01, op_b10,
-                                                       op_b11
-                                                      };
+  std::array<std::array<decltype(op_b00), 2>, 2> temp{
+      {op_b00, op_b01, op_b10, op_b11}};
   auto op_b = block_operator<2, 2, BlockVector<double>>(temp);
 
   {
@@ -185,10 +184,8 @@ int main()
 
   // And finally complicated block structures:
 
-  std::array<std::array<decltype(op_b00), 3>, 3> temp2
-  {
-    op_b00, op_b01, op_b00, op_b10, op_b11, op_b10, op_b10, op_b11, op_b10
-  };
+  std::array<std::array<decltype(op_b00), 3>, 3> temp2{
+      {op_b00, op_b01, op_b00, op_b10, op_b11, op_b10, op_b10, op_b11, op_b10}};
   auto op_upp_x_upu = block_operator<3, 3, BlockVector<double>>(temp2);
 
   op_upp_x_upu.reinit_domain_vector(u, false);
@@ -206,10 +203,12 @@ int main()
   op_upp_x_upu.vmult_add(v, u);
   PRINTME("v", v);
 
-  std::array<std::array<decltype(op_b01), 1>, 3> temp3 {op_b01, op_b11, op_b11};
+  std::array<std::array<decltype(op_b01), 1>, 3> temp3{
+      {op_b01, op_b11, op_b11}};
   auto op_upp_x_p = block_operator<3, 1, BlockVector<double>>(temp3);
 
-  std::array<std::array<decltype(op_b01), 3>, 1> temp4 {op_b00, op_b01, op_b00};
+  std::array<std::array<decltype(op_b01), 3>, 1> temp4{
+      {op_b00, op_b01, op_b00}};
   auto op_u_x_upu = block_operator<1, 3, BlockVector<double>>(temp4);
 
   auto op_long = op_u_x_upu * transpose_operator(op_upp_x_upu) * op_upp_x_p;

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -84,8 +84,7 @@ int main()
   auto op_b1 = linear_operator(a.block(1, 1));
   auto op_b2 = linear_operator(a.block(2, 2));
 
-
-  std::array<decltype(op_b0), 3> temp {op_b0, op_b1, op_b2};
+  std::array<decltype(op_b0), 3> temp{{op_b0, op_b1, op_b2}};
   auto op_b = block_diagonal_operator<3, BlockVector<double>>(temp);
 
 
@@ -157,7 +156,7 @@ int main()
 
   // And finally the other block_diagonal_operator variant:
 
-  std::array<decltype(op_b0), 5> temp2 {op_b0, op_b0, op_b0, op_b0, op_b0};
+  std::array<decltype(op_b0), 5> temp2{{op_b0, op_b0, op_b0, op_b0, op_b0}};
   auto op_c = block_diagonal_operator<5, BlockVector<double>>(temp2);
 
   auto op_d = block_diagonal_operator<5, BlockVector<double>>(op_b0);

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -84,7 +84,7 @@ int main()
   auto op_b1 = linear_operator(a.block(1, 1));
   auto op_b2 = linear_operator(a.block(2, 2));
 
-  std::array<decltype(op_b0), 3> temp{{op_b0, op_b1, op_b2}};
+  std::array<decltype(op_b0), 3> temp {{op_b0, op_b1, op_b2}};
   auto op_b = block_diagonal_operator<3, BlockVector<double>>(temp);
 
 
@@ -156,7 +156,7 @@ int main()
 
   // And finally the other block_diagonal_operator variant:
 
-  std::array<decltype(op_b0), 5> temp2{{op_b0, op_b0, op_b0, op_b0, op_b0}};
+  std::array<decltype(op_b0), 5> temp2 {{op_b0, op_b0, op_b0, op_b0, op_b0}};
   auto op_c = block_diagonal_operator<5, BlockVector<double>>(temp2);
 
   auto op_d = block_diagonal_operator<5, BlockVector<double>>(op_b0);


### PR DESCRIPTION
Bugfix: Provide missing operator+ and operator- variants

  Unfortunately, it is not possible any more to exploit an implicit
  conversion from SymmetricTensor to Tensor due to the heavily templated
  operator variants for Tensor.

  Thus, provide mixed operator types. (And clean up symmetric_tensor.h
  later).

  Fixes #1556


Bugfix: Add additional braces around subobject initializers..

  Hopefully this makes icc happy