### PR TITLE
Fix MappingQ1

### DIFF
--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -106,8 +106,10 @@ namespace internal
             eta1 = -c/b;
             eta2 = -c/b;
           }
-        // special case #2: if c is very small:
-        else if (std::abs(c/b) < 1e-12)
+        // special case #2: if c is very small or the square root of the
+        // discriminant is nearly b.
+        else if (std::abs(c) < 1e-12*std::abs(b)
+                 || std::abs(std::sqrt(discriminant) - b) <= 1e-14*std::abs(b))
           {
             eta1 = (-b - std::sqrt(discriminant)) / (2*a);
             eta2 = (-b + std::sqrt(discriminant)) / (2*a);


### PR DESCRIPTION
Somewhere along #1537 the fixes introduced in #1669 got lost. With a recent master I get floating point exceptions in deal.II/source/fe/mapping_q_generic.cc:119 again, just like reported in #1652. This reapplies #1669 to the new file and fixes the problem.