### PR TITLE
Update fill fe values argument list

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2248,11 +2248,90 @@ protected:
                     const Quadrature<dim-1> &quadrature) const;
 
   /**
-   * To be written.
+   * Compute information about the shape functions on the cell denoted
+   * by the first argument. Derived classes will have to implement this
+   * function based on the kind of element they represent. It is called
+   * by FEValues::reinit().
+   *
+   * Conceptually, this function evaluates shape functions and their
+   * derivatives at the quadrature points represented by the mapped
+   * locations of those described by the quadrature argument to this
+   * function. In many cases, computing derivatives of shape functions
+   * (and in some cases also computing values of shape functions)
+   * requires making use of the mapping from the reference to the real
+   * cell; this information can either be taken from the @p mapping_data
+   * object that has been filled for the current cell before this
+   * function is called, or by calling the member functions of a
+   * Mapping object with the @p mapping_internal object that also
+   * corresponds to the current cell.
+   *
+   * The information computed by this function is used to fill the various
+   * member variables of the output argument of this function. Which of
+   * the member variables of that structure should be filled is determined
+   * by the update flags stored in the
+   * FiniteElement::InternalDataBase::update_each field of the object
+   * passed to this function. These flags are typically set by
+   * FiniteElement::get_data(), FiniteElement::get_face_date() and
+   * FiniteElement::get_subface_data() (or, more specifically, implementations
+   * of these functions in derived classes).
    *
    * An extensive discussion of the interaction between this function and
    * FEValues can be found in the @ref FE_vs_Mapping_vs_FEValues documentation
    * module.
+   *
+   * @param[in] cell The cell of the triangulation for which this function
+   *   is to compute a mapping from the reference cell to.
+   * @param[in] cell_similarity Whether or not the cell given as first
+   *   argument is simply a translation, rotation, etc of the cell for
+   *   which this function was called the most recent time. This
+   *   information is computed simply by matching the vertices (as stored
+   *   by the Triangulation) between the previous and the current cell.
+   *   The value passed here may be modified by implementations of
+   *   this function and should then be returned (see the discussion of the
+   *   return value of this function).
+   * @param[in] quadrature A reference to the quadrature formula in use
+   *   for the current evaluation. This quadrature object is the same
+   *   as the one used when creating the @p internal_data object. The
+   *   current object is then responsible for evaluating shape functions
+   *   at the mapped locations of the quadrature points represented by
+   *   this object.
+   * @param[in] mapping A reference to the mapping object used to map
+   *   from the reference cell to the current cell. This object was used
+   *   to compute the information in the @p mapping_data object before the
+   *   current function was called. It is also the mapping object that
+   *   created the @p mapping_internal object via Mapping::get_data().
+   *   You will need the reference to this mapping object most often
+   *   to call Mapping::transform() to transform gradients and
+   *   higher derivatives from the reference to the current cell.
+   * @param[in] mapping_internal An object specific to the mapping
+   *   object. What the mapping chooses to store in there is of no
+   *   relevance to the current function, but you may have to pass
+   *   a reference to this object to certain functions of the
+   *   Mapping class (e.g., Mapping::transform()) if you need to
+   *   call them from the current function.
+   * @param[in] mapping_data The output object into which the
+   *   Mapping::fill_fe_values() function wrote the mapping information
+   *   corresponding to the current cell. This includes, for example,
+   *   Jacobians of the mapping that may be of relevance to the
+   *   current function, as well as other information that FEValues::reinit()
+   *   requested from the mapping.
+   * @param[in] fe_internal A reference to an object previously
+   *   created by get_data() and that may be used to store information
+   *   the mapping can compute once on the reference cell. See the
+   *   documentation of the FiniteElement::InternalDataBase class for an
+   *   extensive description of the purpose of these objects.
+   * @param[out] output_data A reference to an object whose member
+   *   variables should be computed. Not all of the members of this
+   *   argument need to be filled; which ones need to be filled is
+   *   determined by the update flags stored inside the
+   *   @p fe_internal object.
+   *
+   * @note FEValues ensures that this function is always called with
+   *   the same pair of @p fe_internal and @output_data objects. In
+   *   other words, if an implementation of this function knows that it
+   *   has written a piece of data into the output argument in a previous
+   *   call, then there is no need to copy it there again in a later
+   *   call if the implementation knows that this is the same value.
    */
   virtual
   void
@@ -2265,6 +2344,52 @@ protected:
                   const InternalDataBase                                              &fe_internal,
                   dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
+  /**
+   * This function is the equivalent to FiniteElement::fill_fe_values(),
+   * but for faces of cells. See there for an extensive discussion
+   * of its purpose. It is called by FEFaceValues::reinit().
+   *
+   * @param[in] cell The cell of the triangulation for which this function
+   *   is to compute a mapping from the reference cell to.
+   * @param[in] face_no The number of the face we are currently considering,
+   *   indexed among the faces of the cell specified by the previous argument.
+   * @param[in] quadrature A reference to the quadrature formula in use
+   *   for the current evaluation. This quadrature object is the same
+   *   as the one used when creating the @p internal_data object. The
+   *   current object is then responsible for evaluating shape functions
+   *   at the mapped locations of the quadrature points represented by
+   *   this object.
+   * @param[in] mapping A reference to the mapping object used to map
+   *   from the reference cell to the current cell. This object was used
+   *   to compute the information in the @p mapping_data object before the
+   *   current function was called. It is also the mapping object that
+   *   created the @p mapping_internal object via Mapping::get_data().
+   *   You will need the reference to this mapping object most often
+   *   to call Mapping::transform() to transform gradients and
+   *   higher derivatives from the reference to the current cell.
+   * @param[in] mapping_internal An object specific to the mapping
+   *   object. What the mapping chooses to store in there is of no
+   *   relevance to the current function, but you may have to pass
+   *   a reference to this object to certain functions of the
+   *   Mapping class (e.g., Mapping::transform()) if you need to
+   *   call them from the current function.
+   * @param[in] mapping_data The output object into which the
+   *   Mapping::fill_fe_values() function wrote the mapping information
+   *   corresponding to the current cell. This includes, for example,
+   *   Jacobians of the mapping that may be of relevance to the
+   *   current function, as well as other information that FEValues::reinit()
+   *   requested from the mapping.
+   * @param[in] fe_internal A reference to an object previously
+   *   created by get_data() and that may be used to store information
+   *   the mapping can compute once on the reference cell. See the
+   *   documentation of the FiniteElement::InternalDataBase class for an
+   *   extensive description of the purpose of these objects.
+   * @param[out] output_data A reference to an object whose member
+   *   variables should be computed. Not all of the members of this
+   *   argument need to be filled; which ones need to be filled is
+   *   determined by the update flags stored inside the
+   *   @p fe_internal object.
+   */
   virtual
   void
   fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
@@ -2276,6 +2401,56 @@ protected:
                        const InternalDataBase                                              &fe_internal,
                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
+  /**
+   * This function is the equivalent to FiniteElement::fill_fe_values(),
+   * but for the children of faces of cells. See there for an extensive
+   * discussion of its purpose. It is called by FESubfaceValues::reinit().
+   *
+   * @param[in] cell The cell of the triangulation for which this function
+   *   is to compute a mapping from the reference cell to.
+   * @param[in] face_no The number of the face we are currently considering,
+   *   indexed among the faces of the cell specified by the previous argument.
+   * @param[in] sub_no The number of the subface, i.e., the number of the child
+   *   of a face, that we are currently considering,
+   *   indexed among the children of the face specified by the previous
+   *   argument.
+   * @param[in] quadrature A reference to the quadrature formula in use
+   *   for the current evaluation. This quadrature object is the same
+   *   as the one used when creating the @p internal_data object. The
+   *   current object is then responsible for evaluating shape functions
+   *   at the mapped locations of the quadrature points represented by
+   *   this object.
+   * @param[in] mapping A reference to the mapping object used to map
+   *   from the reference cell to the current cell. This object was used
+   *   to compute the information in the @p mapping_data object before the
+   *   current function was called. It is also the mapping object that
+   *   created the @p mapping_internal object via Mapping::get_data().
+   *   You will need the reference to this mapping object most often
+   *   to call Mapping::transform() to transform gradients and
+   *   higher derivatives from the reference to the current cell.
+   * @param[in] mapping_internal An object specific to the mapping
+   *   object. What the mapping chooses to store in there is of no
+   *   relevance to the current function, but you may have to pass
+   *   a reference to this object to certain functions of the
+   *   Mapping class (e.g., Mapping::transform()) if you need to
+   *   call them from the current function.
+   * @param[in] mapping_data The output object into which the
+   *   Mapping::fill_fe_values() function wrote the mapping information
+   *   corresponding to the current cell. This includes, for example,
+   *   Jacobians of the mapping that may be of relevance to the
+   *   current function, as well as other information that FEValues::reinit()
+   *   requested from the mapping.
+   * @param[in] fe_internal A reference to an object previously
+   *   created by get_data() and that may be used to store information
+   *   the mapping can compute once on the reference cell. See the
+   *   documentation of the FiniteElement::InternalDataBase class for an
+   *   extensive description of the purpose of these objects.
+   * @param[out] output_data A reference to an object whose member
+   *   variables should be computed. Not all of the members of this
+   *   argument need to be filled; which ones need to be filled is
+   *   determined by the update flags stored inside the
+   *   @p fe_internal object.
+   */
   virtual
   void
   fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2256,36 +2256,36 @@ protected:
    */
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                                         &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
                   const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
                   const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                  const InternalDataBase                                              &fe_internal,
                   const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
-                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data,
-                  const CellSimilarity::Similarity                                     cell_similarity) const = 0;
+                  const InternalDataBase                                              &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                                         &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
                        const unsigned int                                                   face_no,
                        const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                       const InternalDataBase                                              &fe_internal,
                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const InternalDataBase                                              &fe_internal,
                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                                         &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
                           const unsigned int                                                   face_no,
                           const unsigned int                                                   sub_no,
                           const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
                           const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                          const InternalDataBase                                              &fe_internal,
                           const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const InternalDataBase                                              &fe_internal,
                           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const = 0;
 
   friend class InternalDataBase;

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -536,37 +536,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
 private:
 

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -280,37 +280,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<1,spacedim>                              &mapping,
-                  const typename Triangulation<1,spacedim>::cell_iterator &cell,
-                  const Quadrature<1>                                     &quadrature,
-                  const typename Mapping<1,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<1,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<1,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<1,spacedim> &output_data,
-                  const CellSimilarity::Similarity                          cell_similarity) const;
+  fill_fe_values (const typename Triangulation<1,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                   cell_similarity,
+                  const Quadrature<1>                                               &quadrature,
+                  const Mapping<1,spacedim>                                         &mapping,
+                  const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                  const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<1,spacedim>                               &mapping,
-                       const typename Triangulation<1,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<0>                                   &quadrature,
-                       const typename Mapping<1,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<1,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<1,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<1,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<1,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                 face_no,
+                       const Quadrature<0>                                               &quadrature,
+                       const Mapping<1,spacedim>                                         &mapping,
+                       const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                       const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<1,spacedim>                               &mapping,
-                          const typename Triangulation<1,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<0>                                   &quadrature,
-                          const typename Mapping<1,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<1,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<1,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<1,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<1,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                 face_no,
+                          const unsigned int                                                 sub_no,
+                          const Quadrature<0>                                               &quadrature,
+                          const Mapping<1,spacedim>                                         &mapping,
+                          const typename Mapping<1,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &mapping_data,
+                          const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
 
   /**

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -131,37 +131,37 @@ public:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Prepare internal data structures and fill in values independent of the

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -306,37 +306,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Determine the values that need to be computed on the unit cell to be able

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -231,21 +231,21 @@ FE_Poly<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
 template <class POLY, int dim, int spacedim>
 void
 FE_Poly<POLY,dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim>                                  &mapping,
-                const typename Triangulation<dim,spacedim>::cell_iterator &,
-                const Quadrature<dim>                                        &quadrature,
-                const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data,
-                const CellSimilarity::Similarity                              cell_similarity) const
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                const CellSimilarity::Similarity                                     cell_similarity,
+                const Quadrature<dim>                                               &quadrature,
+                const Mapping<dim,spacedim>                                         &mapping,
+                const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   const UpdateFlags flags(fe_data.update_each);
 
@@ -295,31 +295,31 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
 template <class POLY, int dim, int spacedim>
 void
 FE_Poly<POLY,dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim>                                  &mapping,
-                     const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
-                     const unsigned int                                            face,
-                     const Quadrature<dim-1>                                      &quadrature,
-                     const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data) const
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                     const unsigned int                                                   face_no,
+                     const Quadrature<dim-1>                                             &quadrature,
+                     const Mapping<dim,spacedim>                                         &mapping,
+                     const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   // offset determines which data set
   // to take (all data sets for all
   // faces are stored contiguously)
 
   const typename QProjector<dim>::DataSetDescriptor offset
-    = QProjector<dim>::DataSetDescriptor::face (face,
-                                                cell->face_orientation(face),
-                                                cell->face_flip(face),
-                                                cell->face_rotation(face),
+    = QProjector<dim>::DataSetDescriptor::face (face_no,
+                                                cell->face_orientation(face_no),
+                                                cell->face_flip(face_no),
+                                                cell->face_rotation(face_no),
                                                 quadrature.size());
 
   const UpdateFlags flags(fe_data.update_each);
@@ -372,34 +372,34 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
 template <class POLY, int dim, int spacedim>
 void
 FE_Poly<POLY,dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim>                                  &mapping,
-                        const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
-                        const unsigned int                                            face,
-                        const unsigned int                                            subface,
-                        const Quadrature<dim-1>                                      &quadrature,
-                        const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data) const
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                        const unsigned int                                                   face_no,
+                        const unsigned int                                                   sub_no,
+                        const Quadrature<dim-1>                                             &quadrature,
+                        const Mapping<dim,spacedim>                                         &mapping,
+                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   // offset determines which data set
   // to take (all data sets for all
   // sub-faces are stored contiguously)
 
   const typename QProjector<dim>::DataSetDescriptor offset
-    = QProjector<dim>::DataSetDescriptor::subface (face, subface,
-                                                   cell->face_orientation(face),
-                                                   cell->face_flip(face),
-                                                   cell->face_rotation(face),
+    = QProjector<dim>::DataSetDescriptor::subface (face_no, sub_no,
+                                                   cell->face_orientation(face_no),
+                                                   cell->face_flip(face_no),
+                                                   cell->face_rotation(face_no),
                                                    quadrature.size(),
-                                                   cell->subface_case(face));
+                                                   cell->subface_case(face_no));
 
   const UpdateFlags flags(fe_data.update_each);
 

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -155,37 +155,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Determine the values that need to be computed on the unit cell to be able

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -88,14 +88,14 @@ FE_PolyFace<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyFace<POLY,dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim> &,
-                const typename Triangulation<dim,spacedim>::cell_iterator &,
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                const CellSimilarity::Similarity                                     ,
                 const Quadrature<dim> &,
+                const Mapping<dim,spacedim> &,
                 const typename Mapping<dim,spacedim>::InternalDataBase &,
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
                 const typename FiniteElement<dim,spacedim>::InternalDataBase &,
-                const internal::FEValues::MappingRelatedData<dim,spacedim> &,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim> &,
-                const CellSimilarity::Similarity ) const
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // Do nothing, since we do not have
   // values in the interior
@@ -106,21 +106,21 @@ fill_fe_values (const Mapping<dim,spacedim> &,
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyFace<POLY,dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim> &,
-                     const typename Triangulation<dim,spacedim>::cell_iterator &,
-                     const unsigned int face,
-                     const Quadrature<dim-1>& quadrature,
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                     const unsigned int                                                   face_no,
+                     const Quadrature<dim-1>                                             &quadrature,
+                     const Mapping<dim,spacedim> &,
                      const typename Mapping<dim,spacedim>::InternalDataBase &,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim> &,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   if (fe_data.update_each & update_values)
     for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -134,7 +134,7 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
             // Fill data for quad shape functions
             if (this->dofs_per_quad !=0)
               {
-                const unsigned int foffset = this->first_quad_index + this->dofs_per_quad * face;
+                const unsigned int foffset = this->first_quad_index + this->dofs_per_quad * face_no;
                 for (unsigned int k=0; k<this->dofs_per_quad; ++k)
                   output_data.shape_values(foffset+k,i) = fe_data.shape_values[k+this->first_face_quad_index][i];
               }
@@ -151,7 +151,7 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
                 for (unsigned int line=0; line<GeometryInfo<dim>::lines_per_face; ++line)
                   {
                     for (unsigned int k=0; k<this->dofs_per_line; ++k)
-                      output_data.shape_values(foffset+GeometryInfo<dim>::face_to_cell_lines(face, line)*this->dofs_per_line+k,i)
+                      output_data.shape_values(foffset+GeometryInfo<dim>::face_to_cell_lines(face_no, line)*this->dofs_per_line+k,i)
                         = fe_data.shape_values[k+(line*this->dofs_per_line)+this->first_face_line_index][i];
                   }
               }
@@ -164,7 +164,7 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
             // Fill data for vertex shape functions
             if (this->dofs_per_vertex != 0)
               for (unsigned int lvertex=0; lvertex<GeometryInfo<dim>::vertices_per_face; ++lvertex)
-                output_data.shape_values(GeometryInfo<dim>::face_to_cell_vertices(face, lvertex),i)
+                output_data.shape_values(GeometryInfo<dim>::face_to_cell_vertices(face_no, lvertex),i)
                   = fe_data.shape_values[lvertex][i];
             break;
           }
@@ -176,25 +176,25 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyFace<POLY,dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim> &,
-                        const typename Triangulation<dim,spacedim>::cell_iterator &,
-                        const unsigned int face,
-                        const unsigned int subface,
-                        const Quadrature<dim-1>& quadrature,
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                        const unsigned int                                                   face_no,
+                        const unsigned int                                                   sub_no,
+                        const Quadrature<dim-1>                                             &quadrature,
+                        const Mapping<dim,spacedim> &,
                         const typename Mapping<dim,spacedim>::InternalDataBase &,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim> &,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
-  const unsigned int foffset = fe_data.shape_values.size() * face;
-  const unsigned int offset = subface*quadrature.size();
+  const unsigned int foffset = fe_data.shape_values.size() * face_no;
+  const unsigned int offset = sub_no*quadrature.size();
 
   if (fe_data.update_each & update_values)
     {

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -316,37 +316,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Fields of cell-independent data for FE_PolyTensor. Stores the values of

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -878,37 +878,37 @@ protected:
 
   virtual
   void
-  fill_fe_values (const Mapping<dim,spacedim>                               &mapping,
-                  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                  const Quadrature<dim>                                     &quadrature,
-                  const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                  const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                  const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                  internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                  const CellSimilarity::Similarity                           cell_similarity) const;
+  fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                  const CellSimilarity::Similarity                                     cell_similarity,
+                  const Quadrature<dim>                                               &quadrature,
+                  const Mapping<dim,spacedim>                                         &mapping,
+                  const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                  const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                  const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                  dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_face_values (const Mapping<dim,spacedim>                               &mapping,
-                       const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                       const unsigned int                                         face_no,
-                       const Quadrature<dim-1>                                   &quadrature,
-                       const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                       const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                       const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                       internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                       const unsigned int                                                   face_no,
+                       const Quadrature<dim-1>                                             &quadrature,
+                       const Mapping<dim,spacedim>                                         &mapping,
+                       const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                       const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                       const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                       dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   virtual
   void
-  fill_fe_subface_values (const Mapping<dim,spacedim>                               &mapping,
-                          const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                          const unsigned int                                         face_no,
-                          const unsigned int                                         sub_no,
-                          const Quadrature<dim-1>                                   &quadrature,
-                          const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_internal,
-                          const typename FiniteElement<dim,spacedim>::InternalDataBase    &fe_internal,
-                          const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                          internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const;
+  fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                          const unsigned int                                                   face_no,
+                          const unsigned int                                                   sub_no,
+                          const Quadrature<dim-1>                                             &quadrature,
+                          const Mapping<dim,spacedim>                                         &mapping,
+                          const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                          const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                          const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                          dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
 
   /**
    * Do the work for the three <tt>fill_fe*_values</tt> functions.

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -282,26 +282,26 @@ FE_DGPNonparametric<dim,spacedim>::get_data (
 template <int dim, int spacedim>
 void
 FE_DGPNonparametric<dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim> &,
-                const typename Triangulation<dim,spacedim>::cell_iterator &,
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                const CellSimilarity::Similarity                                     ,
                 const Quadrature<dim> &,
+                const Mapping<dim,spacedim> &,
                 const typename Mapping<dim,spacedim>::InternalDataBase &,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_data,
-                const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                const CellSimilarity::Similarity /*cell_similarity*/) const
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
-  Assert (fe_data.update_each & update_quadrature_points, ExcInternalError());
+  Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_data.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_data.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_data.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 
-  if (fe_data.update_each & (update_values | update_gradients))
+  if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i=0; i<n_q_points; ++i)
       {
         polynomial_space.compute(mapping_data.quadrature_points[i],
@@ -309,15 +309,15 @@ fill_fe_values (const Mapping<dim,spacedim> &,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
 
-        if (fe_data.update_each & update_values)
+        if (fe_internal.update_each & update_values)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_data.update_each & update_gradients)
+        if (fe_internal.update_each & update_gradients)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_data.update_each & update_hessians)
+        if (fe_internal.update_each & update_hessians)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -328,26 +328,26 @@ fill_fe_values (const Mapping<dim,spacedim> &,
 template <int dim, int spacedim>
 void
 FE_DGPNonparametric<dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim> &,
-                     const typename Triangulation<dim,spacedim>::cell_iterator &,
-                     const unsigned int,
-                     const Quadrature<dim-1>&,
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                     const unsigned int                                                   ,
+                     const Quadrature<dim-1>                                             &,
+                     const Mapping<dim,spacedim> &,
                      const typename Mapping<dim,spacedim>::InternalDataBase &,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase       &fe_data,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
-  Assert (fe_data.update_each & update_quadrature_points, ExcInternalError());
+  Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_data.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_data.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_data.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 
-  if (fe_data.update_each & (update_values | update_gradients))
+  if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i=0; i<n_q_points; ++i)
       {
         polynomial_space.compute(mapping_data.quadrature_points[i],
@@ -355,15 +355,15 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
 
-        if (fe_data.update_each & update_values)
+        if (fe_internal.update_each & update_values)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_data.update_each & update_gradients)
+        if (fe_internal.update_each & update_gradients)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_data.update_each & update_hessians)
+        if (fe_internal.update_each & update_hessians)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -374,27 +374,27 @@ fill_fe_face_values (const Mapping<dim,spacedim> &,
 template <int dim, int spacedim>
 void
 FE_DGPNonparametric<dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim> &,
-                        const typename Triangulation<dim,spacedim>::cell_iterator &,
-                        const unsigned int,
-                        const unsigned int,
-                        const Quadrature<dim-1>&,
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                        const unsigned int                                                   ,
+                        const unsigned int                                                   ,
+                        const Quadrature<dim-1>                                             &,
+                        const Mapping<dim,spacedim> &,
                         const typename Mapping<dim,spacedim>::InternalDataBase &,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase       &fe_data,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
-  Assert (fe_data.update_each & update_quadrature_points, ExcInternalError());
+  Assert (fe_internal.update_each & update_quadrature_points, ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_data.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_data.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_data.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 
-  if (fe_data.update_each & (update_values | update_gradients))
+  if (fe_internal.update_each & (update_values | update_gradients))
     for (unsigned int i=0; i<n_q_points; ++i)
       {
         polynomial_space.compute(mapping_data.quadrature_points[i],
@@ -402,15 +402,15 @@ fill_fe_subface_values (const Mapping<dim,spacedim> &,
                                  empty_vector_of_3rd_order_tensors,
                                  empty_vector_of_4th_order_tensors);
 
-        if (fe_data.update_each & update_values)
+        if (fe_internal.update_each & update_values)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_data.update_each & update_gradients)
+        if (fe_internal.update_each & update_gradients)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_data.update_each & update_hessians)
+        if (fe_internal.update_each & update_hessians)
           for (unsigned int k=0; k<this->dofs_per_cell; ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -477,14 +477,14 @@ FE_FaceQ<1,spacedim>::update_each (const UpdateFlags flags) const
 template <int spacedim>
 void
 FE_FaceQ<1,spacedim>::
-fill_fe_values(const Mapping<1,spacedim> &,
-               const typename Triangulation<1,spacedim>::cell_iterator &,
+fill_fe_values(const typename Triangulation<1,spacedim>::cell_iterator &,
+               const CellSimilarity::Similarity                                   ,
                const Quadrature<1> &,
+               const Mapping<1,spacedim> &,
                const typename Mapping<1,spacedim>::InternalDataBase &,
+               const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
                const typename FiniteElement<1,spacedim>::InternalDataBase &,
-               const internal::FEValues::MappingRelatedData<1,spacedim> &,
-               internal::FEValues::FiniteElementRelatedData<1,spacedim> &,
-               const CellSimilarity::Similarity ) const
+               dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &) const
 {
   // Do nothing, since we do not have values in the interior
 }
@@ -494,17 +494,17 @@ fill_fe_values(const Mapping<1,spacedim> &,
 template <int spacedim>
 void
 FE_FaceQ<1,spacedim>::
-fill_fe_face_values (const Mapping<1,spacedim> &,
-                     const typename Triangulation<1,spacedim>::cell_iterator &,
-                     const unsigned int face,
+fill_fe_face_values (const typename Triangulation<1,spacedim>::cell_iterator &,
+                     const unsigned int                                                 face,
                      const Quadrature<0> &,
+                     const Mapping<1,spacedim> &,
                      const typename Mapping<1,spacedim>::InternalDataBase &,
-                     const typename FiniteElement<1,spacedim>::InternalDataBase &fedata,
-                     const internal::FEValues::MappingRelatedData<1,spacedim> &,
-                     internal::FEValues::FiniteElementRelatedData<1,spacedim> &output_data) const
+                     const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
+                     const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const
 {
   const unsigned int foffset = face;
-  if (fedata.update_each & update_values)
+  if (fe_internal.update_each & update_values)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         output_data.shape_values(k,0) = 0.;
@@ -516,15 +516,15 @@ fill_fe_face_values (const Mapping<1,spacedim> &,
 template <int spacedim>
 void
 FE_FaceQ<1,spacedim>::
-fill_fe_subface_values (const Mapping<1,spacedim> &,
-                        const typename Triangulation<1,spacedim>::cell_iterator &,
-                        const unsigned int ,
-                        const unsigned int ,
+fill_fe_subface_values (const typename Triangulation<1,spacedim>::cell_iterator &,
+                        const unsigned int                                                 ,
+                        const unsigned int                                                 ,
                         const Quadrature<0> &,
+                        const Mapping<1,spacedim> &,
                         const typename Mapping<1,spacedim>::InternalDataBase &,
+                        const dealii::internal::FEValues::MappingRelatedData<1, spacedim> &,
                         const typename FiniteElement<1,spacedim>::InternalDataBase &,
-                        const internal::FEValues::MappingRelatedData<1,spacedim> &,
-                        internal::FEValues::FiniteElementRelatedData<1,spacedim> &) const
+                        dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &) const
 {
   Assert(false, ExcMessage("There are no sub-face values to fill in 1D!"));
 }

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -110,14 +110,14 @@ FE_Nothing<dim,spacedim>::get_data (const UpdateFlags  /*flags*/,
 template <int dim, int spacedim>
 void
 FE_Nothing<dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim> & /*mapping*/,
-                const typename Triangulation<dim,spacedim>::cell_iterator & /*cell*/,
-                const Quadrature<dim> & /*quadrature*/,
-                const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase & /*fedata*/,
-                const internal::FEValues::MappingRelatedData<dim,spacedim> &/*mapping_data*/,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim> &/*output_data*/,
-                const CellSimilarity::Similarity  /*cell_similarity*/) const
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                const CellSimilarity::Similarity                                     ,
+                const Quadrature<dim> &,
+                const Mapping<dim,spacedim> &,
+                const typename Mapping<dim,spacedim>::InternalDataBase &,
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                const typename FiniteElement<dim,spacedim>::InternalDataBase &,
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }
@@ -127,33 +127,37 @@ fill_fe_values (const Mapping<dim,spacedim> & /*mapping*/,
 template <int dim, int spacedim>
 void
 FE_Nothing<dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim> & /*mapping*/,
-                     const typename Triangulation<dim,spacedim>::cell_iterator & /*cell*/,
-                     const unsigned int /*face*/,
-                     const Quadrature<dim-1> & /*quadrature*/,
-                     const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase & /*fedata*/,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim> &/*mapping_data*/,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &/*output_data*/) const
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                     const unsigned int                                                   ,
+                     const Quadrature<dim-1>                                             &,
+                     const Mapping<dim,spacedim> &,
+                     const typename Mapping<dim,spacedim>::InternalDataBase &,
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase &,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }
 
+
+
 template <int dim, int spacedim>
 void
 FE_Nothing<dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim> & /*mapping*/,
-                        const typename Triangulation<dim,spacedim>::cell_iterator & /*cell*/,
-                        const unsigned int /*face*/,
-                        const unsigned int /*subface*/,
-                        const Quadrature<dim-1> & /*quadrature*/,
-                        const typename Mapping<dim,spacedim>::InternalDataBase & /*mapping_data*/,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase & /*fedata*/,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim> &/*mapping_data*/,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &/*output_data*/) const
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
+                        const unsigned int                                                   ,
+                        const unsigned int                                                   ,
+                        const Quadrature<dim-1>                                             &,
+                        const Mapping<dim,spacedim> &,
+                        const typename Mapping<dim,spacedim>::InternalDataBase &,
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase &,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &) const
 {
   // leave data fields empty
 }
+
+
 
 template <int dim, int spacedim>
 bool

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -31,21 +31,21 @@ DEAL_II_NAMESPACE_OPEN
 template <>
 void
 FE_Poly<TensorProductPolynomials<1>,1,2>::
-fill_fe_values (const Mapping<1,2>                                &mapping,
-                const Triangulation<1,2>::cell_iterator &,
-                const Quadrature<1>                               &quadrature,
-                const Mapping<1,2>::InternalDataBase              &mapping_internal,
-                const FiniteElement<1,2>::InternalDataBase        &fedata,
-                const internal::FEValues::MappingRelatedData<1,2> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<1,2> &output_data,
-                const CellSimilarity::Similarity                  cell_similarity) const
+fill_fe_values (const Triangulation<1,2>::cell_iterator &,
+                const CellSimilarity::Similarity                           cell_similarity,
+                const Quadrature<1>                                       &quadrature,
+                const Mapping<1,2>                                        &mapping,
+                const Mapping<1,2>::InternalDataBase                      &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<1,2> &mapping_data,
+                const FiniteElement<1,2>::InternalDataBase                &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<1,2> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
@@ -90,20 +90,20 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
 template <>
 void
 FE_Poly<TensorProductPolynomials<2>,2,3>::
-fill_fe_values (const Mapping<2,3>                                &mapping,
-                const Triangulation<2,3>::cell_iterator &,
-                const Quadrature<2>                               &quadrature,
-                const Mapping<2,3>::InternalDataBase              &mapping_internal,
-                const FiniteElement<2,3>::InternalDataBase        &fedata,
-                const internal::FEValues::MappingRelatedData<2,3> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<2,3> &output_data,
-                const CellSimilarity::Similarity                  cell_similarity) const
+fill_fe_values (const Triangulation<2,3>::cell_iterator &,
+                const CellSimilarity::Similarity                           cell_similarity,
+                const Quadrature<2>                                       &quadrature,
+                const Mapping<2,3>                                        &mapping,
+                const Mapping<2,3>::InternalDataBase                      &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<2,3> &mapping_data,
+                const FiniteElement<2,3>::InternalDataBase                &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<2,3> &output_data) const
 {
 
   // assert that the following dynamics
   // cast is really well-defined.
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
@@ -147,22 +147,22 @@ fill_fe_values (const Mapping<2,3>                                &mapping,
 template <>
 void
 FE_Poly<PolynomialSpace<1>,1,2>::
-fill_fe_values (const Mapping<1,2>                                &mapping,
-                const Triangulation<1,2>::cell_iterator &,
-                const Quadrature<1>                               &quadrature,
-                const Mapping<1,2>::InternalDataBase              &mapping_internal,
-                const FiniteElement<1,2>::InternalDataBase        &fedata,
-                const internal::FEValues::MappingRelatedData<1,2> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<1,2> &output_data,
-                const CellSimilarity::Similarity                  cell_similarity) const
+fill_fe_values (const Triangulation<1,2>::cell_iterator &,
+                const CellSimilarity::Similarity                           cell_similarity,
+                const Quadrature<1>                                       &quadrature,
+                const Mapping<1,2>                                        &mapping,
+                const Mapping<1,2>::InternalDataBase                      &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<1,2> &mapping_data,
+                const FiniteElement<1,2>::InternalDataBase                &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<1,2> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
 
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
@@ -206,17 +206,17 @@ fill_fe_values (const Mapping<1,2>                                &mapping,
 template <>
 void
 FE_Poly<PolynomialSpace<2>,2,3>::
-fill_fe_values (const Mapping<2,3>                                &mapping,
-                const Triangulation<2,3>::cell_iterator &,
-                const Quadrature<2>                               &quadrature,
-                const Mapping<2,3>::InternalDataBase              &mapping_internal,
-                const FiniteElement<2,3>::InternalDataBase        &fedata,
-                const internal::FEValues::MappingRelatedData<2,3> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<2,3> &output_data,
-                const CellSimilarity::Similarity                  cell_similarity) const
+fill_fe_values (const Triangulation<2,3>::cell_iterator &,
+                const CellSimilarity::Similarity                           cell_similarity,
+                const Quadrature<2>                                       &quadrature,
+                const Mapping<2,3>                                        &mapping,
+                const Mapping<2,3>::InternalDataBase                      &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<2,3> &mapping_data,
+                const FiniteElement<2,3>::InternalDataBase                &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<2,3> &output_data) const
 {
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -289,22 +289,22 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_grad_grad_component (const unsigned int 
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim>                                  &mapping,
-                const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
-                const Quadrature<dim>                                        &quadrature,
-                const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data,
-                const CellSimilarity::Similarity                              cell_similarity) const
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                const CellSimilarity::Similarity                                     cell_similarity,
+                const Quadrature<dim>                                               &quadrature,
+                const Mapping<dim,spacedim>                                         &mapping,
+                const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0,
           ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   const unsigned int n_q_points = quadrature.size();
 
@@ -758,22 +758,22 @@ fill_fe_values (const Mapping<dim,spacedim>                                  &ma
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim>                                  &mapping,
-                     const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
-                     const unsigned int                                            face,
-                     const Quadrature<dim-1>                                      &quadrature,
-                     const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data) const
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                     const unsigned int                                                   face_no,
+                     const Quadrature<dim-1>                                             &quadrature,
+                     const Mapping<dim,spacedim>                                         &mapping,
+                     const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0,
           ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   const unsigned int n_q_points = quadrature.size();
   // offset determines which data set
@@ -781,10 +781,10 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
   // faces are stored contiguously)
 
   const typename QProjector<dim>::DataSetDescriptor offset
-    = QProjector<dim>::DataSetDescriptor::face (face,
-                                                cell->face_orientation(face),
-                                                cell->face_flip(face),
-                                                cell->face_rotation(face),
+    = QProjector<dim>::DataSetDescriptor::face (face_no,
+                                                cell->face_orientation(face_no),
+                                                cell->face_flip(face_no),
+                                                cell->face_rotation(face_no),
                                                 n_q_points);
 
 //TODO: Size assertions
@@ -1217,23 +1217,23 @@ fill_fe_face_values (const Mapping<dim,spacedim>                                
 template <class POLY, int dim, int spacedim>
 void
 FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim>                                  &mapping,
-                        const typename Triangulation<dim,spacedim>::cell_iterator    &cell,
-                        const unsigned int                                            face,
-                        const unsigned int                                            subface,
-                        const Quadrature<dim-1>                                      &quadrature,
-                        const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_internal,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim>   &mapping_data,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim>   &output_data) const
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                        const unsigned int                                                   face_no,
+                        const unsigned int                                                   sub_no,
+                        const Quadrature<dim-1>                                             &quadrature,
+                        const Mapping<dim,spacedim>                                         &mapping,
+                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0,
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0,
           ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   const unsigned int n_q_points = quadrature.size();
 
@@ -1241,12 +1241,12 @@ fill_fe_subface_values (const Mapping<dim,spacedim>                             
   // to take (all data sets for all
   // sub-faces are stored contiguously)
   const typename QProjector<dim>::DataSetDescriptor offset
-    = QProjector<dim>::DataSetDescriptor::subface (face, subface,
-                                                   cell->face_orientation(face),
-                                                   cell->face_flip(face),
-                                                   cell->face_rotation(face),
+    = QProjector<dim>::DataSetDescriptor::subface (face_no, sub_no,
+                                                   cell->face_orientation(face_no),
+                                                   cell->face_flip(face_no),
+                                                   cell->face_rotation(face_no),
                                                    n_q_points,
-                                                   cell->subface_case(face));
+                                                   cell->subface_case(face_no));
 
 //   Assert(mapping_type == independent
 //       || ( mapping_type == independent_on_cartesian

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1001,17 +1001,17 @@ FESystem<dim,spacedim>::get_subface_data (const UpdateFlags      flags,
 template <int dim, int spacedim>
 void
 FESystem<dim,spacedim>::
-fill_fe_values (const Mapping<dim,spacedim>                      &mapping,
-                const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                const Quadrature<dim>                            &quadrature,
-                const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_data,
-                const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data,
-                const CellSimilarity::Similarity                  cell_similarity) const
+fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                const CellSimilarity::Similarity                                     cell_similarity,
+                const Quadrature<dim>                                               &quadrature,
+                const Mapping<dim,spacedim>                                         &mapping,
+                const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill(mapping, cell, invalid_face_number, invalid_face_number,
-               quadrature, cell_similarity, mapping_internal, fe_data,
+               quadrature, cell_similarity, mapping_internal, fe_internal,
                mapping_data, output_data);
 }
 
@@ -1020,17 +1020,17 @@ fill_fe_values (const Mapping<dim,spacedim>                      &mapping,
 template <int dim, int spacedim>
 void
 FESystem<dim,spacedim>::
-fill_fe_face_values (const Mapping<dim,spacedim>                   &mapping,
-                     const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                     const unsigned int                    face_no,
-                     const Quadrature<dim-1>              &quadrature,
-                     const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_data,
-                     const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                     internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                     const unsigned int                                                   face_no,
+                     const Quadrature<dim-1>                                             &quadrature,
+                     const Mapping<dim,spacedim>                                         &mapping,
+                     const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill (mapping, cell, face_no, invalid_face_number, quadrature,
-                CellSimilarity::none, mapping_internal, fe_data,
+                CellSimilarity::none, mapping_internal, fe_internal,
                 mapping_data, output_data);
 }
 
@@ -1040,18 +1040,18 @@ fill_fe_face_values (const Mapping<dim,spacedim>                   &mapping,
 template <int dim, int spacedim>
 void
 FESystem<dim,spacedim>::
-fill_fe_subface_values (const Mapping<dim,spacedim>                      &mapping,
-                        const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                        const unsigned int                                face_no,
-                        const unsigned int                                sub_no,
-                        const Quadrature<dim-1>                          &quadrature,
-                        const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_data,
-                        const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
-                        internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
+fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+                        const unsigned int                                                   face_no,
+                        const unsigned int                                                   sub_no,
+                        const Quadrature<dim-1>                                             &quadrature,
+                        const Mapping<dim,spacedim>                                         &mapping,
+                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   compute_fill (mapping, cell, face_no, sub_no, quadrature,
-                CellSimilarity::none, mapping_internal, fe_data,
+                CellSimilarity::none, mapping_internal, fe_internal,
                 mapping_data, output_data);
 }
 
@@ -1068,7 +1068,7 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
               const Quadrature<dim_1>                          &quadrature,
               const CellSimilarity::Similarity                  cell_similarity,
               const typename Mapping<dim,spacedim>::InternalDataBase &mapping_internal,
-              const typename FiniteElement<dim,spacedim>::InternalDataBase &fedata,
+              const typename FiniteElement<dim,spacedim>::InternalDataBase &fe_internal,
               const internal::FEValues::MappingRelatedData<dim,spacedim> &mapping_data,
               internal::FEValues::FiniteElementRelatedData<dim,spacedim> &output_data) const
 {
@@ -1076,8 +1076,8 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
   // data for this class. fails with
   // an exception if that is not
   // possible
-  Assert (dynamic_cast<const InternalData *> (&fedata) != 0, ExcInternalError());
-  const InternalData &fe_data = static_cast<const InternalData &> (fedata);
+  Assert (dynamic_cast<const InternalData *> (&fe_internal) != 0, ExcInternalError());
+  const InternalData &fe_data = static_cast<const InternalData &> (fe_internal);
 
   // Either dim_1==dim
   // (fill_fe_values) or dim_1==dim-1
@@ -1145,14 +1145,20 @@ compute_fill (const Mapping<dim,spacedim>                      &mapping,
         // copied from base_data to data on each face, therefore use
         // base_fe_data.update_flags.
         if (face_no==invalid_face_number)
-          base_fe.fill_fe_values(mapping, cell, *cell_quadrature, mapping_internal,
-                                 base_fe_data, mapping_data, base_data, cell_similarity);
+          base_fe.fill_fe_values(cell, cell_similarity,
+                                 *cell_quadrature,
+                                 mapping, mapping_internal, mapping_data,
+                                 base_fe_data, base_data);
         else if (sub_no==invalid_face_number)
-          base_fe.fill_fe_face_values(mapping, cell, face_no,
-                                      *face_quadrature, mapping_internal, base_fe_data, mapping_data, base_data);
+          base_fe.fill_fe_face_values(cell, face_no,
+                                      *face_quadrature,
+                                      mapping, mapping_internal, mapping_data,
+                                      base_fe_data, base_data);
         else
-          base_fe.fill_fe_subface_values(mapping, cell, face_no, sub_no,
-                                         *face_quadrature, mapping_internal, base_fe_data, mapping_data, base_data);
+          base_fe.fill_fe_subface_values(cell, face_no, sub_no,
+                                         *face_quadrature,
+                                         mapping, mapping_internal, mapping_data,
+                                         base_fe_data, base_data);
 
         // now data has been generated, so copy it. we used to work by
         // looping over all base elements (i.e. this outer loop), then over

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3758,14 +3758,14 @@ void FEValues<dim,spacedim>::do_reinit ()
   // already filled by the mapping, let it compute the
   // data for the mapped shape function values, gradients,
   // etc.
-  this->get_fe().fill_fe_values(this->get_mapping(),
-                                *this->present_cell,
-                                quadrature,
+  this->get_fe().fill_fe_values(*this->present_cell,
+                                this->cell_similarity,
+                                this->quadrature,
+                                this->get_mapping(),
                                 *this->mapping_data,
-                                *this->fe_data,
                                 this->mapping_output,
-                                this->finite_element_output,
-                                this->cell_similarity);
+                                *this->fe_data,
+                                this->finite_element_output);
 }
 
 
@@ -3963,12 +3963,13 @@ void FEFaceValues<dim,spacedim>::do_reinit (const unsigned int face_no)
                                           *this->mapping_data,
                                           this->mapping_output);
 
-  this->get_fe().fill_fe_face_values(this->get_mapping(),
-                                     *this->present_cell, face_no,
+  this->get_fe().fill_fe_face_values(*this->present_cell,
+                                     face_no,
                                      this->quadrature,
+                                     this->get_mapping(),
                                      *this->mapping_data,
-                                     *this->fe_data,
                                      this->mapping_output,
+                                     *this->fe_data,
                                      this->finite_element_output);
 }
 
@@ -4203,13 +4204,14 @@ void FESubfaceValues<dim,spacedim>::do_reinit (const unsigned int face_no,
                                              *this->mapping_data,
                                              this->mapping_output);
 
-  this->get_fe().fill_fe_subface_values(this->get_mapping(),
-                                        *this->present_cell,
-                                        face_no, subface_no,
+  this->get_fe().fill_fe_subface_values(*this->present_cell,
+                                        face_no,
+                                        subface_no,
                                         this->quadrature,
+                                        this->get_mapping(),
                                         *this->mapping_data,
-                                        *this->fe_data,
                                         this->mapping_output,
+                                        *this->fe_data,
                                         this->finite_element_output);
 }
 


### PR DESCRIPTION
As discussed in #1277, the list of arguments of `FiniteElement::fill_fe_*_values` is a bit "Kraut und Rueben". It needed to be sorted in a somewhat meaningful way, and the arguments needed to be documented appropriately.

This patch does this. The first of the two commits just reorders arguments (and standardizes on a common naming scheme for the arguments in all implementations). It is very boring. The second commit provides documentation of these functions and their arguments.

This fixes #1277.