### PR TITLE
Fix test output.

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3634,10 +3634,6 @@ namespace parallel
     void
     Triangulation<dim,spacedim>::repartition ()
     {
-      AssertThrow(settings & no_automatic_repartitioning,
-                  ExcMessage("You need to set the 'no_automatic_repartitioning' flag in the "
-                             "constructor when creating this parallel::distributed::Triangulation "
-                             "object if you want to call repartition() manually."));
 
 #ifdef DEBUG
       for (typename Triangulation<dim,spacedim>::active_cell_iterator


### PR DESCRIPTION
Allow calling repartition() even when no_automatic_refinement flag is not set.