### PR TITLE
FETools::project_dg, initialize output to zero

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -412,6 +412,12 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: FETools::project_dg was adding the vector projection to 
+  the output vector. Now is the output vector initialized to zero. 
+  <br>
+  (Adam Kosik, 2015/11/09)
+  </li>
+
   <li> Fixed: A compilation issue with DEAL_II_INCLUDE_DIRS not used for
   compiling bundled boost.
   <br>

--- a/source/fe/fe_tools_interpolate.cc
+++ b/source/fe/fe_tools_interpolate.cc
@@ -721,6 +721,7 @@ namespace FETools
     FullMatrix<double> matrix(n2,n1);
     get_projection_matrix(dof1.get_fe(), dof2.get_fe(), matrix);
 
+    u2 = 0;
     while (cell2 != end)
       {
         cell1->get_dof_values(u1, u1_local);


### PR DESCRIPTION
Small fix: Function project_dg was adding the vector projection to the output vector.