### PR TITLE
CMake: Bugfix: Also use DEAL_II_INCLUDE_DIRS for bundled boost

### DIFF
--- a/bundled/boost-1.56.0/libs/iostreams/src/CMakeLists.txt
+++ b/bundled/boost-1.56.0/libs/iostreams/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## ---------------------------------------------------------------------
 ## $Id$
 ##
-## Copyright (C) 2013 - 2014 by the deal.II authors
+## Copyright (C) 2013 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -14,7 +14,10 @@
 ##
 ## ---------------------------------------------------------------------
 
-INCLUDE_DIRECTORIES(${BOOST_BUNDLED_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(
+  ${BOOST_BUNDLED_INCLUDE_DIRS}
+  ${DEAL_II_INCLUDE_DIRS}
+  )
 
 SET(src_boost_iostreams
     file_descriptor.cpp

--- a/bundled/boost-1.56.0/libs/serialization/src/CMakeLists.txt
+++ b/bundled/boost-1.56.0/libs/serialization/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## ---------------------------------------------------------------------
 ## $Id$
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -14,7 +14,10 @@
 ##
 ## ---------------------------------------------------------------------
 
-INCLUDE_DIRECTORIES(${BOOST_BUNDLED_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(
+  ${BOOST_BUNDLED_INCLUDE_DIRS}
+  ${DEAL_II_INCLUDE_DIRS}
+  )
 
 SET(src_boost_serialization
   basic_archive.cpp

--- a/bundled/boost-1.56.0/libs/system/src/CMakeLists.txt
+++ b/bundled/boost-1.56.0/libs/system/src/CMakeLists.txt
@@ -14,7 +14,10 @@
 ##
 ## ---------------------------------------------------------------------
 
-INCLUDE_DIRECTORIES(${BOOST_BUNDLED_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(
+  ${BOOST_BUNDLED_INCLUDE_DIRS}
+  ${DEAL_II_INCLUDE_DIRS}
+  )
 
 SET(src_boost_system
   error_code.cpp

--- a/bundled/boost-1.56.0/libs/thread/src/CMakeLists.txt
+++ b/bundled/boost-1.56.0/libs/thread/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## ---------------------------------------------------------------------
 ## $Id$
 ##
-## Copyright (C) 2012 - 2014 by the deal.II authors
+## Copyright (C) 2012 - 2015 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -14,7 +14,10 @@
 ##
 ## ---------------------------------------------------------------------
 
-INCLUDE_DIRECTORIES(${BOOST_BUNDLED_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(
+  ${BOOST_BUNDLED_INCLUDE_DIRS}
+  ${DEAL_II_INCLUDE_DIRS}
+  )
 
 IF(DEAL_II_USE_MT_POSIX)
   SET(src_boost_thread

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -398,6 +398,11 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: A compilation issue with DEAL_II_INCLUDE_DIRS not used for
+  compiling bundled boost.
+  <br>
+  (Lukas Korous, 2015/11/01)
+  </li>
 
   <li> Fixed: PolynomialsBDM::degree() now returns the correct value.
   <br>


### PR DESCRIPTION
This fixes a compilation issue with a zlib library not in a default
location in combination with bundled boost. Many thanks to Lukas Korous for
pointing this out.

Closes #1610