### PR TITLE
Remove first_cell mechanism in FiniteElement

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -520,16 +520,6 @@ public:
     virtual ~InternalDataBase ();
 
     /**
-     * Values updated by the constructor or by reinit.
-     */
-    UpdateFlags          update_flags;
-
-    /**
-     * Values computed by constructor.
-     */
-    UpdateFlags          update_once;
-
-    /**
      * A set of update flags specifying the kind of information that
      * an implementation of the FiniteElement interface needs to compute on
      * each cell or face, i.e., in FiniteElement::fill_fe_values() and
@@ -548,29 +538,9 @@ public:
     UpdateFlags          update_each;
 
     /**
-     * If <tt>first_cell==true</tt> this function returns @p update_flags,
-     * i.e. <tt>update_once|update_each</tt>. If <tt>first_cell==false</tt> it
-     * returns @p update_each.
-     */
-    UpdateFlags  current_update_flags() const;
-
-    /**
-     * Set the @p first_cell flag to @p false. Used by the @p FEValues class
-     * to indicate that we have already done the work on the first cell.
-     */
-    virtual void clear_first_cell ();
-
-    /**
      * Return an estimate (in bytes) or the memory consumption of this object.
      */
     virtual std::size_t memory_consumption () const;
-
-  private:
-    /**
-     * Initially set to true, but reset to false when clear_first_cell()
-     * is called.
-     */
-    bool first_cell;
   };
 
 public:

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -250,20 +250,14 @@ protected:
     // generate a new data object and initialize some fields
     typename FiniteElement<1,spacedim>::InternalDataBase *data =
       new typename FiniteElement<1,spacedim>::InternalDataBase;
+    data->update_each = update_once(update_flags) | update_each(update_flags);  // FIX: only update_each required
 
-    // check what needs to be initialized only once and what on every
-    // cell/face/subface we visit
-    data->update_once = update_once(update_flags);
-    data->update_each = update_each(update_flags);
-    data->update_flags = data->update_once | data->update_each;
-
-    const UpdateFlags flags(data->update_flags);
     const unsigned int n_q_points = quadrature.size();
     AssertDimension(n_q_points, 1);
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (flags & update_gradients || flags & update_hessians)
+    if (data->update_each & update_gradients || data->update_each & update_hessians)
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -222,16 +222,8 @@ protected:
     // generate a new data object and
     // initialize some fields
     InternalData *data = new InternalData;
+    data->update_each = update_each(update_flags) | update_once(update_flags);  // FIX: only update_each required
 
-    // check what needs to be
-    // initialized only once and what
-    // on every cell/face/subface we
-    // visit
-    data->update_once = update_once(update_flags);
-    data->update_each = update_each(update_flags);
-    data->update_flags = data->update_once | data->update_each;
-
-    const UpdateFlags flags(data->update_flags);
     const unsigned int n_q_points = quadrature.size();
 
     // some scratch arrays
@@ -244,28 +236,28 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (flags & update_values)
+    if (update_flags & update_values)
       {
         values.resize (this->dofs_per_cell);
         data->shape_values.resize (this->dofs_per_cell,
                                    std::vector<double> (n_q_points));
       }
 
-    if (flags & update_gradients)
+    if (update_flags & update_gradients)
       {
         grads.resize (this->dofs_per_cell);
         data->shape_gradients.resize (this->dofs_per_cell,
                                       std::vector<Tensor<1,dim> > (n_q_points));
       }
 
-    if (flags & update_hessians)
+    if (update_flags & update_hessians)
       {
         grad_grads.resize (this->dofs_per_cell);
         data->shape_hessians.resize (this->dofs_per_cell,
                                      std::vector<Tensor<2,dim> > (n_q_points));
       }
 
-    if (flags & update_3rd_derivatives)
+    if (update_flags & update_3rd_derivatives)
       {
         third_derivatives.resize (this->dofs_per_cell);
         data->shape_3rd_derivatives.resize (this->dofs_per_cell,
@@ -279,8 +271,8 @@ protected:
     // unit cell, and need to be
     // transformed when visiting an
     // actual cell
-    if (flags & (update_values | update_gradients
-                 | update_hessians | update_3rd_derivatives) )
+    if (update_flags & (update_values | update_gradients
+                        | update_hessians | update_3rd_derivatives) )
       for (unsigned int i=0; i<n_q_points; ++i)
         {
           poly_space.compute(quadrature.point(i),
@@ -288,19 +280,19 @@ protected:
                              third_derivatives,
                              fourth_derivatives);
 
-          if (flags & update_values)
+          if (update_flags & update_values)
             for (unsigned int k=0; k<this->dofs_per_cell; ++k)
               data->shape_values[k][i] = values[k];
 
-          if (flags & update_gradients)
+          if (update_flags & update_gradients)
             for (unsigned int k=0; k<this->dofs_per_cell; ++k)
               data->shape_gradients[k][i] = grads[k];
 
-          if (flags & update_hessians)
+          if (update_flags & update_hessians)
             for (unsigned int k=0; k<this->dofs_per_cell; ++k)
               data->shape_hessians[k][i] = grad_grads[k];
 
-          if (flags & update_3rd_derivatives)
+          if (update_flags & update_3rd_derivatives)
             for (unsigned int k=0; k<this->dofs_per_cell; ++k)
               data->shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -240,7 +240,7 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.current_update_flags());
+  const UpdateFlags flags(fe_data.update_each);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
@@ -312,7 +312,7 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
                                                 cell->face_rotation(face),
                                                 quadrature.size());
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
+  const UpdateFlags flags(fe_data.update_each);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
@@ -388,7 +388,7 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
                                                    quadrature.size(),
                                                    cell->subface_case(face));
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
+  const UpdateFlags flags(fe_data.update_each);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -99,16 +99,8 @@ protected:
     // generate a new data object and
     // initialize some fields
     InternalData *data = new InternalData;
+    data->update_each = update_once(update_flags) | update_each(update_flags);  // FIX: only update_each required
 
-    // check what needs to be
-    // initialized only once and what
-    // on every cell/face/subface we
-    // visit
-    data->update_once = update_once(update_flags);
-    data->update_each = update_each(update_flags);
-    data->update_flags = data->update_once | data->update_each;
-
-    const UpdateFlags flags(data->update_flags);
     const unsigned int n_q_points = quadrature.size();
 
     // some scratch arrays
@@ -121,7 +113,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (flags & update_values)
+    if (data->update_each & update_values)
       {
         values.resize (poly_space.n());
         data->shape_values.resize (poly_space.n(),
@@ -139,7 +131,7 @@ protected:
       }
     // No derivatives of this element
     // are implemented.
-    if (flags & update_gradients || flags & update_hessians)
+    if (data->update_each & update_gradients || data->update_each & update_hessians)
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -118,9 +118,7 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
-
-  if (flags & update_values)
+  if (fe_data.update_each & update_values)
     for (unsigned int i=0; i<quadrature.size(); ++i)
       {
         for (unsigned int k=0; k<this->dofs_per_cell; ++k)
@@ -136,7 +134,10 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
                 for (unsigned int k=0; k<this->dofs_per_quad; ++k)
                   output_data.shape_values(foffset+k,i) = fe_data.shape_values[k+this->first_face_quad_index][i];
               }
+
+            // fall through...
           }
+
           case 2:
           {
             // Fill data for line shape functions
@@ -150,7 +151,10 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
                         = fe_data.shape_values[k+(line*this->dofs_per_line)+this->first_face_line_index][i];
                   }
               }
+
+            // fall through...
           }
+
           case 1:
           {
             // Fill data for vertex shape functions
@@ -185,12 +189,10 @@ fill_fe_subface_values (const Mapping<dim,spacedim> &,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
-
   const unsigned int foffset = fe_data.shape_values.size() * face;
   const unsigned int offset = subface*quadrature.size();
 
-  if (flags & update_values)
+  if (fe_data.update_each & update_values)
     for (unsigned int i=0; i<quadrature.size(); ++i)
       {
         for (unsigned int k=0; k<this->dofs_per_cell; ++k)
@@ -199,8 +201,8 @@ fill_fe_subface_values (const Mapping<dim,spacedim> &,
           output_data.shape_values(foffset+k,i) = fe_data.shape_values[k][i+offset];
       }
 
-  Assert (!(flags & update_gradients), ExcNotImplemented());
-  Assert (!(flags & update_hessians), ExcNotImplemented());
+  Assert (!(fe_data.update_each & update_gradients), ExcNotImplemented());
+  Assert (!(fe_data.update_each & update_hessians), ExcNotImplemented());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -1145,15 +1145,6 @@ private:
     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &
     get_fe_output_object (const unsigned int base_no) const;
 
-    /**
-     * Set the @p first_cell flag to @p false. Used by the @p FEValues class
-     * to indicate that we have already done the work on the first cell.
-     *
-     * In addition to calling the respective function of the base class, this
-     * function also calls the functions of the sub-data objects.
-     */
-    virtual void clear_first_cell ();
-
   private:
 
     /**

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -36,10 +36,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase ():
-  update_flags(update_default),
-  update_once(update_default),
-  update_each(update_default),
-  first_cell(true)
+  update_each(update_default)
 {}
 
 
@@ -56,32 +53,6 @@ FiniteElement<dim, spacedim>::InternalDataBase::memory_consumption () const
 {
   return sizeof(*this);
 }
-
-
-
-template <int dim, int spacedim>
-UpdateFlags
-FiniteElement<dim,spacedim>::InternalDataBase::current_update_flags () const
-{
-  if (first_cell)
-    {
-      Assert (update_flags==(update_once|update_each),
-              ExcInternalError());
-      return update_flags;
-    }
-  else
-    return update_each;
-}
-
-
-
-template <int dim, int spacedim>
-void
-FiniteElement<dim,spacedim>::InternalDataBase::clear_first_cell ()
-{
-  first_cell = false;
-}
-
 
 
 

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -494,10 +494,8 @@ fill_fe_face_values (const Mapping<1,spacedim> &,
                      const internal::FEValues::MappingRelatedData<1,spacedim> &,
                      internal::FEValues::FiniteElementRelatedData<1,spacedim> &output_data) const
 {
-  const UpdateFlags flags(fedata.update_once | fedata.update_each);
-
   const unsigned int foffset = face;
-  if (flags & update_values)
+  if (fedata.update_each & update_values)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         output_data.shape_values(k,0) = 0.;

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -47,21 +47,19 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.current_update_flags());
-
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
-      if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
                            mapping_internal,
                            output_data.shape_gradients[k]);
 
-      if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_hessians[k],
                              mapping_covariant_gradient,
@@ -75,7 +73,7 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
                 * output_data.shape_gradients[k][i][j];
         }
 
-      if (flags & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_3rd_derivatives[k],
                              mapping_covariant_hessian,
@@ -107,21 +105,19 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.current_update_flags());
-
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
-      if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
                            mapping_internal,
                            output_data.shape_gradients[k]);
 
-      if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_hessians[k],
                              mapping_covariant_gradient,
@@ -135,7 +131,7 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
                 * output_data.shape_gradients[k][i][j];
         }
 
-      if (flags & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_3rd_derivatives[k],
                              mapping_covariant_hessian,
@@ -168,21 +164,19 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.current_update_flags());
-
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
-      if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
                            mapping_internal,
                            output_data.shape_gradients[k]);
 
-      if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_hessians[k],
                              mapping_covariant_gradient,
@@ -196,7 +190,7 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
                 * output_data.shape_gradients[k][i][j];
         }
 
-      if (flags & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_3rd_derivatives[k],
                              mapping_covariant_hessian,
@@ -224,22 +218,20 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
   Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
-  const UpdateFlags flags(fe_data.current_update_flags());
-
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(k,i) = fe_data.shape_values[k][i];
 
 
-      if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
                            mapping_internal,
                            output_data.shape_gradients[k]);
 
-      if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_hessians[k],
                              mapping_covariant_gradient,
@@ -253,7 +245,7 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
                 * output_data.shape_gradients[k][i][j];
         }
 
-      if (flags & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
+      if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
         {
           mapping.transform (fe_data.shape_3rd_derivatives[k],
                              mapping_covariant_hessian,

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -307,11 +307,10 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
   const InternalData &fe_data = static_cast<const InternalData &> (fedata);
 
   const unsigned int n_q_points = quadrature.size();
-  const UpdateFlags flags(fe_data.current_update_flags());
 
-  Assert(!(flags & update_values) || fe_data.shape_values.size() == this->dofs_per_cell,
+  Assert(!(fe_data.update_each & update_values) || fe_data.shape_values.size() == this->dofs_per_cell,
          ExcDimensionMismatch(fe_data.shape_values.size(), this->dofs_per_cell));
-  Assert(!(flags & update_values) || fe_data.shape_values[0].size() == n_q_points,
+  Assert(!(fe_data.update_each & update_values) || fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
   // Create table with sign changes, due to the special structure of the RT elements.
@@ -338,7 +337,7 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
       // the previous one; or, even if it is a translation, if we use mappings
       // other than the standard mappings that require us to recompute values
       // and derivatives because of possible sign changes
-      if (flags & update_values &&
+      if (fe_data.update_each & update_values &&
           ((cell_similarity != CellSimilarity::translation)
            ||
            ((mapping_type == mapping_piola) || (mapping_type == mapping_raviart_thomas)
@@ -404,7 +403,7 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
         }
 
       // update gradients. apply the same logic as above
-      if (flags & update_gradients
+      if (fe_data.update_each & update_gradients
           &&
           ((cell_similarity != CellSimilarity::translation)
            ||
@@ -532,7 +531,7 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
         }
 
       // update hessians. apply the same logic as above
-      if (flags & update_hessians
+      if (fe_data.update_each & update_hessians
           &&
           ((cell_similarity != CellSimilarity::translation)
            ||
@@ -742,7 +741,7 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
         }
 
       // third derivatives are not implemented
-      if (flags & update_3rd_derivatives
+      if (fe_data.update_each & update_3rd_derivatives
           &&
           ((cell_similarity != CellSimilarity::translation)
            ||
@@ -788,8 +787,6 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
                                                 cell->face_rotation(face),
                                                 n_q_points);
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
-
 //TODO: Size assertions
 
 // Create table with sign changes, due to the special structure of the RT elements.
@@ -810,7 +807,7 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
       const unsigned int first = output_data.shape_function_to_row_table[i * this->n_components() +
                                  this->get_nonzero_components(i).first_selected_component()];
 
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         {
           switch (mapping_type)
             {
@@ -880,7 +877,7 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             }
         }
 
-      if (flags & update_gradients)
+      if (fe_data.update_each & update_gradients)
         {
           VectorSlice< std::vector<Tensor<2,spacedim> > >
           transformed_shape_grads (fe_data.transformed_shape_grads, offset, n_q_points);
@@ -1004,7 +1001,7 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
             }
         }
 
-      if (flags & update_hessians)
+      if (fe_data.update_each & update_hessians)
 
         {
 
@@ -1208,7 +1205,7 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
         }
 
       // third derivatives are not implemented
-      if (flags & update_3rd_derivatives)
+      if (fe_data.update_each & update_3rd_derivatives)
         {
           Assert(false, ExcNotImplemented())
         }
@@ -1251,8 +1248,6 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
                                                    n_q_points,
                                                    cell->subface_case(face));
 
-  const UpdateFlags flags(fe_data.update_once | fe_data.update_each);
-
 //   Assert(mapping_type == independent
 //       || ( mapping_type == independent_on_cartesian
 //            && dynamic_cast<const MappingCartesian<dim>*>(&mapping) != 0),
@@ -1276,7 +1271,7 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
       const unsigned int first = output_data.shape_function_to_row_table[i * this->n_components() +
                                  this->get_nonzero_components(i).first_selected_component()];
 
-      if (flags & update_values)
+      if (fe_data.update_each & update_values)
         {
           switch (mapping_type)
             {
@@ -1343,7 +1338,7 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             }
         }
 
-      if (flags & update_gradients)
+      if (fe_data.update_each & update_gradients)
         {
           VectorSlice< std::vector<Tensor<2, spacedim > > >
           transformed_shape_grads (fe_data.transformed_shape_grads, offset, n_q_points);
@@ -1469,7 +1464,7 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
             }
         }
 
-      if (flags & update_hessians)
+      if (fe_data.update_each & update_hessians)
 
         {
 
@@ -1672,7 +1667,7 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
         }
 
       // third derivatives are not implemented
-      if (flags & update_3rd_derivatives)
+      if (fe_data.update_each & update_3rd_derivatives)
         {
           Assert(false, ExcNotImplemented())
         }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3768,8 +3768,6 @@ void FEValues<dim,spacedim>::do_reinit ()
                                 this->mapping_output,
                                 this->finite_element_output,
                                 this->cell_similarity);
-
-  this->fe_data->clear_first_cell ();
 }
 
 
@@ -3974,8 +3972,6 @@ void FEFaceValues<dim,spacedim>::do_reinit (const unsigned int face_no)
                                      *this->fe_data,
                                      this->mapping_output,
                                      this->finite_element_output);
-
-  this->fe_data->clear_first_cell ();
 }
 
 
@@ -4217,8 +4213,6 @@ void FESubfaceValues<dim,spacedim>::do_reinit (const unsigned int face_no,
                                         *this->fe_data,
                                         this->mapping_output,
                                         this->finite_element_output);
-
-  this->fe_data->clear_first_cell ();
 }
 
 


### PR DESCRIPTION
What this patch does is address the issue that `FiniteElement::get_data()` (as was previously the case with Mappings as well) sets a flag in the returned `InternalData` object that indicates that we are visiting a cell for the first time. `FEValues` later sets this flag back once we're done with the first cell.

The way this is used is that the various finite element implementations query `current_update_flags` in `FE::fill_fe_*_values()`, which equals `update_each|update_once` if we are on the first cell, and `update_each` on later cells. That means that on the first cell we update fields in the output object that we need to initialize only once, e.g., the values of shape functions on quadrature points, but we won't do this again on later cells.

I don't particularly like this approach. It is opaque and took even me a long time to reconstruct when I saw it (see #1305 for a discussion). My preference is to do things we only need to do once in `FE::get_data()`, and do things we need to do every time in `FE::fill_fe_*_values()`. This kind of change was already implemented for mappings in the patches references from #1305, and the current pull request goes into the same direction.

The current PR only does one half of the necessary changes in order to keep the patch reasonably self contained and readable. In particular, what it really does is simply *always* do everything, by storing `update_once|update_each` in `FE::InternalDataBase::update_each`. In other words, it is the equivalent to telling finite element implementations that we are always on the first cell. This requires more work than in the previous state, although copying shape values every time is arguably of small expense compared to transforming gradients.

I will of course fix this up in upcoming patches. It requires significant shuffling around. I'll open an issue in a minute discussing the details. I'd simply like to propose this here already as an incremental step forward, without making patch review too onerous. The patch is mostly mechanical once you understand what it does.

This fixes #1305. In reference to #1198.