### PR TITLE
Rather than creating a copy-data object in build_one_patch, build it locally and move it

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -332,6 +332,11 @@ namespace DataOutBase
     std::size_t memory_consumption () const;
 
     /**
+     * Swap the current object's contents with those of the given argument.
+     */
+    void swap (Patch<dim,spacedim> &other_patch);
+
+    /**
      * Value to be used if this patch has no neighbor on one side.
      */
     static const unsigned int no_neighbor = numbers::invalid_unsigned_int;

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -286,13 +286,17 @@ private:
   /**
    * Build one patch. This function is called in a WorkStream context.
    *
-   * The result is written into the patch variable.
+   * The first argument here is the iterator, the second the scratch data object.
+   * All following are tied to particular values when calling WorkStream::run().
+   * The function does not take a CopyData object but rather allocates one
+   * on its own stack for memory access efficiency reasons.
    */
-  void build_one_patch (const std::pair<cell_iterator, unsigned int> *cell_and_index,
-                        internal::DataOut::ParallelData<DH::dimension, DH::space_dimension> &data,
-                        ::dealii::DataOutBase::Patch<DH::dimension, DH::space_dimension> &patch,
-                        const CurvedCellRegion curved_cell_region,
-                        std::vector<dealii::DataOutBase::Patch<DH::dimension, DH::space_dimension> > &patches);
+  void build_one_patch (const std::pair<cell_iterator, unsigned int>                         *cell_and_index,
+                        internal::DataOut::ParallelData<DH::dimension, DH::space_dimension>  &scratch_data,
+                        const unsigned int                                                    n_subdivisions,
+                        const unsigned int                                                    n_datasets,
+                        const CurvedCellRegion                                                curved_cell_region,
+                        std::vector<DataOutBase::Patch<DH::dimension, DH::space_dimension> > &patches);
 };
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1584,6 +1584,20 @@ namespace DataOutBase
 
 
 
+  template <int dim, int spacedim>
+  void
+  Patch<dim,spacedim>::swap (Patch<dim,spacedim> &other_patch)
+  {
+    std::swap (vertices, other_patch.vertices);
+    std::swap (neighbors, other_patch.neighbors);
+    std::swap (patch_index, other_patch.patch_index);
+    std::swap (n_subdivisions, other_patch.n_subdivisions);
+    data.swap (other_patch.data);
+    std::swap (points_are_available, other_patch.points_are_available);
+  }
+
+
+
   UcdFlags::UcdFlags (const bool write_preamble)
     :
     write_preamble (write_preamble)


### PR DESCRIPTION

This avoids a bunch of rather annoying remote-NUMA-region memory write contention issues
that @kronbichler identified.

@kronbichler -- this is completely untested, and I really need to go to bed now. Is this roughly what you had in mind? If you want to time and see whether that addresses part of the problem, then I can test this correctly tomorrow and formally submit it for merge.