### PR TITLE
Improve loop nesting.

### DIFF
--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -197,13 +197,14 @@ fill_fe_subface_values (const Mapping<dim,spacedim> &,
   const unsigned int offset = subface*quadrature.size();
 
   if (fe_data.update_each & update_values)
-    for (unsigned int i=0; i<quadrature.size(); ++i)
-      {
-        for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+    {
+      for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+        for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(k,i) = 0.;
-        for (unsigned int k=0; k<fe_data.shape_values.size(); ++k)
+      for (unsigned int k=0; k<fe_data.shape_values.size(); ++k)
+        for (unsigned int i=0; i<quadrature.size(); ++i)
           output_data.shape_values(foffset+k,i) = fe_data.shape_values[k][i+offset];
-      }
+    }
 
   Assert (!(fe_data.update_each & update_gradients), ExcNotImplemented());
   Assert (!(fe_data.update_each & update_hessians), ExcNotImplemented());

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -308,15 +308,18 @@ fill_fe_values (const Mapping<dim,spacedim> &,
                                  values, grads, grad_grads,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
-        for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-          {
-            if (fe_data.update_each & update_values)
-              output_data.shape_values[k][i] = values[k];
-            if (fe_data.update_each & update_gradients)
-              output_data.shape_gradients[k][i] = grads[k];
-            if (fe_data.update_each & update_hessians)
-              output_data.shape_hessians[k][i] = grad_grads[k];
-          }
+
+        if (fe_data.update_each & update_values)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_values[k][i] = values[k];
+
+        if (fe_data.update_each & update_gradients)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_gradients[k][i] = grads[k];
+
+        if (fe_data.update_each & update_hessians)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }
 
@@ -351,15 +354,18 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
                                  values, grads, grad_grads,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
-        for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-          {
-            if (fe_data.update_each & update_values)
-              output_data.shape_values[k][i] = values[k];
-            if (fe_data.update_each & update_gradients)
-              output_data.shape_gradients[k][i] = grads[k];
-            if (fe_data.update_each & update_hessians)
-              output_data.shape_hessians[k][i] = grad_grads[k];
-          }
+
+        if (fe_data.update_each & update_values)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_values[k][i] = values[k];
+
+        if (fe_data.update_each & update_gradients)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_gradients[k][i] = grads[k];
+
+        if (fe_data.update_each & update_hessians)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }
 
@@ -395,15 +401,18 @@ fill_fe_subface_values (const Mapping<dim,spacedim> &,
                                  values, grads, grad_grads,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
-        for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-          {
-            if (fe_data.update_each & update_values)
-              output_data.shape_values[k][i] = values[k];
-            if (fe_data.update_each & update_gradients)
-              output_data.shape_gradients[k][i] = grads[k];
-            if (fe_data.update_each & update_hessians)
-              output_data.shape_hessians[k][i] = grad_grads[k];
-          }
+
+        if (fe_data.update_each & update_values)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_values[k][i] = values[k];
+
+        if (fe_data.update_each & update_gradients)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_gradients[k][i] = grads[k];
+
+        if (fe_data.update_each & update_hessians)
+          for (unsigned int k=0; k<this->dofs_per_cell; ++k)
+            output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1197,29 +1197,31 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
                 Assert (this->n_nonzero_components(system_index) ==
                         base_fe.n_nonzero_components(base_index),
                         ExcInternalError());
-                for (unsigned int s=0; s<this->n_nonzero_components(system_index); ++s)
-                  {
-                    if (base_flags & update_values)
-                      for (unsigned int q=0; q<n_q_points; ++q)
-                        output_data.shape_values[out_index+s][q] =
-                          base_data.shape_values(in_index+s,q);
 
-                    if (base_flags & update_gradients)
-                      for (unsigned int q=0; q<n_q_points; ++q)
-                        output_data.shape_gradients[out_index+s][q] =
-                          base_data.shape_gradients[in_index+s][q];
+                if (base_flags & update_values)
+                  for (unsigned int s=0; s<this->n_nonzero_components(system_index); ++s)
+                    for (unsigned int q=0; q<n_q_points; ++q)
+                      output_data.shape_values[out_index+s][q] =
+                        base_data.shape_values(in_index+s,q);
 
-                    if (base_flags & update_hessians)
-                      for (unsigned int q=0; q<n_q_points; ++q)
-                        output_data.shape_hessians[out_index+s][q] =
-                          base_data.shape_hessians[in_index+s][q];
+                if (base_flags & update_gradients)
+                  for (unsigned int s=0; s<this->n_nonzero_components(system_index); ++s)
+                    for (unsigned int q=0; q<n_q_points; ++q)
+                      output_data.shape_gradients[out_index+s][q] =
+                        base_data.shape_gradients[in_index+s][q];
 
-                    if (base_flags & update_3rd_derivatives)
-                      for (unsigned int q=0; q<n_q_points; ++q)
-                        output_data.shape_3rd_derivatives[out_index+s][q] =
-                          base_data.shape_3rd_derivatives[in_index+s][q];
+                if (base_flags & update_hessians)
+                  for (unsigned int s=0; s<this->n_nonzero_components(system_index); ++s)
+                    for (unsigned int q=0; q<n_q_points; ++q)
+                      output_data.shape_hessians[out_index+s][q] =
+                        base_data.shape_hessians[in_index+s][q];
 
-                  }
+                if (base_flags & update_3rd_derivatives)
+                  for (unsigned int s=0; s<this->n_nonzero_components(system_index); ++s)
+                    for (unsigned int q=0; q<n_q_points; ++q)
+                      output_data.shape_3rd_derivatives[out_index+s][q] =
+                        base_data.shape_3rd_derivatives[in_index+s][q];
+
               }
       }
 }


### PR DESCRIPTION
We had a number of places of the form
  for (...tight loop...)
    if (constant condition)
      data update;

The compiler almost certainly can hoist the condition out of the loop,
but why make it this complicated for the compiler. I also find the code
easier to read because the loop is really only over a counting index
and does not carry any particular meaning at a level higher than the
if-statement.


This fixes most of #1821.