### PR TITLE
Fix examples

### DIFF
--- a/examples/step-45/CMakeLists.txt
+++ b/examples/step-45/CMakeLists.txt
@@ -34,6 +34,21 @@ IF(NOT ${deal.II_FOUND})
     )
 ENDIF()
 
+#
+# Are all dependencies fulfilled?
+#
+IF( NOT DEAL_II_WITH_MPI OR
+    NOT DEAL_II_WITH_P4EST OR
+    NOT DEAL_II_WITH_TRILINOS )
+  MESSAGE(FATAL_ERROR "
+Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+    DEAL_II_WITH_MPI = ON
+    DEAL_II_WITH_P4EST = ON
+    DEAL_II_WITH_TRILINOS = ON
+One or all of these are OFF in your installation but are required for this tutorial step."
+    )
+ENDIF()
+
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT(${TARGET})
 DEAL_II_INVOKE_AUTOPILOT()

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1297,8 +1297,7 @@ namespace Step9
     // using this quantity and the right powers of the mesh width:
     const Tensor<2,dim> Y_inverse = invert(Y);
 
-    Tensor<1,dim> gradient;
-    contract (gradient, Y_inverse, projected_gradient);
+    Tensor<1,dim> gradient = Y_inverse * projected_gradient;
 
     // The last part of this function is the one where we
     // write into the element of the output vector what


### PR DESCRIPTION
- remove contract() deprecation warning in step-9
- step-45 requires MPI and Trilinos