### PR TITLE
Consistent template type names

### DIFF
--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -167,8 +167,8 @@ public:
   bool is_type(const unsigned int i) const;
 
   /// List the contents to a stream
-  template <class STREAM>
-  void list (STREAM &os) const;
+  template <class StreamType>
+  void list (StreamType &os) const;
 
   /// An entry with this name does not exist in the AnyData object.
   DeclException1(ExcNameNotFound, std::string,
@@ -448,9 +448,9 @@ AnyData::merge(const AnyData &other)
 }
 
 
-template <class STREAM>
+template <class StreamType>
 inline
-void AnyData::list(STREAM &os) const
+void AnyData::list(StreamType &os) const
 {
   for (unsigned int i=0; i<names.size(); ++i)
     {

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -63,15 +63,15 @@ namespace Algorithms
    *
    * @author Guido Kanschat, 2006, 2010
    */
-  template <class VECTOR>
-  class Newton : public Operator<VECTOR>
+  template <typename VectorType>
+  class Newton : public Operator<VectorType>
   {
   public:
     /**
      * Constructor, receiving the applications computing the residual and
      * solving the linear problem, respectively.
      */
-    Newton (Operator<VECTOR> &residual, Operator<VECTOR> &inverse_derivative);
+    Newton (Operator<VectorType> &residual, Operator<VectorType> &inverse_derivative);
 
     /**
      * Declare the parameters applicable to Newton's method.
@@ -86,7 +86,7 @@ namespace Algorithms
     /**
      * Initialize the pointer data_out for debugging.
      */
-    void initialize (OutputOperator<VECTOR> &output);
+    void initialize (OutputOperator<VectorType> &output);
 
     /**
      * The actual Newton iteration. The initial value is in <tt>out(0)</tt>,
@@ -112,18 +112,18 @@ namespace Algorithms
     /**
      * The operator computing the residual.
      */
-    SmartPointer<Operator<VECTOR>, Newton<VECTOR> > residual;
+    SmartPointer<Operator<VectorType>, Newton<VectorType> > residual;
 
     /**
      * The operator applying the inverse derivative to the residual.
      */
-    SmartPointer<Operator<VECTOR>, Newton<VECTOR> > inverse_derivative;
+    SmartPointer<Operator<VectorType>, Newton<VectorType> > inverse_derivative;
 
     /**
      * The operator handling the output in case the debug_vectors is true.
      * Call the initialize function first.
      */
-    SmartPointer<OutputOperator<VECTOR>, Newton<VECTOR> > data_out;
+    SmartPointer<OutputOperator<VectorType>, Newton<VectorType> > data_out;
 
     /**
      * This flag is set by the function assemble(), indicating that the matrix

--- a/include/deal.II/algorithms/newton.templates.h
+++ b/include/deal.II/algorithms/newton.templates.h
@@ -27,8 +27,8 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  template <class VECTOR>
-  Newton<VECTOR>::Newton(Operator<VECTOR> &residual, Operator<VECTOR> &inverse_derivative)
+  template <typename VectorType>
+  Newton<VectorType>::Newton(Operator<VectorType> &residual, Operator<VectorType> &inverse_derivative)
     :
     residual(&residual), inverse_derivative(&inverse_derivative),
     assemble_now(false),
@@ -39,9 +39,9 @@ namespace Algorithms
   {}
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Newton<VECTOR>::declare_parameters(ParameterHandler &param)
+  Newton<VectorType>::declare_parameters(ParameterHandler &param)
   {
     param.enter_subsection("Newton");
     ReductionControl::declare_parameters (param);
@@ -52,9 +52,9 @@ namespace Algorithms
     param.leave_subsection();
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Newton<VECTOR>::parse_parameters (ParameterHandler &param)
+  Newton<VectorType>::parse_parameters (ParameterHandler &param)
   {
     param.enter_subsection("Newton");
     control.parse_parameters (param);
@@ -64,25 +64,25 @@ namespace Algorithms
     param.leave_subsection ();
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Newton<VECTOR>::initialize (OutputOperator<VECTOR> &output)
+  Newton<VectorType>::initialize (OutputOperator<VectorType> &output)
   {
     data_out = &output;
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Newton<VECTOR>::notify(const Event &e)
+  Newton<VectorType>::notify(const Event &e)
   {
     residual->notify(e);
     inverse_derivative->notify(e);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   double
-  Newton<VECTOR>::threshold(const double thr)
+  Newton<VectorType>::threshold(const double thr)
   {
     const double t = assemble_threshold;
     assemble_threshold = thr;
@@ -90,33 +90,33 @@ namespace Algorithms
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Newton<VECTOR>::operator() (AnyData &out, const AnyData &in)
+  Newton<VectorType>::operator() (AnyData &out, const AnyData &in)
   {
     Assert (out.size() == 1, ExcNotImplemented());
     deallog.push ("Newton");
 
-    VECTOR &u = *out.entry<VECTOR *>(0);
+    VectorType &u = *out.entry<VectorType *>(0);
 
     if (debug>2)
       deallog << "u: " << u.l2_norm() << std::endl;
 
-    GrowingVectorMemory<VECTOR> mem;
-    typename VectorMemory<VECTOR>::Pointer Du(mem);
-    typename VectorMemory<VECTOR>::Pointer res(mem);
+    GrowingVectorMemory<VectorType> mem;
+    typename VectorMemory<VectorType>::Pointer Du(mem);
+    typename VectorMemory<VectorType>::Pointer res(mem);
 
     res->reinit(u);
     AnyData src1;
     AnyData src2;
-    src1.add<const VECTOR *>(&u, "Newton iterate");
+    src1.add<const VectorType *>(&u, "Newton iterate");
     src1.merge(in);
-    src2.add<const VECTOR *>(res, "Newton residual");
+    src2.add<const VectorType *>(res, "Newton residual");
     src2.merge(src1);
     AnyData out1;
-    out1.add<VECTOR *>(res, "Residual");
+    out1.add<VectorType *>(res, "Residual");
     AnyData out2;
-    out2.add<VECTOR *>(Du, "Update");
+    out2.add<VectorType *>(Du, "Update");
 
     unsigned int step = 0;
     // fill res with (f(u), v)
@@ -127,12 +127,12 @@ namespace Algorithms
     if (debug_vectors)
       {
         AnyData out;
-        VECTOR *p = &u;
-        out.add<const VECTOR *>(p, "solution");
+        VectorType *p = &u;
+        out.add<const VectorType *>(p, "solution");
         p = Du;
-        out.add<const VECTOR *>(p, "update");
+        out.add<const VectorType *>(p, "update");
         p = res;
-        out.add<const VECTOR *>(p, "residual");
+        out.add<const VectorType *>(p, "residual");
         *data_out << step;
         *data_out << out;
       }
@@ -158,12 +158,12 @@ namespace Algorithms
         if (debug_vectors)
           {
             AnyData out;
-            VECTOR *p = &u;
-            out.add<const VECTOR *>(p, "solution");
+            VectorType *p = &u;
+            out.add<const VectorType *>(p, "solution");
             p = Du;
-            out.add<const VECTOR *>(p, "update");
+            out.add<const VectorType *>(p, "update");
             p = res;
-            out.add<const VECTOR *>(p, "residual");
+            out.add<const VectorType *>(p, "residual");
             *data_out << step;
             *data_out << out;
           }

--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -125,7 +125,7 @@ namespace Algorithms
    *
    * @author Guido Kanschat, 2010
    */
-  template <class VECTOR>
+  template <typename VectorType>
   class Operator : public OperatorBase
   {
   public:
@@ -138,10 +138,10 @@ namespace Algorithms
    *
    * @author Guido Kanschat, 2010
    */
-  template <class VECTOR>
+  template <typename VectorType>
   class OutputOperator : public Subscriptor
   {
-    OutputOperator(const OutputOperator<VECTOR> &);
+    OutputOperator(const OutputOperator<VectorType> &);
   public:
     OutputOperator ();
     /**
@@ -161,7 +161,7 @@ namespace Algorithms
     /**
      * Output all the vectors in AnyData.
      */
-    virtual OutputOperator<VECTOR> &operator<< (const AnyData &vectors);
+    virtual OutputOperator<VectorType> &operator<< (const AnyData &vectors);
 
   protected:
     unsigned int step;
@@ -169,10 +169,10 @@ namespace Algorithms
     std::ostream *os;
   };
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
   void
-  OutputOperator<VECTOR>::set_step (const unsigned int s)
+  OutputOperator<VectorType>::set_step (const unsigned int s)
   {
     step = s;
   }
@@ -183,10 +183,10 @@ namespace Algorithms
    *
    * @relates OutputOperator
    */
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  OutputOperator<VECTOR> &
-  operator<< (OutputOperator<VECTOR> &out, unsigned int step)
+  OutputOperator<VectorType> &
+  operator<< (OutputOperator<VectorType> &out, unsigned int step)
   {
     out.set_step(step);
     return out;

--- a/include/deal.II/algorithms/operator.templates.h
+++ b/include/deal.II/algorithms/operator.templates.h
@@ -21,36 +21,36 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  template <class VECTOR>
-  Operator<VECTOR>::Operator()
+  template <typename VectorType>
+  Operator<VectorType>::Operator()
   {}
 
-  template <class VECTOR>
-  OutputOperator<VECTOR>::~OutputOperator()
+  template <typename VectorType>
+  OutputOperator<VectorType>::~OutputOperator()
   {}
 
-  template <class VECTOR>
-  OutputOperator<VECTOR>::OutputOperator()
+  template <typename VectorType>
+  OutputOperator<VectorType>::OutputOperator()
     :
     os(0)
   {}
 
-  template <class VECTOR>
-  void OutputOperator<VECTOR>::initialize_stream(std::ostream &stream)
+  template <typename VectorType>
+  void OutputOperator<VectorType>::initialize_stream(std::ostream &stream)
   {
     os =&stream;
   }
 
-  template <class VECTOR>
-  OutputOperator<VECTOR> &
-  OutputOperator<VECTOR>::operator<< (const AnyData &vectors)
+  template <typename VectorType>
+  OutputOperator<VectorType> &
+  OutputOperator<VectorType>::operator<< (const AnyData &vectors)
   {
     if (os == 0)
       {
         deallog << "Step " << step << std::endl;
         for (unsigned int i=0; i<vectors.size(); ++i)
           {
-            const VECTOR *v = vectors.try_read_ptr<VECTOR>(i);
+            const VectorType *v = vectors.try_read_ptr<VectorType>(i);
             if (v == 0) continue;
             deallog << vectors.name(i);
             for (unsigned int j=0; j<v->size(); ++j)
@@ -64,7 +64,7 @@ namespace Algorithms
         (*os) << ' ' << step;
         for (unsigned int i=0; i<vectors.size(); ++i)
           {
-            const VECTOR *v = vectors.try_read_ptr<VECTOR>(i);
+            const VectorType *v = vectors.try_read_ptr<VectorType>(i);
             if (v == 0) continue;
             for (unsigned int j=0; j<v->size(); ++j)
               (*os) << ' ' << (*v)(j);

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -186,8 +186,8 @@ namespace Algorithms
    * @author Guido Kanschat
    * @date 2010
    */
-  template <class VECTOR>
-  class ThetaTimestepping : public Operator<VECTOR>
+  template <typename VectorType>
+  class ThetaTimestepping : public Operator<VectorType>
   {
   public:
     /**
@@ -195,8 +195,8 @@ namespace Algorithms
      * #op_implicit. For their meaning, see the description of those
      * variables.
      */
-    ThetaTimestepping (Operator<VECTOR> &op_explicit,
-                       Operator<VECTOR> &op_implicit);
+    ThetaTimestepping (Operator<VectorType> &op_explicit,
+                       Operator<VectorType> &op_implicit);
 
     /**
      * The timestepping scheme.
@@ -205,9 +205,9 @@ namespace Algorithms
      * AnyData objects used as input for the operators #op_explicit and
      * #op_implicit.
      *
-     * @param out in its first argument must contain a pointer to a `VECTOR`,
-     * which contains the initial value when the operator is called. It
-     * contains the final value when the operator returns.
+     * @param out in its first argument must contain a pointer to a VectorType
+     * instance, which contains the initial value when the operator is
+     * called. It contains the final value when the operator returns.
      */
     virtual void operator() (AnyData &out, const AnyData &in);
 
@@ -220,7 +220,7 @@ namespace Algorithms
      * Define an operator which will output the result in each step. Note that
      * no output will be generated without this.
      */
-    void set_output(OutputOperator<VECTOR> &output);
+    void set_output(OutputOperator<VectorType> &output);
 
     /**
      * Declare parameters in a parameter handler.
@@ -309,7 +309,7 @@ namespace Algorithms
      * vector, $M$ the mass matrix, $F$ the operator in space and $c$ is the
      * adjusted time step size $(1-\theta) \Delta t$.
      */
-    SmartPointer<Operator<VECTOR>, ThetaTimestepping<VECTOR> > op_explicit;
+    SmartPointer<Operator<VectorType>, ThetaTimestepping<VectorType> > op_explicit;
 
     /**
      * The operator solving the implicit part of the scheme. It will receive
@@ -321,60 +321,60 @@ namespace Algorithms
      * the input data, <i>M</i> the mass matrix, <i>F</i> the operator in
      * space and <i>c</i> is the adjusted time step size $ \theta \Delta t$
      */
-    SmartPointer<Operator<VECTOR>, ThetaTimestepping<VECTOR> > op_implicit;
+    SmartPointer<Operator<VectorType>, ThetaTimestepping<VectorType> > op_implicit;
 
     /**
      * The operator writing the output in each time step
      */
-    SmartPointer<OutputOperator<VECTOR>, ThetaTimestepping<VECTOR> > output;
+    SmartPointer<OutputOperator<VectorType>, ThetaTimestepping<VectorType> > output;
   };
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
   const TimestepData &
-  ThetaTimestepping<VECTOR>::explicit_data () const
+  ThetaTimestepping<VectorType>::explicit_data () const
   {
     return d_explicit;
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
   const TimestepData &
-  ThetaTimestepping<VECTOR>::implicit_data () const
+  ThetaTimestepping<VectorType>::implicit_data () const
   {
     return d_implicit;
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
   TimestepControl &
-  ThetaTimestepping<VECTOR>::timestep_control ()
+  ThetaTimestepping<VectorType>::timestep_control ()
   {
     return control;
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  void ThetaTimestepping<VECTOR>::set_output (OutputOperator<VECTOR> &out)
+  void ThetaTimestepping<VectorType>::set_output (OutputOperator<VectorType> &out)
   {
     output = &out;
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  double ThetaTimestepping<VECTOR>::theta () const
+  double ThetaTimestepping<VectorType>::theta () const
   {
     return vtheta;
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  double ThetaTimestepping<VECTOR>::theta (double new_theta)
+  double ThetaTimestepping<VectorType>::theta (double new_theta)
   {
     const double tmp = vtheta;
     vtheta = new_theta;
@@ -382,9 +382,9 @@ namespace Algorithms
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  double ThetaTimestepping<VECTOR>::current_time () const
+  double ThetaTimestepping<VectorType>::current_time () const
   {
     return control.now();
   }

--- a/include/deal.II/algorithms/theta_timestepping.templates.h
+++ b/include/deal.II/algorithms/theta_timestepping.templates.h
@@ -23,23 +23,23 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  template <class VECTOR>
-  ThetaTimestepping<VECTOR>::ThetaTimestepping (Operator<VECTOR> &e, Operator<VECTOR> &i)
+  template <typename VectorType>
+  ThetaTimestepping<VectorType>::ThetaTimestepping (Operator<VectorType> &e, Operator<VectorType> &i)
     : vtheta(0.5), adaptive(false), op_explicit(&e), op_implicit(&i)
   {}
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  ThetaTimestepping<VECTOR>::notify(const Event &e)
+  ThetaTimestepping<VectorType>::notify(const Event &e)
   {
     op_explicit->notify(e);
     op_implicit->notify(e);
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  ThetaTimestepping<VECTOR>::declare_parameters(ParameterHandler &param)
+  ThetaTimestepping<VectorType>::declare_parameters(ParameterHandler &param)
   {
     param.enter_subsection("ThetaTimestepping");
     TimestepControl::declare_parameters (param);
@@ -48,9 +48,9 @@ namespace Algorithms
     param.leave_subsection();
   }
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  ThetaTimestepping<VECTOR>::parse_parameters (ParameterHandler &param)
+  ThetaTimestepping<VectorType>::parse_parameters (ParameterHandler &param)
   {
     param.enter_subsection("ThetaTimestepping");
     control.parse_parameters (param);
@@ -60,17 +60,17 @@ namespace Algorithms
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  ThetaTimestepping<VECTOR>::operator() (AnyData &out, const AnyData &in)
+  ThetaTimestepping<VectorType>::operator() (AnyData &out, const AnyData &in)
   {
     Assert(!adaptive, ExcNotImplemented());
 
     deallog.push ("Theta");
 
-    VECTOR &solution = *out.entry<VECTOR *>(0);
-    GrowingVectorMemory<VECTOR> mem;
-    typename VectorMemory<VECTOR>::Pointer aux(mem);
+    VectorType &solution = *out.entry<VectorType *>(0);
+    GrowingVectorMemory<VectorType> mem;
+    typename VectorMemory<VectorType>::Pointer aux(mem);
     aux->reinit(solution);
 
     control.restart();
@@ -81,7 +81,7 @@ namespace Algorithms
     // vector associated with the old
     // timestep
     AnyData src1;
-    src1.add<const VECTOR *>(&solution, "Previous iterate");
+    src1.add<const VectorType *>(&solution, "Previous iterate");
     src1.add<const double *>(&d_explicit.time, "Time");
     src1.add<const double *>(&d_explicit.step, "Timestep");
     src1.add<const double *>(&vtheta, "Theta");
@@ -90,10 +90,10 @@ namespace Algorithms
     AnyData src2;
 
     AnyData out1;
-    out1.add<VECTOR *>(aux, "Solution");
+    out1.add<VectorType *>(aux, "Solution");
     // The data provided to the inner solver
-    src2.add<const VECTOR *>(aux, "Previous time");
-    src2.add<const VECTOR *>(&solution, "Previous iterate");
+    src2.add<const VectorType *>(aux, "Previous time");
+    src2.add<const VectorType *>(&solution, "Previous iterate");
     src2.add<const double *>(&d_implicit.time, "Time");
     src2.add<const double *>(&d_implicit.step, "Timestep");
     src2.add<const double *>(&vtheta, "Theta");

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -302,8 +302,8 @@ public:
    * Outputs a text representation of this IndexSet to the given stream. Used
    * for testing.
    */
-  template <class STREAM>
-  void print(STREAM &out) const;
+  template <class StreamType>
+  void print(StreamType &out) const;
 
   /**
    * Writes the IndexSet into a text based file format, that can be read in
@@ -1563,10 +1563,10 @@ IndexSet::fill_binary_vector (Vector &vector) const
 
 
 
-template <class STREAM>
+template <class StreamType>
 inline
 void
-IndexSet::print (STREAM &out) const
+IndexSet::print (StreamType &out) const
 {
   compress();
   out << "{";

--- a/include/deal.II/base/path_search.h
+++ b/include/deal.II/base/path_search.h
@@ -149,8 +149,8 @@ public:
   /**
    * Show the paths and suffixes used for this object.
    */
-  template <class STREAM>
-  void show(STREAM &stream) const;
+  template <class StreamType>
+  void show(StreamType &stream) const;
 
   /**
    * Add a new class.
@@ -252,10 +252,10 @@ private:
 /* ----------------------------- inline functions ------------------------- */
 
 
-template <class STREAM>
+template <class StreamType>
 inline
 void
-PathSearch::show(STREAM &out) const
+PathSearch::show(StreamType &out) const
 {
   out << "DEAL_II_" << cls << "PATH=\"";
   bool first = true;

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -116,8 +116,8 @@ public:
   /**
    * Prints the list of the indices to <tt>out</tt>.
    */
-  template <class STREAM>
-  void output_indices(STREAM &out) const;
+  template <class StreamType>
+  void output_indices(StreamType &out) const;
 
   /**
    * Sets the ordering of the polynomials. Requires
@@ -299,9 +299,9 @@ PolynomialSpace<dim>::degree() const
 
 
 template <int dim>
-template <class STREAM>
+template <class StreamType>
 void
-PolynomialSpace<dim>::output_indices(STREAM &out) const
+PolynomialSpace<dim>::output_indices(StreamType &out) const
 {
   unsigned int ix[dim];
   for (unsigned int i=0; i<n_pols; ++i)

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -60,7 +60,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Ralf Hartmann, 2000, 2004, Guido Kanschat, 2000, Wolfgang Bangerth
  * 2003
  */
-template <int dim, typename POLY=Polynomials::Polynomial<double> >
+template <int dim, typename PolynomialType=Polynomials::Polynomial<double> >
 class TensorProductPolynomials
 {
 public:
@@ -73,8 +73,8 @@ public:
   /**
    * Constructor. <tt>pols</tt> is a vector of objects that should be derived
    * or otherwise convertible to one-dimensional polynomial objects of type @p
-   * POLY (template argument of class). It will be copied element by element
-   * into a private variable.
+   * PolynomialType (template argument of class). It will be copied element by
+   * element into a private variable.
    */
   template <class Pol>
   TensorProductPolynomials (const std::vector<Pol> &pols);
@@ -193,7 +193,7 @@ protected:
   /**
    * Copy of the vector <tt>pols</tt> of polynomials given to the constructor.
    */
-  std::vector<POLY> polynomials;
+  std::vector<PolynomialType> polynomials;
 
   /**
    * Number of tensor product polynomials. See n().
@@ -380,10 +380,10 @@ private:
 /* ---------------- template and inline functions ---------- */
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 template <class Pol>
 inline
-TensorProductPolynomials<dim,POLY>::
+TensorProductPolynomials<dim,PolynomialType>::
 TensorProductPolynomials(const std::vector<Pol> &pols)
   :
   polynomials (pols.begin(), pols.end()),
@@ -402,10 +402,10 @@ TensorProductPolynomials(const std::vector<Pol> &pols)
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 inline
 unsigned int
-TensorProductPolynomials<dim,POLY>::n() const
+TensorProductPolynomials<dim,PolynomialType>::n() const
 {
   if (dim == 0)
     return numbers::invalid_unsigned_int;
@@ -415,28 +415,29 @@ TensorProductPolynomials<dim,POLY>::n() const
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 inline
 const std::vector<unsigned int> &
-TensorProductPolynomials<dim,POLY>::get_numbering() const
+TensorProductPolynomials<dim,PolynomialType>::get_numbering() const
 {
   return index_map;
 }
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 inline
 const std::vector<unsigned int> &
-TensorProductPolynomials<dim,POLY>::get_numbering_inverse() const
+TensorProductPolynomials<dim,PolynomialType>::get_numbering_inverse() const
 {
   return index_map_inverse;
 }
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 template <int order>
 Tensor<order,dim>
-TensorProductPolynomials<dim,POLY>::compute_derivative (const unsigned int i,
-                                                        const Point<dim> &p) const
+TensorProductPolynomials<dim,PolynomialType>::compute_derivative
+(const unsigned int  i,
+ const Point<dim>   &p) const
 {
   unsigned int indices[dim];
   compute_index (i, indices);

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -65,7 +65,7 @@ namespace TimeStepping
    * Abstract class for time stepping methods. These methods assume that the
    * equation has the form: $ \frac{\partial y}{\partial t} = f(t,y) $.
    */
-  template <typename VECTOR>
+  template <typename VectorType>
   class TimeStepping
   {
   public:
@@ -84,12 +84,12 @@ namespace TimeStepping
      * and a vector. The output is the value of function at this point. This
      * function returns the time at the end of the time step.
      */
-    virtual double evolve_one_time_step(
-      std::vector<std_cxx11::function<VECTOR (const double, const VECTOR &)> > &F,
-      std::vector<std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> > &J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y) = 0;
+    virtual double evolve_one_time_step
+    (std::vector<std_cxx11::function<VectorType (const double, const VectorType &)> >               &F,
+     std::vector<std_cxx11::function<VectorType (const double, const double, const VectorType &)> > &J_inverse,
+     double                                                                                         t,
+     double                                                                                         delta_t,
+     VectorType                                                                                     &y) = 0;
 
     /**
      * Empty structure used to store information.
@@ -110,8 +110,8 @@ namespace TimeStepping
    * @author Damien Lebrun-Grandie, Bruno Turcksin
    * @date 2014
    */
-  template <typename VECTOR>
-  class RungeKutta : public TimeStepping<VECTOR>
+  template <typename VectorType>
+  class RungeKutta : public TimeStepping<VectorType>
   {
   public:
     /**
@@ -134,12 +134,12 @@ namespace TimeStepping
      * returns the time at the end of the time step. When using Runge-Kutta
      * methods, @p F and @ J_inverse can only contain one element.
      */
-    double evolve_one_time_step(
-      std::vector<std_cxx11::function<VECTOR (const double, const VECTOR &)> > &F,
-      std::vector<std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> > &J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y);
+    double evolve_one_time_step
+    (std::vector<std_cxx11::function<VectorType (const double, const VectorType &)> >               &F,
+     std::vector<std_cxx11::function<VectorType (const double, const double, const VectorType &)> > &J_inverse,
+     double                                                                                         t,
+     double                                                                                         delta_t,
+     VectorType &y);
 
     /**
      * Purely virtual function. This function is used to advance from time @p
@@ -152,12 +152,12 @@ namespace TimeStepping
      * vector. The output is the value of function at this point.
      * evolve_one_time_step returns the time at the end of the time step.
      */
-    virtual double evolve_one_time_step(
-      std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-      std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y) = 0;
+    virtual double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)>               f,
+     std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType                                                                       &y) = 0;
 
   protected:
     /**
@@ -187,11 +187,11 @@ namespace TimeStepping
    * ExplicitRungeKutta is derived from RungeKutta and implement the explicit
    * methods.
    */
-  template <typename VECTOR>
-  class ExplicitRungeKutta : public RungeKutta<VECTOR>
+  template <typename VectorType>
+  class ExplicitRungeKutta : public RungeKutta<VectorType>
   {
   public:
-    using RungeKutta<VECTOR>::evolve_one_time_step;
+    using RungeKutta<VectorType>::evolve_one_time_step;
 
     /**
      * Default constructor. initialize(runge_kutta_method) needs to be called
@@ -220,12 +220,12 @@ namespace TimeStepping
      * of function at this point. evolve_one_time_step returns the time at the
      * end of the time step.
      */
-    double evolve_one_time_step(
-      std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-      std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y);
+    double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)>               f,
+     std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType &y);
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. This
@@ -234,15 +234,16 @@ namespace TimeStepping
      * methods. evolve_one_time_step returns the time at the end of the time
      * step.
      */
-    double evolve_one_time_step(std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-                                double t,
-                                double delta_t,
-                                VECTOR &y);
+    double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+     double                                                             t,
+     double                                                             delta_t,
+     VectorType                                                         &y);
 
     /**
      * This structure stores the name of the method used.
      */
-    struct Status : public TimeStepping<VECTOR>::Status
+    struct Status : public TimeStepping<VectorType>::Status
     {
       runge_kutta_method method;
     };
@@ -256,11 +257,12 @@ namespace TimeStepping
     /**
      * Compute the different stages needed.
      */
-    void compute_stages(std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-                        const double t,
-                        const double delta_t,
-                        const VECTOR &y,
-                        std::vector<VECTOR> &f_stages) const;
+    void compute_stages
+    (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+     const double                                                       t,
+     const double                                                       delta_t,
+     const VectorType                                                   &y,
+     std::vector<VectorType>                                            &f_stages) const;
 
     /**
      * Status structure of the object.
@@ -274,11 +276,11 @@ namespace TimeStepping
    * This class is derived from RungeKutta and implement the implicit methods.
    * This class works only for Diagonal Implicit Runge-Kutta (DIRK) methods.
    */
-  template <typename VECTOR>
-  class ImplicitRungeKutta : public RungeKutta<VECTOR>
+  template <typename VectorType>
+  class ImplicitRungeKutta : public RungeKutta<VectorType>
   {
   public:
-    using RungeKutta<VECTOR>::evolve_one_time_step;
+    using RungeKutta<VectorType>::evolve_one_time_step;
 
     /**
      * Default constructor. initialize(runge_kutta_method) and
@@ -310,12 +312,12 @@ namespace TimeStepping
      * The output is the value of function at this point. evolve_one_time_step
      * returns the time at the end of the time step.
      */
-    double evolve_one_time_step(
-      std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-      std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y);
+    double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)>               f,
+     std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType                                                                       &y);
 
     /**
      * Set the maximum number of iterations and the tolerance used by the
@@ -327,7 +329,7 @@ namespace TimeStepping
      * Structure that stores the name of the method, the number of Newton
      * iterations and the norm of the residual when exiting the Newton solver.
      */
-    struct Status : public TimeStepping<VECTOR>::Status
+    struct Status : public TimeStepping<VectorType>::Status
     {
       runge_kutta_method method;
       unsigned int       n_iterations;
@@ -343,31 +345,31 @@ namespace TimeStepping
     /**
      * Compute the different stages needed.
      */
-    void compute_stages(
-      std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-      std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y,
-      std::vector<VECTOR> &f_stages);
+    void compute_stages
+    (std_cxx11::function<VectorType (const double, const VectorType &)>               f,
+     std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType                                                                       &y,
+     std::vector<VectorType> &f_stages);
 
     /**
      * Newton solver used for the implicit stages.
      */
-    void newton_solve(std_cxx11::function<void (const VECTOR &,VECTOR &)> get_residual,
-                      std_cxx11::function<VECTOR (const VECTOR &)> id_minus_tau_J_inverse,
-                      VECTOR &y);
+    void newton_solve(std_cxx11::function<void (const VectorType &,VectorType &)> get_residual,
+                      std_cxx11::function<VectorType (const VectorType &)>        id_minus_tau_J_inverse,
+                      VectorType                                                  &y);
 
     /**
      * Compute the residual needed by the Newton solver.
      */
-    void compute_residual(std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-                          double t,
-                          double delta_t,
-                          const VECTOR &old_y,
-                          const VECTOR &y,
-                          VECTOR &tendency,
-                          VECTOR &residual) const;
+    void compute_residual(std_cxx11::function<VectorType (const double, const VectorType &)> f,
+                          double                                                             t,
+                          double                                                             delta_t,
+                          const VectorType                                                   &old_y,
+                          const VectorType                                                   &y,
+                          VectorType                                                         &tendency,
+                          VectorType                                                         &residual) const;
 
     /**
      * When using SDIRK, there is no need to compute the linear combination of
@@ -398,11 +400,11 @@ namespace TimeStepping
    * This is class is derived from RungeKutta and implement embedded explicit
    * methods.
    */
-  template <typename VECTOR>
-  class EmbeddedExplicitRungeKutta : public RungeKutta<VECTOR>
+  template <typename VectorType>
+  class EmbeddedExplicitRungeKutta : public RungeKutta<VectorType>
   {
   public:
-    using RungeKutta<VECTOR>::evolve_one_time_step;
+    using RungeKutta<VectorType>::evolve_one_time_step;
 
     /**
      * Default constructor. initialize(runge_kutta_method) and
@@ -452,12 +454,12 @@ namespace TimeStepping
      * value of function at this point. evolve_one_time_step returns the time
      * at the end of the time step.
      */
-    double evolve_one_time_step(
-      std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-      std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-      double t,
-      double delta_t,
-      VECTOR &y);
+    double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)>               f,
+     std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+     double                                                                           t,
+     double                                                                           delta_t,
+     VectorType &y);
 
     /**
      * This function is used to advance from time @p t to t+ @p delta_t. This
@@ -466,10 +468,11 @@ namespace TimeStepping
      * methods. evolve_one_time_step returns the time at the end of the time
      * step.
      */
-    double evolve_one_time_step(std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-                                double t,
-                                double delta_t,
-                                VECTOR &y);
+    double evolve_one_time_step
+    (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+     double                                                             t,
+     double                                                             delta_t,
+     VectorType &y);
 
     /**
      * Set the parameters necessary for the time adaptation.
@@ -487,7 +490,7 @@ namespace TimeStepping
      * guess of what the next time step should be, and an estimate of the norm
      * of the error.
      */
-    struct Status : public TimeStepping<VECTOR>::Status
+    struct Status : public TimeStepping<VectorType>::Status
     {
       runge_kutta_method method;
       embedded_runge_kutta_time_step exit_delta_t;
@@ -505,11 +508,11 @@ namespace TimeStepping
     /**
      * Compute the different stages needed.
      */
-    void compute_stages(std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-                        const double t,
-                        const double delta_t,
-                        const VECTOR &y,
-                        std::vector<VECTOR> &f_stages);
+    void compute_stages(std_cxx11::function<VectorType (const double, const VectorType &)> f,
+                        const double                                                       t,
+                        const double                                                       delta_t,
+                        const VectorType                                                   &y,
+                        std::vector<VectorType>                                            &f_stages);
 
     /**
      * This parameter is the factor (>1) by which the time step is multiplied
@@ -565,7 +568,7 @@ namespace TimeStepping
      * If the last_same_as_first flag is set to true, the last stage is saved
      * and reused as the first stage of the next time step.
      */
-    VECTOR *last_stage;
+    VectorType *last_stage;
 
     /**
      * Status structure of the object.

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -202,8 +202,8 @@ namespace TimeStepping
 
   template <typename VectorType>
   ImplicitRungeKutta<VectorType>::ImplicitRungeKutta(runge_kutta_method method,
-                                                 unsigned int max_it,
-                                                 double tolerance)
+                                                     unsigned int max_it,
+                                                     double tolerance)
     :
     RungeKutta<VectorType> (),
     skip_linear_combi(false),

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -28,14 +28,14 @@ namespace TimeStepping
   // RungeKutta
   // ----------------------------------------------------------------------
 
-  template <typename VECTOR>
-  double RungeKutta<VECTOR>::evolve_one_time_step(
-    std::vector<std_cxx11::function<VECTOR (const double, const VECTOR &)> > &F,
-    std::vector<std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> > &J_inverse,
+  template <typename VectorType>
+  double RungeKutta<VectorType>::evolve_one_time_step(
+    std::vector<std_cxx11::function<VectorType (const double, const VectorType &)> > &F,
+    std::vector<std_cxx11::function<VectorType (const double, const double, const VectorType &)> > &J_inverse,
 
     double t,
     double delta_t,
-    VECTOR &y)
+    VectorType &y)
   {
     AssertThrow(F.size()==0,
                 ExcMessage("RungeKutta methods cannot handle more that one function to integate."));
@@ -51,16 +51,16 @@ namespace TimeStepping
   // ExplicitRungeKutta
   // ----------------------------------------------------------------------
 
-  template <typename VECTOR>
-  ExplicitRungeKutta<VECTOR>::ExplicitRungeKutta(runge_kutta_method method)
+  template <typename VectorType>
+  ExplicitRungeKutta<VectorType>::ExplicitRungeKutta(runge_kutta_method method)
   {
     initialize(method);
   }
 
 
 
-  template <typename VECTOR>
-  void ExplicitRungeKutta<VECTOR>::initialize(runge_kutta_method method)
+  template <typename VectorType>
+  void ExplicitRungeKutta<VectorType>::initialize(runge_kutta_method method)
   {
     status.method = method;
 
@@ -135,27 +135,27 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  double ExplicitRungeKutta<VECTOR>::evolve_one_time_step(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> /*id_minus_tau_J_inverse*/,
-    double t,
-    double delta_t,
-    VECTOR &y)
+  template <typename VectorType>
+  double ExplicitRungeKutta<VectorType>::evolve_one_time_step
+  (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+   std_cxx11::function<VectorType (const double, const double, const VectorType &)> /*id_minus_tau_J_inverse*/,
+   double                                                             t,
+   double                                                             delta_t,
+   VectorType                                                         &y)
   {
     return evolve_one_time_step(f,t,delta_t,y);
   }
 
 
 
-  template <typename VECTOR>
-  double ExplicitRungeKutta<VECTOR>::evolve_one_time_step(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    double t,
-    double delta_t,
-    VECTOR &y)
+  template <typename VectorType>
+  double ExplicitRungeKutta<VectorType>::evolve_one_time_step
+  (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+   double                                                             t,
+   double                                                             delta_t,
+   VectorType                                                         &y)
   {
-    std::vector<VECTOR> f_stages(this->n_stages,y);
+    std::vector<VectorType> f_stages(this->n_stages,y);
     // Compute the different stages needed.
     compute_stages(f,t,delta_t,y,f_stages);
 
@@ -168,25 +168,25 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  const typename ExplicitRungeKutta<VECTOR>::Status &ExplicitRungeKutta<VECTOR>::get_status() const
+  template <typename VectorType>
+  const typename ExplicitRungeKutta<VectorType>::Status &ExplicitRungeKutta<VectorType>::get_status() const
   {
     return status;
   }
 
 
 
-  template <typename VECTOR>
-  void ExplicitRungeKutta<VECTOR>::compute_stages(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    const double t,
-    const double delta_t,
-    const VECTOR &y,
-    std::vector<VECTOR> &f_stages) const
+  template <typename VectorType>
+  void ExplicitRungeKutta<VectorType>::compute_stages
+  (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+   const double                                                       t,
+   const double                                                       delta_t,
+   const VectorType                                                   &y,
+   std::vector<VectorType>                                            &f_stages) const
   {
     for (unsigned int i=0; i<this->n_stages; ++i)
       {
-        VECTOR Y(y);
+        VectorType Y(y);
         for (unsigned int j=0; j<i; ++j)
           Y.sadd(1.,delta_t *this->a[i][j],f_stages[j]);
         // Evaluate the function f at the point (t+c[i]*delta_t,Y).
@@ -200,12 +200,12 @@ namespace TimeStepping
   // ImplicitRungeKutta
   // ----------------------------------------------------------------------
 
-  template <typename VECTOR>
-  ImplicitRungeKutta<VECTOR>::ImplicitRungeKutta(runge_kutta_method method,
+  template <typename VectorType>
+  ImplicitRungeKutta<VectorType>::ImplicitRungeKutta(runge_kutta_method method,
                                                  unsigned int max_it,
                                                  double tolerance)
     :
-    RungeKutta<VECTOR> (),
+    RungeKutta<VectorType> (),
     skip_linear_combi(false),
     max_it(max_it),
     tolerance(tolerance)
@@ -215,8 +215,8 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void ImplicitRungeKutta<VECTOR>::initialize(runge_kutta_method method)
+  template <typename VectorType>
+  void ImplicitRungeKutta<VectorType>::initialize(runge_kutta_method method)
   {
     status.method = method;
 
@@ -278,16 +278,16 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  double ImplicitRungeKutta<VECTOR>::evolve_one_time_step(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
-    double t,
-    double delta_t,
-    VECTOR &y)
+  template <typename VectorType>
+  double ImplicitRungeKutta<VectorType>::evolve_one_time_step
+  (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+   std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
+   double                                                             t,
+   double                                                             delta_t,
+   VectorType                                                         &y)
   {
-    VECTOR old_y(y);
-    std::vector<VECTOR> f_stages(this->n_stages,y);
+    VectorType old_y(y);
+    std::vector<VectorType> f_stages(this->n_stages,y);
     // Compute the different stages needed.
     compute_stages(f,id_minus_tau_J_inverse,t,delta_t,y,f_stages);
 
@@ -304,8 +304,8 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void ImplicitRungeKutta<VECTOR>::set_newton_solver_parameters(unsigned int max_it_, double tolerance_)
+  template <typename VectorType>
+  void ImplicitRungeKutta<VectorType>::set_newton_solver_parameters(unsigned int max_it_, double tolerance_)
   {
     max_it = max_it_;
     tolerance = tolerance_;
@@ -313,34 +313,34 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  const typename ImplicitRungeKutta<VECTOR>::Status &ImplicitRungeKutta<VECTOR>::get_status() const
+  template <typename VectorType>
+  const typename ImplicitRungeKutta<VectorType>::Status &ImplicitRungeKutta<VectorType>::get_status() const
   {
     return status;
   }
 
 
 
-  template <typename VECTOR>
-  void ImplicitRungeKutta<VECTOR>::compute_stages(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> id_minus_tau_J_inverse,
+  template <typename VectorType>
+  void ImplicitRungeKutta<VectorType>::compute_stages(
+    std_cxx11::function<VectorType (const double, const VectorType &)> f,
+    std_cxx11::function<VectorType (const double, const double, const VectorType &)> id_minus_tau_J_inverse,
     double t,
     double delta_t,
-    VECTOR &y,
-    std::vector<VECTOR> &f_stages)
+    VectorType &y,
+    std::vector<VectorType> &f_stages)
   {
-    VECTOR z(y);
+    VectorType z(y);
     for (unsigned int i=0; i<this->n_stages; ++i)
       {
-        VECTOR old_y(z);
+        VectorType old_y(z);
         for (unsigned int j=0; j<i; ++j)
           old_y.sadd(1.,delta_t *this->a[i][j],f_stages[j]);
 
         // Solve the nonlinear system using Newton's method
         const double new_t = t+this->c[i]*delta_t;
         const double new_delta_t = this->a[i][i]*delta_t;
-        newton_solve(std_cxx11::bind(&ImplicitRungeKutta<VECTOR>::compute_residual,this,f,new_t,new_delta_t,
+        newton_solve(std_cxx11::bind(&ImplicitRungeKutta<VectorType>::compute_residual,this,f,new_t,new_delta_t,
                                      std_cxx11::cref(old_y),std_cxx11::_1,std_cxx11::ref(f_stages[i]),std_cxx11::_2),
                      std_cxx11::bind(id_minus_tau_J_inverse,new_t,new_delta_t,std_cxx11::_1),y);
       }
@@ -348,13 +348,13 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void ImplicitRungeKutta<VECTOR>::newton_solve(
-    std_cxx11::function<void (const VECTOR &,VECTOR &)> get_residual,
-    std_cxx11::function<VECTOR (const VECTOR &)> id_minus_tau_J_inverse,
-    VECTOR &y)
+  template <typename VectorType>
+  void ImplicitRungeKutta<VectorType>::newton_solve(
+    std_cxx11::function<void (const VectorType &,VectorType &)> get_residual,
+    std_cxx11::function<VectorType (const VectorType &)> id_minus_tau_J_inverse,
+    VectorType &y)
   {
-    VECTOR residual(y);
+    VectorType residual(y);
     get_residual(y,residual);
     unsigned int i=0;
     const double initial_residual_norm = residual.l2_norm();
@@ -374,15 +374,15 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void ImplicitRungeKutta<VECTOR>::compute_residual(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    double t,
-    double delta_t,
-    const VECTOR &old_y,
-    const VECTOR &y,
-    VECTOR &tendency,
-    VECTOR &residual) const
+  template <typename VectorType>
+  void ImplicitRungeKutta<VectorType>::compute_residual
+  (std_cxx11::function<VectorType (const double, const VectorType &)> f,
+   double                                                             t,
+   double                                                             delta_t,
+   const VectorType                                                   &old_y,
+   const VectorType                                                   &y,
+   VectorType                                                         &tendency,
+   VectorType                                                         &residual) const
   {
     // The tendency is stored to save one evaluation of f.
     tendency = f(t,y);
@@ -397,14 +397,15 @@ namespace TimeStepping
   // EmbeddedExplicitRungeKutta
   // ----------------------------------------------------------------------
 
-  template <typename VECTOR>
-  EmbeddedExplicitRungeKutta<VECTOR>::EmbeddedExplicitRungeKutta(runge_kutta_method method,
-      double coarsen_param,
-      double refine_param,
-      double min_delta,
-      double max_delta,
-      double refine_tol,
-      double coarsen_tol)
+  template <typename VectorType>
+  EmbeddedExplicitRungeKutta<VectorType>::EmbeddedExplicitRungeKutta
+  (runge_kutta_method method,
+   double             coarsen_param,
+   double             refine_param,
+   double             min_delta,
+   double             max_delta,
+   double             refine_tol,
+   double             coarsen_tol)
     :
     coarsen_param(coarsen_param),
     refine_param(refine_param),
@@ -420,8 +421,8 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void EmbeddedExplicitRungeKutta<VECTOR>::initialize(runge_kutta_method method)
+  template <typename VectorType>
+  void EmbeddedExplicitRungeKutta<VectorType>::initialize(runge_kutta_method method)
   {
     status.method = method;
 
@@ -660,8 +661,8 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void EmbeddedExplicitRungeKutta<VECTOR>::free_memory()
+  template <typename VectorType>
+  void EmbeddedExplicitRungeKutta<VectorType>::free_memory()
   {
     if (last_stage!=NULL)
       delete last_stage;
@@ -671,30 +672,30 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  double EmbeddedExplicitRungeKutta<VECTOR>::evolve_one_time_step(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    std_cxx11::function<VECTOR (const double, const double, const VECTOR &)> /*id_minus_tau_J_inverse*/,
+  template <typename VectorType>
+  double EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
+    std_cxx11::function<VectorType (const double, const VectorType &)> f,
+    std_cxx11::function<VectorType (const double, const double, const VectorType &)> /*id_minus_tau_J_inverse*/,
     double t,
     double delta_t,
-    VECTOR &y)
+    VectorType &y)
   {
     return evolve_one_time_step(f,t,delta_t,y);
   }
 
 
 
-  template <typename VECTOR>
-  double EmbeddedExplicitRungeKutta<VECTOR>::evolve_one_time_step(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
-    double t, double delta_t, VECTOR &y)
+  template <typename VectorType>
+  double EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
+    std_cxx11::function<VectorType (const double, const VectorType &)> f,
+    double t, double delta_t, VectorType &y)
   {
     bool done = false;
     unsigned int count = 0;
     double error_norm = 0.;
-    VECTOR old_y(y);
-    VECTOR error(y);
-    std::vector<VECTOR> f_stages(this->n_stages,y);
+    VectorType old_y(y);
+    VectorType error(y);
+    std::vector<VectorType> f_stages(this->n_stages,y);
 
     while (!done)
       {
@@ -761,7 +762,7 @@ namespace TimeStepping
     if (last_same_as_first==true)
       {
         if (last_stage==NULL)
-          last_stage = new VECTOR(f_stages.back());
+          last_stage = new VectorType(f_stages.back());
         else
           *last_stage = f_stages.back();
       }
@@ -774,8 +775,8 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  void EmbeddedExplicitRungeKutta<VECTOR>::set_time_adaptation_parameters(double coarsen_param_,
+  template <typename VectorType>
+  void EmbeddedExplicitRungeKutta<VectorType>::set_time_adaptation_parameters(double coarsen_param_,
       double refine_param_,
       double min_delta_,
       double max_delta_,
@@ -792,22 +793,22 @@ namespace TimeStepping
 
 
 
-  template <typename VECTOR>
-  const typename EmbeddedExplicitRungeKutta<VECTOR>::Status &EmbeddedExplicitRungeKutta<VECTOR>::get_status() const
+  template <typename VectorType>
+  const typename EmbeddedExplicitRungeKutta<VectorType>::Status &EmbeddedExplicitRungeKutta<VectorType>::get_status() const
   {
     return status;
   }
 
 
-  template <typename VECTOR>
-  void EmbeddedExplicitRungeKutta<VECTOR>::compute_stages(
-    std_cxx11::function<VECTOR (const double, const VECTOR &)> f,
+  template <typename VectorType>
+  void EmbeddedExplicitRungeKutta<VectorType>::compute_stages(
+    std_cxx11::function<VectorType (const double, const VectorType &)> f,
     const double t,
     const double delta_t,
-    const VECTOR &y,
-    std::vector<VECTOR> &f_stages)
+    const VectorType &y,
+    std::vector<VectorType> &f_stages)
   {
-    VECTOR Y(y);
+    VectorType Y(y);
     unsigned int i = 0;
 
     // If the last stage is the same as the first, we can skip the evaluation

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -109,8 +109,8 @@ public:
   /**
    * Prints the data to the given stream.
    */
-  template <class STREAM>
-  void print_data(STREAM &stream) const;
+  template <class StreamType>
+  void print_data(StreamType &stream) const;
 
 
 #endif
@@ -685,10 +685,10 @@ Timer::get_data() const
 
 
 
-template <class STREAM>
+template <class StreamType>
 inline
 void
-Timer::print_data(STREAM &stream) const
+Timer::print_data(StreamType &stream) const
 {
   unsigned int my_id = dealii::Utilities::MPI::this_mpi_process(mpi_communicator);
   if (my_id==0)

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -27,7 +27,7 @@ DEAL_II_NAMESPACE_OPEN
  * (unsigned int)</tt> and a function <tt>size() const</tt>.
  *
  * The use of this object is straightforward. It duplicates the random access
- * operator of the <tt>VECTOR</tt> and adds an offset to every index.
+ * operator of the <tt>VectorType</tt> and adds an offset to every index.
  *
  * Some precautions have to be taken if it is used for a constant vector: the
  * VectorSlice object has to be constant, too. The appropriate initialization
@@ -44,7 +44,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup data
  * @author Guido Kanschat, 2004
  */
-template <class VECTOR>
+template <typename VectorType>
 class VectorSlice
 {
 public:
@@ -54,12 +54,12 @@ public:
    * just put in the vector itself as argument and let this constructor make a
    * slice for you.
    */
-  VectorSlice(VECTOR &v);
+  VectorSlice(VectorType &v);
   /**
    * The real constructor for a vector slice, allowing you to specify the
    * start index and the length of the slice.
    */
-  VectorSlice(VECTOR &v,
+  VectorSlice(VectorType   &v,
               unsigned int start,
               unsigned int length);
 
@@ -73,39 +73,39 @@ public:
    * Access an element of the slice using the same interface as
    * <tt>std::vector</tt>.
    */
-  typename VECTOR::reference operator[] (unsigned int i);
+  typename VectorType::reference operator[] (unsigned int i);
 
   /**
    * Access an element of a constant slice using the same interface as
    * <tt>std::vector</tt>.
    */
-  typename VECTOR::const_reference operator[] (unsigned int i) const;
+  typename VectorType::const_reference operator[] (unsigned int i) const;
 
   /**
    * Standard-conforming iterator function.
    */
-  typename VECTOR::iterator begin();
+  typename VectorType::iterator begin();
 
   /**
    * Standard-conforming iterator function.
    */
-  typename VECTOR::const_iterator begin() const;
+  typename VectorType::const_iterator begin() const;
 
   /**
    * Standard-conforming iterator function.
    */
-  typename VECTOR::iterator end();
+  typename VectorType::iterator end();
 
   /**
    * Standard-conforming iterator function.
    */
-  typename VECTOR::const_iterator end() const;
+  typename VectorType::const_iterator end() const;
 
 private:
   /**
    * The vector we extract from.
    */
-  VECTOR &v;
+  VectorType &v;
   /**
    * The start index of the slice.
    */
@@ -124,12 +124,12 @@ private:
  * @relates VectorSlice
  * @author Guido Kanschat, 2004
  */
-template <class VECTOR>
+template <typename VectorType>
 inline
-const VectorSlice<const VECTOR>
-make_slice (VECTOR &v)
+const VectorSlice<const VectorType>
+make_slice (VectorType &v)
 {
-  const VectorSlice<const VECTOR> r(v);
+  const VectorSlice<const VectorType> r(v);
   return r;
 }
 
@@ -142,14 +142,14 @@ make_slice (VECTOR &v)
  * @relates VectorSlice
  * @author Guido Kanschat, 2004
  */
-template <class VECTOR>
+template <typename VectorType>
 inline
-const VectorSlice<const VECTOR>
-make_slice (VECTOR &v,
+const VectorSlice<const VectorType>
+make_slice (VectorType         &v,
             const unsigned int start,
             const unsigned int length)
 {
-  const VectorSlice<const VECTOR> r(v, start, length);
+  const VectorSlice<const VectorType> r(v, start, length);
   return r;
 }
 
@@ -158,19 +158,19 @@ make_slice (VECTOR &v,
 
 //---------------------------------------------------------------------------
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-VectorSlice<VECTOR>::VectorSlice(VECTOR &v)
+VectorSlice<VectorType>::VectorSlice(VectorType &v)
   :
   v(v), start(0), length(v.size())
 {}
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-VectorSlice<VECTOR>::VectorSlice(VECTOR &v,
-                                 unsigned int start,
-                                 unsigned int length)
+VectorSlice<VectorType>::VectorSlice(VectorType   &v,
+                                     unsigned int start,
+                                     unsigned int length)
   :
   v(v), start(start), length(length)
 {
@@ -179,19 +179,19 @@ VectorSlice<VECTOR>::VectorSlice(VECTOR &v,
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 unsigned int
-VectorSlice<VECTOR>::size() const
+VectorSlice<VectorType>::size() const
 {
   return length;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::reference
-VectorSlice<VECTOR>::operator[](unsigned int i)
+typename VectorType::reference
+VectorSlice<VectorType>::operator[](unsigned int i)
 {
   Assert ((i<length), ExcIndexRange(i, 0, length));
 
@@ -199,10 +199,10 @@ VectorSlice<VECTOR>::operator[](unsigned int i)
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::const_reference
-VectorSlice<VECTOR>::operator[](unsigned int i) const
+typename VectorType::const_reference
+VectorSlice<VectorType>::operator[](unsigned int i) const
 {
   Assert ((i<length), ExcIndexRange(i, 0, length));
 
@@ -210,37 +210,37 @@ VectorSlice<VECTOR>::operator[](unsigned int i) const
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::const_iterator
-VectorSlice<VECTOR>::begin() const
+typename VectorType::const_iterator
+VectorSlice<VectorType>::begin() const
 {
   return v.begin()+start;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::iterator
-VectorSlice<VECTOR>::begin()
+typename VectorType::iterator
+VectorSlice<VectorType>::begin()
 {
   return v.begin()+start;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::const_iterator
-VectorSlice<VECTOR>::end() const
+typename VectorType::const_iterator
+VectorSlice<VectorType>::end() const
 {
   return v.begin()+start+length;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-typename VECTOR::iterator
-VectorSlice<VECTOR>::end()
+typename VectorType::iterator
+VectorSlice<VectorType>::end()
 {
   return v.begin()+start+length;
 }

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -48,11 +48,11 @@ namespace parallel
      * interpolate() or deserialize() you need to supply distributed vectors
      * without ghost elements.
      *
-     * <h3>Transferring a solution</h3> Here VECTOR is your favorite vector
+     * <h3>Transferring a solution</h3> Here VectorType is your favorite vector
      * type, e.g. PETScWrappers::MPI::Vector, TrilinosWrappers::MPI::Vector,
      * or corresponding blockvectors.
      * @code
-     * SolutionTransfer<dim, VECTOR> soltrans(dof_handler);
+     * SolutionTransfer<dim, VectorType> soltrans(dof_handler);
      *                                   // flag some cells for refinement
      *                                   // and coarsening, e.g.
      * GridRefinement::refine_and_coarsen_fixed_fraction(
@@ -69,8 +69,8 @@ namespace parallel
      *                                   // redistribute dofs,
      * dof_handler.distribute_dofs (fe);
      *                                   // and interpolate the solution
-     * VECTOR interpolated_solution;
-     * //create VECTOR in the right size here
+     * VectorType interpolated_solution;
+     * //create VectorType in the right size here
      * soltrans.interpolate(interpolated_solution);
      * @endcode
      *
@@ -85,7 +85,7 @@ namespace parallel
      * follows:
      * *@code
      *
-     * parallel::distributed::SolutionTransfer<dim,VECTOR> sol_trans(dof_handler);
+     * parallel::distributed::SolutionTransfer<dim,VectorType> sol_trans(dof_handler);
      * sol_trans.prepare_serialization (vector);
      *
      * triangulation.save(filename);
@@ -96,7 +96,7 @@ namespace parallel
      * //[create coarse mesh...]
      * triangulation.load(filename);
      *
-     * parallel::distributed::SolutionTransfer<dim,VECTOR> sol_trans(dof_handler);
+     * parallel::distributed::SolutionTransfer<dim,VectorType> sol_trans(dof_handler);
      * sol_trans.deserialize (distributed_vector);
      * @endcode
      *
@@ -112,7 +112,7 @@ namespace parallel
      * @ingroup distributed
      * @author Timo Heister, 2009-2011
      */
-    template<int dim, typename VECTOR, class DH=DoFHandler<dim> >
+    template<int dim, typename VectorType, class DH=DoFHandler<dim> >
     class SolutionTransfer
     {
     public:
@@ -132,13 +132,13 @@ namespace parallel
        * includes all vectors that are to be interpolated onto the new
        * (refined and/or coarsened) grid.
        */
-      void prepare_for_coarsening_and_refinement (const std::vector<const VECTOR *> &all_in);
+      void prepare_for_coarsening_and_refinement (const std::vector<const VectorType *> &all_in);
 
       /**
        * Same as previous function but for only one discrete function to be
        * interpolated.
        */
-      void prepare_for_coarsening_and_refinement (const VECTOR &in);
+      void prepare_for_coarsening_and_refinement (const VectorType &in);
 
       /**
        * Interpolate the data previously stored in this object before the mesh
@@ -147,7 +147,7 @@ namespace parallel
        * prepare_for_coarsening_and_refinement() and write the result into the
        * given set of vectors.
        */
-      void interpolate (std::vector<VECTOR *> &all_out);
+      void interpolate (std::vector<VectorType *> &all_out);
 
       /**
        * Same as the previous function. It interpolates only one function. It
@@ -158,7 +158,7 @@ namespace parallel
        * several functions can be performed in one step by using
        * <tt>interpolate (all_in, all_out)</tt>
        */
-      void interpolate (VECTOR &out);
+      void interpolate (VectorType &out);
 
 
       /**
@@ -173,13 +173,13 @@ namespace parallel
        * on the locally active DoFs (it must be ghosted). See documentation of
        * this class for more information.
        */
-      void prepare_serialization(const VECTOR &in);
+      void prepare_serialization(const VectorType &in);
 
 
       /**
        * Same as the function above, only for a list of vectors.
        */
-      void prepare_serialization(const std::vector<const VECTOR *> &all_in);
+      void prepare_serialization(const std::vector<const VectorType *> &all_in);
 
 
       /**
@@ -188,25 +188,25 @@ namespace parallel
        * fully distributed vector without ghost elements. See documentation of
        * this class for more information.
        */
-      void deserialize(VECTOR &in);
+      void deserialize(VectorType &in);
 
 
       /**
        * Same as the function above, only for a list of vectors.
        */
-      void deserialize(std::vector<VECTOR *> &all_in);
+      void deserialize(std::vector<VectorType *> &all_in);
 
     private:
       /**
        * Pointer to the degree of freedom handler to work with.
        */
-      SmartPointer<const DH,SolutionTransfer<dim,VECTOR,DH> > dof_handler;
+      SmartPointer<const DH,SolutionTransfer<dim,VectorType,DH> > dof_handler;
 
       /**
        * A vector that stores pointers to all the vectors we are supposed to
        * copy over from the old to the new mesh.
        */
-      std::vector<const VECTOR *> input_vectors;
+      std::vector<const VectorType *> input_vectors;
 
       /**
        * The offset that the Triangulation has assigned to this object
@@ -231,7 +231,7 @@ namespace parallel
       void unpack_callback(const typename Triangulation<dim,dim>::cell_iterator &cell,
                            const typename Triangulation<dim,dim>::CellStatus status,
                            const void *data,
-                           std::vector<VECTOR *> &all_out);
+                           std::vector<VectorType *> &all_out);
 
 
       /**

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -43,7 +43,7 @@ template <int dim, int spacedim> class MappingQ;
  * are suitable for DG and hybrid formulations involving these function
  * spaces.
  *
- * The template argument <tt>POLY</tt> refers to a vector valued polynomial
+ * The template argument <tt>PolynomialType</tt> refers to a vector valued polynomial
  * space like PolynomialsRaviartThomas or PolynomialsNedelec. Note that the
  * dimension of the polynomial space and the argument <tt>dim</tt> must
  * coincide.
@@ -52,10 +52,10 @@ template <int dim, int spacedim> class MappingQ;
  * @author Guido Kanschat
  * @date 2010
  */
-template <class POLY, int dim, int spacedim=dim>
+template <class PolynomialType, int dim, int spacedim=dim>
 class FE_DGVector
   :
-  public FE_PolyTensor<POLY, dim, spacedim>
+  public FE_PolyTensor<PolynomialType, dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -23,16 +23,16 @@ DEAL_II_NAMESPACE_OPEN
 
 //TODO:[GK] deg+1 is wrong here and should be fixed after FiniteElementData was cleaned up
 
-template <class POLY, int dim, int spacedim>
-FE_DGVector<POLY,dim,spacedim>::FE_DGVector (
+template <class PolynomialType, int dim, int spacedim>
+FE_DGVector<PolynomialType,dim,spacedim>::FE_DGVector (
   const unsigned int deg, MappingType map)
   :
-  FE_PolyTensor<POLY, dim, spacedim>(
+  FE_PolyTensor<PolynomialType, dim, spacedim>(
     deg,
     FiniteElementData<dim>(
       get_dpo_vector(deg), dim, deg+1, FiniteElementData<dim>::L2, 1),
-    std::vector<bool>(POLY::compute_n_pols(deg), true),
-    std::vector<ComponentMask>(POLY::compute_n_pols(deg),
+    std::vector<bool>(PolynomialType::compute_n_pols(deg), true),
+    std::vector<ComponentMask>(PolynomialType::compute_n_pols(deg),
                                ComponentMask(dim,true)))
 {
   this->mapping_type = map;
@@ -47,17 +47,17 @@ FE_DGVector<POLY,dim,spacedim>::FE_DGVector (
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 FiniteElement<dim, spacedim> *
-FE_DGVector<POLY,dim,spacedim>::clone() const
+FE_DGVector<PolynomialType,dim,spacedim>::clone() const
 {
-  return new FE_DGVector<POLY, dim, spacedim>(*this);
+  return new FE_DGVector<PolynomialType, dim, spacedim>(*this);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::string
-FE_DGVector<POLY,dim,spacedim>::get_name() const
+FE_DGVector<PolynomialType,dim,spacedim>::get_name() const
 {
   std::ostringstream namebuf;
   namebuf << "FE_DGVector_" << this->poly_space.name()
@@ -66,59 +66,60 @@ FE_DGVector<POLY,dim,spacedim>::get_name() const
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<unsigned int>
-FE_DGVector<POLY,dim,spacedim>::get_dpo_vector (const unsigned int deg)
+FE_DGVector<PolynomialType,dim,spacedim>::get_dpo_vector (const unsigned int deg)
 {
   std::vector<unsigned int> dpo(dim+1);
-  dpo[dim] = POLY::compute_n_pols(deg);
+  dpo[dim] = PolynomialType::compute_n_pols(deg);
 
   return dpo;
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 bool
-FE_DGVector<POLY,dim,spacedim>::has_support_on_face (const unsigned int,
-                                                     const unsigned int) const
+FE_DGVector<PolynomialType,dim,spacedim>::has_support_on_face
+(const unsigned int,
+ const unsigned int) const
 {
   return true;
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_DGVector<POLY,dim,spacedim>::interpolate(
-  std::vector<double> &,
-  const std::vector<double> &) const
+FE_DGVector<PolynomialType,dim,spacedim>::interpolate
+(std::vector<double> &,
+ const std::vector<double> &) const
 {
   Assert(false, ExcNotImplemented());
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_DGVector<POLY,dim,spacedim>::interpolate(
-  std::vector<double> & /*local_dofs*/,
-  const std::vector<Vector<double> > & /*values*/,
-  unsigned int /*offset*/) const
+FE_DGVector<PolynomialType,dim,spacedim>::interpolate
+(std::vector<double> & /*local_dofs*/,
+ const std::vector<Vector<double> > & /*values*/,
+ unsigned int /*offset*/) const
 {
   Assert(false, ExcNotImplemented());
 }
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_DGVector<POLY,dim,spacedim>::interpolate(
-  std::vector<double> & /*local_dofs*/,
-  const VectorSlice<const std::vector<std::vector<double> > > & /*values*/) const
+FE_DGVector<PolynomialType,dim,spacedim>::interpolate
+(std::vector<double> & /*local_dofs*/,
+ const VectorSlice<const std::vector<std::vector<double> > > & /*values*/) const
 {
   Assert(false, ExcNotImplemented());
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::size_t
-FE_DGVector<POLY,dim,spacedim>::memory_consumption() const
+FE_DGVector<PolynomialType,dim,spacedim>::memory_consumption() const
 {
   Assert(false, ExcNotImplemented());
   return 0;

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -31,7 +31,7 @@ DEAL_II_NAMESPACE_OPEN
  * TensorProductPolynomials or PolynomialSpace classes.
  *
  * Every class conforming to the following interface can be used as template
- * parameter POLY.
+ * parameter PolynomialType.
  *
  * @code
  * static const unsigned int dimension;
@@ -65,14 +65,14 @@ DEAL_II_NAMESPACE_OPEN
  * @author Ralf Hartmann 2004, Guido Kanschat, 2009
  */
 
-template <class POLY, int dim=POLY::dimension, int spacedim=dim>
+template <class PolynomialType, int dim=PolynomialType::dimension, int spacedim=dim>
 class FE_Poly : public FiniteElement<dim,spacedim>
 {
 public:
   /**
    * Constructor.
    */
-  FE_Poly (const POLY &poly_space,
+  FE_Poly (const PolynomialType &poly_space,
            const FiniteElementData<dim> &fe_data,
            const std::vector<bool> &restriction_is_additive_flags,
            const std::vector<ComponentMask> &nonzero_components);
@@ -91,13 +91,13 @@ public:
   /**
    * Return the numbering of the underlying polynomial space compared to
    * lexicographic ordering of the basis functions. Returns
-   * POLY::get_numbering().
+   * PolynomialType::get_numbering().
    */
   std::vector<unsigned int> get_poly_space_numbering() const;
 
   /**
    * Return the inverse numbering of the underlying polynomial space. Returns
-   * POLY::get_numbering_inverse().
+   * PolynomialType::get_numbering_inverse().
    */
   std::vector<unsigned int> get_poly_space_numbering_inverse() const;
 
@@ -463,9 +463,9 @@ protected:
                              const unsigned int                                                dof) const;
 
   /**
-   * The polynomial space. Its type is given by the template parameter POLY.
+   * The polynomial space. Its type is given by the template parameter PolynomialType.
    */
-  POLY poly_space;
+  PolynomialType poly_space;
 };
 
 /*@}*/

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -25,43 +25,45 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <class POLY, int dim, int spacedim>
-FE_Poly<POLY,dim,spacedim>::FE_Poly (const POLY &poly_space,
-                                     const FiniteElementData<dim> &fe_data,
-                                     const std::vector<bool> &restriction_is_additive_flags,
-                                     const std::vector<ComponentMask> &nonzero_components):
+template <class PolynomialType, int dim, int spacedim>
+FE_Poly<PolynomialType,dim,spacedim>::FE_Poly
+(const PolynomialType             &poly_space,
+ const FiniteElementData<dim>     &fe_data,
+ const std::vector<bool>          &restriction_is_additive_flags,
+ const std::vector<ComponentMask> &nonzero_components):
   FiniteElement<dim,spacedim> (fe_data,
                                restriction_is_additive_flags,
                                nonzero_components),
   poly_space(poly_space)
 {
-  AssertDimension(dim, POLY::dimension);
+  AssertDimension(dim, PolynomialType::dimension);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 unsigned int
-FE_Poly<POLY,dim,spacedim>::get_degree () const
+FE_Poly<PolynomialType,dim,spacedim>::get_degree () const
 {
   return this->degree;
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 double
-FE_Poly<POLY,dim,spacedim>::shape_value (const unsigned int i,
-                                         const Point<dim> &p) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_value (const unsigned int i,
+                                                   const Point<dim>  &p) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   return poly_space.compute_value(i, p);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 double
-FE_Poly<POLY,dim,spacedim>::shape_value_component (const unsigned int i,
-                                                   const Point<dim> &p,
-                                                   const unsigned int component) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_value_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   (void)component;
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
@@ -71,10 +73,10 @@ FE_Poly<POLY,dim,spacedim>::shape_value_component (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<1,dim>
-FE_Poly<POLY,dim,spacedim>::shape_grad (const unsigned int i,
-                                        const Point<dim> &p) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_grad (const unsigned int i,
+                                                  const Point<dim>  &p) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   return poly_space.template compute_derivative<1>(i, p);
@@ -82,11 +84,11 @@ FE_Poly<POLY,dim,spacedim>::shape_grad (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<1,dim>
-FE_Poly<POLY,dim,spacedim>::shape_grad_component (const unsigned int i,
-                                                  const Point<dim> &p,
-                                                  const unsigned int component) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_grad_component (const unsigned int  i,
+                                                            const Point<dim>   &p,
+                                                            const unsigned int  component) const
 {
   (void)component;
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
@@ -96,10 +98,10 @@ FE_Poly<POLY,dim,spacedim>::shape_grad_component (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<2,dim>
-FE_Poly<POLY,dim,spacedim>::shape_grad_grad (const unsigned int i,
-                                             const Point<dim> &p) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_grad_grad (const unsigned int i,
+                                                       const Point<dim>  &p) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   return poly_space.template compute_derivative<2>(i, p);
@@ -107,11 +109,12 @@ FE_Poly<POLY,dim,spacedim>::shape_grad_grad (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<2,dim>
-FE_Poly<POLY,dim,spacedim>::shape_grad_grad_component (const unsigned int i,
-                                                       const Point<dim> &p,
-                                                       const unsigned int component) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_grad_grad_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   (void)component;
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
@@ -121,10 +124,10 @@ FE_Poly<POLY,dim,spacedim>::shape_grad_grad_component (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<3,dim>
-FE_Poly<POLY,dim,spacedim>::shape_3rd_derivative (const unsigned int i,
-                                                  const Point<dim> &p) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_3rd_derivative (const unsigned int i,
+                                                            const Point<dim>  &p) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   return poly_space.template compute_derivative<3>(i, p);
@@ -132,11 +135,12 @@ FE_Poly<POLY,dim,spacedim>::shape_3rd_derivative (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<3,dim>
-FE_Poly<POLY,dim,spacedim>::shape_3rd_derivative_component (const unsigned int i,
-                                                            const Point<dim> &p,
-                                                            const unsigned int component) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_3rd_derivative_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   (void)component;
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
@@ -146,10 +150,10 @@ FE_Poly<POLY,dim,spacedim>::shape_3rd_derivative_component (const unsigned int i
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<4,dim>
-FE_Poly<POLY,dim,spacedim>::shape_4th_derivative (const unsigned int i,
-                                                  const Point<dim> &p) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_4th_derivative (const unsigned int i,
+                                                            const Point<dim>  &p) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   return poly_space.template compute_derivative<4>(i, p);
@@ -157,11 +161,12 @@ FE_Poly<POLY,dim,spacedim>::shape_4th_derivative (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<4,dim>
-FE_Poly<POLY,dim,spacedim>::shape_4th_derivative_component (const unsigned int i,
-                                                            const Point<dim> &p,
-                                                            const unsigned int component) const
+FE_Poly<PolynomialType,dim,spacedim>::shape_4th_derivative_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   (void)component;
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
@@ -176,18 +181,18 @@ FE_Poly<POLY,dim,spacedim>::shape_4th_derivative_component (const unsigned int i
 //---------------------------------------------------------------------------
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_Poly<POLY,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
+FE_Poly<PolynomialType,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 {
   return update_once(flags) | update_each(flags);
 }
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_Poly<POLY,dim,spacedim>::update_once (const UpdateFlags flags) const
+FE_Poly<PolynomialType,dim,spacedim>::update_once (const UpdateFlags flags) const
 {
   // for this kind of elements, only
   // the values can be precomputed
@@ -199,9 +204,9 @@ FE_Poly<POLY,dim,spacedim>::update_once (const UpdateFlags flags) const
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_Poly<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
+FE_Poly<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
@@ -228,9 +233,9 @@ FE_Poly<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
 //---------------------------------------------------------------------------
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Poly<POLY,dim,spacedim>::
+FE_Poly<PolynomialType,dim,spacedim>::
 fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const CellSimilarity::Similarity                                     cell_similarity,
                 const Quadrature<dim>                                               &quadrature,
@@ -292,9 +297,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Poly<POLY,dim,spacedim>::
+FE_Poly<PolynomialType,dim,spacedim>::
 fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
                      const unsigned int                                                   face_no,
                      const Quadrature<dim-1>                                             &quadrature,
@@ -369,9 +374,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
     }
 }
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Poly<POLY,dim,spacedim>::
+FE_Poly<PolynomialType,dim,spacedim>::
 fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
                         const unsigned int                                                   face_no,
                         const unsigned int                                                   sub_no,
@@ -450,9 +455,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 inline void
-FE_Poly<POLY,dim,spacedim>::
+FE_Poly<PolynomialType,dim,spacedim>::
 correct_third_derivatives (internal::FEValues::FiniteElementRelatedData<dim,spacedim>       &output_data,
                            const internal::FEValues::MappingRelatedData<dim,spacedim>       &mapping_data,
                            const unsigned int                                                n_q_points,
@@ -479,36 +484,36 @@ correct_third_derivatives (internal::FEValues::FiniteElementRelatedData<dim,spac
 
 namespace internal
 {
-  template <class POLY>
+  template <class PolynomialType>
   inline
   std::vector<unsigned int>
-  get_poly_space_numbering (const POLY &)
+  get_poly_space_numbering (const PolynomialType &)
   {
     Assert (false, ExcNotImplemented());
     return std::vector<unsigned int>();
   }
 
-  template <class POLY>
+  template <class PolynomialType>
   inline
   std::vector<unsigned int>
-  get_poly_space_numbering_inverse (const POLY &)
+  get_poly_space_numbering_inverse (const PolynomialType &)
   {
     Assert (false, ExcNotImplemented());
     return std::vector<unsigned int>();
   }
 
-  template <int dim, typename POLY>
+  template <int dim, typename PolynomialType>
   inline
   std::vector<unsigned int>
-  get_poly_space_numbering (const TensorProductPolynomials<dim,POLY> &poly)
+  get_poly_space_numbering (const TensorProductPolynomials<dim,PolynomialType> &poly)
   {
     return poly.get_numbering();
   }
 
-  template <int dim, typename POLY>
+  template <int dim, typename PolynomialType>
   inline
   std::vector<unsigned int>
-  get_poly_space_numbering_inverse (const TensorProductPolynomials<dim,POLY> &poly)
+  get_poly_space_numbering_inverse (const TensorProductPolynomials<dim,PolynomialType> &poly)
   {
     return poly.get_numbering_inverse();
   }
@@ -532,9 +537,9 @@ namespace internal
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<unsigned int>
-FE_Poly<POLY,dim,spacedim>::get_poly_space_numbering () const
+FE_Poly<PolynomialType,dim,spacedim>::get_poly_space_numbering () const
 {
   return internal::get_poly_space_numbering (poly_space);
 }
@@ -542,9 +547,9 @@ FE_Poly<POLY,dim,spacedim>::get_poly_space_numbering () const
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<unsigned int>
-FE_Poly<POLY,dim,spacedim>::get_poly_space_numbering_inverse () const
+FE_Poly<PolynomialType,dim,spacedim>::get_poly_space_numbering_inverse () const
 {
   return internal::get_poly_space_numbering_inverse (poly_space);
 }

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -35,7 +35,7 @@ DEAL_II_NAMESPACE_OPEN
  * classes.
  *
  * Every class that implements the following functions can be used as template
- * parameter POLY.
+ * parameter PolynomialType.
  *
  * @code
  * double compute_value (const unsigned int i,
@@ -57,14 +57,14 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 2009
  */
-template <class POLY, int dim=POLY::dimension+1, int spacedim=dim>
+template <class PolynomialType, int dim=PolynomialType::dimension+1, int spacedim=dim>
 class FE_PolyFace : public FiniteElement<dim,spacedim>
 {
 public:
   /**
    * Constructor.
    */
-  FE_PolyFace (const POLY &poly_space,
+  FE_PolyFace (const PolynomialType &poly_space,
                const FiniteElementData<dim> &fe_data,
                const std::vector<bool> &restriction_is_additive_flags);
 
@@ -264,9 +264,9 @@ protected:
   };
 
   /**
-   * The polynomial space. Its type is given by the template parameter POLY.
+   * The polynomial space. Its type is given by the template parameter PolynomialType.
    */
-  POLY poly_space;
+  PolynomialType poly_space;
 };
 
 /*@}*/

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -22,9 +22,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <class POLY, int dim, int spacedim>
-FE_PolyFace<POLY,dim,spacedim>::FE_PolyFace (
-  const POLY &poly_space,
+template <class PolynomialType, int dim, int spacedim>
+FE_PolyFace<PolynomialType,dim,spacedim>::FE_PolyFace (
+  const PolynomialType &poly_space,
   const FiniteElementData<dim> &fe_data,
   const std::vector<bool> &restriction_is_additive_flags):
   FiniteElement<dim,spacedim> (fe_data,
@@ -32,13 +32,13 @@ FE_PolyFace<POLY,dim,spacedim>::FE_PolyFace (
                                std::vector<ComponentMask> (1, ComponentMask(1,true))),
   poly_space(poly_space)
 {
-  AssertDimension(dim, POLY::dimension+1);
+  AssertDimension(dim, PolynomialType::dimension+1);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 unsigned int
-FE_PolyFace<POLY,dim,spacedim>::get_degree () const
+FE_PolyFace<PolynomialType,dim,spacedim>::get_degree () const
 {
   return this->degree;
 }
@@ -49,26 +49,26 @@ FE_PolyFace<POLY,dim,spacedim>::get_degree () const
 //---------------------------------------------------------------------------
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyFace<POLY,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
+FE_PolyFace<PolynomialType,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 {
   return update_once(flags) | update_each(flags);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyFace<POLY,dim,spacedim>::update_once (const UpdateFlags) const
+FE_PolyFace<PolynomialType,dim,spacedim>::update_once (const UpdateFlags) const
 {
   return update_default;
 }
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyFace<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
+FE_PolyFace<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
   if (flags & update_gradients)
@@ -85,9 +85,9 @@ FE_PolyFace<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
 //---------------------------------------------------------------------------
 // Fill data of FEValues
 //---------------------------------------------------------------------------
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyFace<POLY,dim,spacedim>::
+FE_PolyFace<PolynomialType,dim,spacedim>::
 fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                 const CellSimilarity::Similarity                                     ,
                 const Quadrature<dim> &,
@@ -103,9 +103,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyFace<POLY,dim,spacedim>::
+FE_PolyFace<PolynomialType,dim,spacedim>::
 fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                      const unsigned int                                                   face_no,
                      const Quadrature<dim-1>                                             &quadrature,
@@ -173,9 +173,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyFace<POLY,dim,spacedim>::
+FE_PolyFace<PolynomialType,dim,spacedim>::
 fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
                         const unsigned int                                                   face_no,
                         const unsigned int                                                   sub_no,

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -30,7 +30,7 @@ DEAL_II_NAMESPACE_OPEN
  * PolynomialsBDM and PolynomialsRaviartThomas.
  *
  * Every class that implements following function can be used as template
- * parameter POLY.
+ * parameter PolynomialType.
  *
  * @code
  * void compute (const Point<dim>            &unit_point,
@@ -94,7 +94,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @note The matrix #inverse_node_matrix should have dimensions zero before
  * this piece of code is executed. Only then, shape_value_component() will
- * return the raw polynomial <i>j</i> as defined in the polynomial space POLY.
+ * return the raw polynomial <i>j</i> as defined in the polynomial space PolynomialType.
  *
  * <h4>Setting the transformation</h4>
  *
@@ -111,7 +111,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat
  * @date 2005
  */
-template <class POLY, int dim, int spacedim=dim>
+template <class PolynomialType, int dim, int spacedim=dim>
 class FE_PolyTensor : public FiniteElement<dim,spacedim>
 {
 public:
@@ -397,9 +397,9 @@ protected:
 
 
   /**
-   * The polynomial space. Its type is given by the template parameter POLY.
+   * The polynomial space. Its type is given by the template parameter PolynomialType.
    */
-  POLY poly_space;
+  PolynomialType poly_space;
 
   /**
    * The inverse of the matrix <i>a<sub>ij</sub></i> of node values

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -35,14 +35,14 @@ DEAL_II_NAMESPACE_OPEN
  * 2001, 2004, 2005; Oliver Kayser-Herold, 2004; Katharina Kormann, 2008;
  * Martin Kronbichler, 2008, 2013
  */
-template <class POLY, int dim=POLY::dimension, int spacedim=dim>
-class FE_Q_Base : public FE_Poly<POLY,dim,spacedim>
+template <class PolynomialType, int dim=PolynomialType::dimension, int spacedim=dim>
+class FE_Q_Base : public FE_Poly<PolynomialType,dim,spacedim>
 {
 public:
   /**
    * Constructor.
    */
-  FE_Q_Base (const POLY &poly_space,
+  FE_Q_Base (const PolynomialType &poly_space,
              const FiniteElementData<dim> &fe_data,
              const std::vector<bool> &restriction_is_additive_flags);
 
@@ -317,7 +317,7 @@ protected:
   /*
    * Declare implementation friend.
    */
-  friend struct FE_Q_Base<POLY,dim,spacedim>::Implementation;
+  friend struct FE_Q_Base<PolynomialType,dim,spacedim>::Implementation;
 
 private:
   /*

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -243,9 +243,9 @@ enum UpdateFlags
  *
  * @ref UpdateFlags
  */
-template <class STREAM>
+template <class StreamType>
 inline
-STREAM &operator << (STREAM &s, UpdateFlags u)
+StreamType &operator << (StreamType &s, UpdateFlags u)
 {
   s << " UpdateFlags|";
   if (u & update_values)                                  s << "values|";

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -69,13 +69,13 @@ DEAL_II_NAMESPACE_OPEN
  * @author Luca Heltai, Marco Tezzele 2013, 2015
  */
 template <int dim, int spacedim=dim,
-          class VECTOR=Vector<double>,
+          typename VectorType=Vector<double>,
           class DH=DoFHandler<dim,spacedim> >
 class MappingFEField : public Mapping<dim,spacedim>
 {
 public:
   /**
-   * Constructor. The first argument is a VECTOR that specifies the
+   * Constructor. The first argument is a VectorType that specifies the
    * transformation of the domain from the reference to the current
    * configuration.
    *
@@ -106,14 +106,14 @@ public:
    *
    * If an incompatible mask is passed, an exception is thrown.
    */
-  MappingFEField (const DH      &euler_dof_handler,
-                  const VECTOR  &euler_vector,
+  MappingFEField (const DH            &euler_dof_handler,
+                  const VectorType    &euler_vector,
                   const ComponentMask mask=ComponentMask());
 
   /**
    * Copy constructor.
    */
-  MappingFEField (const MappingFEField<dim,spacedim,VECTOR,DH> &mapping);
+  MappingFEField (const MappingFEField<dim,spacedim,VectorType,DH> &mapping);
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy
@@ -489,7 +489,7 @@ private:
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VECTOR, MappingFEField<dim,spacedim,VECTOR,DH> > euler_vector;
+  SmartPointer<const VectorType, MappingFEField<dim,spacedim,VectorType,DH> > euler_vector;
 
   /**
    * A FiniteElement object which is only needed in 3D, since it knows how to
@@ -498,13 +498,13 @@ private:
    * prevent construction in 1D and 2D, but since memory and time requirements
    * are not particularly high this seems unnecessary at the moment.
    */
-  SmartPointer<const FiniteElement<dim,spacedim>, MappingFEField<dim,spacedim,VECTOR,DH> > fe;
+  SmartPointer<const FiniteElement<dim,spacedim>, MappingFEField<dim,spacedim,VectorType,DH> > fe;
 
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DH,MappingFEField<dim,spacedim,VECTOR,DH> > euler_dof_handler;
+  SmartPointer<const DH,MappingFEField<dim,spacedim,VectorType,DH> > euler_dof_handler;
 
 private:
   /**

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -22,7 +22,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, typename POLY> class TensorProductPolynomials;
+template <int dim, typename PolynomialType> class TensorProductPolynomials;
 
 
 /*!@addtogroup mapping */

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -82,7 +82,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Michael Stadler, 2001
  */
-template <int dim, class VECTOR = Vector<double>, int spacedim=dim >
+template <int dim, typename VectorType = Vector<double>, int spacedim=dim >
 class MappingQ1Eulerian : public MappingQGeneric<dim,spacedim>
 {
 public:
@@ -97,7 +97,7 @@ public:
    * problem. Alternatively, the @p Vector can be initialized by
    * <tt>DoFAccessor::set_dof_values()</tt>.
    */
-  MappingQ1Eulerian (const VECTOR  &euler_transform_vectors,
+  MappingQ1Eulerian (const VectorType  &euler_transform_vectors,
                      const DoFHandler<dim,spacedim> &shiftmap_dof_handler);
 
   /**
@@ -115,7 +115,7 @@ public:
    * then assumes ownership of it.
    */
   virtual
-  MappingQ1Eulerian<dim,VECTOR,spacedim> *clone () const;
+  MappingQ1Eulerian<dim,VectorType,spacedim> *clone () const;
 
   /**
    * Always returns @p false because MappingQ1Eulerian does not in general
@@ -161,12 +161,12 @@ protected:
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VECTOR, MappingQ1Eulerian<dim,VECTOR,spacedim> > euler_transform_vectors;
+  SmartPointer<const VectorType, MappingQ1Eulerian<dim,VectorType,spacedim> > euler_transform_vectors;
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DoFHandler<dim,spacedim>,MappingQ1Eulerian<dim,VECTOR,spacedim> > shiftmap_dof_handler;
+  SmartPointer<const DoFHandler<dim,spacedim>,MappingQ1Eulerian<dim,VectorType,spacedim> > shiftmap_dof_handler;
 };
 
 /*@}*/
@@ -175,10 +175,10 @@ protected:
 
 #ifndef DOXYGEN
 
-template <int dim, class VECTOR, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 inline
 bool
-MappingQ1Eulerian<dim,VECTOR,spacedim>::preserves_vertex_locations () const
+MappingQ1Eulerian<dim,VectorType,spacedim>::preserves_vertex_locations () const
 {
   return false;
 }

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -188,7 +188,7 @@ private:
      * Constructor.
      */
     MappingQEulerianGeneric (const unsigned int degree,
-                             const MappingQEulerian<dim,VECTOR,spacedim> &mapping_q_eulerian);
+                             const MappingQEulerian<dim,VectorType,spacedim> &mapping_q_eulerian);
 
     /**
      * Return the mapped vertices of the cell. For the current class, this function does
@@ -213,7 +213,7 @@ private:
     /**
      * Reference to the surrounding object off of which we live.
      */
-    const MappingQEulerian<dim,VECTOR,spacedim> &mapping_q_eulerian;
+    const MappingQEulerian<dim,VectorType,spacedim> &mapping_q_eulerian;
 
 
     /**

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -87,7 +87,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Joshua White, 2008
  */
-template <int dim, class VECTOR = Vector<double>, int spacedim=dim >
+template <int dim, typename VectorType = Vector<double>, int spacedim=dim >
 class MappingQEulerian : public MappingQ<dim, spacedim>
 {
 public:
@@ -104,16 +104,16 @@ public:
    * interpreted as the displacement we use in defining the mapping,
    * relative to the location of cells of the underlying triangulation.
    */
-  MappingQEulerian (const unsigned int              degree,
+  MappingQEulerian (const unsigned int             degree,
                     const DoFHandler<dim,spacedim> &euler_dof_handler,
-                    const VECTOR                   &euler_vector);
+                    const VectorType               &euler_vector);
 
   /**
    * @deprecated Use the constructor with the reverse order of second and
    * third argument.
    */
-  MappingQEulerian (const unsigned int              degree,
-                    const VECTOR                   &euler_vector,
+  MappingQEulerian (const unsigned int             degree,
+                    const VectorType               &euler_vector,
                     const DoFHandler<dim,spacedim> &euler_dof_handler) DEAL_II_DEPRECATED;
 
   /**
@@ -165,12 +165,12 @@ protected:
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VECTOR, MappingQEulerian<dim,VECTOR,spacedim> > euler_vector;
+  SmartPointer<const VectorType, MappingQEulerian<dim,VectorType,spacedim> > euler_vector;
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DoFHandler<dim,spacedim>,MappingQEulerian<dim,VECTOR,spacedim> > euler_dof_handler;
+  SmartPointer<const DoFHandler<dim,spacedim>,MappingQEulerian<dim,VectorType,spacedim> > euler_dof_handler;
 
 
 private:
@@ -261,10 +261,10 @@ private:
 
 #ifndef DOXYGEN
 
-template <int dim, class VECTOR, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 inline
 bool
-MappingQEulerian<dim,VECTOR,spacedim>::preserves_vertex_locations () const
+MappingQEulerian<dim,VectorType,spacedim>::preserves_vertex_locations () const
 {
   return false;
 }
@@ -276,4 +276,3 @@ DEAL_II_NAMESPACE_CLOSE
 
 
 #endif // dealii__mapping_q_eulerian_h
-

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -473,8 +473,8 @@ public:
    * Print the iterator to a stream <code>out</code>. The format is
    * <tt>level.index</tt>.
    */
-  template <class STREAM>
-  void print (STREAM &out) const;
+  template <class StreamType>
+  void print (StreamType &out) const;
 
 
   /**
@@ -1059,10 +1059,10 @@ TriaRawIterator<Accessor>::operator -- ()
 
 
 template <typename Accessor>
-template <class STREAM>
+template <class StreamType>
 inline
 void
-TriaRawIterator<Accessor>::print (STREAM &out) const
+TriaRawIterator<Accessor>::print (StreamType &out) const
 {
   if (Accessor::structure_dimension==Accessor::dimension)
     out << accessor.level() << "." << accessor.index();

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -172,15 +172,14 @@ public:
    * Leave it at its default zero, which will be reset to the size of
    * <code>eigenvalues</code> internally.
    */
-  template <typename VECTOR, typename MATRIX1,
+  template <typename VectorType, typename MATRIX1,
             typename MATRIX2, typename INVERSE>
-  void solve(
-    const MATRIX1 &A,
-    const MATRIX2 &B,
-    const INVERSE &inverse,
-    std::vector<std::complex<double> > &eigenvalues,
-    std::vector<VECTOR> &eigenvectors,
-    const unsigned int n_eigenvalues = 0);
+  void solve (const MATRIX1                      &A,
+              const MATRIX2                      &B,
+              const INVERSE                      &inverse,
+              std::vector<std::complex<double> > &eigenvalues,
+              std::vector<VectorType>            &eigenvectors,
+              const unsigned int                 n_eigenvalues = 0);
 
 protected:
 
@@ -258,16 +257,15 @@ ArpackSolver::ArpackSolver (SolverControl &control,
 {}
 
 
-template <typename VECTOR, typename MATRIX1,
+template <typename VectorType, typename MATRIX1,
           typename MATRIX2, typename INVERSE>
 inline
-void ArpackSolver::solve (
-  const MATRIX1 &system_matrix,
-  const MATRIX2 &mass_matrix,
-  const INVERSE &inverse,
-  std::vector<std::complex<double> > &eigenvalues,
-  std::vector<VECTOR> &eigenvectors,
-  const unsigned int n_eigenvalues)
+void ArpackSolver::solve (const MATRIX1                      &system_matrix,
+                          const MATRIX2                      &mass_matrix,
+                          const INVERSE                      &inverse,
+                          std::vector<std::complex<double> > &eigenvalues,
+                          std::vector<VectorType>            &eigenvectors,
+                          const unsigned int                 n_eigenvalues)
 {
   //inside the routines of ARPACK the
   //values change magically, so store
@@ -403,7 +401,7 @@ void ArpackSolver::solve (
             case -1:
             {
 
-              VECTOR src,dst,tmp;
+              VectorType src,dst,tmp;
               src.reinit(eigenvectors[0]);
               dst.reinit(src);
               tmp.reinit(src);
@@ -425,7 +423,7 @@ void ArpackSolver::solve (
             case  1:
             {
 
-              VECTOR src,dst,tmp, tmp2;
+              VectorType src,dst,tmp, tmp2;
               src.reinit(eigenvectors[0]);
               dst.reinit(src);
               tmp.reinit(src);
@@ -447,7 +445,7 @@ void ArpackSolver::solve (
             case  2:
             {
 
-              VECTOR src,dst;
+              VectorType src,dst;
               src.reinit(eigenvectors[0]);
               dst.reinit(src);
 

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -172,14 +172,14 @@ public:
    * Leave it at its default zero, which will be reset to the size of
    * <code>eigenvalues</code> internally.
    */
-  template <typename VectorType, typename MATRIX1,
-            typename MATRIX2, typename INVERSE>
-  void solve (const MATRIX1                      &A,
-              const MATRIX2                      &B,
+  template <typename VectorType, typename MatrixType1,
+            typename MatrixType2, typename INVERSE>
+  void solve (const MatrixType1                  &A,
+              const MatrixType2                  &B,
               const INVERSE                      &inverse,
               std::vector<std::complex<double> > &eigenvalues,
               std::vector<VectorType>            &eigenvectors,
-              const unsigned int                 n_eigenvalues = 0);
+              const unsigned int                  n_eigenvalues = 0);
 
 protected:
 
@@ -257,15 +257,15 @@ ArpackSolver::ArpackSolver (SolverControl &control,
 {}
 
 
-template <typename VectorType, typename MATRIX1,
-          typename MATRIX2, typename INVERSE>
+template <typename VectorType, typename MatrixType1,
+          typename MatrixType2, typename INVERSE>
 inline
-void ArpackSolver::solve (const MATRIX1                      &system_matrix,
-                          const MATRIX2                      &mass_matrix,
+void ArpackSolver::solve (const MatrixType1                  &system_matrix,
+                          const MatrixType2                  &mass_matrix,
                           const INVERSE                      &inverse,
                           std::vector<std::complex<double> > &eigenvalues,
                           std::vector<VectorType>            &eigenvectors,
-                          const unsigned int                 n_eigenvalues)
+                          const unsigned int                  n_eigenvalues)
 {
   //inside the routines of ARPACK the
   //values change magically, so store

--- a/include/deal.II/lac/block_matrix.h
+++ b/include/deal.II/lac/block_matrix.h
@@ -47,7 +47,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ref GlossBlockLA "Block (linear algebra)"
  * @author Guido Kanschat, 2000
  */
-template <class MATRIX>
+template <typename MatrixType>
 class BlockDiagonalMatrix : public Subscriptor
 {
 public:
@@ -55,7 +55,7 @@ public:
    * Constructor for an @p n_blocks by @p n_blocks matrix with diagonal blocks
    * @p M.
    */
-  BlockDiagonalMatrix (const MATRIX       &M,
+  BlockDiagonalMatrix (const MatrixType   &M,
                        const unsigned int  n_blocks);
 
   /**
@@ -80,26 +80,26 @@ private:
   /**
    * Diagonal entry.
    */
-  SmartPointer<const MATRIX,BlockDiagonalMatrix<MATRIX> > matrix;
+  SmartPointer<const MatrixType,BlockDiagonalMatrix<MatrixType> > matrix;
 };
 
 /*@}*/
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
-BlockDiagonalMatrix<MATRIX>::BlockDiagonalMatrix (const MATRIX &M,
-                                                  const unsigned int num_blocks)
+template <typename MatrixType>
+BlockDiagonalMatrix<MatrixType>::BlockDiagonalMatrix (const MatrixType &M,
+                                                      const unsigned int num_blocks)
   :
   num_blocks (num_blocks),
   matrix(&M)
 {}
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number1, typename number2>
 void
-BlockDiagonalMatrix<MATRIX>::vmult (BlockVector<number1> &dst,
-                                    const BlockVector<number2> &src) const
+BlockDiagonalMatrix<MatrixType>::vmult (BlockVector<number1>       &dst,
+                                        const BlockVector<number2> &src) const
 {
   Assert (dst.n_blocks()==num_blocks,
           ExcDimensionMismatch(dst.n_blocks(),num_blocks));
@@ -111,11 +111,11 @@ BlockDiagonalMatrix<MATRIX>::vmult (BlockVector<number1> &dst,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number1, typename number2>
 void
-BlockDiagonalMatrix<MATRIX>::Tvmult (BlockVector<number1> &dst,
-                                     const BlockVector<number2> &src) const
+BlockDiagonalMatrix<MatrixType>::Tvmult (BlockVector<number1>       &dst,
+                                         const BlockVector<number2> &src) const
 {
   Assert (dst.n_blocks()==num_blocks,
           ExcDimensionMismatch(dst.n_blocks(),num_blocks));

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -60,9 +60,9 @@ DEAL_II_NAMESPACE_OPEN
  * this class. If you need a preconditioner for a BlockMatrixArray object, use
  * BlockTrianglePrecondition.
  *
- * <h3>Requirements on MATRIX</h3>
+ * <h3>Requirements on MatrixType</h3>
  *
- * The template argument <tt>MATRIX</tt> is a class providing the matrix-
+ * The template argument <tt>MatrixType</tt> is a class providing the matrix-
  * vector multiplication functions vmult(), Tvmult(), vmult_add() and
  * Tvmult_add() used in this class, but with arguments of type
  * Vector&lt;number&gt; instead of BlockVector&lt;number&gt;. Every matrix
@@ -154,8 +154,8 @@ public:
    * entering a block of wrong dimension here will only lead to a
    * ExcDimensionMismatch in one of the multiplication functions.
    */
-  template <class MATRIX>
-  void enter (const MATRIX       &matrix,
+  template <typename MatrixType>
+  void enter (const MatrixType   &matrix,
               const unsigned int  row,
               const unsigned int  col,
               const number        prefix = 1.,
@@ -272,10 +272,12 @@ protected:
      * Constructor initializing all data fields. A PointerMatrix object is
      * generated for <tt>matrix</tt>.
      */
-    template<class MATRIX>
-    Entry (const MATRIX &matrix,
-           size_type row, size_type col,
-           number prefix, bool transpose);
+    template<typename MatrixType>
+    Entry (const MatrixType &matrix,
+           size_type row,
+           size_type col,
+           number prefix,
+           bool transpose);
 
     /**
      * Copy constructor invalidating the old object. Since it is only used for
@@ -423,12 +425,12 @@ public:
    * Enter a block. This calls BlockMatrixArray::enter(). Remember that the
    * diagonal blocks should actually be inverse matrices or preconditioners.
    */
-  template <class MATRIX>
-  void enter (const MATRIX   &matrix,
-              const size_type row,
-              const size_type col,
-              const number    prefix = 1.,
-              const bool      transpose = false);
+  template <typename MatrixType>
+  void enter (const MatrixType &matrix,
+              const size_type   row,
+              const size_type   col,
+              const number      prefix    = 1.,
+              const bool        transpose = false);
 
   /**
    * Preconditioning.
@@ -513,14 +515,14 @@ private:
 //---------------------------------------------------------------------------
 
 template <typename number, typename BLOCK_VECTOR>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 BlockMatrixArray<number, BLOCK_VECTOR>::Entry::Entry (
-  const MATRIX &m,
-  size_type row,
-  size_type col,
-  number prefix,
-  bool transpose)
+  const MatrixType &m,
+  size_type         row,
+  size_type         col,
+  number            prefix,
+  bool              transpose)
   :
   row (row),
   col (col),
@@ -532,15 +534,14 @@ BlockMatrixArray<number, BLOCK_VECTOR>::Entry::Entry (
 
 
 template <typename number, typename BLOCK_VECTOR>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 void
-BlockMatrixArray<number, BLOCK_VECTOR>::enter (
-  const MATRIX &matrix,
-  unsigned int row,
-  unsigned int col,
-  number prefix,
-  bool transpose)
+BlockMatrixArray<number, BLOCK_VECTOR>::enter (const MatrixType &matrix,
+                                               unsigned int      row,
+                                               unsigned int      col,
+                                               number            prefix,
+                                               bool              transpose)
 {
   Assert(row<n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
   Assert(col<n_block_cols(), ExcIndexRange(col, 0, n_block_cols()));
@@ -612,12 +613,14 @@ BlockMatrixArray<number, BLOCK_VECTOR>::print_latex (STREAM &out) const
 }
 
 template <typename number, typename BLOCK_VECTOR>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 void
-BlockTrianglePrecondition<number, BLOCK_VECTOR>::enter (const MATRIX &matrix,
-                                                        size_type row, size_type col,
-                                                        number prefix, bool transpose)
+BlockTrianglePrecondition<number, BLOCK_VECTOR>::enter (const MatrixType &matrix,
+                                                        size_type         row,
+                                                        size_type         col,
+                                                        number            prefix,
+                                                        bool              transpose)
 {
   BlockMatrixArray<number, BLOCK_VECTOR>::enter(matrix, row, col, prefix, transpose);
 }

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -110,7 +110,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat
  * @date 2000-2005, 2010
  */
-template <typename number = double, typename BLOCK_VECTOR=BlockVector<number> >
+template <typename number = double, typename BlockVectorType=BlockVector<number> >
 class BlockMatrixArray : public Subscriptor
 {
 public:
@@ -179,39 +179,39 @@ public:
   /**
    * Matrix-vector multiplication.
    */
-  void vmult (BLOCK_VECTOR &dst,
-              const BLOCK_VECTOR &src) const;
+  void vmult (BlockVectorType &dst,
+              const BlockVectorType &src) const;
 
   /**
    * Matrix-vector multiplication adding to <tt>dst</tt>.
    */
-  void vmult_add(BLOCK_VECTOR &dst,
-                 const BLOCK_VECTOR &src) const;
+  void vmult_add(BlockVectorType &dst,
+                 const BlockVectorType &src) const;
 
   /**
    * Transposed matrix-vector multiplication.
    */
-  void Tvmult (BLOCK_VECTOR &dst,
-               const BLOCK_VECTOR &src) const;
+  void Tvmult (BlockVectorType &dst,
+               const BlockVectorType &src) const;
 
   /**
    * Transposed matrix-vector multiplication adding to <tt>dst</tt>.
    */
-  void Tvmult_add (BLOCK_VECTOR &dst,
-                   const BLOCK_VECTOR &src) const;
+  void Tvmult_add (BlockVectorType &dst,
+                   const BlockVectorType &src) const;
 
   /**
    * Matrix scalar product between two vectors (at least for a symmetric
    * matrix).
    */
-  number matrix_scalar_product (const BLOCK_VECTOR &u,
-                                const BLOCK_VECTOR &v) const;
+  number matrix_scalar_product (const BlockVectorType &u,
+                                const BlockVectorType &v) const;
 
   /**
    * Compute $u^T M u$. This is the square of the norm induced by the matrix
    * assuming the matrix is symmetric positive definitive.
    */
-  number matrix_norm_square (const BLOCK_VECTOR &u) const;
+  number matrix_norm_square (const BlockVectorType &u) const;
 
   /**
    * Print the block structure as a LaTeX-array. This output will not be very
@@ -317,7 +317,7 @@ protected:
     /**
      * The matrix block itself.
      */
-    PointerMatrixBase<typename BLOCK_VECTOR::BlockType > *matrix;
+    PointerMatrixBase<typename BlockVectorType::BlockType > *matrix;
   };
 
   /**
@@ -393,9 +393,9 @@ private:
  * @ingroup Preconditioners
  * @author Guido Kanschat, 2001, 2005
  */
-template <typename number = double, typename BLOCK_VECTOR = BlockVector<number> >
+template <typename number = double, typename BlockVectorType = BlockVector<number> >
 class BlockTrianglePrecondition
-  : private BlockMatrixArray<number,BLOCK_VECTOR>
+  : private BlockMatrixArray<number,BlockVectorType>
 {
 public:
   /**
@@ -435,44 +435,44 @@ public:
   /**
    * Preconditioning.
    */
-  void vmult (BLOCK_VECTOR &dst,
-              const BLOCK_VECTOR &src) const;
+  void vmult (BlockVectorType &dst,
+              const BlockVectorType &src) const;
 
   /**
    * Preconditioning adding to <tt>dst</tt>.
    */
-  void vmult_add (BLOCK_VECTOR &dst,
-                  const BLOCK_VECTOR &src) const;
+  void vmult_add (BlockVectorType &dst,
+                  const BlockVectorType &src) const;
 
   /**
    * Transposed preconditioning
    */
-  void Tvmult (BLOCK_VECTOR &dst,
-               const BLOCK_VECTOR &src) const;
+  void Tvmult (BlockVectorType &dst,
+               const BlockVectorType &src) const;
 
   /**
    * Transposed preconditioning adding to <tt>dst</tt>.
    */
-  void Tvmult_add (BLOCK_VECTOR &dst,
-                   const BLOCK_VECTOR &src) const;
+  void Tvmult_add (BlockVectorType &dst,
+                   const BlockVectorType &src) const;
 
   /**
    * Make function of base class available.
    */
-  using BlockMatrixArray<number,BLOCK_VECTOR>::print_latex;
+  using BlockMatrixArray<number,BlockVectorType>::print_latex;
 
   /**
    * Make function of base class available.
    */
-  using BlockMatrixArray<number,BLOCK_VECTOR>::n_block_rows;
+  using BlockMatrixArray<number,BlockVectorType>::n_block_rows;
 
   /**
    * Make function of base class available.
    */
-  using BlockMatrixArray<number,BLOCK_VECTOR>::n_block_cols;
-  using BlockMatrixArray<number,BLOCK_VECTOR>::clear;
-  using BlockMatrixArray<number,BLOCK_VECTOR>::Subscriptor::subscribe;
-  using BlockMatrixArray<number,BLOCK_VECTOR>::Subscriptor::unsubscribe;
+  using BlockMatrixArray<number,BlockVectorType>::n_block_cols;
+  using BlockMatrixArray<number,BlockVectorType>::clear;
+  using BlockMatrixArray<number,BlockVectorType>::Subscriptor::subscribe;
+  using BlockMatrixArray<number,BlockVectorType>::Subscriptor::unsubscribe;
 
   /**
    * @addtogroup Exceptions
@@ -501,7 +501,7 @@ private:
    * Add all off-diagonal contributions and return the entry of the diagonal
    * element for one row.
    */
-  void do_row (BLOCK_VECTOR &dst,
+  void do_row (BlockVectorType &dst,
                size_type row_num) const;
 
   /**
@@ -514,34 +514,34 @@ private:
 #ifndef DOXYGEN
 //---------------------------------------------------------------------------
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 template <typename MatrixType>
 inline
-BlockMatrixArray<number, BLOCK_VECTOR>::Entry::Entry (
-  const MatrixType &m,
-  size_type         row,
-  size_type         col,
-  number            prefix,
-  bool              transpose)
+BlockMatrixArray<number, BlockVectorType>::Entry::Entry
+(const MatrixType &m,
+ size_type         row,
+ size_type         col,
+ number            prefix,
+ bool              transpose)
   :
   row (row),
   col (col),
   prefix (prefix),
   transpose (transpose),
-  matrix (new_pointer_matrix_base(m, typename BLOCK_VECTOR::BlockType(), typeid(*this).name()))
+  matrix (new_pointer_matrix_base(m, typename BlockVectorType::BlockType(), typeid(*this).name()))
 {}
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 template <typename MatrixType>
 inline
 void
-BlockMatrixArray<number, BLOCK_VECTOR>::enter (const MatrixType &matrix,
-                                               unsigned int      row,
-                                               unsigned int      col,
-                                               number            prefix,
-                                               bool              transpose)
+BlockMatrixArray<number, BlockVectorType>::enter (const MatrixType &matrix,
+                                                  unsigned int      row,
+                                                  unsigned int      col,
+                                                  number            prefix,
+                                                  bool              transpose)
 {
   Assert(row<n_block_rows(), ExcIndexRange(row, 0, n_block_rows()));
   Assert(col<n_block_cols(), ExcIndexRange(col, 0, n_block_cols()));
@@ -549,11 +549,11 @@ BlockMatrixArray<number, BLOCK_VECTOR>::enter (const MatrixType &matrix,
 }
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 template <class STREAM>
 inline
 void
-BlockMatrixArray<number, BLOCK_VECTOR>::print_latex (STREAM &out) const
+BlockMatrixArray<number, BlockVectorType>::print_latex (STREAM &out) const
 {
   out << "\\begin{array}{"
       << std::string(n_block_cols(), 'c')
@@ -561,7 +561,7 @@ BlockMatrixArray<number, BLOCK_VECTOR>::print_latex (STREAM &out) const
 
   Table<2,std::string> array(n_block_rows(), n_block_cols());
 
-  typedef std::map<const PointerMatrixBase<typename BLOCK_VECTOR::BlockType > *, std::string> NameMap;
+  typedef std::map<const PointerMatrixBase<typename BlockVectorType::BlockType > *, std::string> NameMap;
   NameMap matrix_names;
 
   typename std::vector<Entry>::const_iterator m = entries.begin();
@@ -574,7 +574,7 @@ BlockMatrixArray<number, BLOCK_VECTOR>::print_latex (STREAM &out) const
         {
           std::pair<typename NameMap::iterator, bool> x =
             matrix_names.insert(
-              std::pair<const PointerMatrixBase<typename BLOCK_VECTOR::BlockType >*, std::string> (m->matrix,
+              std::pair<const PointerMatrixBase<typename BlockVectorType::BlockType >*, std::string> (m->matrix,
                   std::string("M")));
           std::ostringstream stream;
           stream << matrix_number++;
@@ -612,17 +612,17 @@ BlockMatrixArray<number, BLOCK_VECTOR>::print_latex (STREAM &out) const
   out << "\\end{array}" << std::endl;
 }
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 template <typename MatrixType>
 inline
 void
-BlockTrianglePrecondition<number, BLOCK_VECTOR>::enter (const MatrixType &matrix,
-                                                        size_type         row,
-                                                        size_type         col,
-                                                        number            prefix,
-                                                        bool              transpose)
+BlockTrianglePrecondition<number, BlockVectorType>::enter (const MatrixType &matrix,
+                                                           size_type         row,
+                                                           size_type         col,
+                                                           number            prefix,
+                                                           bool              transpose)
 {
-  BlockMatrixArray<number, BLOCK_VECTOR>::enter(matrix, row, col, prefix, transpose);
+  BlockMatrixArray<number, BlockVectorType>::enter(matrix, row, col, prefix, transpose);
 }
 
 

--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -252,8 +252,8 @@ public:
    * Nevertheless, the output at least gives some kind of idea of the block
    * structure of this matrix.
    */
-  template <class STREAM>
-  void print_latex (STREAM &out) const;
+  template <class StreamType>
+  void print_latex (StreamType &out) const;
 
 protected:
   /**
@@ -550,10 +550,10 @@ BlockMatrixArray<number, BlockVectorType>::enter (const MatrixType &matrix,
 
 
 template <typename number, typename BlockVectorType>
-template <class STREAM>
+template <class StreamType>
 inline
 void
-BlockMatrixArray<number, BlockVectorType>::print_latex (STREAM &out) const
+BlockMatrixArray<number, BlockVectorType>::print_latex (StreamType &out) const
 {
   out << "\\begin{array}{"
       << std::string(n_block_cols(), 'c')

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -241,8 +241,8 @@ public:
    * existing row lengths and allocated row lengths. Otherwise, just the
    * relation of allocated and used entries is shown.
    */
-  template <class STREAM>
-  void print_statistics (STREAM &s, bool full = false);
+  template <class StreamType>
+  void print_statistics (StreamType &s, bool full = false);
 
 private:
   /**
@@ -478,10 +478,10 @@ Tvmult_add (BlockVector<somenumber>       &dst,
 
 
 template <typename number>
-template <class STREAM>
+template <class StreamType>
 inline
 void
-BlockSparseMatrixEZ<number>::print_statistics (STREAM &out, bool full)
+BlockSparseMatrixEZ<number>::print_statistics (StreamType &out, bool full)
 {
   size_type used_total = 0;
   size_type allocated_total = 0;

--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -50,8 +50,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 2000
  */
-template <class VECTOR = Vector<double> >
-class EigenPower : private Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class EigenPower : private Solver<VectorType>
 {
 public:
   /**
@@ -82,9 +82,9 @@ public:
   /**
    * Constructor.
    */
-  EigenPower (SolverControl &cn,
-              VectorMemory<VECTOR> &mem,
-              const AdditionalData &data=AdditionalData());
+  EigenPower (SolverControl            &cn,
+              VectorMemory<VectorType> &mem,
+              const AdditionalData     &data=AdditionalData());
 
   /**
    * Virtual destructor.
@@ -101,7 +101,7 @@ public:
   void
   solve (double       &value,
          const MATRIX &A,
-         VECTOR       &x);
+         VectorType   &x);
 
 protected:
   /**
@@ -133,8 +133,8 @@ protected:
  *
  * @author Guido Kanschat, 2000, 2003
  */
-template <class VECTOR = Vector<double> >
-class EigenInverse : private Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class EigenInverse : private Solver<VectorType>
 {
 public:
   /**
@@ -177,9 +177,9 @@ public:
   /**
    * Constructor.
    */
-  EigenInverse (SolverControl &cn,
-                VectorMemory<VECTOR> &mem,
-                const AdditionalData &data=AdditionalData());
+  EigenInverse (SolverControl            &cn,
+                VectorMemory<VectorType> &mem,
+                const AdditionalData     &data=AdditionalData());
 
 
   /**
@@ -198,7 +198,7 @@ public:
   void
   solve (double       &value,
          const MATRIX &A,
-         VECTOR       &x);
+         VectorType   &x);
 
 protected:
   /**
@@ -211,39 +211,39 @@ protected:
 //---------------------------------------------------------------------------
 
 
-template <class VECTOR>
-EigenPower<VECTOR>::EigenPower (SolverControl &cn,
-                                VectorMemory<VECTOR> &mem,
-                                const AdditionalData &data)
+template <class VectorType>
+EigenPower<VectorType>::EigenPower (SolverControl            &cn,
+                                    VectorMemory<VectorType> &mem,
+                                    const AdditionalData     &data)
   :
-  Solver<VECTOR>(cn, mem),
+  Solver<VectorType>(cn, mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-EigenPower<VECTOR>::~EigenPower ()
+template <class VectorType>
+EigenPower<VectorType>::~EigenPower ()
 {}
 
 
 
-template <class VECTOR>
+template <class VectorType>
 template <class MATRIX>
 void
-EigenPower<VECTOR>::solve (double       &value,
-                           const MATRIX &A,
-                           VECTOR       &x)
+EigenPower<VectorType>::solve (double       &value,
+                               const MATRIX &A,
+                               VectorType   &x)
 {
   SolverControl::State conv=SolverControl::iterate;
 
   deallog.push("Power method");
 
-  VECTOR *Vy = this->memory.alloc ();
-  VECTOR &y = *Vy;
+  VectorType *Vy = this->memory.alloc ();
+  VectorType &y = *Vy;
   y.reinit (x);
-  VECTOR *Vr = this->memory.alloc ();
-  VECTOR &r = *Vr;
+  VectorType *Vr = this->memory.alloc ();
+  VectorType &r = *Vr;
   r.reinit (x);
 
   double length = x.l2_norm ();
@@ -305,29 +305,29 @@ EigenPower<VECTOR>::solve (double       &value,
 
 //---------------------------------------------------------------------------
 
-template <class VECTOR>
-EigenInverse<VECTOR>::EigenInverse (SolverControl &cn,
-                                    VectorMemory<VECTOR> &mem,
-                                    const AdditionalData &data)
+template <class VectorType>
+EigenInverse<VectorType>::EigenInverse (SolverControl            &cn,
+                                        VectorMemory<VectorType> &mem,
+                                        const AdditionalData     &data)
   :
-  Solver<VECTOR>(cn, mem),
+  Solver<VectorType>(cn, mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-EigenInverse<VECTOR>::~EigenInverse ()
+template <class VectorType>
+EigenInverse<VectorType>::~EigenInverse ()
 {}
 
 
 
-template <class VECTOR>
+template <class VectorType>
 template <class MATRIX>
 void
-EigenInverse<VECTOR>::solve (double       &value,
-                             const MATRIX &A,
-                             VECTOR       &x)
+EigenInverse<VectorType>::solve (double       &value,
+                                 const MATRIX &A,
+                                 VectorType   &x)
 {
   deallog.push("Wielandt");
 
@@ -339,18 +339,18 @@ EigenInverse<VECTOR>::solve (double       &value,
   // Define solver
   ReductionControl inner_control (5000, 1.e-16, 1.e-5, false, false);
   PreconditionIdentity prec;
-  SolverGMRES<VECTOR>
+  SolverGMRES<VectorType>
   solver(inner_control, this->memory);
 
   // Next step for recomputing the shift
   unsigned int goal = additional_data.start_adaption;
 
   // Auxiliary vector
-  VECTOR *Vy = this->memory.alloc ();
-  VECTOR &y = *Vy;
+  VectorType *Vy = this->memory.alloc ();
+  VectorType &y = *Vy;
   y.reinit (x);
-  VECTOR *Vr = this->memory.alloc ();
-  VECTOR &r = *Vr;
+  VectorType *Vr = this->memory.alloc ();
+  VectorType &r = *Vr;
   r.reinit (x);
 
   double length = x.l2_norm ();

--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -97,11 +97,11 @@ public:
    * approximated eigenvalue and @p x is the corresponding eigenvector,
    * normalized with respect to the l2-norm.
    */
-  template <class MATRIX>
+  template <typename MatrixType>
   void
-  solve (double       &value,
-         const MATRIX &A,
-         VectorType   &x);
+  solve (double           &value,
+         const MatrixType &A,
+         VectorType       &x);
 
 protected:
   /**
@@ -194,11 +194,11 @@ public:
    * eigenvalue and @p x is the corresponding eigenvector, normalized with
    * respect to the l2-norm.
    */
-  template <class MATRIX>
+  template <typename MatrixType>
   void
-  solve (double       &value,
-         const MATRIX &A,
-         VectorType   &x);
+  solve (double           &value,
+         const MatrixType &A,
+         VectorType       &x);
 
 protected:
   /**
@@ -229,11 +229,11 @@ EigenPower<VectorType>::~EigenPower ()
 
 
 template <class VectorType>
-template <class MATRIX>
+template <typename MatrixType>
 void
-EigenPower<VectorType>::solve (double       &value,
-                               const MATRIX &A,
-                               VectorType   &x)
+EigenPower<VectorType>::solve (double           &value,
+                               const MatrixType &A,
+                               VectorType       &x)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -323,18 +323,18 @@ EigenInverse<VectorType>::~EigenInverse ()
 
 
 template <class VectorType>
-template <class MATRIX>
+template <typename MatrixType>
 void
-EigenInverse<VectorType>::solve (double       &value,
-                                 const MATRIX &A,
-                                 VectorType   &x)
+EigenInverse<VectorType>::solve (double           &value,
+                                 const MatrixType &A,
+                                 VectorType       &x)
 {
   deallog.push("Wielandt");
 
   SolverControl::State conv=SolverControl::iterate;
 
   // Prepare matrix for solver
-  ShiftedMatrix <MATRIX> A_s(A, -value);
+  ShiftedMatrix <MatrixType> A_s(A, -value);
 
   // Define solver
   ReductionControl inner_control (5000, 1.e-16, 1.e-5, false, false);

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -30,7 +30,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <typename number> class Vector;
-template <class VECTOR> class FilteredMatrixBlock;
+template <class VectorType> class FilteredMatrixBlock;
 
 
 /*! @addtogroup Matrix2
@@ -190,7 +190,7 @@ template <class VECTOR> class FilteredMatrixBlock;
  *
  * @author Wolfgang Bangerth 2001, Luca Heltai 2006, Guido Kanschat 2007, 2008
  */
-template <class VECTOR>
+template <typename VectorType>
 class FilteredMatrix : public Subscriptor
 {
 public:
@@ -210,8 +210,8 @@ public:
      * Constructor. Since we use accessors only for read access, a const
      * matrix pointer is sufficient.
      */
-    Accessor (const FilteredMatrix<VECTOR> *matrix,
-              const size_type               index);
+    Accessor (const FilteredMatrix<VectorType> *matrix,
+              const size_type                  index);
 
   public:
     /**
@@ -238,7 +238,7 @@ public:
     /**
      * The matrix accessed.
      */
-    const FilteredMatrix<VECTOR> *matrix;
+    const FilteredMatrix<VectorType> *matrix;
 
     /**
      * Current row number.
@@ -260,8 +260,8 @@ public:
     /**
      * Constructor.
      */
-    const_iterator(const FilteredMatrix<VECTOR> *matrix,
-                   const size_type index);
+    const_iterator(const FilteredMatrix<VectorType> *matrix,
+                   const size_type                  index);
 
     /**
      * Prefix increment.
@@ -412,28 +412,28 @@ public:
    * the second parameter to @p true to use a faster algorithm. Note: This
    * method is deprecated as matrix_is_symmetric parameter is no longer used.
    */
-  void apply_constraints (VECTOR     &v,
-                          const bool  matrix_is_symmetric) const DEAL_II_DEPRECATED;
+  void apply_constraints (VectorType &v,
+                          const bool matrix_is_symmetric) const DEAL_II_DEPRECATED;
   /**
    * Apply the constraints to a right hand side vector. This needs to be done
    * before starting to solve with the filtered matrix.
    */
-  void apply_constraints (VECTOR     &v) const;
+  void apply_constraints (VectorType &v) const;
 
   /**
    * Matrix-vector multiplication: this operation performs pre_filter(),
    * multiplication with the stored matrix and post_filter() in that order.
    */
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const;
+  void vmult (VectorType       &dst,
+              const VectorType &src) const;
 
   /**
    * Matrix-vector multiplication: this operation performs pre_filter(),
    * transposed multiplication with the stored matrix and post_filter() in
    * that order.
    */
-  void Tvmult (VECTOR       &dst,
-               const VECTOR &src) const;
+  void Tvmult (VectorType       &dst,
+               const VectorType &src) const;
 
   /**
    * Adding matrix-vector multiplication.
@@ -442,8 +442,8 @@ public:
    * entries set to zero, independent of the previous value of <tt>dst</tt>.
    * We excpect that in most cases this is the required behavior.
    */
-  void vmult_add (VECTOR       &dst,
-                  const VECTOR &src) const;
+  void vmult_add (VectorType       &dst,
+                  const VectorType &src) const;
 
   /**
    * Adding transpose matrix-vector multiplication:
@@ -452,8 +452,8 @@ public:
    * entries set to zero, independent of the previous value of <tt>dst</tt>.
    * We excpect that in most cases this is the required behavior.
    */
-  void Tvmult_add (VECTOR       &dst,
-                   const VECTOR &src) const;
+  void Tvmult_add (VectorType       &dst,
+                   const VectorType &src) const;
 //@}
 
   /**
@@ -514,7 +514,7 @@ private:
   /**
    * Pointer to the sparsity pattern used for this matrix.
    */
-  std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > matrix;
+  std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > matrix;
 
   /**
    * Sorted list of pairs denoting the index of the variable and the value to
@@ -526,21 +526,21 @@ private:
    * Do the pre-filtering step, i.e. zero out those components that belong to
    * constrained degrees of freedom.
    */
-  void pre_filter (VECTOR &v) const;
+  void pre_filter (VectorType &v) const;
 
   /**
    * Do the postfiltering step, i.e. set constrained degrees of freedom to the
    * value of the input vector, as the matrix contains only ones on the
    * diagonal for these degrees of freedom.
    */
-  void post_filter (const VECTOR &in,
-                    VECTOR       &out) const;
+  void post_filter (const VectorType &in,
+                    VectorType       &out) const;
 
   friend class Accessor;
   /**
    * FilteredMatrixBlock accesses pre_filter() and post_filter().
    */
-  friend class FilteredMatrixBlock<VECTOR>;
+  friend class FilteredMatrixBlock<VectorType>;
 };
 
 /*@}*/
@@ -549,11 +549,11 @@ private:
 
 //--------------------------------Iterators--------------------------------------//
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-FilteredMatrix<VECTOR>::Accessor::Accessor(
-  const FilteredMatrix<VECTOR> *matrix,
-  const size_type index)
+FilteredMatrix<VectorType>::Accessor::Accessor
+(const FilteredMatrix<VectorType> *matrix,
+ const size_type                   index)
   :
   matrix(matrix),
   index(index)
@@ -564,40 +564,40 @@ FilteredMatrix<VECTOR>::Accessor::Accessor(
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 types::global_dof_index
-FilteredMatrix<VECTOR>::Accessor::row() const
+FilteredMatrix<VectorType>::Accessor::row() const
 {
   return matrix->constraints[index].first;
 }
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 types::global_dof_index
-FilteredMatrix<VECTOR>::Accessor::column() const
+FilteredMatrix<VectorType>::Accessor::column() const
 {
   return matrix->constraints[index].first;
 }
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 double
-FilteredMatrix<VECTOR>::Accessor::value() const
+FilteredMatrix<VectorType>::Accessor::value() const
 {
   return matrix->constraints[index].second;
 }
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::Accessor::advance()
+FilteredMatrix<VectorType>::Accessor::advance()
 {
   Assert (index < matrix->constraints.size(), ExcIteratorPastEnd());
   ++index;
@@ -606,21 +606,21 @@ FilteredMatrix<VECTOR>::Accessor::advance()
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-FilteredMatrix<VECTOR>::const_iterator::const_iterator(
-  const FilteredMatrix<VECTOR> *matrix,
-  const size_type index)
+FilteredMatrix<VectorType>::const_iterator::const_iterator
+(const FilteredMatrix<VectorType> *matrix,
+ const size_type                   index)
   :
   accessor(matrix, index)
 {}
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-typename FilteredMatrix<VECTOR>::const_iterator &
-FilteredMatrix<VECTOR>::const_iterator::operator++ ()
+typename FilteredMatrix<VectorType>::const_iterator &
+FilteredMatrix<VectorType>::const_iterator::operator++ ()
 {
   accessor.advance();
   return *this;
@@ -687,10 +687,10 @@ FilteredMatrix<number>::end () const
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 bool
-FilteredMatrix<VECTOR>::PairComparison::
+FilteredMatrix<VectorType>::PairComparison::
 operator () (const IndexValuePair &i1,
              const IndexValuePair &i2) const
 {
@@ -699,29 +699,29 @@ operator () (const IndexValuePair &i1,
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX>
 inline
 void
-FilteredMatrix<VECTOR>::initialize (const MATRIX &m, bool ecs)
+FilteredMatrix<VectorType>::initialize (const MATRIX &m, bool ecs)
 {
-  matrix.reset (new_pointer_matrix_base(m, VECTOR()));
+  matrix.reset (new_pointer_matrix_base(m, VectorType()));
 
   expect_constrained_source = ecs;
 }
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-FilteredMatrix<VECTOR>::FilteredMatrix ()
+FilteredMatrix<VectorType>::FilteredMatrix ()
 {}
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-FilteredMatrix<VECTOR>::FilteredMatrix (const FilteredMatrix &fm)
+FilteredMatrix<VectorType>::FilteredMatrix (const FilteredMatrix &fm)
   :
   Subscriptor(),
   expect_constrained_source(fm.expect_constrained_source),
@@ -731,10 +731,10 @@ FilteredMatrix<VECTOR>::FilteredMatrix (const FilteredMatrix &fm)
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX>
 inline
-FilteredMatrix<VECTOR>::
+FilteredMatrix<VectorType>::
 FilteredMatrix (const MATRIX &m, bool ecs)
 {
   initialize (m, ecs);
@@ -742,10 +742,10 @@ FilteredMatrix (const MATRIX &m, bool ecs)
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-FilteredMatrix<VECTOR> &
-FilteredMatrix<VECTOR>::operator = (const FilteredMatrix &fm)
+FilteredMatrix<VectorType> &
+FilteredMatrix<VectorType>::operator = (const FilteredMatrix &fm)
 {
   matrix = fm.matrix;
   expect_constrained_source = fm.expect_constrained_source;
@@ -755,10 +755,10 @@ FilteredMatrix<VECTOR>::operator = (const FilteredMatrix &fm)
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::add_constraint (const size_type index, const double value)
+FilteredMatrix<VectorType>::add_constraint (const size_type index, const double value)
 {
   // add new constraint to end
   constraints.push_back(IndexValuePair(index, value));
@@ -766,11 +766,11 @@ FilteredMatrix<VECTOR>::add_constraint (const size_type index, const double valu
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class ConstraintList>
 inline
 void
-FilteredMatrix<VECTOR>::add_constraints (const ConstraintList &new_constraints)
+FilteredMatrix<VectorType>::add_constraints (const ConstraintList &new_constraints)
 {
   // add new constraints to end
   const size_type old_size = constraints.size();
@@ -788,10 +788,10 @@ FilteredMatrix<VECTOR>::add_constraints (const ConstraintList &new_constraints)
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::clear_constraints ()
+FilteredMatrix<VectorType>::clear_constraints ()
 {
   // swap vectors to release memory
   std::vector<IndexValuePair> empty;
@@ -800,10 +800,10 @@ FilteredMatrix<VECTOR>::clear_constraints ()
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::clear ()
+FilteredMatrix<VectorType>::clear ()
 {
   clear_constraints();
   matrix.reset();
@@ -811,25 +811,24 @@ FilteredMatrix<VECTOR>::clear ()
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::apply_constraints (
-  VECTOR     &v,
-  const bool  /* matrix_is_symmetric */) const
+FilteredMatrix<VectorType>::apply_constraints
+(VectorType &v,
+ const bool  /* matrix_is_symmetric */) const
 {
   apply_constraints(v);
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::apply_constraints (
-  VECTOR     &v) const
+FilteredMatrix<VectorType>::apply_constraints (VectorType &v) const
 {
-  GrowingVectorMemory<VECTOR> mem;
-  typename VectorMemory<VECTOR>::Pointer tmp_vector(mem);
+  GrowingVectorMemory<VectorType> mem;
+  typename VectorMemory<VectorType>::Pointer tmp_vector(mem);
   tmp_vector->reinit(v);
   const_index_value_iterator       i = constraints.begin();
   const const_index_value_iterator e = constraints.end();
@@ -853,10 +852,10 @@ FilteredMatrix<VECTOR>::apply_constraints (
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::pre_filter (VECTOR &v) const
+FilteredMatrix<VectorType>::pre_filter (VectorType &v) const
 {
   // iterate over all constraints and
   // zero out value
@@ -868,11 +867,11 @@ FilteredMatrix<VECTOR>::pre_filter (VECTOR &v) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::post_filter (const VECTOR &in,
-                                     VECTOR       &out) const
+FilteredMatrix<VectorType>::post_filter (const VectorType &in,
+                                         VectorType       &out) const
 {
   // iterate over all constraints and
   // set value correctly
@@ -887,15 +886,15 @@ FilteredMatrix<VECTOR>::post_filter (const VECTOR &in,
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
+FilteredMatrix<VectorType>::vmult (VectorType &dst, const VectorType &src) const
 {
   if (!expect_constrained_source)
     {
-      GrowingVectorMemory<VECTOR> mem;
-      VECTOR *tmp_vector = mem.alloc();
+      GrowingVectorMemory<VectorType> mem;
+      VectorType *tmp_vector = mem.alloc();
       // first copy over src vector and
       // pre-filter
       tmp_vector->reinit(src, true);
@@ -916,15 +915,15 @@ FilteredMatrix<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::Tvmult (VECTOR &dst, const VECTOR &src) const
+FilteredMatrix<VectorType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
   if (!expect_constrained_source)
     {
-      GrowingVectorMemory<VECTOR> mem;
-      VECTOR *tmp_vector = mem.alloc();
+      GrowingVectorMemory<VectorType> mem;
+      VectorType *tmp_vector = mem.alloc();
       // first copy over src vector and
       // pre-filter
       tmp_vector->reinit(src, true);
@@ -945,15 +944,15 @@ FilteredMatrix<VECTOR>::Tvmult (VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::vmult_add (VECTOR &dst, const VECTOR &src) const
+FilteredMatrix<VectorType>::vmult_add (VectorType &dst, const VectorType &src) const
 {
   if (!expect_constrained_source)
     {
-      GrowingVectorMemory<VECTOR> mem;
-      VECTOR *tmp_vector = mem.alloc();
+      GrowingVectorMemory<VectorType> mem;
+      VectorType *tmp_vector = mem.alloc();
       // first copy over src vector and
       // pre-filter
       tmp_vector->reinit(src, true);
@@ -974,15 +973,15 @@ FilteredMatrix<VECTOR>::vmult_add (VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-FilteredMatrix<VECTOR>::Tvmult_add (VECTOR &dst, const VECTOR &src) const
+FilteredMatrix<VectorType>::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
   if (!expect_constrained_source)
     {
-      GrowingVectorMemory<VECTOR> mem;
-      VECTOR *tmp_vector = mem.alloc();
+      GrowingVectorMemory<VectorType> mem;
+      VectorType *tmp_vector = mem.alloc();
       // first copy over src vector and
       // pre-filter
       tmp_vector->reinit(src, true);
@@ -1003,10 +1002,10 @@ FilteredMatrix<VECTOR>::Tvmult_add (VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 std::size_t
-FilteredMatrix<VECTOR>::memory_consumption () const
+FilteredMatrix<VectorType>::memory_consumption () const
 {
   return (MemoryConsumption::memory_consumption (matrix) +
           MemoryConsumption::memory_consumption (constraints));

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -341,9 +341,9 @@ public:
    * @arg @p expect_constrained_source: See documentation of
    * #expect_constrained_source.
    */
-  template <class MATRIX>
-  FilteredMatrix (const MATRIX &matrix,
-                  bool expect_constrained_source = false);
+  template <typename MatrixType>
+  FilteredMatrix (const MatrixType &matrix,
+                  bool              expect_constrained_source = false);
 
   /**
    * Copy operator. Take over matrix and constraints from the other object.
@@ -359,9 +359,9 @@ public:
    * @arg @p expect_constrained_source: See documentation of
    * #expect_constrained_source.
    */
-  template <class MATRIX>
-  void initialize (const MATRIX &m,
-                   bool expect_constrained_source = false);
+  template <typename MatrixType>
+  void initialize (const MatrixType &m,
+                   bool              expect_constrained_source = false);
 
   /**
    * Delete all constraints and the matrix pointer.
@@ -700,10 +700,10 @@ operator () (const IndexValuePair &i1,
 
 
 template <typename VectorType>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 void
-FilteredMatrix<VectorType>::initialize (const MATRIX &m, bool ecs)
+FilteredMatrix<VectorType>::initialize (const MatrixType &m, bool ecs)
 {
   matrix.reset (new_pointer_matrix_base(m, VectorType()));
 
@@ -732,10 +732,10 @@ FilteredMatrix<VectorType>::FilteredMatrix (const FilteredMatrix &fm)
 
 
 template <typename VectorType>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 FilteredMatrix<VectorType>::
-FilteredMatrix (const MATRIX &m, bool ecs)
+FilteredMatrix (const MatrixType &m, bool ecs)
 {
   initialize (m, ecs);
 }

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -566,8 +566,8 @@ public:
    * stream before setting these given values for output, and restores the
    * previous values after output.
    */
-  template <class STREAM>
-  void print (STREAM             &s,
+  template <class StreamType>
+  void print (StreamType         &s,
               const unsigned int  width=5,
               const unsigned int  precision=2) const;
 
@@ -1529,10 +1529,10 @@ FullMatrix<number>::add (const size_type    row,
 
 
 template <typename number>
-template <class STREAM>
+template <class StreamType>
 inline
 void
-FullMatrix<number>::print (STREAM             &s,
+FullMatrix<number>::print (StreamType         &s,
                            const unsigned int  w,
                            const unsigned int  p) const
 {

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -312,19 +312,19 @@ public:
 
   /**
    * Assignment from different matrix classes. This assignment operator uses
-   * iterators of the class MATRIX. Therefore, sparse matrices are possible
+   * iterators of the typename MatrixType. Therefore, sparse matrices are possible
    * sources.
    */
-  template <class MATRIX>
-  void copy_from (const MATRIX &);
+  template <typename MatrixType>
+  void copy_from (const MatrixType &);
 
   /**
    * Transposing assignment from different matrix classes. This assignment
-   * operator uses iterators of the class MATRIX. Therefore, sparse matrices
+   * operator uses iterators of the typename MatrixType. Therefore, sparse matrices
    * are possible sources.
    */
-  template <class MATRIX>
-  void copy_transposed (const MATRIX &);
+  template <typename MatrixType>
+  void copy_transposed (const MatrixType &);
 
   /**
    * Fill matrix with elements extracted from a tensor, taking rows included
@@ -373,7 +373,7 @@ public:
    * this operation.
    */
   template <typename MatrixType, typename index_type>
-  void extract_submatrix_from (const MatrixType &matrix,
+  void extract_submatrix_from (const MatrixType              &matrix,
                                const std::vector<index_type> &row_index_set,
                                const std::vector<index_type> &column_index_set);
 
@@ -393,7 +393,7 @@ public:
   void
   scatter_matrix_to (const std::vector<index_type> &row_index_set,
                      const std::vector<index_type> &column_index_set,
-                     MatrixType &matrix) const;
+                     MatrixType                    &matrix) const;
 
   /**
    * Fill rectangular block.
@@ -1206,9 +1206,9 @@ void FullMatrix<number>::fill (const number2 *src)
 
 
 template <typename number>
-template <class MATRIX>
+template <typename MatrixType>
 void
-FullMatrix<number>::copy_from (const MATRIX &M)
+FullMatrix<number>::copy_from (const MatrixType &M)
 {
   this->reinit (M.m(), M.n());
 
@@ -1217,8 +1217,8 @@ FullMatrix<number>::copy_from (const MATRIX &M)
   // copy them into the current object
   for (size_type row = 0; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         this->el(row, entry->column()) = entry->value();
     }
@@ -1227,9 +1227,9 @@ FullMatrix<number>::copy_from (const MATRIX &M)
 
 
 template <typename number>
-template <class MATRIX>
+template <typename MatrixType>
 void
-FullMatrix<number>::copy_transposed (const MATRIX &M)
+FullMatrix<number>::copy_transposed (const MatrixType &M)
 {
   this->reinit (M.n(), M.m());
 
@@ -1238,8 +1238,8 @@ FullMatrix<number>::copy_transposed (const MATRIX &M)
   // copy them into the current object
   for (size_type row = 0; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         this->el(entry->column(), row) = entry->value();
     }
@@ -1251,7 +1251,7 @@ template <typename number>
 template <typename MatrixType, typename index_type>
 inline
 void
-FullMatrix<number>::extract_submatrix_from (const MatrixType &matrix,
+FullMatrix<number>::extract_submatrix_from (const MatrixType              &matrix,
                                             const std::vector<index_type> &row_index_set,
                                             const std::vector<index_type> &column_index_set)
 {
@@ -1274,7 +1274,7 @@ inline
 void
 FullMatrix<number>::scatter_matrix_to (const std::vector<index_type> &row_index_set,
                                        const std::vector<index_type> &column_index_set,
-                                       MatrixType &matrix) const
+                                       MatrixType                    &matrix) const
 {
   AssertDimension(row_index_set.size(), this->n_rows());
   AssertDimension(column_index_set.size(), this->n_cols());

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -101,7 +101,8 @@ public:
                         const BlockVector<number2> &src) const;
 
   /**
-   * A wrapper to least_squares(), implementing the standard MATRIX interface.
+   * A wrapper to least_squares(), implementing the standard MatrixType
+   * interface.
    */
   template<class VectorType>
   void vmult (VectorType &dst, const VectorType &src) const;

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -103,11 +103,11 @@ public:
   /**
    * A wrapper to least_squares(), implementing the standard MATRIX interface.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &dst, const VECTOR &src) const;
+  template<class VectorType>
+  void vmult (VectorType &dst, const VectorType &src) const;
 
-  template<class VECTOR>
-  void Tvmult (VECTOR &dst, const VECTOR &src) const;
+  template<class VectorType>
+  void Tvmult (VectorType &dst, const VectorType &src) const;
 
 
 private:
@@ -295,18 +295,18 @@ Householder<number>::least_squares (BlockVector<number2> &dst,
 
 
 template <typename number>
-template <class VECTOR>
+template <class VectorType>
 void
-Householder<number>::vmult (VECTOR &dst, const VECTOR &src) const
+Householder<number>::vmult (VectorType &dst, const VectorType &src) const
 {
   least_squares (dst, src);
 }
 
 
 template <typename number>
-template <class VECTOR>
+template <class VectorType>
 void
-Householder<number>::Tvmult (VECTOR &, const VECTOR &) const
+Householder<number>::Tvmult (VectorType &, const VectorType &) const
 {
   Assert(false, ExcNotImplemented());
 }
@@ -318,4 +318,3 @@ Householder<number>::Tvmult (VECTOR &, const VECTOR &) const
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-

--- a/include/deal.II/lac/identity_matrix.h
+++ b/include/deal.II/lac/identity_matrix.h
@@ -107,27 +107,27 @@ public:
    * Matrix-vector multiplication. For the present case, this of course
    * amounts to simply copying the input vector to the output vector.
    */
-  template <class VECTOR1, class VECTOR2>
-  void vmult (VECTOR1       &out,
-              const VECTOR2 &in) const;
+  template <typename OutVectorType, typename InVectorType>
+  void vmult (OutVectorType      &out,
+              const InVectorType &in) const;
 
   /**
    * Matrix-vector multiplication with addition to the output vector. For the
    * present case, this of course amounts to simply adding the input vector to
    * the output vector.
    */
-  template <class VECTOR1, class VECTOR2>
-  void vmult_add (VECTOR1       &out,
-                  const VECTOR2 &in) const;
+  template <typename OutVectorType, typename InVectorType>
+  void vmult_add (OutVectorType      &out,
+                  const InVectorType &in) const;
 
   /**
    * Matrix-vector multiplication with the transpose matrix. For the present
    * case, this of course amounts to simply copying the input vector to the
    * output vector.
    */
-  template <class VECTOR1, class VECTOR2>
-  void Tvmult (VECTOR1       &out,
-               const VECTOR2 &in) const;
+  template <typename OutVectorType, typename InVectorType>
+  void Tvmult (OutVectorType      &out,
+               const InVectorType &in) const;
 
 
   /**
@@ -135,9 +135,9 @@ public:
    * the output vector. For the present case, this of course amounts to simply
    * adding the input vector to the output vector.
    */
-  template <class VECTOR1, class VECTOR2>
-  void Tvmult_add (VECTOR1       &out,
-                   const VECTOR2 &in) const;
+  template <typename OutVectorType, typename InVectorType>
+  void Tvmult_add (OutVectorType      &out,
+                   const InVectorType &in) const;
 private:
 
   /**
@@ -196,11 +196,11 @@ IdentityMatrix::n () const
 
 
 
-template <class VECTOR1, class VECTOR2>
+template <typename OutVectorType, typename InVectorType>
 inline
 void
-IdentityMatrix::vmult (VECTOR1       &out,
-                       const VECTOR2 &in) const
+IdentityMatrix::vmult (OutVectorType      &out,
+                       const InVectorType &in) const
 {
   Assert (out.size() == size, ExcDimensionMismatch (out.size(), size));
   Assert (in.size() == size, ExcDimensionMismatch (in.size(), size));
@@ -210,11 +210,11 @@ IdentityMatrix::vmult (VECTOR1       &out,
 
 
 
-template <class VECTOR1, class VECTOR2>
+template <typename OutVectorType, typename InVectorType>
 inline
 void
-IdentityMatrix::vmult_add (VECTOR1       &out,
-                           const VECTOR2 &in) const
+IdentityMatrix::vmult_add (OutVectorType      &out,
+                           const InVectorType &in) const
 {
   Assert (out.size() == size, ExcDimensionMismatch (out.size(), size));
   Assert (in.size() == size, ExcDimensionMismatch (in.size(), size));
@@ -224,11 +224,11 @@ IdentityMatrix::vmult_add (VECTOR1       &out,
 
 
 
-template <class VECTOR1, class VECTOR2>
+template <typename OutVectorType, typename InVectorType>
 inline
 void
-IdentityMatrix::Tvmult (VECTOR1       &out,
-                        const VECTOR2 &in) const
+IdentityMatrix::Tvmult (OutVectorType      &out,
+                        const InVectorType &in) const
 {
   Assert (out.size() == size, ExcDimensionMismatch (out.size(), size));
   Assert (in.size() == size, ExcDimensionMismatch (in.size(), size));
@@ -238,11 +238,11 @@ IdentityMatrix::Tvmult (VECTOR1       &out,
 
 
 
-template <class VECTOR1, class VECTOR2>
+template <typename OutVectorType, typename InVectorType>
 inline
 void
-IdentityMatrix::Tvmult_add (VECTOR1       &out,
-                            const VECTOR2 &in) const
+IdentityMatrix::Tvmult_add (OutVectorType      &out,
+                            const InVectorType &in) const
 {
   Assert (out.size() == size, ExcDimensionMismatch (out.size(), size));
   Assert (in.size() == size, ExcDimensionMismatch (in.size(), size));
@@ -258,4 +258,3 @@ IdentityMatrix::Tvmult_add (VECTOR1       &out,
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -75,7 +75,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat
  * @date 2010
  */
-template <class VECTOR>
+template <typename VectorType>
 class IterativeInverse : public Subscriptor
 {
 public:
@@ -94,7 +94,7 @@ public:
   /**
    * Solve for right hand side <tt>src</tt>.
    */
-  void vmult (VECTOR &dst, const VECTOR &src) const;
+  void vmult (VectorType &dst, const VectorType &src) const;
 
   /**
    * Solve for right hand side <tt>src</tt>, but allow for the fact that the
@@ -108,47 +108,47 @@ public:
    * The solver, which allows selection of the actual solver as well as
    * adjustment of parameters.
    */
-  SolverSelector<VECTOR> solver;
+  SolverSelector<VectorType> solver;
 
 private:
   /**
    * The matrix in use.
    */
-  std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > matrix;
+  std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > matrix;
 
   /**
    * The preconditioner to use.
    */
-  std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > preconditioner;
+  std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > preconditioner;
 };
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX, class PRECONDITION>
 inline
 void
-IterativeInverse<VECTOR>::initialize(const MATRIX &m, const PRECONDITION &p)
+IterativeInverse<VectorType>::initialize(const MATRIX &m, const PRECONDITION &p)
 {
   // dummy variable
-  VECTOR *v = 0;
-  matrix = std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > (new_pointer_matrix_base(m, *v));
-  preconditioner = std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > (new_pointer_matrix_base(p, *v));
+  VectorType *v = 0;
+  matrix = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(m, *v));
+  preconditioner = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(p, *v));
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 void
-IterativeInverse<VECTOR>::clear()
+IterativeInverse<VectorType>::clear()
 {
   matrix = 0;
   preconditioner = 0;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-IterativeInverse<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
+IterativeInverse<VectorType>::vmult (VectorType &dst, const VectorType &src) const
 {
   Assert(matrix.get() != 0, ExcNotInitialized());
   Assert(preconditioner.get() != 0, ExcNotInitialized());
@@ -157,16 +157,16 @@ IterativeInverse<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class VECTOR2>
 inline void
-IterativeInverse<VECTOR>::vmult (VECTOR2 &dst, const VECTOR2 &src) const
+IterativeInverse<VectorType>::vmult (VECTOR2 &dst, const VECTOR2 &src) const
 {
   Assert(matrix.get() != 0, ExcNotInitialized());
   Assert(preconditioner.get() != 0, ExcNotInitialized());
-  GrowingVectorMemory<VECTOR> mem;
-  typename VectorMemory<VECTOR>::Pointer sol(mem);
-  typename VectorMemory<VECTOR>::Pointer rhs(mem);
+  GrowingVectorMemory<VectorType> mem;
+  typename VectorMemory<VectorType>::Pointer sol(mem);
+  typename VectorMemory<VectorType>::Pointer rhs(mem);
   sol->reinit(dst);
   *rhs = src;
   solver.solve(*matrix, *sol, *rhs, *preconditioner);
@@ -178,5 +178,3 @@ IterativeInverse<VECTOR>::vmult (VECTOR2 &dst, const VECTOR2 &src) const
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-
-

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -83,8 +83,8 @@ public:
    * Initialization function. Provide a matrix and preconditioner for the
    * solve in vmult().
    */
-  template <typename MatrixType, class PRECONDITION>
-  void initialize (const MatrixType &, const PRECONDITION &);
+  template <typename MatrixType, typename PreconditionerType>
+  void initialize (const MatrixType &, const PreconditionerType &);
 
   /**
    * Delete the pointers to matrix and preconditioner.
@@ -124,10 +124,10 @@ private:
 
 
 template <typename VectorType>
-template <typename MatrixType, class PRECONDITION>
+template <typename MatrixType, typename PreconditionerType>
 inline
 void
-IterativeInverse<VectorType>::initialize(const MatrixType &m, const PRECONDITION &p)
+IterativeInverse<VectorType>::initialize(const MatrixType &m, const PreconditionerType &p)
 {
   // dummy variable
   VectorType *v = 0;

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -101,8 +101,8 @@ public:
    * vectors given to this function have different type from the vectors used
    * by the inner solver.
    */
-  template <class VECTOR2>
-  void vmult (VECTOR2 &dst, const VECTOR2 &src) const;
+  template <class OtherVectorType>
+  void vmult (OtherVectorType &dst, const OtherVectorType &src) const;
 
   /**
    * The solver, which allows selection of the actual solver as well as
@@ -158,9 +158,9 @@ IterativeInverse<VectorType>::vmult (VectorType &dst, const VectorType &src) con
 
 
 template <typename VectorType>
-template <class VECTOR2>
+template <class OtherVectorType>
 inline void
-IterativeInverse<VectorType>::vmult (VECTOR2 &dst, const VECTOR2 &src) const
+IterativeInverse<VectorType>::vmult (OtherVectorType &dst, const OtherVectorType &src) const
 {
   Assert(matrix.get() != 0, ExcNotInitialized());
   Assert(preconditioner.get() != 0, ExcNotInitialized());

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -83,8 +83,8 @@ public:
    * Initialization function. Provide a matrix and preconditioner for the
    * solve in vmult().
    */
-  template <class MATRIX, class PRECONDITION>
-  void initialize (const MATRIX &, const PRECONDITION &);
+  template <typename MatrixType, class PRECONDITION>
+  void initialize (const MatrixType &, const PRECONDITION &);
 
   /**
    * Delete the pointers to matrix and preconditioner.
@@ -124,10 +124,10 @@ private:
 
 
 template <typename VectorType>
-template <class MATRIX, class PRECONDITION>
+template <typename MatrixType, class PRECONDITION>
 inline
 void
-IterativeInverse<VectorType>::initialize(const MATRIX &m, const PRECONDITION &p)
+IterativeInverse<VectorType>::initialize(const MatrixType &m, const PRECONDITION &p)
 {
   // dummy variable
   VectorType *v = 0;

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -124,11 +124,11 @@ public:
   /**
    * Assignment from different matrix classes, performing the usual conversion
    * to the transposed format expected by LAPACK. This assignment operator
-   * uses iterators of the class MATRIX. Therefore, sparse matrices are
+   * uses iterators of the typename MatrixType. Therefore, sparse matrices are
    * possible sources.
    */
-  template <class MATRIX>
-  void copy_from (const MATRIX &);
+  template <typename MatrixType>
+  void copy_from (const MatrixType &);
 
   /**
    * Regenerate the current matrix by one that has the same properties as if
@@ -172,8 +172,8 @@ public:
    * The final two arguments allow to enter a multiple of the source or its
    * transpose.
    */
-  template<class MATRIX>
-  void fill (const MATRIX &src,
+  template<typename MatrixType>
+  void fill (const MatrixType &src,
              const size_type dst_offset_i = 0,
              const size_type dst_offset_j = 0,
              const size_type src_offset_i = 0,
@@ -702,9 +702,9 @@ LAPACKFullMatrix<number>::n () const
 }
 
 template <typename number>
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-LAPACKFullMatrix<number>::copy_from (const MATRIX &M)
+LAPACKFullMatrix<number>::copy_from (const MatrixType &M)
 {
   this->reinit (M.m(), M.n());
 
@@ -713,8 +713,8 @@ LAPACKFullMatrix<number>::copy_from (const MATRIX &M)
   // copy them into the current object
   for (size_type row = 0; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         this->el(row, entry->column()) = entry->value();
     }
@@ -725,23 +725,22 @@ LAPACKFullMatrix<number>::copy_from (const MATRIX &M)
 
 
 template <typename number>
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-LAPACKFullMatrix<number>::fill (
-  const MATRIX &M,
-  const size_type dst_offset_i,
-  const size_type dst_offset_j,
-  const size_type src_offset_i,
-  const size_type src_offset_j,
-  const number factor,
-  const bool transpose)
+LAPACKFullMatrix<number>::fill (const MatrixType &M,
+                                const size_type   dst_offset_i,
+                                const size_type   dst_offset_j,
+                                const size_type   src_offset_i,
+                                const size_type   src_offset_j,
+                                const number      factor,
+                                const bool        transpose)
 {
   // loop over the elements of the argument matrix row by row, as suggested
   // in the documentation of the sparse matrix iterator class
   for (size_type row = src_offset_i; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         {
           const size_type i = transpose ? entry->column() : row;

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -1027,12 +1027,12 @@ namespace
  *   // with appropriate size and internal layout
  *
  *   // Application of matrix to vector src, writes the result into dst.
- *   vmult(VECTOR &dst, const VECTOR &src);
+ *   vmult(Range &dst, const Domain &src);
  *
  *   // Application of the transpose of matrix to vector src, writes the
  *   // result into dst. (Depending on the usage of the linear operator
  *   // class this can be a dummy implementation throwing an error.)
- *   Tvmult(VECTOR &dst, const VECTOR &src);
+ *   Tvmult(Range &dst, const Domain &src);
  * };
  * @endcode
  *
@@ -1043,11 +1043,11 @@ namespace
  * {
  * public:
  *   // Application of matrix to vector src, adds the result to dst.
- *   vmult_add(VECTOR &dst, const VECTOR &src);
+ *   vmult_add(Range &dst, const Domain &src);
  *
  *   // Application of the transpose of matrix to vector src, adds the
  *   // result to dst.
- *   Tvmult_add(VECTOR &dst, const VECTOR &src);
+ *   Tvmult_add(Range &dst, const Domain &src);
  * };
  * @endcode
  *

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -235,32 +235,32 @@ public:
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &w, const VECTOR &v) const;
+  template<class VectorType>
+  void vmult (VectorType &w, const VectorType &v) const;
 
   /**
    * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
-  template<class VECTOR>
-  void vmult_add (VECTOR &w, const VECTOR &v) const;
+  template<class VectorType>
+  void vmult_add (VectorType &w, const VectorType &v) const;
 
   /**
    * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &w, const VECTOR &v) const;
+  template<class VectorType>
+  void Tvmult (VectorType &w, const VectorType &v) const;
 
   /**
    * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
-  template<class VECTOR>
-  void Tvmult_add (VECTOR &w, const VECTOR &v) const;
+  template<class VectorType>
+  void Tvmult_add (VectorType &w, const VectorType &v) const;
 
   /**
    * The memory used by this object.
@@ -767,40 +767,40 @@ MatrixBlock<MATRIX>::add (const size_type               row,
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::vmult (VECTOR &w, const VECTOR &v) const
+MatrixBlock<MATRIX>::vmult (VectorType &w, const VectorType &v) const
 {
   matrix.vmult(w,v);
 }
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::vmult_add (VECTOR &w, const VECTOR &v) const
+MatrixBlock<MATRIX>::vmult_add (VectorType &w, const VectorType &v) const
 {
   matrix.vmult_add(w,v);
 }
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::Tvmult (VECTOR &w, const VECTOR &v) const
+MatrixBlock<MATRIX>::Tvmult (VectorType &w, const VectorType &v) const
 {
   matrix.Tvmult(w,v);
 }
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::Tvmult_add (VECTOR &w, const VECTOR &v) const
+MatrixBlock<MATRIX>::Tvmult_add (VectorType &w, const VectorType &v) const
 {
   matrix.Tvmult_add(w,v);
 }

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -30,13 +30,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <class MATRIX> class MatrixBlock;
+template <typename MatrixType> class MatrixBlock;
 
 namespace internal
 {
-  template <class MATRIX>
+  template <typename MatrixType>
   void
-  reinit(MatrixBlock<MATRIX> &v,
+  reinit(MatrixBlock<MatrixType> &v,
          const BlockSparsityPattern &p);
 
   template <typename number>
@@ -65,7 +65,7 @@ namespace internal
  *
  * While the add() functions make a MatrixBlock appear like a block matrix for
  * assembling, the functions vmult(), Tvmult(), vmult_add(), and Tvmult_add()
- * make it behave like a MATRIX, when it comes to applying it to a vector.
+ * make it behave like a MatrixType, when it comes to applying it to a vector.
  * This behavior allows us to store MatrixBlock objects in vectors, for
  * instance in MGLevelObject without extracting the #matrix first.
  *
@@ -100,7 +100,7 @@ namespace internal
  * @ref GlossBlockLA "Block (linear algebra)"
  * @author Guido Kanschat, 2006
  */
-template <class MATRIX>
+template <typename MatrixType>
 class MatrixBlock
   : public Subscriptor
 {
@@ -113,7 +113,7 @@ public:
   /**
    * Declare a type for matrix entries.
    */
-  typedef typename MATRIX::value_type value_type;
+  typedef typename MatrixType::value_type value_type;
 
   /**
    * Constructor rendering an uninitialized object.
@@ -123,7 +123,7 @@ public:
   /**
    * Copy constructor.
    */
-  MatrixBlock(const MatrixBlock<MATRIX> &M);
+  MatrixBlock(const MatrixBlock<MatrixType> &M);
 
   /**
    * Constructor setting block coordinates, but not initializing the matrix.
@@ -140,16 +140,16 @@ public:
    */
   void reinit(const BlockSparsityPattern &sparsity);
 
-  operator MATRIX &();
-  operator const MATRIX &() const;
+  operator MatrixType &();
+  operator const MatrixType &() const;
 
   /**
    * Add <tt>value</tt> to the element (<i>i,j</i>). Throws an error if the
    * entry does not exist or if it is in a different block.
    */
-  void add (const size_type i,
-            const size_type j,
-            const typename MATRIX::value_type value);
+  void add (const size_type                       i,
+            const size_type                       j,
+            const typename MatrixType::value_type value);
 
   /**
    * Add all elements in a FullMatrix into sparse matrix locations given by
@@ -231,7 +231,7 @@ public:
             const bool       col_indices_are_sorted = false);
 
   /**
-   * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
+   * Matrix-vector-multiplication, forwarding to the same function in MatrixType.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
@@ -239,7 +239,7 @@ public:
   void vmult (VectorType &w, const VectorType &v) const;
 
   /**
-   * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
+   * Matrix-vector-multiplication, forwarding to the same function in MatrixType.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
@@ -247,7 +247,7 @@ public:
   void vmult_add (VectorType &w, const VectorType &v) const;
 
   /**
-   * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
+   * Matrix-vector-multiplication, forwarding to the same function in MatrixType.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
@@ -255,7 +255,7 @@ public:
   void Tvmult (VectorType &w, const VectorType &v) const;
 
   /**
-   * Matrix-vector-multiplication, forwarding to the same function in MATRIX.
+   * Matrix-vector-multiplication, forwarding to the same function in MatrixType.
    * No index computations are done, thus, the vectors need to have sizes
    * matching #matrix.
    */
@@ -288,7 +288,7 @@ public:
   /**
    * The matrix itself
    */
-  MATRIX matrix;
+  MatrixType matrix;
 
 private:
   /**
@@ -303,9 +303,9 @@ private:
    */
   BlockIndices column_indices;
 
-  template <class OTHER_MATRIX>
+  template <class OTHER_MatrixType>
   friend
-  void dealii::internal::reinit(MatrixBlock<OTHER_MATRIX> &,
+  void dealii::internal::reinit(MatrixBlock<OTHER_MatrixType> &,
                                 const BlockSparsityPattern &);
 
   template <typename number>
@@ -324,7 +324,7 @@ private:
  * @ingroup vector_valued
  * @author Baerbel Janssen, Guido Kanschat, 2010
  */
-template <class MATRIX>
+template <typename MatrixType>
 class MatrixBlockVector
   :
   private AnyData
@@ -338,7 +338,7 @@ public:
   /**
    * The type of object stored.
    */
-  typedef MatrixBlock<MATRIX> value_type;
+  typedef MatrixBlock<MatrixType> value_type;
 
   /**
    * The pointer type used for storing the objects. We use a shard pointer,
@@ -388,7 +388,7 @@ public:
   /**
    * Access the matrix at position <i>i</i> for read and write access.
    */
-  MATRIX &matrix(size_type i);
+  MatrixType &matrix(size_type i);
 
   /**
    * import functions from private base class
@@ -409,7 +409,7 @@ public:
  * @ingroup vector_valued
  * @author Baerbel Janssen, Guido Kanschat, 2010
  */
-template <class MATRIX>
+template <typename MatrixType>
 class MGMatrixBlockVector
   : public Subscriptor
 {
@@ -422,7 +422,7 @@ public:
   /**
    * The type of object stored.
    */
-  typedef MGLevelObject<MatrixBlock<MATRIX> > value_type;
+  typedef MGLevelObject<MatrixBlock<MatrixType> > value_type;
   /**
    * Constructor, determining which matrices should be stored.
    *
@@ -567,9 +567,9 @@ private:
 
 namespace internal
 {
-  template <class MATRIX>
+  template <typename MatrixType>
   void
-  reinit(MatrixBlock<MATRIX> &v,
+  reinit(MatrixBlock<MatrixType> &v,
          const BlockSparsityPattern &p)
   {
     v.row_indices = p.get_row_indices();
@@ -589,18 +589,18 @@ namespace internal
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MatrixBlock<MATRIX>::MatrixBlock()
+MatrixBlock<MatrixType>::MatrixBlock ()
   :
   row(numbers::invalid_size_type),
   column(numbers::invalid_size_type)
 {}
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MatrixBlock<MATRIX>::MatrixBlock(const MatrixBlock<MATRIX> &M)
+MatrixBlock<MatrixType>::MatrixBlock (const MatrixBlock<MatrixType> &M)
   :
   Subscriptor(),
   row(M.row),
@@ -611,45 +611,44 @@ MatrixBlock<MATRIX>::MatrixBlock(const MatrixBlock<MATRIX> &M)
 {}
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MatrixBlock<MATRIX>::MatrixBlock(size_type i, size_type j)
+MatrixBlock<MatrixType>::MatrixBlock (size_type i, size_type j)
   :
   row(i), column(j)
 {}
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
 void
-MatrixBlock<MATRIX>::reinit(const BlockSparsityPattern &sparsity)
+MatrixBlock<MatrixType>::reinit (const BlockSparsityPattern &sparsity)
 {
   internal::reinit(*this, sparsity);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MatrixBlock<MATRIX>::operator MATRIX &()
+MatrixBlock<MatrixType>::operator MatrixType &()
 {
   return matrix;
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MatrixBlock<MATRIX>::operator const MATRIX &() const
+MatrixBlock<MatrixType>::operator const MatrixType &() const
 {
   return matrix;
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MatrixBlock<MATRIX>::add (
-  const size_type gi,
-  const size_type gj,
-  const typename MATRIX::value_type value)
+MatrixBlock<MatrixType>::add (const size_type gi,
+                              const size_type gj,
+                              const typename MatrixType::value_type value)
 {
   Assert(row_indices.size() != 0, ExcNotInitialized());
   Assert(column_indices.size() != 0, ExcNotInitialized());
@@ -666,14 +665,14 @@ MatrixBlock<MATRIX>::add (
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number>
 inline
 void
-MatrixBlock<MATRIX>::add (const std::vector<size_type> &r_indices,
-                          const std::vector<size_type> &c_indices,
-                          const FullMatrix<number>     &values,
-                          const bool                    elide_zero_values)
+MatrixBlock<MatrixType>::add (const std::vector<size_type> &r_indices,
+                              const std::vector<size_type> &c_indices,
+                              const FullMatrix<number>     &values,
+                              const bool                    elide_zero_values)
 {
   Assert(row_indices.size() != 0, ExcNotInitialized());
   Assert(column_indices.size() != 0, ExcNotInitialized());
@@ -687,16 +686,16 @@ MatrixBlock<MATRIX>::add (const std::vector<size_type> &r_indices,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number>
 inline
 void
-MatrixBlock<MATRIX>::add (const size_type  b_row,
-                          const size_type  n_cols,
-                          const size_type *col_indices,
-                          const number    *values,
-                          const bool,
-                          const bool)
+MatrixBlock<MatrixType>::add (const size_type  b_row,
+                              const size_type  n_cols,
+                              const size_type *col_indices,
+                              const number    *values,
+                              const bool,
+                              const bool)
 {
   Assert(row_indices.size() != 0, ExcNotInitialized());
   Assert(column_indices.size() != 0, ExcNotInitialized());
@@ -727,13 +726,13 @@ MatrixBlock<MATRIX>::add (const size_type  b_row,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number>
 inline
 void
-MatrixBlock<MATRIX>::add (const std::vector<size_type> &indices,
-                          const FullMatrix<number>     &values,
-                          const bool                    elide_zero_values)
+MatrixBlock<MatrixType>::add (const std::vector<size_type> &indices,
+                              const FullMatrix<number>     &values,
+                              const bool                    elide_zero_values)
 {
   Assert(row_indices.size() != 0, ExcNotInitialized());
   Assert(column_indices.size() != 0, ExcNotInitialized());
@@ -748,14 +747,14 @@ MatrixBlock<MATRIX>::add (const std::vector<size_type> &indices,
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename number>
 inline
 void
-MatrixBlock<MATRIX>::add (const size_type               row,
-                          const std::vector<size_type> &col_indices,
-                          const std::vector<number>    &values,
-                          const bool                    elide_zero_values)
+MatrixBlock<MatrixType>::add (const size_type               row,
+                              const std::vector<size_type> &col_indices,
+                              const std::vector<number>    &values,
+                              const bool                    elide_zero_values)
 {
   Assert(row_indices.size() != 0, ExcNotInitialized());
   Assert(column_indices.size() != 0, ExcNotInitialized());
@@ -766,50 +765,50 @@ MatrixBlock<MATRIX>::add (const size_type               row,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::vmult (VectorType &w, const VectorType &v) const
+MatrixBlock<MatrixType>::vmult (VectorType &w, const VectorType &v) const
 {
   matrix.vmult(w,v);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::vmult_add (VectorType &w, const VectorType &v) const
+MatrixBlock<MatrixType>::vmult_add (VectorType &w, const VectorType &v) const
 {
   matrix.vmult_add(w,v);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::Tvmult (VectorType &w, const VectorType &v) const
+MatrixBlock<MatrixType>::Tvmult (VectorType &w, const VectorType &v) const
 {
   matrix.Tvmult(w,v);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline
 void
-MatrixBlock<MATRIX>::Tvmult_add (VectorType &w, const VectorType &v) const
+MatrixBlock<MatrixType>::Tvmult_add (VectorType &w, const VectorType &v) const
 {
   matrix.Tvmult_add(w,v);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
 std::size_t
-MatrixBlock<MATRIX>::memory_consumption () const
+MatrixBlock<MatrixType>::memory_consumption () const
 {
   return (sizeof(*this)
           + MemoryConsumption::memory_consumption(matrix)
@@ -818,20 +817,20 @@ MatrixBlock<MATRIX>::memory_consumption () const
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MatrixBlockVector<MATRIX>::add(
-  size_type row, size_type column,
-  const std::string &name)
+MatrixBlockVector<MatrixType>::add(size_type          row,
+                                   size_type          column,
+                                   const std::string &name)
 {
   ptr_type p(new value_type(row, column));
   AnyData::add(p, name);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MatrixBlockVector<MATRIX>::reinit(const BlockSparsityPattern &sparsity)
+MatrixBlockVector<MatrixType>::reinit (const BlockSparsityPattern &sparsity)
 {
   for (size_type i=0; i<this->size(); ++i)
     {
@@ -840,9 +839,9 @@ MatrixBlockVector<MATRIX>::reinit(const BlockSparsityPattern &sparsity)
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MatrixBlockVector<MATRIX>::clear(bool really_clean)
+MatrixBlockVector<MatrixType>::clear (bool really_clean)
 {
   if (really_clean)
     {
@@ -857,25 +856,25 @@ MatrixBlockVector<MATRIX>::clear(bool really_clean)
 
 
 
-template <class MATRIX>
-inline const MatrixBlock<MATRIX> &
-MatrixBlockVector<MATRIX>::block(size_type i) const
+template <typename MatrixType>
+inline const MatrixBlock<MatrixType> &
+MatrixBlockVector<MatrixType>::block (size_type i) const
 {
   return *this->read<ptr_type>(i);
 }
 
 
-template <class MATRIX>
-inline MatrixBlock<MATRIX> &
-MatrixBlockVector<MATRIX>::block(size_type i)
+template <typename MatrixType>
+inline MatrixBlock<MatrixType> &
+MatrixBlockVector<MatrixType>::block (size_type i)
 {
   return *this->entry<ptr_type>(i);
 }
 
 
-template <class MATRIX>
-inline MATRIX &
-MatrixBlockVector<MATRIX>::matrix(size_type i)
+template <typename MatrixType>
+inline MatrixType &
+MatrixBlockVector<MatrixType>::matrix (size_type i)
 {
   return this->entry<ptr_type>(i)->matrix;
 }
@@ -884,32 +883,31 @@ MatrixBlockVector<MATRIX>::matrix(size_type i)
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-MGMatrixBlockVector<MATRIX>::MGMatrixBlockVector(
-  const bool e, const bool f)
+MGMatrixBlockVector<MatrixType>::MGMatrixBlockVector(const bool e, const bool f)
   :
   edge_matrices(e),
   edge_flux_matrices(f)
 {}
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
 unsigned int
-MGMatrixBlockVector<MATRIX>::size () const
+MGMatrixBlockVector<MatrixType>::size () const
 {
   return matrices.size();
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::add(
+MGMatrixBlockVector<MatrixType>::add(
   size_type row, size_type column,
   const std::string &name)
 {
-  MGLevelObject<MatrixBlock<MATRIX> > p(0, 1);
+  MGLevelObject<MatrixBlock<MatrixType> > p(0, 1);
   p[0].row = row;
   p[0].column = column;
 
@@ -927,93 +925,93 @@ MGMatrixBlockVector<MATRIX>::add(
 }
 
 
-template <class MATRIX>
-inline const MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block(size_type i) const
+template <typename MatrixType>
+inline const MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block(size_type i) const
 {
-  return *matrices.read<const MGLevelObject<MATRIX>* >(i);
+  return *matrices.read<const MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block(size_type i)
+template <typename MatrixType>
+inline MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block(size_type i)
 {
-  return *matrices.entry<MGLevelObject<MATRIX>* >(i);
+  return *matrices.entry<MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline const MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_in(size_type i) const
+template <typename MatrixType>
+inline const MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_in(size_type i) const
 {
-  return *matrices_in.read<const MGLevelObject<MATRIX>* >(i);
+  return *matrices_in.read<const MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_in(size_type i)
+template <typename MatrixType>
+inline MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_in(size_type i)
 {
-  return *matrices_in.entry<MGLevelObject<MATRIX>* >(i);
+  return *matrices_in.entry<MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline const MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_out(size_type i) const
+template <typename MatrixType>
+inline const MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_out(size_type i) const
 {
-  return *matrices_out.read<const MGLevelObject<MATRIX>* >(i);
+  return *matrices_out.read<const MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_out(size_type i)
+template <typename MatrixType>
+inline MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_out(size_type i)
 {
-  return *matrices_out.entry<MGLevelObject<MATRIX>* >(i);
+  return *matrices_out.entry<MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline const MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_up(size_type i) const
+template <typename MatrixType>
+inline const MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_up(size_type i) const
 {
-  return *flux_matrices_up.read<const MGLevelObject<MATRIX>* >(i);
+  return *flux_matrices_up.read<const MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_up(size_type i)
+template <typename MatrixType>
+inline MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_up(size_type i)
 {
-  return *flux_matrices_up.entry<MGLevelObject<MATRIX>* >(i);
+  return *flux_matrices_up.entry<MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline const MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_down(size_type i) const
+template <typename MatrixType>
+inline const MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_down(size_type i) const
 {
-  return *flux_matrices_down.read<const MGLevelObject<MATRIX>* >(i);
+  return *flux_matrices_down.read<const MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
-inline MGLevelObject<MatrixBlock<MATRIX> > &
-MGMatrixBlockVector<MATRIX>::block_down(size_type i)
+template <typename MatrixType>
+inline MGLevelObject<MatrixBlock<MatrixType> > &
+MGMatrixBlockVector<MatrixType>::block_down(size_type i)
 {
-  return *flux_matrices_down.entry<MGLevelObject<MATRIX>* >(i);
+  return *flux_matrices_down.entry<MGLevelObject<MatrixType>* >(i);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::reinit_matrix(const MGLevelObject<BlockSparsityPattern> &sparsity)
+MGMatrixBlockVector<MatrixType>::reinit_matrix(const MGLevelObject<BlockSparsityPattern> &sparsity)
 {
   for (size_type i=0; i<this->size(); ++i)
     {
-      MGLevelObject<MatrixBlock<MATRIX> > &o = block(i);
+      MGLevelObject<MatrixBlock<MatrixType> > &o = block(i);
       const size_type row = o[o.min_level()].row;
       const size_type col = o[o.min_level()].column;
 
@@ -1028,13 +1026,13 @@ MGMatrixBlockVector<MATRIX>::reinit_matrix(const MGLevelObject<BlockSparsityPatt
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::reinit_edge(const MGLevelObject<BlockSparsityPattern> &sparsity)
+MGMatrixBlockVector<MatrixType>::reinit_edge(const MGLevelObject<BlockSparsityPattern> &sparsity)
 {
   for (size_type i=0; i<this->size(); ++i)
     {
-      MGLevelObject<MatrixBlock<MATRIX> > &o = block(i);
+      MGLevelObject<MatrixBlock<MatrixType> > &o = block(i);
       const size_type row = o[o.min_level()].row;
       const size_type col = o[o.min_level()].column;
 
@@ -1053,13 +1051,14 @@ MGMatrixBlockVector<MATRIX>::reinit_edge(const MGLevelObject<BlockSparsityPatter
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::reinit_edge_flux(const MGLevelObject<BlockSparsityPattern> &sparsity)
+MGMatrixBlockVector<MatrixType>::reinit_edge_flux
+(const MGLevelObject<BlockSparsityPattern> &sparsity)
 {
   for (size_type i=0; i<this->size(); ++i)
     {
-      MGLevelObject<MatrixBlock<MATRIX> > &o = block(i);
+      MGLevelObject<MatrixBlock<MatrixType> > &o = block(i);
       const size_type row = o[o.min_level()].row;
       const size_type col = o[o.min_level()].column;
 
@@ -1079,22 +1078,22 @@ MGMatrixBlockVector<MATRIX>::reinit_edge_flux(const MGLevelObject<BlockSparsityP
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::clear_object(AnyData &mo)
+MGMatrixBlockVector<MatrixType>::clear_object (AnyData &mo)
 {
   for (size_type i=0; i<mo.size(); ++i)
     {
-      MGLevelObject<MatrixBlock<MATRIX> > &o = mo.entry<MGLevelObject<MATRIX>* >(i);
+      MGLevelObject<MatrixBlock<MatrixType> > &o = mo.entry<MGLevelObject<MatrixType>* >(i);
       for (size_type level = o.min_level(); level <= o.max_level(); ++level)
         o[level].matrix.clear();
     }
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-MGMatrixBlockVector<MATRIX>::clear(bool really_clean)
+MGMatrixBlockVector<MatrixType>::clear (bool really_clean)
 {
   if (really_clean)
     {

--- a/include/deal.II/lac/matrix_lib.h
+++ b/include/deal.II/lac/matrix_lib.h
@@ -71,9 +71,9 @@ public:
    * Constructor.  Additionally to the two constituting matrices, a memory
    * pool for the auxiliary vector must be provided.
    */
-  template <class MATRIX1, class MATRIX2>
-  ProductMatrix (const MATRIX1            &m1,
-                 const MATRIX2            &m2,
+  template <typename MatrixType1, typename MatrixType2>
+  ProductMatrix (const MatrixType1        &m1,
+                 const MatrixType2        &m2,
                  VectorMemory<VectorType> &mem);
 
   /**
@@ -84,15 +84,16 @@ public:
   /**
    * Change the matrices.
    */
-  template <class MATRIX1, class MATRIX2>
-  void reinit(const MATRIX1 &m1, const MATRIX2 &m2);
+  template <typename MatrixType1, typename MatrixType2>
+  void reinit (const MatrixType1 &m1, const MatrixType2 &m2);
 
   /**
    * Change the matrices and memory pool.
    */
-  template <class MATRIX1, class MATRIX2>
-  void initialize(const MATRIX1 &m1, const MATRIX2 &m2,
-                  VectorMemory<VectorType> &mem);
+  template <typename MatrixType1, typename MatrixType2>
+  void initialize (const MatrixType1 &m1,
+                   const MatrixType2 &m2,
+                   VectorMemory<VectorType> &mem);
 
   // Doc in PointerMatrixBase
   void clear();
@@ -165,8 +166,8 @@ public:
   /**
    * Constructor with initialization.
    */
-  template <class MATRIX>
-  ScaledMatrix (const MATRIX &M, const double factor);
+  template <typename MatrixType>
+  ScaledMatrix (const MatrixType &M, const double factor);
 
   /**
    * Destructor
@@ -175,8 +176,8 @@ public:
   /**
    * Initialize for use with a new matrix and factor.
    */
-  template <class MATRIX>
-  void initialize (const MATRIX &M, const double factor);
+  template <typename MatrixType>
+  void initialize (const MatrixType &M, const double factor);
 
   /**
    * Reset the object to its original state.
@@ -448,8 +449,8 @@ public:
    * Initialization function. Provide a solver object, a matrix, and another
    * preconditioner for this.
    */
-  template <class MATRIX, class PRECONDITION>
-  void initialize (const MATRIX &,
+  template <typename MatrixType, class PRECONDITION>
+  void initialize (const MatrixType &,
                    const PRECONDITION &);
 
   /**
@@ -515,9 +516,9 @@ ScaledMatrix<VectorType>::ScaledMatrix()
 
 
 template<typename VectorType>
-template<class MATRIX>
+template<typename MatrixType>
 inline
-ScaledMatrix<VectorType>::ScaledMatrix(const MATRIX &mat, const double factor)
+ScaledMatrix<VectorType>::ScaledMatrix(const MatrixType &mat, const double factor)
   :
   m(new_pointer_matrix_base(mat, VectorType())),
   factor(factor)
@@ -526,10 +527,10 @@ ScaledMatrix<VectorType>::ScaledMatrix(const MATRIX &mat, const double factor)
 
 
 template<typename VectorType>
-template<class MATRIX>
+template<typename MatrixType>
 inline
 void
-ScaledMatrix<VectorType>::initialize(const MATRIX &mat, const double f)
+ScaledMatrix<VectorType>::initialize(const MatrixType &mat, const double f)
 {
   if (m) delete m;
   m = new_pointer_matrix_base(mat, VectorType());
@@ -592,41 +593,41 @@ ProductMatrix<VectorType>::ProductMatrix (VectorMemory<VectorType> &m)
 
 
 template<typename VectorType>
-template<class MATRIX1, class MATRIX2>
-ProductMatrix<VectorType>::ProductMatrix (const MATRIX1            &mat1,
-                                          const MATRIX2            &mat2,
+template<typename MatrixType1, typename MatrixType2>
+ProductMatrix<VectorType>::ProductMatrix (const MatrixType1        &mat1,
+                                          const MatrixType2        &mat2,
                                           VectorMemory<VectorType> &m)
   : mem(&m)
 {
-  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MatrixType1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MatrixType2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
 template<typename VectorType>
-template<class MATRIX1, class MATRIX2>
+template<typename MatrixType1, typename MatrixType2>
 void
-ProductMatrix<VectorType>::reinit (const MATRIX1 &mat1, const MATRIX2 &mat2)
+ProductMatrix<VectorType>::reinit (const MatrixType1 &mat1, const MatrixType2 &mat2)
 {
   if (m1) delete m1;
   if (m2) delete m2;
-  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MatrixType1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MatrixType2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
 template<typename VectorType>
-template<class MATRIX1, class MATRIX2>
+template<typename MatrixType1, typename MatrixType2>
 void
-ProductMatrix<VectorType>::initialize (const MATRIX1            &mat1,
-                                       const MATRIX2            &mat2,
+ProductMatrix<VectorType>::initialize (const MatrixType1        &mat1,
+                                       const MatrixType2        &mat2,
                                        VectorMemory<VectorType> &memory)
 {
   mem = &memory;
   if (m1) delete m1;
   if (m2) delete m2;
-  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MatrixType1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MatrixType2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
@@ -734,13 +735,13 @@ MeanValueFilter::Tvmult_add(VectorType &, const VectorType &) const
 //-----------------------------------------------------------------------//
 
 template <typename VectorType>
-template <class MATRIX, class PRECONDITION>
+template <typename MatrixType, class PRECONDITION>
 inline void
-InverseMatrixRichardson<VectorType>::initialize (const MATRIX &m, const PRECONDITION &p)
+InverseMatrixRichardson<VectorType>::initialize (const MatrixType &m, const PRECONDITION &p)
 {
   if (matrix != 0)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
+  matrix = new PointerMatrix<MatrixType, VectorType>(&m);
   if (precondition != 0)
     delete precondition;
   precondition = new PointerMatrix<PRECONDITION, VectorType>(&p);

--- a/include/deal.II/lac/matrix_lib.h
+++ b/include/deal.II/lac/matrix_lib.h
@@ -449,9 +449,9 @@ public:
    * Initialization function. Provide a solver object, a matrix, and another
    * preconditioner for this.
    */
-  template <typename MatrixType, class PRECONDITION>
+  template <typename MatrixType, typename PreconditionerType>
   void initialize (const MatrixType &,
-                   const PRECONDITION &);
+                   const PreconditionerType &);
 
   /**
    * Access to the SolverControl object used by the solver.
@@ -735,16 +735,17 @@ MeanValueFilter::Tvmult_add(VectorType &, const VectorType &) const
 //-----------------------------------------------------------------------//
 
 template <typename VectorType>
-template <typename MatrixType, class PRECONDITION>
+template <typename MatrixType, typename PreconditionerType>
 inline void
-InverseMatrixRichardson<VectorType>::initialize (const MatrixType &m, const PRECONDITION &p)
+InverseMatrixRichardson<VectorType>::initialize (const MatrixType &m,
+                                                 const PreconditionerType &p)
 {
   if (matrix != 0)
     delete matrix;
   matrix = new PointerMatrix<MatrixType, VectorType>(&m);
   if (precondition != 0)
     delete precondition;
-  precondition = new PointerMatrix<PRECONDITION, VectorType>(&p);
+  precondition = new PointerMatrix<PreconditionerType, VectorType>(&p);
 }
 
 

--- a/include/deal.II/lac/matrix_lib.h
+++ b/include/deal.II/lac/matrix_lib.h
@@ -51,8 +51,8 @@ template<typename number> class SparseMatrix;
  *
  * @author Guido Kanschat, 2000, 2001, 2002, 2005
  */
-template<class VECTOR>
-class ProductMatrix : public PointerMatrixBase<VECTOR>
+template<typename VectorType>
+class ProductMatrix : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -65,16 +65,16 @@ public:
    * Constructor only assigning the memory pool. Matrices must be added by
    * reinit() later.
    */
-  ProductMatrix(VectorMemory<VECTOR> &mem);
+  ProductMatrix(VectorMemory<VectorType> &mem);
 
   /**
    * Constructor.  Additionally to the two constituting matrices, a memory
    * pool for the auxiliary vector must be provided.
    */
   template <class MATRIX1, class MATRIX2>
-  ProductMatrix(const MATRIX1 &m1,
-                const MATRIX2 &m2,
-                VectorMemory<VECTOR> &mem);
+  ProductMatrix (const MATRIX1            &m1,
+                 const MATRIX2            &m2,
+                 VectorMemory<VectorType> &mem);
 
   /**
    * Destructor.
@@ -92,7 +92,7 @@ public:
    */
   template <class MATRIX1, class MATRIX2>
   void initialize(const MATRIX1 &m1, const MATRIX2 &m2,
-                  VectorMemory<VECTOR> &mem);
+                  VectorMemory<VectorType> &mem);
 
   // Doc in PointerMatrixBase
   void clear();
@@ -100,44 +100,44 @@ public:
   /**
    * Matrix-vector product <i>w = m1 * m2 * v</i>.
    */
-  virtual void vmult (VECTOR       &w,
-                      const VECTOR &v) const;
+  virtual void vmult (VectorType       &w,
+                      const VectorType &v) const;
 
   /**
    * Transposed matrix-vector product <i>w = m2<sup>T</sup> * m1<sup>T</sup> *
    * v</i>.
    */
-  virtual void Tvmult (VECTOR       &w,
-                       const VECTOR &v) const;
+  virtual void Tvmult (VectorType       &w,
+                       const VectorType &v) const;
 
   /**
    * Adding matrix-vector product <i>w += m1 * m2 * v</i>
    */
-  virtual void vmult_add (VECTOR       &w,
-                          const VECTOR &v) const;
+  virtual void vmult_add (VectorType       &w,
+                          const VectorType &v) const;
 
   /**
    * Adding, transposed matrix-vector product <i>w += m2<sup>T</sup> *
    * m1<sup>T</sup> * v</i>.
    */
-  virtual void Tvmult_add (VECTOR       &w,
-                           const VECTOR &v) const;
+  virtual void Tvmult_add (VectorType       &w,
+                           const VectorType &v) const;
 
 private:
   /**
    * The left matrix of the product.
    */
-  PointerMatrixBase<VECTOR> *m1;
+  PointerMatrixBase<VectorType> *m1;
 
   /**
    * The right matrix of the product.
    */
-  PointerMatrixBase<VECTOR> *m2;
+  PointerMatrixBase<VectorType> *m2;
 
   /**
    * Memory for auxiliary vector.
    */
-  SmartPointer<VectorMemory<VECTOR>,ProductMatrix<VECTOR> > mem;
+  SmartPointer<VectorMemory<VectorType>,ProductMatrix<VectorType> > mem;
 };
 
 
@@ -154,7 +154,7 @@ private:
  *
  * @author Guido Kanschat, 2007
  */
-template<class VECTOR>
+template<typename VectorType>
 class ScaledMatrix : public Subscriptor
 {
 public:
@@ -186,18 +186,18 @@ public:
   /**
    * Matrix-vector product.
    */
-  void vmult (VECTOR &w, const VECTOR &v) const;
+  void vmult (VectorType &w, const VectorType &v) const;
 
   /**
    * Transposed matrix-vector product.
    */
-  void Tvmult (VECTOR &w, const VECTOR &v) const;
+  void Tvmult (VectorType &w, const VectorType &v) const;
 
 private:
   /**
    * The matrix.
    */
-  PointerMatrixBase<VECTOR> *m;
+  PointerMatrixBase<VectorType> *m;
   /**
    * The scaling factor;
    */
@@ -240,9 +240,9 @@ public:
    * Constructor.  Additionally to the two constituting matrices, a memory
    * pool for the auxiliary vector must be provided.
    */
-  ProductSparseMatrix(const MatrixType &m1,
-                      const MatrixType &m2,
-                      VectorMemory<VectorType> &mem);
+  ProductSparseMatrix (const MatrixType         &m1,
+                       const MatrixType         &m2,
+                       VectorMemory<VectorType> &mem);
 
   /**
    * Constructor leaving an uninitialized matrix. initialize() must be called,
@@ -250,9 +250,9 @@ public:
    */
   ProductSparseMatrix();
 
-  void initialize(const MatrixType &m1,
-                  const MatrixType &m2,
-                  VectorMemory<VectorType> &mem);
+  void initialize (const MatrixType         &m1,
+                   const MatrixType         &m2,
+                   VectorMemory<VectorType> &mem);
 
   // Doc in PointerMatrixBase
   void clear();
@@ -346,14 +346,14 @@ public:
    * Return the source vector with subtracted mean value.
    */
   template <typename number>
-  void vmult (Vector<number> &dst,
+  void vmult (Vector<number>       &dst,
               const Vector<number> &src) const;
 
   /**
    * Add source vector with subtracted mean value to dest.
    */
   template <typename number>
-  void vmult_add (Vector<number> &dst,
+  void vmult_add (Vector<number>       &dst,
                   const Vector<number> &src) const;
 
   /**
@@ -361,7 +361,7 @@ public:
    * component.
    */
   template <typename number>
-  void vmult (BlockVector<number> &dst,
+  void vmult (BlockVector<number>       &dst,
               const BlockVector<number> &src) const;
 
   /**
@@ -369,21 +369,21 @@ public:
    * subtracted.
    */
   template <typename number>
-  void vmult_add (BlockVector<number> &dst,
+  void vmult_add (BlockVector<number>       &dst,
                   const BlockVector<number> &src) const;
 
 
   /**
    * Not implemented.
    */
-  template <typename VECTOR>
-  void Tvmult(VECTOR &, const VECTOR &) const;
+  template <typename VectorType>
+  void Tvmult(VectorType &, const VectorType &) const;
 
   /**
    * Not implemented.
    */
-  template <typename VECTOR>
-  void Tvmult_add(VECTOR &, const VECTOR &) const;
+  template <typename VectorType>
+  void Tvmult_add(VectorType &, const VectorType &) const;
 
 private:
   /**
@@ -429,7 +429,7 @@ private:
  *
  * @author Guido Kanschat, 2005
  */
-template<class VECTOR>
+template<typename VectorType>
 class InverseMatrixRichardson : public Subscriptor
 {
 public:
@@ -437,8 +437,8 @@ public:
    * Constructor, initializing the solver with a control and memory object.
    * The inverted matrix and the preconditioner are added in initialize().
    */
-  InverseMatrixRichardson (SolverControl &control,
-                           VectorMemory<VECTOR> &mem);
+  InverseMatrixRichardson (SolverControl            &control,
+                           VectorMemory<VectorType> &mem);
   /**
    * Since we use two pointers, we must implement a destructor.
    */
@@ -459,43 +459,43 @@ public:
   /**
    * Execute solver.
    */
-  void vmult (VECTOR &, const VECTOR &) const;
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Execute solver.
    */
-  void vmult_add (VECTOR &, const VECTOR &) const;
+  void vmult_add (VectorType &, const VectorType &) const;
 
   /**
    * Execute transpose solver.
    */
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  void Tvmult (VectorType &, const VectorType &) const;
 
   /**
    * Execute transpose solver.
    */
-  void Tvmult_add (VECTOR &, const VECTOR &) const;
+  void Tvmult_add (VectorType &, const VectorType &) const;
 
 private:
   /**
    * A reference to the provided VectorMemory object.
    */
-  VectorMemory<VECTOR> &mem;
+  VectorMemory<VectorType> &mem;
 
   /**
    * The solver object.
    */
-  mutable SolverRichardson<VECTOR> solver;
+  mutable SolverRichardson<VectorType> solver;
 
   /**
    * The matrix in use.
    */
-  PointerMatrixBase<VECTOR> *matrix;
+  PointerMatrixBase<VectorType> *matrix;
 
   /**
    * The preconditioner to use.
    */
-  PointerMatrixBase<VECTOR> *precondition;
+  PointerMatrixBase<VectorType> *precondition;
 };
 
 
@@ -505,43 +505,43 @@ private:
 //---------------------------------------------------------------------------
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-ScaledMatrix<VECTOR>::ScaledMatrix()
+ScaledMatrix<VectorType>::ScaledMatrix()
   :
   m(0)
 {}
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX>
 inline
-ScaledMatrix<VECTOR>::ScaledMatrix(const MATRIX &mat, const double factor)
+ScaledMatrix<VectorType>::ScaledMatrix(const MATRIX &mat, const double factor)
   :
-  m(new_pointer_matrix_base(mat, VECTOR())),
+  m(new_pointer_matrix_base(mat, VectorType())),
   factor(factor)
 {}
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX>
 inline
 void
-ScaledMatrix<VECTOR>::initialize(const MATRIX &mat, const double f)
+ScaledMatrix<VectorType>::initialize(const MATRIX &mat, const double f)
 {
   if (m) delete m;
-  m = new_pointer_matrix_base(mat, VECTOR());
+  m = new_pointer_matrix_base(mat, VectorType());
   factor = f;
 }
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 void
-ScaledMatrix<VECTOR>::clear()
+ScaledMatrix<VectorType>::clear()
 {
   if (m) delete m;
   m = 0;
@@ -549,28 +549,28 @@ ScaledMatrix<VECTOR>::clear()
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-ScaledMatrix<VECTOR>::~ScaledMatrix()
+ScaledMatrix<VectorType>::~ScaledMatrix()
 {
   clear ();
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 void
-ScaledMatrix<VECTOR>::vmult (VECTOR &w, const VECTOR &v) const
+ScaledMatrix<VectorType>::vmult (VectorType &w, const VectorType &v) const
 {
   m->vmult(w, v);
   w *= factor;
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 inline
 void
-ScaledMatrix<VECTOR>::Tvmult (VECTOR &w, const VECTOR &v) const
+ScaledMatrix<VectorType>::Tvmult (VectorType &w, const VectorType &v) const
 {
   m->Tvmult(w, v);
   w *= factor;
@@ -579,72 +579,68 @@ ScaledMatrix<VECTOR>::Tvmult (VECTOR &w, const VECTOR &v) const
 
 //---------------------------------------------------------------------------
 
-template<class VECTOR>
-ProductMatrix<VECTOR>::ProductMatrix ()
+template<typename VectorType>
+ProductMatrix<VectorType>::ProductMatrix ()
   : m1(0), m2(0), mem(0)
 {}
 
 
-template<class VECTOR>
-ProductMatrix<VECTOR>::ProductMatrix (VectorMemory<VECTOR> &m)
+template<typename VectorType>
+ProductMatrix<VectorType>::ProductMatrix (VectorMemory<VectorType> &m)
   : m1(0), m2(0), mem(&m)
 {}
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX1, class MATRIX2>
-ProductMatrix<VECTOR>::ProductMatrix (
-  const MATRIX1 &mat1,
-  const MATRIX2 &mat2,
-  VectorMemory<VECTOR> &m)
+ProductMatrix<VectorType>::ProductMatrix (const MATRIX1            &mat1,
+                                          const MATRIX2            &mat2,
+                                          VectorMemory<VectorType> &m)
   : mem(&m)
 {
-  m1 = new PointerMatrix<MATRIX1, VECTOR>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VECTOR>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX1, class MATRIX2>
 void
-ProductMatrix<VECTOR>::reinit (
-  const MATRIX1 &mat1,
-  const MATRIX2 &mat2)
+ProductMatrix<VectorType>::reinit (const MATRIX1 &mat1, const MATRIX2 &mat2)
 {
   if (m1) delete m1;
   if (m2) delete m2;
-  m1 = new PointerMatrix<MATRIX1, VECTOR>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VECTOR>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX1, class MATRIX2>
 void
-ProductMatrix<VECTOR>::initialize (
-  const MATRIX1 &mat1,
-  const MATRIX2 &mat2,
-  VectorMemory<VECTOR> &memory)
+ProductMatrix<VectorType>::initialize (const MATRIX1            &mat1,
+                                       const MATRIX2            &mat2,
+                                       VectorMemory<VectorType> &memory)
 {
   mem = &memory;
   if (m1) delete m1;
   if (m2) delete m2;
-  m1 = new PointerMatrix<MATRIX1, VECTOR>(&mat1, typeid(*this).name());
-  m2 = new PointerMatrix<MATRIX2, VECTOR>(&mat2, typeid(*this).name());
+  m1 = new PointerMatrix<MATRIX1, VectorType>(&mat1, typeid(*this).name());
+  m2 = new PointerMatrix<MATRIX2, VectorType>(&mat2, typeid(*this).name());
 }
 
 
-template<class VECTOR>
-ProductMatrix<VECTOR>::~ProductMatrix ()
+template<typename VectorType>
+ProductMatrix<VectorType>::~ProductMatrix ()
 {
   if (m1) delete m1;
   if (m2) delete m2;
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-ProductMatrix<VECTOR>::clear ()
+ProductMatrix<VectorType>::clear ()
 {
   if (m1) delete m1;
   m1 = 0;
@@ -653,15 +649,15 @@ ProductMatrix<VECTOR>::clear ()
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-ProductMatrix<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
+ProductMatrix<VectorType>::vmult (VectorType &dst, const VectorType &src) const
 {
   Assert (mem != 0, ExcNotInitialized());
   Assert (m1 != 0, ExcNotInitialized());
   Assert (m2 != 0, ExcNotInitialized());
 
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m2->vmult (*v, src);
   m1->vmult (dst, *v);
@@ -669,15 +665,15 @@ ProductMatrix<VECTOR>::vmult (VECTOR &dst, const VECTOR &src) const
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-ProductMatrix<VECTOR>::vmult_add (VECTOR &dst, const VECTOR &src) const
+ProductMatrix<VectorType>::vmult_add (VectorType &dst, const VectorType &src) const
 {
   Assert (mem != 0, ExcNotInitialized());
   Assert (m1 != 0, ExcNotInitialized());
   Assert (m2 != 0, ExcNotInitialized());
 
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m2->vmult (*v, src);
   m1->vmult_add (dst, *v);
@@ -685,15 +681,15 @@ ProductMatrix<VECTOR>::vmult_add (VECTOR &dst, const VECTOR &src) const
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-ProductMatrix<VECTOR>::Tvmult (VECTOR &dst, const VECTOR &src) const
+ProductMatrix<VectorType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
   Assert (mem != 0, ExcNotInitialized());
   Assert (m1 != 0, ExcNotInitialized());
   Assert (m2 != 0, ExcNotInitialized());
 
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m1->Tvmult (*v, src);
   m2->Tvmult (dst, *v);
@@ -701,15 +697,15 @@ ProductMatrix<VECTOR>::Tvmult (VECTOR &dst, const VECTOR &src) const
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-ProductMatrix<VECTOR>::Tvmult_add (VECTOR &dst, const VECTOR &src) const
+ProductMatrix<VectorType>::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
   Assert (mem != 0, ExcNotInitialized());
   Assert (m1 != 0, ExcNotInitialized());
   Assert (m2 != 0, ExcNotInitialized());
 
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m1->Tvmult (*v, src);
   m2->Tvmult_add (dst, *v);
@@ -720,34 +716,34 @@ ProductMatrix<VECTOR>::Tvmult_add (VECTOR &dst, const VECTOR &src) const
 
 //---------------------------------------------------------------------------
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MeanValueFilter::Tvmult(VECTOR &, const VECTOR &) const
+MeanValueFilter::Tvmult(VectorType &, const VectorType &) const
 {
   Assert(false, ExcNotImplemented());
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MeanValueFilter::Tvmult_add(VECTOR &, const VECTOR &) const
+MeanValueFilter::Tvmult_add(VectorType &, const VectorType &) const
 {
   Assert(false, ExcNotImplemented());
 }
 
 //-----------------------------------------------------------------------//
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX, class PRECONDITION>
 inline void
-InverseMatrixRichardson<VECTOR>::initialize (const MATRIX &m, const PRECONDITION &p)
+InverseMatrixRichardson<VectorType>::initialize (const MATRIX &m, const PRECONDITION &p)
 {
   if (matrix != 0)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VECTOR>(&m);
+  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
   if (precondition != 0)
     delete precondition;
-  precondition = new PointerMatrix<PRECONDITION, VECTOR>(&p);
+  precondition = new PointerMatrix<PRECONDITION, VectorType>(&p);
 }
 
 

--- a/include/deal.II/lac/matrix_lib.templates.h
+++ b/include/deal.II/lac/matrix_lib.templates.h
@@ -124,10 +124,10 @@ MeanValueFilter::vmult_add(BlockVector<number> &dst,
 //----------------------------------------------------------------------//
 
 
-template <class VECTOR>
-InverseMatrixRichardson<VECTOR>::InverseMatrixRichardson(
+template <typename VectorType>
+InverseMatrixRichardson<VectorType>::InverseMatrixRichardson(
   SolverControl &c,
-  VectorMemory<VECTOR> &m)
+  VectorMemory<VectorType> &m)
   :
   mem(m),
   solver(c,m),
@@ -136,17 +136,17 @@ InverseMatrixRichardson<VECTOR>::InverseMatrixRichardson(
 {}
 
 
-template <class VECTOR>
-InverseMatrixRichardson<VECTOR>::~InverseMatrixRichardson()
+template <typename VectorType>
+InverseMatrixRichardson<VectorType>::~InverseMatrixRichardson()
 {
   if (matrix != 0) delete matrix;
   if (precondition != 0) delete precondition;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-InverseMatrixRichardson<VECTOR>::vmult(VECTOR &dst, const VECTOR &src) const
+InverseMatrixRichardson<VectorType>::vmult(VectorType &dst, const VectorType &src) const
 {
   Assert (matrix != 0, ExcNotInitialized());
   Assert (precondition != 0, ExcNotInitialized());
@@ -156,13 +156,13 @@ InverseMatrixRichardson<VECTOR>::vmult(VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-InverseMatrixRichardson<VECTOR>::vmult_add(VECTOR &dst, const VECTOR &src) const
+InverseMatrixRichardson<VectorType>::vmult_add(VectorType &dst, const VectorType &src) const
 {
   Assert (matrix != 0, ExcNotInitialized());
   Assert (precondition != 0, ExcNotInitialized());
-  VECTOR *aux = mem.alloc();
+  VectorType *aux = mem.alloc();
   aux->reinit(dst);
 
   solver.solve(*matrix, *aux, src, *precondition);
@@ -173,9 +173,9 @@ InverseMatrixRichardson<VECTOR>::vmult_add(VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-InverseMatrixRichardson<VECTOR>::Tvmult(VECTOR &dst, const VECTOR &src) const
+InverseMatrixRichardson<VectorType>::Tvmult(VectorType &dst, const VectorType &src) const
 {
   Assert (matrix != 0, ExcNotInitialized());
   Assert (precondition != 0, ExcNotInitialized());
@@ -185,13 +185,13 @@ InverseMatrixRichardson<VECTOR>::Tvmult(VECTOR &dst, const VECTOR &src) const
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-InverseMatrixRichardson<VECTOR>::Tvmult_add(VECTOR &dst, const VECTOR &src) const
+InverseMatrixRichardson<VectorType>::Tvmult_add(VectorType &dst, const VectorType &src) const
 {
   Assert (matrix != 0, ExcNotInitialized());
   Assert (precondition != 0, ExcNotInitialized());
-  VECTOR *aux = mem.alloc();
+  VectorType *aux = mem.alloc();
   aux->reinit(dst);
 
   solver.Tsolve(*matrix, *aux, src, *precondition);

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -159,7 +159,7 @@ public:
   /**
    * Auxiliary class to represent <code>A-sigma*B</code> operator.
    */
-  template <typename MATRIX>
+  template <typename MatrixType>
   class Shift : public dealii::Subscriptor
   {
   public:
@@ -167,9 +167,9 @@ public:
     /**
      * Constructor.
      */
-    Shift (const MATRIX &A,
-           const MATRIX &B,
-           const double sigma)
+    Shift (const MatrixType &A,
+           const MatrixType &B,
+           const double      sigma)
       :
       A(A),
       B(B),
@@ -197,8 +197,8 @@ public:
     }
 
   private:
-    const MATRIX &A;
-    const MATRIX &B;
+    const MatrixType &A;
+    const MatrixType &B;
     const double sigma;
   };
 
@@ -244,15 +244,15 @@ public:
    * calling the <code>pd(n/s)eupd</code> and <code>pd(n/s)aupd</code>
    * functions of PARPACK.
    */
-  template <typename MATRIX1,
-            typename MATRIX2, typename INVERSE>
+  template <typename MatrixType1,
+            typename MatrixType2, typename INVERSE>
   void solve
-  (const MATRIX1                      &A,
-   const MATRIX2                      &B,
+  (const MatrixType1                  &A,
+   const MatrixType2                  &B,
    const INVERSE                      &inverse,
    std::vector<std::complex<double> > &eigenvalues,
    std::vector<VectorType>            &eigenvectors,
-   const unsigned int                 n_eigenvalues);
+   const unsigned int                  n_eigenvalues);
 
   std::size_t memory_consumption() const;
 
@@ -517,14 +517,14 @@ void PArpackSolver<VectorType>::reinit(const dealii::IndexSet &locally_owned_dof
 }
 
 template <typename VectorType>
-template <typename MATRIX1,typename MATRIX2, typename INVERSE>
+template <typename MatrixType1,typename MatrixType2, typename INVERSE>
 void PArpackSolver<VectorType>::solve
-(const MATRIX1                      &/*system_matrix*/,
- const MATRIX2                      &mass_matrix,
+(const MatrixType1                  &/*system_matrix*/,
+ const MatrixType2                  &mass_matrix,
  const INVERSE                      &inverse,
  std::vector<std::complex<double> > &eigenvalues,
  std::vector<VectorType>            &eigenvectors,
- const unsigned int                 n_eigenvalues)
+ const unsigned int                  n_eigenvalues)
 {
 
   Assert (n_eigenvalues <= eigenvectors.size(),

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -127,7 +127,7 @@ extern "C" {
  *
  * @author Denis Davydov, 2015.
  */
-template <typename VECTOR>
+template <typename VectorType>
 class PArpackSolver : public Subscriptor
 {
 public:
@@ -179,7 +179,7 @@ public:
     /**
      * Apply <code>A-sigma * B</code>
      */
-    void vmult (VECTOR &dst, const VECTOR &src) const
+    void vmult (VectorType &dst, const VectorType &src) const
     {
       B.vmult(dst,src);
       dst *= (-sigma);
@@ -189,7 +189,7 @@ public:
     /**
      * Apply <code>A^T-sigma * B^T</code>
      */
-    void Tvmult (VECTOR &dst, const VECTOR &src) const
+    void Tvmult (VectorType &dst, const VectorType &src) const
     {
       B.Tvmult(dst,src);
       dst *= (-sigma);
@@ -246,13 +246,13 @@ public:
    */
   template <typename MATRIX1,
             typename MATRIX2, typename INVERSE>
-  void solve(
-    const MATRIX1 &A,
-    const MATRIX2 &B,
-    const INVERSE &inverse,
-    std::vector<std::complex<double> > &eigenvalues,
-    std::vector<VECTOR> &eigenvectors,
-    const unsigned int n_eigenvalues);
+  void solve
+  (const MATRIX1                      &A,
+   const MATRIX2                      &B,
+   const INVERSE                      &inverse,
+   std::vector<std::complex<double> > &eigenvalues,
+   std::vector<VectorType>            &eigenvectors,
+   const unsigned int                 n_eigenvalues);
 
   std::size_t memory_consumption() const;
 
@@ -356,7 +356,7 @@ protected:
   /**
    * Temporary vectors used between Arpack and deal.II
    */
-  VECTOR src,dst,tmp;
+  VectorType src,dst,tmp;
 
   /**
    * Indices of local degrees of freedom.
@@ -422,9 +422,9 @@ private:
                   << " Arnoldi vectors.");
 };
 
-template <typename VECTOR>
+template <typename VectorType>
 std::size_t
-PArpackSolver<VECTOR>::memory_consumption() const
+PArpackSolver<VectorType>::memory_consumption() const
 {
   return  MemoryConsumption::memory_consumption (double()) *
           (workl.size()  +
@@ -439,21 +439,21 @@ PArpackSolver<VECTOR>::memory_consumption() const
           MemoryConsumption::memory_consumption (types::global_dof_index()) * local_indices.size();
 }
 
-template <typename VECTOR>
-PArpackSolver<VECTOR>::AdditionalData::
-AdditionalData (const unsigned int number_of_arnoldi_vectors,
+template <typename VectorType>
+PArpackSolver<VectorType>::AdditionalData::
+AdditionalData (const unsigned int     number_of_arnoldi_vectors,
                 const WhichEigenvalues eigenvalue_of_interest,
-                const bool symmetric)
+                const bool             symmetric)
   :
   number_of_arnoldi_vectors(number_of_arnoldi_vectors),
   eigenvalue_of_interest(eigenvalue_of_interest),
   symmetric(symmetric)
 {}
 
-template <typename VECTOR>
-PArpackSolver<VECTOR>::PArpackSolver (SolverControl &control,
-                                      const MPI_Comm &mpi_communicator,
-                                      const AdditionalData &data)
+template <typename VectorType>
+PArpackSolver<VectorType>::PArpackSolver (SolverControl        &control,
+                                          const MPI_Comm       &mpi_communicator,
+                                          const AdditionalData &data)
   :
   solver_control (control),
   additional_data (data),
@@ -463,14 +463,14 @@ PArpackSolver<VECTOR>::PArpackSolver (SolverControl &control,
 
 {}
 
-template <typename VECTOR>
-void PArpackSolver<VECTOR>::set_shift(const double s )
+template <typename VectorType>
+void PArpackSolver<VectorType>::set_shift(const double s )
 {
   shift_value = s;
 }
 
-template <typename VECTOR>
-void PArpackSolver<VECTOR>::reinit(const dealii::IndexSet &locally_owned_dofs)
+template <typename VectorType>
+void PArpackSolver<VectorType>::reinit(const dealii::IndexSet &locally_owned_dofs)
 {
   // store local indices to write to vectors
   locally_owned_dofs.fill_index_vector(local_indices);
@@ -516,15 +516,15 @@ void PArpackSolver<VECTOR>::reinit(const dealii::IndexSet &locally_owned_dofs)
 
 }
 
-template <typename VECTOR>
+template <typename VectorType>
 template <typename MATRIX1,typename MATRIX2, typename INVERSE>
-void PArpackSolver<VECTOR>::solve (
-  const MATRIX1 &/*system_matrix*/,
-  const MATRIX2 &mass_matrix,
-  const INVERSE &inverse,
-  std::vector<std::complex<double> > &eigenvalues,
-  std::vector<VECTOR> &eigenvectors,
-  const unsigned int n_eigenvalues)
+void PArpackSolver<VectorType>::solve
+(const MATRIX1                      &/*system_matrix*/,
+ const MATRIX2                      &mass_matrix,
+ const INVERSE                      &inverse,
+ std::vector<std::complex<double> > &eigenvalues,
+ std::vector<VectorType>            &eigenvectors,
+ const unsigned int                 n_eigenvalues)
 {
 
   Assert (n_eigenvalues <= eigenvectors.size(),
@@ -863,8 +863,8 @@ void PArpackSolver<VECTOR>::solve (
 
 }
 
-template <typename VECTOR>
-SolverControl &PArpackSolver<VECTOR>::control () const
+template <typename VectorType>
+SolverControl &PArpackSolver<VectorType>::control () const
 {
   return solver_control;
 }

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -23,7 +23,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<class VECTOR> class VectorMemory;
+template<typename VectorType> class VectorMemory;
 
 class IdentityMatrix;
 template <typename number> class FullMatrix;
@@ -47,7 +47,7 @@ template <typename number, typename BlockVectorType> class BlockMatrixArray;
  *
  * @author Guido Kanschat, 2000, 2001, 2002
  */
-template<class VECTOR>
+template<typename VectorType>
 class PointerMatrixBase : public Subscriptor
 {
 public:
@@ -59,7 +59,7 @@ public:
    * This was defined to make this matrix a possible template argument to
    * BlockMatrixArray.
    */
-  typedef typename VECTOR::value_type value_type;
+  typedef typename VectorType::value_type value_type;
 
   /**
    * Virtual destructor.  Does nothing except making sure that the destructor
@@ -76,26 +76,26 @@ public:
   /**
    * Matrix-vector product.
    */
-  virtual void vmult (VECTOR &dst,
-                      const VECTOR &src) const = 0;
+  virtual void vmult (VectorType       &dst,
+                      const VectorType &src) const = 0;
 
   /**
    * Transposed matrix-vector product.
    */
-  virtual void Tvmult (VECTOR &dst,
-                       const VECTOR &src) const = 0;
+  virtual void Tvmult (VectorType       &dst,
+                       const VectorType &src) const = 0;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void vmult_add (VECTOR &dst,
-                          const VECTOR &src) const = 0;
+  virtual void vmult_add (VectorType       &dst,
+                          const VectorType &src) const = 0;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void Tvmult_add (VECTOR &dst,
-                           const VECTOR &src) const = 0;
+  virtual void Tvmult_add (VectorType       &dst,
+                           const VectorType &src) const = 0;
 };
 
 
@@ -109,8 +109,8 @@ public:
  *
  * @author Guido Kanschat 2000, 2001, 2002
  */
-template<class MATRIX, class VECTOR>
-class PointerMatrix : public PointerMatrixBase<VECTOR>
+template<class MATRIX, typename VectorType>
+class PointerMatrix : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -166,32 +166,32 @@ public:
   /**
    * Matrix-vector product.
    */
-  virtual void vmult (VECTOR &dst,
-                      const VECTOR &src) const;
+  virtual void vmult (VectorType       &dst,
+                      const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product.
    */
-  virtual void Tvmult (VECTOR &dst,
-                       const VECTOR &src) const;
+  virtual void Tvmult (VectorType       &dst,
+                       const VectorType &src) const;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void vmult_add (VECTOR &dst,
-                          const VECTOR &src) const;
+  virtual void vmult_add (VectorType       &dst,
+                          const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void Tvmult_add (VECTOR &dst,
-                           const VECTOR &src) const;
+  virtual void Tvmult_add (VectorType       &dst,
+                           const VectorType &src) const;
 
 private:
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,PointerMatrix<MATRIX,VECTOR> > m;
+  SmartPointer<const MATRIX,PointerMatrix<MATRIX,VectorType> > m;
 };
 
 
@@ -209,8 +209,8 @@ private:
  *
  * @author Guido Kanschat 2006
  */
-template<class MATRIX, class VECTOR>
-class PointerMatrixAux : public PointerMatrixBase<VECTOR>
+template<class MATRIX, typename VectorType>
+class PointerMatrixAux : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -222,8 +222,8 @@ public:
    *
    * If <tt>mem</tt> is zero, then GrowingVectorMemory is used.
    */
-  PointerMatrixAux (VectorMemory<VECTOR> *mem = 0,
-                    const MATRIX *M=0);
+  PointerMatrixAux (VectorMemory<VectorType> *mem = 0,
+                    const MATRIX             *M=0);
 
   /**
    * Constructor not using a matrix.
@@ -235,8 +235,8 @@ public:
    * argument to this function is used to this end, i.e., you can in essence
    * assign a name to the current PointerMatrix object.
    */
-  PointerMatrixAux(VectorMemory<VECTOR> *mem,
-                   const char *name);
+  PointerMatrixAux(VectorMemory<VectorType> *mem,
+                   const char               *name);
 
   /**
    * Constructor. <tt>M</tt> points to a matrix which must live longer than
@@ -249,9 +249,9 @@ public:
    * argument to this function is used to this end, i.e., you can in essence
    * assign a name to the current PointerMatrix object.
    */
-  PointerMatrixAux(VectorMemory<VECTOR> *mem,
-                   const MATRIX *M,
-                   const char *name);
+  PointerMatrixAux(VectorMemory<VectorType> *mem,
+                   const MATRIX             *M,
+                   const char               *name);
 
   // Use doc from base class
   virtual void clear();
@@ -264,7 +264,7 @@ public:
   /**
    * Assign a new VectorMemory object for getting auxiliary vectors.
    */
-  void set_memory(VectorMemory<VECTOR> *mem);
+  void set_memory(VectorMemory<VectorType> *mem);
 
   /**
    * Assign a new matrix pointer. Deletes the old pointer and releases its
@@ -276,42 +276,42 @@ public:
   /**
    * Matrix-vector product.
    */
-  virtual void vmult (VECTOR &dst,
-                      const VECTOR &src) const;
+  virtual void vmult (VectorType       &dst,
+                      const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product.
    */
-  virtual void Tvmult (VECTOR &dst,
-                       const VECTOR &src) const;
+  virtual void Tvmult (VectorType       &dst,
+                       const VectorType &src) const;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void vmult_add (VECTOR &dst,
-                          const VECTOR &src) const;
+  virtual void vmult_add (VectorType       &dst,
+                          const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void Tvmult_add (VECTOR &dst,
-                           const VECTOR &src) const;
+  virtual void Tvmult_add (VectorType       &dst,
+                           const VectorType &src) const;
 
 private:
   /**
    * The backup memory if none was provided.
    */
-  mutable GrowingVectorMemory<VECTOR> my_memory;
+  mutable GrowingVectorMemory<VectorType> my_memory;
 
   /**
    * Object for getting the auxiliary vector.
    */
-  mutable SmartPointer<VectorMemory<VECTOR>,PointerMatrixAux<MATRIX,VECTOR> > mem;
+  mutable SmartPointer<VectorMemory<VectorType>,PointerMatrixAux<MATRIX,VectorType> > mem;
 
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,PointerMatrixAux<MATRIX,VECTOR> > m;
+  SmartPointer<const MATRIX,PointerMatrixAux<MATRIX,VectorType> > m;
 };
 
 
@@ -439,17 +439,17 @@ private:
  * should overload the function in order to save memory and time.
  *
  * The result is a PointerMatrixBase* pointing to <tt>matrix</tt>. The
- * <tt>VECTOR</tt> argument is a dummy just used to determine the template
+ * <tt>VectorType</tt> argument is a dummy just used to determine the template
  * arguments.
  *
  * @relates PointerMatrixBase @relates PointerMatrixAux
  */
-template <class VECTOR, class MATRIX>
+template <typename VectorType, class MATRIX>
 inline
-PointerMatrixBase<VECTOR> *
-new_pointer_matrix_base(MATRIX &matrix, const VECTOR &, const char *name = "PointerMatrixAux")
+PointerMatrixBase<VectorType> *
+new_pointer_matrix_base(MATRIX &matrix, const VectorType &, const char *name = "PointerMatrixAux")
 {
-  return new PointerMatrixAux<MATRIX, VECTOR>(0, &matrix, name);
+  return new PointerMatrixAux<MATRIX, VectorType>(0, &matrix, name);
 }
 
 /**
@@ -509,11 +509,11 @@ new_pointer_matrix_base(const SparseMatrix<numberm> &matrix, const Vector<number
  *
  * @relates PointerMatrixBase @relates PointerMatrix
  */
-template <class VECTOR, typename numberm>
-PointerMatrixBase<VECTOR> *
-new_pointer_matrix_base(const BlockSparseMatrix<numberm> &matrix, const VECTOR &, const char *name = "PointerMatrix")
+template <typename VectorType, typename numberm>
+PointerMatrixBase<VectorType> *
+new_pointer_matrix_base(const BlockSparseMatrix<numberm> &matrix, const VectorType &, const char *name = "PointerMatrix")
 {
-  return new PointerMatrix<BlockSparseMatrix<numberm>, VECTOR>(&matrix, name);
+  return new PointerMatrix<BlockSparseMatrix<numberm>, VectorType>(&matrix, name);
 }
 
 
@@ -535,11 +535,11 @@ new_pointer_matrix_base(const SparseMatrixEZ<numberm> &matrix, const Vector<numb
  *
  * @relates PointerMatrixBase @relates PointerMatrix
  */
-template <class VECTOR, typename numberm>
-PointerMatrixBase<VECTOR> *
-new_pointer_matrix_base(const BlockSparseMatrixEZ<numberm> &matrix, const VECTOR &, const char *name = "PointerMatrix")
+template <typename VectorType, typename numberm>
+PointerMatrixBase<VectorType> *
+new_pointer_matrix_base(const BlockSparseMatrixEZ<numberm> &matrix, const VectorType &, const char *name = "PointerMatrix")
 {
-  return new PointerMatrix<BlockSparseMatrixEZ<numberm>, VECTOR>(&matrix, name);
+  return new PointerMatrix<BlockSparseMatrixEZ<numberm>, VectorType>(&matrix, name);
 }
 
 
@@ -548,11 +548,11 @@ new_pointer_matrix_base(const BlockSparseMatrixEZ<numberm> &matrix, const VECTOR
  *
  * @relates PointerMatrixBase @relates PointerMatrix
  */
-template <typename numberv, typename numberm, typename BLOCK_VECTOR>
-PointerMatrixBase<BLOCK_VECTOR> *
-new_pointer_matrix_base(const BlockMatrixArray<numberm,BLOCK_VECTOR> &matrix, const BLOCK_VECTOR &, const char *name = "PointerMatrix")
+template <typename numberv, typename numberm, typename BLOCK_VectorType>
+PointerMatrixBase<BLOCK_VectorType> *
+new_pointer_matrix_base(const BlockMatrixArray<numberm,BLOCK_VectorType> &matrix, const BLOCK_VectorType &, const char *name = "PointerMatrix")
 {
-  return new PointerMatrix<BlockMatrixArray<numberm,BLOCK_VECTOR>, BlockVector<numberv> >(&matrix, name);
+  return new PointerMatrix<BlockMatrixArray<numberm,BLOCK_VectorType>, BlockVector<numberv> >(&matrix, name);
 }
 
 
@@ -573,9 +573,9 @@ new_pointer_matrix_base(const TridiagonalMatrix<numberm> &matrix, const Vector<n
 /*@}*/
 //---------------------------------------------------------------------------
 
-template<class VECTOR>
+template<typename VectorType>
 inline
-PointerMatrixBase<VECTOR>::~PointerMatrixBase ()
+PointerMatrixBase<VectorType>::~PointerMatrixBase ()
 {}
 
 
@@ -583,86 +583,85 @@ PointerMatrixBase<VECTOR>::~PointerMatrixBase ()
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrix<MATRIX, VECTOR>::PointerMatrix (const MATRIX *M)
+template<class MATRIX, typename VectorType>
+PointerMatrix<MATRIX, VectorType>::PointerMatrix (const MATRIX *M)
   : m(M, typeid(*this).name())
 {}
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrix<MATRIX, VECTOR>::PointerMatrix (const char *name)
+template<class MATRIX, typename VectorType>
+PointerMatrix<MATRIX, VectorType>::PointerMatrix (const char *name)
   : m(0, name)
 {}
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrix<MATRIX, VECTOR>::PointerMatrix (
-  const MATRIX *M,
-  const char *name)
+template<class MATRIX, typename VectorType>
+PointerMatrix<MATRIX, VectorType>::PointerMatrix (const MATRIX *M,
+                                                  const char *name)
   : m(M, name)
 {}
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VECTOR>::clear ()
+PointerMatrix<MATRIX, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, class VECTOR>
-inline const PointerMatrix<MATRIX, VECTOR> &
-PointerMatrix<MATRIX, VECTOR>::operator= (const MATRIX *M)
+template<class MATRIX, typename VectorType>
+inline const PointerMatrix<MATRIX, VectorType> &
+PointerMatrix<MATRIX, VectorType>::operator= (const MATRIX *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline bool
-PointerMatrix<MATRIX, VECTOR>::empty () const
+PointerMatrix<MATRIX, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VECTOR>::vmult (VECTOR &dst,
-                                      const VECTOR &src) const
+PointerMatrix<MATRIX, VectorType>::vmult (VectorType       &dst,
+                                          const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VECTOR>::Tvmult (VECTOR &dst,
-                                       const VECTOR &src) const
+PointerMatrix<MATRIX, VectorType>::Tvmult (VectorType       &dst,
+                                           const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VECTOR>::vmult_add (VECTOR &dst,
-                                          const VECTOR &src) const
+PointerMatrix<MATRIX, VectorType>::vmult_add (VectorType       &dst,
+                                              const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult_add (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VECTOR>::Tvmult_add (VECTOR &dst,
-                                           const VECTOR &src) const
+PointerMatrix<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
+                                               const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult_add (dst, src);
@@ -673,9 +672,9 @@ PointerMatrix<MATRIX, VECTOR>::Tvmult_add (VECTOR &dst,
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
-  VectorMemory<VECTOR> *mem,
+template<class MATRIX, typename VectorType>
+PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
+  VectorMemory<VectorType> *mem,
   const MATRIX *M)
   : mem(mem, typeid(*this).name()),
     m(M, typeid(*this).name())
@@ -684,9 +683,9 @@ PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
-  VectorMemory<VECTOR> *mem,
+template<class MATRIX, typename VectorType>
+PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
+  VectorMemory<VectorType> *mem,
   const char *name)
   : mem(mem, name),
     m(0, name)
@@ -695,9 +694,9 @@ PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, class VECTOR>
-PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
-  VectorMemory<VECTOR> *mem,
+template<class MATRIX, typename VectorType>
+PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
+  VectorMemory<VectorType> *mem,
   const MATRIX *M,
   const char *name)
   : mem(mem, name),
@@ -707,26 +706,26 @@ PointerMatrixAux<MATRIX, VECTOR>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::clear ()
+PointerMatrixAux<MATRIX, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, class VECTOR>
-inline const PointerMatrixAux<MATRIX, VECTOR> &
-PointerMatrixAux<MATRIX, VECTOR>::operator= (const MATRIX *M)
+template<class MATRIX, typename VectorType>
+inline const PointerMatrixAux<MATRIX, VectorType> &
+PointerMatrixAux<MATRIX, VectorType>::operator= (const MATRIX *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::set_memory(VectorMemory<VECTOR> *M)
+PointerMatrixAux<MATRIX, VectorType>::set_memory(VectorMemory<VectorType> *M)
 {
   mem = M;
   if (mem == 0)
@@ -734,19 +733,19 @@ PointerMatrixAux<MATRIX, VECTOR>::set_memory(VectorMemory<VECTOR> *M)
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline bool
-PointerMatrixAux<MATRIX, VECTOR>::empty () const
+PointerMatrixAux<MATRIX, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::vmult (VECTOR &dst,
-                                         const VECTOR &src) const
+PointerMatrixAux<MATRIX, VectorType>::vmult (VectorType       &dst,
+                                             const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
@@ -756,10 +755,10 @@ PointerMatrixAux<MATRIX, VECTOR>::vmult (VECTOR &dst,
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::Tvmult (VECTOR &dst,
-                                          const VECTOR &src) const
+PointerMatrixAux<MATRIX, VectorType>::Tvmult (VectorType       &dst,
+                                              const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
@@ -769,16 +768,16 @@ PointerMatrixAux<MATRIX, VECTOR>::Tvmult (VECTOR &dst,
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::vmult_add (VECTOR &dst,
-                                             const VECTOR &src) const
+PointerMatrixAux<MATRIX, VectorType>::vmult_add (VectorType       &dst,
+                                                 const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
   Assert (mem != 0, ExcNotInitialized());
   Assert (m != 0, ExcNotInitialized());
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m->vmult (*v, src);
   dst += *v;
@@ -786,16 +785,16 @@ PointerMatrixAux<MATRIX, VECTOR>::vmult_add (VECTOR &dst,
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VECTOR>::Tvmult_add (VECTOR &dst,
-                                              const VECTOR &src) const
+PointerMatrixAux<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
+                                                  const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
   Assert (mem != 0, ExcNotInitialized());
   Assert (m != 0, ExcNotInitialized());
-  VECTOR *v = mem->alloc();
+  VectorType *v = mem->alloc();
   v->reinit(dst);
   m->Tvmult (*v, src);
   dst += *v;

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -109,7 +109,7 @@ public:
  *
  * @author Guido Kanschat 2000, 2001, 2002
  */
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 class PointerMatrix : public PointerMatrixBase<VectorType>
 {
 public:
@@ -120,7 +120,7 @@ public:
    *
    * If <tt>M</tt> is zero, no matrix is stored.
    */
-  PointerMatrix (const MATRIX *M=0);
+  PointerMatrix (const MatrixType *M=0);
 
   /**
    * Constructor.
@@ -145,7 +145,7 @@ public:
    * argument to this function is used to this end, i.e., you can in essence
    * assign a name to the current PointerMatrix object.
    */
-  PointerMatrix(const MATRIX *M,
+  PointerMatrix(const MatrixType *M,
                 const char *name);
 
   // Use doc from base class
@@ -161,7 +161,7 @@ public:
    * matrix.
    * @see SmartPointer
    */
-  const PointerMatrix &operator= (const MATRIX *M);
+  const PointerMatrix &operator= (const MatrixType *M);
 
   /**
    * Matrix-vector product.
@@ -191,7 +191,7 @@ private:
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,PointerMatrix<MATRIX,VectorType> > m;
+  SmartPointer<const MatrixType,PointerMatrix<MatrixType,VectorType> > m;
 };
 
 
@@ -205,11 +205,11 @@ private:
  *
  * This class differs form PointerMatrix by its additional VectorMemory object
  * and by the fact that it implements the functions vmult_add() and
- * Tvmult_add() only using vmult() and Tvmult() of the MATRIX.
+ * Tvmult_add() only using vmult() and Tvmult() of the MatrixType.
  *
  * @author Guido Kanschat 2006
  */
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 class PointerMatrixAux : public PointerMatrixBase<VectorType>
 {
 public:
@@ -223,7 +223,7 @@ public:
    * If <tt>mem</tt> is zero, then GrowingVectorMemory is used.
    */
   PointerMatrixAux (VectorMemory<VectorType> *mem = 0,
-                    const MATRIX             *M=0);
+                    const MatrixType         *M = 0);
 
   /**
    * Constructor not using a matrix.
@@ -250,7 +250,7 @@ public:
    * assign a name to the current PointerMatrix object.
    */
   PointerMatrixAux(VectorMemory<VectorType> *mem,
-                   const MATRIX             *M,
+                   const MatrixType         *M,
                    const char               *name);
 
   // Use doc from base class
@@ -271,7 +271,7 @@ public:
    * matrix.
    * @see SmartPointer
    */
-  const PointerMatrixAux &operator= (const MATRIX *M);
+  const PointerMatrixAux &operator= (const MatrixType *M);
 
   /**
    * Matrix-vector product.
@@ -306,12 +306,12 @@ private:
   /**
    * Object for getting the auxiliary vector.
    */
-  mutable SmartPointer<VectorMemory<VectorType>,PointerMatrixAux<MATRIX,VectorType> > mem;
+  mutable SmartPointer<VectorMemory<VectorType>,PointerMatrixAux<MatrixType,VectorType> > mem;
 
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,PointerMatrixAux<MATRIX,VectorType> > m;
+  SmartPointer<const MatrixType,PointerMatrixAux<MatrixType,VectorType> > m;
 };
 
 
@@ -444,12 +444,12 @@ private:
  *
  * @relates PointerMatrixBase @relates PointerMatrixAux
  */
-template <typename VectorType, class MATRIX>
+template <typename VectorType, typename MatrixType>
 inline
 PointerMatrixBase<VectorType> *
-new_pointer_matrix_base(MATRIX &matrix, const VectorType &, const char *name = "PointerMatrixAux")
+new_pointer_matrix_base(MatrixType &matrix, const VectorType &, const char *name = "PointerMatrixAux")
 {
-  return new PointerMatrixAux<MATRIX, VectorType>(0, &matrix, name);
+  return new PointerMatrixAux<MatrixType, VectorType>(0, &matrix, name);
 }
 
 /**
@@ -583,85 +583,85 @@ PointerMatrixBase<VectorType>::~PointerMatrixBase ()
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrix<MATRIX, VectorType>::PointerMatrix (const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+PointerMatrix<MatrixType, VectorType>::PointerMatrix (const MatrixType *M)
   : m(M, typeid(*this).name())
 {}
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrix<MATRIX, VectorType>::PointerMatrix (const char *name)
+template<typename MatrixType, typename VectorType>
+PointerMatrix<MatrixType, VectorType>::PointerMatrix (const char *name)
   : m(0, name)
 {}
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrix<MATRIX, VectorType>::PointerMatrix (const MATRIX *M,
-                                                  const char *name)
+template<typename MatrixType, typename VectorType>
+PointerMatrix<MatrixType, VectorType>::PointerMatrix (const MatrixType *M,
+                                                      const char       *name)
   : m(M, name)
 {}
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VectorType>::clear ()
+PointerMatrix<MatrixType, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, typename VectorType>
-inline const PointerMatrix<MATRIX, VectorType> &
-PointerMatrix<MATRIX, VectorType>::operator= (const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+inline const PointerMatrix<MatrixType, VectorType> &
+PointerMatrix<MatrixType, VectorType>::operator= (const MatrixType *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline bool
-PointerMatrix<MATRIX, VectorType>::empty () const
+PointerMatrix<MatrixType, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VectorType>::vmult (VectorType       &dst,
-                                          const VectorType &src) const
+PointerMatrix<MatrixType, VectorType>::vmult (VectorType       &dst,
+                                              const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VectorType>::Tvmult (VectorType       &dst,
-                                           const VectorType &src) const
+PointerMatrix<MatrixType, VectorType>::Tvmult (VectorType       &dst,
+                                               const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VectorType>::vmult_add (VectorType       &dst,
-                                              const VectorType &src) const
+PointerMatrix<MatrixType, VectorType>::vmult_add (VectorType       &dst,
+                                                  const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult_add (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrix<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
-                                               const VectorType &src) const
+PointerMatrix<MatrixType, VectorType>::Tvmult_add (VectorType       &dst,
+                                                   const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult_add (dst, src);
@@ -672,10 +672,9 @@ PointerMatrix<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
-  VectorMemory<VectorType> *mem,
-  const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+PointerMatrixAux<MatrixType, VectorType>::PointerMatrixAux (VectorMemory<VectorType> *mem,
+                                                            const MatrixType *M)
   : mem(mem, typeid(*this).name()),
     m(M, typeid(*this).name())
 {
@@ -683,10 +682,9 @@ PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
-  VectorMemory<VectorType> *mem,
-  const char *name)
+template<typename MatrixType, typename VectorType>
+PointerMatrixAux<MatrixType, VectorType>::PointerMatrixAux (VectorMemory<VectorType> *mem,
+                                                            const char               *name)
   : mem(mem, name),
     m(0, name)
 {
@@ -694,11 +692,10 @@ PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, typename VectorType>
-PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
-  VectorMemory<VectorType> *mem,
-  const MATRIX *M,
-  const char *name)
+template<typename MatrixType, typename VectorType>
+PointerMatrixAux<MatrixType, VectorType>::PointerMatrixAux (VectorMemory<VectorType> *mem,
+                                                            const MatrixType         *M,
+                                                            const char               *name)
   : mem(mem, name),
     m(M, name)
 {
@@ -706,26 +703,26 @@ PointerMatrixAux<MATRIX, VectorType>::PointerMatrixAux (
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::clear ()
+PointerMatrixAux<MatrixType, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, typename VectorType>
-inline const PointerMatrixAux<MATRIX, VectorType> &
-PointerMatrixAux<MATRIX, VectorType>::operator= (const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+inline const PointerMatrixAux<MatrixType, VectorType> &
+PointerMatrixAux<MatrixType, VectorType>::operator= (const MatrixType *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::set_memory(VectorMemory<VectorType> *M)
+PointerMatrixAux<MatrixType, VectorType>::set_memory(VectorMemory<VectorType> *M)
 {
   mem = M;
   if (mem == 0)
@@ -733,18 +730,18 @@ PointerMatrixAux<MATRIX, VectorType>::set_memory(VectorMemory<VectorType> *M)
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline bool
-PointerMatrixAux<MATRIX, VectorType>::empty () const
+PointerMatrixAux<MatrixType, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::vmult (VectorType       &dst,
+PointerMatrixAux<MatrixType, VectorType>::vmult (VectorType       &dst,
                                              const VectorType &src) const
 {
   if (mem == 0)
@@ -755,9 +752,9 @@ PointerMatrixAux<MATRIX, VectorType>::vmult (VectorType       &dst,
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::Tvmult (VectorType       &dst,
+PointerMatrixAux<MatrixType, VectorType>::Tvmult (VectorType       &dst,
                                               const VectorType &src) const
 {
   if (mem == 0)
@@ -768,9 +765,9 @@ PointerMatrixAux<MATRIX, VectorType>::Tvmult (VectorType       &dst,
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::vmult_add (VectorType       &dst,
+PointerMatrixAux<MatrixType, VectorType>::vmult_add (VectorType       &dst,
                                                  const VectorType &src) const
 {
   if (mem == 0)
@@ -785,9 +782,9 @@ PointerMatrixAux<MATRIX, VectorType>::vmult_add (VectorType       &dst,
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-PointerMatrixAux<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
+PointerMatrixAux<MatrixType, VectorType>::Tvmult_add (VectorType       &dst,
                                                   const VectorType &src) const
 {
   if (mem == 0)
@@ -818,9 +815,8 @@ PointerMatrixVector<number>::PointerMatrixVector (const char *name)
 
 
 template<typename number>
-PointerMatrixVector<number>::PointerMatrixVector (
-  const Vector<number> *M,
-  const char *name)
+PointerMatrixVector<number>::PointerMatrixVector (const Vector<number> *M,
+                                                  const char           *name)
   : m(M, name)
 {}
 
@@ -853,9 +849,8 @@ PointerMatrixVector<number>::empty () const
 
 template<typename number>
 inline void
-PointerMatrixVector<number>::vmult (
-  Vector<number> &dst,
-  const Vector<number> &src) const
+PointerMatrixVector<number>::vmult (Vector<number>       &dst,
+                                    const Vector<number> &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   Assert (dst.size() == 1, ExcDimensionMismatch(dst.size(), 1));
@@ -866,9 +861,8 @@ PointerMatrixVector<number>::vmult (
 
 template<typename number>
 inline void
-PointerMatrixVector<number>::Tvmult (
-  Vector<number> &dst,
-  const Vector<number> &src) const
+PointerMatrixVector<number>::Tvmult (Vector<number>       &dst,
+                                     const Vector<number> &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   Assert(src.size() == 1, ExcDimensionMismatch(src.size(), 1));
@@ -879,9 +873,8 @@ PointerMatrixVector<number>::Tvmult (
 
 template<typename number>
 inline void
-PointerMatrixVector<number>::vmult_add (
-  Vector<number> &dst,
-  const Vector<number> &src) const
+PointerMatrixVector<number>::vmult_add (Vector<number>       &dst,
+                                        const Vector<number> &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   Assert (dst.size() == 1, ExcDimensionMismatch(dst.size(), 1));
@@ -892,9 +885,8 @@ PointerMatrixVector<number>::vmult_add (
 
 template<typename number>
 inline void
-PointerMatrixVector<number>::Tvmult_add (
-  Vector<number> &dst,
-  const Vector<number> &src) const
+PointerMatrixVector<number>::Tvmult_add (Vector<number>       &dst,
+                                         const Vector<number> &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   Assert(src.size() == 1, ExcDimensionMismatch(src.size(), 1));

--- a/include/deal.II/lac/pointer_matrix.h
+++ b/include/deal.II/lac/pointer_matrix.h
@@ -742,7 +742,7 @@ PointerMatrixAux<MatrixType, VectorType>::empty () const
 template<typename MatrixType, typename VectorType>
 inline void
 PointerMatrixAux<MatrixType, VectorType>::vmult (VectorType       &dst,
-                                             const VectorType &src) const
+                                                 const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
@@ -755,7 +755,7 @@ PointerMatrixAux<MatrixType, VectorType>::vmult (VectorType       &dst,
 template<typename MatrixType, typename VectorType>
 inline void
 PointerMatrixAux<MatrixType, VectorType>::Tvmult (VectorType       &dst,
-                                              const VectorType &src) const
+                                                  const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
@@ -768,7 +768,7 @@ PointerMatrixAux<MatrixType, VectorType>::Tvmult (VectorType       &dst,
 template<typename MatrixType, typename VectorType>
 inline void
 PointerMatrixAux<MatrixType, VectorType>::vmult_add (VectorType       &dst,
-                                                 const VectorType &src) const
+                                                     const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;
@@ -785,7 +785,7 @@ PointerMatrixAux<MatrixType, VectorType>::vmult_add (VectorType       &dst,
 template<typename MatrixType, typename VectorType>
 inline void
 PointerMatrixAux<MatrixType, VectorType>::Tvmult_add (VectorType       &dst,
-                                                  const VectorType &src) const
+                                                      const VectorType &src) const
 {
   if (mem == 0)
     mem = &my_memory;

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -98,8 +98,8 @@ public:
    * The matrix argument is ignored and here just for compatibility with more
    * complex preconditioners.
    */
-  template <class MATRIX>
-  void initialize (const MATRIX         &matrix,
+  template <typename MatrixType>
+  void initialize (const MatrixType     &matrix,
                    const AdditionalData &additional_data = AdditionalData());
 
   /**
@@ -221,8 +221,8 @@ public:
    * preconditioners. The matrix argument is ignored and here just for
    * compatibility with more complex preconditioners.
    */
-  template <class MATRIX>
-  void initialize (const MATRIX &matrix,
+  template <typename MatrixType>
+  void initialize (const MatrixType     &matrix,
                    const AdditionalData &parameters);
 
   /**
@@ -333,21 +333,21 @@ private:
  *
  * @author Guido Kanschat, Wolfgang Bangerth, 1999
  */
-template<class MATRIX = SparseMatrix<double>, class VectorType = Vector<double> >
+template<typename MatrixType = SparseMatrix<double>, class VectorType = Vector<double> >
 class PreconditionUseMatrix : public Subscriptor
 {
 public:
   /**
    * Type of the preconditioning function of the matrix.
    */
-  typedef void ( MATRIX::* function_ptr)(VectorType &, const VectorType &) const;
+  typedef void ( MatrixType::* function_ptr)(VectorType &, const VectorType &) const;
 
   /**
    * Constructor.  This constructor stores a reference to the matrix object
    * for later use and selects a preconditioning method, which must be a
    * member function of that matrix.
    */
-  PreconditionUseMatrix(const MATRIX      &M,
+  PreconditionUseMatrix(const MatrixType  &M,
                         const function_ptr method);
 
   /**
@@ -361,7 +361,7 @@ private:
   /**
    * Pointer to the matrix in use.
    */
-  const MATRIX &matrix;
+  const MatrixType &matrix;
 
   /**
    * Pointer to the preconditioning function.
@@ -379,14 +379,14 @@ private:
  * @author Guido Kanschat, 2000; extension for full compatibility with
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
-template<class MATRIX = SparseMatrix<double> >
+template<typename MatrixType = SparseMatrix<double> >
 class PreconditionRelaxation : public Subscriptor
 {
 public:
   /**
    * Declare type for container size.
    */
-  typedef typename MATRIX::size_type size_type;
+  typedef typename MatrixType::size_type size_type;
 
   /**
    * Class for parameters.
@@ -410,7 +410,7 @@ public:
    * the preconditioner object. The relaxation parameter should be larger than
    * zero and smaller than 2 for numerical reasons. It defaults to 1.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType     &A,
                    const AdditionalData &parameters = AdditionalData());
 
   /**
@@ -434,7 +434,7 @@ protected:
   /**
    * Pointer to the matrix object.
    */
-  SmartPointer<const MATRIX, PreconditionRelaxation<MATRIX> > A;
+  SmartPointer<const MatrixType, PreconditionRelaxation<MatrixType> > A;
 
   /**
    * Relaxation parameter.
@@ -445,7 +445,7 @@ protected:
 
 
 /**
- * Jacobi preconditioner using matrix built-in function.  The <tt>MATRIX</tt>
+ * Jacobi preconditioner using matrix built-in function.  The <tt>MatrixType</tt>
  * class used is required to have a function <tt>precondition_Jacobi(VectorType&,
  * const VectorType&, double</tt>)
  *
@@ -469,8 +469,8 @@ protected:
  *
  * @author Guido Kanschat, 2000
  */
-template <class MATRIX = SparseMatrix<double> >
-class PreconditionJacobi : public PreconditionRelaxation<MATRIX>
+template <typename MatrixType = SparseMatrix<double> >
+class PreconditionJacobi : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
@@ -520,7 +520,7 @@ public:
  * Using the right hand side <i>b</i> and the previous iterate <i>x</i>, this
  * is the operation implemented by step().
  *
- * The MATRIX class used is required to have functions
+ * The MatrixType class used is required to have functions
  * <tt>precondition_SOR(VectorType&, const VectorType&, double)</tt> and
  * <tt>precondition_TSOR(VectorType&, const VectorType&, double)</tt>.
  *
@@ -544,8 +544,8 @@ public:
  *
  * @author Guido Kanschat, 2000
  */
-template <class MATRIX = SparseMatrix<double> >
-class PreconditionSOR : public PreconditionRelaxation<MATRIX>
+template <typename MatrixType = SparseMatrix<double> >
+class PreconditionSOR : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
@@ -576,7 +576,7 @@ public:
 
 
 /**
- * SSOR preconditioner using matrix built-in function.  The <tt>MATRIX</tt>
+ * SSOR preconditioner using matrix built-in function.  The <tt>MatrixType</tt>
  * class used is required to have a function <tt>precondition_SSOR(VectorType&,
  * const VectorType&, double)</tt>
  *
@@ -600,19 +600,19 @@ public:
  *
  * @author Guido Kanschat, 2000
  */
-template <class MATRIX = SparseMatrix<double> >
-class PreconditionSSOR : public PreconditionRelaxation<MATRIX>
+template <typename MatrixType = SparseMatrix<double> >
+class PreconditionSSOR : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
    * Declare type for container size.
    */
-  typedef typename MATRIX::size_type size_type;
+  typedef typename MatrixType::size_type size_type;
 
   /**
    * A typedef to the base class.
    */
-  typedef PreconditionRelaxation<MATRIX> BaseClass;
+  typedef PreconditionRelaxation<MatrixType> BaseClass;
 
 
   /**
@@ -620,7 +620,7 @@ public:
    * the preconditioner object. The relaxation parameter should be larger than
    * zero and smaller than 2 for numerical reasons. It defaults to 1.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType &A,
                    const typename BaseClass::AdditionalData &parameters = typename BaseClass::AdditionalData());
 
   /**
@@ -660,7 +660,7 @@ private:
 
 /**
  * Permuted SOR preconditioner using matrix built-in function.  The
- * <tt>MATRIX</tt> class used is required to have functions <tt>PSOR(VectorType&,
+ * <tt>MatrixType</tt> class used is required to have functions <tt>PSOR(VectorType&,
  * const VectorType&, double)</tt> and <tt>TPSOR(VectorType&, const VectorType&,
  * double)</tt>.
  *
@@ -690,14 +690,14 @@ private:
  * @author Guido Kanschat, 2003; extension for full compatibility with
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
-template <class MATRIX = SparseMatrix<double> >
-class PreconditionPSOR : public PreconditionRelaxation<MATRIX>
+template <typename MatrixType = SparseMatrix<double> >
+class PreconditionPSOR : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
    * Declare type for container size.
    */
-  typedef typename MATRIX::size_type size_type;
+  typedef typename MatrixType::size_type size_type;
 
   /**
     * Parameters for PreconditionPSOR.
@@ -717,8 +717,8 @@ public:
      */
     AdditionalData (const std::vector<size_type> &permutation,
                     const std::vector<size_type> &inverse_permutation,
-                    const typename PreconditionRelaxation<MATRIX>::AdditionalData
-                    &parameters = typename PreconditionRelaxation<MATRIX>::AdditionalData());
+                    const typename PreconditionRelaxation<MatrixType>::AdditionalData
+                    &parameters = typename PreconditionRelaxation<MatrixType>::AdditionalData());
 
     /**
      * Storage for the permutation vector.
@@ -731,7 +731,7 @@ public:
     /**
      * Relaxation parameters
      */
-    typename PreconditionRelaxation<MATRIX>::AdditionalData parameters;
+    typename PreconditionRelaxation<MatrixType>::AdditionalData parameters;
   };
 
   /**
@@ -745,11 +745,11 @@ public:
    * The relaxation parameter should be larger than zero and smaller than 2
    * for numerical reasons. It defaults to 1.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType             &A,
                    const std::vector<size_type> &permutation,
                    const std::vector<size_type> &inverse_permutation,
-                   const typename PreconditionRelaxation<MATRIX>::AdditionalData &
-                   parameters = typename PreconditionRelaxation<MATRIX>::AdditionalData());
+                   const typename PreconditionRelaxation<MatrixType>::AdditionalData &
+                   parameters = typename PreconditionRelaxation<MatrixType>::AdditionalData());
 
   /**
    * Initialize matrix and relaxation parameter. The matrix is just stored in
@@ -761,7 +761,7 @@ public:
    * After this function is called the preconditioner is ready to be used
    * (using the <code>vmult</code> function of derived classes).
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType &A,
                    const AdditionalData &additional_data);
 
   /**
@@ -803,7 +803,7 @@ private:
  * @author Martin Kronbichler, 2009; extension for full compatibility with
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
-template <class MATRIX=SparseMatrix<double>, class VectorType=Vector<double> >
+template <typename MatrixType=SparseMatrix<double>, class VectorType=Vector<double> >
 class PreconditionChebyshev : public Subscriptor
 {
 public:
@@ -899,7 +899,7 @@ public:
    * matrix weighted by its diagonal using a modified CG iteration in case the
    * given number of iterations is positive.
    */
-  void initialize (const MATRIX         &matrix,
+  void initialize (const MatrixType     &matrix,
                    const AdditionalData &additional_data = AdditionalData());
 
   /**
@@ -938,7 +938,7 @@ private:
   /**
    * A pointer to the underlying matrix.
    */
-  SmartPointer<const MATRIX,PreconditionChebyshev<MATRIX,VectorType> > matrix_ptr;
+  SmartPointer<const MatrixType,PreconditionChebyshev<MatrixType,VectorType> > matrix_ptr;
 
   /**
    * Internal vector used for the <tt>vmult</tt> operation.
@@ -986,11 +986,10 @@ PreconditionIdentity::PreconditionIdentity ()
   n_columns (0)
 {}
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionIdentity::initialize (
-  const MATRIX &matrix,
-  const PreconditionIdentity::AdditionalData &)
+PreconditionIdentity::initialize (const MatrixType &matrix,
+                                  const PreconditionIdentity::AdditionalData &)
 {
   n_rows = matrix.m();
   n_columns = matrix.n();
@@ -1046,8 +1045,7 @@ PreconditionIdentity::n () const
 //---------------------------------------------------------------------------
 
 inline
-PreconditionRichardson::AdditionalData::AdditionalData (
-  const double relaxation)
+PreconditionRichardson::AdditionalData::AdditionalData (const double relaxation)
   :
   relaxation(relaxation)
 {}
@@ -1067,19 +1065,19 @@ PreconditionRichardson::PreconditionRichardson ()
 
 
 inline void
-PreconditionRichardson::initialize (
-  const PreconditionRichardson::AdditionalData &parameters)
+PreconditionRichardson::initialize
+(const PreconditionRichardson::AdditionalData &parameters)
 {
   relaxation = parameters.relaxation;
 }
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionRichardson::initialize (
-  const MATRIX &matrix,
-  const PreconditionRichardson::AdditionalData &parameters)
+PreconditionRichardson::initialize
+(const MatrixType                             &matrix,
+ const PreconditionRichardson::AdditionalData &parameters)
 {
   relaxation = parameters.relaxation;
   n_rows = matrix.m();
@@ -1160,34 +1158,34 @@ PreconditionRichardson::n () const
 
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionRelaxation<MATRIX>::initialize (const MATRIX &rA,
-                                            const AdditionalData &parameters)
+PreconditionRelaxation<MatrixType>::initialize (const MatrixType     &rA,
+                                                const AdditionalData &parameters)
 {
   A = &rA;
   relaxation = parameters.relaxation;
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionRelaxation<MATRIX>::clear ()
+PreconditionRelaxation<MatrixType>::clear ()
 {
   A = 0;
 }
 
-template <class MATRIX>
-inline typename PreconditionRelaxation<MATRIX>::size_type
-PreconditionRelaxation<MATRIX>::m () const
+template <typename MatrixType>
+inline typename PreconditionRelaxation<MatrixType>::size_type
+PreconditionRelaxation<MatrixType>::m () const
 {
   Assert (A!=0, ExcNotInitialized());
   return A->m();
 }
 
-template <class MATRIX>
-inline typename PreconditionRelaxation<MATRIX>::size_type
-PreconditionRelaxation<MATRIX>::n () const
+template <typename MatrixType>
+inline typename PreconditionRelaxation<MatrixType>::size_type
+PreconditionRelaxation<MatrixType>::n () const
 {
   Assert (A!=0, ExcNotInitialized());
   return A->n();
@@ -1195,14 +1193,14 @@ PreconditionRelaxation<MATRIX>::n () const
 
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
+PreconditionJacobi<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1212,14 +1210,14 @@ PreconditionJacobi<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
+PreconditionJacobi<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1229,14 +1227,14 @@ PreconditionJacobi<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) cons
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::step (VectorType &dst, const VectorType &src) const
+PreconditionJacobi<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1246,14 +1244,14 @@ PreconditionJacobi<MATRIX>::step (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
+PreconditionJacobi<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1264,14 +1262,14 @@ PreconditionJacobi<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
+PreconditionSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1281,14 +1279,14 @@ PreconditionSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
+PreconditionSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1298,14 +1296,14 @@ PreconditionSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
+PreconditionSOR<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1315,14 +1313,14 @@ PreconditionSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
+PreconditionSOR<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1334,17 +1332,17 @@ PreconditionSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionSSOR<MATRIX>::initialize (const MATRIX &rA,
+PreconditionSSOR<MatrixType>::initialize (const MatrixType                     &rA,
                                       const typename BaseClass::AdditionalData &parameters)
 {
-  this->PreconditionRelaxation<MATRIX>::initialize (rA, parameters);
+  this->PreconditionRelaxation<MatrixType>::initialize (rA, parameters);
 
   // in case we have a SparseMatrix class, we can extract information about
   // the diagonal.
-  const SparseMatrix<typename MATRIX::value_type> *mat =
-    dynamic_cast<const SparseMatrix<typename MATRIX::value_type> *>(&*this->A);
+  const SparseMatrix<typename MatrixType::value_type> *mat =
+    dynamic_cast<const SparseMatrix<typename MatrixType::value_type> *>(&*this->A);
 
   // calculate the positions first after the diagonal.
   if (mat != 0)
@@ -1357,7 +1355,7 @@ PreconditionSSOR<MATRIX>::initialize (const MATRIX &rA,
           // diagonal.  we need to precondition with the elements on the left
           // only. note: the first entry in each line denotes the diagonal
           // element, which we need not check.
-          typename SparseMatrix<typename MATRIX::value_type>::const_iterator
+          typename SparseMatrix<typename MatrixType::value_type>::const_iterator
           it = mat->begin(row)+1;
           for ( ; it < mat->end(row); ++it)
             if (it->column() > row)
@@ -1368,14 +1366,14 @@ PreconditionSSOR<MATRIX>::initialize (const MATRIX &rA,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
+PreconditionSSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1385,14 +1383,14 @@ PreconditionSSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
+PreconditionSSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1402,14 +1400,14 @@ PreconditionSSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
+PreconditionSSOR<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1419,14 +1417,14 @@ PreconditionSSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
+PreconditionSSOR<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1437,25 +1435,24 @@ PreconditionSSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionPSOR<MATRIX>::initialize (
-  const MATRIX &rA,
-  const std::vector<size_type> &p,
-  const std::vector<size_type> &ip,
-  const typename PreconditionRelaxation<MATRIX>::AdditionalData &parameters)
+PreconditionPSOR<MatrixType>::initialize
+(const MatrixType             &rA,
+ const std::vector<size_type> &p,
+ const std::vector<size_type> &ip,
+ const typename PreconditionRelaxation<MatrixType>::AdditionalData &parameters)
 {
   permutation = &p;
   inverse_permutation = &ip;
-  PreconditionRelaxation<MATRIX>::initialize(rA, parameters);
+  PreconditionRelaxation<MatrixType>::initialize(rA, parameters);
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-PreconditionPSOR<MATRIX>::initialize (
-  const MATRIX         &A,
-  const AdditionalData &additional_data)
+PreconditionPSOR<MatrixType>::initialize (const MatrixType     &A,
+                                          const AdditionalData &additional_data)
 {
   initialize(A,
              additional_data.permutation,
@@ -1464,14 +1461,14 @@ PreconditionPSOR<MATRIX>::initialize (
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <typename VectorType>
 inline void
-PreconditionPSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
+PreconditionPSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionPSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionPSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1482,14 +1479,14 @@ PreconditionPSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template<class VectorType>
 inline void
-PreconditionPSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
+PreconditionPSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    std::is_same<typename PreconditionPSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionPSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
@@ -1498,11 +1495,11 @@ PreconditionPSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
   this->A->TPSOR (dst, *permutation, *inverse_permutation, this->relaxation);
 }
 
-template <class MATRIX>
-PreconditionPSOR<MATRIX>::AdditionalData::AdditionalData (
-  const std::vector<size_type> &permutation,
-  const std::vector<size_type> &inverse_permutation,
-  const typename PreconditionRelaxation<MATRIX>::AdditionalData &parameters)
+template <typename MatrixType>
+PreconditionPSOR<MatrixType>::AdditionalData::AdditionalData
+(const std::vector<size_type> &permutation,
+ const std::vector<size_type> &inverse_permutation,
+ const typename PreconditionRelaxation<MatrixType>::AdditionalData &parameters)
   :
   permutation(permutation),
   inverse_permutation(inverse_permutation),
@@ -1515,28 +1512,28 @@ PreconditionPSOR<MATRIX>::AdditionalData::AdditionalData (
 //---------------------------------------------------------------------------
 
 
-template<class MATRIX, class VectorType>
-PreconditionUseMatrix<MATRIX,VectorType>::PreconditionUseMatrix(const MATRIX       &M,
-                                                                const function_ptr method)
+template<typename MatrixType, class VectorType>
+PreconditionUseMatrix<MatrixType,VectorType>::PreconditionUseMatrix(const MatrixType   &M,
+                                                                    const function_ptr method)
   :
   matrix(M), precondition(method)
 {}
 
 
 
-template<class MATRIX, class VectorType>
+template<typename MatrixType, class VectorType>
 void
-PreconditionUseMatrix<MATRIX,VectorType>::vmult (VectorType       &dst,
-                                                 const VectorType &src) const
+PreconditionUseMatrix<MatrixType,VectorType>::vmult (VectorType       &dst,
+                                                     const VectorType &src) const
 {
   (matrix.*precondition)(dst, src);
 }
 
 //---------------------------------------------------------------------------
 
-template<class MATRIX>
+template<typename MatrixType>
 inline
-PreconditionRelaxation<MATRIX>::AdditionalData::
+PreconditionRelaxation<MatrixType>::AdditionalData::
 AdditionalData (const double relaxation)
   :
   relaxation (relaxation)
@@ -1761,9 +1758,9 @@ namespace internal
 
 
 
-template <class MATRIX, class VectorType>
+template <typename MatrixType, class VectorType>
 inline
-PreconditionChebyshev<MATRIX,VectorType>::AdditionalData::
+PreconditionChebyshev<MatrixType,VectorType>::AdditionalData::
 AdditionalData (const unsigned int degree,
                 const double       smoothing_range,
                 const bool         nonzero_starting,
@@ -1781,9 +1778,9 @@ AdditionalData (const unsigned int degree,
 
 
 
-template <class MATRIX, class VectorType>
+template <typename MatrixType, class VectorType>
 inline
-PreconditionChebyshev<MATRIX,VectorType>::PreconditionChebyshev ()
+PreconditionChebyshev<MatrixType,VectorType>::PreconditionChebyshev ()
   :
   is_initialized (false)
 {
@@ -1796,11 +1793,12 @@ PreconditionChebyshev<MATRIX,VectorType>::PreconditionChebyshev ()
 
 
 
-template <class MATRIX, class VectorType>
+template <typename MatrixType, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VectorType>::initialize (const MATRIX         &matrix,
-                                                      const AdditionalData &additional_data)
+PreconditionChebyshev<MatrixType,VectorType>::initialize
+(const MatrixType     &matrix,
+ const AdditionalData &additional_data)
 {
   matrix_ptr = &matrix;
   data = additional_data;
@@ -1892,11 +1890,11 @@ PreconditionChebyshev<MATRIX,VectorType>::initialize (const MATRIX         &matr
 
 
 
-template <class MATRIX, class VectorType>
+template <typename MatrixType, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VectorType>::vmult (VectorType       &dst,
-                                                 const VectorType &src) const
+PreconditionChebyshev<MatrixType,VectorType>::vmult (VectorType       &dst,
+                                                     const VectorType &src) const
 {
   Assert (is_initialized, ExcMessage("Preconditioner not initialized"));
   double rhok  = delta / theta,  sigma = theta / delta;
@@ -1926,11 +1924,11 @@ PreconditionChebyshev<MATRIX,VectorType>::vmult (VectorType       &dst,
 
 
 
-template <class MATRIX, class VectorType>
+template <typename MatrixType, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VectorType>::Tvmult (VectorType       &dst,
-                                                  const VectorType &src) const
+PreconditionChebyshev<MatrixType,VectorType>::Tvmult (VectorType       &dst,
+                                                      const VectorType &src) const
 {
   Assert (is_initialized, ExcMessage("Preconditioner not initialized"));
   double rhok  = delta / theta,  sigma = theta / delta;
@@ -1960,9 +1958,9 @@ PreconditionChebyshev<MATRIX,VectorType>::Tvmult (VectorType       &dst,
 
 
 
-template <class MATRIX, typename VectorType>
+template <typename MatrixType, typename VectorType>
 inline
-void PreconditionChebyshev<MATRIX,VectorType>::clear ()
+void PreconditionChebyshev<MatrixType,VectorType>::clear ()
 {
   is_initialized = false;
   matrix_ptr = 0;
@@ -1972,20 +1970,20 @@ void PreconditionChebyshev<MATRIX,VectorType>::clear ()
 }
 
 
-template <class MATRIX, typename VectorType>
+template <typename MatrixType, typename VectorType>
 inline
-typename PreconditionChebyshev<MATRIX,VectorType>::size_type
-PreconditionChebyshev<MATRIX,VectorType>::m () const
+typename PreconditionChebyshev<MatrixType,VectorType>::size_type
+PreconditionChebyshev<MatrixType,VectorType>::m () const
 {
   Assert (matrix_ptr!=0, ExcNotInitialized());
   return matrix_ptr->m();
 }
 
 
-template <class MATRIX, typename VectorType>
+template <typename MatrixType, typename VectorType>
 inline
-typename PreconditionChebyshev<MATRIX,VectorType>::size_type
-PreconditionChebyshev<MATRIX,VectorType>::n () const
+typename PreconditionChebyshev<MatrixType,VectorType>::size_type
+PreconditionChebyshev<MatrixType,VectorType>::n () const
 {
   Assert (matrix_ptr!=0, ExcNotInitialized());
   return matrix_ptr->n();

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -105,28 +105,28 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner. Since this is the identity, this function
    * is the same as vmult().
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply preconditioner, adding to the previous value.
    */
-  template<class VECTOR>
-  void vmult_add (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult_add (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner, adding. Since this is the identity, this
    * function is the same as vmult_add().
    */
-  template<class VECTOR>
-  void Tvmult_add (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult_add (VectorType &, const VectorType &) const;
 
   /**
    * This function is only present to provide the interface of a
@@ -228,27 +228,27 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner. Since this is the identity, this function
    * is the same as vmult().
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
   /**
    * Apply preconditioner, adding to the previous value.
    */
-  template<class VECTOR>
-  void vmult_add (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult_add (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner, adding. Since this is the identity, this
    * function is the same as vmult_add().
    */
-  template<class VECTOR>
-  void Tvmult_add (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult_add (VectorType &, const VectorType &) const;
 
   /**
    * This function is only present to provide the interface of a
@@ -333,14 +333,14 @@ private:
  *
  * @author Guido Kanschat, Wolfgang Bangerth, 1999
  */
-template<class MATRIX = SparseMatrix<double>, class VECTOR = Vector<double> >
+template<class MATRIX = SparseMatrix<double>, class VectorType = Vector<double> >
 class PreconditionUseMatrix : public Subscriptor
 {
 public:
   /**
    * Type of the preconditioning function of the matrix.
    */
-  typedef void ( MATRIX::* function_ptr)(VECTOR &, const VECTOR &) const;
+  typedef void ( MATRIX::* function_ptr)(VectorType &, const VectorType &) const;
 
   /**
    * Constructor.  This constructor stores a reference to the matrix object
@@ -354,8 +354,8 @@ public:
    * Execute preconditioning. Calls the function passed to the constructor of
    * this object with the two arguments given here.
    */
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const;
+  void vmult (VectorType       &dst,
+              const VectorType &src) const;
 
 private:
   /**
@@ -446,8 +446,8 @@ protected:
 
 /**
  * Jacobi preconditioner using matrix built-in function.  The <tt>MATRIX</tt>
- * class used is required to have a function <tt>precondition_Jacobi(VECTOR&,
- * const VECTOR&, double</tt>)
+ * class used is required to have a function <tt>precondition_Jacobi(VectorType&,
+ * const VectorType&, double</tt>)
  *
  * @code
  *     // Declare related objects
@@ -476,27 +476,27 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner. Since this is a symmetric preconditioner,
    * this function is the same as vmult().
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
 
   /**
    * Perform one step of the preconditioned Richardson iteration.
    */
-  template<class VECTOR>
-  void step (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void step (VectorType &x, const VectorType &rhs) const;
 
   /**
    * Perform one transposed step of the preconditioned Richardson iteration.
    */
-  template<class VECTOR>
-  void Tstep (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void Tstep (VectorType &x, const VectorType &rhs) const;
 };
 
 
@@ -521,8 +521,8 @@ public:
  * is the operation implemented by step().
  *
  * The MATRIX class used is required to have functions
- * <tt>precondition_SOR(VECTOR&, const VECTOR&, double)</tt> and
- * <tt>precondition_TSOR(VECTOR&, const VECTOR&, double)</tt>.
+ * <tt>precondition_SOR(VectorType&, const VectorType&, double)</tt> and
+ * <tt>precondition_TSOR(VectorType&, const VectorType&, double)</tt>.
  *
  * @code
  *     // Declare related objects
@@ -551,34 +551,34 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner.
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
 
   /**
    * Perform one step of the preconditioned Richardson iteration.
    */
-  template<class VECTOR>
-  void step (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void step (VectorType &x, const VectorType &rhs) const;
 
   /**
    * Perform one transposed step of the preconditioned Richardson iteration.
    */
-  template<class VECTOR>
-  void Tstep (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void Tstep (VectorType &x, const VectorType &rhs) const;
 };
 
 
 
 /**
  * SSOR preconditioner using matrix built-in function.  The <tt>MATRIX</tt>
- * class used is required to have a function <tt>precondition_SSOR(VECTOR&,
- * const VECTOR&, double)</tt>
+ * class used is required to have a function <tt>precondition_SSOR(VectorType&,
+ * const VectorType&, double)</tt>
  *
  * @code
  *     // Declare related objects
@@ -626,28 +626,28 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner. Since this is a symmetric preconditioner,
    * this function is the same as vmult().
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
 
 
   /**
    * Perform one step of the preconditioned Richardson iteration
    */
-  template<class VECTOR>
-  void step (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void step (VectorType &x, const VectorType &rhs) const;
 
   /**
    * Perform one transposed step of the preconditioned Richardson iteration.
    */
-  template<class VECTOR>
-  void Tstep (VECTOR &x, const VECTOR &rhs) const;
+  template<class VectorType>
+  void Tstep (VectorType &x, const VectorType &rhs) const;
 
 private:
   /**
@@ -660,8 +660,8 @@ private:
 
 /**
  * Permuted SOR preconditioner using matrix built-in function.  The
- * <tt>MATRIX</tt> class used is required to have functions <tt>PSOR(VECTOR&,
- * const VECTOR&, double)</tt> and <tt>TPSOR(VECTOR&, const VECTOR&,
+ * <tt>MATRIX</tt> class used is required to have functions <tt>PSOR(VectorType&,
+ * const VectorType&, double)</tt> and <tt>TPSOR(VectorType&, const VectorType&,
  * double)</tt>.
  *
  * @code
@@ -767,14 +767,14 @@ public:
   /**
    * Apply preconditioner.
    */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose preconditioner.
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<class VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
 private:
   /**
    * Storage for the permutation vector.
@@ -803,7 +803,7 @@ private:
  * @author Martin Kronbichler, 2009; extension for full compatibility with
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
-template <class MATRIX=SparseMatrix<double>, class VECTOR=Vector<double> >
+template <class MATRIX=SparseMatrix<double>, class VectorType=Vector<double> >
 class PreconditionChebyshev : public Subscriptor
 {
 public:
@@ -883,7 +883,7 @@ public:
     /**
      * Stores the inverse of the diagonal of the underlying matrix.
      */
-    VECTOR matrix_diagonal_inverse;
+    VectorType matrix_diagonal_inverse;
   };
 
   PreconditionChebyshev ();
@@ -906,15 +906,15 @@ public:
    * Computes the action of the preconditioner on <tt>src</tt>, storing the
    * result in <tt>dst</tt>.
    */
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const;
+  void vmult (VectorType       &dst,
+              const VectorType &src) const;
 
   /**
    * Computes the action of the transposed preconditioner on <tt>src</tt>,
    * storing the result in <tt>dst</tt>.
    */
-  void Tvmult (VECTOR       &dst,
-               const VECTOR &src) const;
+  void Tvmult (VectorType       &dst,
+               const VectorType &src) const;
 
   /**
    * Resets the preconditioner.
@@ -938,17 +938,17 @@ private:
   /**
    * A pointer to the underlying matrix.
    */
-  SmartPointer<const MATRIX,PreconditionChebyshev<MATRIX,VECTOR> > matrix_ptr;
+  SmartPointer<const MATRIX,PreconditionChebyshev<MATRIX,VectorType> > matrix_ptr;
 
   /**
    * Internal vector used for the <tt>vmult</tt> operation.
    */
-  mutable VECTOR update1;
+  mutable VectorType update1;
 
   /**
    * Internal vector used for the <tt>vmult</tt> operation.
    */
-  mutable VECTOR update2;
+  mutable VectorType update2;
 
   /**
    * Stores the additional data provided to the initialize function.
@@ -997,34 +997,34 @@ PreconditionIdentity::initialize (
 }
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionIdentity::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionIdentity::vmult (VectorType &dst, const VectorType &src) const
 {
   dst = src;
 }
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionIdentity::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionIdentity::Tvmult (VectorType &dst, const VectorType &src) const
 {
   dst = src;
 }
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionIdentity::vmult_add (VECTOR &dst, const VECTOR &src) const
+PreconditionIdentity::vmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(src);
 }
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionIdentity::Tvmult_add (VECTOR &dst, const VECTOR &src) const
+PreconditionIdentity::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(src);
 }
@@ -1088,14 +1088,14 @@ PreconditionRichardson::initialize (
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionRichardson::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionRichardson::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<size_type, typename VECTOR::size_type>::value,
-    "PreconditionRichardson and VECTOR must have the same size_type.");
+    std::is_same<size_type, typename VectorType::size_type>::value,
+    "PreconditionRichardson and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   dst.equ(relaxation,src);
@@ -1103,27 +1103,27 @@ PreconditionRichardson::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionRichardson::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionRichardson::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<size_type, typename VECTOR::size_type>::value,
-    "PreconditionRichardson and VECTOR must have the same size_type.");
+    std::is_same<size_type, typename VectorType::size_type>::value,
+    "PreconditionRichardson and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   dst.equ(relaxation,src);
 }
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionRichardson::vmult_add (VECTOR &dst, const VECTOR &src) const
+PreconditionRichardson::vmult_add (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<size_type, typename VECTOR::size_type>::value,
-    "PreconditionRichardson and VECTOR must have the same size_type.");
+    std::is_same<size_type, typename VectorType::size_type>::value,
+    "PreconditionRichardson and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   dst.add(relaxation,src);
@@ -1131,14 +1131,14 @@ PreconditionRichardson::vmult_add (VECTOR &dst, const VECTOR &src) const
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionRichardson::Tvmult_add (VECTOR &dst, const VECTOR &src) const
+PreconditionRichardson::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<size_type, typename VECTOR::size_type>::value,
-    "PreconditionRichardson and VECTOR must have the same size_type.");
+    std::is_same<size_type, typename VectorType::size_type>::value,
+    "PreconditionRichardson and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   dst.add(relaxation,src);
@@ -1196,14 +1196,14 @@ PreconditionRelaxation<MATRIX>::n () const
 //---------------------------------------------------------------------------
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionJacobi<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionJacobi and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1213,14 +1213,14 @@ PreconditionJacobi<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionJacobi<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionJacobi and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1230,14 +1230,14 @@ PreconditionJacobi<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
+PreconditionJacobi<MATRIX>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionJacobi and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1247,14 +1247,14 @@ PreconditionJacobi<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionJacobi<MATRIX>::Tstep (VECTOR &dst, const VECTOR &src) const
+PreconditionJacobi<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionJacobi and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionJacobi<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionJacobi and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   step (dst, src);
@@ -1265,14 +1265,14 @@ PreconditionJacobi<MATRIX>::Tstep (VECTOR &dst, const VECTOR &src) const
 //---------------------------------------------------------------------------
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1282,14 +1282,14 @@ PreconditionSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1299,14 +1299,14 @@ PreconditionSOR<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
+PreconditionSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1316,14 +1316,14 @@ PreconditionSOR<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSOR<MATRIX>::Tstep (VECTOR &dst, const VECTOR &src) const
+PreconditionSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1369,14 +1369,14 @@ PreconditionSSOR<MATRIX>::initialize (const MATRIX &rA,
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionSSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1386,14 +1386,14 @@ PreconditionSSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionSSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1403,14 +1403,14 @@ PreconditionSSOR<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
+PreconditionSSOR<MATRIX>::step (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1420,14 +1420,14 @@ PreconditionSSOR<MATRIX>::step (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionSSOR<MATRIX>::Tstep (VECTOR &dst, const VECTOR &src) const
+PreconditionSSOR<MATRIX>::Tstep (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionSSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionSSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionSSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   step (dst, src);
@@ -1465,14 +1465,14 @@ PreconditionPSOR<MATRIX>::initialize (
 
 
 template <class MATRIX>
-template<class VECTOR>
+template <typename VectorType>
 inline void
-PreconditionPSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
+PreconditionPSOR<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionPSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionPSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1483,14 +1483,14 @@ PreconditionPSOR<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template<class VECTOR>
+template<class VectorType>
 inline void
-PreconditionPSOR<MATRIX>::Tvmult (VECTOR &dst, const VECTOR &src) const
+PreconditionPSOR<MATRIX>::Tvmult (VectorType &dst, const VectorType &src) const
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VECTOR::size_type>::value,
-    "PreconditionPSOR and VECTOR must have the same size_type.");
+    std::is_same<typename PreconditionPSOR<MATRIX>::size_type, typename VectorType::size_type>::value,
+    "PreconditionPSOR and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
@@ -1515,19 +1515,19 @@ PreconditionPSOR<MATRIX>::AdditionalData::AdditionalData (
 //---------------------------------------------------------------------------
 
 
-template<class MATRIX, class VECTOR>
-PreconditionUseMatrix<MATRIX,VECTOR>::PreconditionUseMatrix(const MATRIX       &M,
-                                                            const function_ptr  method)
+template<class MATRIX, class VectorType>
+PreconditionUseMatrix<MATRIX,VectorType>::PreconditionUseMatrix(const MATRIX       &M,
+                                                                const function_ptr method)
   :
   matrix(M), precondition(method)
 {}
 
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, class VectorType>
 void
-PreconditionUseMatrix<MATRIX,VECTOR>::vmult (VECTOR &dst,
-                                             const VECTOR &src) const
+PreconditionUseMatrix<MATRIX,VectorType>::vmult (VectorType       &dst,
+                                                 const VectorType &src) const
 {
   (matrix.*precondition)(dst, src);
 }
@@ -1556,17 +1556,17 @@ namespace internal
     // size of the vector
 
     // generic part for non-deal.II vectors
-    template <typename VECTOR>
+    template <typename VectorType>
     inline
     void
-    vector_updates (const VECTOR &src,
-                    const VECTOR &matrix_diagonal_inverse,
-                    const bool    start_zero,
-                    const double  factor1,
-                    const double  factor2,
-                    VECTOR &update1,
-                    VECTOR &update2,
-                    VECTOR &dst)
+    vector_updates (const VectorType &src,
+                    const VectorType &matrix_diagonal_inverse,
+                    const bool       start_zero,
+                    const double     factor1,
+                    const double     factor2,
+                    VectorType       &update1,
+                    VectorType       &update2,
+                    VectorType       &dst)
     {
       if (start_zero)
         {
@@ -1728,22 +1728,22 @@ namespace internal
       VectorUpdatesRange<Number>(upd, src.local_size());
     }
 
-    template <typename VECTOR>
+    template <typename VectorType>
     struct DiagonalPreconditioner
     {
-      DiagonalPreconditioner (const VECTOR &vector)
+      DiagonalPreconditioner (const VectorType &vector)
         :
         diagonal_vector(vector)
       {}
 
-      void vmult (VECTOR &dst,
-                  const VECTOR &src) const
+      void vmult (VectorType       &dst,
+                  const VectorType &src) const
       {
         dst = src;
         dst.scale(diagonal_vector);
       }
 
-      const VECTOR &diagonal_vector;
+      const VectorType &diagonal_vector;
     };
 
     struct EigenvalueTracker
@@ -1761,9 +1761,9 @@ namespace internal
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, class VectorType>
 inline
-PreconditionChebyshev<MATRIX,VECTOR>::AdditionalData::
+PreconditionChebyshev<MATRIX,VectorType>::AdditionalData::
 AdditionalData (const unsigned int degree,
                 const double       smoothing_range,
                 const bool         nonzero_starting,
@@ -1781,26 +1781,26 @@ AdditionalData (const unsigned int degree,
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, class VectorType>
 inline
-PreconditionChebyshev<MATRIX,VECTOR>::PreconditionChebyshev ()
+PreconditionChebyshev<MATRIX,VectorType>::PreconditionChebyshev ()
   :
   is_initialized (false)
 {
 #ifdef DEAL_II_WITH_CXX11
   static_assert(
-    std::is_same<size_type, typename VECTOR::size_type>::value,
-    "PreconditionChebyshev and VECTOR must have the same size_type.");
+    std::is_same<size_type, typename VectorType::size_type>::value,
+    "PreconditionChebyshev and VectorType must have the same size_type.");
 #endif // DEAL_II_WITH_CXX11
 }
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VECTOR>::initialize (const MATRIX &matrix,
-                                                  const AdditionalData &additional_data)
+PreconditionChebyshev<MATRIX,VectorType>::initialize (const MATRIX         &matrix,
+                                                      const AdditionalData &additional_data)
 {
   matrix_ptr = &matrix;
   data = additional_data;
@@ -1825,9 +1825,9 @@ PreconditionChebyshev<MATRIX,VECTOR>::initialize (const MATRIX &matrix,
 
       // set a very strict tolerance to force at least two iterations
       ReductionControl control (data.eig_cg_n_iterations, 1e-35, 1e-10);
-      GrowingVectorMemory<VECTOR> memory;
-      VECTOR *rhs = memory.alloc();
-      VECTOR *dummy = memory.alloc();
+      GrowingVectorMemory<VectorType> memory;
+      VectorType *rhs = memory.alloc();
+      VectorType *dummy = memory.alloc();
       rhs->reinit(data.matrix_diagonal_inverse);
       dummy->reinit(data.matrix_diagonal_inverse);
 
@@ -1842,11 +1842,11 @@ PreconditionChebyshev<MATRIX,VECTOR>::initialize (const MATRIX &matrix,
       rhs->compress(VectorOperation::insert);
 
       internal::PreconditionChebyshev::EigenvalueTracker eigenvalue_tracker;
-      SolverCG<VECTOR> solver (control, memory);
+      SolverCG<VectorType> solver (control, memory);
       solver.connect_eigenvalues_slot(std_cxx11::bind(&internal::PreconditionChebyshev::EigenvalueTracker::slot,
                                                       &eigenvalue_tracker,
                                                       std_cxx11::_1));
-      internal::PreconditionChebyshev::DiagonalPreconditioner<VECTOR>
+      internal::PreconditionChebyshev::DiagonalPreconditioner<VectorType>
       preconditioner(data.matrix_diagonal_inverse);
       try
         {
@@ -1892,11 +1892,11 @@ PreconditionChebyshev<MATRIX,VECTOR>::initialize (const MATRIX &matrix,
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VECTOR>::vmult (VECTOR &dst,
-                                             const VECTOR &src) const
+PreconditionChebyshev<MATRIX,VectorType>::vmult (VectorType       &dst,
+                                                 const VectorType &src) const
 {
   Assert (is_initialized, ExcMessage("Preconditioner not initialized"));
   double rhok  = delta / theta,  sigma = theta / delta;
@@ -1926,11 +1926,11 @@ PreconditionChebyshev<MATRIX,VECTOR>::vmult (VECTOR &dst,
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, class VectorType>
 inline
 void
-PreconditionChebyshev<MATRIX,VECTOR>::Tvmult (VECTOR &dst,
-                                              const VECTOR &src) const
+PreconditionChebyshev<MATRIX,VectorType>::Tvmult (VectorType       &dst,
+                                                  const VectorType &src) const
 {
   Assert (is_initialized, ExcMessage("Preconditioner not initialized"));
   double rhok  = delta / theta,  sigma = theta / delta;
@@ -1960,9 +1960,9 @@ PreconditionChebyshev<MATRIX,VECTOR>::Tvmult (VECTOR &dst,
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, typename VectorType>
 inline
-void PreconditionChebyshev<MATRIX,VECTOR>::clear ()
+void PreconditionChebyshev<MATRIX,VectorType>::clear ()
 {
   is_initialized = false;
   matrix_ptr = 0;
@@ -1972,20 +1972,20 @@ void PreconditionChebyshev<MATRIX,VECTOR>::clear ()
 }
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, typename VectorType>
 inline
-typename PreconditionChebyshev<MATRIX,VECTOR>::size_type
-PreconditionChebyshev<MATRIX,VECTOR>::m () const
+typename PreconditionChebyshev<MATRIX,VectorType>::size_type
+PreconditionChebyshev<MATRIX,VectorType>::m () const
 {
   Assert (matrix_ptr!=0, ExcNotInitialized());
   return matrix_ptr->m();
 }
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, typename VectorType>
 inline
-typename PreconditionChebyshev<MATRIX,VECTOR>::size_type
-PreconditionChebyshev<MATRIX,VECTOR>::n () const
+typename PreconditionChebyshev<MATRIX,VectorType>::size_type
+PreconditionChebyshev<MATRIX,VectorType>::n () const
 {
   Assert (matrix_ptr!=0, ExcNotInitialized());
   return matrix_ptr->n();

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1335,7 +1335,7 @@ PreconditionSOR<MatrixType>::Tstep (VectorType &dst, const VectorType &src) cons
 template <typename MatrixType>
 inline void
 PreconditionSSOR<MatrixType>::initialize (const MatrixType                     &rA,
-                                      const typename BaseClass::AdditionalData &parameters)
+                                          const typename BaseClass::AdditionalData &parameters)
 {
   this->PreconditionRelaxation<MatrixType>::initialize (rA, parameters);
 
@@ -1514,7 +1514,7 @@ PreconditionPSOR<MatrixType>::AdditionalData::AdditionalData
 
 template<typename MatrixType, class VectorType>
 PreconditionUseMatrix<MatrixType,VectorType>::PreconditionUseMatrix(const MatrixType   &M,
-                                                                    const function_ptr method)
+    const function_ptr method)
   :
   matrix(M), precondition(method)
 {}

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -27,7 +27,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 class PreconditionBlockJacobi;
 
 /*! @addtogroup Preconditioners
@@ -37,7 +37,7 @@ class PreconditionBlockJacobi;
 
 /**
  * Base class for actual block preconditioners. This class assumes the
- * <tt>MATRIX</tt> consisting of invertible blocks of @p blocksize on the
+ * <tt>MatrixType</tt> consisting of invertible blocks of @p blocksize on the
  * diagonal and provides the inversion of the diagonal blocks of the matrix.
  * It is not necessary for this class that the matrix be block diagonal;
  * rather, it applies to matrices of arbitrary structure with the minimal
@@ -80,7 +80,7 @@ class PreconditionBlockJacobi;
  * @author Ralf Hartmann, Guido Kanschat
  * @date 1999, 2000, 2010
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class PreconditionBlock
   : public virtual Subscriptor,
     protected PreconditionBlockBase<inverse_type>
@@ -89,7 +89,7 @@ private:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Value type for inverse matrices.
@@ -167,7 +167,7 @@ public:
    *
    * Additionally, a relaxation parameter for derived classes may be provided.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType &A,
                    const AdditionalData parameters);
 protected:
   /**
@@ -181,7 +181,7 @@ protected:
    *
    * Additionally, a relaxation parameter for derived classes may be provided.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType &A,
                    const std::vector<size_type> &permutation,
                    const std::vector<size_type> &inverse_permutation,
                    const AdditionalData parameters);
@@ -215,9 +215,8 @@ protected:
   /**
    * Replacement of invert_diagblocks() for permuted preconditioning.
    */
-  void invert_permuted_diagblocks(
-    const std::vector<size_type> &permutation,
-    const std::vector<size_type> &inverse_permutation);
+  void invert_permuted_diagblocks(const std::vector<size_type> &permutation,
+                                  const std::vector<size_type> &inverse_permutation);
 public:
   /**
    * Deletes the inverse diagonal block matrices if existent, sets the
@@ -267,11 +266,10 @@ public:
    * function.
    */
   template <typename number2>
-  void forward_step (
-    Vector<number2>       &dst,
-    const Vector<number2> &prev,
-    const Vector<number2> &src,
-    const bool transpose_diagonal) const;
+  void forward_step (Vector<number2>       &dst,
+                     const Vector<number2> &prev,
+                     const Vector<number2> &src,
+                     const bool             transpose_diagonal) const;
 
   /**
    * Perform one block relaxation step in backward numbering.
@@ -285,11 +283,10 @@ public:
    * function.
    */
   template <typename number2>
-  void backward_step (
-    Vector<number2>       &dst,
-    const Vector<number2> &prev,
-    const Vector<number2> &src,
-    const bool transpose_diagonal) const;
+  void backward_step (Vector<number2>       &dst,
+                      const Vector<number2> &prev,
+                      const Vector<number2> &src,
+                      const bool             transpose_diagonal) const;
 
 
   /**
@@ -338,7 +335,7 @@ protected:
    * inverse matrices should not be stored) until the last call of the
    * preconditoining @p vmult function of the derived classes.
    */
-  SmartPointer<const MATRIX,PreconditionBlock<MATRIX,inverse_type> > A;
+  SmartPointer<const MatrixType,PreconditionBlock<MatrixType,inverse_type> > A;
   /**
    * Relaxation parameter to be used by derived classes.
    */
@@ -369,15 +366,15 @@ protected:
  *
  * @author Ralf Hartmann, Guido Kanschat, 1999, 2000, 2003
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class PreconditionBlockJacobi : public virtual Subscriptor,
-  private PreconditionBlock<MATRIX, inverse_type>
+  private PreconditionBlock<MatrixType, inverse_type>
 {
 private:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
 public:
   /**
@@ -401,7 +398,7 @@ public:
        * Constructor. Since we use accessors only for read access, a const
        * matrix pointer is sufficient.
        */
-      Accessor (const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix,
+      Accessor (const PreconditionBlockJacobi<MatrixType, inverse_type> *matrix,
                 const size_type row);
 
       /**
@@ -423,7 +420,7 @@ public:
       /**
        * The matrix accessed.
        */
-      const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix;
+      const PreconditionBlockJacobi<MatrixType, inverse_type> *matrix;
 
       /**
        * Save block size here for further reference.
@@ -455,7 +452,7 @@ public:
     /**
      * Constructor.
      */
-    const_iterator(const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix,
+    const_iterator(const PreconditionBlockJacobi<MatrixType, inverse_type> *matrix,
                    const size_type row);
 
     /**
@@ -503,19 +500,19 @@ public:
   /**
    * import functions from private base class
    */
-  using PreconditionBlock<MATRIX, inverse_type>::initialize;
-  using PreconditionBlock<MATRIX, inverse_type>::clear;
-  using PreconditionBlock<MATRIX, inverse_type>::empty;
-  using PreconditionBlock<MATRIX, inverse_type>::el;
-  using PreconditionBlock<MATRIX, inverse_type>::set_same_diagonal;
-  using PreconditionBlock<MATRIX, inverse_type>::invert_diagblocks;
-  using PreconditionBlock<MATRIX, inverse_type>::block_size;
+  using PreconditionBlock<MatrixType, inverse_type>::initialize;
+  using PreconditionBlock<MatrixType, inverse_type>::clear;
+  using PreconditionBlock<MatrixType, inverse_type>::empty;
+  using PreconditionBlock<MatrixType, inverse_type>::el;
+  using PreconditionBlock<MatrixType, inverse_type>::set_same_diagonal;
+  using PreconditionBlock<MatrixType, inverse_type>::invert_diagblocks;
+  using PreconditionBlock<MatrixType, inverse_type>::block_size;
   using PreconditionBlockBase<inverse_type>::size;
   using PreconditionBlockBase<inverse_type>::inverse;
   using PreconditionBlockBase<inverse_type>::inverse_householder;
   using PreconditionBlockBase<inverse_type>::inverse_svd;
   using PreconditionBlockBase<inverse_type>::log_statistics;
-  using PreconditionBlock<MATRIX, inverse_type>::set_permutation;
+  using PreconditionBlock<MatrixType, inverse_type>::set_permutation;
 
   /**
    * Execute block Jacobi preconditioning.
@@ -633,9 +630,9 @@ private:
  *
  * @author Ralf Hartmann, Guido Kanschat, 1999, 2000, 2001, 2002, 2003
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class PreconditionBlockSOR : public virtual Subscriptor,
-  protected PreconditionBlock<MATRIX, inverse_type>
+  protected PreconditionBlock<MatrixType, inverse_type>
 {
 public:
   /**
@@ -651,23 +648,23 @@ public:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * import types and functions from protected base class.
    */
-  using typename PreconditionBlock<MATRIX,inverse_type>::AdditionalData;
-  using PreconditionBlock<MATRIX, inverse_type>::initialize;
-  using PreconditionBlock<MATRIX, inverse_type>::clear;
-  using PreconditionBlock<MATRIX, inverse_type>::empty;
+  using typename PreconditionBlock<MatrixType,inverse_type>::AdditionalData;
+  using PreconditionBlock<MatrixType, inverse_type>::initialize;
+  using PreconditionBlock<MatrixType, inverse_type>::clear;
+  using PreconditionBlock<MatrixType, inverse_type>::empty;
   using PreconditionBlockBase<inverse_type>::size;
   using PreconditionBlockBase<inverse_type>::inverse;
   using PreconditionBlockBase<inverse_type>::inverse_householder;
   using PreconditionBlockBase<inverse_type>::inverse_svd;
-  using PreconditionBlock<MATRIX, inverse_type>::el;
-  using PreconditionBlock<MATRIX, inverse_type>::set_same_diagonal;
-  using PreconditionBlock<MATRIX, inverse_type>::invert_diagblocks;
-  using PreconditionBlock<MATRIX, inverse_type>::set_permutation;
+  using PreconditionBlock<MatrixType, inverse_type>::el;
+  using PreconditionBlock<MatrixType, inverse_type>::set_same_diagonal;
+  using PreconditionBlock<MatrixType, inverse_type>::invert_diagblocks;
+  using PreconditionBlock<MatrixType, inverse_type>::set_permutation;
   using PreconditionBlockBase<inverse_type>::log_statistics;
 
   /**
@@ -790,9 +787,9 @@ protected:
  *
  * @author Ralf Hartmann, Guido Kanschat, 1999, 2000
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class PreconditionBlockSSOR : public virtual Subscriptor,
-  private PreconditionBlockSOR<MATRIX, inverse_type>
+  private PreconditionBlockSOR<MatrixType, inverse_type>
 {
 public:
   /**
@@ -803,7 +800,7 @@ public:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Constructor.
@@ -811,7 +808,7 @@ public:
   PreconditionBlockSSOR ();
 
   // Keep AdditionalData accessible
-  using typename PreconditionBlockSOR<MATRIX,inverse_type>::AdditionalData;
+  using typename PreconditionBlockSOR<MatrixType,inverse_type>::AdditionalData;
 
   // The following are the
   // functions of the base classes
@@ -820,18 +817,18 @@ public:
   /**
    * Make initialization function publicly available.
    */
-  using PreconditionBlockSOR<MATRIX,inverse_type>::initialize;
-  using PreconditionBlockSOR<MATRIX,inverse_type>::clear;
+  using PreconditionBlockSOR<MatrixType,inverse_type>::initialize;
+  using PreconditionBlockSOR<MatrixType,inverse_type>::clear;
   using PreconditionBlockBase<inverse_type>::size;
   using PreconditionBlockBase<inverse_type>::inverse;
   using PreconditionBlockBase<inverse_type>::inverse_householder;
   using PreconditionBlockBase<inverse_type>::inverse_svd;
   using PreconditionBlockBase<inverse_type>::log_statistics;
-  using PreconditionBlockSOR<MATRIX,inverse_type>::set_permutation;
-  using PreconditionBlockSOR<MATRIX, inverse_type>::empty;
-  using PreconditionBlockSOR<MATRIX, inverse_type>::el;
-  using PreconditionBlockSOR<MATRIX,inverse_type>::set_same_diagonal;
-  using PreconditionBlockSOR<MATRIX,inverse_type>::invert_diagblocks;
+  using PreconditionBlockSOR<MatrixType,inverse_type>::set_permutation;
+  using PreconditionBlockSOR<MatrixType, inverse_type>::empty;
+  using PreconditionBlockSOR<MatrixType, inverse_type>::el;
+  using PreconditionBlockSOR<MatrixType,inverse_type>::set_same_diagonal;
+  using PreconditionBlockSOR<MatrixType,inverse_type>::invert_diagblocks;
 
   /**
    * Execute block SSOR preconditioning.
@@ -867,9 +864,9 @@ public:
 
 #ifndef DOXYGEN
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline bool
-PreconditionBlock<MATRIX, inverse_type>::empty () const
+PreconditionBlock<MatrixType, inverse_type>::empty () const
 {
   if (A == 0)
     return true;
@@ -877,9 +874,9 @@ PreconditionBlock<MATRIX, inverse_type>::empty () const
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline inverse_type
-PreconditionBlock<MATRIX, inverse_type>::el (
+PreconditionBlock<MatrixType, inverse_type>::el (
   size_type i,
   size_type j) const
 {
@@ -901,10 +898,10 @@ PreconditionBlock<MATRIX, inverse_type>::el (
 
 //---------------------------------------------------------------------------
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::
-Accessor (const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix,
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor::
+Accessor (const PreconditionBlockJacobi<MatrixType, inverse_type> *matrix,
           const size_type row)
   :
   matrix(matrix),
@@ -929,10 +926,10 @@ Accessor (const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix,
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::size_type
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::row() const
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::size_type
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor::row() const
 {
   Assert (a_block < matrix->size(),
           ExcIteratorPastEnd());
@@ -941,10 +938,10 @@ PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::row() c
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::size_type
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::column() const
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::size_type
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor::column() const
 {
   Assert (a_block < matrix->size(),
           ExcIteratorPastEnd());
@@ -953,10 +950,10 @@ PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::column(
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
 inverse_type
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::value() const
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor::value() const
 {
   Assert (a_block < matrix->size(),
           ExcIteratorPastEnd());
@@ -965,20 +962,20 @@ PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor::value()
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::
-const_iterator(const PreconditionBlockJacobi<MATRIX, inverse_type> *matrix,
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
+const_iterator(const PreconditionBlockJacobi<MatrixType, inverse_type> *matrix,
                const size_type row)
   :
   accessor(matrix, row)
 {}
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator &
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::operator++ ()
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator &
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator++ ()
 {
   Assert (*this != accessor.matrix->end(), ExcIteratorPastEnd());
 
@@ -997,28 +994,28 @@ PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::operator++ ()
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-const typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor &
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::operator* () const
+const typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor &
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator* () const
 {
   return accessor;
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-const typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::Accessor *
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::operator-> () const
+const typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::Accessor *
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator-> () const
 {
   return &accessor;
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
 bool
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
 operator == (const const_iterator &other) const
 {
   if (accessor.a_block == accessor.matrix->size() &&
@@ -1033,20 +1030,20 @@ operator == (const const_iterator &other) const
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
 bool
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
 operator != (const const_iterator &other) const
 {
   return ! (*this == other);
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
 bool
-PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator::
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
 operator < (const const_iterator &other) const
 {
   return (accessor.row() < other.accessor.row() ||
@@ -1055,28 +1052,28 @@ operator < (const const_iterator &other) const
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator
-PreconditionBlockJacobi<MATRIX, inverse_type>::begin () const
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator
+PreconditionBlockJacobi<MatrixType, inverse_type>::begin () const
 {
   return const_iterator(this, 0);
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator
-PreconditionBlockJacobi<MATRIX, inverse_type>::end () const
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator
+PreconditionBlockJacobi<MatrixType, inverse_type>::end () const
 {
   return const_iterator(this, this->size() * this->block_size());
 }
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator
-PreconditionBlockJacobi<MATRIX, inverse_type>::begin (
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator
+PreconditionBlockJacobi<MatrixType, inverse_type>::begin (
   const size_type r) const
 {
   Assert (r < this->A->m(), ExcIndexRange(r, 0, this->A->m()));
@@ -1085,10 +1082,10 @@ PreconditionBlockJacobi<MATRIX, inverse_type>::begin (
 
 
 
-template<class MATRIX, typename inverse_type>
+template<typename MatrixType, typename inverse_type>
 inline
-typename PreconditionBlockJacobi<MATRIX, inverse_type>::const_iterator
-PreconditionBlockJacobi<MATRIX, inverse_type>::end (
+typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator
+PreconditionBlockJacobi<MatrixType, inverse_type>::end (
   const size_type r) const
 {
   Assert (r < this->A->m(), ExcIndexRange(r, 0, this->A->m()));

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -979,7 +979,7 @@ PreconditionBlockSSOR<MatrixType,inverse_type>::PreconditionBlockSSOR ()
 template <typename MatrixType, typename inverse_type>
 template <typename number2>
 void PreconditionBlockSSOR<MatrixType,inverse_type>::vmult (Vector<number2>       &dst,
-                                                        const Vector<number2> &src) const
+                                                            const Vector<number2> &src) const
 {
   Vector<number2> help;
   help.reinit(dst);
@@ -1010,7 +1010,7 @@ void PreconditionBlockSSOR<MatrixType,inverse_type>::vmult (Vector<number2>     
 template <typename MatrixType, typename inverse_type>
 template <typename number2>
 void PreconditionBlockSSOR<MatrixType,inverse_type>::Tvmult (Vector<number2>       &dst,
-                                                             const Vector<number2> &src) const
+    const Vector<number2> &src) const
 {
   Vector<number2> help;
   help.reinit(dst);

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -29,12 +29,12 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template<class MATRIX, typename inverse_type>
-PreconditionBlock<MATRIX, inverse_type>::AdditionalData::
+template<typename MatrixType, typename inverse_type>
+PreconditionBlock<MatrixType, inverse_type>::AdditionalData::
 AdditionalData (const size_type block_size,
-                const double relaxation,
-                const bool invert_diagonal,
-                const bool same_diagonal)
+                const double    relaxation,
+                const bool      invert_diagonal,
+                const bool      same_diagonal)
   :
   relaxation (relaxation),
   block_size(block_size),
@@ -50,21 +50,21 @@ PreconditionBlockBase<number>::~PreconditionBlockBase ()
 {}
 
 
-template <class MATRIX, typename inverse_type>
-PreconditionBlock<MATRIX,inverse_type>::PreconditionBlock (bool store)
+template <typename MatrixType, typename inverse_type>
+PreconditionBlock<MatrixType,inverse_type>::PreconditionBlock (bool store)
   : PreconditionBlockBase<inverse_type>(store),
     blocksize(0),
     A(0, typeid(*this).name())
 {}
 
 
-template <class MATRIX, typename inverse_type>
-PreconditionBlock<MATRIX,inverse_type>::~PreconditionBlock ()
+template <typename MatrixType, typename inverse_type>
+PreconditionBlock<MatrixType,inverse_type>::~PreconditionBlock ()
 {}
 
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::clear ()
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::clear ()
 {
   PreconditionBlockBase<inverse_type>::clear();
   blocksize     = 0;
@@ -72,10 +72,10 @@ void PreconditionBlock<MATRIX,inverse_type>::clear ()
 }
 
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::initialize (
-  const MATRIX &M,
-  const AdditionalData parameters)
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::initialize
+(const MatrixType     &M,
+ const AdditionalData  parameters)
 {
   const size_type bsize = parameters.block_size;
 
@@ -100,26 +100,26 @@ void PreconditionBlock<MATRIX,inverse_type>::initialize (
 }
 
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::initialize (
-  const MATRIX &M,
-  const std::vector<size_type> &permutation,
-  const std::vector<size_type> &inverse_permutation,
-  const AdditionalData parameters)
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::initialize
+(const MatrixType             &M,
+ const std::vector<size_type> &permutation,
+ const std::vector<size_type> &inverse_permutation,
+ const AdditionalData          parameters)
 {
   set_permutation(permutation, inverse_permutation);
   initialize(M, parameters);
 }
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::invert_permuted_diagblocks(
-  const std::vector<size_type> &permutation,
-  const std::vector<size_type> &inverse_permutation)
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::invert_permuted_diagblocks
+(const std::vector<size_type> &permutation,
+ const std::vector<size_type> &inverse_permutation)
 {
   Assert (A!=0, ExcNotInitialized());
   Assert (blocksize!=0, ExcNotInitialized());
 
-  const MATRIX &M=*A;
+  const MatrixType &M=*A;
   Assert (this->inverses_ready()==0, ExcInverseMatricesAlreadyExist());
   AssertDimension (permutation.size(), M.m());
   AssertDimension (inverse_permutation.size(), M.m());
@@ -132,8 +132,8 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_permuted_diagblocks(
 
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
-          typename MATRIX::const_iterator entry = M.begin(row_cell);
-          const typename MATRIX::const_iterator row_end = M.end(row_cell);
+          typename MatrixType::const_iterator entry = M.begin(row_cell);
+          const typename MatrixType::const_iterator row_end = M.end(row_cell);
           while (entry != row_end)
             {
               if (entry->column() < blocksize)
@@ -180,8 +180,8 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_permuted_diagblocks(
 
               const size_type row = permutation[urow];
 
-              typename MATRIX::const_iterator entry = M.begin(row);
-              const typename MATRIX::const_iterator row_end = M.end(row);
+              typename MatrixType::const_iterator entry = M.begin(row);
+              const typename MatrixType::const_iterator row_end = M.end(row);
 
               for (; entry != row_end; ++entry)
                 {
@@ -221,17 +221,17 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_permuted_diagblocks(
 
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlock<MATRIX,inverse_type>::forward_step (
-  Vector<number2>       &dst,
-  const Vector<number2> &prev,
-  const Vector<number2> &src,
-  const bool transpose_diagonal) const
+void PreconditionBlock<MatrixType,inverse_type>::forward_step
+(Vector<number2>       &dst,
+ const Vector<number2> &prev,
+ const Vector<number2> &src,
+ const bool             transpose_diagonal) const
 {
   Assert (this->A!=0, ExcNotInitialized());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
 
   if (permutation.size() != 0)
     Assert (permutation.size() == M.m() || permutation.size() == this->size(),
@@ -272,8 +272,8 @@ void PreconditionBlock<MATRIX,inverse_type>::forward_step (
            ++row_cell, ++row)
         {
 //        deallog << ' ' << row;
-          const typename MATRIX::const_iterator row_end = M.end(row);
-          typename MATRIX::const_iterator entry = M.begin(row);
+          const typename MatrixType::const_iterator row_end = M.end(row);
+          typename MatrixType::const_iterator entry = M.begin(row);
 
           b_cell_row=src(row);
           for (; entry != row_end; ++entry)
@@ -319,17 +319,17 @@ void PreconditionBlock<MATRIX,inverse_type>::forward_step (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlock<MATRIX,inverse_type>::backward_step (
-  Vector<number2>       &dst,
-  const Vector<number2> &prev,
-  const Vector<number2> &src,
-  const bool transpose_diagonal) const
+void PreconditionBlock<MatrixType,inverse_type>::backward_step
+(Vector<number2>       &dst,
+ const Vector<number2> &prev,
+ const Vector<number2> &src,
+ const bool             transpose_diagonal) const
 {
   Assert (this->A!=0, ExcNotInitialized());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
 
   if (permutation.size() != 0)
     Assert (permutation.size() == M.m() || permutation.size() == this->size(),
@@ -364,8 +364,8 @@ void PreconditionBlock<MATRIX,inverse_type>::backward_step (
            row_cell<this->blocksize;
            ++row_cell, ++row)
         {
-          const typename MATRIX::const_iterator row_end = M.end(row);
-          typename MATRIX::const_iterator entry = M.begin(row);
+          const typename MatrixType::const_iterator row_end = M.end(row);
+          typename MatrixType::const_iterator entry = M.begin(row);
 
           b_cell_row=src(row);
           for (; entry != row_end; ++entry)
@@ -417,21 +417,21 @@ void PreconditionBlock<MATRIX,inverse_type>::backward_step (
 }
 
 
-template <class MATRIX, typename inverse_type>
-typename PreconditionBlock<MATRIX,inverse_type>::size_type
-PreconditionBlock<MATRIX,inverse_type>::block_size() const
+template <typename MatrixType, typename inverse_type>
+typename PreconditionBlock<MatrixType,inverse_type>::size_type
+PreconditionBlock<MatrixType,inverse_type>::block_size() const
 {
   return blocksize;
 }
 
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::invert_diagblocks()
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::invert_diagblocks()
 {
   Assert (A!=0, ExcNotInitialized());
   Assert (blocksize!=0, ExcNotInitialized());
 
-  const MATRIX &M=*A;
+  const MatrixType &M=*A;
   Assert (this->inverses_ready()==0, ExcInverseMatricesAlreadyExist());
 
   FullMatrix<inverse_type> M_cell(blocksize);
@@ -441,8 +441,8 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_diagblocks()
       deallog << "PreconditionBlock uses only one diagonal block" << std::endl;
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
-          typename MATRIX::const_iterator entry = M.begin(row_cell);
-          const typename MATRIX::const_iterator row_end = M.end(row_cell);
+          typename MatrixType::const_iterator entry = M.begin(row_cell);
+          const typename MatrixType::const_iterator row_end = M.end(row_cell);
           while (entry != row_end)
             {
               if (entry->column() < blocksize)
@@ -478,8 +478,8 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_diagblocks()
           for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
             {
               const size_type row = row_cell + cell_start;
-              typename MATRIX::const_iterator entry = M.begin(row);
-              const typename MATRIX::const_iterator row_end = M.end(row);
+              typename MatrixType::const_iterator entry = M.begin(row);
+              const typename MatrixType::const_iterator row_end = M.end(row);
 
               for (; entry != row_end; ++entry)
                 {
@@ -517,10 +517,10 @@ void PreconditionBlock<MATRIX,inverse_type>::invert_diagblocks()
 
 
 
-template <class MATRIX, typename inverse_type>
-void PreconditionBlock<MATRIX,inverse_type>::set_permutation (
-  const std::vector<size_type> &p,
-  const std::vector<size_type> &i)
+template <typename MatrixType, typename inverse_type>
+void PreconditionBlock<MatrixType,inverse_type>::set_permutation
+(const std::vector<size_type> &p,
+ const std::vector<size_type> &i)
 {
   Assert (p.size() == i.size(), ExcDimensionMismatch(p.size(), i.size()));
 
@@ -539,9 +539,9 @@ void PreconditionBlock<MATRIX,inverse_type>::set_permutation (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 std::size_t
-PreconditionBlock<MATRIX,inverse_type>::memory_consumption () const
+PreconditionBlock<MatrixType,inverse_type>::memory_consumption () const
 {
   return (sizeof(*this)
           - sizeof(PreconditionBlockBase<inverse_type>)
@@ -554,16 +554,16 @@ PreconditionBlock<MATRIX,inverse_type>::memory_consumption () const
 /*--------------------- PreconditionBlockJacobi -----------------------*/
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::do_vmult (Vector<number2>       &dst,
             const Vector<number2> &src,
-            bool adding) const
+            bool                   adding) const
 {
   Assert(this->A!=0, ExcNotInitialized());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
 
   Vector<number2> b_cell(this->blocksize), x_cell(this->blocksize);
 
@@ -629,9 +629,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::vmult (Vector<number2>       &dst,
          const Vector<number2> &src) const
 {
@@ -639,9 +639,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::Tvmult (Vector<number2>       &dst,
           const Vector<number2> &src) const
 {
@@ -649,9 +649,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::vmult_add (Vector<number2>       &dst,
              const Vector<number2> &src) const
 {
@@ -659,9 +659,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::Tvmult_add (Vector<number2>       &dst,
               const Vector<number2> &src) const
 {
@@ -669,9 +669,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::step (Vector<number2>       &dst,
         const Vector<number2> &src) const
 {
@@ -684,9 +684,9 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockJacobi<MATRIX,inverse_type>
+void PreconditionBlockJacobi<MatrixType,inverse_type>
 ::Tstep (Vector<number2>       &dst,
          const Vector<number2> &src) const
 {
@@ -704,29 +704,29 @@ void PreconditionBlockJacobi<MATRIX,inverse_type>
 /*--------------------- PreconditionBlockSOR -----------------------*/
 
 
-template <class MATRIX, typename inverse_type>
-PreconditionBlockSOR<MATRIX,inverse_type>::PreconditionBlockSOR ()
-  : PreconditionBlock<MATRIX,inverse_type> (false)
+template <typename MatrixType, typename inverse_type>
+PreconditionBlockSOR<MatrixType,inverse_type>::PreconditionBlockSOR ()
+  : PreconditionBlock<MatrixType,inverse_type> (false)
 
 {}
 
-template <class MATRIX, typename inverse_type>
-PreconditionBlockSOR<MATRIX,inverse_type>::PreconditionBlockSOR (bool store)
-  : PreconditionBlock<MATRIX,inverse_type> (store)
+template <typename MatrixType, typename inverse_type>
+PreconditionBlockSOR<MatrixType,inverse_type>::PreconditionBlockSOR (bool store)
+  : PreconditionBlock<MatrixType,inverse_type> (store)
 
 {}
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>::forward (
-  Vector<number2>       &dst,
-  const Vector<number2> &src,
-  const bool transpose_diagonal,
-  const bool) const
+void PreconditionBlockSOR<MatrixType,inverse_type>::forward
+(Vector<number2>       &dst,
+ const Vector<number2> &src,
+ const bool             transpose_diagonal,
+ const bool) const
 {
   Assert (this->A!=0, ExcNotInitialized());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
   const bool permuted = (this->permutation.size() != 0);
   if (permuted)
     {
@@ -758,8 +758,8 @@ void PreconditionBlockSOR<MATRIX,inverse_type>::forward (
            row_cell < this->blocksize;
            ++row_cell, ++row)
         {
-          const typename MATRIX::const_iterator row_end = M.end(row);
-          typename MATRIX::const_iterator entry = M.begin(row);
+          const typename MatrixType::const_iterator row_end = M.end(row);
+          typename MatrixType::const_iterator entry = M.begin(row);
 
           b_cell_row=src(row);
           for (; entry != row_end; ++entry)
@@ -806,17 +806,17 @@ void PreconditionBlockSOR<MATRIX,inverse_type>::forward (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>::backward (
-  Vector<number2>       &dst,
-  const Vector<number2> &src,
-  const bool transpose_diagonal,
-  const bool) const
+void PreconditionBlockSOR<MatrixType,inverse_type>::backward
+(Vector<number2>       &dst,
+ const Vector<number2> &src,
+ const bool              transpose_diagonal,
+ const bool) const
 {
   Assert (this->A!=0, ExcNotInitialized());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
   const bool permuted = (this->permutation.size() != 0);
   if (permuted)
     {
@@ -849,8 +849,8 @@ void PreconditionBlockSOR<MATRIX,inverse_type>::backward (
            row_cell<this->blocksize;
            ++row_cell, ++row)
         {
-          const typename MATRIX::const_iterator row_end = M.end(row);
-          typename MATRIX::const_iterator entry = M.begin(row);
+          const typename MatrixType::const_iterator row_end = M.end(row);
+          typename MatrixType::const_iterator entry = M.begin(row);
 
           b_cell_row=src(row);
           for (; entry != row_end; ++entry)
@@ -903,9 +903,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>::backward (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::vmult (Vector<number2>       &dst,
          const Vector<number2> &src) const
 {
@@ -913,9 +913,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::vmult_add (Vector<number2>       &dst,
              const Vector<number2> &src) const
 {
@@ -923,9 +923,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::Tvmult (Vector<number2>       &dst,
           const Vector<number2> &src) const
 {
@@ -933,9 +933,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::Tvmult_add (Vector<number2>       &dst,
               const Vector<number2> &src) const
 {
@@ -944,9 +944,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::step (Vector<number2>       &dst,
         const Vector<number2> &src) const
 {
@@ -954,9 +954,9 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSOR<MATRIX,inverse_type>
+void PreconditionBlockSOR<MatrixType,inverse_type>
 ::Tstep (Vector<number2>       &dst,
          const Vector<number2> &src) const
 {
@@ -969,16 +969,16 @@ void PreconditionBlockSOR<MATRIX,inverse_type>
 //---------------------------------------------------------------------------
 
 
-template <class MATRIX, typename inverse_type>
-PreconditionBlockSSOR<MATRIX,inverse_type>::PreconditionBlockSSOR ()
-  : PreconditionBlockSOR<MATRIX,inverse_type> (true)
+template <typename MatrixType, typename inverse_type>
+PreconditionBlockSSOR<MatrixType,inverse_type>::PreconditionBlockSSOR ()
+  : PreconditionBlockSOR<MatrixType,inverse_type> (true)
 
 {}
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSSOR<MATRIX,inverse_type>::vmult (Vector<number2>       &dst,
+void PreconditionBlockSSOR<MatrixType,inverse_type>::vmult (Vector<number2>       &dst,
                                                         const Vector<number2> &src) const
 {
   Vector<number2> help;
@@ -1007,10 +1007,10 @@ void PreconditionBlockSSOR<MATRIX,inverse_type>::vmult (Vector<number2>       &d
   this->backward(dst, help, false, false);
 }
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSSOR<MATRIX,inverse_type>::Tvmult (Vector<number2>       &dst,
-                                                         const Vector<number2> &src) const
+void PreconditionBlockSSOR<MatrixType,inverse_type>::Tvmult (Vector<number2>       &dst,
+                                                             const Vector<number2> &src) const
 {
   Vector<number2> help;
   help.reinit(dst);
@@ -1039,9 +1039,9 @@ void PreconditionBlockSSOR<MATRIX,inverse_type>::Tvmult (Vector<number2>       &
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSSOR<MATRIX,inverse_type>
+void PreconditionBlockSSOR<MatrixType,inverse_type>
 ::step (Vector<number2>       &dst,
         const Vector<number2> &src) const
 {
@@ -1050,9 +1050,9 @@ void PreconditionBlockSSOR<MATRIX,inverse_type>
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void PreconditionBlockSSOR<MATRIX,inverse_type>
+void PreconditionBlockSSOR<MatrixType,inverse_type>
 ::Tstep (Vector<number2>       &dst,
          const Vector<number2> &src) const
 {

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -90,7 +90,7 @@ template <class number> class SparseMatrix;
  * @author Ralf Hartmann, 1999; extension for full compatibility with
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
-template <class MATRIX = SparseMatrix<double>,
+template <typename MatrixType = SparseMatrix<double>,
           typename VectorType = dealii::Vector<double> >
 class PreconditionSelector : public Subscriptor
 {
@@ -98,7 +98,7 @@ public:
   /**
    * Declare type for container size.
    */
-  typedef typename MATRIX::size_type size_type;
+  typedef typename MatrixType::size_type size_type;
 
   /**
    * Constructor. @p omega denotes the damping parameter of the
@@ -116,7 +116,7 @@ public:
    * Takes the matrix that is needed for preconditionings that involves a
    * matrix. e.g. for @p precondition_jacobi, <tt>~_sor</tt>, <tt>~_ssor</tt>.
    */
-  void use_matrix(const MATRIX &M);
+  void use_matrix(const MatrixType &M);
 
   /**
    * Return the dimension of the codomain (or range) space. To remember: the
@@ -171,7 +171,7 @@ private:
    * Matrix that is used for the matrix-builtin preconditioning function. cf.
    * also @p PreconditionUseMatrix.
    */
-  SmartPointer<const MATRIX,PreconditionSelector<MATRIX,VectorType> > A;
+  SmartPointer<const MatrixType,PreconditionSelector<MatrixType,VectorType> > A;
 
   /**
    * Stores the damping parameter of the preconditioner.
@@ -183,42 +183,42 @@ private:
 /* --------------------- Inline and template functions ------------------- */
 
 
-template <class MATRIX, typename VectorType>
-PreconditionSelector<MATRIX,VectorType>
+template <typename MatrixType, typename VectorType>
+PreconditionSelector<MatrixType,VectorType>
 ::PreconditionSelector(const std::string                     &preconditioning,
                        const typename VectorType::value_type &omega) :
   preconditioning(preconditioning),
   omega(omega)  {}
 
 
-template <class MATRIX, typename VectorType>
-PreconditionSelector<MATRIX,VectorType>::~PreconditionSelector()
+template <typename MatrixType, typename VectorType>
+PreconditionSelector<MatrixType,VectorType>::~PreconditionSelector()
 {
   // release the matrix A
   A=0;
 }
 
 
-template <class MATRIX, typename VectorType>
-void PreconditionSelector<MATRIX,VectorType>::use_matrix(const MATRIX &M)
+template <typename MatrixType, typename VectorType>
+void PreconditionSelector<MatrixType,VectorType>::use_matrix(const MatrixType &M)
 {
   A=&M;
 }
 
 <<<<<<< fc87b7c22812a5fc7751b36c66b20e6fa54df72c
 
-template <class MATRIX, typename VectorType>
-inline typename PreconditionSelector<MATRIX,VectorType>::size_type
-PreconditionSelector<MATRIX,VectorType>::m () const
+template <typename MatrixType, typename VectorType>
+inline typename PreconditionSelector<MatrixType,VectorType>::size_type
+PreconditionSelector<MatrixType,VectorType>::m () const
 {
   Assert(A!=0, ExcNoMatrixGivenToUse());
   return A->m();
 }
 
 
-template <class MATRIX, typename VectorType>
-inline typename PreconditionSelector<MATRIX,VectorType>::size_type
-PreconditionSelector<MATRIX,VectorType>::n () const
+template <typename MatrixType, typename VectorType>
+inline typename PreconditionSelector<MatrixType,VectorType>::size_type
+PreconditionSelector<MatrixType,VectorType>::n () const
 {
   Assert(A!=0, ExcNoMatrixGivenToUse());
   return A->n();
@@ -226,9 +226,9 @@ PreconditionSelector<MATRIX,VectorType>::n () const
 
 
 
-template <class MATRIX, typename VectorType>
-void PreconditionSelector<MATRIX,VectorType>::vmult (VectorType       &dst,
-                                                     const VectorType &src) const
+template <typename MatrixType, typename VectorType>
+void PreconditionSelector<MatrixType,VectorType>::vmult (VectorType &dst,
+                                                         const VectorType &src) const
 {
   if (preconditioning=="none")
     {
@@ -256,9 +256,9 @@ void PreconditionSelector<MATRIX,VectorType>::vmult (VectorType       &dst,
 }
 
 
-template <class MATRIX, typename VectorType>
-void PreconditionSelector<MATRIX,VectorType>::Tvmult (VectorType       &dst,
-                                                      const VectorType &src) const
+template <typename MatrixType, typename VectorType>
+void PreconditionSelector<MatrixType,VectorType>::Tvmult (VectorType &dst,
+                                                          const VectorType &src) const
 {
   if (preconditioning=="none")
     {
@@ -286,8 +286,8 @@ void PreconditionSelector<MATRIX,VectorType>::Tvmult (VectorType       &dst,
 }
 
 
-template <class MATRIX, typename VectorType>
-std::string PreconditionSelector<MATRIX,VectorType>::get_precondition_names()
+template <typename MatrixType, typename VectorType>
+std::string PreconditionSelector<MatrixType,VectorType>::get_precondition_names()
 {
   return "none|jacobi|sor|ssor";
 }

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -91,7 +91,7 @@ template <class number> class SparseMatrix;
  * LinearOperator class: Jean-Paul Pelteret, 2015
  */
 template <class MATRIX = SparseMatrix<double>,
-          class VECTOR = dealii::Vector<double> >
+          typename VectorType = dealii::Vector<double> >
 class PreconditionSelector : public Subscriptor
 {
 public:
@@ -104,8 +104,8 @@ public:
    * Constructor. @p omega denotes the damping parameter of the
    * preconditioning.
    */
-  PreconditionSelector(const std::string                 &preconditioning,
-                       const typename VECTOR::value_type &omega=1.);
+  PreconditionSelector (const std::string                     &preconditioning,
+                        const typename VectorType::value_type &omega=1.);
 
   /**
    * Destructor.
@@ -134,13 +134,13 @@ public:
    * Precondition procedure. Calls the preconditioning that was specified in
    * the constructor.
    */
-  virtual void vmult (VECTOR &dst, const VECTOR &src) const;
+  virtual void vmult (VectorType &dst, const VectorType &src) const;
 
   /**
    * Transpose precondition procedure. Calls the preconditioning that was
    * specified in the constructor.
    */
-  virtual void Tvmult (VECTOR &dst, const VECTOR &src) const;
+  virtual void Tvmult (VectorType &dst, const VectorType &src) const;
 
   /**
    * Get the names of all implemented preconditionings.
@@ -171,62 +171,64 @@ private:
    * Matrix that is used for the matrix-builtin preconditioning function. cf.
    * also @p PreconditionUseMatrix.
    */
-  SmartPointer<const MATRIX,PreconditionSelector<MATRIX,VECTOR> > A;
+  SmartPointer<const MATRIX,PreconditionSelector<MATRIX,VectorType> > A;
 
   /**
    * Stores the damping parameter of the preconditioner.
    */
-  const typename VECTOR::value_type omega;
+  const typename VectorType::value_type omega;
 };
 
 /*@}*/
 /* --------------------- Inline and template functions ------------------- */
 
 
-template <class MATRIX, class VECTOR>
-PreconditionSelector<MATRIX,VECTOR>
-::PreconditionSelector(const std::string                 &preconditioning,
-                       const typename VECTOR::value_type &omega) :
+template <class MATRIX, typename VectorType>
+PreconditionSelector<MATRIX,VectorType>
+::PreconditionSelector(const std::string                     &preconditioning,
+                       const typename VectorType::value_type &omega) :
   preconditioning(preconditioning),
   omega(omega)  {}
 
 
-template <class MATRIX, class VECTOR>
-PreconditionSelector<MATRIX,VECTOR>::~PreconditionSelector()
+template <class MATRIX, typename VectorType>
+PreconditionSelector<MATRIX,VectorType>::~PreconditionSelector()
 {
   // release the matrix A
   A=0;
 }
 
 
-template <class MATRIX, class VECTOR>
-void PreconditionSelector<MATRIX,VECTOR>::use_matrix(const MATRIX &M)
+template <class MATRIX, typename VectorType>
+void PreconditionSelector<MATRIX,VectorType>::use_matrix(const MATRIX &M)
 {
   A=&M;
 }
 
+<<<<<<< fc87b7c22812a5fc7751b36c66b20e6fa54df72c
 
-template <class MATRIX, class VECTOR>
-inline typename PreconditionSelector<MATRIX,VECTOR>::size_type
-PreconditionSelector<MATRIX,VECTOR>::m () const
+template <class MATRIX, typename VectorType>
+inline typename PreconditionSelector<MATRIX,VectorType>::size_type
+PreconditionSelector<MATRIX,VectorType>::m () const
 {
   Assert(A!=0, ExcNoMatrixGivenToUse());
   return A->m();
 }
 
 
-template <class MATRIX, class VECTOR>
-inline typename PreconditionSelector<MATRIX,VECTOR>::size_type
-PreconditionSelector<MATRIX,VECTOR>::n () const
+template <class MATRIX, typename VectorType>
+inline typename PreconditionSelector<MATRIX,VectorType>::size_type
+PreconditionSelector<MATRIX,VectorType>::n () const
 {
   Assert(A!=0, ExcNoMatrixGivenToUse());
   return A->n();
 }
 
 
-template <class MATRIX, class VECTOR>
-void PreconditionSelector<MATRIX,VECTOR>::vmult (VECTOR &dst,
-                                                 const VECTOR &src) const
+
+template <class MATRIX, typename VectorType>
+void PreconditionSelector<MATRIX,VectorType>::vmult (VectorType       &dst,
+                                                     const VectorType &src) const
 {
   if (preconditioning=="none")
     {
@@ -254,9 +256,9 @@ void PreconditionSelector<MATRIX,VECTOR>::vmult (VECTOR &dst,
 }
 
 
-template <class MATRIX, class VECTOR>
-void PreconditionSelector<MATRIX,VECTOR>::Tvmult (VECTOR &dst,
-                                                  const VECTOR &src) const
+template <class MATRIX, typename VectorType>
+void PreconditionSelector<MATRIX,VectorType>::Tvmult (VectorType       &dst,
+                                                      const VectorType &src) const
 {
   if (preconditioning=="none")
     {
@@ -284,8 +286,8 @@ void PreconditionSelector<MATRIX,VECTOR>::Tvmult (VECTOR &dst,
 }
 
 
-template <class MATRIX, class VECTOR>
-std::string PreconditionSelector<MATRIX,VECTOR>::get_precondition_names()
+template <class MATRIX, typename VectorType>
+std::string PreconditionSelector<MATRIX,VectorType>::get_precondition_names()
 {
   return "none|jacobi|sor|ssor";
 }

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -47,7 +47,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat
  * @date 2010
  */
-template <class MATRIX, typename inverse_type=typename MATRIX::value_type>
+template <typename MatrixType, typename inverse_type=typename MatrixType::value_type>
 class RelaxationBlock :
   protected PreconditionBlockBase<inverse_type>
 {
@@ -55,7 +55,7 @@ private:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Value type for inverse matrices.
@@ -162,7 +162,7 @@ public:
    * rather a pointer is stored. Thus, the lifetime of
    * <code>additional_data</code> hast to exceed the lifetime of this object.
    */
-  void initialize (const MATRIX &A,
+  void initialize (const MatrixType     &A,
                    const AdditionalData &parameters);
 
   /**
@@ -222,12 +222,12 @@ protected:
    * inverse matrices should not be stored) until the last call of the
    * preconditioning @p vmult function of the derived classes.
    */
-  SmartPointer<const MATRIX,RelaxationBlock<MATRIX,inverse_type> > A;
+  SmartPointer<const MatrixType,RelaxationBlock<MatrixType,inverse_type> > A;
 
   /**
    * Control information.
    */
-  SmartPointer<const AdditionalData, RelaxationBlock<MATRIX,inverse_type> > additional_data;
+  SmartPointer<const AdditionalData, RelaxationBlock<MatrixType,inverse_type> > additional_data;
 };
 
 
@@ -245,9 +245,9 @@ protected:
  * @author Guido Kanschat
  * @date 2010
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class RelaxationBlockJacobi : public virtual Subscriptor,
-  protected RelaxationBlock<MATRIX, inverse_type>
+  protected RelaxationBlock<MatrixType, inverse_type>
 {
 public:
   /**
@@ -258,43 +258,43 @@ public:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Make type publicly available.
    */
-  using typename RelaxationBlock<MATRIX,inverse_type>::AdditionalData;
+  using typename RelaxationBlock<MatrixType,inverse_type>::AdditionalData;
 
   /**
    * Make initialization function publicly available.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::initialize;
+  using RelaxationBlock<MatrixType, inverse_type>::initialize;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::clear;
+  using RelaxationBlock<MatrixType, inverse_type>::clear;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::empty;
+  using RelaxationBlock<MatrixType, inverse_type>::empty;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::size;
+  using RelaxationBlock<MatrixType, inverse_type>::size;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_householder;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_householder;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_svd;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_svd;
   using PreconditionBlockBase<inverse_type>::log_statistics;
   /**
    * Perform one step of the Jacobi iteration.
@@ -329,9 +329,9 @@ public:
  * @author Guido Kanschat
  * @date 2010
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class RelaxationBlockSOR : public virtual Subscriptor,
-  protected RelaxationBlock<MATRIX, inverse_type>
+  protected RelaxationBlock<MatrixType, inverse_type>
 {
 public:
   /**
@@ -342,43 +342,43 @@ public:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Make type publicly available.
    */
-  using typename RelaxationBlock<MATRIX,inverse_type>::AdditionalData;
+  using typename RelaxationBlock<MatrixType,inverse_type>::AdditionalData;
 
   /**
    * Make initialization function publicly available.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::initialize;
+  using RelaxationBlock<MatrixType, inverse_type>::initialize;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::clear;
+  using RelaxationBlock<MatrixType, inverse_type>::clear;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::empty;
+  using RelaxationBlock<MatrixType, inverse_type>::empty;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::size;
+  using RelaxationBlock<MatrixType, inverse_type>::size;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_householder;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_householder;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_svd;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_svd;
   using PreconditionBlockBase<inverse_type>::log_statistics;
   /**
    * Perform one step of the SOR iteration.
@@ -409,52 +409,52 @@ public:
  * @author Guido Kanschat
  * @date 2010
  */
-template<class MATRIX, typename inverse_type = typename MATRIX::value_type>
+template<typename MatrixType, typename inverse_type = typename MatrixType::value_type>
 class RelaxationBlockSSOR : public virtual Subscriptor,
-  protected RelaxationBlock<MATRIX, inverse_type>
+  protected RelaxationBlock<MatrixType, inverse_type>
 {
 public:
   /**
    * Define number type of matrix.
    */
-  typedef typename MATRIX::value_type number;
+  typedef typename MatrixType::value_type number;
 
   /**
    * Make type publicly available.
    */
-  using typename RelaxationBlock<MATRIX,inverse_type>::AdditionalData;
+  using typename RelaxationBlock<MatrixType,inverse_type>::AdditionalData;
 
   /**
    * Make initialization function publicly available.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::initialize;
+  using RelaxationBlock<MatrixType, inverse_type>::initialize;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::clear;
+  using RelaxationBlock<MatrixType, inverse_type>::clear;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::empty;
+  using RelaxationBlock<MatrixType, inverse_type>::empty;
 
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::size;
+  using RelaxationBlock<MatrixType, inverse_type>::size;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_householder;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_householder;
   /**
    * Make function of base class public again.
    */
-  using RelaxationBlock<MATRIX, inverse_type>::inverse_svd;
+  using RelaxationBlock<MatrixType, inverse_type>::inverse_svd;
   using PreconditionBlockBase<inverse_type>::log_statistics;
   /**
    * Perform one step of the SOR iteration.

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -22,12 +22,12 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 inline
-RelaxationBlock<MATRIX,inverse_type>::AdditionalData::AdditionalData (
-  const double relaxation,
-  const bool invert_diagonal,
-  const bool same_diagonal)
+RelaxationBlock<MatrixType,inverse_type>::AdditionalData::AdditionalData
+(const double relaxation,
+ const bool   invert_diagonal,
+ const bool   same_diagonal)
   :
   relaxation(relaxation),
   invert_diagonal(invert_diagonal),
@@ -37,10 +37,10 @@ RelaxationBlock<MATRIX,inverse_type>::AdditionalData::AdditionalData (
 {}
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 inline
 std::size_t
-RelaxationBlock<MATRIX,inverse_type>::AdditionalData::memory_consumption() const
+RelaxationBlock<MatrixType,inverse_type>::AdditionalData::memory_consumption() const
 {
   std::size_t result = sizeof(*this)
                        + - sizeof(block_list) + block_list.memory_consumption();
@@ -50,12 +50,11 @@ RelaxationBlock<MATRIX,inverse_type>::AdditionalData::memory_consumption() const
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 inline
 void
-RelaxationBlock<MATRIX,inverse_type>::initialize (
-  const MATRIX &M,
-  const AdditionalData &parameters)
+RelaxationBlock<MatrixType,inverse_type>::initialize (const MatrixType     &M,
+                                                      const AdditionalData &parameters)
 {
   Assert (parameters.invert_diagonal, ExcNotImplemented());
 
@@ -73,10 +72,10 @@ RelaxationBlock<MATRIX,inverse_type>::initialize (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 inline
 void
-RelaxationBlock<MATRIX,inverse_type>::clear ()
+RelaxationBlock<MatrixType,inverse_type>::clear ()
 {
   A = 0;
   additional_data = 0;
@@ -84,12 +83,12 @@ RelaxationBlock<MATRIX,inverse_type>::clear ()
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 inline
 void
-RelaxationBlock<MATRIX,inverse_type>::invert_diagblocks ()
+RelaxationBlock<MatrixType,inverse_type>::invert_diagblocks ()
 {
-  const MATRIX &M=*A;
+  const MatrixType &M=*A;
   FullMatrix<inverse_type> M_cell;
 
   if (this->same_diagonal())
@@ -111,7 +110,7 @@ RelaxationBlock<MATRIX,inverse_type>::invert_diagblocks ()
           for (size_type row_cell=0; row_cell<bs; ++row_cell, ++row)
             {
 //TODO:[GK] Optimize here
-              for (typename MATRIX::const_iterator entry = M.begin(row->column());
+              for (typename MatrixType::const_iterator entry = M.begin(row->column());
                    entry != M.end(row->column()); ++entry)
                 {
                   const size_type column = entry->column();
@@ -152,19 +151,18 @@ RelaxationBlock<MATRIX,inverse_type>::invert_diagblocks ()
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
 inline
 void
-RelaxationBlock<MATRIX,inverse_type>::do_step (
-  Vector<number2>       &dst,
-  const Vector<number2> &prev,
-  const Vector<number2> &src,
-  const bool backward) const
+RelaxationBlock<MatrixType,inverse_type>::do_step (Vector<number2>       &dst,
+                                                   const Vector<number2> &prev,
+                                                   const Vector<number2> &src,
+                                                   const bool             backward) const
 {
   Assert (additional_data->invert_diagonal, ExcNotImplemented());
 
-  const MATRIX &M=*this->A;
+  const MatrixType &M=*this->A;
   Vector<number2> b_cell, x_cell;
 
   const bool permutation_empty = additional_data->order.size() == 0;
@@ -196,7 +194,7 @@ RelaxationBlock<MATRIX,inverse_type>::do_step (
           for (size_type row_cell=0; row_cell<bs; ++row_cell, ++row)
             {
               b_cell(row_cell) = src(row->column());
-              for (typename MATRIX::const_iterator entry = M.begin(row->column());
+              for (typename MatrixType::const_iterator entry = M.begin(row->column());
                    entry != M.end(row->column()); ++entry)
                 b_cell(row_cell) -= entry->value() * prev(entry->column());
             }
@@ -219,11 +217,11 @@ RelaxationBlock<MATRIX,inverse_type>::do_step (
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockJacobi<MATRIX,inverse_type>::step (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockJacobi<MatrixType,inverse_type>::step
+(Vector<number2>       &dst,
+ const Vector<number2> &src) const
 {
   GrowingVectorMemory<Vector<number2> > mem;
   typename VectorMemory<Vector<number2> >::Pointer aux = mem;
@@ -233,11 +231,11 @@ void RelaxationBlockJacobi<MATRIX,inverse_type>::step (
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockJacobi<MATRIX,inverse_type>::Tstep (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockJacobi<MatrixType,inverse_type>::Tstep
+(Vector<number2>       &dst,
+ const Vector<number2> &src) const
 {
   GrowingVectorMemory<Vector<number2> > mem;
   typename VectorMemory<Vector<number2> >::Pointer aux = mem;
@@ -249,21 +247,21 @@ void RelaxationBlockJacobi<MATRIX,inverse_type>::Tstep (
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockSOR<MATRIX,inverse_type>::step (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockSOR<MatrixType,inverse_type>::step
+(Vector<number2> &dst,
+ const Vector<number2> &src) const
 {
   this->do_step(dst, dst, src, false);
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockSOR<MATRIX,inverse_type>::Tstep (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockSOR<MatrixType,inverse_type>::Tstep
+(Vector<number2>       &dst,
+ const Vector<number2> &src) const
 {
   this->do_step(dst, dst, src, true);
 }
@@ -271,22 +269,22 @@ void RelaxationBlockSOR<MATRIX,inverse_type>::Tstep (
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockSSOR<MATRIX,inverse_type>::step (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockSSOR<MatrixType,inverse_type>::step
+(Vector<number2>       &dst,
+ const Vector<number2> &src) const
 {
   this->do_step(dst, dst, src, false);
   this->do_step(dst, dst, src, true);
 }
 
 
-template <class MATRIX, typename inverse_type>
+template <typename MatrixType, typename inverse_type>
 template <typename number2>
-void RelaxationBlockSSOR<MATRIX,inverse_type>::Tstep (
-  Vector<number2>       &dst,
-  const Vector<number2> &src) const
+void RelaxationBlockSSOR<MatrixType,inverse_type>::Tstep
+(Vector<number2>       &dst,
+ const Vector<number2> &src) const
 {
   this->do_step(dst, dst, src, true);
   this->do_step(dst, dst, src, false);

--- a/include/deal.II/lac/shifted_matrix.h
+++ b/include/deal.II/lac/shifted_matrix.h
@@ -61,14 +61,14 @@ public:
   /**
    * Matrix-vector-product.
    */
-  template <class VECTOR>
-  void vmult (VECTOR &dst, const VECTOR &src) const;
+  template <typename VectorType>
+  void vmult (VectorType &dst, const VectorType &src) const;
 
   /**
    * Residual.
    */
-  template <class VECTOR>
-  double residual (VECTOR &dst, const VECTOR &src, const VECTOR &rhs) const;
+  template <typename VectorType>
+  double residual (VectorType &dst, const VectorType &src, const VectorType &rhs) const;
 
 private:
   /**
@@ -79,7 +79,7 @@ private:
   /**
    * Auxiliary vector.
    */
-  //    VECTOR aux;
+  //    VectorType aux;
   /**
    * Shift parameter.
    */
@@ -103,7 +103,7 @@ private:
  *
  * @author Guido Kanschat, 2001
  */
-template<class MATRIX, class MASSMATRIX, class VECTOR>
+template<class MATRIX, class MASSMATRIX, class VectorType>
 class ShiftedMatrixGeneralized
 {
 public:
@@ -127,27 +127,27 @@ public:
   /**
    * Matrix-vector-product.
    */
-  void vmult (VECTOR &dst, const VECTOR &src) const;
+  void vmult (VectorType &dst, const VectorType &src) const;
 
   /**
    * Residual.
    */
-  double residual (VECTOR &dst, const VECTOR &src, const VECTOR &rhs) const;
+  double residual (VectorType &dst, const VectorType &src, const VectorType &rhs) const;
 
 private:
   /**
    * Storage for base matrix.
    */
-  SmartPointer<const MATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VECTOR> > A;
+  SmartPointer<const MATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VectorType> > A;
   /**
    * Storage for mass matrix.
    */
-  SmartPointer<const MASSMATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VECTOR> > M;
+  SmartPointer<const MASSMATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VectorType> > M;
 
   /**
    * Auxiliary vector.
    */
-  VECTOR aux;
+  VectorType aux;
 
   /**
    * Shift parameter.
@@ -186,9 +186,9 @@ ShiftedMatrix<MATRIX>::shift () const
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline void
-ShiftedMatrix<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
+ShiftedMatrix<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -197,11 +197,11 @@ ShiftedMatrix<MATRIX>::vmult (VECTOR &dst, const VECTOR &src) const
 
 
 template <class MATRIX>
-template <class VECTOR>
+template <class VectorType>
 inline double
-ShiftedMatrix<MATRIX>::residual (VECTOR &dst,
-                                 const VECTOR &src,
-                                 const VECTOR &rhs) const
+ShiftedMatrix<MATRIX>::residual (VectorType       &dst,
+                                 const VectorType &src,
+                                 const VectorType &rhs) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -212,36 +212,36 @@ ShiftedMatrix<MATRIX>::residual (VECTOR &dst,
 
 
 //---------------------------------------------------------------------------
-template <class MATRIX, class MASSMATRIX, class VECTOR>
+template <class MATRIX, class MASSMATRIX, class VectorType>
 inline
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>
-::ShiftedMatrixGeneralized (const MATRIX &A,
+ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>
+::ShiftedMatrixGeneralized (const MATRIX     &A,
                             const MASSMATRIX &M,
-                            const double sigma)
+                            const double     sigma)
   :
   A(&A), M(&M), sigma(sigma)
 {}
 
 
-template <class MATRIX, class MASSMATRIX, class VECTOR>
+template <class MATRIX, class MASSMATRIX, class VectorType>
 inline void
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>::shift (const double s)
+ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::shift (const double s)
 {
   sigma = s;
 }
 
-template <class MATRIX, class MASSMATRIX, class VECTOR>
+template <class MATRIX, class MASSMATRIX, class VectorType>
 inline double
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>::shift () const
+ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::shift () const
 {
   return sigma;
 }
 
 
-template <class MATRIX, class MASSMATRIX, class VECTOR>
+template <class MATRIX, class MASSMATRIX, class VectorType>
 inline void
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>::vmult (VECTOR &dst,
-    const VECTOR &src) const
+ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::vmult (VectorType       &dst,
+                                                                 const VectorType &src) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -253,11 +253,11 @@ ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>::vmult (VECTOR &dst,
 }
 
 
-template <class MATRIX, class MASSMATRIX, class VECTOR>
+template <class MATRIX, class MASSMATRIX, class VectorType>
 inline double
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VECTOR>::residual (VECTOR &dst,
-    const VECTOR &src,
-    const VECTOR &rhs) const
+ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::residual (VectorType       &dst,
+                                                                    const VectorType &src,
+                                                                    const VectorType &rhs) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)

--- a/include/deal.II/lac/shifted_matrix.h
+++ b/include/deal.II/lac/shifted_matrix.h
@@ -39,14 +39,14 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 2000, 2001
  */
-template<class MATRIX>
+template<typename MatrixType>
 class ShiftedMatrix
 {
 public:
   /**
    * Constructor.  Provide the base matrix and a shift parameter.
    */
-  ShiftedMatrix (const MATRIX &A, const double sigma);
+  ShiftedMatrix (const MatrixType &A, const double sigma);
 
   /**
    * Set the shift parameter.
@@ -74,7 +74,7 @@ private:
   /**
    * Storage for base matrix.
    */
-  SmartPointer<const MATRIX,ShiftedMatrix<MATRIX> > A;
+  SmartPointer<const MatrixType,ShiftedMatrix<MatrixType> > A;
 
   /**
    * Auxiliary vector.
@@ -103,16 +103,16 @@ private:
  *
  * @author Guido Kanschat, 2001
  */
-template<class MATRIX, class MASSMATRIX, class VectorType>
+template<typename MatrixType, class MASSMatrixType, class VectorType>
 class ShiftedMatrixGeneralized
 {
 public:
   /**
    * Constructor. Provide the base matrix and a shift parameter.
    */
-  ShiftedMatrixGeneralized (const MATRIX &A,
-                            const MASSMATRIX &M,
-                            const double sigma);
+  ShiftedMatrixGeneralized (const MatrixType     &A,
+                            const MASSMatrixType &M,
+                            const double          sigma);
 
   /**
    * Set the shift parameter.
@@ -138,11 +138,11 @@ private:
   /**
    * Storage for base matrix.
    */
-  SmartPointer<const MATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VectorType> > A;
+  SmartPointer<const MatrixType,ShiftedMatrixGeneralized<MatrixType,MASSMatrixType,VectorType> > A;
   /**
    * Storage for mass matrix.
    */
-  SmartPointer<const MASSMATRIX,ShiftedMatrixGeneralized<MATRIX,MASSMATRIX,VectorType> > M;
+  SmartPointer<const MASSMatrixType,ShiftedMatrixGeneralized<MatrixType,MASSMatrixType,VectorType> > M;
 
   /**
    * Auxiliary vector.
@@ -159,36 +159,37 @@ private:
 /*@}*/
 //---------------------------------------------------------------------------
 
-template <class MATRIX>
+template <typename MatrixType>
 inline
-ShiftedMatrix<MATRIX>::ShiftedMatrix (const MATRIX &A, const double sigma)
+ShiftedMatrix<MatrixType>::ShiftedMatrix (const MatrixType &A,
+                                          const double      sigma)
   :
   A(&A), sigma(sigma)
 {}
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline void
-ShiftedMatrix<MATRIX>::shift (const double s)
+ShiftedMatrix<MatrixType>::shift (const double s)
 {
   sigma = s;
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 inline double
-ShiftedMatrix<MATRIX>::shift () const
+ShiftedMatrix<MatrixType>::shift () const
 {
   return sigma;
 }
 
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline void
-ShiftedMatrix<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
+ShiftedMatrix<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -196,12 +197,12 @@ ShiftedMatrix<MATRIX>::vmult (VectorType &dst, const VectorType &src) const
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 template <class VectorType>
 inline double
-ShiftedMatrix<MATRIX>::residual (VectorType       &dst,
-                                 const VectorType &src,
-                                 const VectorType &rhs) const
+ShiftedMatrix<MatrixType>::residual (VectorType       &dst,
+                                     const VectorType &src,
+                                     const VectorType &rhs) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -212,36 +213,37 @@ ShiftedMatrix<MATRIX>::residual (VectorType       &dst,
 
 
 //---------------------------------------------------------------------------
-template <class MATRIX, class MASSMATRIX, class VectorType>
+template <typename MatrixType, class MASSMatrixType, class VectorType>
 inline
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>
-::ShiftedMatrixGeneralized (const MATRIX     &A,
-                            const MASSMATRIX &M,
-                            const double     sigma)
+ShiftedMatrixGeneralized<MatrixType, MASSMatrixType, VectorType>
+::ShiftedMatrixGeneralized (const MatrixType     &A,
+                            const MASSMatrixType &M,
+                            const double          sigma)
   :
   A(&A), M(&M), sigma(sigma)
 {}
 
 
-template <class MATRIX, class MASSMATRIX, class VectorType>
+template <typename MatrixType, class MASSMatrixType, class VectorType>
 inline void
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::shift (const double s)
+ShiftedMatrixGeneralized<MatrixType, MASSMatrixType, VectorType>::shift (const double s)
 {
   sigma = s;
 }
 
-template <class MATRIX, class MASSMATRIX, class VectorType>
+template <typename MatrixType, class MASSMatrixType, class VectorType>
 inline double
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::shift () const
+ShiftedMatrixGeneralized<MatrixType, MASSMatrixType, VectorType>::shift () const
 {
   return sigma;
 }
 
 
-template <class MATRIX, class MASSMATRIX, class VectorType>
+template <typename MatrixType, class MASSMatrixType, class VectorType>
 inline void
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::vmult (VectorType       &dst,
-                                                                 const VectorType &src) const
+ShiftedMatrixGeneralized<MatrixType, MASSMatrixType, VectorType>::vmult
+(VectorType       &dst,
+ const VectorType &src) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)
@@ -253,11 +255,12 @@ ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::vmult (VectorType     
 }
 
 
-template <class MATRIX, class MASSMATRIX, class VectorType>
+template <typename MatrixType, class MASSMatrixType, class VectorType>
 inline double
-ShiftedMatrixGeneralized<MATRIX, MASSMATRIX, VectorType>::residual (VectorType       &dst,
-                                                                    const VectorType &src,
-                                                                    const VectorType &rhs) const
+ShiftedMatrixGeneralized<MatrixType, MASSMatrixType, VectorType>::residual
+(VectorType       &dst,
+ const VectorType &src,
+ const VectorType &rhs) const
 {
   A->vmult(dst, src);
   if (sigma != 0.)

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -60,13 +60,13 @@ template <typename number> class Vector;
  *   public:
  *                        // Application of matrix to vector src.
  *                        // Write result into dst
- *     void vmult (VECTOR &dst,
- *                 const VECTOR &src) const;
+ *     void vmult (VectorType       &dst,
+ *                 const VectorType &src) const;
  *
  *                        // Application of transpose to a vector.
  *                        // Only used by some iterative methods.
- *     void Tvmult (VECTOR &dst,
- *                  const VECTOR &src) const;
+ *     void Tvmult (VectorType       &dst,
+ *                  const VectorType &src) const;
  * };
  *
  *
@@ -120,11 +120,11 @@ template <typename number> class Vector;
  * @endcode
  *
  * In addition, for some solvers there has to be a global function
- * <tt>swap(VECTOR &a, VECTOR &b)</tt> that exchanges the values of the two
- * vectors.
+ * <tt>swap(VectorType &a, VectorType &b)</tt> that exchanges the values of
+ * the two vectors.
  *
  * Finally, the solvers also expect an instantiation of
- * GrowingVectorMemory@<VECTOR@>. These instantiations are provided by the
+ * GrowingVectorMemory@<VectorType@>. These instantiations are provided by the
  * deal.II library for the built-in vector types, but must be explicitly added
  * for user-provided vector classes. Otherwise, the linker will complain that
  * it cannot find the constructors and destructors of GrowingVectorMemory that
@@ -321,14 +321,14 @@ template <typename number> class Vector;
  * @author Wolfgang Bangerth, Guido Kanschat, Ralf Hartmann, 1997-2001, 2005,
  * 2014
  */
-template <class VECTOR = Vector<double> >
+template <class VectorType = Vector<double> >
 class Solver : public Subscriptor
 {
 public:
   /**
    * A typedef for the underlying vector type
    */
-  typedef VECTOR vector_type;
+  typedef VectorType vector_type;
 
   /**
    * Constructor. Takes a control object which evaluates the conditions for
@@ -339,8 +339,8 @@ public:
    * responsibility to guarantee that the lifetime of the two arguments is at
    * least as long as that of the solver object.
    */
-  Solver (SolverControl        &solver_control,
-          VectorMemory<VECTOR> &vector_memory);
+  Solver (SolverControl            &solver_control,
+          VectorMemory<VectorType> &vector_memory);
 
   /**
    * Constructor. Takes a control object which evaluates the conditions for
@@ -384,8 +384,8 @@ public:
    */
   boost::signals2::connection
   connect (const std_cxx11::function<SolverControl::State (const unsigned int iteration,
-                                                           const double        check_value,
-                                                           const VECTOR       &current_iterate)> &slot);
+                                                           const double       check_value,
+                                                           const VectorType   &current_iterate)> &slot);
 
 
 
@@ -394,12 +394,12 @@ protected:
    * A static vector memory object to be used whenever no such object has been
    * given to the constructor.
    */
-  mutable GrowingVectorMemory<VECTOR> static_vector_memory;
+  mutable GrowingVectorMemory<VectorType> static_vector_memory;
 
   /**
    * A reference to an object that provides memory for auxiliary vectors.
    */
-  VectorMemory<VECTOR> &memory;
+  VectorMemory<VectorType> &memory;
 
 private:
   /**
@@ -443,8 +443,8 @@ protected:
    * signal's return value indicates that the iteration should be terminated.
    */
   boost::signals2::signal<SolverControl::State (const unsigned int iteration,
-                                                const double        check_value,
-                                                const VECTOR       &current_iterate),
+                                                const double       check_value,
+                                                const VectorType   &current_iterate),
                                                       StateCombiner> iteration_status;
 };
 
@@ -452,10 +452,10 @@ protected:
 /*-------------------------------- Inline functions ------------------------*/
 
 
-template <class VECTOR>
+template <class VectorType>
 inline
 SolverControl::State
-Solver<VECTOR>::StateCombiner::operator ()(const SolverControl::State state1,
+Solver<VectorType>::StateCombiner::operator ()(const SolverControl::State state1,
                                            const SolverControl::State state2) const
 {
   if ((state1 == SolverControl::failure)
@@ -471,11 +471,11 @@ Solver<VECTOR>::StateCombiner::operator ()(const SolverControl::State state1,
 }
 
 
-template <class VECTOR>
+template <class VectorType>
 template <typename Iterator>
 inline
 SolverControl::State
-Solver<VECTOR>::StateCombiner::operator ()(const Iterator begin,
+Solver<VectorType>::StateCombiner::operator ()(const Iterator begin,
                                            const Iterator end) const
 {
   Assert (begin != end, ExcMessage ("You can't combine iterator states if no state is given."));
@@ -491,10 +491,10 @@ Solver<VECTOR>::StateCombiner::operator ()(const Iterator begin,
 }
 
 
-template<class VECTOR>
+template<class VectorType>
 inline
-Solver<VECTOR>::Solver (SolverControl        &solver_control,
-                        VectorMemory<VECTOR> &vector_memory)
+Solver<VectorType>::Solver (SolverControl        &solver_control,
+                        VectorMemory<VectorType> &vector_memory)
   :
   memory(vector_memory)
 {
@@ -510,9 +510,9 @@ Solver<VECTOR>::Solver (SolverControl        &solver_control,
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline
-Solver<VECTOR>::Solver (SolverControl        &solver_control)
+Solver<VectorType>::Solver (SolverControl &solver_control)
   :
   // use the static memory object this class owns
   memory(static_vector_memory)
@@ -529,13 +529,13 @@ Solver<VECTOR>::Solver (SolverControl        &solver_control)
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline
 boost::signals2::connection
-Solver<VECTOR>::
+Solver<VectorType>::
 connect (const std_cxx11::function<SolverControl::State (const unsigned int iteration,
-                                                         const double        check_value,
-                                                         const VECTOR       &current_iterate)> &slot)
+                                                         const double       check_value,
+                                                         const VectorType   &current_iterate)> &slot)
 {
   return iteration_status.connect (slot);
 }

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -456,7 +456,7 @@ template <class VectorType>
 inline
 SolverControl::State
 Solver<VectorType>::StateCombiner::operator ()(const SolverControl::State state1,
-                                           const SolverControl::State state2) const
+                                               const SolverControl::State state2) const
 {
   if ((state1 == SolverControl::failure)
       ||
@@ -476,7 +476,7 @@ template <typename Iterator>
 inline
 SolverControl::State
 Solver<VectorType>::StateCombiner::operator ()(const Iterator begin,
-                                           const Iterator end) const
+                                               const Iterator end) const
 {
   Assert (begin != end, ExcMessage ("You can't combine iterator states if no state is given."));
 
@@ -494,7 +494,7 @@ Solver<VectorType>::StateCombiner::operator ()(const Iterator begin,
 template<class VectorType>
 inline
 Solver<VectorType>::Solver (SolverControl        &solver_control,
-                        VectorMemory<VectorType> &vector_memory)
+                            VectorMemory<VectorType> &vector_memory)
   :
   memory(vector_memory)
 {

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -68,8 +68,8 @@ DEAL_II_NAMESPACE_OPEN
  * to observe the progress of the iteration.
  *
  */
-template <class VECTOR = Vector<double> >
-class SolverBicgstab : public Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class SolverBicgstab : public Solver<VectorType>
 {
 public:
   /**
@@ -109,9 +109,9 @@ public:
   /**
    * Constructor.
    */
-  SolverBicgstab (SolverControl        &cn,
-                  VectorMemory<VECTOR> &mem,
-                  const AdditionalData &data=AdditionalData());
+  SolverBicgstab (SolverControl            &cn,
+                  VectorMemory<VectorType> &mem,
+                  const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -130,9 +130,9 @@ public:
    */
   template<class MATRIX, class PRECONDITIONER>
   void
-  solve (const MATRIX &A,
-         VECTOR       &x,
-         const VECTOR &b,
+  solve (const MATRIX         &A,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
 protected:
@@ -140,7 +140,7 @@ protected:
    * Computation of the stopping criterion.
    */
   template <class MATRIX>
-  double criterion (const MATRIX &A, const VECTOR &x, const VECTOR &b);
+  double criterion (const MATRIX &A, const VectorType &x, const VectorType &b);
 
   /**
    * Interface for derived class.  This function gets the current iteration
@@ -148,46 +148,46 @@ protected:
    * for a graphical output of the convergence history.
    */
   virtual void print_vectors(const unsigned int step,
-                             const VECTOR &x,
-                             const VECTOR &r,
-                             const VECTOR &d) const;
+                             const VectorType   &x,
+                             const VectorType   &r,
+                             const VectorType   &d) const;
 
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vx;
+  VectorType *Vx;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vr;
+  VectorType *Vr;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vrbar;
+  VectorType *Vrbar;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vp;
+  VectorType *Vp;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vy;
+  VectorType *Vy;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vz;
+  VectorType *Vz;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vt;
+  VectorType *Vt;
   /**
    * Auxiliary vector.
    */
-  VECTOR *Vv;
+  VectorType *Vv;
   /**
    * Right hand side vector.
    */
-  const VECTOR *Vb;
+  const VectorType *Vb;
 
   /**
    * Auxiliary value.
@@ -265,11 +265,12 @@ private:
 #ifndef DOXYGEN
 
 
-template<class VECTOR>
-SolverBicgstab<VECTOR>::IterationResult::IterationResult(const bool breakdown,
-                                                         const SolverControl::State state,
-                                                         const unsigned int         last_step,
-                                                         const double               last_residual)
+template<typename VectorType>
+SolverBicgstab<VectorType>::IterationResult::IterationResult
+(const bool                 breakdown,
+ const SolverControl::State state,
+ const unsigned int         last_step,
+ const double               last_residual)
   :
   breakdown (breakdown),
   state (state),
@@ -278,37 +279,37 @@ SolverBicgstab<VECTOR>::IterationResult::IterationResult(const bool breakdown,
 {}
 
 
-template<class VECTOR>
-SolverBicgstab<VECTOR>::SolverBicgstab (SolverControl &cn,
-                                        VectorMemory<VECTOR> &mem,
-                                        const AdditionalData &data)
+template<typename VectorType>
+SolverBicgstab<VectorType>::SolverBicgstab (SolverControl            &cn,
+                                            VectorMemory<VectorType> &mem,
+                                            const AdditionalData     &data)
   :
-  Solver<VECTOR>(cn,mem),
+  Solver<VectorType>(cn,mem),
   additional_data(data)
 {}
 
 
 
-template<class VECTOR>
-SolverBicgstab<VECTOR>::SolverBicgstab (SolverControl &cn,
-                                        const AdditionalData &data)
+template<typename VectorType>
+SolverBicgstab<VectorType>::SolverBicgstab (SolverControl        &cn,
+                                            const AdditionalData &data)
   :
-  Solver<VECTOR>(cn),
+  Solver<VectorType>(cn),
   additional_data(data)
 {}
 
 
 
-template<class VECTOR>
-SolverBicgstab<VECTOR>::~SolverBicgstab ()
+template<typename VectorType>
+SolverBicgstab<VectorType>::~SolverBicgstab ()
 {}
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX>
 double
-SolverBicgstab<VECTOR>::criterion (const MATRIX &A, const VECTOR &x, const VECTOR &b)
+SolverBicgstab<VectorType>::criterion (const MATRIX &A, const VectorType &x, const VectorType &b)
 {
   A.vmult(*Vt, x);
   Vt->add(-1.,b);
@@ -319,10 +320,10 @@ SolverBicgstab<VECTOR>::criterion (const MATRIX &A, const VECTOR &x, const VECTO
 
 
 
-template <class VECTOR >
+template <typename VectorType >
 template <class MATRIX>
 SolverControl::State
-SolverBicgstab<VECTOR>::start(const MATRIX &A)
+SolverBicgstab<VectorType>::start(const MATRIX &A)
 {
   A.vmult(*Vr, *Vx);
   Vr->sadd(-1.,1.,*Vb);
@@ -333,33 +334,33 @@ SolverBicgstab<VECTOR>::start(const MATRIX &A)
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
-SolverBicgstab<VECTOR>::print_vectors(const unsigned int,
-                                      const VECTOR &,
-                                      const VECTOR &,
-                                      const VECTOR &) const
+SolverBicgstab<VectorType>::print_vectors(const unsigned int,
+                                          const VectorType &,
+                                          const VectorType &,
+                                          const VectorType &) const
 {}
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX, class PRECONDITIONER>
-typename SolverBicgstab<VECTOR>::IterationResult
-SolverBicgstab<VECTOR>::iterate(const MATRIX &A,
-                                const PRECONDITIONER &precondition)
+typename SolverBicgstab<VectorType>::IterationResult
+SolverBicgstab<VectorType>::iterate(const MATRIX         &A,
+                                    const PRECONDITIONER &precondition)
 {
 //TODO:[GK] Implement "use the length of the computed orthogonal residual" in the BiCGStab method.
   SolverControl::State state = SolverControl::iterate;
   alpha = omega = rho = 1.;
 
-  VECTOR &r = *Vr;
-  VECTOR &rbar = *Vrbar;
-  VECTOR &p = *Vp;
-  VECTOR &y = *Vy;
-  VECTOR &z = *Vz;
-  VECTOR &t = *Vt;
-  VECTOR &v = *Vv;
+  VectorType &r = *Vr;
+  VectorType &rbar = *Vrbar;
+  VectorType &p = *Vp;
+  VectorType &y = *Vy;
+  VectorType &z = *Vz;
+  VectorType &t = *Vt;
+  VectorType &v = *Vv;
 
   rbar = r;
   bool startup = true;
@@ -430,13 +431,13 @@ SolverBicgstab<VECTOR>::iterate(const MATRIX &A,
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 template<class MATRIX, class PRECONDITIONER>
 void
-SolverBicgstab<VECTOR>::solve(const MATRIX &A,
-                              VECTOR       &x,
-                              const VECTOR &b,
-                              const PRECONDITIONER &precondition)
+SolverBicgstab<VectorType>::solve(const MATRIX         &A,
+                                  VectorType           &x,
+                                  const VectorType     &b,
+                                  const PRECONDITIONER &precondition)
 {
   deallog.push("Bicgstab");
   Vr    = this->memory.alloc();

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -128,12 +128,12 @@ public:
   /**
    * Solve primal problem only.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
 protected:
   /**
@@ -253,10 +253,10 @@ private:
    * The iteration loop itself. The function returns a structure indicating
    * what happened in this function.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   IterationResult
-  iterate(const MatrixType     &A,
-          const PRECONDITIONER &precondition);
+  iterate(const MatrixType         &A,
+          const PreconditionerType &precondition);
 };
 
 /*@}*/
@@ -347,10 +347,10 @@ SolverBicgstab<VectorType>::print_vectors(const unsigned int,
 
 
 template<typename VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 typename SolverBicgstab<VectorType>::IterationResult
-SolverBicgstab<VectorType>::iterate(const MatrixType     &A,
-                                    const PRECONDITIONER &precondition)
+SolverBicgstab<VectorType>::iterate(const MatrixType         &A,
+                                    const PreconditionerType &precondition)
 {
 //TODO:[GK] Implement "use the length of the computed orthogonal residual" in the BiCGStab method.
   SolverControl::State state = SolverControl::iterate;
@@ -434,12 +434,12 @@ SolverBicgstab<VectorType>::iterate(const MatrixType     &A,
 
 
 template<typename VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 void
-SolverBicgstab<VectorType>::solve(const MatrixType     &A,
-                                  VectorType           &x,
-                                  const VectorType     &b,
-                                  const PRECONDITIONER &precondition)
+SolverBicgstab<VectorType>::solve(const MatrixType         &A,
+                                  VectorType               &x,
+                                  const VectorType         &b,
+                                  const PreconditionerType &precondition)
 {
   deallog.push("Bicgstab");
   Vr    = this->memory.alloc();

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -128,9 +128,9 @@ public:
   /**
    * Solve primal problem only.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -139,8 +139,8 @@ protected:
   /**
    * Computation of the stopping criterion.
    */
-  template <class MATRIX>
-  double criterion (const MATRIX &A, const VectorType &x, const VectorType &b);
+  template <typename MatrixType>
+  double criterion (const MatrixType &A, const VectorType &x, const VectorType &b);
 
   /**
    * Interface for derived class.  This function gets the current iteration
@@ -229,8 +229,8 @@ private:
   /**
    * Everything before the iteration loop.
    */
-  template <class MATRIX>
-  SolverControl::State start(const MATRIX &A);
+  template <typename MatrixType>
+  SolverControl::State start(const MatrixType &A);
 
   /**
    * A structure returned by the iterate() function representing what it found
@@ -253,9 +253,9 @@ private:
    * The iteration loop itself. The function returns a structure indicating
    * what happened in this function.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   IterationResult
-  iterate(const MATRIX &A,
+  iterate(const MatrixType     &A,
           const PRECONDITIONER &precondition);
 };
 
@@ -307,9 +307,11 @@ SolverBicgstab<VectorType>::~SolverBicgstab ()
 
 
 template <typename VectorType>
-template <class MATRIX>
+template <typename MatrixType>
 double
-SolverBicgstab<VectorType>::criterion (const MATRIX &A, const VectorType &x, const VectorType &b)
+SolverBicgstab<VectorType>::criterion (const MatrixType &A,
+                                       const VectorType &x,
+                                       const VectorType &b)
 {
   A.vmult(*Vt, x);
   Vt->add(-1.,b);
@@ -321,9 +323,9 @@ SolverBicgstab<VectorType>::criterion (const MATRIX &A, const VectorType &x, con
 
 
 template <typename VectorType >
-template <class MATRIX>
+template <typename MatrixType>
 SolverControl::State
-SolverBicgstab<VectorType>::start(const MATRIX &A)
+SolverBicgstab<VectorType>::start (const MatrixType &A)
 {
   A.vmult(*Vr, *Vx);
   Vr->sadd(-1.,1.,*Vb);
@@ -345,9 +347,9 @@ SolverBicgstab<VectorType>::print_vectors(const unsigned int,
 
 
 template<typename VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 typename SolverBicgstab<VectorType>::IterationResult
-SolverBicgstab<VectorType>::iterate(const MATRIX         &A,
+SolverBicgstab<VectorType>::iterate(const MatrixType     &A,
                                     const PRECONDITIONER &precondition)
 {
 //TODO:[GK] Implement "use the length of the computed orthogonal residual" in the BiCGStab method.
@@ -432,9 +434,9 @@ SolverBicgstab<VectorType>::iterate(const MATRIX         &A,
 
 
 template<typename VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 void
-SolverBicgstab<VectorType>::solve(const MATRIX         &A,
+SolverBicgstab<VectorType>::solve(const MatrixType     &A,
                                   VectorType           &x,
                                   const VectorType     &b,
                                   const PRECONDITIONER &precondition)

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -95,8 +95,8 @@ class PreconditionIdentity;
  *
  * @author W. Bangerth, G. Kanschat, R. Becker and F.-T. Suttmeier
  */
-template <class VECTOR = Vector<double> >
-class SolverCG : public Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class SolverCG : public Solver<VectorType>
 {
 public:
   /**
@@ -156,9 +156,9 @@ public:
   /**
    * Constructor.
    */
-  SolverCG (SolverControl        &cn,
-            VectorMemory<VECTOR> &mem,
-            const AdditionalData &data = AdditionalData());
+  SolverCG (SolverControl            &cn,
+            VectorMemory<VectorType> &mem,
+            const AdditionalData     &data = AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -178,8 +178,8 @@ public:
   template <class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
   /**
@@ -227,9 +227,9 @@ protected:
    * for a graphical output of the convergence history.
    */
   virtual void print_vectors(const unsigned int step,
-                             const VECTOR &x,
-                             const VECTOR &r,
-                             const VECTOR &d) const;
+                             const VectorType   &x,
+                             const VectorType   &r,
+                             const VectorType   &d) const;
 
   /**
    * Estimates the eigenvalues from diagonal and offdiagonal. Uses
@@ -251,9 +251,9 @@ protected:
    * Temporary vectors, allocated through the @p VectorMemory object at the
    * start of the actual solution process and deallocated at the end.
    */
-  VECTOR *Vr;
-  VECTOR *Vp;
-  VECTOR *Vz;
+  VectorType *Vr;
+  VectorType *Vp;
+  VectorType *Vz;
 
   /**
    * Within the iteration loop, the square of the residual vector is stored in
@@ -308,9 +308,9 @@ private:
 
 #ifndef DOXYGEN
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-SolverCG<VECTOR>::AdditionalData::
+SolverCG<VectorType>::AdditionalData::
 AdditionalData (const bool log_coefficients,
                 const bool compute_condition_number,
                 const bool compute_all_condition_numbers,
@@ -324,9 +324,9 @@ AdditionalData (const bool log_coefficients,
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-SolverCG<VECTOR>::AdditionalData::
+SolverCG<VectorType>::AdditionalData::
 AdditionalData ()
   :
   log_coefficients (false),
@@ -337,45 +337,45 @@ AdditionalData ()
 
 
 
-template <class VECTOR>
-SolverCG<VECTOR>::SolverCG (SolverControl        &cn,
-                            VectorMemory<VECTOR> &mem,
-                            const AdditionalData &data)
+template <typename VectorType>
+SolverCG<VectorType>::SolverCG (SolverControl        &cn,
+                            VectorMemory<VectorType> &mem,
+                            const AdditionalData     &data)
   :
-  Solver<VECTOR>(cn,mem),
+  Solver<VectorType>(cn,mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverCG<VECTOR>::SolverCG (SolverControl        &cn,
-                            const AdditionalData &data)
+template <typename VectorType>
+SolverCG<VectorType>::SolverCG (SolverControl        &cn,
+                                const AdditionalData &data)
   :
-  Solver<VECTOR>(cn),
+  Solver<VectorType>(cn),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverCG<VECTOR>::~SolverCG ()
+template <typename VectorType>
+SolverCG<VectorType>::~SolverCG ()
 {}
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 double
-SolverCG<VECTOR>::criterion()
+SolverCG<VectorType>::criterion()
 {
   return std::sqrt(res2);
 }
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-SolverCG<VECTOR>::cleanup()
+SolverCG<VectorType>::cleanup()
 {
   this->memory.free(Vr);
   this->memory.free(Vp);
@@ -385,25 +385,25 @@ SolverCG<VECTOR>::cleanup()
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-SolverCG<VECTOR>::print_vectors(const unsigned int,
-                                const VECTOR &,
-                                const VECTOR &,
-                                const VECTOR &) const
+SolverCG<VectorType>::print_vectors(const unsigned int,
+                                    const VectorType &,
+                                    const VectorType &,
+                                    const VectorType &) const
 {}
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-SolverCG<VECTOR>::compute_eigs_and_cond(
-  const std::vector<double> &diagonal,
-  const std::vector<double> &offdiagonal,
-  const boost::signals2::signal<void (const std::vector<double> &)> &eigenvalues_signal,
-  const boost::signals2::signal<void (double)> &cond_signal,
-  const bool log_eigenvalues,
-  const bool log_cond)
+SolverCG<VectorType>::compute_eigs_and_cond
+(const std::vector<double> &diagonal,
+ const std::vector<double> &offdiagonal,
+ const boost::signals2::signal<void (const std::vector<double> &)> &eigenvalues_signal,
+ const boost::signals2::signal<void (double)>                      &cond_signal,
+ const bool                log_eigenvalues,
+ const bool                log_cond)
 {
   //Avoid computing eigenvalues unless they are needed.
   if (!cond_signal.empty()|| !eigenvalues_signal.empty()  || log_cond ||
@@ -452,13 +452,13 @@ SolverCG<VECTOR>::compute_eigs_and_cond(
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <class MATRIX, class PRECONDITIONER>
 void
-SolverCG<VECTOR>::solve (const MATRIX         &A,
-                         VECTOR               &x,
-                         const VECTOR         &b,
-                         const PRECONDITIONER &precondition)
+SolverCG<VectorType>::solve (const MATRIX         &A,
+                             VectorType           &x,
+                             const VectorType     &b,
+                             const PRECONDITIONER &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -490,9 +490,9 @@ SolverCG<VECTOR>::solve (const MATRIX         &A,
   try
     {
       // define some aliases for simpler access
-      VECTOR &g = *Vr;
-      VECTOR &d = *Vz;
-      VECTOR &h = *Vp;
+      VectorType &g = *Vr;
+      VectorType &d = *Vz;
+      VectorType &h = *Vp;
       // resize the vectors, but do not set
       // the values since they'd be overwritten
       // soon anyway.
@@ -611,21 +611,21 @@ SolverCG<VECTOR>::solve (const MATRIX         &A,
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 boost::signals2::connection
-SolverCG<VECTOR>::connect_coefficients_slot(
-  const std_cxx11::function<void(double,double)> &slot)
+SolverCG<VectorType>::connect_coefficients_slot
+(const std_cxx11::function<void(double,double)> &slot)
 {
   return coefficients_signal.connect(slot);
 }
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 boost::signals2::connection
-SolverCG<VECTOR>::connect_condition_number_slot(
-  const std_cxx11::function<void(double)> &slot,
-  const bool every_iteration)
+SolverCG<VectorType>::connect_condition_number_slot
+(const std_cxx11::function<void(double)> &slot,
+ const bool                              every_iteration)
 {
   if (every_iteration)
     {
@@ -639,11 +639,11 @@ SolverCG<VECTOR>::connect_condition_number_slot(
 
 
 
-template<class VECTOR>
+template<typename VectorType>
 boost::signals2::connection
-SolverCG<VECTOR>::connect_eigenvalues_slot(
-  const std_cxx11::function<void (const std::vector<double> &)> &slot,
-  const bool every_iteration)
+SolverCG<VectorType>::connect_eigenvalues_slot
+(const std_cxx11::function<void (const std::vector<double> &)> &slot,
+ const bool                                                    every_iteration)
 {
   if (every_iteration)
     {

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -175,12 +175,12 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template <typename MatrixType, class PRECONDITIONER>
+  template <typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
   /**
    * Connect a slot to retrieve the CG coefficients. The slot will be called
@@ -453,12 +453,12 @@ SolverCG<VectorType>::compute_eigs_and_cond
 
 
 template <typename VectorType>
-template <typename MatrixType, class PRECONDITIONER>
+template <typename MatrixType, typename PreconditionerType>
 void
-SolverCG<VectorType>::solve (const MatrixType     &A,
-                             VectorType           &x,
-                             const VectorType     &b,
-                             const PRECONDITIONER &precondition)
+SolverCG<VectorType>::solve (const MatrixType         &A,
+                             VectorType               &x,
+                             const VectorType         &b,
+                             const PreconditionerType &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -521,7 +521,7 @@ SolverCG<VectorType>::solve (const MatrixType     &A,
           return;
         }
 
-      if (types_are_equal<PRECONDITIONER,PreconditionIdentity>::value == false)
+      if (types_are_equal<PreconditionerType,PreconditionIdentity>::value == false)
         {
           precondition.vmult(h,g);
 
@@ -553,7 +553,7 @@ SolverCG<VectorType>::solve (const MatrixType     &A,
           if (conv != SolverControl::iterate)
             break;
 
-          if (types_are_equal<PRECONDITIONER,PreconditionIdentity>::value
+          if (types_are_equal<PreconditionerType,PreconditionIdentity>::value
               == false)
             {
               precondition.vmult(h,g);

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -175,9 +175,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template <class MATRIX, class PRECONDITIONER>
+  template <typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -453,9 +453,9 @@ SolverCG<VectorType>::compute_eigs_and_cond
 
 
 template <typename VectorType>
-template <class MATRIX, class PRECONDITIONER>
+template <typename MatrixType, class PRECONDITIONER>
 void
-SolverCG<VectorType>::solve (const MATRIX         &A,
+SolverCG<VectorType>::solve (const MatrixType     &A,
                              VectorType           &x,
                              const VectorType     &b,
                              const PRECONDITIONER &precondition)

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -339,8 +339,8 @@ AdditionalData ()
 
 template <typename VectorType>
 SolverCG<VectorType>::SolverCG (SolverControl        &cn,
-                            VectorMemory<VectorType> &mem,
-                            const AdditionalData     &data)
+                                VectorMemory<VectorType> &mem,
+                                const AdditionalData     &data)
   :
   Solver<VectorType>(cn,mem),
   additional_data(data)

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -259,12 +259,12 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
   /**
    * Connect a slot to retrieve the estimated condition number.
@@ -452,12 +452,12 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
 private:
 
@@ -746,12 +746,12 @@ SolverGMRES<VectorType>::compute_eigs_and_cond
 
 
 template<class VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 void
-SolverGMRES<VectorType>::solve (const MatrixType     &A,
-                                VectorType           &x,
-                                const VectorType     &b,
-                                const PRECONDITIONER &precondition)
+SolverGMRES<VectorType>::solve (const MatrixType         &A,
+                                VectorType               &x,
+                                const VectorType         &b,
+                                const PreconditionerType &precondition)
 {
   // this code was written a very long time ago by people not associated with
   // deal.II. we don't make any guarantees to its optimality or that it even
@@ -1114,12 +1114,12 @@ SolverFGMRES<VectorType>::SolverFGMRES (SolverControl        &cn,
 
 
 template<class VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 void
-SolverFGMRES<VectorType>::solve (const MatrixType     &A,
-                                 VectorType           &x,
-                                 const VectorType     &b,
-                                 const PRECONDITIONER &precondition)
+SolverFGMRES<VectorType>::solve (const MatrixType         &A,
+                                 VectorType               &x,
+                                 const VectorType         &b,
+                                 const PreconditionerType &precondition)
 {
   deallog.push("FGMRES");
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -524,7 +524,7 @@ namespace internal
     template <class VectorType>
     inline VectorType &
     TmpVectors<VectorType>::operator() (const unsigned int i,
-                                    const VectorType       &temp)
+                                        const VectorType       &temp)
     {
       Assert (i+offset<data.size(),
               ExcIndexRange(i,-offset, data.size()-offset));

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -52,15 +52,15 @@ namespace internal
      * automatically, avoiding restart.
      */
 
-    template <class VECTOR>
+    template <typename VectorType>
     class TmpVectors
     {
     public:
       /**
-       * Constructor. Prepares an array of @p VECTOR of length @p max_size.
+       * Constructor. Prepares an array of @p VectorType of length @p max_size.
        */
-      TmpVectors(const unsigned int    max_size,
-                 VectorMemory<VECTOR> &vmem);
+      TmpVectors(const unsigned int       max_size,
+                 VectorMemory<VectorType> &vmem);
 
       /**
        * Delete all allocated vectors.
@@ -71,7 +71,7 @@ namespace internal
        * Get vector number @p i. If this vector was unused before, an error
        * occurs.
        */
-      VECTOR &operator[] (const unsigned int i) const;
+      VectorType &operator[] (const unsigned int i) const;
 
       /**
        * Get vector number @p i. Allocate it if necessary.
@@ -79,19 +79,19 @@ namespace internal
        * If a vector must be allocated, @p temp is used to reinit it to the
        * proper dimensions.
        */
-      VECTOR &operator() (const unsigned int i,
-                          const VECTOR      &temp);
+      VectorType &operator() (const unsigned int i,
+                              const VectorType   &temp);
 
     private:
       /**
        * Pool were vectors are obtained from.
        */
-      VectorMemory<VECTOR> &mem;
+      VectorMemory<VectorType> &mem;
 
       /**
        * Field for storing the vectors.
        */
-      std::vector<VECTOR *> data;
+      std::vector<VectorType *> data;
 
       /**
        * Offset of the first vector. This is for later when vector rotation
@@ -169,8 +169,8 @@ namespace internal
  *
  * @author Wolfgang Bangerth, Guido Kanschat, Ralf Hartmann.
  */
-template <class VECTOR = Vector<double> >
-class SolverGMRES : public Solver<VECTOR>
+template <class VectorType = Vector<double> >
+class SolverGMRES : public Solver<VectorType>
 {
 public:
   /**
@@ -245,9 +245,9 @@ public:
   /**
    * Constructor.
    */
-  SolverGMRES (SolverControl        &cn,
-               VectorMemory<VECTOR> &mem,
-               const AdditionalData &data=AdditionalData());
+  SolverGMRES (SolverControl            &cn,
+               VectorMemory<VectorType> &mem,
+               const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -262,8 +262,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
   /**
@@ -349,12 +349,12 @@ protected:
    * All subsequent iterations use re-orthogonalization.
    */
   static double
-  modified_gram_schmidt (const internal::SolverGMRES::TmpVectors<VECTOR> &orthogonal_vectors,
-                         const unsigned int  dim,
-                         const unsigned int  accumulated_iterations,
-                         VECTOR             &vv,
-                         Vector<double>     &h,
-                         bool               &re_orthogonalize);
+  modified_gram_schmidt (const internal::SolverGMRES::TmpVectors<VectorType> &orthogonal_vectors,
+                         const unsigned int                                  dim,
+                         const unsigned int                                  accumulated_iterations,
+                         VectorType                                          &vv,
+                         Vector<double>                                      &h,
+                         bool                                                &re_orthogonalize);
 
   /**
     * Estimates the eigenvalues from the Hessenberg matrix, H_orig, generated
@@ -386,7 +386,7 @@ private:
   /**
    * No copy constructor.
    */
-  SolverGMRES (const SolverGMRES<VECTOR> &);
+  SolverGMRES (const SolverGMRES<VectorType> &);
 };
 
 /**
@@ -410,8 +410,8 @@ private:
  *
  * @author Guido Kanschat, 2003
  */
-template <class VECTOR = Vector<double> >
-class SolverFGMRES : public Solver<VECTOR>
+template <class VectorType = Vector<double> >
+class SolverFGMRES : public Solver<VectorType>
 {
 public:
   /**
@@ -438,9 +438,9 @@ public:
   /**
    * Constructor.
    */
-  SolverFGMRES (SolverControl        &cn,
-                VectorMemory<VECTOR> &mem,
-                const AdditionalData &data=AdditionalData());
+  SolverFGMRES (SolverControl            &cn,
+                VectorMemory<VectorType> &mem,
+                const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -455,8 +455,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
 private:
@@ -486,11 +486,11 @@ namespace internal
 {
   namespace SolverGMRES
   {
-    template <class VECTOR>
+    template <class VectorType>
     inline
-    TmpVectors<VECTOR>::
-    TmpVectors (const unsigned int    max_size,
-                VectorMemory<VECTOR> &vmem)
+    TmpVectors<VectorType>::
+    TmpVectors (const unsigned int       max_size,
+                VectorMemory<VectorType> &vmem)
       :
       mem(vmem),
       data (max_size, 0),
@@ -498,20 +498,20 @@ namespace internal
     {}
 
 
-    template <class VECTOR>
+    template <class VectorType>
     inline
-    TmpVectors<VECTOR>::~TmpVectors ()
+    TmpVectors<VectorType>::~TmpVectors ()
     {
-      for (typename std::vector<VECTOR *>::iterator v = data.begin();
+      for (typename std::vector<VectorType *>::iterator v = data.begin();
            v != data.end(); ++v)
         if (*v != 0)
           mem.free(*v);
     }
 
 
-    template <class VECTOR>
-    inline VECTOR &
-    TmpVectors<VECTOR>::operator[] (const unsigned int i) const
+    template <class VectorType>
+    inline VectorType &
+    TmpVectors<VectorType>::operator[] (const unsigned int i) const
     {
       Assert (i+offset<data.size(),
               ExcIndexRange(i, -offset, data.size()-offset));
@@ -521,10 +521,10 @@ namespace internal
     }
 
 
-    template <class VECTOR>
-    inline VECTOR &
-    TmpVectors<VECTOR>::operator() (const unsigned int i,
-                                    const VECTOR      &temp)
+    template <class VectorType>
+    inline VectorType &
+    TmpVectors<VectorType>::operator() (const unsigned int i,
+                                    const VectorType       &temp)
     {
       Assert (i+offset<data.size(),
               ExcIndexRange(i,-offset, data.size()-offset));
@@ -548,9 +548,9 @@ namespace internal
 
 
 
-template <class VECTOR>
+template <class VectorType>
 inline
-SolverGMRES<VECTOR>::AdditionalData::
+SolverGMRES<VectorType>::AdditionalData::
 AdditionalData (const unsigned int max_n_tmp_vectors,
                 const bool         right_preconditioning,
                 const bool         use_default_residual,
@@ -565,9 +565,9 @@ AdditionalData (const unsigned int max_n_tmp_vectors,
 
 
 
-template <class VECTOR>
+template <class VectorType>
 inline
-SolverGMRES<VECTOR>::AdditionalData::
+SolverGMRES<VectorType>::AdditionalData::
 AdditionalData (const unsigned int max_n_tmp_vectors,
                 const bool         right_preconditioning,
                 const bool         use_default_residual,
@@ -583,34 +583,34 @@ AdditionalData (const unsigned int max_n_tmp_vectors,
 
 
 
-template <class VECTOR>
-SolverGMRES<VECTOR>::SolverGMRES (SolverControl        &cn,
-                                  VectorMemory<VECTOR> &mem,
-                                  const AdditionalData &data)
+template <class VectorType>
+SolverGMRES<VectorType>::SolverGMRES (SolverControl            &cn,
+                                      VectorMemory<VectorType> &mem,
+                                      const AdditionalData     &data)
   :
-  Solver<VECTOR> (cn,mem),
+  Solver<VectorType> (cn,mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverGMRES<VECTOR>::SolverGMRES (SolverControl        &cn,
-                                  const AdditionalData &data) :
-  Solver<VECTOR> (cn),
+template <class VectorType>
+SolverGMRES<VectorType>::SolverGMRES (SolverControl        &cn,
+                                      const AdditionalData &data) :
+  Solver<VectorType> (cn),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
+template <class VectorType>
 inline
 void
-SolverGMRES<VECTOR>::givens_rotation (Vector<double> &h,
-                                      Vector<double> &b,
-                                      Vector<double> &ci,
-                                      Vector<double> &si,
-                                      int     col) const
+SolverGMRES<VectorType>::givens_rotation (Vector<double> &h,
+                                          Vector<double> &b,
+                                          Vector<double> &ci,
+                                          Vector<double> &si,
+                                          int            col) const
 {
   for (int i=0 ; i<col ; i++)
     {
@@ -631,15 +631,16 @@ SolverGMRES<VECTOR>::givens_rotation (Vector<double> &h,
 
 
 
-template <class VECTOR>
+template <class VectorType>
 inline
 double
-SolverGMRES<VECTOR>::modified_gram_schmidt (const internal::SolverGMRES::TmpVectors<VECTOR> &orthogonal_vectors,
-                                            const unsigned int  dim,
-                                            const unsigned int  accumulated_iterations,
-                                            VECTOR             &vv,
-                                            Vector<double>     &h,
-                                            bool               &re_orthogonalize)
+SolverGMRES<VectorType>::modified_gram_schmidt
+(const internal::SolverGMRES::TmpVectors<VectorType> &orthogonal_vectors,
+ const unsigned int                                  dim,
+ const unsigned int                                  accumulated_iterations,
+ VectorType                                          &vv,
+ Vector<double>                                      &h,
+ bool                                                &re_orthogonalize)
 {
   Assert(dim > 0, ExcInternalError());
   const unsigned int inner_iteration = dim - 1;
@@ -665,7 +666,7 @@ SolverGMRES<VECTOR>::modified_gram_schmidt (const internal::SolverGMRES::TmpVect
   if (re_orthogonalize == false && inner_iteration % 5 == 4)
     {
       if (norm_vv > 10. * norm_vv_start *
-          std::sqrt(std::numeric_limits<typename VECTOR::value_type>::epsilon()))
+          std::sqrt(std::numeric_limits<typename VectorType::value_type>::epsilon()))
         return norm_vv;
 
       else
@@ -693,14 +694,14 @@ SolverGMRES<VECTOR>::modified_gram_schmidt (const internal::SolverGMRES::TmpVect
 
 
 
-template<class VECTOR>
+template<class VectorType>
 inline void
-SolverGMRES<VECTOR>::compute_eigs_and_cond(
-  const FullMatrix<double> &H_orig,
-  const unsigned int dim,
-  const boost::signals2::signal<void (const std::vector<std::complex<double> > &)> &eigenvalues_signal,
-  const boost::signals2::signal<void (double)> &cond_signal,
-  const bool log_eigenvalues)
+SolverGMRES<VectorType>::compute_eigs_and_cond
+(const FullMatrix<double>                     &H_orig,
+ const unsigned int                           dim,
+ const boost::signals2::signal<void (const std::vector<std::complex<double> > &)> &eigenvalues_signal,
+ const boost::signals2::signal<void (double)> &cond_signal,
+ const bool                                   log_eigenvalues)
 {
   //Avoid copying the Hessenberg matrix if it isn't needed.
   if (!eigenvalues_signal.empty() || !cond_signal.empty() || log_eigenvalues )
@@ -744,13 +745,13 @@ SolverGMRES<VECTOR>::compute_eigs_and_cond(
 
 
 
-template<class VECTOR>
+template<class VectorType>
 template<class MATRIX, class PRECONDITIONER>
 void
-SolverGMRES<VECTOR>::solve (const MATRIX         &A,
-                            VECTOR               &x,
-                            const VECTOR         &b,
-                            const PRECONDITIONER &precondition)
+SolverGMRES<VectorType>::solve (const MATRIX         &A,
+                                VectorType           &x,
+                                const VectorType     &b,
+                                const PRECONDITIONER &precondition)
 {
   // this code was written a very long time ago by people not associated with
   // deal.II. we don't make any guarantees to its optimality or that it even
@@ -763,7 +764,7 @@ SolverGMRES<VECTOR>::solve (const MATRIX         &A,
   const unsigned int n_tmp_vectors = additional_data.max_n_tmp_vectors;
 
   // Generate an object where basis vectors are stored.
-  internal::SolverGMRES::TmpVectors<VECTOR> tmp_vectors (n_tmp_vectors, this->memory);
+  internal::SolverGMRES::TmpVectors<VectorType> tmp_vectors (n_tmp_vectors, this->memory);
 
   // number of the present iteration; this
   // number is not reset to zero upon a
@@ -808,14 +809,14 @@ SolverGMRES<VECTOR>::solve (const MATRIX         &A,
   const bool use_default_residual = additional_data.use_default_residual;
 
   // define two aliases
-  VECTOR &v = tmp_vectors(0, x);
-  VECTOR &p = tmp_vectors(n_tmp_vectors-1, x);
+  VectorType &v = tmp_vectors(0, x);
+  VectorType &p = tmp_vectors(n_tmp_vectors-1, x);
 
   // Following vectors are needed
   // when not the default residuals
   // are used as stopping criterion
-  VECTOR *r=0;
-  VECTOR *x_=0;
+  VectorType *r=0;
+  VectorType *x_=0;
   dealii::Vector<double> *gamma_=0;
   if (!use_default_residual)
     {
@@ -898,7 +899,7 @@ SolverGMRES<VECTOR>::solve (const MATRIX         &A,
         {
           ++accumulated_iterations;
           // yet another alias
-          VECTOR &vv = tmp_vectors(inner_iteration+1, x);
+          VectorType &vv = tmp_vectors(inner_iteration+1, x);
 
           if (left_precondition)
             {
@@ -1042,11 +1043,11 @@ SolverGMRES<VECTOR>::solve (const MATRIX         &A,
 
 
 
-template<class VECTOR>
+template<class VectorType>
 boost::signals2::connection
-SolverGMRES<VECTOR>::connect_condition_number_slot(
-  const std_cxx11::function<void(double)> &slot,
-  const bool every_iteration)
+SolverGMRES<VectorType>::connect_condition_number_slot
+(const std_cxx11::function<void(double)> &slot,
+ const bool every_iteration)
 {
   if (every_iteration)
     {
@@ -1060,11 +1061,11 @@ SolverGMRES<VECTOR>::connect_condition_number_slot(
 
 
 
-template<class VECTOR>
+template<class VectorType>
 boost::signals2::connection
-SolverGMRES<VECTOR>::connect_eigenvalues_slot(
-  const std_cxx11::function<void (const std::vector<std::complex<double> > &)> &slot,
-  const bool every_iteration)
+SolverGMRES<VectorType>::connect_eigenvalues_slot
+(const std_cxx11::function<void (const std::vector<std::complex<double> > &)> &slot,
+ const bool every_iteration)
 {
   if (every_iteration)
     {
@@ -1078,9 +1079,9 @@ SolverGMRES<VECTOR>::connect_eigenvalues_slot(
 
 
 
-template<class VECTOR>
+template<class VectorType>
 double
-SolverGMRES<VECTOR>::criterion ()
+SolverGMRES<VectorType>::criterion ()
 {
   // dummy implementation. this function is not needed for the present
   // implementation of gmres
@@ -1091,35 +1092,34 @@ SolverGMRES<VECTOR>::criterion ()
 
 //----------------------------------------------------------------------//
 
-template <class VECTOR>
-SolverFGMRES<VECTOR>::SolverFGMRES (SolverControl        &cn,
-                                    VectorMemory<VECTOR> &mem,
-                                    const AdditionalData &data)
+template <class VectorType>
+SolverFGMRES<VectorType>::SolverFGMRES (SolverControl            &cn,
+                                        VectorMemory<VectorType> &mem,
+                                        const AdditionalData     &data)
   :
-  Solver<VECTOR> (cn, mem),
+  Solver<VectorType> (cn, mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverFGMRES<VECTOR>::SolverFGMRES (SolverControl        &cn,
-                                    const AdditionalData &data)
+template <class VectorType>
+SolverFGMRES<VectorType>::SolverFGMRES (SolverControl        &cn,
+                                        const AdditionalData &data)
   :
-  Solver<VECTOR> (cn),
+  Solver<VectorType> (cn),
   additional_data(data)
 {}
 
 
 
-template<class VECTOR>
+template<class VectorType>
 template<class MATRIX, class PRECONDITIONER>
 void
-SolverFGMRES<VECTOR>::solve (
-  const MATRIX &A,
-  VECTOR &x,
-  const VECTOR &b,
-  const PRECONDITIONER &precondition)
+SolverFGMRES<VectorType>::solve (const MATRIX         &A,
+                                 VectorType           &x,
+                                 const VectorType     &b,
+                                 const PRECONDITIONER &precondition)
 {
   deallog.push("FGMRES");
 
@@ -1128,8 +1128,8 @@ SolverFGMRES<VECTOR>::solve (
   const unsigned int basis_size = additional_data.max_basis_size;
 
   // Generate an object where basis vectors are stored.
-  typename internal::SolverGMRES::TmpVectors<VECTOR> v (basis_size, this->memory);
-  typename internal::SolverGMRES::TmpVectors<VECTOR> z (basis_size, this->memory);
+  typename internal::SolverGMRES::TmpVectors<VectorType> v (basis_size, this->memory);
+  typename internal::SolverGMRES::TmpVectors<VectorType> z (basis_size, this->memory);
 
   // number of the present iteration; this number is not reset to zero upon a
   // restart
@@ -1145,7 +1145,7 @@ SolverFGMRES<VECTOR>::solve (
   // Iteration starts here
   double res = -std::numeric_limits<double>::max();
 
-  VECTOR *aux = this->memory.alloc();
+  VectorType *aux = this->memory.alloc();
   aux->reinit(x);
   do
     {

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -259,9 +259,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -452,9 +452,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -746,9 +746,9 @@ SolverGMRES<VectorType>::compute_eigs_and_cond
 
 
 template<class VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 void
-SolverGMRES<VectorType>::solve (const MATRIX         &A,
+SolverGMRES<VectorType>::solve (const MatrixType     &A,
                                 VectorType           &x,
                                 const VectorType     &b,
                                 const PRECONDITIONER &precondition)
@@ -1114,9 +1114,9 @@ SolverFGMRES<VectorType>::SolverFGMRES (SolverControl        &cn,
 
 
 template<class VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 void
-SolverFGMRES<VectorType>::solve (const MATRIX         &A,
+SolverFGMRES<VectorType>::solve (const MatrixType     &A,
                                  VectorType           &x,
                                  const VectorType     &b,
                                  const PRECONDITIONER &precondition)

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -64,8 +64,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Thomas Richter, 2000, Luca Heltai, 2006
  */
-template <class VECTOR = Vector<double> >
-class SolverMinRes : public Solver<VECTOR>
+template <class VectorType = Vector<double> >
+class SolverMinRes : public Solver<VectorType>
 {
 public:
   /**
@@ -79,9 +79,9 @@ public:
   /**
    * Constructor.
    */
-  SolverMinRes (SolverControl &cn,
-                VectorMemory<VECTOR> &mem,
-                const AdditionalData &data=AdditionalData());
+  SolverMinRes (SolverControl            &cn,
+                VectorMemory<VectorType> &mem,
+                const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -101,8 +101,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
   /**
@@ -127,17 +127,17 @@ protected:
    * for a graphical output of the convergence history.
    */
   virtual void print_vectors(const unsigned int step,
-                             const VECTOR &x,
-                             const VECTOR &r,
-                             const VECTOR &d) const;
+                             const VectorType   &x,
+                             const VectorType   &r,
+                             const VectorType   &d) const;
 
   /**
    * Temporary vectors, allocated through the @p VectorMemory object at the
    * start of the actual solution process and deallocated at the end.
    */
-  VECTOR *Vu0, *Vu1, *Vu2;
-  VECTOR *Vm0, *Vm1, *Vm2;
-  VECTOR *Vv;
+  VectorType *Vu0, *Vu1, *Vu2;
+  VectorType *Vm0, *Vm1, *Vm2;
+  VectorType *Vv;
 
   /**
    * Within the iteration loop, the square of the residual vector is stored in
@@ -153,55 +153,55 @@ protected:
 
 #ifndef DOXYGEN
 
-template<class VECTOR>
-SolverMinRes<VECTOR>::SolverMinRes (SolverControl &cn,
-                                    VectorMemory<VECTOR> &mem,
-                                    const AdditionalData &)
+template<class VectorType>
+SolverMinRes<VectorType>::SolverMinRes (SolverControl            &cn,
+                                        VectorMemory<VectorType> &mem,
+                                        const AdditionalData     &)
   :
-  Solver<VECTOR>(cn,mem)
+  Solver<VectorType>(cn,mem)
 {}
 
 
 
-template<class VECTOR>
-SolverMinRes<VECTOR>::SolverMinRes (SolverControl &cn,
-                                    const AdditionalData &)
+template<class VectorType>
+SolverMinRes<VectorType>::SolverMinRes (SolverControl        &cn,
+                                        const AdditionalData &)
   :
-  Solver<VECTOR>(cn)
+  Solver<VectorType>(cn)
 {}
 
 
-template<class VECTOR>
-SolverMinRes<VECTOR>::~SolverMinRes ()
+template<class VectorType>
+SolverMinRes<VectorType>::~SolverMinRes ()
 {}
 
 
 
-template<class VECTOR>
+template<class VectorType>
 double
-SolverMinRes<VECTOR>::criterion()
+SolverMinRes<VectorType>::criterion()
 {
   return res2;
 }
 
 
-template<class VECTOR>
+template<class VectorType>
 void
-SolverMinRes<VECTOR>::print_vectors(const unsigned int,
-                                    const VECTOR &,
-                                    const VECTOR &,
-                                    const VECTOR &) const
+SolverMinRes<VectorType>::print_vectors(const unsigned int,
+                                        const VectorType &,
+                                        const VectorType &,
+                                        const VectorType &) const
 {}
 
 
 
-template<class VECTOR>
+template<class VectorType>
 template<class MATRIX, class PRECONDITIONER>
 void
-SolverMinRes<VECTOR>::solve (const MATRIX         &A,
-                             VECTOR               &x,
-                             const VECTOR         &b,
-                             const PRECONDITIONER &precondition)
+SolverMinRes<VectorType>::solve (const MATRIX         &A,
+                                 VectorType           &x,
+                                 const VectorType     &b,
+                                 const PRECONDITIONER &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -216,10 +216,10 @@ SolverMinRes<VECTOR>::solve (const MATRIX         &A,
   Vm1  = this->memory.alloc();
   Vm2  = this->memory.alloc();
   // define some aliases for simpler access
-  typedef VECTOR *vecptr;
+  typedef VectorType *vecptr;
   vecptr u[3] = {Vu0, Vu1, Vu2};
   vecptr m[3] = {Vm0, Vm1, Vm2};
-  VECTOR &v   = *Vv;
+  VectorType &v   = *Vv;
   // resize the vectors, but do not set
   // the values since they'd be overwritten
   // soon anyway.

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -156,7 +156,7 @@ protected:
 template<class VectorType>
 SolverMinRes<VectorType>::SolverMinRes (SolverControl            &cn,
                                         VectorMemory<VectorType> &mem,
-                                        const AdditionalData     &)
+                                        const AdditionalData &)
   :
   Solver<VectorType>(cn,mem)
 {}

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -98,12 +98,12 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
   /**
    * @addtogroup Exceptions
@@ -196,12 +196,12 @@ SolverMinRes<VectorType>::print_vectors(const unsigned int,
 
 
 template<class VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 void
-SolverMinRes<VectorType>::solve (const MatrixType     &A,
-                                 VectorType           &x,
-                                 const VectorType     &b,
-                                 const PRECONDITIONER &precondition)
+SolverMinRes<VectorType>::solve (const MatrixType         &A,
+                                 VectorType               &x,
+                                 const VectorType         &b,
+                                 const PreconditionerType &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -98,9 +98,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -196,9 +196,9 @@ SolverMinRes<VectorType>::print_vectors(const unsigned int,
 
 
 template<class VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 void
-SolverMinRes<VectorType>::solve (const MATRIX         &A,
+SolverMinRes<VectorType>::solve (const MatrixType     &A,
                                  VectorType           &x,
                                  const VectorType     &b,
                                  const PRECONDITIONER &precondition)

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -125,9 +125,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -198,9 +198,9 @@ private:
    * The iteration loop itself. The function returns a structure indicating
    * what happened in this function.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   IterationResult
-  iterate (const MATRIX &A,
+  iterate (const MatrixType     &A,
            const PRECONDITIONER &precondition);
 
   /**
@@ -264,9 +264,9 @@ SolverQMRS<VectorType>::print_vectors(const unsigned int,
 
 
 template<class VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 void
-SolverQMRS<VectorType>::solve (const MATRIX         &A,
+SolverQMRS<VectorType>::solve (const MatrixType     &A,
                                VectorType           &x,
                                const VectorType     &b,
                                const PRECONDITIONER &precondition)
@@ -322,9 +322,9 @@ SolverQMRS<VectorType>::solve (const MATRIX         &A,
 
 
 template<class VectorType>
-template<class MATRIX, class PRECONDITIONER>
+template<typename MatrixType, class PRECONDITIONER>
 typename SolverQMRS<VectorType>::IterationResult
-SolverQMRS<VectorType>::iterate(const MATRIX         &A,
+SolverQMRS<VectorType>::iterate(const MatrixType     &A,
                                 const PRECONDITIONER &precondition)
 {
   /* Remark: the matrix A in the article is the preconditioned matrix.

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -67,8 +67,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 1999
  */
-template <class VECTOR = Vector<double> >
-class SolverQMRS : public Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class SolverQMRS : public Solver<VectorType>
 {
 public:
   /**
@@ -111,9 +111,9 @@ public:
   /**
    * Constructor.
    */
-  SolverQMRS (SolverControl &cn,
-              VectorMemory<VECTOR> &mem,
-              const AdditionalData &data=AdditionalData());
+  SolverQMRS (SolverControl            &cn,
+              VectorMemory<VectorType> &mem,
+              const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -128,8 +128,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
   /**
@@ -137,10 +137,10 @@ public:
    * vector, the residual and the update vector in each step. It can be used
    * for a graphical output of the convergence history.
    */
-  virtual void print_vectors(const unsigned int step,
-                             const VECTOR &x,
-                             const VECTOR &r,
-                             const VECTOR &d) const;
+  virtual void print_vectors (const unsigned int step,
+                              const VectorType   &x,
+                              const VectorType   &r,
+                              const VectorType   &d) const;
 protected:
   /**
    * Implementation of the computation of the norm of the residual.
@@ -151,19 +151,19 @@ protected:
    * Temporary vectors, allocated through the @p VectorMemory object at the
    * start of the actual solution process and deallocated at the end.
    */
-  VECTOR *Vv;
-  VECTOR *Vp;
-  VECTOR *Vq;
-  VECTOR *Vt;
-  VECTOR *Vd;
+  VectorType *Vv;
+  VectorType *Vp;
+  VectorType *Vq;
+  VectorType *Vt;
+  VectorType *Vd;
   /**
    * Iteration vector.
    */
-  VECTOR *Vx;
+  VectorType *Vx;
   /**
    * RHS vector.
    */
-  const VECTOR *Vb;
+  const VectorType *Vb;
 
   /**
    * Within the iteration loop, the square of the residual vector is stored in
@@ -214,62 +214,62 @@ private:
 
 #ifndef DOXYGEN
 
-template<class VECTOR>
-SolverQMRS<VECTOR>::IterationResult::IterationResult(const SolverControl::State state,
-                                                     const double               last_residual)
+template<class VectorType>
+SolverQMRS<VectorType>::IterationResult::IterationResult (const SolverControl::State state,
+                                                          const double               last_residual)
   :
   state (state),
   last_residual (last_residual)
 {}
 
 
-template<class VECTOR>
-SolverQMRS<VECTOR>::SolverQMRS(SolverControl &cn,
-                               VectorMemory<VECTOR> &mem,
-                               const AdditionalData &data)
+template<class VectorType>
+SolverQMRS<VectorType>::SolverQMRS (SolverControl            &cn,
+                                    VectorMemory<VectorType> &mem,
+                                    const AdditionalData     &data)
   :
-  Solver<VECTOR>(cn,mem),
+  Solver<VectorType>(cn,mem),
   additional_data(data)
 {}
 
 
 
-template<class VECTOR>
-SolverQMRS<VECTOR>::SolverQMRS(SolverControl &cn,
-                               const AdditionalData &data)
+template<class VectorType>
+SolverQMRS<VectorType>::SolverQMRS(SolverControl        &cn,
+                                   const AdditionalData &data)
   :
-  Solver<VECTOR>(cn),
+  Solver<VectorType>(cn),
   additional_data(data)
 {}
 
 
 
-template<class VECTOR>
+template<class VectorType>
 double
-SolverQMRS<VECTOR>::criterion()
+SolverQMRS<VectorType>::criterion()
 {
   return std::sqrt(res2);
 }
 
 
 
-template<class VECTOR>
+template<class VectorType>
 void
-SolverQMRS<VECTOR>::print_vectors(const unsigned int,
-                                  const VECTOR &,
-                                  const VECTOR &,
-                                  const VECTOR &) const
+SolverQMRS<VectorType>::print_vectors(const unsigned int,
+                                      const VectorType &,
+                                      const VectorType &,
+                                      const VectorType &) const
 {}
 
 
 
-template<class VECTOR>
+template<class VectorType>
 template<class MATRIX, class PRECONDITIONER>
 void
-SolverQMRS<VECTOR>::solve (const MATRIX         &A,
-                           VECTOR               &x,
-                           const VECTOR         &b,
-                           const PRECONDITIONER &precondition)
+SolverQMRS<VectorType>::solve (const MATRIX         &A,
+                               VectorType           &x,
+                               const VectorType     &b,
+                               const PRECONDITIONER &precondition)
 {
   deallog.push("QMRS");
 
@@ -321,11 +321,11 @@ SolverQMRS<VECTOR>::solve (const MATRIX         &A,
 
 
 
-template<class VECTOR>
+template<class VectorType>
 template<class MATRIX, class PRECONDITIONER>
-typename SolverQMRS<VECTOR>::IterationResult
-SolverQMRS<VECTOR>::iterate(const MATRIX         &A,
-                            const PRECONDITIONER &precondition)
+typename SolverQMRS<VectorType>::IterationResult
+SolverQMRS<VectorType>::iterate(const MATRIX         &A,
+                                const PRECONDITIONER &precondition)
 {
   /* Remark: the matrix A in the article is the preconditioned matrix.
    * Therefore, we have to precondition x before we compute the first residual.
@@ -336,13 +336,13 @@ SolverQMRS<VECTOR>::iterate(const MATRIX         &A,
   SolverControl::State state = SolverControl::iterate;
 
   // define some aliases for simpler access
-  VECTOR &v  = *Vv;
-  VECTOR &p  = *Vp;
-  VECTOR &q  = *Vq;
-  VECTOR &t  = *Vt;
-  VECTOR &d  = *Vd;
-  VECTOR &x  = *Vx;
-  const VECTOR &b = *Vb;
+  VectorType &v  = *Vv;
+  VectorType &p  = *Vp;
+  VectorType &q  = *Vq;
+  VectorType &t  = *Vt;
+  VectorType &d  = *Vd;
+  VectorType &x  = *Vx;
+  const VectorType &b = *Vb;
 
   int  it=0;
 

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -125,12 +125,12 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
   /**
    * Interface for derived class. This function gets the current iteration
@@ -198,10 +198,10 @@ private:
    * The iteration loop itself. The function returns a structure indicating
    * what happened in this function.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   IterationResult
-  iterate (const MatrixType     &A,
-           const PRECONDITIONER &precondition);
+  iterate (const MatrixType         &A,
+           const PreconditionerType &precondition);
 
   /**
    * Number of the current iteration (accumulated over restarts)
@@ -264,12 +264,12 @@ SolverQMRS<VectorType>::print_vectors(const unsigned int,
 
 
 template<class VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 void
-SolverQMRS<VectorType>::solve (const MatrixType     &A,
-                               VectorType           &x,
-                               const VectorType     &b,
-                               const PRECONDITIONER &precondition)
+SolverQMRS<VectorType>::solve (const MatrixType         &A,
+                               VectorType               &x,
+                               const VectorType         &b,
+                               const PreconditionerType &precondition)
 {
   deallog.push("QMRS");
 
@@ -322,10 +322,10 @@ SolverQMRS<VectorType>::solve (const MatrixType     &A,
 
 
 template<class VectorType>
-template<typename MatrixType, class PRECONDITIONER>
+template<typename MatrixType, typename PreconditionerType>
 typename SolverQMRS<VectorType>::IterationResult
-SolverQMRS<VectorType>::iterate(const MatrixType     &A,
-                                const PRECONDITIONER &precondition)
+SolverQMRS<VectorType>::iterate(const MatrixType         &A,
+                                const PreconditionerType &precondition)
 {
   /* Remark: the matrix A in the article is the preconditioned matrix.
    * Therefore, we have to precondition x before we compute the first residual.

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -79,9 +79,9 @@ public:
    * R(x_k,b)$. The matrix <i>A</i> itself is only used to compute the
    * residual.
    */
-  template<class MATRIX, class RELAXATION>
+  template<typename MatrixType, class RELAXATION>
   void
-  solve (const MATRIX     &A,
+  solve (const MatrixType &A,
          VectorType       &x,
          const VectorType &b,
          const RELAXATION &R);
@@ -104,9 +104,9 @@ SolverRelaxation<VectorType>::~SolverRelaxation()
 
 
 template <class VectorType>
-template <class MATRIX, class RELAXATION>
+template <typename MatrixType, class RELAXATION>
 void
-SolverRelaxation<VectorType>::solve (const MATRIX     &A,
+SolverRelaxation<VectorType>::solve (const MatrixType &A,
                                      VectorType       &x,
                                      const VectorType &b,
                                      const RELAXATION &R)

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -53,8 +53,8 @@ DEAL_II_NAMESPACE_OPEN
  * @author Guido Kanschat
  * @date 2010
  */
-template <class VECTOR = Vector<double> >
-class SolverRelaxation : public Solver<VECTOR>
+template <typename VectorType = Vector<double> >
+class SolverRelaxation : public Solver<VectorType>
 {
 public:
   /**
@@ -81,46 +81,45 @@ public:
    */
   template<class MATRIX, class RELAXATION>
   void
-  solve (const MATRIX &A,
-         VECTOR &x,
-         const VECTOR &b,
+  solve (const MATRIX     &A,
+         VectorType       &x,
+         const VectorType &b,
          const RELAXATION &R);
 };
 
 //----------------------------------------------------------------------//
 
-template <class VECTOR>
-SolverRelaxation<VECTOR>::SolverRelaxation(SolverControl &cn,
-                                           const AdditionalData &)
+template <class VectorType>
+SolverRelaxation<VectorType>::SolverRelaxation (SolverControl        &cn,
+                                                const AdditionalData &)
   :
-  Solver<VECTOR> (cn)
+  Solver<VectorType> (cn)
 {}
 
 
 
-template <class VECTOR>
-SolverRelaxation<VECTOR>::~SolverRelaxation()
+template <class VectorType>
+SolverRelaxation<VectorType>::~SolverRelaxation()
 {}
 
 
-template <class VECTOR>
+template <class VectorType>
 template <class MATRIX, class RELAXATION>
 void
-SolverRelaxation<VECTOR>::solve (
-  const MATRIX &A,
-  VECTOR &x,
-  const VECTOR &b,
-  const RELAXATION &R)
+SolverRelaxation<VectorType>::solve (const MATRIX     &A,
+                                     VectorType       &x,
+                                     const VectorType &b,
+                                     const RELAXATION &R)
 {
-  GrowingVectorMemory<VECTOR> mem;
+  GrowingVectorMemory<VectorType> mem;
   SolverControl::State conv=SolverControl::iterate;
 
   // Memory allocation
-  typename VectorMemory<VECTOR>::Pointer Vr(mem);
-  VECTOR &r  = *Vr;
+  typename VectorMemory<VectorType>::Pointer Vr(mem);
+  VectorType &r  = *Vr;
   r.reinit(x);
-  typename VectorMemory<VECTOR>::Pointer Vd(mem);
-  VECTOR &d  = *Vd;
+  typename VectorMemory<VectorType>::Pointer Vd(mem);
+  VectorType &d  = *Vd;
   d.reinit(x);
 
   deallog.push("Relaxation");

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -107,22 +107,22 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  solve (const MatrixType     &A,
-         VectorType           &x,
-         const VectorType     &b,
-         const PRECONDITIONER &precondition);
+  solve (const MatrixType         &A,
+         VectorType               &x,
+         const VectorType         &b,
+         const PreconditionerType &precondition);
 
   /**
    * Solve $A^Tx=b$ for $x$.
    */
-  template<typename MatrixType, class PRECONDITIONER>
+  template<typename MatrixType, typename PreconditionerType>
   void
-  Tsolve (const MatrixType     &A,
-          VectorType           &x,
-          const VectorType     &b,
-          const PRECONDITIONER &precondition);
+  Tsolve (const MatrixType         &A,
+          VectorType               &x,
+          const VectorType         &b,
+          const PreconditionerType &precondition);
 
   /**
    * Set the damping-coefficient. Default is 1., i.e. no damping.
@@ -214,12 +214,12 @@ SolverRichardson<VectorType>::~SolverRichardson()
 
 
 template <class VectorType>
-template <typename MatrixType, class PRECONDITIONER>
+template <typename MatrixType, typename PreconditionerType>
 void
-SolverRichardson<VectorType>::solve (const MatrixType     &A,
-                                     VectorType           &x,
-                                     const VectorType     &b,
-                                     const PRECONDITIONER &precondition)
+SolverRichardson<VectorType>::solve (const MatrixType         &A,
+                                     VectorType               &x,
+                                     const VectorType         &b,
+                                     const PreconditionerType &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -285,12 +285,12 @@ SolverRichardson<VectorType>::solve (const MatrixType     &A,
 
 
 template <class VectorType>
-template <typename MatrixType, class PRECONDITIONER>
+template <typename MatrixType, typename PreconditionerType>
 void
-SolverRichardson<VectorType>::Tsolve (const MatrixType     &A,
-                                      VectorType           &x,
-                                      const VectorType     &b,
-                                      const PRECONDITIONER &precondition)
+SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
+                                      VectorType               &x,
+                                      const VectorType         &b,
+                                      const PreconditionerType &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
   double last_criterion = -std::numeric_limits<double>::max();

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -57,8 +57,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Ralf Hartmann
  */
-template <class VECTOR = Vector<double> >
-class SolverRichardson : public Solver<VECTOR>
+template <class VectorType = Vector<double> >
+class SolverRichardson : public Solver<VectorType>
 {
 public:
   /**
@@ -88,9 +88,9 @@ public:
   /**
    * Constructor.
    */
-  SolverRichardson (SolverControl        &cn,
-                    VectorMemory<VECTOR> &mem,
-                    const AdditionalData &data=AdditionalData());
+  SolverRichardson (SolverControl            &cn,
+                    VectorMemory<VectorType> &mem,
+                    const AdditionalData     &data=AdditionalData());
 
   /**
    * Constructor. Use an object of type GrowingVectorMemory as a default to
@@ -110,8 +110,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   solve (const MATRIX         &A,
-         VECTOR               &x,
-         const VECTOR         &b,
+         VectorType           &x,
+         const VectorType     &b,
          const PRECONDITIONER &precondition);
 
   /**
@@ -120,8 +120,8 @@ public:
   template<class MATRIX, class PRECONDITIONER>
   void
   Tsolve (const MATRIX         &A,
-          VECTOR               &x,
-          const VECTOR         &b,
+          VectorType           &x,
+          const VectorType     &b,
           const PRECONDITIONER &precondition);
 
   /**
@@ -134,28 +134,28 @@ public:
    * vector, the residual and the update vector in each step. It can be used
    * for a graphical output of the convergence history.
    */
-  virtual void print_vectors(const unsigned int step,
-                             const VECTOR &x,
-                             const VECTOR &r,
-                             const VECTOR &d) const;
+  virtual void print_vectors (const unsigned int step,
+                              const VectorType &x,
+                              const VectorType &r,
+                              const VectorType &d) const;
 
 protected:
   /**
    * Implementation of the computation of the norm of the residual.
    */
-  virtual typename VECTOR::value_type criterion();
+  virtual typename VectorType::value_type criterion();
 
   /**
    * Residual. Temporary vector allocated through the VectorMemory object at
    * the start of the actual solution process and deallocated at the end.
    */
-  VECTOR *Vr;
+  VectorType *Vr;
   /**
    * Preconditioned residual. Temporary vector allocated through the
    * VectorMemory object at the start of the actual solution process and
    * deallocated at the end.
    */
-  VECTOR *Vd;
+  VectorType *Vd;
 
   /**
    * Control parameters.
@@ -168,7 +168,7 @@ protected:
    * convergence value, which in this class is the norm of the residual vector
    * and thus the square root of the @p res2 value.
    */
-  typename VECTOR::value_type res;
+  typename VectorType::value_type res;
 };
 
 /*@}*/
@@ -176,9 +176,9 @@ protected:
 
 #ifndef DOXYGEN
 
-template <class VECTOR>
+template <class VectorType>
 inline
-SolverRichardson<VECTOR>::AdditionalData::
+SolverRichardson<VectorType>::AdditionalData::
 AdditionalData (const double omega,
                 const bool   use_preconditioned_residual)
   :
@@ -187,39 +187,39 @@ AdditionalData (const double omega,
 {}
 
 
-template <class VECTOR>
-SolverRichardson<VECTOR>::SolverRichardson(SolverControl &cn,
-                                           VectorMemory<VECTOR> &mem,
-                                           const AdditionalData &data)
+template <class VectorType>
+SolverRichardson<VectorType>::SolverRichardson(SolverControl            &cn,
+                                               VectorMemory<VectorType> &mem,
+                                               const AdditionalData     &data)
   :
-  Solver<VECTOR> (cn,mem),
+  Solver<VectorType> (cn,mem),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverRichardson<VECTOR>::SolverRichardson(SolverControl &cn,
-                                           const AdditionalData &data)
+template <class VectorType>
+SolverRichardson<VectorType>::SolverRichardson(SolverControl        &cn,
+                                               const AdditionalData &data)
   :
-  Solver<VECTOR> (cn),
+  Solver<VectorType> (cn),
   additional_data(data)
 {}
 
 
 
-template <class VECTOR>
-SolverRichardson<VECTOR>::~SolverRichardson()
+template <class VectorType>
+SolverRichardson<VectorType>::~SolverRichardson()
 {}
 
 
-template <class VECTOR>
+template <class VectorType>
 template <class MATRIX, class PRECONDITIONER>
 void
-SolverRichardson<VECTOR>::solve (const MATRIX         &A,
-                                 VECTOR               &x,
-                                 const VECTOR         &b,
-                                 const PRECONDITIONER &precondition)
+SolverRichardson<VectorType>::solve (const MATRIX         &A,
+                                     VectorType           &x,
+                                     const VectorType     &b,
+                                     const PRECONDITIONER &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -229,10 +229,10 @@ SolverRichardson<VECTOR>::solve (const MATRIX         &A,
 
   // Memory allocation
   Vr  = this->memory.alloc();
-  VECTOR &r  = *Vr;
+  VectorType &r  = *Vr;
   r.reinit(x);
   Vd  = this->memory.alloc();
-  VECTOR &d  = *Vd;
+  VectorType &d  = *Vd;
   d.reinit(x);
 
   deallog.push("Richardson");
@@ -284,13 +284,13 @@ SolverRichardson<VECTOR>::solve (const MATRIX         &A,
 }
 
 
-template <class VECTOR>
+template <class VectorType>
 template <class MATRIX, class PRECONDITIONER>
 void
-SolverRichardson<VECTOR>::Tsolve (const MATRIX         &A,
-                                  VECTOR               &x,
-                                  const VECTOR         &b,
-                                  const PRECONDITIONER &precondition)
+SolverRichardson<VectorType>::Tsolve (const MATRIX         &A,
+                                      VectorType           &x,
+                                      const VectorType     &b,
+                                      const PRECONDITIONER &precondition)
 {
   SolverControl::State conv=SolverControl::iterate;
   double last_criterion = -std::numeric_limits<double>::max();
@@ -299,10 +299,10 @@ SolverRichardson<VECTOR>::Tsolve (const MATRIX         &A,
 
   // Memory allocation
   Vr  = this->memory.alloc();
-  VECTOR &r  = *Vr;
+  VectorType &r  = *Vr;
   r.reinit(x);
   Vd  =this-> memory.alloc();
-  VECTOR &d  = *Vd;
+  VectorType &d  = *Vd;
   d.reinit(x);
 
   deallog.push("RichardsonT");
@@ -349,19 +349,19 @@ SolverRichardson<VECTOR>::Tsolve (const MATRIX         &A,
 }
 
 
-template <class VECTOR>
+template <class VectorType>
 void
-SolverRichardson<VECTOR>::print_vectors(const unsigned int,
-                                        const VECTOR &,
-                                        const VECTOR &,
-                                        const VECTOR &) const
+SolverRichardson<VectorType>::print_vectors(const unsigned int,
+                                            const VectorType &,
+                                            const VectorType &,
+                                            const VectorType &) const
 {}
 
 
 
-template <class VECTOR>
-inline typename VECTOR::value_type
-SolverRichardson<VECTOR>::criterion()
+template <class VectorType>
+inline typename VectorType::value_type
+SolverRichardson<VectorType>::criterion()
 {
   if (!additional_data.use_preconditioned_residual)
     res = Vr->l2_norm();
@@ -371,9 +371,9 @@ SolverRichardson<VECTOR>::criterion()
 }
 
 
-template <class VECTOR>
+template <class VectorType>
 inline void
-SolverRichardson<VECTOR>::set_omega (const double om)
+SolverRichardson<VectorType>::set_omega (const double om)
 {
   additional_data.omega=om;
 }

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -107,9 +107,9 @@ public:
   /**
    * Solve the linear system $Ax=b$ for x.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  solve (const MATRIX         &A,
+  solve (const MatrixType     &A,
          VectorType           &x,
          const VectorType     &b,
          const PRECONDITIONER &precondition);
@@ -117,9 +117,9 @@ public:
   /**
    * Solve $A^Tx=b$ for $x$.
    */
-  template<class MATRIX, class PRECONDITIONER>
+  template<typename MatrixType, class PRECONDITIONER>
   void
-  Tsolve (const MATRIX         &A,
+  Tsolve (const MatrixType     &A,
           VectorType           &x,
           const VectorType     &b,
           const PRECONDITIONER &precondition);
@@ -214,9 +214,9 @@ SolverRichardson<VectorType>::~SolverRichardson()
 
 
 template <class VectorType>
-template <class MATRIX, class PRECONDITIONER>
+template <typename MatrixType, class PRECONDITIONER>
 void
-SolverRichardson<VectorType>::solve (const MATRIX         &A,
+SolverRichardson<VectorType>::solve (const MatrixType     &A,
                                      VectorType           &x,
                                      const VectorType     &b,
                                      const PRECONDITIONER &precondition)
@@ -285,9 +285,9 @@ SolverRichardson<VectorType>::solve (const MATRIX         &A,
 
 
 template <class VectorType>
-template <class MATRIX, class PRECONDITIONER>
+template <typename MatrixType, class PRECONDITIONER>
 void
-SolverRichardson<VectorType>::Tsolve (const MATRIX         &A,
+SolverRichardson<VectorType>::Tsolve (const MatrixType     &A,
                                       VectorType           &x,
                                       const VectorType     &b,
                                       const PRECONDITIONER &precondition)

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -94,14 +94,14 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Ralf Hartmann, 1999
  */
-template <class VECTOR = Vector<double> >
+template <typename VectorType = Vector<double> >
 class SolverSelector : public Subscriptor
 {
 public:
   /**
    * A typedef for the underlying vector type
    */
-  typedef VECTOR vector_type;
+  typedef VectorType vector_type;
 
   /**
    * Constructor, filling in default values
@@ -119,10 +119,10 @@ public:
    *
    */
   template<class Matrix, class Preconditioner>
-  void solve(const Matrix &A,
-             VECTOR &x,
-             const VECTOR &b,
-             const Preconditioner &precond) const;
+  void solve (const Matrix         &A,
+              VectorType           &x,
+              const VectorType     &b,
+              const Preconditioner &precond) const;
 
   /**
    * Select a new solver. Note that all solver names used in this class are
@@ -138,37 +138,37 @@ public:
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverRichardson<VECTOR>
+  void set_data(const typename SolverRichardson<VectorType>
                 ::AdditionalData &data);
 
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverCG<VECTOR>
+  void set_data(const typename SolverCG<VectorType>
                 ::AdditionalData &data);
 
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverMinRes<VECTOR>
+  void set_data(const typename SolverMinRes<VectorType>
                 ::AdditionalData &data);
 
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverBicgstab<VECTOR>
+  void set_data(const typename SolverBicgstab<VectorType>
                 ::AdditionalData &data);
 
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverGMRES<VECTOR>
+  void set_data(const typename SolverGMRES<VectorType>
                 ::AdditionalData &data);
 
   /**
    * Set the additional data. For more info see the @p Solver class.
    */
-  void set_data(const typename SolverFGMRES<VECTOR>
+  void set_data(const typename SolverFGMRES<VectorType>
                 ::AdditionalData &data);
 
   /**
@@ -190,7 +190,7 @@ protected:
    * Stores the @p SolverControl that is needed in the constructor of each @p
    * Solver class. This can be changed with @p set_control().
    */
-  SmartPointer< SolverControl, SolverSelector< VECTOR > >     control;
+  SmartPointer< SolverControl, SolverSelector< VectorType > > control;
 
   /**
    * Stores the name of the solver.
@@ -201,92 +201,92 @@ private:
   /**
    * Stores the additional data.
    */
-  typename SolverRichardson<VECTOR>::AdditionalData richardson_data;
+  typename SolverRichardson<VectorType>::AdditionalData richardson_data;
 
   /**
    * Stores the additional data.
    */
-  typename SolverCG<VECTOR>::AdditionalData cg_data;
+  typename SolverCG<VectorType>::AdditionalData cg_data;
 
   /**
    * Stores the additional data.
    */
-  typename SolverMinRes<VECTOR>::AdditionalData minres_data;
+  typename SolverMinRes<VectorType>::AdditionalData minres_data;
 
   /**
    * Stores the additional data.
    */
-  typename SolverBicgstab<VECTOR>::AdditionalData bicgstab_data;
+  typename SolverBicgstab<VectorType>::AdditionalData bicgstab_data;
 
   /**
    * Stores the additional data.
    */
-  typename SolverGMRES<VECTOR>::AdditionalData gmres_data;
+  typename SolverGMRES<VectorType>::AdditionalData gmres_data;
 
   /**
    * Stores the additional data.
    */
-  typename SolverFGMRES<VECTOR>::AdditionalData fgmres_data;
+  typename SolverFGMRES<VectorType>::AdditionalData fgmres_data;
 };
 
 /*@}*/
 /* --------------------- Inline and template functions ------------------- */
 
 
-template <class VECTOR>
-SolverSelector<VECTOR>::SolverSelector()
+template <typename VectorType>
+SolverSelector<VectorType>::SolverSelector()
 {}
 
 
-template <class VECTOR>
-SolverSelector<VECTOR>::~SolverSelector()
+template <typename VectorType>
+SolverSelector<VectorType>::~SolverSelector()
 {}
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-SolverSelector<VECTOR>::select(const std::string &name)
+SolverSelector<VectorType>::select(const std::string &name)
 {
   solver_name = name;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 template<class Matrix, class Preconditioner>
 void
-SolverSelector<VECTOR>::solve(const Matrix &A,
-                              VECTOR &x,
-                              const VECTOR &b,
-                              const Preconditioner &precond) const
+SolverSelector<VectorType>::solve (const Matrix         &A,
+                                   VectorType           &x,
+                                   const VectorType     &b,
+                                   const Preconditioner &precond) const
 {
   if (solver_name=="richardson")
     {
-      SolverRichardson<VECTOR> solver(*control, richardson_data);
+      SolverRichardson<VectorType> solver(*control, richardson_data);
       solver.solve(A,x,b,precond);
     }
   else if (solver_name=="cg")
     {
-      SolverCG<VECTOR> solver(*control, cg_data);
+      SolverCG<VectorType> solver(*control, cg_data);
       solver.solve(A,x,b,precond);
     }
   else if (solver_name=="minres")
     {
-      SolverMinRes<VECTOR> solver(*control, minres_data);
+      SolverMinRes<VectorType> solver(*control, minres_data);
       solver.solve(A,x,b,precond);
     }
   else if (solver_name=="bicgstab")
     {
-      SolverBicgstab<VECTOR> solver(*control, bicgstab_data);
+      SolverBicgstab<VectorType> solver(*control, bicgstab_data);
       solver.solve(A,x,b,precond);
     }
   else if (solver_name=="gmres")
     {
-      SolverGMRES<VECTOR> solver(*control, gmres_data);
+      SolverGMRES<VectorType> solver(*control, gmres_data);
       solver.solve(A,x,b,precond);
     }
   else if (solver_name=="fgmres")
     {
-      SolverFGMRES<VECTOR> solver(*control, fgmres_data);
+      SolverFGMRES<VectorType> solver(*control, fgmres_data);
       solver.solve(A,x,b,precond);
     }
   else
@@ -294,64 +294,63 @@ SolverSelector<VECTOR>::solve(const Matrix &A,
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_control(
-  SolverControl &ctrl)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_control (SolverControl &ctrl)
 {
   control=&ctrl;
 }
 
 
-template <class VECTOR>
-std::string SolverSelector<VECTOR>::get_solver_names()
+template <typename VectorType>
+std::string SolverSelector<VectorType>::get_solver_names()
 {
   return "richardson|cg|bicgstab|gmres|fgmres|minres";
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverGMRES<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data
+(const typename SolverGMRES<VectorType>::AdditionalData &data)
 {
   gmres_data=data;
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverFGMRES<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data
+(const typename SolverFGMRES<VectorType>::AdditionalData &data)
 {
   fgmres_data=data;
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverRichardson<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data
+(const typename SolverRichardson<VectorType>::AdditionalData &data)
 {
   richardson_data=data;
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverCG<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data(
+  const typename SolverCG<VectorType>::AdditionalData &data)
 {
   cg_data=data;
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverMinRes<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data
+(const typename SolverMinRes<VectorType>::AdditionalData &data)
 {
   minres_data=data;
 }
 
 
-template <class VECTOR>
-void SolverSelector<VECTOR>::set_data(
-  const typename SolverBicgstab<VECTOR>::AdditionalData &data)
+template <typename VectorType>
+void SolverSelector<VectorType>::set_data
+(const typename SolverBicgstab<VectorType>::AdditionalData &data)
 {
   bicgstab_data=data;
 }

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1428,10 +1428,10 @@ public:
    * internal storage scheme. If it is false, the elements in a row are
    * written in ascending column order.
    */
-  template <class STREAM>
-  void print (STREAM &out,
-              const bool across = false,
-              const bool diagonal_first = true) const;
+  template <class StreamType>
+  void print (StreamType &out,
+              const bool  across = false,
+              const bool  diagonal_first = true) const;
 
   /**
    * Print the matrix in the usual format, i.e. as a matrix and not as a list
@@ -2340,11 +2340,11 @@ SparseMatrix<number>::end (const size_type r)
 
 
 template <typename number>
-template <class STREAM>
+template <class StreamType>
 inline
-void SparseMatrix<number>::print (STREAM &out,
-                                  const bool across,
-                                  const bool diagonal_first) const
+void SparseMatrix<number>::print (StreamType &out,
+                                  const bool  across,
+                                  const bool  diagonal_first) const
 {
   Assert (cols != 0, ExcNotInitialized());
   Assert (val != 0, ExcNotInitialized());

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -539,9 +539,9 @@ public:
    *
    * The function returns a reference to @p this.
    */
-  template <class MATRIX>
+  template <typename MatrixType>
   SparseMatrixEZ<number> &
-  copy_from (const MATRIX &source, const bool elide_zero_values = true);
+  copy_from (const MatrixType &source, const bool elide_zero_values = true);
 
   /**
    * Add @p matrix scaled by @p factor to this matrix.
@@ -550,9 +550,9 @@ public:
    * type is convertible to the data type of this matrix and it has the
    * standard @p const_iterator.
    */
-  template <class MATRIX>
-  void add (const number factor,
-            const MATRIX &matrix);
+  template <typename MatrixType>
+  void add (const number      factor,
+            const MatrixType &matrix);
 //@}
   /**
    * @name Entry Access
@@ -673,10 +673,10 @@ public:
    * matrix entries and that @p A has a function <tt>el(i,j)</tt> for access
    * to a specific entry.
    */
-  template <class MATRIXA, class MATRIXB>
-  void conjugate_add (const MATRIXA &A,
-                      const MATRIXB &B,
-                      const bool transpose = false);
+  template <typename MatrixTypeA, typename MatrixTypeB>
+  void conjugate_add (const MatrixTypeA &A,
+                      const MatrixTypeB &B,
+                      const bool         transpose = false);
 //@}
   /**
    * @name Iterators
@@ -1392,10 +1392,10 @@ SparseMatrixEZ<number>::end (const size_type r) const
 }
 
 template<typename number>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 SparseMatrixEZ<number> &
-SparseMatrixEZ<number>::copy_from (const MATRIX &M, const bool elide_zero_values)
+SparseMatrixEZ<number>::copy_from (const MatrixType &M, const bool elide_zero_values)
 {
   reinit(M.m(),
          M.n(),
@@ -1407,8 +1407,8 @@ SparseMatrixEZ<number>::copy_from (const MATRIX &M, const bool elide_zero_values
   // copy them into the current object
   for (size_type row = 0; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         set(row, entry->column(), entry->value(), elide_zero_values);
     }
@@ -1417,11 +1417,11 @@ SparseMatrixEZ<number>::copy_from (const MATRIX &M, const bool elide_zero_values
 }
 
 template<typename number>
-template <class MATRIX>
+template <typename MatrixType>
 inline
 void
-SparseMatrixEZ<number>::add (const number factor,
-                             const MATRIX &M)
+SparseMatrixEZ<number>::add (const number      factor,
+                             const MatrixType &M)
 {
   Assert (M.m() == m(), ExcDimensionMismatch(M.m(), m()));
   Assert (M.n() == n(), ExcDimensionMismatch(M.n(), n()));
@@ -1434,8 +1434,8 @@ SparseMatrixEZ<number>::add (const number factor,
   // add them into the current object
   for (size_type row = 0; row < M.m(); ++row)
     {
-      const typename MATRIX::const_iterator end_row = M.end(row);
-      for (typename MATRIX::const_iterator entry = M.begin(row);
+      const typename MatrixType::const_iterator end_row = M.end(row);
+      for (typename MatrixType::const_iterator entry = M.begin(row);
            entry != end_row; ++entry)
         if (entry->value() != 0)
           add(row, entry->column(), factor * entry->value());
@@ -1445,11 +1445,11 @@ SparseMatrixEZ<number>::add (const number factor,
 
 
 template<typename number>
-template <class MATRIXA, class MATRIXB>
+template <typename MatrixTypeA, typename MatrixTypeB>
 inline void
-SparseMatrixEZ<number>::conjugate_add (const MATRIXA &A,
-                                       const MATRIXB &B,
-                                       const bool transpose)
+SparseMatrixEZ<number>::conjugate_add (const MatrixTypeA &A,
+                                       const MatrixTypeB &B,
+                                       const bool         transpose)
 {
 // Compute the result
 // r_ij = \sum_kl b_ik b_jl a_kl
@@ -1467,20 +1467,20 @@ SparseMatrixEZ<number>::conjugate_add (const MATRIXA &A,
   // corresponding rows of B only.
   // For the non-transpose case, we
   // must find a trick.
-  typename MATRIXB::const_iterator b1 = B.begin();
-  const typename MATRIXB::const_iterator b_final = B.end();
+  typename MatrixTypeB::const_iterator b1 = B.begin();
+  const typename MatrixTypeB::const_iterator b_final = B.end();
   if (transpose)
     while (b1 != b_final)
       {
         const size_type i = b1->column();
         const size_type k = b1->row();
-        typename MATRIXB::const_iterator b2 = B.begin();
+        typename MatrixTypeB::const_iterator b2 = B.begin();
         while (b2 != b_final)
           {
             const size_type j = b2->column();
             const size_type l = b2->row();
 
-            const typename MATRIXA::value_type a = A.el(k,l);
+            const typename MatrixTypeA::value_type a = A.el(k,l);
 
             if (a != 0.)
               add (i, j, a * b1->value() * b2->value());
@@ -1506,12 +1506,12 @@ SparseMatrixEZ<number>::conjugate_add (const MATRIXA &A,
           ++b1;
         }
 
-      typename MATRIXA::const_iterator ai = A.begin();
-      const typename MATRIXA::const_iterator ae = A.end();
+      typename MatrixTypeA::const_iterator ai = A.begin();
+      const typename MatrixTypeA::const_iterator ae = A.end();
 
       while (ai != ae)
         {
-          const typename MATRIXA::value_type a = ai->value();
+          const typename MatrixTypeA::value_type a = ai->value();
           // Don't do anything if
           // this entry is zero.
           if (a == 0.) continue;
@@ -1521,9 +1521,9 @@ SparseMatrixEZ<number>::conjugate_add (const MATRIXA &A,
           // nonzero entry in column
           // ai->row()
           b1 = B.begin(minrow[ai->row()]);
-          const typename MATRIXB::const_iterator
+          const typename MatrixTypeB::const_iterator
           be1 = B.end(maxrow[ai->row()]);
-          const typename MATRIXB::const_iterator
+          const typename MatrixTypeB::const_iterator
           be2 = B.end(maxrow[ai->column()]);
 
           while (b1 != be1)
@@ -1537,7 +1537,7 @@ SparseMatrixEZ<number>::conjugate_add (const MATRIXA &A,
                 {
                   const size_type i = b1->row();
 
-                  typename MATRIXB::const_iterator
+                  typename MatrixTypeB::const_iterator
                   b2 = B.begin(minrow[ai->column()]);
                   while (b2 != be2)
                     {

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -406,8 +406,8 @@ public:
    * existing row lengths and allocated row lengths. Otherwise, just the
    * relation of allocated and used entries is shown.
    */
-  template <class STREAM>
-  void print_statistics (STREAM &s, bool full = false);
+  template <class StreamType>
+  void print_statistics (StreamType &s, bool full = false);
 
   /**
    * Compute numbers of entries.
@@ -1558,10 +1558,10 @@ SparseMatrixEZ<number>::conjugate_add (const MatrixTypeA &A,
 
 
 template <typename number>
-template <class STREAM>
+template <class StreamType>
 inline
 void
-SparseMatrixEZ<number>::print_statistics(STREAM &out, bool full)
+SparseMatrixEZ<number>::print_statistics(StreamType &out, bool full)
 {
   size_type used;
   size_type allocated;

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -34,7 +34,7 @@ template <typename number> class FullMatrix;
 template <typename number> class SparseMatrix;
 template <typename number> class SparseLUDecomposition;
 template <typename number> class SparseILU;
-template <class VECTOR> class VectorSlice;
+template <typename VectorType> class VectorSlice;
 
 namespace ChunkSparsityPatternIterators
 {

--- a/include/deal.II/lac/transpose_matrix.h
+++ b/include/deal.II/lac/transpose_matrix.h
@@ -40,9 +40,9 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup Matrix2
  * @author Guido Kanschat, 2006
  */
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 class
-  TransposeMatrix : public PointerMatrixBase<VECTOR>
+  TransposeMatrix : public PointerMatrixBase<VectorType>
 {
 public:
   /**
@@ -86,118 +86,118 @@ public:
   /**
    * Matrix-vector product.
    */
-  virtual void vmult (VECTOR &dst,
-                      const VECTOR &src) const;
+  virtual void vmult (VectorType       &dst,
+                      const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product.
    */
-  virtual void Tvmult (VECTOR &dst,
-                       const VECTOR &src) const;
+  virtual void Tvmult (VectorType       &dst,
+                       const VectorType &src) const;
 
   /**
    * Matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void vmult_add (VECTOR &dst,
-                          const VECTOR &src) const;
+  virtual void vmult_add (VectorType       &dst,
+                          const VectorType &src) const;
 
   /**
    * Transposed matrix-vector product, adding to <tt>dst</tt>.
    */
-  virtual void Tvmult_add (VECTOR &dst,
-                           const VECTOR &src) const;
+  virtual void Tvmult_add (VectorType       &dst,
+                           const VectorType &src) const;
 
 private:
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,TransposeMatrix<MATRIX,VECTOR> > m;
+  SmartPointer<const MATRIX,TransposeMatrix<MATRIX,VectorType> > m;
 };
 
 
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, class VECTOR>
-TransposeMatrix<MATRIX, VECTOR>::TransposeMatrix (const MATRIX *M)
+template<class MATRIX, typename VectorType>
+TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (const MATRIX *M)
   : m(M)
 {}
 
 
-template<class MATRIX, class VECTOR>
-TransposeMatrix<MATRIX, VECTOR>::TransposeMatrix (const char *name)
+template<class MATRIX, typename VectorType>
+TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (const char *name)
   : m(0, name)
 {}
 
 
-template<class MATRIX, class VECTOR>
-TransposeMatrix<MATRIX, VECTOR>::TransposeMatrix (
+template<class MATRIX, typename VectorType>
+TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (
   const MATRIX *M,
   const char *name)
   : m(M, name)
 {}
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VECTOR>::clear ()
+TransposeMatrix<MATRIX, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, class VECTOR>
-inline const TransposeMatrix<MATRIX, VECTOR> &
-TransposeMatrix<MATRIX, VECTOR>::operator= (const MATRIX *M)
+template<class MATRIX, typename VectorType>
+inline const TransposeMatrix<MATRIX, VectorType> &
+TransposeMatrix<MATRIX, VectorType>::operator= (const MATRIX *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline bool
-TransposeMatrix<MATRIX, VECTOR>::empty () const
+TransposeMatrix<MATRIX, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VECTOR>::vmult (VECTOR &dst,
-                                        const VECTOR &src) const
+TransposeMatrix<MATRIX, VectorType>::vmult (VectorType       &dst,
+                                            const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VECTOR>::Tvmult (VECTOR &dst,
-                                         const VECTOR &src) const
+TransposeMatrix<MATRIX, VectorType>::Tvmult (VectorType       &dst,
+                                             const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VECTOR>::vmult_add (VECTOR &dst,
-                                            const VECTOR &src) const
+TransposeMatrix<MATRIX, VectorType>::vmult_add (VectorType       &dst,
+                                                const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult_add (dst, src);
 }
 
 
-template<class MATRIX, class VECTOR>
+template<class MATRIX, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VECTOR>::Tvmult_add (VECTOR &dst,
-                                             const VECTOR &src) const
+TransposeMatrix<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
+                                                 const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult_add (dst, src);

--- a/include/deal.II/lac/transpose_matrix.h
+++ b/include/deal.II/lac/transpose_matrix.h
@@ -40,7 +40,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup Matrix2
  * @author Guido Kanschat, 2006
  */
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 class
   TransposeMatrix : public PointerMatrixBase<VectorType>
 {
@@ -52,7 +52,7 @@ public:
    *
    * If <tt>M</tt> is zero, no matrix is stored.
    */
-  TransposeMatrix (const MATRIX *M=0);
+  TransposeMatrix (const MatrixType *M=0);
 
   /**
    * Constructor. The name argument is used to identify the SmartPointer for
@@ -65,8 +65,8 @@ public:
    * the TransposeMatrix. The name argument is used to identify the
    * SmartPointer for this object.
    */
-  TransposeMatrix(const MATRIX *M,
-                  const char *name);
+  TransposeMatrix(const MatrixType *M,
+                  const char       *name);
 
   // Use doc from base class
   virtual void clear();
@@ -81,7 +81,7 @@ public:
    * matrix.
    * @see SmartPointer
    */
-  const TransposeMatrix &operator= (const MATRIX *M);
+  const TransposeMatrix &operator= (const MatrixType *M);
 
   /**
    * Matrix-vector product.
@@ -111,93 +111,92 @@ private:
   /**
    * The pointer to the actual matrix.
    */
-  SmartPointer<const MATRIX,TransposeMatrix<MATRIX,VectorType> > m;
+  SmartPointer<const MatrixType,TransposeMatrix<MatrixType,VectorType> > m;
 };
 
 
 //----------------------------------------------------------------------//
 
 
-template<class MATRIX, typename VectorType>
-TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+TransposeMatrix<MatrixType, VectorType>::TransposeMatrix (const MatrixType *M)
   : m(M)
 {}
 
 
-template<class MATRIX, typename VectorType>
-TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (const char *name)
+template<typename MatrixType, typename VectorType>
+TransposeMatrix<MatrixType, VectorType>::TransposeMatrix (const char *name)
   : m(0, name)
 {}
 
 
-template<class MATRIX, typename VectorType>
-TransposeMatrix<MATRIX, VectorType>::TransposeMatrix (
-  const MATRIX *M,
-  const char *name)
+template<typename MatrixType, typename VectorType>
+TransposeMatrix<MatrixType, VectorType>::TransposeMatrix (const MatrixType *M,
+                                                          const char       *name)
   : m(M, name)
 {}
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VectorType>::clear ()
+TransposeMatrix<MatrixType, VectorType>::clear ()
 {
   m = 0;
 }
 
 
-template<class MATRIX, typename VectorType>
-inline const TransposeMatrix<MATRIX, VectorType> &
-TransposeMatrix<MATRIX, VectorType>::operator= (const MATRIX *M)
+template<typename MatrixType, typename VectorType>
+inline const TransposeMatrix<MatrixType, VectorType> &
+TransposeMatrix<MatrixType, VectorType>::operator= (const MatrixType *M)
 {
   m = M;
   return *this;
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline bool
-TransposeMatrix<MATRIX, VectorType>::empty () const
+TransposeMatrix<MatrixType, VectorType>::empty () const
 {
   if (m == 0)
     return true;
   return m->empty();
 }
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VectorType>::vmult (VectorType       &dst,
-                                            const VectorType &src) const
+TransposeMatrix<MatrixType, VectorType>::vmult (VectorType       &dst,
+                                                const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VectorType>::Tvmult (VectorType       &dst,
-                                             const VectorType &src) const
+TransposeMatrix<MatrixType, VectorType>::Tvmult (VectorType       &dst,
+                                                 const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VectorType>::vmult_add (VectorType       &dst,
-                                                const VectorType &src) const
+TransposeMatrix<MatrixType, VectorType>::vmult_add (VectorType       &dst,
+                                                    const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->Tvmult_add (dst, src);
 }
 
 
-template<class MATRIX, typename VectorType>
+template<typename MatrixType, typename VectorType>
 inline void
-TransposeMatrix<MATRIX, VectorType>::Tvmult_add (VectorType       &dst,
-                                                 const VectorType &src) const
+TransposeMatrix<MatrixType, VectorType>::Tvmult_add (VectorType       &dst,
+                                                     const VectorType &src) const
 {
   Assert (m != 0, ExcNotInitialized());
   m->vmult_add (dst, src);

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -67,7 +67,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 1998-2003
  */
-template<class VECTOR = dealii::Vector<double> >
+template<typename VectorType = dealii::Vector<double> >
 class VectorMemory : public Subscriptor
 {
 public:
@@ -84,13 +84,13 @@ public:
    * function should reset vectors to their proper size. The same holds for
    * the contents of vectors: they are unspecified.
    */
-  virtual VECTOR *alloc () = 0;
+  virtual VectorType *alloc () = 0;
 
   /**
    * Return a vector and indicate that it is not going to be used any further
    * by the instance that called alloc() to get a pointer to it.
    */
-  virtual void free (const VECTOR *const) = 0;
+  virtual void free (const VectorType *const) = 0;
 
   /**
    * @addtogroup Exceptions
@@ -121,7 +121,7 @@ public:
     /**
      * Constructor, automatically allocating a vector from @p mem.
      */
-    Pointer(VectorMemory<VECTOR> &mem);
+    Pointer(VectorMemory<VectorType> &mem);
     /**
      * Destructor, automatically releasing the vector from the memory #pool.
      */
@@ -130,26 +130,26 @@ public:
     /**
      * Conversion to regular pointer.
      */
-    operator VECTOR *() const;
+    operator VectorType *() const;
 
     /**
      * Dereferencing operator.
      */
-    VECTOR &operator * () const;
+    VectorType &operator * () const;
 
     /**
      * Dereferencing operator.
      */
-    VECTOR *operator -> () const;
+    VectorType *operator -> () const;
   private:
     /**
      * The memory pool used.
      */
-    SmartPointer<VectorMemory<VECTOR>,Pointer> pool;
+    SmartPointer<VectorMemory<VectorType>,Pointer> pool;
     /**
      * The pointer to the vector.
      */
-    VECTOR *v;
+    VectorType *v;
   };
 };
 
@@ -162,8 +162,8 @@ public:
  * This class allocates and deletes vectors as needed from the global heap,
  * i.e. performs no specially adapted actions for memory management.
  */
-template<class VECTOR = dealii::Vector<double> >
-class PrimitiveVectorMemory : public VectorMemory<VECTOR>
+template<typename VectorType = dealii::Vector<double> >
+class PrimitiveVectorMemory : public VectorMemory<VectorType>
 {
 public:
   /**
@@ -180,9 +180,9 @@ public:
    * For the present class, calling this function will allocate a new vector
    * on the heap and returning a pointer to it.
    */
-  virtual VECTOR *alloc ()
+  virtual VectorType *alloc ()
   {
-    return new VECTOR();
+    return new VectorType();
   }
 
   /**
@@ -193,7 +193,7 @@ public:
    * For the present class, this means that the vector is returned to the
    * global heap.
    */
-  virtual void free (const VECTOR *const v)
+  virtual void free (const VectorType *const v)
   {
     delete v;
   }
@@ -225,8 +225,8 @@ public:
  *
  * @author Guido Kanschat, 1999, 2007
  */
-template<class VECTOR = dealii::Vector<double> >
-class GrowingVectorMemory : public VectorMemory<VECTOR>
+template<typename VectorType = dealii::Vector<double> >
+class GrowingVectorMemory : public VectorMemory<VectorType>
 {
 public:
   /**
@@ -256,7 +256,7 @@ public:
    * function should reset vectors to their proper size. The same holds for
    * the contents of vectors: they are unspecified.
    */
-  virtual VECTOR *alloc ();
+  virtual VectorType *alloc ();
 
   /**
    * Return a vector and indicate that it is not going to be used any further
@@ -265,7 +265,7 @@ public:
    * For the present class, this means retaining the vector for later reuse by
    * the alloc() method.
    */
-  virtual void free (const VECTOR *const);
+  virtual void free (const VectorType *const);
 
   /**
    * Release all vectors that are not currently in use.
@@ -282,7 +282,7 @@ private:
    * Type to enter into the array. First component will be a flag telling
    * whether the vector is used, second the vector itself.
    */
-  typedef std::pair<bool, VECTOR *> entry_type;
+  typedef std::pair<bool, VectorType *> entry_type;
 
   /**
    * The class providing the actual storage for the memory pool.
@@ -347,9 +347,9 @@ private:
 /* --------------------- inline functions ---------------------- */
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-VectorMemory<VECTOR>::Pointer::Pointer(VectorMemory<VECTOR> &mem)
+VectorMemory<VectorType>::Pointer::Pointer(VectorMemory<VectorType> &mem)
   :
   pool(&mem, typeid(*this).name()), v(0)
 {
@@ -357,33 +357,33 @@ VectorMemory<VECTOR>::Pointer::Pointer(VectorMemory<VECTOR> &mem)
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-VectorMemory<VECTOR>::Pointer::~Pointer()
+VectorMemory<VectorType>::Pointer::~Pointer()
 {
   pool->free(v);
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-VectorMemory<VECTOR>::Pointer::operator VECTOR *() const
+VectorMemory<VectorType>::Pointer::operator VectorType *() const
 {
   return v;
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-VECTOR &VectorMemory<VECTOR>::Pointer::operator * () const
+VectorType &VectorMemory<VectorType>::Pointer::operator * () const
 {
   return *v;
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-VECTOR *VectorMemory<VECTOR>::Pointer::operator -> () const
+VectorType *VectorMemory<VectorType>::Pointer::operator -> () const
 {
   return v;
 }

--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -22,24 +22,24 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <typename VECTOR>
-typename GrowingVectorMemory<VECTOR>::Pool GrowingVectorMemory<VECTOR>::pool;
+template <typename VectorType>
+typename GrowingVectorMemory<VectorType>::Pool GrowingVectorMemory<VectorType>::pool;
 
-template <typename VECTOR>
-Threads::Mutex GrowingVectorMemory<VECTOR>::mutex;
+template <typename VectorType>
+Threads::Mutex GrowingVectorMemory<VectorType>::mutex;
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-GrowingVectorMemory<VECTOR>::Pool::Pool()
+GrowingVectorMemory<VectorType>::Pool::Pool()
   :
   data(0)
 {}
 
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-GrowingVectorMemory<VECTOR>::Pool::~Pool()
+GrowingVectorMemory<VectorType>::Pool::~Pool()
 {
   // Nothing to do if memory was unused.
   if (data == 0) return;
@@ -58,10 +58,10 @@ GrowingVectorMemory<VECTOR>::Pool::~Pool()
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
 void
-GrowingVectorMemory<VECTOR>::Pool::initialize(const size_type size)
+GrowingVectorMemory<VectorType>::Pool::initialize(const size_type size)
 {
   if (data == 0)
     {
@@ -72,16 +72,16 @@ GrowingVectorMemory<VECTOR>::Pool::initialize(const size_type size)
            ++i)
         {
           i->first = false;
-          i->second = new VECTOR;
+          i->second = new VectorType;
         }
     }
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 inline
-GrowingVectorMemory<VECTOR>::GrowingVectorMemory (const size_type initial_size,
-                                                  const bool log_statistics)
+GrowingVectorMemory<VectorType>::GrowingVectorMemory (const size_type initial_size,
+                                                      const bool log_statistics)
 
   :
   total_alloc(0),
@@ -93,9 +93,9 @@ GrowingVectorMemory<VECTOR>::GrowingVectorMemory (const size_type initial_size,
 }
 
 
-template<typename VECTOR>
+template<typename VectorType>
 inline
-GrowingVectorMemory<VECTOR>::~GrowingVectorMemory()
+GrowingVectorMemory<VectorType>::~GrowingVectorMemory()
 {
   AssertNothrow(current_alloc == 0,
                 StandardExceptions::ExcMemoryLeak(current_alloc));
@@ -110,10 +110,10 @@ GrowingVectorMemory<VECTOR>::~GrowingVectorMemory()
 
 
 
-template<typename VECTOR>
+template<typename VectorType>
 inline
-VECTOR *
-GrowingVectorMemory<VECTOR>::alloc ()
+VectorType *
+GrowingVectorMemory<VectorType>::alloc ()
 {
   Threads::Mutex::ScopedLock lock(mutex);
   ++total_alloc;
@@ -132,7 +132,7 @@ GrowingVectorMemory<VECTOR>::alloc ()
 
   // no free vector found, so let's
   // just allocate a new one
-  const entry_type t (true, new VECTOR);
+  const entry_type t (true, new VectorType);
   pool.data->push_back(t);
 
   return t.second;
@@ -140,10 +140,10 @@ GrowingVectorMemory<VECTOR>::alloc ()
 
 
 
-template<typename VECTOR>
+template<typename VectorType>
 inline
 void
-GrowingVectorMemory<VECTOR>::free(const VECTOR *const v)
+GrowingVectorMemory<VectorType>::free(const VectorType *const v)
 {
   Threads::Mutex::ScopedLock lock(mutex);
   for (typename std::vector<entry_type>::iterator i=pool.data->begin();
@@ -156,15 +156,15 @@ GrowingVectorMemory<VECTOR>::free(const VECTOR *const v)
           return;
         }
     }
-  Assert(false, typename VectorMemory<VECTOR>::ExcNotAllocatedHere());
+  Assert(false, typename VectorMemory<VectorType>::ExcNotAllocatedHere());
 }
 
 
 
-template<typename VECTOR>
+template<typename VectorType>
 inline
 void
-GrowingVectorMemory<VECTOR>::release_unused_memory ()
+GrowingVectorMemory<VectorType>::release_unused_memory ()
 {
   Threads::Mutex::ScopedLock lock(mutex);
 
@@ -187,10 +187,10 @@ GrowingVectorMemory<VECTOR>::release_unused_memory ()
 
 
 
-template<typename VECTOR>
+template<typename VectorType>
 inline
 std::size_t
-GrowingVectorMemory<VECTOR>::memory_consumption () const
+GrowingVectorMemory<VectorType>::memory_consumption () const
 {
   Threads::Mutex::ScopedLock lock(mutex);
 

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -282,8 +282,8 @@ namespace internal
        * Prints a detailed summary of memory consumption in the different
        * structures of this class to the given output stream.
        */
-      template <typename STREAM>
-      void print_memory_consumption(STREAM         &out,
+      template <typename StreamType>
+      void print_memory_consumption(StreamType     &out,
                                     const SizeInfo &size_info) const;
 
       /**

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1933,9 +1933,9 @@ not_connect:
 
 
 
-    template <typename STREAM>
+    template <typename StreamType>
     void
-    DoFInfo::print_memory_consumption (STREAM         &out,
+    DoFInfo::print_memory_consumption (StreamType     &out,
                                        const SizeInfo &size_info) const
     {
       out << "       Memory row starts indices:    ";

--- a/include/deal.II/matrix_free/helper_functions.h
+++ b/include/deal.II/matrix_free/helper_functions.h
@@ -101,8 +101,8 @@ namespace internal
        * Prints minimum, average, and maximal memory consumption over the MPI
        * processes.
        */
-      template <typename STREAM>
-      void print_memory_statistics (STREAM     &out,
+      template <typename StreamType>
+      void print_memory_statistics (StreamType &out,
                                     std::size_t data_length) const;
 
       /**

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -116,8 +116,8 @@ namespace internal
        * Prints a detailed summary of memory consumption in the different
        * structures of this class to the given output stream.
        */
-      template <typename STREAM>
-      void print_memory_consumption(STREAM         &out,
+      template <typename StreamType>
+      void print_memory_consumption(StreamType     &out,
                                     const SizeInfo &size_info) const;
 
       /**
@@ -274,8 +274,8 @@ namespace internal
          * Prints a detailed summary of memory consumption in the different
          * structures of this class to the given output stream.
          */
-        template <typename STREAM>
-        void print_memory_consumption(STREAM         &out,
+        template <typename StreamType>
+        void print_memory_consumption(StreamType     &out,
                                       const SizeInfo &size_info) const;
 
         /**

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -856,9 +856,9 @@ namespace internal
 
 
     template <int dim, typename Number>
-    template <typename STREAM>
+    template <typename StreamType>
     void MappingInfo<dim,Number>::MappingInfoDependent::print_memory_consumption
-    (STREAM         &out,
+    (StreamType     &out,
      const SizeInfo &size_info) const
     {
       // print_memory_statistics involves global communication, so we can
@@ -901,8 +901,8 @@ namespace internal
 
 
     template <int dim, typename Number>
-    template <typename STREAM>
-    void MappingInfo<dim,Number>::print_memory_consumption(STREAM &out,
+    template <typename StreamType>
+    void MappingInfo<dim,Number>::print_memory_consumption(StreamType     &out,
                                                            const SizeInfo &size_info) const
     {
       out << "    Cell types:                      ";

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -730,8 +730,8 @@ public:
    * Prints a detailed summary of memory consumption in the different
    * structures of this class to the given output stream.
    */
-  template <typename STREAM>
-  void print_memory_consumption(STREAM &out) const;
+  template <typename StreamType>
+  void print_memory_consumption(StreamType &out) const;
 
   /**
    * Prints a summary of this class to the given output stream. It is focused

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -772,8 +772,8 @@ std::size_t MatrixFree<dim,Number>::memory_consumption () const
 
 
 template <int dim, typename Number>
-template <typename STREAM>
-void MatrixFree<dim,Number>::print_memory_consumption (STREAM &out) const
+template <typename StreamType>
+void MatrixFree<dim,Number>::print_memory_consumption (StreamType &out) const
 {
   out << "  Memory cell FE operator total: --> ";
   size_info.print_memory_statistics (out, memory_consumption());
@@ -890,8 +890,8 @@ namespace internal
 
 
 
-    template <typename STREAM>
-    void SizeInfo::print_memory_statistics (STREAM     &out,
+    template <typename StreamType>
+    void SizeInfo::print_memory_statistics (StreamType &out,
                                             std::size_t data_length) const
     {
       Utilities::MPI::MinMaxAvg memory_c

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -103,7 +103,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class VECTOR>
+    template <typename VectorType>
     class ResidualLocalBlocksToGlobalBlocks
     {
     public:
@@ -143,8 +143,8 @@ namespace MeshWorker
       /**
        * Assemble a single local residual into the global.
        */
-      void assemble(VECTOR &global,
-                    const BlockVector<double> &local,
+      void assemble(VectorType                                 &global,
+                    const BlockVector<double>                  &local,
                     const std::vector<types::global_dof_index> &dof);
 
       /**
@@ -156,12 +156,12 @@ namespace MeshWorker
        * A pointer to the object containing the block structure.
        */
       SmartPointer<const BlockInfo,
-                   ResidualLocalBlocksToGlobalBlocks<VECTOR> > block_info;
+                   ResidualLocalBlocksToGlobalBlocks<VectorType> > block_info;
       /**
        * A pointer to the object containing constraints.
        */
       SmartPointer<const ConstraintMatrix,
-                   ResidualLocalBlocksToGlobalBlocks<VECTOR> > constraints;
+                   ResidualLocalBlocksToGlobalBlocks<VectorType> > constraints;
     };
 
 
@@ -493,39 +493,39 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class VECTOR>
+    template <typename VectorType>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::initialize(const BlockInfo *b,
-                                                          AnyData &m)
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::initialize(const BlockInfo *b,
+                                                              AnyData         &m)
     {
       block_info = b;
       residuals = m;
     }
 
-    template <class VECTOR>
+    template <typename VectorType>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::initialize(
-      const ConstraintMatrix &c)
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::initialize
+    (const ConstraintMatrix &c)
     {
       constraints = &c;
     }
 
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::initialize_info(
-      DOFINFO &info, bool) const
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::initialize_info
+    (DOFINFO &info, bool) const
     {
       info.initialize_vectors(residuals.size());
     }
 
-    template <class VECTOR>
+    template <typename VectorType>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::assemble(
-      VECTOR &global,
-      const BlockVector<double> &local,
-      const std::vector<types::global_dof_index> &dof)
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::assemble
+    (VectorType                                 &global,
+     const BlockVector<double>                  &local,
+     const std::vector<types::global_dof_index> &dof)
     {
       if (constraints == 0)
         {
@@ -549,23 +549,23 @@ namespace MeshWorker
     }
 
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::assemble(
-      const DOFINFO &info)
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::assemble
+    (const DOFINFO &info)
     {
       for (unsigned int i=0; i<residuals.size(); ++i)
         assemble(*residuals(i), info.vector(i), info.indices);
     }
 
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualLocalBlocksToGlobalBlocks<VECTOR>::assemble(
-      const DOFINFO &info1,
-      const DOFINFO &info2)
+    ResidualLocalBlocksToGlobalBlocks<VectorType>::assemble
+    (const DOFINFO &info1,
+     const DOFINFO &info2)
     {
       for (unsigned int i=0; i<residuals.size(); ++i)
         {

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -93,8 +93,8 @@ namespace MeshWorker
      * used locally.
      *
      * In the block model, each of the blocks of the local vectors corresponds
-     * to the restriction of a single block of the system to this cell (
-     * @ref GlossBlock).
+     * to the restriction of a single block of the system to this cell
+     (* @ref GlossBlock).
      * Thus, the size of this local block is the number of degrees of freedom
      * of the corresponding base element of the FESystem.
      *
@@ -192,7 +192,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX, typename number = double>
+    template <typename MatrixType, typename number = double>
     class MatrixLocalBlocksToGlobalBlocks
     {
     public:
@@ -207,7 +207,7 @@ namespace MeshWorker
        * initialize cell matrix vectors.
        */
       void initialize(const BlockInfo *block_info,
-                      MatrixBlockVector<MATRIX> &matrices);
+                      MatrixBlockVector<MatrixType> &matrices);
 
       /**
        * Initialize the constraints.
@@ -241,30 +241,29 @@ namespace MeshWorker
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble(
-        MatrixBlock<MATRIX> &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2);
+      void assemble(MatrixBlock<MatrixType>                    &global,
+                    const FullMatrix<number>                   &local,
+                    const unsigned int                          block_row,
+                    const unsigned int                          block_col,
+                    const std::vector<types::global_dof_index> &dof1,
+                    const std::vector<types::global_dof_index> &dof2);
 
       /**
        * The global matrices, stored as a vector of pointers.
        */
-      SmartPointer<MatrixBlockVector<MATRIX>,
-                   MatrixLocalBlocksToGlobalBlocks<MATRIX, number> > matrices;
+      SmartPointer<MatrixBlockVector<MatrixType>,
+                   MatrixLocalBlocksToGlobalBlocks<MatrixType, number> > matrices;
 
       /**
        * A pointer to the object containing the block structure.
        */
       SmartPointer<const BlockInfo,
-                   MatrixLocalBlocksToGlobalBlocks<MATRIX, number> > block_info;
+                   MatrixLocalBlocksToGlobalBlocks<MatrixType, number> > block_info;
       /**
        * A pointer to the object containing constraints.
        */
       SmartPointer<const ConstraintMatrix,
-                   MatrixLocalBlocksToGlobalBlocks<MATRIX,number> > constraints;
+                   MatrixLocalBlocksToGlobalBlocks<MatrixType,number> > constraints;
 
       /**
        * The smallest positive number that will be entered into the global
@@ -299,12 +298,12 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX, typename number = double>
+    template <typename MatrixType, typename number = double>
     class MGMatrixLocalBlocksToGlobalBlocks
     {
     public:
-      typedef MGMatrixBlockVector<MATRIX> MatrixPtrVector;
-      typedef SmartPointer<MatrixPtrVector, MGMatrixLocalBlocksToGlobalBlocks<MATRIX,number> >
+      typedef MGMatrixBlockVector<MatrixType> MatrixPtrVector;
+      typedef SmartPointer<MatrixPtrVector, MGMatrixLocalBlocksToGlobalBlocks<MatrixType,number> >
       MatrixPtrVectorPtr;
 
       /**
@@ -366,81 +365,75 @@ namespace MeshWorker
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2,
-        bool transpose = false);
+      void assemble(MatrixType                                 &global,
+                    const FullMatrix<number>                   &local,
+                    const unsigned int                          block_row,
+                    const unsigned int                          block_col,
+                    const std::vector<types::global_dof_index> &dof1,
+                    const std::vector<types::global_dof_index> &dof2,
+                    const unsigned int                          level1,
+                    const unsigned int                          level2,
+                    bool                                        transpose = false);
 
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble_fluxes(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2);
+      void assemble_fluxes(MatrixType                                 &global,
+                           const FullMatrix<number>                   &local,
+                           const unsigned int                          block_row,
+                           const unsigned int                          block_col,
+                           const std::vector<types::global_dof_index> &dof1,
+                           const std::vector<types::global_dof_index> &dof2,
+                           const unsigned int                          level1,
+                           const unsigned int                          level2);
 
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble_up(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2);
+      void assemble_up(MatrixType                                 &global,
+                       const FullMatrix<number>                   &local,
+                       const unsigned int                          block_row,
+                       const unsigned int                          block_col,
+                       const std::vector<types::global_dof_index> &dof1,
+                       const std::vector<types::global_dof_index> &dof2,
+                       const unsigned int                          level1,
+                       const unsigned int                          level2);
 
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble_down(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2);
+      void assemble_down(MatrixType                                 &global,
+                         const FullMatrix<number>                   &local,
+                         const unsigned int                          block_row,
+                         const unsigned int                          block_col,
+                         const std::vector<types::global_dof_index> &dof1,
+                         const std::vector<types::global_dof_index> &dof2,
+                         const unsigned int                          level1,
+                         const unsigned int                          level2);
 
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble_in(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2);
+      void assemble_in(MatrixType                                 &global,
+                       const FullMatrix<number>                   &local,
+                       const unsigned int                          block_row,
+                       const unsigned int                          block_col,
+                       const std::vector<types::global_dof_index> &dof1,
+                       const std::vector<types::global_dof_index> &dof2,
+                       const unsigned int                          level1,
+                       const unsigned int                          level2);
 
       /**
        * Assemble a single local matrix into a global one.
        */
-      void assemble_out(
-        MATRIX &global,
-        const FullMatrix<number> &local,
-        const unsigned int block_row,
-        const unsigned int block_col,
-        const std::vector<types::global_dof_index> &dof1,
-        const std::vector<types::global_dof_index> &dof2,
-        const unsigned int level1,
-        const unsigned int level2);
+      void assemble_out(MatrixType                                 &global,
+                        const FullMatrix<number>                   &local,
+                        const unsigned int                          block_row,
+                        const unsigned int                          block_col,
+                        const std::vector<types::global_dof_index> &dof1,
+                        const std::vector<types::global_dof_index> &dof2,
+                        const unsigned int                          level1,
+                        const unsigned int                          level2);
 
       /**
        * The level matrices, stored as a vector of pointers.
@@ -474,12 +467,12 @@ namespace MeshWorker
       /**
        * A pointer to the object containing the block structure.
        */
-      SmartPointer<const BlockInfo, MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number> > block_info;
+      SmartPointer<const BlockInfo, MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number> > block_info;
 
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const MGConstrainedDoFs,MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number> > mg_constrained_dofs;
+      SmartPointer<const MGConstrainedDoFs,MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number> > mg_constrained_dofs;
 
 
       /**
@@ -577,20 +570,20 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::MatrixLocalBlocksToGlobalBlocks(
-      double threshold)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::MatrixLocalBlocksToGlobalBlocks
+    (double threshold)
       :
       threshold(threshold)
     {}
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize(
-      const BlockInfo *b,
-      MatrixBlockVector<MATRIX> &m)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize
+    (const BlockInfo               *b,
+     MatrixBlockVector<MatrixType> &m)
     {
       block_info = b;
       matrices = &m;
@@ -598,37 +591,37 @@ namespace MeshWorker
 
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize(
-      const ConstraintMatrix &c)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize
+    (const ConstraintMatrix &c)
     {
       constraints = &c;
     }
 
 
 
-    template <class MATRIX ,typename number>
+    template <typename MatrixType ,typename number>
     template <class DOFINFO>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize_info(
-      DOFINFO &info,
-      bool face) const
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize_info
+    (DOFINFO &info,
+     bool face) const
     {
       info.initialize_matrices(*matrices, face);
     }
 
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(
-      MatrixBlock<MATRIX> &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble
+    (MatrixBlock<MatrixType>                    &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2)
     {
       if (constraints == 0)
         {
@@ -667,11 +660,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     template <class DOFINFO>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(
-      const DOFINFO &info)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble (const DOFINFO &info)
     {
       for (unsigned int i=0; i<matrices->size(); ++i)
         {
@@ -685,12 +677,11 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     template <class DOFINFO>
     inline void
-    MatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(
-      const DOFINFO &info1,
-      const DOFINFO &info2)
+    MatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble (const DOFINFO &info1,
+        const DOFINFO &info2)
     {
       for (unsigned int i=0; i<matrices->size(); ++i)
         {
@@ -709,20 +700,20 @@ namespace MeshWorker
 
 // ----------------------------------------------------------------------//
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::MGMatrixLocalBlocksToGlobalBlocks(
-      double threshold)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::MGMatrixLocalBlocksToGlobalBlocks
+    (double threshold)
       :
       threshold(threshold)
     {}
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize(
-      const BlockInfo *b,
-      MatrixPtrVector &m)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize
+    (const BlockInfo *b,
+     MatrixPtrVector &m)
     {
       block_info = b;
       AssertDimension(block_info->local().size(), block_info->global().size());
@@ -730,61 +721,61 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize(
-      const MGConstrainedDoFs &mg_c)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize
+    (const MGConstrainedDoFs &mg_c)
     {
       mg_constrained_dofs = &mg_c;
     }
 
 
-    template <class MATRIX ,typename number>
+    template <typename MatrixType ,typename number>
     template <class DOFINFO>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize_info(
-      DOFINFO &info,
-      bool face) const
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize_info
+    (DOFINFO &info,
+     bool face) const
     {
       info.initialize_matrices(*matrices, face);
     }
 
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize_edge_flux(
-      MatrixPtrVector &up,
-      MatrixPtrVector &down)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize_edge_flux
+    (MatrixPtrVector &up,
+     MatrixPtrVector &down)
     {
       flux_up = up;
       flux_down = down;
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::initialize_interfaces(
-      MatrixPtrVector &in,
-      MatrixPtrVector &out)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::initialize_interfaces
+    (MatrixPtrVector &in,
+     MatrixPtrVector &out)
     {
       interface_in = in;
       interface_out = out;
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2,
-      bool transpose)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2,
+     bool                                        transpose)
     {
       for (unsigned int j=0; j<local.n_rows(); ++j)
         for (unsigned int k=0; k<local.n_cols(); ++k)
@@ -852,17 +843,17 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble_fluxes(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble_fluxes
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2)
     {
       for (unsigned int j=0; j<local.n_rows(); ++j)
         for (unsigned int k=0; k<local.n_cols(); ++k)
@@ -905,17 +896,17 @@ namespace MeshWorker
             }
     }
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble_up(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble_up
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2)
     {
       for (unsigned int j=0; j<local.n_rows(); ++j)
         for (unsigned int k=0; k<local.n_cols(); ++k)
@@ -958,17 +949,17 @@ namespace MeshWorker
             }
     }
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble_down(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble_down
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2)
     {
       for (unsigned int j=0; j<local.n_rows(); ++j)
         for (unsigned int k=0; k<local.n_cols(); ++k)
@@ -1011,17 +1002,17 @@ namespace MeshWorker
             }
     }
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble_in(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble_in
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2)
     {
 //      AssertDimension(local.n(), dof1.size());
 //      AssertDimension(local.m(), dof2.size());
@@ -1076,17 +1067,17 @@ namespace MeshWorker
             }
     }
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble_out(
-      MATRIX &global,
-      const FullMatrix<number> &local,
-      const unsigned int block_row,
-      const unsigned int block_col,
-      const std::vector<types::global_dof_index> &dof1,
-      const std::vector<types::global_dof_index> &dof2,
-      const unsigned int level1,
-      const unsigned int level2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble_out
+    (MatrixType                                 &global,
+     const FullMatrix<number>                   &local,
+     const unsigned int                          block_row,
+     const unsigned int                          block_col,
+     const std::vector<types::global_dof_index> &dof1,
+     const std::vector<types::global_dof_index> &dof2,
+     const unsigned int                          level1,
+     const unsigned int                          level2)
     {
 //      AssertDimension(local.n(), dof1.size());
 //      AssertDimension(local.m(), dof2.size());
@@ -1142,10 +1133,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     template <class DOFINFO>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(const DOFINFO &info)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble(const DOFINFO &info)
     {
       const unsigned int level = info.cell->level();
 
@@ -1176,19 +1167,19 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX, typename number>
+    template <typename MatrixType, typename number>
     template <class DOFINFO>
     inline void
-    MGMatrixLocalBlocksToGlobalBlocks<MATRIX, number>::assemble(
-      const DOFINFO &info1,
-      const DOFINFO &info2)
+    MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>::assemble
+    (const DOFINFO &info1,
+     const DOFINFO &info2)
     {
       const unsigned int level1 = info1.cell->level();
       const unsigned int level2 = info2.cell->level();
 
       for (unsigned int i=0; i<matrices->size(); ++i)
         {
-          MGLevelObject<MatrixBlock<MATRIX> > &o = matrices->block(i);
+          MGLevelObject<MatrixBlock<MatrixType> > &o = matrices->block(i);
 
           // Row and column index of
           // the block we are dealing with

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -36,7 +36,7 @@ namespace MeshWorker
    * Objects of this class contain one or more objects of type FEValues,
    * FEFaceValues or FESubfaceValues to be used in local integration. They are
    * stored in an array of pointers to the base classes FEValuesBase. The
-   * template parameter VECTOR allows the use of different data types for the
+   * template parameter VectorType allows the use of different data types for the
    * global system.
    *
    * Additionally, this function contains space to store the values of finite
@@ -310,12 +310,12 @@ namespace MeshWorker
      * and also set uninitialized quadrature rules to Gauss formulas, which
      * integrate polynomial bilinear forms exactly.
      */
-    template <typename VECTOR>
+    template <typename VectorType>
     void initialize(const FiniteElement<dim, spacedim> &el,
-                    const Mapping<dim, spacedim> &mapping,
-                    const AnyData &data,
-                    const VECTOR &dummy,
-                    const BlockInfo *block_info = 0);
+                    const Mapping<dim, spacedim>       &mapping,
+                    const AnyData                      &data,
+                    const VectorType                   &dummy,
+                    const BlockInfo                    *block_info = 0);
     /**
      * Initialize the IntegrationInfo objects contained.
      *
@@ -323,12 +323,12 @@ namespace MeshWorker
      * and also set uninitialized quadrature rules to Gauss formulas, which
      * integrate polynomial bilinear forms exactly.
      */
-    template <typename VECTOR>
+    template <typename VectorType>
     void initialize(const FiniteElement<dim, spacedim> &el,
-                    const Mapping<dim, spacedim> &mapping,
-                    const AnyData &data,
-                    const MGLevelObject<VECTOR> &dummy,
-                    const BlockInfo *block_info = 0);
+                    const Mapping<dim, spacedim>       &mapping,
+                    const AnyData                      &data,
+                    const MGLevelObject<VectorType>    &dummy,
+                    const BlockInfo                    *block_info = 0);
     /**
      * @name FEValues setup
      */
@@ -773,20 +773,20 @@ namespace MeshWorker
 
 
   template <int dim, int sdim>
-  template <typename VECTOR>
+  template <typename VectorType>
   void
-  IntegrationInfoBox<dim,sdim>::initialize(
-    const FiniteElement<dim,sdim> &el,
-    const Mapping<dim,sdim> &mapping,
-    const AnyData &data,
-    const VECTOR &,
-    const BlockInfo *block_info)
+  IntegrationInfoBox<dim,sdim>::initialize
+  (const FiniteElement<dim,sdim> &el,
+   const Mapping<dim,sdim>       &mapping,
+   const AnyData                 &data,
+   const VectorType              &,
+   const BlockInfo               *block_info)
   {
     initialize(el, mapping, block_info);
-    std_cxx11::shared_ptr<VectorData<VECTOR, dim, sdim> > p;
+    std_cxx11::shared_ptr<VectorData<VectorType, dim, sdim> > p;
     VectorDataBase<dim,sdim> *pp;
 
-    p = std_cxx11::shared_ptr<VectorData<VECTOR, dim, sdim> >(new VectorData<VECTOR, dim, sdim> (cell_selector));
+    p = std_cxx11::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (cell_selector));
     // Public member function of parent class was not found without
     // explicit cast
     pp = &*p;
@@ -794,13 +794,13 @@ namespace MeshWorker
     cell_data = p;
     cell.initialize_data(p);
 
-    p = std_cxx11::shared_ptr<VectorData<VECTOR, dim, sdim> >(new VectorData<VECTOR, dim, sdim> (boundary_selector));
+    p = std_cxx11::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (boundary_selector));
     pp = &*p;
     pp->initialize(data);
     boundary_data = p;
     boundary.initialize_data(p);
 
-    p = std_cxx11::shared_ptr<VectorData<VECTOR, dim, sdim> >(new VectorData<VECTOR, dim, sdim> (face_selector));
+    p = std_cxx11::shared_ptr<VectorData<VectorType, dim, sdim> >(new VectorData<VectorType, dim, sdim> (face_selector));
     pp = &*p;
     pp->initialize(data);
     face_data = p;
@@ -810,20 +810,20 @@ namespace MeshWorker
   }
 
   template <int dim, int sdim>
-  template <typename VECTOR>
+  template <typename VectorType>
   void
-  IntegrationInfoBox<dim,sdim>::initialize(
-    const FiniteElement<dim,sdim> &el,
-    const Mapping<dim,sdim> &mapping,
-    const AnyData &data,
-    const MGLevelObject<VECTOR> &,
-    const BlockInfo *block_info)
+  IntegrationInfoBox<dim,sdim>::initialize
+  (const FiniteElement<dim,sdim>   &el,
+   const Mapping<dim,sdim>         &mapping,
+   const AnyData                   &data,
+   const MGLevelObject<VectorType> &,
+   const BlockInfo                 *block_info)
   {
     initialize(el, mapping, block_info);
-    std_cxx11::shared_ptr<MGVectorData<VECTOR, dim, sdim> > p;
+    std_cxx11::shared_ptr<MGVectorData<VectorType, dim, sdim> > p;
     VectorDataBase<dim,sdim> *pp;
 
-    p = std_cxx11::shared_ptr<MGVectorData<VECTOR, dim, sdim> >(new MGVectorData<VECTOR, dim, sdim> (cell_selector));
+    p = std_cxx11::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (cell_selector));
     // Public member function of parent class was not found without
     // explicit cast
     pp = &*p;
@@ -831,13 +831,13 @@ namespace MeshWorker
     cell_data = p;
     cell.initialize_data(p);
 
-    p = std_cxx11::shared_ptr<MGVectorData<VECTOR, dim, sdim> >(new MGVectorData<VECTOR, dim, sdim> (boundary_selector));
+    p = std_cxx11::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (boundary_selector));
     pp = &*p;
     pp->initialize(data);
     boundary_data = p;
     boundary.initialize_data(p);
 
-    p = std_cxx11::shared_ptr<MGVectorData<VECTOR, dim, sdim> >(new MGVectorData<VECTOR, dim, sdim> (face_selector));
+    p = std_cxx11::shared_ptr<MGVectorData<VectorType, dim, sdim> >(new MGVectorData<VectorType, dim, sdim> (face_selector));
     pp = &*p;
     pp->initialize(data);
     face_data = p;

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -779,7 +779,7 @@ namespace MeshWorker
   (const FiniteElement<dim,sdim> &el,
    const Mapping<dim,sdim>       &mapping,
    const AnyData                 &data,
-   const VectorType              &,
+   const VectorType &,
    const BlockInfo               *block_info)
   {
     initialize(el, mapping, block_info);

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -321,8 +321,8 @@ namespace MeshWorker
      *
      * @note This function is usually only called by the assembler.
      */
-    template <class MATRIX>
-    void initialize_matrices(const MatrixBlockVector<MATRIX> &matrices,
+    template <typename MatrixType>
+    void initialize_matrices(const MatrixBlockVector<MatrixType> &matrices,
                              bool both);
 
     /**
@@ -332,8 +332,8 @@ namespace MeshWorker
      *
      * @note This function is usually only called by the assembler.
      */
-    template <class MATRIX>
-    void initialize_matrices(const MGMatrixBlockVector<MATRIX> &matrices,
+    template <typename MatrixType>
+    void initialize_matrices(const MGMatrixBlockVector<MatrixType> &matrices,
                              bool both);
 
     /**
@@ -416,11 +416,11 @@ namespace MeshWorker
 
 
   template <typename number>
-  template <class MATRIX>
+  template <typename MatrixType>
   inline void
-  LocalResults<number>::initialize_matrices(
-    const MatrixBlockVector<MATRIX> &matrices,
-    bool both)
+  LocalResults<number>::initialize_matrices
+  (const MatrixBlockVector<MatrixType> &matrices,
+   bool                                 both)
   {
     M1.resize(matrices.size());
     if (both)
@@ -442,18 +442,18 @@ namespace MeshWorker
 
 
   template <typename number>
-  template <class MATRIX>
+  template <typename MatrixType>
   inline void
-  LocalResults<number>::initialize_matrices(
-    const MGMatrixBlockVector<MATRIX> &matrices,
-    bool both)
+  LocalResults<number>::initialize_matrices
+  (const MGMatrixBlockVector<MatrixType> &matrices,
+   bool                                   both)
   {
     M1.resize(matrices.size());
     if (both)
       M2.resize(matrices.size());
     for (unsigned int i=0; i<matrices.size(); ++i)
       {
-        const MGLevelObject<MatrixBlock<MATRIX> > &o = matrices.block(i);
+        const MGLevelObject<MatrixBlock<MatrixType> > &o = matrices.block(i);
         const unsigned int row = o[o.min_level()].row;
         const unsigned int col = o[o.min_level()].column;
 

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -349,8 +349,8 @@ namespace MeshWorker
      */
     void reinit(const BlockIndices &local_sizes);
 
-    template <class STREAM>
-    void print_debug(STREAM &os) const;
+    template <class StreamType>
+    void print_debug(StreamType &os) const;
 
     /**
      * The memory used by this object.
@@ -640,9 +640,9 @@ namespace MeshWorker
 
 
   template <typename number>
-  template <class STREAM>
+  template <class StreamType>
   void
-  LocalResults<number>::print_debug(STREAM &os) const
+  LocalResults<number>::print_debug(StreamType &os) const
   {
     os << "J: " << J.size() << std::endl;
     os << "R: " << R.size() << std::endl;

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -50,7 +50,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class VECTOR>
+    template <typename VectorType>
     class ResidualSimple
     {
     public:
@@ -115,7 +115,7 @@ namespace MeshWorker
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const ConstraintMatrix,ResidualSimple<VECTOR> > constraints;
+      SmartPointer<const ConstraintMatrix,ResidualSimple<VectorType> > constraints;
     };
 
 
@@ -409,10 +409,10 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     class SystemSimple :
       private MatrixSimple<MATRIX>,
-      private ResidualSimple<VECTOR>
+      private ResidualSimple<VectorType>
     {
     public:
       /**
@@ -423,7 +423,7 @@ namespace MeshWorker
       /**
        * Store the two objects data is assembled into.
        */
-      void initialize(MATRIX &m, VECTOR &rhs);
+      void initialize(MATRIX &m, VectorType &rhs);
 
       /**
        * Initialize the constraints. After this function has been called with
@@ -462,16 +462,16 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class VECTOR>
+    template <typename VectorType>
     inline void
-    ResidualSimple<VECTOR>::initialize(AnyData &results)
+    ResidualSimple<VectorType>::initialize(AnyData &results)
     {
       residuals = results;
     }
 
-    template <class VECTOR>
+    template <typename VectorType>
     inline void
-    ResidualSimple<VECTOR>::initialize(const ConstraintMatrix &c)
+    ResidualSimple<VectorType>::initialize(const ConstraintMatrix &c)
     {
       constraints = &c;
     }
@@ -483,23 +483,23 @@ namespace MeshWorker
     {}
 
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualSimple<VECTOR>::initialize_info(DOFINFO &info, bool) const
+    ResidualSimple<VectorType>::initialize_info(DOFINFO &info, bool) const
     {
       info.initialize_vectors(residuals.size());
     }
 
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualSimple<VECTOR>::assemble(const DOFINFO &info)
+    ResidualSimple<VectorType>::assemble(const DOFINFO &info)
     {
       for (unsigned int k=0; k<residuals.size(); ++k)
         {
-          VECTOR *v = residuals.entry<VECTOR *>(k);
+          VectorType *v = residuals.entry<VectorType *>(k);
           if (constraints == 0)
             {
               for (unsigned int i=0; i<info.vector(k).block(0).size(); ++i)
@@ -516,15 +516,15 @@ namespace MeshWorker
         }
     }
 
-    template <class VECTOR>
+    template <typename VectorType>
     template <class DOFINFO>
     inline void
-    ResidualSimple<VECTOR>::assemble(const DOFINFO &info1,
-                                     const DOFINFO &info2)
+    ResidualSimple<VectorType>::assemble(const DOFINFO &info1,
+                                         const DOFINFO &info2)
     {
       for (unsigned int k=0; k<residuals.size(); ++k)
         {
-          VECTOR *v = residuals.entry<VECTOR *>(k);
+          VectorType *v = residuals.entry<VectorType *>(k);
           if (constraints == 0)
             {
               for (unsigned int i=0; i<info1.vector(k).block(0).size(); ++i)
@@ -1097,63 +1097,63 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class MATRIX, class VECTOR>
-    SystemSimple<MATRIX,VECTOR>::SystemSimple(double t)
+    template <class MATRIX, typename VectorType>
+    SystemSimple<MATRIX,VectorType>::SystemSimple(double t)
       :
       MatrixSimple<MATRIX>(t)
     {}
 
 
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     inline void
-    SystemSimple<MATRIX,VECTOR>::initialize(MATRIX &m, VECTOR &rhs)
+    SystemSimple<MATRIX,VectorType>::initialize(MATRIX &m, VectorType &rhs)
     {
       AnyData data;
-      VECTOR *p = &rhs;
+      VectorType *p = &rhs;
       data.add(p, "right hand side");
 
       MatrixSimple<MATRIX>::initialize(m);
-      ResidualSimple<VECTOR>::initialize(data);
+      ResidualSimple<VectorType>::initialize(data);
     }
 
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     inline void
-    SystemSimple<MATRIX,VECTOR>::initialize(const ConstraintMatrix &c)
+    SystemSimple<MATRIX,VectorType>::initialize(const ConstraintMatrix &c)
     {
       MatrixSimple<MATRIX>::initialize(c);
-      ResidualSimple<VECTOR>::initialize(c);
+      ResidualSimple<VectorType>::initialize(c);
     }
 
 
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VECTOR>::initialize_info(DOFINFO &info,
-                                                 bool face) const
+    SystemSimple<MATRIX,VectorType>::initialize_info(DOFINFO &info,
+                                                     bool    face) const
     {
       MatrixSimple<MATRIX>::initialize_info(info, face);
-      ResidualSimple<VECTOR>::initialize_info(info, face);
+      ResidualSimple<VectorType>::initialize_info(info, face);
     }
 
 
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VECTOR>::assemble(const DOFINFO &info)
+    SystemSimple<MATRIX,VectorType>::assemble(const DOFINFO &info)
     {
       MatrixSimple<MATRIX>::assemble(info);
-      ResidualSimple<VECTOR>::assemble(info);
+      ResidualSimple<VectorType>::assemble(info);
     }
 
 
-    template <class MATRIX, class VECTOR>
+    template <class MATRIX, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VECTOR>::assemble(const DOFINFO &info1,
-                                          const DOFINFO &info2)
+    SystemSimple<MATRIX,VectorType>::assemble(const DOFINFO &info1,
+                                              const DOFINFO &info2)
     {
       MatrixSimple<MATRIX>::assemble(info1, info2);
-      ResidualSimple<VECTOR>::assemble(info1, info2);
+      ResidualSimple<VectorType>::assemble(info1, info2);
     }
   }
 }

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -150,7 +150,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX>
+    template <typename MatrixType>
     class MatrixSimple
     {
     public:
@@ -163,12 +163,12 @@ namespace MeshWorker
       /**
        * Store the result matrix for later assembling.
        */
-      void initialize(MATRIX &m);
+      void initialize(MatrixType &m);
 
       /**
        * Store several result matrices for later assembling.
        */
-      void initialize(std::vector<MATRIX> &m);
+      void initialize(std::vector<MatrixType> &m);
 
       /**
        * Initialize the constraints. After this function has been called with
@@ -216,11 +216,11 @@ namespace MeshWorker
       /**
        * The vector of global matrices being assembled.
        */
-      std::vector<SmartPointer<MATRIX,MatrixSimple<MATRIX> > > matrix;
+      std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const ConstraintMatrix,MatrixSimple<MATRIX> > constraints;
+      SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
 
       /**
        * The smallest positive number that will be entered into the global
@@ -242,7 +242,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX>
+    template <typename MatrixType>
     class MGMatrixSimple
     {
     public:
@@ -255,7 +255,7 @@ namespace MeshWorker
       /**
        * Store the result matrix for later assembling.
        */
-      void initialize(MGLevelObject<MATRIX> &m);
+      void initialize(MGLevelObject<MatrixType> &m);
 
       /**
        * Initialize the multilevel constraints.
@@ -266,16 +266,16 @@ namespace MeshWorker
        * Initialize the matrices #flux_up and #flux_down used for local
        * refinement with discontinuous Galerkin methods.
        */
-      void initialize_fluxes(MGLevelObject<MATRIX> &flux_up,
-                             MGLevelObject<MATRIX> &flux_down);
+      void initialize_fluxes(MGLevelObject<MatrixType> &flux_up,
+                             MGLevelObject<MatrixType> &flux_down);
 
       /**
        * Initialize the matrices #interface_in and #interface_out used for
        * local refinement with continuous Galerkin methods.
        */
 
-      void initialize_interfaces(MGLevelObject<MATRIX> &interface_in,
-                                 MGLevelObject<MATRIX> &interface_out);
+      void initialize_interfaces(MGLevelObject<MatrixType> &interface_in,
+                                 MGLevelObject<MatrixType> &interface_out);
       /**
        * Initialize the local data in the DoFInfo object used later for
        * assembling.
@@ -303,7 +303,7 @@ namespace MeshWorker
       /**
        * Assemble a single matrix into a global matrix.
        */
-      void assemble(MATRIX &G,
+      void assemble(MatrixType &G,
                     const FullMatrix<double> &M,
                     const std::vector<types::global_dof_index> &i1,
                     const std::vector<types::global_dof_index> &i2);
@@ -311,7 +311,7 @@ namespace MeshWorker
       /**
        * Assemble a single matrix into a global matrix.
        */
-      void assemble(MATRIX &G,
+      void assemble(MatrixType &G,
                     const FullMatrix<double> &M,
                     const std::vector<types::global_dof_index> &i1,
                     const std::vector<types::global_dof_index> &i2,
@@ -321,7 +321,7 @@ namespace MeshWorker
        * Assemble a single matrix into a global matrix.
        */
 
-      void assemble_up(MATRIX &G,
+      void assemble_up(MatrixType &G,
                        const FullMatrix<double> &M,
                        const std::vector<types::global_dof_index> &i1,
                        const std::vector<types::global_dof_index> &i2,
@@ -330,7 +330,7 @@ namespace MeshWorker
        * Assemble a single matrix into a global matrix.
        */
 
-      void assemble_down(MATRIX &G,
+      void assemble_down(MatrixType &G,
                          const FullMatrix<double> &M,
                          const std::vector<types::global_dof_index> &i1,
                          const std::vector<types::global_dof_index> &i2,
@@ -340,7 +340,7 @@ namespace MeshWorker
        * Assemble a single matrix into a global matrix.
        */
 
-      void assemble_in(MATRIX &G,
+      void assemble_in(MatrixType &G,
                        const FullMatrix<double> &M,
                        const std::vector<types::global_dof_index> &i1,
                        const std::vector<types::global_dof_index> &i2,
@@ -350,7 +350,7 @@ namespace MeshWorker
        * Assemble a single matrix into a global matrix.
        */
 
-      void assemble_out(MATRIX &G,
+      void assemble_out(MatrixType &G,
                         const FullMatrix<double> &M,
                         const std::vector<types::global_dof_index> &i1,
                         const std::vector<types::global_dof_index> &i2,
@@ -359,35 +359,35 @@ namespace MeshWorker
       /**
        * The global matrix being assembled.
        */
-      SmartPointer<MGLevelObject<MATRIX>,MGMatrixSimple<MATRIX> > matrix;
+      SmartPointer<MGLevelObject<MatrixType>,MGMatrixSimple<MatrixType> > matrix;
 
       /**
        * The matrix used for face flux terms across the refinement edge,
        * coupling coarse to fine.
        */
-      SmartPointer<MGLevelObject<MATRIX>,MGMatrixSimple<MATRIX> > flux_up;
+      SmartPointer<MGLevelObject<MatrixType>,MGMatrixSimple<MatrixType> > flux_up;
 
       /**
        * The matrix used for face flux terms across the refinement edge,
        * coupling fine to coarse.
        */
-      SmartPointer<MGLevelObject<MATRIX>,MGMatrixSimple<MATRIX> > flux_down;
+      SmartPointer<MGLevelObject<MatrixType>,MGMatrixSimple<MatrixType> > flux_down;
 
       /**
        * The matrix used for face contributions for continuous elements across
        * the refinement edge, coupling coarse to fine.
        */
-      SmartPointer<MGLevelObject<MATRIX>,MGMatrixSimple<MATRIX> > interface_in;
+      SmartPointer<MGLevelObject<MatrixType>,MGMatrixSimple<MatrixType> > interface_in;
 
       /**
        * The matrix used for face contributions for continuous elements across
        * the refinement edge, coupling fine to coarse.
        */
-      SmartPointer<MGLevelObject<MATRIX>,MGMatrixSimple<MATRIX> > interface_out;
+      SmartPointer<MGLevelObject<MatrixType>,MGMatrixSimple<MatrixType> > interface_out;
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const MGConstrainedDoFs,MGMatrixSimple<MATRIX> > mg_constrained_dofs;
+      SmartPointer<const MGConstrainedDoFs,MGMatrixSimple<MatrixType> > mg_constrained_dofs;
 
       /**
        * The smallest positive number that will be entered into the global
@@ -409,9 +409,9 @@ namespace MeshWorker
      * @ingroup MeshWorker
      * @author Guido Kanschat, 2009
      */
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     class SystemSimple :
-      private MatrixSimple<MATRIX>,
+      private MatrixSimple<MatrixType>,
       private ResidualSimple<VectorType>
     {
     public:
@@ -423,7 +423,7 @@ namespace MeshWorker
       /**
        * Store the two objects data is assembled into.
        */
-      void initialize(MATRIX &m, VectorType &rhs);
+      void initialize(MatrixType &m, VectorType &rhs);
 
       /**
        * Initialize the constraints. After this function has been called with
@@ -477,9 +477,9 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    ResidualSimple<MATRIX>::initialize_local_blocks(const BlockIndices &)
+    ResidualSimple<MatrixType>::initialize_local_blocks(const BlockIndices &)
     {}
 
 
@@ -562,26 +562,26 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline
-    MatrixSimple<MATRIX>::MatrixSimple(double threshold)
+    MatrixSimple<MatrixType>::MatrixSimple(double threshold)
       :
       threshold(threshold)
     {}
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MatrixSimple<MATRIX>::initialize(MATRIX &m)
+    MatrixSimple<MatrixType>::initialize(MatrixType &m)
     {
       matrix.resize(1);
       matrix[0] = &m;
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MatrixSimple<MATRIX>::initialize(std::vector<MATRIX> &m)
+    MatrixSimple<MatrixType>::initialize(std::vector<MatrixType> &m)
     {
       matrix.resize(m.size());
       for (unsigned int i=0; i<m.size(); ++i)
@@ -589,18 +589,18 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MatrixSimple<MATRIX>::initialize(const ConstraintMatrix &c)
+    MatrixSimple<MatrixType>::initialize(const ConstraintMatrix &c)
     {
       constraints = &c;
     }
 
 
-    template <class MATRIX >
+    template <typename MatrixType >
     template <class DOFINFO>
     inline void
-    MatrixSimple<MATRIX>::initialize_info(DOFINFO &info, bool face) const
+    MatrixSimple<MatrixType>::initialize_info(DOFINFO &info, bool face) const
     {
       Assert(matrix.size() != 0, ExcNotInitialized());
 
@@ -629,9 +629,9 @@ namespace MeshWorker
 
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MatrixSimple<MATRIX>::assemble(const FullMatrix<double> &M,
+    MatrixSimple<MatrixType>::assemble(const FullMatrix<double> &M,
                                    const unsigned int index,
                                    const std::vector<types::global_dof_index> &i1,
                                    const std::vector<types::global_dof_index> &i2)
@@ -651,10 +651,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     template <class DOFINFO>
     inline void
-    MatrixSimple<MATRIX>::assemble(const DOFINFO &info)
+    MatrixSimple<MatrixType>::assemble(const DOFINFO &info)
     {
       Assert(!info.level_cell, ExcMessage("Cell may not access level dofs"));
       const unsigned int n = info.indices_by_block.size();
@@ -675,10 +675,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     template <class DOFINFO>
     inline void
-    MatrixSimple<MATRIX>::assemble(const DOFINFO &info1, const DOFINFO &info2)
+    MatrixSimple<MatrixType>::assemble(const DOFINFO &info1, const DOFINFO &info2)
     {
       Assert(!info1.level_cell, ExcMessage("Cell may not access level dofs"));
       Assert(!info2.level_cell, ExcMessage("Cell may not access level dofs"));
@@ -719,53 +719,53 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline
-    MGMatrixSimple<MATRIX>::MGMatrixSimple(double threshold)
+    MGMatrixSimple<MatrixType>::MGMatrixSimple(double threshold)
       :
       threshold(threshold)
     {}
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::initialize(MGLevelObject<MATRIX> &m)
+    MGMatrixSimple<MatrixType>::initialize(MGLevelObject<MatrixType> &m)
     {
       matrix = &m;
     }
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::initialize(const MGConstrainedDoFs &c)
+    MGMatrixSimple<MatrixType>::initialize(const MGConstrainedDoFs &c)
     {
       mg_constrained_dofs = &c;
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::initialize_fluxes(
-      MGLevelObject<MATRIX> &up, MGLevelObject<MATRIX> &down)
+    MGMatrixSimple<MatrixType>::initialize_fluxes(MGLevelObject<MatrixType> &up,
+                                                  MGLevelObject<MatrixType> &down)
     {
       flux_up = &up;
       flux_down = &down;
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::initialize_interfaces(
-      MGLevelObject<MATRIX> &in, MGLevelObject<MATRIX> &out)
+    MGMatrixSimple<MatrixType>::initialize_interfaces
+    (MGLevelObject<MatrixType> &in, MGLevelObject<MatrixType> &out)
     {
       interface_in = &in;
       interface_out = &out;
     }
 
 
-    template <class MATRIX >
+    template <typename MatrixType >
     template <class DOFINFO>
     inline void
-    MGMatrixSimple<MATRIX>::initialize_info(DOFINFO &info, bool face) const
+    MGMatrixSimple<MatrixType>::initialize_info(DOFINFO &info, bool face) const
     {
       const unsigned int n = info.indices_by_block.size();
 
@@ -790,13 +790,13 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2)
+    MGMatrixSimple<MatrixType>::assemble
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2)
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
@@ -810,14 +810,14 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2,
-      const unsigned int level)
+    MGMatrixSimple<MatrixType>::assemble
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2,
+     const unsigned int                          level)
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
@@ -863,14 +863,14 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble_up(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2,
-      const unsigned int level)
+    MGMatrixSimple<MatrixType>::assemble_up
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2,
+     const unsigned int                          level)
     {
       AssertDimension(M.n(), i1.size());
       AssertDimension(M.m(), i2.size());
@@ -892,14 +892,14 @@ namespace MeshWorker
         }
     }
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble_down(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2,
-      const unsigned int level)
+    MGMatrixSimple<MatrixType>::assemble_down
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2,
+     const unsigned int                          level)
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
@@ -921,14 +921,14 @@ namespace MeshWorker
         }
     }
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble_in(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2,
-      const unsigned int level)
+    MGMatrixSimple<MatrixType>::assemble_in
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2,
+     const unsigned int                          level)
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
@@ -962,14 +962,14 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     inline void
-    MGMatrixSimple<MATRIX>::assemble_out(
-      MATRIX &G,
-      const FullMatrix<double> &M,
-      const std::vector<types::global_dof_index> &i1,
-      const std::vector<types::global_dof_index> &i2,
-      const unsigned int level)
+    MGMatrixSimple<MatrixType>::assemble_out
+    (MatrixType                                 &G,
+     const FullMatrix<double>                   &M,
+     const std::vector<types::global_dof_index> &i1,
+     const std::vector<types::global_dof_index> &i2,
+     const unsigned int                          level)
     {
       AssertDimension(M.n(), i1.size());
       AssertDimension(M.m(), i2.size());
@@ -992,10 +992,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     template <class DOFINFO>
     inline void
-    MGMatrixSimple<MATRIX>::assemble(const DOFINFO &info)
+    MGMatrixSimple<MatrixType>::assemble(const DOFINFO &info)
     {
       Assert(info.level_cell, ExcMessage("Cell must access level dofs"));
       const unsigned int level = info.cell->level();
@@ -1032,10 +1032,10 @@ namespace MeshWorker
     }
 
 
-    template <class MATRIX>
+    template <typename MatrixType>
     template <class DOFINFO>
     inline void
-    MGMatrixSimple<MATRIX>::assemble(const DOFINFO &info1,
+    MGMatrixSimple<MatrixType>::assemble(const DOFINFO &info1,
                                      const DOFINFO &info2)
     {
       Assert(info1.level_cell, ExcMessage("Cell must access level dofs"));
@@ -1097,62 +1097,62 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-    template <class MATRIX, typename VectorType>
-    SystemSimple<MATRIX,VectorType>::SystemSimple(double t)
+    template <typename MatrixType, typename VectorType>
+    SystemSimple<MatrixType,VectorType>::SystemSimple(double t)
       :
-      MatrixSimple<MATRIX>(t)
+      MatrixSimple<MatrixType>(t)
     {}
 
 
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     inline void
-    SystemSimple<MATRIX,VectorType>::initialize(MATRIX &m, VectorType &rhs)
+    SystemSimple<MatrixType,VectorType>::initialize(MatrixType &m, VectorType &rhs)
     {
       AnyData data;
       VectorType *p = &rhs;
       data.add(p, "right hand side");
 
-      MatrixSimple<MATRIX>::initialize(m);
+      MatrixSimple<MatrixType>::initialize(m);
       ResidualSimple<VectorType>::initialize(data);
     }
 
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     inline void
-    SystemSimple<MATRIX,VectorType>::initialize(const ConstraintMatrix &c)
+    SystemSimple<MatrixType,VectorType>::initialize(const ConstraintMatrix &c)
     {
-      MatrixSimple<MATRIX>::initialize(c);
+      MatrixSimple<MatrixType>::initialize(c);
       ResidualSimple<VectorType>::initialize(c);
     }
 
 
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VectorType>::initialize_info(DOFINFO &info,
+    SystemSimple<MatrixType,VectorType>::initialize_info(DOFINFO &info,
                                                      bool    face) const
     {
-      MatrixSimple<MATRIX>::initialize_info(info, face);
+      MatrixSimple<MatrixType>::initialize_info(info, face);
       ResidualSimple<VectorType>::initialize_info(info, face);
     }
 
 
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VectorType>::assemble(const DOFINFO &info)
+    SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info)
     {
-      MatrixSimple<MATRIX>::assemble(info);
+      MatrixSimple<MatrixType>::assemble(info);
       ResidualSimple<VectorType>::assemble(info);
     }
 
 
-    template <class MATRIX, typename VectorType>
+    template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
-    SystemSimple<MATRIX,VectorType>::assemble(const DOFINFO &info1,
+    SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info1,
                                               const DOFINFO &info2)
     {
-      MatrixSimple<MATRIX>::assemble(info1, info2);
+      MatrixSimple<MatrixType>::assemble(info1, info2);
       ResidualSimple<VectorType>::assemble(info1, info2);
     }
   }

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -632,9 +632,9 @@ namespace MeshWorker
     template <typename MatrixType>
     inline void
     MatrixSimple<MatrixType>::assemble(const FullMatrix<double> &M,
-                                   const unsigned int index,
-                                   const std::vector<types::global_dof_index> &i1,
-                                   const std::vector<types::global_dof_index> &i2)
+                                       const unsigned int index,
+                                       const std::vector<types::global_dof_index> &i1,
+                                       const std::vector<types::global_dof_index> &i2)
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
@@ -1036,7 +1036,7 @@ namespace MeshWorker
     template <class DOFINFO>
     inline void
     MGMatrixSimple<MatrixType>::assemble(const DOFINFO &info1,
-                                     const DOFINFO &info2)
+                                         const DOFINFO &info2)
     {
       Assert(info1.level_cell, ExcMessage("Cell must access level dofs"));
       Assert(info2.level_cell, ExcMessage("Cell must access level dofs"));
@@ -1129,7 +1129,7 @@ namespace MeshWorker
     template <class DOFINFO>
     inline void
     SystemSimple<MatrixType,VectorType>::initialize_info(DOFINFO &info,
-                                                     bool    face) const
+                                                         bool    face) const
     {
       MatrixSimple<MatrixType>::initialize_info(info, face);
       ResidualSimple<VectorType>::initialize_info(info, face);
@@ -1150,7 +1150,7 @@ namespace MeshWorker
     template <class DOFINFO>
     inline void
     SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info1,
-                                              const DOFINFO &info2)
+                                                  const DOFINFO &info2)
     {
       MatrixSimple<MatrixType>::assemble(info1, info2);
       ResidualSimple<VectorType>::assemble(info1, info2);

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -285,9 +285,9 @@ namespace MeshWorker
    * @ingroup MeshWorker
    * @author Guido Kanschat, 2009
    */
-  template <class VECTOR, int dim, int spacedim = dim>
+  template <typename VectorType, int dim, int spacedim = dim>
   class VectorData :
-    public VectorDataBase<dim, spacedim,typename VECTOR::value_type>
+    public VectorDataBase<dim, spacedim,typename VectorType::value_type>
   {
   public:
     /**
@@ -311,12 +311,12 @@ namespace MeshWorker
      * @note Make sure the VectorSelector base class was filled with
      * reasonable data before calling this function.
      */
-    void initialize(const VECTOR *, const std::string &name);
+    void initialize(const VectorType *, const std::string &name);
 
     virtual void fill(
-      std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
-      std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
-      std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
+      std::vector<std::vector<std::vector<typename VectorType::value_type> > > &values,
+      std::vector<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > &gradients,
+      std::vector<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > &hessians,
       const FEValuesBase<dim,spacedim> &fe,
       const std::vector<types::global_dof_index> &index,
       const unsigned int component,
@@ -325,9 +325,9 @@ namespace MeshWorker
       const unsigned int size) const;
 
     virtual void mg_fill(
-      std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
-      std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
-      std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
+      std::vector<std::vector<std::vector<typename VectorType::value_type> > > &values,
+      std::vector<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > &gradients,
+      std::vector<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > &hessians,
       const FEValuesBase<dim,spacedim> &fe,
       const unsigned int level,
       const std::vector<types::global_dof_index> &index,
@@ -351,9 +351,9 @@ namespace MeshWorker
    * @ingroup MeshWorker
    * @author Guido Kanschat, 2010
    */
-  template <class VECTOR, int dim, int spacedim = dim>
+  template <typename VectorType, int dim, int spacedim = dim>
   class MGVectorData :
-    public VectorData<VECTOR, dim, spacedim>
+    public VectorData<VectorType, dim, spacedim>
   {
   public:
     /**
@@ -378,7 +378,7 @@ namespace MeshWorker
      * @note Make sure the VectorSelector base class was filled with
      * reasonable data before calling this function.
      */
-    void initialize(const MGLevelObject<VECTOR> *, const std::string &name);
+    void initialize(const MGLevelObject<VectorType> *, const std::string &name);
 
 
     /**

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -134,14 +134,14 @@ namespace MeshWorker
     /**
      * Print the contents of the selection to the stream.
      */
-    template <class STREAM, typename DATA>
-    void print (STREAM &s, const AnyData &v) const;
+    template <class StreamType, typename DATA>
+    void print (StreamType &s, const AnyData &v) const;
 
     /**
      * Print the number of selections to the stream.
      */
-    template <class STREAM>
-    void print (STREAM &s) const;
+    template <class StreamType>
+    void print (StreamType &s) const;
 
     /**
      * The memory used by this object.
@@ -496,9 +496,9 @@ namespace MeshWorker
   }
 
 
-  template <class STREAM>
+  template <class StreamType>
   inline void
-  VectorSelector::print(STREAM &s) const
+  VectorSelector::print(StreamType &s) const
   {
     s << "values: " << n_values()
       << " gradients: " << n_gradients()
@@ -507,9 +507,9 @@ namespace MeshWorker
   }
 
 
-  template <class STREAM, typename DATA>
+  template <class StreamType, typename DATA>
   inline void
-  VectorSelector::print(STREAM &s, const AnyData &v) const
+  VectorSelector::print(StreamType &s, const AnyData &v) const
   {
     s << "values:   ";
     for (unsigned int i=0; i<n_values(); ++i)

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -85,43 +85,43 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-  template <class VECTOR, int dim, int spacedim>
-  VectorData<VECTOR, dim, spacedim>::VectorData()
+  template <typename VectorType, int dim, int spacedim>
+  VectorData<VectorType, dim, spacedim>::VectorData()
   {}
 
 
-  template <class VECTOR, int dim, int spacedim>
-  VectorData<VECTOR, dim, spacedim>::VectorData(const VectorSelector &s)
+  template <typename VectorType, int dim, int spacedim>
+  VectorData<VectorType, dim, spacedim>::VectorData(const VectorSelector &s)
     :
-    VectorDataBase<dim, spacedim, typename VECTOR::value_type>(s)
+    VectorDataBase<dim, spacedim, typename VectorType::value_type>(s)
   {}
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  VectorData<VECTOR, dim, spacedim>::initialize(const AnyData &d)
+  VectorData<VectorType, dim, spacedim>::initialize(const AnyData &d)
   {
     this->data = d;
     VectorSelector::initialize(d);
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  VectorData<VECTOR, dim, spacedim>::initialize(const VECTOR *v, const std::string &name)
+  VectorData<VectorType, dim, spacedim>::initialize(const VectorType *v, const std::string &name)
   {
-    SmartPointer<const VECTOR,VectorData<VECTOR, dim, spacedim> > p = v;
+    SmartPointer<const VectorType,VectorData<VectorType, dim, spacedim> > p = v;
     this->data.add(p, name);
     VectorSelector::initialize(this->data);
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  VectorData<VECTOR, dim, spacedim>::fill(
-    std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
-    std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
-    std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
+  VectorData<VectorType, dim, spacedim>::fill(
+    std::vector<std::vector<std::vector<typename VectorType::value_type> > > &values,
+    std::vector<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > &gradients,
+    std::vector<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > &hessians,
     const FEValuesBase<dim,spacedim> &fe,
     const std::vector<types::global_dof_index> &index,
     const unsigned int component,
@@ -136,30 +136,30 @@ namespace MeshWorker
     const AnyData &data = this->data;
     for (unsigned int i=0; i<this->n_values(); ++i)
       {
-        const VECTOR *src = data.read_ptr<VECTOR>(this->value_index(i));
-        VectorSlice<std::vector<std::vector<typename VECTOR::value_type> > > dst(values[i], component, n_comp);
+        const VectorType *src = data.read_ptr<VectorType>(this->value_index(i));
+        VectorSlice<std::vector<std::vector<typename VectorType::value_type> > > dst(values[i], component, n_comp);
         fe.get_function_values(*src, make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_gradients(); ++i)
       {
-        const VECTOR *src = data.read_ptr<VECTOR>(this->gradient_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > dst(gradients[i], component, n_comp);
+        const VectorType *src = data.read_ptr<VectorType>(this->gradient_index(i));
+        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > dst(gradients[i], component, n_comp);
         fe.get_function_gradients(*src, make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_hessians(); ++i)
       {
-        const VECTOR *src = data.read_ptr<VECTOR>(this->hessian_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > dst(hessians[i], component, n_comp);
+        const VectorType *src = data.read_ptr<VectorType>(this->hessian_index(i));
+        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > dst(hessians[i], component, n_comp);
         fe.get_function_hessians(*src, make_slice(index, start, size), dst, true);
       }
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   std::size_t
-  VectorData<VECTOR, dim, spacedim>::memory_consumption () const
+  VectorData<VectorType, dim, spacedim>::memory_consumption () const
   {
     std::size_t mem = VectorSelector::memory_consumption();
     mem += sizeof (this->data);
@@ -168,51 +168,52 @@ namespace MeshWorker
 
 //----------------------------------------------------------------------//
 
-  template <class VECTOR, int dim, int spacedim>
-  MGVectorData<VECTOR, dim, spacedim>::MGVectorData()
+  template <typename VectorType, int dim, int spacedim>
+  MGVectorData<VectorType, dim, spacedim>::MGVectorData()
   {}
 
 
-  template <class VECTOR, int dim, int spacedim>
-  MGVectorData<VECTOR, dim, spacedim>::MGVectorData(const VectorSelector &s)
+  template <typename VectorType, int dim, int spacedim>
+  MGVectorData<VectorType, dim, spacedim>::MGVectorData(const VectorSelector &s)
     :
-    VectorData<VECTOR, dim, spacedim>(s)
+    VectorData<VectorType, dim, spacedim>(s)
   {}
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  MGVectorData<VECTOR, dim, spacedim>::initialize(const AnyData &d)
+  MGVectorData<VectorType, dim, spacedim>::initialize(const AnyData &d)
   {
     this->data = d;
     VectorSelector::initialize(d);
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  MGVectorData<VECTOR, dim, spacedim>::initialize(const MGLevelObject<VECTOR> *v, const std::string &name)
+  MGVectorData<VectorType, dim, spacedim>::initialize(const MGLevelObject<VectorType> *v, const std::string &name)
   {
-    SmartPointer<const MGLevelObject<VECTOR>, MGVectorData<VECTOR, dim, spacedim> >
+    SmartPointer<const MGLevelObject<VectorType>, MGVectorData<VectorType, dim, spacedim> >
     p = v;
     this->data.add(p, name);
     VectorSelector::initialize(this->data);
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  VectorData<VECTOR, dim, spacedim>::mg_fill(
-    std::vector<std::vector<std::vector<typename VECTOR::value_type> > > &values,
-    std::vector<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > &gradients,
-    std::vector<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > &hessians,
-    const FEValuesBase<dim,spacedim> &fe,
-    const unsigned int level,
-    const std::vector<types::global_dof_index> &index,
-    const unsigned int component,
-    const unsigned int n_comp,
-    const unsigned int start,
-    const unsigned int size) const
+  VectorData<VectorType, dim, spacedim>::mg_fill
+  (std::vector<std::vector<std::vector<typename VectorType::value_type> > >                &values,
+   std::vector<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > &gradients,
+   std::vector<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > &hessians,
+   const FEValuesBase<dim,spacedim>           &fe,
+   const unsigned int                         level,
+   const std::vector<types::global_dof_index> &index,
+   const unsigned int                         component,
+   const unsigned int                         n_comp,
+   const unsigned int                         start,
+   const unsigned int                         size)
+  const
   {
     AssertDimension(values.size(), this->n_values());
     AssertDimension(gradients.size(), this->n_gradients());
@@ -221,22 +222,22 @@ namespace MeshWorker
     const AnyData &data = this->data;
     for (unsigned int i=0; i<this->n_values(); ++i)
       {
-        const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<typename VECTOR::value_type> > > dst(values[i], component, n_comp);
+        const MGLevelObject<VectorType> *src = data.read_ptr<MGLevelObject<VectorType> >(this->value_index(i));
+        VectorSlice<std::vector<std::vector<typename VectorType::value_type> > > dst(values[i], component, n_comp);
         fe.get_function_values((*src)[level], make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_gradients(); ++i)
       {
-        const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VECTOR::value_type> > > > dst(gradients[i], component, n_comp);
+        const MGLevelObject<VectorType> *src = data.read_ptr<MGLevelObject<VectorType> >(this->value_index(i));
+        VectorSlice<std::vector<std::vector<Tensor<1,dim,typename VectorType::value_type> > > > dst(gradients[i], component, n_comp);
         fe.get_function_gradients((*src)[level], make_slice(index, start, size), dst, true);
       }
 
     for (unsigned int i=0; i<this->n_hessians(); ++i)
       {
-        const MGLevelObject<VECTOR> *src = data.read_ptr<MGLevelObject<VECTOR> >(this->value_index(i));
-        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VECTOR::value_type> > > > dst(hessians[i], component, n_comp);
+        const MGLevelObject<VectorType> *src = data.read_ptr<MGLevelObject<VectorType> >(this->value_index(i));
+        VectorSlice<std::vector<std::vector<Tensor<2,dim,typename VectorType::value_type> > > > dst(hessians[i], component, n_comp);
         fe.get_function_hessians((*src)[level], make_slice(index, start, size), dst, true);
       }
   }

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -45,7 +45,7 @@ template <typename> class MGLevelObject;
  *
  * @author Guido Kanschat, 2002
  */
-template <class VECTOR>
+template <typename VectorType>
 class MGMatrixBase : public Subscriptor
 {
 public:
@@ -58,29 +58,29 @@ public:
    * Matrix-vector-multiplication on a certain level.
    */
   virtual void vmult (const unsigned int level,
-                      VECTOR &dst,
-                      const VECTOR &src) const = 0;
+                      VectorType         &dst,
+                      const VectorType   &src) const = 0;
 
   /**
    * Adding matrix-vector-multiplication on a certain level.
    */
   virtual void vmult_add (const unsigned int level,
-                          VECTOR &dst,
-                          const VECTOR &src) const = 0;
+                          VectorType         &dst,
+                          const VectorType   &src) const = 0;
 
   /**
    * Transpose matrix-vector-multiplication on a certain level.
    */
   virtual void Tvmult (const unsigned int level,
-                       VECTOR &dst,
-                       const VECTOR &src) const = 0;
+                       VectorType         &dst,
+                       const VectorType   &src) const = 0;
 
   /**
    * Adding transpose matrix-vector-multiplication on a certain level.
    */
   virtual void Tvmult_add (const unsigned int level,
-                           VECTOR &dst,
-                           const VECTOR &src) const = 0;
+                           VectorType         &dst,
+                           const VectorType   &src) const = 0;
 };
 
 
@@ -91,7 +91,7 @@ public:
  *
  * @author Guido Kanschat, 2002
  */
-template <class VECTOR>
+template <typename VectorType>
 class MGCoarseGridBase : public Subscriptor
 {
 public:
@@ -103,9 +103,9 @@ public:
   /**
    * Solution operator.
    */
-  virtual void operator() (const unsigned int   level,
-                           VECTOR       &dst,
-                           const VECTOR &src) const = 0;
+  virtual void operator() (const unsigned int level,
+                           VectorType         &dst,
+                           const VectorType   &src) const = 0;
 };
 
 
@@ -156,7 +156,7 @@ public:
  *
  * @author Wolfgang Bangerth, Guido Kanschat, 1999, 2002, 2007
  */
-template <class VECTOR>
+template <typename VectorType>
 class MGTransferBase : public Subscriptor
 {
 public:
@@ -176,8 +176,8 @@ public:
    * finer level.
    */
   virtual void prolongate (const unsigned int to_level,
-                           VECTOR            &dst,
-                           const VECTOR      &src) const = 0;
+                           VectorType         &dst,
+                           const VectorType   &src) const = 0;
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
@@ -195,8 +195,8 @@ public:
    *
    */
   virtual void restrict_and_add (const unsigned int from_level,
-                                 VECTOR            &dst,
-                                 const VECTOR      &src) const = 0;
+                                 VectorType         &dst,
+                                 const VectorType   &src) const = 0;
 };
 
 
@@ -207,7 +207,7 @@ public:
  *
  * @author Guido Kanschat, 2002
  */
-template <class VECTOR>
+template <typename VectorType>
 class MGSmootherBase : public Subscriptor
 {
 public:
@@ -224,8 +224,8 @@ public:
    * Smoothing function. This is the function used in multigrid methods.
    */
   virtual void smooth (const unsigned int level,
-                       VECTOR            &u,
-                       const VECTOR      &rhs) const = 0;
+                       VectorType         &u,
+                       const VectorType   &rhs) const = 0;
 };
 
 /*@}*/

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -43,7 +43,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 2005
  */
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 class MGSmootherBlock
   : public MGSmootherBase<BlockVector<number> >
 {
@@ -51,18 +51,18 @@ public:
   /**
    * Constructor. Sets memory and smoothing parameters.
    */
-  MGSmootherBlock(VectorMemory<BlockVector<number> > &mem,
-                  const unsigned int steps = 1,
-                  const bool variable = false,
-                  const bool symmetric = false,
-                  const bool transpose = false,
-                  const bool reverse = false);
+  MGSmootherBlock (VectorMemory<BlockVector<number> > &mem,
+                  const unsigned int                   steps     = 1,
+                  const bool                           variable  = false,
+                  const bool                           symmetric = false,
+                  const bool                           transpose = false,
+                  const bool                           reverse   = false);
 
   /**
    * Initialize for matrices. The parameter <tt>matrices</tt> can be any
    * object having functions <tt>get_minlevel()</tt> and
    * <tt>get_maxlevel()</tt> as well as an <tt>operator[]</tt> returning a
-   * reference to @p MATRIX.
+   * reference to @p MatrixType.
    *
    * The same convention is used for the parameter <tt>smoothers</tt>, such
    * that <tt>operator[]</tt> returns the object doing the block-smoothing on
@@ -71,9 +71,9 @@ public:
    * This function stores pointers to the level matrices and smoothing
    * operator for each level.
    */
-  template <class MGMATRIX, class MGRELAX>
-  void initialize (const MGMATRIX &matrices,
-                   const MGRELAX &smoothers);
+  template <class MGMatrixType, class MGRELAX>
+  void initialize (const MGMatrixType &matrices,
+                   const MGRELAX      &smoothers);
 
   /**
    * Empty all vectors.
@@ -117,7 +117,7 @@ private:
   /**
    * Pointer to the matrices.
    */
-  MGLevelObject<PointerMatrix<MATRIX, BlockVector<number> > > matrices;
+  MGLevelObject<PointerMatrix<MatrixType, BlockVector<number> > > matrices;
 
   /**
    * Pointer to the matrices.
@@ -162,15 +162,15 @@ private:
 
 #ifndef DOXYGEN
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline
-MGSmootherBlock<MATRIX, RELAX, number>::MGSmootherBlock(
-  VectorMemory<BlockVector<number> > &mem,
-  const unsigned int steps,
-  const bool variable,
-  const bool symmetric,
-  const bool transpose,
-  const bool reverse)
+MGSmootherBlock<MatrixType, RELAX, number>::MGSmootherBlock
+(VectorMemory<BlockVector<number> > &mem,
+ const unsigned int                  steps,
+ const bool                          variable,
+ const bool                          symmetric,
+ const bool                          transpose,
+ const bool                          reverse)
   :
   steps(steps),
   variable(variable),
@@ -181,9 +181,9 @@ MGSmootherBlock<MATRIX, RELAX, number>::MGSmootherBlock(
 {}
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::clear ()
+MGSmootherBlock<MatrixType, RELAX, number>::clear ()
 {
   unsigned int i=matrices.min_level(),
                max_level=matrices.max_level();
@@ -195,12 +195,11 @@ MGSmootherBlock<MATRIX, RELAX, number>::clear ()
 }
 
 
-template <class MATRIX, class RELAX, typename number>
-template <class MGMATRIX, class MGRELAX>
+template <typename MatrixType, class RELAX, typename number>
+template <class MGMatrixType, class MGRELAX>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::initialize (
-  const MGMATRIX &m,
-  const MGRELAX &s)
+MGSmootherBlock<MatrixType, RELAX, number>::initialize (const MGMatrixType &m,
+                                                        const MGRELAX      &s)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -215,56 +214,55 @@ MGSmootherBlock<MATRIX, RELAX, number>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::
+MGSmootherBlock<MatrixType, RELAX, number>::
 set_steps (const unsigned int s)
 {
   steps = s;
 }
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::
+MGSmootherBlock<MatrixType, RELAX, number>::
 set_variable (const bool flag)
 {
   variable = flag;
 }
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::
+MGSmootherBlock<MatrixType, RELAX, number>::
 set_symmetric (const bool flag)
 {
   symmetric = flag;
 }
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::
+MGSmootherBlock<MatrixType, RELAX, number>::
 set_transpose (const bool flag)
 {
   transpose = flag;
 }
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::
+MGSmootherBlock<MatrixType, RELAX, number>::
 set_reverse (const bool flag)
 {
   reverse = flag;
 }
 
 
-template <class MATRIX, class RELAX, typename number>
+template <typename MatrixType, class RELAX, typename number>
 inline void
-MGSmootherBlock<MATRIX, RELAX, number>::smooth(
-  const unsigned int level,
-  BlockVector<number> &u,
+MGSmootherBlock<MatrixType, RELAX, number>::smooth(const unsigned int   level,
+                                                   BlockVector<number> &u,
   const BlockVector<number> &rhs) const
 {
   deallog.push("Smooth");

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -52,11 +52,11 @@ public:
    * Constructor. Sets memory and smoothing parameters.
    */
   MGSmootherBlock (VectorMemory<BlockVector<number> > &mem,
-                  const unsigned int                   steps     = 1,
-                  const bool                           variable  = false,
-                  const bool                           symmetric = false,
-                  const bool                           transpose = false,
-                  const bool                           reverse   = false);
+                   const unsigned int                   steps     = 1,
+                   const bool                           variable  = false,
+                   const bool                           symmetric = false,
+                   const bool                           transpose = false,
+                   const bool                           reverse   = false);
 
   /**
    * Initialize for matrices. The parameter <tt>matrices</tt> can be any
@@ -263,7 +263,7 @@ template <typename MatrixType, class RELAX, typename number>
 inline void
 MGSmootherBlock<MatrixType, RELAX, number>::smooth(const unsigned int   level,
                                                    BlockVector<number> &u,
-  const BlockVector<number> &rhs) const
+                                                   const BlockVector<number> &rhs) const
 {
   deallog.push("Smooth");
 

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -50,10 +50,10 @@ public:
    * Constructor. Store solver, matrix and preconditioning method for later
    * use.
    */
-  template<typename MatrixType, class PRECOND>
+  template<typename MatrixType, typename PreconditionerType>
   MGCoarseGridLACIteration (SolverType &,
                             const MatrixType &,
-                            const PRECOND &);
+                            const PreconditionerType &);
 
   /**
    * Destructor freeing the pointers.
@@ -63,10 +63,10 @@ public:
   /**
    * Initialize new data.
    */
-  template<typename MatrixType, class PRECOND>
+  template<typename MatrixType, typename PreconditionerType>
   void initialize (SolverType &,
                    const MatrixType &,
-                   const PRECOND &);
+                   const PreconditionerType &);
 
   /**
    * Clear all pointers.
@@ -198,16 +198,16 @@ MGCoarseGridLACIteration<SolverType, VectorType>
 
 
 template<typename SolverType, class VectorType>
-template<typename MatrixType, class PRECOND>
+template<typename MatrixType, typename PreconditionerType>
 MGCoarseGridLACIteration<SolverType, VectorType>
-::MGCoarseGridLACIteration (SolverType       &s,
-                            const MatrixType &m,
-                            const PRECOND    &p)
+::MGCoarseGridLACIteration (SolverType               &s,
+                            const MatrixType         &m,
+                            const PreconditionerType &p)
   :
   solver(&s, typeid(*this).name())
 {
   matrix = new PointerMatrix<MatrixType, VectorType>(&m);
-  precondition = new PointerMatrix<PRECOND, VectorType>(&p);
+  precondition = new PointerMatrix<PreconditionerType, VectorType>(&p);
 }
 
 
@@ -220,12 +220,12 @@ MGCoarseGridLACIteration<SolverType, VectorType>
 
 
 template<typename SolverType, class VectorType>
-template<typename MatrixType, class PRECOND>
+template<typename MatrixType, typename PreconditionerType>
 void
 MGCoarseGridLACIteration<SolverType, VectorType>
-::initialize (SolverType       &s,
-              const MatrixType &m,
-              const PRECOND    &p)
+::initialize (SolverType               &s,
+              const MatrixType         &m,
+              const PreconditionerType &p)
 {
   solver = &s;
   if (matrix)
@@ -233,7 +233,7 @@ MGCoarseGridLACIteration<SolverType, VectorType>
   matrix = new PointerMatrix<MatrixType, VectorType>(&m);
   if (precondition)
     delete precondition;
-  precondition = new PointerMatrix<PRECOND, VectorType>(&p);
+  precondition = new PointerMatrix<PreconditionerType, VectorType>(&p);
 }
 
 

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -32,7 +32,7 @@ DEAL_II_NAMESPACE_OPEN
  * transforming a triplet of iterative solver, matrix and preconditioner into
  * a coarse grid solver.
  *
- * The type of the matrix (i.e. the template parameter @p MATRIX) should be
+ * The type of the matrix (i.e. the template parameter @p MatrixType) should be
  * derived from @p Subscriptor to allow for the use of a smart pointer to it.
  *
  * @author Guido Kanschat, 1999, Ralf Hartmann, 2002.
@@ -50,9 +50,9 @@ public:
    * Constructor. Store solver, matrix and preconditioning method for later
    * use.
    */
-  template<class MATRIX, class PRECOND>
+  template<typename MatrixType, class PRECOND>
   MGCoarseGridLACIteration (SOLVER &,
-                            const MATRIX &,
+                            const MatrixType &,
                             const PRECOND &);
 
   /**
@@ -63,9 +63,9 @@ public:
   /**
    * Initialize new data.
    */
-  template<class MATRIX, class PRECOND>
+  template<typename MatrixType, class PRECOND>
   void initialize (SOLVER &,
-                   const MATRIX &,
+                   const MatrixType &,
                    const PRECOND &);
 
   /**
@@ -85,8 +85,8 @@ public:
    * Sets the matrix. This gives the possibility to replace the matrix that
    * was given to the constructor by a new matrix.
    */
-  template <class MATRIX>
-  void set_matrix (const MATRIX &);
+  template <typename MatrixType>
+  void set_matrix (const MatrixType &);
 
 private:
   /**
@@ -198,15 +198,15 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 
 
 template<class SOLVER, class VectorType>
-template<class MATRIX, class PRECOND>
+template<typename MatrixType, class PRECOND>
 MGCoarseGridLACIteration<SOLVER, VectorType>
-::MGCoarseGridLACIteration(SOLVER &s,
-                           const MATRIX  &m,
-                           const PRECOND &p)
+::MGCoarseGridLACIteration (SOLVER           &s,
+                            const MatrixType &m,
+                            const PRECOND    &p)
   :
   solver(&s, typeid(*this).name())
 {
-  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
+  matrix = new PointerMatrix<MatrixType, VectorType>(&m);
   precondition = new PointerMatrix<PRECOND, VectorType>(&p);
 }
 
@@ -220,17 +220,17 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 
 
 template<class SOLVER, class VectorType>
-template<class MATRIX, class PRECOND>
+template<typename MatrixType, class PRECOND>
 void
 MGCoarseGridLACIteration<SOLVER, VectorType>
-::initialize(SOLVER &s,
-             const MATRIX  &m,
-             const PRECOND &p)
+::initialize (SOLVER           &s,
+              const MatrixType &m,
+              const PRECOND    &p)
 {
   solver = &s;
   if (matrix)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
+  matrix = new PointerMatrix<MatrixType, VectorType>(&m);
   if (precondition)
     delete precondition;
   precondition = new PointerMatrix<PRECOND, VectorType>(&p);
@@ -267,21 +267,21 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 
 
 template<class SOLVER, class VectorType>
-template<class MATRIX>
+template<typename MatrixType>
 void
 MGCoarseGridLACIteration<SOLVER, VectorType>
-::set_matrix(const MATRIX &m)
+::set_matrix(const MatrixType &m)
 {
   if (matrix)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
+  matrix = new PointerMatrix<MatrixType, VectorType>(&m);
 }
 
 //---------------------------------------------------------------------------
 
 template<typename number, class VectorType>
-MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder(
-  const FullMatrix<number> *A)
+MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder
+(const FullMatrix<number> *A)
 {
   if (A != 0) householder.initialize(*A);
 }
@@ -290,8 +290,7 @@ MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder(
 
 template<typename number, class VectorType>
 void
-MGCoarseGridHouseholder<number, VectorType>::initialize(
-  const FullMatrix<number> &A)
+MGCoarseGridHouseholder<number, VectorType>::initialize(const FullMatrix<number> &A)
 {
   householder.initialize(A);
 }
@@ -300,10 +299,9 @@ MGCoarseGridHouseholder<number, VectorType>::initialize(
 
 template<typename number, class VectorType>
 void
-MGCoarseGridHouseholder<number, VectorType>::operator() (
-  const unsigned int /*level*/,
-  VectorType         &dst,
-  const VectorType   &src) const
+MGCoarseGridHouseholder<number, VectorType>::operator() (const unsigned int /*level*/,
+                                                         VectorType         &dst,
+                                                         const VectorType   &src) const
 {
   householder.least_squares(dst, src);
 }
@@ -319,9 +317,8 @@ MGCoarseGridSVD<number, VectorType>::MGCoarseGridSVD()
 
 template<typename number, class VectorType>
 void
-MGCoarseGridSVD<number, VectorType>::initialize(
-  const FullMatrix<number> &A,
-  double threshold)
+MGCoarseGridSVD<number, VectorType>::initialize (const FullMatrix<number> &A,
+                                                 double                    threshold)
 {
   matrix.reinit(A.n_rows(), A.n_cols());
   matrix = A;

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -37,7 +37,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 1999, Ralf Hartmann, 2002.
  */
-template<class SOLVER, class VectorType = Vector<double> >
+template<typename SolverType, class VectorType = Vector<double> >
 class MGCoarseGridLACIteration :  public MGCoarseGridBase<VectorType>
 {
 public:
@@ -51,7 +51,7 @@ public:
    * use.
    */
   template<typename MatrixType, class PRECOND>
-  MGCoarseGridLACIteration (SOLVER &,
+  MGCoarseGridLACIteration (SolverType &,
                             const MatrixType &,
                             const PRECOND &);
 
@@ -64,7 +64,7 @@ public:
    * Initialize new data.
    */
   template<typename MatrixType, class PRECOND>
-  void initialize (SOLVER &,
+  void initialize (SolverType &,
                    const MatrixType &,
                    const PRECOND &);
 
@@ -92,7 +92,7 @@ private:
   /**
    * Reference to the solver.
    */
-  SmartPointer<SOLVER,MGCoarseGridLACIteration<SOLVER,VectorType> > solver;
+  SmartPointer<SolverType,MGCoarseGridLACIteration<SolverType,VectorType> > solver;
 
   /**
    * Reference to the matrix.
@@ -187,8 +187,8 @@ private:
 /* ------------------ Functions for MGCoarseGridLACIteration ------------ */
 
 
-template<class SOLVER, class VectorType>
-MGCoarseGridLACIteration<SOLVER, VectorType>
+template<typename SolverType, class VectorType>
+MGCoarseGridLACIteration<SolverType, VectorType>
 ::MGCoarseGridLACIteration()
   :
   solver(0, typeid(*this).name()),
@@ -197,10 +197,10 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 {}
 
 
-template<class SOLVER, class VectorType>
+template<typename SolverType, class VectorType>
 template<typename MatrixType, class PRECOND>
-MGCoarseGridLACIteration<SOLVER, VectorType>
-::MGCoarseGridLACIteration (SOLVER           &s,
+MGCoarseGridLACIteration<SolverType, VectorType>
+::MGCoarseGridLACIteration (SolverType       &s,
                             const MatrixType &m,
                             const PRECOND    &p)
   :
@@ -211,19 +211,19 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 }
 
 
-template<class SOLVER, class VectorType>
-MGCoarseGridLACIteration<SOLVER, VectorType>
+template<typename SolverType, class VectorType>
+MGCoarseGridLACIteration<SolverType, VectorType>
 ::~MGCoarseGridLACIteration()
 {
   clear();
 }
 
 
-template<class SOLVER, class VectorType>
+template<typename SolverType, class VectorType>
 template<typename MatrixType, class PRECOND>
 void
-MGCoarseGridLACIteration<SOLVER, VectorType>
-::initialize (SOLVER           &s,
+MGCoarseGridLACIteration<SolverType, VectorType>
+::initialize (SolverType       &s,
               const MatrixType &m,
               const PRECOND    &p)
 {
@@ -237,9 +237,9 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 }
 
 
-template<class SOLVER, class VectorType>
+template<typename SolverType, class VectorType>
 void
-MGCoarseGridLACIteration<SOLVER, VectorType>
+MGCoarseGridLACIteration<SolverType, VectorType>
 ::clear()
 {
   solver = 0;
@@ -252,9 +252,9 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 }
 
 
-template<class SOLVER, class VectorType>
+template<typename SolverType, class VectorType>
 void
-MGCoarseGridLACIteration<SOLVER, VectorType>
+MGCoarseGridLACIteration<SolverType, VectorType>
 ::operator() (const unsigned int /* level */,
               VectorType         &dst,
               const VectorType   &src) const
@@ -266,10 +266,10 @@ MGCoarseGridLACIteration<SOLVER, VectorType>
 }
 
 
-template<class SOLVER, class VectorType>
+template<typename SolverType, class VectorType>
 template<typename MatrixType>
 void
-MGCoarseGridLACIteration<SOLVER, VectorType>
+MGCoarseGridLACIteration<SolverType, VectorType>
 ::set_matrix(const MatrixType &m)
 {
   if (matrix)

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -37,8 +37,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 1999, Ralf Hartmann, 2002.
  */
-template<class SOLVER, class VECTOR = Vector<double> >
-class MGCoarseGridLACIteration :  public MGCoarseGridBase<VECTOR>
+template<class SOLVER, class VectorType = Vector<double> >
+class MGCoarseGridLACIteration :  public MGCoarseGridBase<VectorType>
 {
 public:
   /**
@@ -77,9 +77,9 @@ public:
    * Implementation of the abstract function. Calls the solver method with
    * matrix, vectors and preconditioner.
    */
-  void operator() (const unsigned int   level,
-                   VECTOR       &dst,
-                   const VECTOR &src) const;
+  void operator() (const unsigned int level,
+                   VectorType         &dst,
+                   const VectorType   &src) const;
 
   /**
    * Sets the matrix. This gives the possibility to replace the matrix that
@@ -92,17 +92,17 @@ private:
   /**
    * Reference to the solver.
    */
-  SmartPointer<SOLVER,MGCoarseGridLACIteration<SOLVER,VECTOR> > solver;
+  SmartPointer<SOLVER,MGCoarseGridLACIteration<SOLVER,VectorType> > solver;
 
   /**
    * Reference to the matrix.
    */
-  PointerMatrixBase<VECTOR> *matrix;
+  PointerMatrixBase<VectorType> *matrix;
 
   /**
    * Reference to the preconditioner.
    */
-  PointerMatrixBase<VECTOR> *precondition;
+  PointerMatrixBase<VectorType> *precondition;
 };
 
 
@@ -117,8 +117,8 @@ private:
  *
  * @author Guido Kanschat, 2003, 2012
  */
-template<typename number = double, class VECTOR = Vector<number> >
-class MGCoarseGridHouseholder : public MGCoarseGridBase<VECTOR>
+template<typename number = double, class VectorType = Vector<number> >
+class MGCoarseGridHouseholder : public MGCoarseGridBase<VectorType>
 {
 public:
   /**
@@ -131,9 +131,9 @@ public:
    */
   void initialize (const FullMatrix<number> &A);
 
-  void operator() (const unsigned int   level,
-                   VECTOR       &dst,
-                   const VECTOR &src) const;
+  void operator() (const unsigned int level,
+                   VectorType         &dst,
+                   const VectorType   &src) const;
 
 private:
   /**
@@ -150,8 +150,8 @@ private:
  *
  * @author Guido Kanschat, 2003, 2012
  */
-template<typename number = double, class VECTOR = Vector<number> >
-class MGCoarseGridSVD : public MGCoarseGridBase<VECTOR>
+template<typename number = double, class VectorType = Vector<number> >
+class MGCoarseGridSVD : public MGCoarseGridBase<VectorType>
 {
 public:
   /**
@@ -164,9 +164,9 @@ public:
    */
   void initialize (const FullMatrix<number> &A, const double threshold = 0);
 
-  void operator() (const unsigned int   level,
-                   VECTOR       &dst,
-                   const VECTOR &src) const;
+  void operator() (const unsigned int level,
+                   VectorType         &dst,
+                   const VectorType   &src) const;
 
   /**
    * Write the singular values to @p deallog.
@@ -187,8 +187,8 @@ private:
 /* ------------------ Functions for MGCoarseGridLACIteration ------------ */
 
 
-template<class SOLVER, class VECTOR>
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+template<class SOLVER, class VectorType>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::MGCoarseGridLACIteration()
   :
   solver(0, typeid(*this).name()),
@@ -197,32 +197,32 @@ MGCoarseGridLACIteration<SOLVER, VECTOR>
 {}
 
 
-template<class SOLVER, class VECTOR>
+template<class SOLVER, class VectorType>
 template<class MATRIX, class PRECOND>
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::MGCoarseGridLACIteration(SOLVER &s,
                            const MATRIX  &m,
                            const PRECOND &p)
   :
   solver(&s, typeid(*this).name())
 {
-  matrix = new PointerMatrix<MATRIX, VECTOR>(&m);
-  precondition = new PointerMatrix<PRECOND, VECTOR>(&p);
+  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
+  precondition = new PointerMatrix<PRECOND, VectorType>(&p);
 }
 
 
-template<class SOLVER, class VECTOR>
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+template<class SOLVER, class VectorType>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::~MGCoarseGridLACIteration()
 {
   clear();
 }
 
 
-template<class SOLVER, class VECTOR>
+template<class SOLVER, class VectorType>
 template<class MATRIX, class PRECOND>
 void
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::initialize(SOLVER &s,
              const MATRIX  &m,
              const PRECOND &p)
@@ -230,16 +230,16 @@ MGCoarseGridLACIteration<SOLVER, VECTOR>
   solver = &s;
   if (matrix)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VECTOR>(&m);
+  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
   if (precondition)
     delete precondition;
-  precondition = new PointerMatrix<PRECOND, VECTOR>(&p);
+  precondition = new PointerMatrix<PRECOND, VectorType>(&p);
 }
 
 
-template<class SOLVER, class VECTOR>
+template<class SOLVER, class VectorType>
 void
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::clear()
 {
   solver = 0;
@@ -252,12 +252,12 @@ MGCoarseGridLACIteration<SOLVER, VECTOR>
 }
 
 
-template<class SOLVER, class VECTOR>
+template<class SOLVER, class VectorType>
 void
-MGCoarseGridLACIteration<SOLVER, VECTOR>
-::operator() (const unsigned int    /* level */,
-              VECTOR       &dst,
-              const VECTOR &src) const
+MGCoarseGridLACIteration<SOLVER, VectorType>
+::operator() (const unsigned int /* level */,
+              VectorType         &dst,
+              const VectorType   &src) const
 {
   Assert(solver!=0, ExcNotInitialized());
   Assert(matrix!=0, ExcNotInitialized());
@@ -266,21 +266,21 @@ MGCoarseGridLACIteration<SOLVER, VECTOR>
 }
 
 
-template<class SOLVER, class VECTOR>
+template<class SOLVER, class VectorType>
 template<class MATRIX>
 void
-MGCoarseGridLACIteration<SOLVER, VECTOR>
+MGCoarseGridLACIteration<SOLVER, VectorType>
 ::set_matrix(const MATRIX &m)
 {
   if (matrix)
     delete matrix;
-  matrix = new PointerMatrix<MATRIX, VECTOR>(&m);
+  matrix = new PointerMatrix<MATRIX, VectorType>(&m);
 }
 
 //---------------------------------------------------------------------------
 
-template<typename number, class VECTOR>
-MGCoarseGridHouseholder<number, VECTOR>::MGCoarseGridHouseholder(
+template<typename number, class VectorType>
+MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder(
   const FullMatrix<number> *A)
 {
   if (A != 0) householder.initialize(*A);
@@ -288,9 +288,9 @@ MGCoarseGridHouseholder<number, VECTOR>::MGCoarseGridHouseholder(
 
 
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 void
-MGCoarseGridHouseholder<number, VECTOR>::initialize(
+MGCoarseGridHouseholder<number, VectorType>::initialize(
   const FullMatrix<number> &A)
 {
   householder.initialize(A);
@@ -298,28 +298,28 @@ MGCoarseGridHouseholder<number, VECTOR>::initialize(
 
 
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 void
-MGCoarseGridHouseholder<number, VECTOR>::operator() (
+MGCoarseGridHouseholder<number, VectorType>::operator() (
   const unsigned int /*level*/,
-  VECTOR       &dst,
-  const VECTOR &src) const
+  VectorType         &dst,
+  const VectorType   &src) const
 {
   householder.least_squares(dst, src);
 }
 
 //---------------------------------------------------------------------------
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 inline
-MGCoarseGridSVD<number, VECTOR>::MGCoarseGridSVD()
+MGCoarseGridSVD<number, VectorType>::MGCoarseGridSVD()
 {}
 
 
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 void
-MGCoarseGridSVD<number, VECTOR>::initialize(
+MGCoarseGridSVD<number, VectorType>::initialize(
   const FullMatrix<number> &A,
   double threshold)
 {
@@ -329,20 +329,20 @@ MGCoarseGridSVD<number, VECTOR>::initialize(
 }
 
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 void
-MGCoarseGridSVD<number, VECTOR>::operator() (
+MGCoarseGridSVD<number, VectorType>::operator() (
   const unsigned int /*level*/,
-  VECTOR       &dst,
-  const VECTOR &src) const
+  VectorType         &dst,
+  const VectorType   &src) const
 {
   matrix.vmult(dst, src);
 }
 
 
-template<typename number, class VECTOR>
+template<typename number, class VectorType>
 void
-MGCoarseGridSVD<number, VECTOR>::log() const
+MGCoarseGridSVD<number, VectorType>::log() const
 {
   const unsigned int n = std::min(matrix.n_rows(), matrix.n_cols());
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -52,16 +52,16 @@ namespace mg
      * Constructor setting up pointers to the matrices in <tt>M</tt> by
      * calling initialize().
      */
-    template <class MATRIX>
-    Matrix(const MGLevelObject<MATRIX> &M);
+    template <typename MatrixType>
+    Matrix(const MGLevelObject<MatrixType> &M);
 
     /**
      * Initialize the object such that the level multiplication uses the
      * matrices in <tt>M</tt>
      */
-    template <class MATRIX>
+    template <typename MatrixType>
     void
-    initialize(const MGLevelObject<MATRIX> &M);
+    initialize(const MGLevelObject<MatrixType> &M);
 
     /**
      * Access matrix on a level.
@@ -86,7 +86,7 @@ namespace mg
 
 /**
  * Multilevel matrix selecting from block matrices. This class implements the
- * interface defined by MGMatrixBase.  The template parameter @p MATRIX should
+ * interface defined by MGMatrixBase.  The template parameter @p MatrixType should
  * be a block matrix class like BlockSparseMatrix or @p BlockSparseMatrixEZ.
  * Then, this class stores a pointer to a MGLevelObject of this matrix class.
  * In each @p vmult, the block selected on initialization will be multiplied
@@ -94,7 +94,7 @@ namespace mg
  *
  * @author Guido Kanschat, 2002
  */
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 class MGMatrixSelect : public MGMatrixBase<Vector<number> >
 {
 public:
@@ -102,15 +102,15 @@ public:
    * Constructor. @p row and @p col are the coordinate of the selected block.
    * The other argument is handed over to the @p SmartPointer constructor.
    */
-  MGMatrixSelect (const unsigned int row = 0,
-                  const unsigned int col = 0,
-                  MGLevelObject<MATRIX> *matrix = 0);
+  MGMatrixSelect (const unsigned int         row    = 0,
+                  const unsigned int         col    = 0,
+                  MGLevelObject<MatrixType> *matrix = 0);
 
   /**
    * Set the matrix object to be used. The matrix object must exist longer as
    * the @p MGMatrix object, since only a pointer is stored.
    */
-  void set_matrix (MGLevelObject<MATRIX> *M);
+  void set_matrix (MGLevelObject<MatrixType> *M);
 
   /**
    * Select the block for multiplication.
@@ -150,7 +150,7 @@ private:
   /**
    * Pointer to the matrix objects on each level.
    */
-  SmartPointer<MGLevelObject<MATRIX>,MGMatrixSelect<MATRIX,number> > matrix;
+  SmartPointer<MGLevelObject<MatrixType>,MGMatrixSelect<MatrixType,number> > matrix;
   /**
    * Row coordinate of selected block.
    */
@@ -169,10 +169,10 @@ private:
 namespace mg
 {
   template <typename VectorType>
-  template <class MATRIX>
+  template <typename MatrixType>
   inline
   void
-  Matrix<VectorType>::initialize (const MGLevelObject<MATRIX> &p)
+  Matrix<VectorType>::initialize (const MGLevelObject<MatrixType> &p)
   {
     matrices.resize(p.min_level(), p.max_level());
     for (unsigned int level=p.min_level(); level <= p.max_level(); ++level)
@@ -182,9 +182,9 @@ namespace mg
 
 
   template <typename VectorType>
-  template <class MATRIX>
+  template <typename MatrixType>
   inline
-  Matrix<VectorType>::Matrix (const MGLevelObject<MATRIX> &p)
+  Matrix<VectorType>::Matrix (const MGLevelObject<MatrixType> &p)
   {
     initialize(p);
   }
@@ -257,11 +257,11 @@ namespace mg
 
 /*----------------------------------------------------------------------*/
 
-template <class MATRIX, typename number>
-MGMatrixSelect<MATRIX, number>::
-MGMatrixSelect (const unsigned int row,
-                const unsigned int col,
-                MGLevelObject<MATRIX> *p)
+template <typename MatrixType, typename number>
+MGMatrixSelect<MatrixType, number>::
+MGMatrixSelect (const unsigned int         row,
+                const unsigned int         col,
+                MGLevelObject<MatrixType> *p)
   :
   matrix (p, typeid(*this).name()),
   row(row),
@@ -270,17 +270,17 @@ MGMatrixSelect (const unsigned int row,
 
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::set_matrix (MGLevelObject<MATRIX> *p)
+MGMatrixSelect<MatrixType, number>::set_matrix (MGLevelObject<MatrixType> *p)
 {
   matrix = p;
 }
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::
+MGMatrixSelect<MatrixType, number>::
 select_block (const unsigned int brow,
               const unsigned int bcol)
 {
@@ -289,58 +289,58 @@ select_block (const unsigned int brow,
 }
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::
-vmult  (const unsigned int level,
-        Vector<number> &dst,
+MGMatrixSelect<MatrixType, number>::
+vmult  (const unsigned int    level,
+        Vector<number>       &dst,
         const Vector<number> &src) const
 {
   Assert(matrix != 0, ExcNotInitialized());
 
-  const MGLevelObject<MATRIX> &m = *matrix;
+  const MGLevelObject<MatrixType> &m = *matrix;
   m[level].block(row, col).vmult(dst, src);
 }
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::
-vmult_add  (const unsigned int level,
-            Vector<number> &dst,
+MGMatrixSelect<MatrixType, number>::
+vmult_add  (const unsigned int    level,
+            Vector<number>       &dst,
             const Vector<number> &src) const
 {
   Assert(matrix != 0, ExcNotInitialized());
 
-  const MGLevelObject<MATRIX> &m = *matrix;
+  const MGLevelObject<MatrixType> &m = *matrix;
   m[level].block(row, col).vmult_add(dst, src);
 }
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::
-Tvmult  (const unsigned int level,
-         Vector<number> &dst,
+MGMatrixSelect<MatrixType, number>::
+Tvmult  (const unsigned int    level,
+         Vector<number>       &dst,
          const Vector<number> &src) const
 {
   Assert(matrix != 0, ExcNotInitialized());
 
-  const MGLevelObject<MATRIX> &m = *matrix;
+  const MGLevelObject<MatrixType> &m = *matrix;
   m[level].block(row, col).Tvmult(dst, src);
 }
 
 
-template <class MATRIX, typename number>
+template <typename MatrixType, typename number>
 void
-MGMatrixSelect<MATRIX, number>::
-Tvmult_add  (const unsigned int level,
-             Vector<number> &dst,
+MGMatrixSelect<MatrixType, number>::
+Tvmult_add  (const unsigned int    level,
+             Vector<number>       &dst,
              const Vector<number> &src) const
 {
   Assert(matrix != 0, ExcNotInitialized());
 
-  const MGLevelObject<MATRIX> &m = *matrix;
+  const MGLevelObject<MatrixType> &m = *matrix;
   m[level].block(row, col).Tvmult_add(dst, src);
 }
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -38,9 +38,9 @@ namespace mg
    * @author Guido Kanschat
    * @date 2002, 2010
    */
-  template <class VECTOR = Vector<double> >
+  template <typename VectorType = Vector<double> >
   class Matrix
-    : public MGMatrixBase<VECTOR>
+    : public MGMatrixBase<VectorType>
   {
   public:
     /**
@@ -66,19 +66,19 @@ namespace mg
     /**
      * Access matrix on a level.
      */
-    const PointerMatrixBase<VECTOR> &operator[] (unsigned int level) const;
+    const PointerMatrixBase<VectorType> &operator[] (unsigned int level) const;
 
-    virtual void vmult (const unsigned int level, VECTOR &dst, const VECTOR &src) const;
-    virtual void vmult_add (const unsigned int level, VECTOR &dst, const VECTOR &src) const;
-    virtual void Tvmult (const unsigned int level, VECTOR &dst, const VECTOR &src) const;
-    virtual void Tvmult_add (const unsigned int level, VECTOR &dst, const VECTOR &src) const;
+    virtual void vmult (const unsigned int level, VectorType &dst, const VectorType &src) const;
+    virtual void vmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
+    virtual void Tvmult (const unsigned int level, VectorType &dst, const VectorType &src) const;
+    virtual void Tvmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
 
     /**
      * Memory used by this object.
      */
     std::size_t memory_consumption () const;
   private:
-    MGLevelObject<std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > > matrices;
+    MGLevelObject<std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > > matrices;
   };
 
 }
@@ -168,88 +168,87 @@ private:
 
 namespace mg
 {
-  template <class VECTOR>
+  template <typename VectorType>
   template <class MATRIX>
   inline
   void
-  Matrix<VECTOR>::initialize (const MGLevelObject<MATRIX> &p)
+  Matrix<VectorType>::initialize (const MGLevelObject<MATRIX> &p)
   {
     matrices.resize(p.min_level(), p.max_level());
     for (unsigned int level=p.min_level(); level <= p.max_level(); ++level)
-      matrices[level] = std_cxx11::shared_ptr<PointerMatrixBase<VECTOR> > (new_pointer_matrix_base(p[level], VECTOR()));
+      matrices[level] = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> >
+        (new_pointer_matrix_base(p[level], VectorType()));
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   template <class MATRIX>
   inline
-  Matrix<VECTOR>::Matrix (const MGLevelObject<MATRIX> &p)
+  Matrix<VectorType>::Matrix (const MGLevelObject<MATRIX> &p)
   {
     initialize(p);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  Matrix<VECTOR>::Matrix ()
+  Matrix<VectorType>::Matrix ()
   {}
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
-  const PointerMatrixBase<VECTOR> &
-  Matrix<VECTOR>::operator[] (unsigned int level) const
+  const PointerMatrixBase<VectorType> &
+  Matrix<VectorType>::operator[] (unsigned int level) const
   {
     return *matrices[level];
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Matrix<VECTOR>::vmult  (
-    const unsigned int level,
-    VECTOR &dst,
-    const VECTOR &src) const
+  Matrix<VectorType>::vmult (const unsigned int level,
+                             VectorType         &dst,
+                             const VectorType   &src) const
   {
     matrices[level]->vmult(dst, src);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Matrix<VECTOR>::vmult_add  (
-    const unsigned int level,
-    VECTOR &dst,
-    const VECTOR &src) const
+  Matrix<VectorType>::vmult_add (const unsigned int level,
+                                 VectorType         &dst,
+                                 const VectorType   &src) const
   {
     matrices[level]->vmult_add(dst, src);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Matrix<VECTOR>::Tvmult  (const unsigned int level,
-                           VECTOR &dst,
-                           const VECTOR &src) const
+  Matrix<VectorType>::Tvmult (const unsigned int level,
+                              VectorType         &dst,
+                              const VectorType   &src) const
   {
     matrices[level]->Tvmult(dst, src);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  Matrix<VECTOR>::Tvmult_add  (const unsigned int level,
-                               VECTOR &dst,
-                               const VECTOR &src) const
+  Matrix<VectorType>::Tvmult_add (const unsigned int level,
+                                  VectorType         &dst,
+                                  const VectorType   &src) const
   {
     matrices[level]->Tvmult_add(dst, src);
   }
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   inline
   std::size_t
-  Matrix<VECTOR>::memory_consumption () const
+  Matrix<VectorType>::memory_consumption () const
   {
     return sizeof(*this) + matrices->memory_consumption();
   }

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -177,7 +177,7 @@ namespace mg
     matrices.resize(p.min_level(), p.max_level());
     for (unsigned int level=p.min_level(); level <= p.max_level(); ++level)
       matrices[level] = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> >
-        (new_pointer_matrix_base(p[level], VectorType()));
+                        (new_pointer_matrix_base(p[level], VectorType()));
   }
 
 

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -42,8 +42,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat 2009
  */
-template <class VECTOR>
-class MGSmoother : public MGSmootherBase<VECTOR>
+template <typename VectorType>
+class MGSmoother : public MGSmootherBase<VectorType>
 {
 public:
   /**
@@ -88,7 +88,7 @@ protected:
    * The object is marked as mutable since we will need to use it to allocate
    * temporary vectors also in functions that are const.
    */
-  mutable GrowingVectorMemory<VECTOR> vector_memory;
+  mutable GrowingVectorMemory<VectorType> vector_memory;
 
   /**
    * Number of smoothing steps on the finest level. If no #variable smoothing
@@ -129,8 +129,8 @@ protected:
  *
  * @author Guido Kanschat, 1999, 2002
  */
-template <class VECTOR>
-class MGSmootherIdentity : public MGSmootherBase<VECTOR>
+template <typename VectorType>
+class MGSmootherIdentity : public MGSmootherBase<VectorType>
 {
 public:
   /**
@@ -139,8 +139,8 @@ public:
    * that the the smoothing operator equals the null operator.
    */
   virtual void smooth (const unsigned int level,
-                       VECTOR            &u,
-                       const VECTOR      &rhs) const;
+                       VectorType         &u,
+                       const VectorType   &rhs) const;
   virtual void clear ();
 };
 
@@ -152,8 +152,8 @@ namespace mg
    *
    * A relaxation class is an object that has two member functions,
    * @code
-   * void  step(VECTOR& x, const VECTOR& d) const;
-   * void Tstep(VECTOR& x, const VECTOR& d) const;
+   * void  step(VectorType& x, const VectorType& d) const;
+   * void Tstep(VectorType& x, const VectorType& d) const;
    * @endcode
    * performing one step of the smoothing scheme.
    *
@@ -180,8 +180,8 @@ namespace mg
    * @author Guido Kanschat,
    * @date 2003, 2009, 2010
    */
-  template<class RELAX, class VECTOR>
-  class SmootherRelaxation : public MGLevelObject<RELAX>, public MGSmoother<VECTOR>
+  template<class RELAX, typename VectorType>
+  class SmootherRelaxation : public MGLevelObject<RELAX>, public MGSmoother<VectorType>
   {
   public:
     /**
@@ -223,8 +223,8 @@ namespace mg
      * The actual smoothing method.
      */
     virtual void smooth (const unsigned int level,
-                         VECTOR            &u,
-                         const VECTOR      &rhs) const;
+                         VectorType         &u,
+                         const VectorType   &rhs) const;
 
     /**
      * Memory used by this object.
@@ -238,8 +238,8 @@ namespace mg
  *
  * A relaxation class is an object that has two member functions,
  * @code
- * void  step(VECTOR& x, const VECTOR& d) const;
- * void Tstep(VECTOR& x, const VECTOR& d) const;
+ * void  step(VectorType& x, const VectorType& d) const;
+ * void Tstep(VectorType& x, const VectorType& d) const;
  * @endcode
  * performing one step of the smoothing scheme.
  *
@@ -270,8 +270,8 @@ namespace mg
  *
  * @author Guido Kanschat, 2003
  */
-template<class MATRIX, class RELAX, class VECTOR>
-class MGSmootherRelaxation : public MGSmoother<VECTOR>
+template<class MATRIX, class RELAX, typename VectorType>
+class MGSmootherRelaxation : public MGSmoother<VectorType>
 {
 public:
   /**
@@ -345,8 +345,8 @@ public:
    * The actual smoothing method.
    */
   virtual void smooth (const unsigned int level,
-                       VECTOR            &u,
-                       const VECTOR      &rhs) const;
+                       VectorType         &u,
+                       const VectorType   &rhs) const;
 
   /**
    * Object containing relaxation methods.
@@ -363,7 +363,7 @@ private:
   /**
    * Pointer to the matrices.
    */
-  MGLevelObject<PointerMatrix<MATRIX, VECTOR> > matrices;
+  MGLevelObject<PointerMatrix<MATRIX, VectorType> > matrices;
 
 };
 
@@ -399,8 +399,8 @@ private:
  *
  * @author Guido Kanschat, 2009
  */
-template<class MATRIX, class PRECONDITIONER, class VECTOR>
-class MGSmootherPrecondition : public MGSmoother<VECTOR>
+template<class MATRIX, class PRECONDITIONER, typename VectorType>
+class MGSmootherPrecondition : public MGSmoother<VectorType>
 {
 public:
   /**
@@ -474,8 +474,8 @@ public:
    * The actual smoothing method.
    */
   virtual void smooth (const unsigned int level,
-                       VECTOR            &u,
-                       const VECTOR      &rhs) const;
+                       VectorType         &u,
+                       const VectorType   &rhs) const;
 
   /**
    * Object containing relaxation methods.
@@ -492,7 +492,7 @@ private:
   /**
    * Pointer to the matrices.
    */
-  MGLevelObject<PointerMatrix<MATRIX, VECTOR> > matrices;
+  MGLevelObject<PointerMatrix<MATRIX, VectorType> > matrices;
 
 };
 
@@ -502,23 +502,23 @@ private:
 
 #ifndef DOXYGEN
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmootherIdentity<VECTOR>::smooth (
-  const unsigned int, VECTOR &,
-  const VECTOR &) const
+MGSmootherIdentity<VectorType>::smooth (const unsigned int,
+                                        VectorType &,
+                                        const VectorType &) const
 {}
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmootherIdentity<VECTOR>::clear ()
+MGSmootherIdentity<VectorType>::clear ()
 {}
 
 //---------------------------------------------------------------------------
 
-template <class VECTOR>
+template <typename VectorType>
 inline
-MGSmoother<VECTOR>::MGSmoother(
+MGSmoother<VectorType>::MGSmoother(
   const unsigned int steps,
   const bool variable,
   const bool symmetric,
@@ -532,41 +532,41 @@ MGSmoother<VECTOR>::MGSmoother(
 {}
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmoother<VECTOR>::set_steps (const unsigned int s)
+MGSmoother<VectorType>::set_steps (const unsigned int s)
 {
   steps = s;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmoother<VECTOR>::set_debug (const unsigned int s)
+MGSmoother<VectorType>::set_debug (const unsigned int s)
 {
   debug = s;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmoother<VECTOR>::set_variable (const bool flag)
+MGSmoother<VectorType>::set_variable (const bool flag)
 {
   variable = flag;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmoother<VECTOR>::set_symmetric (const bool flag)
+MGSmoother<VectorType>::set_symmetric (const bool flag)
 {
   symmetric = flag;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline void
-MGSmoother<VECTOR>::set_transpose (const bool flag)
+MGSmoother<VectorType>::set_transpose (const bool flag)
 {
   transpose = flag;
 }
@@ -575,29 +575,29 @@ MGSmoother<VECTOR>::set_transpose (const bool flag)
 
 namespace mg
 {
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   inline
-  SmootherRelaxation<RELAX, VECTOR>::SmootherRelaxation(
+  SmootherRelaxation<RELAX, VectorType>::SmootherRelaxation(
     const unsigned int steps,
     const bool variable,
     const bool symmetric,
     const bool transpose)
-    : MGSmoother<VECTOR>(steps, variable, symmetric, transpose)
+    : MGSmoother<VectorType>(steps, variable, symmetric, transpose)
   {}
 
 
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   inline void
-  SmootherRelaxation<RELAX, VECTOR>::clear ()
+  SmootherRelaxation<RELAX, VectorType>::clear ()
   {
     MGLevelObject<RELAX>::clear();
   }
 
 
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   template <class MATRIX2>
   inline void
-  SmootherRelaxation<RELAX, VECTOR>::initialize (
+  SmootherRelaxation<RELAX, VectorType>::initialize (
     const MGLevelObject<MATRIX2> &m,
     const typename RELAX::AdditionalData &data)
   {
@@ -611,10 +611,10 @@ namespace mg
   }
 
 
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   template <class MATRIX2, class DATA>
   inline void
-  SmootherRelaxation<RELAX, VECTOR>::initialize (
+  SmootherRelaxation<RELAX, VectorType>::initialize (
     const MGLevelObject<MATRIX2> &m,
     const MGLevelObject<DATA> &data)
   {
@@ -628,12 +628,11 @@ namespace mg
   }
 
 
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   inline void
-  SmootherRelaxation<RELAX, VECTOR>::smooth(
-    const unsigned int level,
-    VECTOR &u,
-    const VECTOR &rhs) const
+  SmootherRelaxation<RELAX, VectorType>::smooth (const unsigned int level,
+                                                 VectorType         &u,
+                                                 const VectorType   &rhs) const
   {
     unsigned int maxlevel = this->max_level();
     unsigned int steps2 = this->steps;
@@ -659,10 +658,10 @@ namespace mg
   }
 
 
-  template <class RELAX, class VECTOR>
+  template <class RELAX, typename VectorType>
   inline
   std::size_t
-  SmootherRelaxation<RELAX, VECTOR>::
+  SmootherRelaxation<RELAX, VectorType>::
   memory_consumption () const
   {
     return sizeof(*this)
@@ -675,22 +674,22 @@ namespace mg
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 inline
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::MGSmootherRelaxation(
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::MGSmootherRelaxation(
   const unsigned int steps,
   const bool variable,
   const bool symmetric,
   const bool transpose)
   :
-  MGSmoother<VECTOR>(steps, variable, symmetric, transpose)
+  MGSmoother<VectorType>(steps, variable, symmetric, transpose)
 {}
 
 
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::clear ()
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::clear ()
 {
   smoothers.clear();
 
@@ -701,10 +700,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::clear ()
 }
 
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 template <class MATRIX2>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const typename RELAX::AdditionalData &data)
 {
@@ -721,10 +720,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const MGLevelObject<DATA> &data)
 {
@@ -746,10 +745,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const DATA &data,
   const unsigned int row,
@@ -768,10 +767,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const MGLevelObject<DATA> &data,
   const unsigned int row,
@@ -796,12 +795,11 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::initialize (
 }
 
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::smooth(
-  const unsigned int level,
-  VECTOR &u,
-  const VECTOR &rhs) const
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::smooth (const unsigned int level,
+                                                         VectorType         &u,
+                                                         const VectorType   &rhs) const
 {
   unsigned int maxlevel = smoothers.max_level();
   unsigned int steps2 = this->steps;
@@ -828,10 +826,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::smooth(
 
 
 
-template <class MATRIX, class RELAX, class VECTOR>
+template <class MATRIX, class RELAX, typename VectorType>
 inline
 std::size_t
-MGSmootherRelaxation<MATRIX, RELAX, VECTOR>::
+MGSmootherRelaxation<MATRIX, RELAX, VectorType>::
 memory_consumption () const
 {
   return sizeof(*this)
@@ -843,22 +841,22 @@ memory_consumption () const
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 inline
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::MGSmootherPrecondition(
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::MGSmootherPrecondition(
   const unsigned int steps,
   const bool variable,
   const bool symmetric,
   const bool transpose)
   :
-  MGSmoother<VECTOR>(steps, variable, symmetric, transpose)
+  MGSmoother<VectorType>(steps, variable, symmetric, transpose)
 {}
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::clear ()
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::clear ()
 {
   smoothers.clear();
 
@@ -870,10 +868,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::clear ()
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 template <class MATRIX2>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const typename PRECONDITIONER::AdditionalData &data)
 {
@@ -892,10 +890,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const MGLevelObject<DATA> &data)
 {
@@ -919,10 +917,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const DATA &data,
   const unsigned int row,
@@ -943,10 +941,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 template <class MATRIX2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
   const MGLevelObject<MATRIX2> &m,
   const MGLevelObject<DATA> &data,
   const unsigned int row,
@@ -972,12 +970,12 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::smooth(
-  const unsigned int level,
-  VECTOR &u,
-  const VECTOR &rhs) const
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::smooth
+(const unsigned int level,
+ VectorType         &u,
+ const VectorType   &rhs) const
 {
   unsigned int maxlevel = matrices.max_level();
   unsigned int steps2 = this->steps;
@@ -985,8 +983,8 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::smooth(
   if (this->variable)
     steps2 *= (1<<(maxlevel-level));
 
-  typename VectorMemory<VECTOR>::Pointer r(this->vector_memory);
-  typename VectorMemory<VECTOR>::Pointer d(this->vector_memory);
+  typename VectorMemory<VectorType>::Pointer r(this->vector_memory);
+  typename VectorMemory<VectorType>::Pointer d(this->vector_memory);
 
   r->reinit(u,true);
   d->reinit(u,true);
@@ -1043,10 +1041,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::smooth(
 
 
 
-template <class MATRIX, class PRECONDITIONER, class VECTOR>
+template <class MATRIX, class PRECONDITIONER, typename VectorType>
 inline
 std::size_t
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VECTOR>::
+MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::
 memory_consumption () const
 {
   return sizeof(*this)

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -797,8 +797,8 @@ MGSmootherRelaxation<MatrixType, RELAX, VectorType>::initialize
 template <typename MatrixType, class RELAX, typename VectorType>
 inline void
 MGSmootherRelaxation<MatrixType, RELAX, VectorType>::smooth (const unsigned int  level,
-                                                             VectorType         &u,
-                                                             const VectorType   &rhs) const
+    VectorType         &u,
+    const VectorType   &rhs) const
 {
   unsigned int maxlevel = smoothers.max_level();
   unsigned int steps2 = this->steps;

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -199,8 +199,8 @@ namespace mg
      * @p additional_data is an object of type @p RELAX::AdditionalData and is
      * handed to the initialization function of the relaxation method.
      */
-    template <class MATRIX2>
-    void initialize (const MGLevelObject<MATRIX2> &matrices,
+    template <typename MatrixType2>
+    void initialize (const MGLevelObject<MatrixType2>     &matrices,
                      const typename RELAX::AdditionalData &additional_data = typename RELAX::AdditionalData());
 
     /**
@@ -210,9 +210,9 @@ namespace mg
      * common range is utilized. This way, smoothing can be restricted to
      * certain levels even if the matrix was generated for all levels.
      */
-    template <class MATRIX2, class DATA>
-    void initialize (const MGLevelObject<MATRIX2> &matrices,
-                     const MGLevelObject<DATA> &additional_data);
+    template <typename MatrixType2, class DATA>
+    void initialize (const MGLevelObject<MatrixType2> &matrices,
+                     const MGLevelObject<DATA>        &additional_data);
 
     /**
      * Empty all vectors.
@@ -270,7 +270,7 @@ namespace mg
  *
  * @author Guido Kanschat, 2003
  */
-template<class MATRIX, class RELAX, typename VectorType>
+template<typename MatrixType, class RELAX, typename VectorType>
 class MGSmootherRelaxation : public MGSmoother<VectorType>
 {
 public:
@@ -290,8 +290,8 @@ public:
    * @p additional_data is an object of type @p RELAX::AdditionalData and is
    * handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
+  template <typename MatrixType2>
+  void initialize (const MGLevelObject<MatrixType2>     &matrices,
                    const typename RELAX::AdditionalData &additional_data = typename RELAX::AdditionalData());
 
   /**
@@ -302,9 +302,9 @@ public:
    * @p additional_data is an object of type @p RELAX::AdditionalData and is
    * handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const MGLevelObject<DATA> &additional_data);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const MGLevelObject<DATA>        &additional_data);
 
   /**
    * Initialize for single blocks of matrices. Of this block matrix, the block
@@ -315,11 +315,11 @@ public:
    * @p additional_data is an object of type @p RELAX::AdditionalData and is
    * handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const DATA &additional_data,
-                   const unsigned int block_row,
-                   const unsigned int block_col);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const DATA                       &additional_data,
+                   const unsigned int                block_row,
+                   const unsigned int                block_col);
 
   /**
    * Initialize for single blocks of matrices. Of this block matrix, the block
@@ -330,11 +330,11 @@ public:
    * @p additional_data is an object of type @p RELAX::AdditionalData and is
    * handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const MGLevelObject<DATA> &additional_data,
-                   const unsigned int block_row,
-                   const unsigned int block_col);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const MGLevelObject<DATA>        &additional_data,
+                   const unsigned int                block_row,
+                   const unsigned int                block_col);
 
   /**
    * Empty all vectors.
@@ -363,7 +363,7 @@ private:
   /**
    * Pointer to the matrices.
    */
-  MGLevelObject<PointerMatrix<MATRIX, VectorType> > matrices;
+  MGLevelObject<PointerMatrix<MatrixType, VectorType> > matrices;
 
 };
 
@@ -399,7 +399,7 @@ private:
  *
  * @author Guido Kanschat, 2009
  */
-template<class MATRIX, class PRECONDITIONER, typename VectorType>
+template<typename MatrixType, class PRECONDITIONER, typename VectorType>
 class MGSmootherPrecondition : public MGSmoother<VectorType>
 {
 public:
@@ -419,8 +419,8 @@ public:
    * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
+  template <typename MatrixType2>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
                    const typename PRECONDITIONER::AdditionalData &additional_data = typename PRECONDITIONER::AdditionalData());
 
   /**
@@ -431,9 +431,9 @@ public:
    * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const MGLevelObject<DATA> &additional_data);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const MGLevelObject<DATA>        &additional_data);
 
   /**
    * Initialize for single blocks of matrices. Of this block matrix, the block
@@ -444,11 +444,11 @@ public:
    * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const DATA &additional_data,
-                   const unsigned int block_row,
-                   const unsigned int block_col);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const DATA                       &additional_data,
+                   const unsigned int                block_row,
+                   const unsigned int                block_col);
 
   /**
    * Initialize for single blocks of matrices. Of this block matrix, the block
@@ -459,11 +459,11 @@ public:
    * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
-  template <class MATRIX2, class DATA>
-  void initialize (const MGLevelObject<MATRIX2> &matrices,
-                   const MGLevelObject<DATA> &additional_data,
-                   const unsigned int block_row,
-                   const unsigned int block_col);
+  template <typename MatrixType2, class DATA>
+  void initialize (const MGLevelObject<MatrixType2> &matrices,
+                   const MGLevelObject<DATA>        &additional_data,
+                   const unsigned int                block_row,
+                   const unsigned int                block_col);
 
   /**
    * Empty all vectors.
@@ -492,7 +492,7 @@ private:
   /**
    * Pointer to the matrices.
    */
-  MGLevelObject<PointerMatrix<MATRIX, VectorType> > matrices;
+  MGLevelObject<PointerMatrix<MatrixType, VectorType> > matrices;
 
 };
 
@@ -518,11 +518,10 @@ MGSmootherIdentity<VectorType>::clear ()
 
 template <typename VectorType>
 inline
-MGSmoother<VectorType>::MGSmoother(
-  const unsigned int steps,
-  const bool variable,
-  const bool symmetric,
-  const bool transpose)
+MGSmoother<VectorType>::MGSmoother (const unsigned int steps,
+                                    const bool         variable,
+                                    const bool         symmetric,
+                                    const bool         transpose)
   :
   steps(steps),
   variable(variable),
@@ -577,11 +576,11 @@ namespace mg
 {
   template <class RELAX, typename VectorType>
   inline
-  SmootherRelaxation<RELAX, VectorType>::SmootherRelaxation(
-    const unsigned int steps,
-    const bool variable,
-    const bool symmetric,
-    const bool transpose)
+  SmootherRelaxation<RELAX, VectorType>::SmootherRelaxation
+  (const unsigned int steps,
+   const bool         variable,
+   const bool         symmetric,
+   const bool         transpose)
     : MGSmoother<VectorType>(steps, variable, symmetric, transpose)
   {}
 
@@ -595,11 +594,11 @@ namespace mg
 
 
   template <class RELAX, typename VectorType>
-  template <class MATRIX2>
+  template <typename MatrixType2>
   inline void
-  SmootherRelaxation<RELAX, VectorType>::initialize (
-    const MGLevelObject<MATRIX2> &m,
-    const typename RELAX::AdditionalData &data)
+  SmootherRelaxation<RELAX, VectorType>::initialize
+  (const MGLevelObject<MatrixType2>     &m,
+   const typename RELAX::AdditionalData &data)
   {
     const unsigned int min = m.min_level();
     const unsigned int max = m.max_level();
@@ -612,11 +611,11 @@ namespace mg
 
 
   template <class RELAX, typename VectorType>
-  template <class MATRIX2, class DATA>
+  template <typename MatrixType2, class DATA>
   inline void
-  SmootherRelaxation<RELAX, VectorType>::initialize (
-    const MGLevelObject<MATRIX2> &m,
-    const MGLevelObject<DATA> &data)
+  SmootherRelaxation<RELAX, VectorType>::initialize
+  (const MGLevelObject<MatrixType2> &m,
+   const MGLevelObject<DATA>        &data)
   {
     const unsigned int min = std::max(m.min_level(), data.min_level());
     const unsigned int max = std::min(m.max_level(), data.max_level());
@@ -674,22 +673,22 @@ namespace mg
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, class RELAX, typename VectorType>
+template <typename MatrixType, class RELAX, typename VectorType>
 inline
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::MGSmootherRelaxation(
-  const unsigned int steps,
-  const bool variable,
-  const bool symmetric,
-  const bool transpose)
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::MGSmootherRelaxation
+(const unsigned int steps,
+ const bool         variable,
+ const bool         symmetric,
+ const bool         transpose)
   :
   MGSmoother<VectorType>(steps, variable, symmetric, transpose)
 {}
 
 
 
-template <class MATRIX, class RELAX, typename VectorType>
+template <typename MatrixType, class RELAX, typename VectorType>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::clear ()
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::clear ()
 {
   smoothers.clear();
 
@@ -700,12 +699,12 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::clear ()
 }
 
 
-template <class MATRIX, class RELAX, typename VectorType>
-template <class MATRIX2>
+template <typename MatrixType, class RELAX, typename VectorType>
+template <typename MatrixType2>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const typename RELAX::AdditionalData &data)
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::initialize
+(const MGLevelObject<MatrixType2>     &m,
+ const typename RELAX::AdditionalData &data)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -720,12 +719,12 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class RELAX, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const MGLevelObject<DATA> &data)
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const MGLevelObject<DATA>        &data)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -745,14 +744,14 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class RELAX, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const DATA &data,
-  const unsigned int row,
-  const unsigned int col)
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const DATA                       &data,
+ const unsigned int                row,
+ const unsigned int                col)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -767,14 +766,14 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
     }
 }
 
-template <class MATRIX, class RELAX, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class RELAX, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const MGLevelObject<DATA> &data,
-  const unsigned int row,
-  const unsigned int col)
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const MGLevelObject<DATA>        &data,
+ const unsigned int                row,
+ const unsigned int                col)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -795,11 +794,11 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::initialize (
 }
 
 
-template <class MATRIX, class RELAX, typename VectorType>
+template <typename MatrixType, class RELAX, typename VectorType>
 inline void
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::smooth (const unsigned int level,
-                                                         VectorType         &u,
-                                                         const VectorType   &rhs) const
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::smooth (const unsigned int  level,
+                                                             VectorType         &u,
+                                                             const VectorType   &rhs) const
 {
   unsigned int maxlevel = smoothers.max_level();
   unsigned int steps2 = this->steps;
@@ -826,10 +825,10 @@ MGSmootherRelaxation<MATRIX, RELAX, VectorType>::smooth (const unsigned int leve
 
 
 
-template <class MATRIX, class RELAX, typename VectorType>
+template <typename MatrixType, class RELAX, typename VectorType>
 inline
 std::size_t
-MGSmootherRelaxation<MATRIX, RELAX, VectorType>::
+MGSmootherRelaxation<MatrixType, RELAX, VectorType>::
 memory_consumption () const
 {
   return sizeof(*this)
@@ -841,22 +840,22 @@ memory_consumption () const
 
 //----------------------------------------------------------------------//
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
 inline
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::MGSmootherPrecondition(
-  const unsigned int steps,
-  const bool variable,
-  const bool symmetric,
-  const bool transpose)
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::MGSmootherPrecondition
+(const unsigned int steps,
+ const bool         variable,
+ const bool         symmetric,
+ const bool         transpose)
   :
   MGSmoother<VectorType>(steps, variable, symmetric, transpose)
 {}
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::clear ()
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::clear ()
 {
   smoothers.clear();
 
@@ -868,12 +867,12 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::clear ()
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
-template <class MATRIX2>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType2>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const typename PRECONDITIONER::AdditionalData &data)
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+(const MGLevelObject<MatrixType2>              &m,
+ const typename PRECONDITIONER::AdditionalData &data)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -890,12 +889,12 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const MGLevelObject<DATA> &data)
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const MGLevelObject<DATA>        &data)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -917,14 +916,14 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const DATA &data,
-  const unsigned int row,
-  const unsigned int col)
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const DATA                       &data,
+ const unsigned int                row,
+ const unsigned int                col)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -941,14 +940,14 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
-template <class MATRIX2, class DATA>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
-  const MGLevelObject<MATRIX2> &m,
-  const MGLevelObject<DATA> &data,
-  const unsigned int row,
-  const unsigned int col)
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+(const MGLevelObject<MatrixType2> &m,
+ const MGLevelObject<DATA>        &data,
+ const unsigned int                row,
+ const unsigned int                col)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -970,9 +969,9 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::initialize (
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
 inline void
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::smooth
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::smooth
 (const unsigned int level,
  VectorType         &u,
  const VectorType   &rhs) const
@@ -1041,10 +1040,10 @@ MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::smooth
 
 
 
-template <class MATRIX, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, class PRECONDITIONER, typename VectorType>
 inline
 std::size_t
-MGSmootherPrecondition<MATRIX, PRECONDITIONER, VectorType>::
+MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::
 memory_consumption () const
 {
   return sizeof(*this)

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -399,7 +399,7 @@ private:
  *
  * @author Guido Kanschat, 2009
  */
-template<typename MatrixType, class PRECONDITIONER, typename VectorType>
+template<typename MatrixType, typename PreconditionerType, typename VectorType>
 class MGSmootherPrecondition : public MGSmoother<VectorType>
 {
 public:
@@ -416,19 +416,19 @@ public:
    * matrices and initializes the smoothing operator with the same smoother
    * for each level.
    *
-   * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
+   * @p additional_data is an object of type @p PreconditionerType::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
   template <typename MatrixType2>
   void initialize (const MGLevelObject<MatrixType2> &matrices,
-                   const typename PRECONDITIONER::AdditionalData &additional_data = typename PRECONDITIONER::AdditionalData());
+                   const typename PreconditionerType::AdditionalData &additional_data = typename PreconditionerType::AdditionalData());
 
   /**
    * Initialize for matrices. This function stores pointers to the level
    * matrices and initializes the smoothing operator with the according
    * smoother for each level.
    *
-   * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
+   * @p additional_data is an object of type @p PreconditionerType::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
   template <typename MatrixType2, class DATA>
@@ -441,7 +441,7 @@ public:
    * This function stores pointers to the level matrices and initializes the
    * smoothing operator with the same smoother for each level.
    *
-   * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
+   * @p additional_data is an object of type @p PreconditionerType::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
   template <typename MatrixType2, class DATA>
@@ -456,7 +456,7 @@ public:
    * This function stores pointers to the level matrices and initializes the
    * smoothing operator with the according smoother for each level.
    *
-   * @p additional_data is an object of type @p PRECONDITIONER::AdditionalData
+   * @p additional_data is an object of type @p PreconditionerType::AdditionalData
    * and is handed to the initialization function of the relaxation method.
    */
   template <typename MatrixType2, class DATA>
@@ -480,7 +480,7 @@ public:
   /**
    * Object containing relaxation methods.
    */
-  MGLevelObject<PRECONDITIONER> smoothers;
+  MGLevelObject<PreconditionerType> smoothers;
 
   /**
    * Memory used by this object.
@@ -840,9 +840,9 @@ memory_consumption () const
 
 //----------------------------------------------------------------------//
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 inline
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::MGSmootherPrecondition
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::MGSmootherPrecondition
 (const unsigned int steps,
  const bool         variable,
  const bool         symmetric,
@@ -853,9 +853,9 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::MGSmootherPrecon
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::clear ()
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::clear ()
 {
   smoothers.clear();
 
@@ -867,12 +867,12 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::clear ()
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 template <typename MatrixType2>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::initialize
 (const MGLevelObject<MatrixType2>              &m,
- const typename PRECONDITIONER::AdditionalData &data)
+ const typename PreconditionerType::AdditionalData &data)
 {
   const unsigned int min = m.min_level();
   const unsigned int max = m.max_level();
@@ -889,10 +889,10 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::initialize
 (const MGLevelObject<MatrixType2> &m,
  const MGLevelObject<DATA>        &data)
 {
@@ -916,10 +916,10 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::initialize
 (const MGLevelObject<MatrixType2> &m,
  const DATA                       &data,
  const unsigned int                row,
@@ -940,10 +940,10 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 template <typename MatrixType2, class DATA>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::initialize
 (const MGLevelObject<MatrixType2> &m,
  const MGLevelObject<DATA>        &data,
  const unsigned int                row,
@@ -969,9 +969,9 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::initialize
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 inline void
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::smooth
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::smooth
 (const unsigned int level,
  VectorType         &u,
  const VectorType   &rhs) const
@@ -1040,10 +1040,10 @@ MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::smooth
 
 
 
-template <typename MatrixType, class PRECONDITIONER, typename VectorType>
+template <typename MatrixType, typename PreconditionerType, typename VectorType>
 inline
 std::size_t
-MGSmootherPrecondition<MatrixType, PRECONDITIONER, VectorType>::
+MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::
 memory_consumption () const
 {
   return sizeof(*this)

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -43,11 +43,11 @@ template <int dim, int spacedim> class DoFHandler;
 
 namespace internal
 {
-  template <class VECTOR>
+  template <typename VectorType>
   struct MatrixSelector
   {
     typedef ::dealii::SparsityPattern Sparsity;
-    typedef ::dealii::SparseMatrix<typename VECTOR::value_type> Matrix;
+    typedef ::dealii::SparseMatrix<typename VectorType::value_type> Matrix;
 
     template <class DSP, class DH>
     static void reinit(Matrix &matrix, Sparsity &sparsity, int level, const DSP &dsp, const DH &)
@@ -124,8 +124,8 @@ namespace internal
  * @author Wolfgang Bangerth, Guido Kanschat
  * @date 1999, 2000, 2001, 2002, 2003, 2004, 2012
  */
-template <class VECTOR>
-class MGTransferPrebuilt : public MGTransferBase<VECTOR>
+template <typename VectorType>
+class MGTransferPrebuilt : public MGTransferBase<VectorType>
 {
 public:
   /**
@@ -161,13 +161,13 @@ public:
   template <int dim, int spacedim>
   void build_matrices (const DoFHandler<dim,spacedim> &mg_dof);
 
-  virtual void prolongate (const unsigned int    to_level,
-                           VECTOR       &dst,
-                           const VECTOR &src) const;
+  virtual void prolongate (const unsigned int to_level,
+                           VectorType         &dst,
+                           const VectorType   &src) const;
 
-  virtual void restrict_and_add (const unsigned int    from_level,
-                                 VECTOR       &dst,
-                                 const VECTOR &src) const;
+  virtual void restrict_and_add (const unsigned int from_level,
+                                 VectorType         &dst,
+                                 const VectorType   &src) const;
 
   /**
    * Transfer from a vector on the global grid to vectors defined on each of
@@ -176,8 +176,8 @@ public:
   template <int dim, class InVector, int spacedim>
   void
   copy_to_mg (const DoFHandler<dim,spacedim> &mg_dof,
-              MGLevelObject<VECTOR> &dst,
-              const InVector &src) const;
+              MGLevelObject<VectorType>      &dst,
+              const InVector                 &src) const;
 
   /**
    * Transfer from multi-level vector to normal vector.
@@ -188,9 +188,9 @@ public:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  copy_from_mg (const DoFHandler<dim,spacedim> &mg_dof,
-                OutVector &dst,
-                const MGLevelObject<VECTOR> &src) const;
+  copy_from_mg (const DoFHandler<dim,spacedim>  &mg_dof,
+                OutVector                       &dst,
+                const MGLevelObject<VectorType> &src) const;
 
   /**
    * Add a multi-level vector to a normal vector.
@@ -199,9 +199,9 @@ public:
    */
   template <int dim, class OutVector, int spacedim>
   void
-  copy_from_mg_add (const DoFHandler<dim,spacedim> &mg_dof,
-                    OutVector &dst,
-                    const MGLevelObject<VECTOR> &src) const;
+  copy_from_mg_add (const DoFHandler<dim,spacedim>  &mg_dof,
+                    OutVector                       &dst,
+                    const MGLevelObject<VectorType> &src) const;
 
   /**
    * If this object operates on BlockVector objects, we need to describe how
@@ -262,14 +262,14 @@ private:
   /**
    * Sparsity patterns for transfer matrices.
    */
-  std::vector<std_cxx11::shared_ptr<typename internal::MatrixSelector<VECTOR>::Sparsity> >   prolongation_sparsities;
+  std::vector<std_cxx11::shared_ptr<typename internal::MatrixSelector<VectorType>::Sparsity> > prolongation_sparsities;
 
   /**
    * The actual prolongation matrix.  column indices belong to the dof indices
    * of the mother cell, i.e. the coarse level.  while row indices belong to
    * the child cell, i.e. the fine level.
    */
-  std::vector<std_cxx11::shared_ptr<typename internal::MatrixSelector<VECTOR>::Matrix> > prolongation_matrices;
+  std::vector<std_cxx11::shared_ptr<typename internal::MatrixSelector<VectorType>::Matrix> > prolongation_matrices;
 
   /**
    * Mapping for the copy_to_mg() and copy_from_mg() functions. Here only
@@ -316,12 +316,12 @@ private:
   /**
    * The constraints of the global system.
    */
-  SmartPointer<const ConstraintMatrix, MGTransferPrebuilt<VECTOR> > constraints;
+  SmartPointer<const ConstraintMatrix, MGTransferPrebuilt<VectorType> > constraints;
   /**
    * The mg_constrained_dofs of the level systems.
    */
 
-  SmartPointer<const MGConstrainedDoFs, MGTransferPrebuilt<VECTOR> > mg_constrained_dofs;
+  SmartPointer<const MGConstrainedDoFs, MGTransferPrebuilt<VectorType> > mg_constrained_dofs;
 };
 
 

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -170,8 +170,8 @@ template <int dim, class InVector, int spacedim>
 void
 MGTransferPrebuilt<VectorType>::copy_to_mg
 (const DoFHandler<dim,spacedim> &mg_dof_handler,
-  MGLevelObject<VectorType>     &dst,
-  const InVector                &src) const
+ MGLevelObject<VectorType>     &dst,
+ const InVector                &src) const
 {
   reinit_vector(mg_dof_handler, component_to_block_map, dst);
   bool first = true;

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -165,13 +165,13 @@ namespace
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <int dim, class InVector, int spacedim>
 void
-MGTransferPrebuilt<VECTOR>::copy_to_mg (
-  const DoFHandler<dim,spacedim> &mg_dof_handler,
-  MGLevelObject<VECTOR> &dst,
-  const InVector &src) const
+MGTransferPrebuilt<VectorType>::copy_to_mg
+(const DoFHandler<dim,spacedim> &mg_dof_handler,
+  MGLevelObject<VectorType>     &dst,
+  const InVector                &src) const
 {
   reinit_vector(mg_dof_handler, component_to_block_map, dst);
   bool first = true;
@@ -182,7 +182,7 @@ MGTransferPrebuilt<VECTOR>::copy_to_mg (
   for (unsigned int level=mg_dof_handler.get_tria().n_global_levels(); level != 0;)
     {
       --level;
-      VECTOR &dst_level = dst[level];
+      VectorType &dst_level = dst[level];
 
 #ifdef DEBUG_OUTPUT
       MPI_Barrier(MPI_COMM_WORLD);
@@ -222,13 +222,13 @@ MGTransferPrebuilt<VECTOR>::copy_to_mg (
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <int dim, class OutVector, int spacedim>
 void
-MGTransferPrebuilt<VECTOR>::copy_from_mg(
-  const DoFHandler<dim,spacedim>       &mg_dof_handler,
-  OutVector                     &dst,
-  const MGLevelObject<VECTOR> &src) const
+MGTransferPrebuilt<VectorType>::copy_from_mg
+(const DoFHandler<dim,spacedim>  &mg_dof_handler,
+ OutVector                       &dst,
+ const MGLevelObject<VectorType> &src) const
 {
   // For non-DG: degrees of
   // freedom in the refinement
@@ -276,13 +276,13 @@ MGTransferPrebuilt<VECTOR>::copy_from_mg(
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <int dim, class OutVector, int spacedim>
 void
-MGTransferPrebuilt<VECTOR>::copy_from_mg_add (
-  const DoFHandler<dim,spacedim> &mg_dof_handler,
-  OutVector                            &dst,
-  const MGLevelObject<VECTOR> &src) const
+MGTransferPrebuilt<VectorType>::copy_from_mg_add
+(const DoFHandler<dim,spacedim>  &mg_dof_handler,
+ OutVector                       &dst,
+ const MGLevelObject<VectorType> &src) const
 {
   // For non-DG: degrees of
   // freedom in the refinement
@@ -311,17 +311,17 @@ MGTransferPrebuilt<VECTOR>::copy_from_mg_add (
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-MGTransferPrebuilt<VECTOR>::
+MGTransferPrebuilt<VectorType>::
 set_component_to_block_map (const std::vector<unsigned int> &map)
 {
   component_to_block_map = map;
 }
 
-template <class VECTOR>
+template <typename VectorType>
 std::size_t
-MGTransferPrebuilt<VECTOR>::memory_consumption () const
+MGTransferPrebuilt<VectorType>::memory_consumption () const
 {
   std::size_t result = sizeof(*this);
   result += sizeof(unsigned int) * sizes.size();

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -330,7 +330,7 @@ private:
    */
   unsigned int debug;
 
-  template<int dim, class VECTOR2, class TRANSFER> friend class PreconditionMG;
+  template<int dim, class OtherVectorType, class TRANSFER> friend class PreconditionMG;
 };
 
 
@@ -368,35 +368,35 @@ public:
    *
    * This is the operator used by LAC iterative solvers.
    */
-  template<class VECTOR2>
-  void vmult (VECTOR2       &dst,
-              const VECTOR2 &src) const;
+  template<class OtherVectorType>
+  void vmult (OtherVectorType       &dst,
+              const OtherVectorType &src) const;
 
   /**
    * Preconditioning operator. Calls the @p vcycle function of the @p MG
    * object passed to the constructor.
    */
-  template<class VECTOR2>
-  void vmult_add (VECTOR2       &dst,
-                  const VECTOR2 &src) const;
+  template<class OtherVectorType>
+  void vmult_add (OtherVectorType       &dst,
+                  const OtherVectorType &src) const;
 
   /**
    * Tranposed preconditioning operator.
    *
    * Not implemented, but the definition may be needed.
    */
-  template<class VECTOR2>
-  void Tvmult (VECTOR2       &dst,
-               const VECTOR2 &src) const;
+  template<class OtherVectorType>
+  void Tvmult (OtherVectorType       &dst,
+               const OtherVectorType &src) const;
 
   /**
    * Tranposed preconditioning operator.
    *
    * Not implemented, but the definition may be needed.
    */
-  template<class VECTOR2>
-  void Tvmult_add (VECTOR2       &dst,
-                   const VECTOR2 &src) const;
+  template<class OtherVectorType>
+  void Tvmult_add (OtherVectorType       &dst,
+                   const OtherVectorType &src) const;
 
 private:
   /**
@@ -491,11 +491,11 @@ PreconditionMG<dim, VectorType, TRANSFER>::empty () const
 }
 
 template<int dim, typename VectorType, class TRANSFER>
-template<class VECTOR2>
+template<class OtherVectorType>
 void
-PreconditionMG<dim, VectorType, TRANSFER>::vmult (
-  VECTOR2 &dst,
-  const VECTOR2 &src) const
+PreconditionMG<dim, VectorType, TRANSFER>::vmult
+(OtherVectorType       &dst,
+ const OtherVectorType &src) const
 {
   transfer->copy_to_mg(*dof_handler,
                        multigrid->defect,
@@ -509,11 +509,11 @@ PreconditionMG<dim, VectorType, TRANSFER>::vmult (
 
 
 template<int dim, typename VectorType, class TRANSFER>
-template<class VECTOR2>
+template<class OtherVectorType>
 void
-PreconditionMG<dim, VectorType, TRANSFER>::vmult_add (
-  VECTOR2 &dst,
-  const VECTOR2 &src) const
+PreconditionMG<dim, VectorType, TRANSFER>::vmult_add
+(OtherVectorType       &dst,
+ const OtherVectorType &src) const
 {
   transfer->copy_to_mg(*dof_handler,
                        multigrid->defect,
@@ -526,22 +526,22 @@ PreconditionMG<dim, VectorType, TRANSFER>::vmult_add (
 
 
 template<int dim, typename VectorType, class TRANSFER>
-template<class VECTOR2>
+template<class OtherVectorType>
 void
-PreconditionMG<dim, VectorType, TRANSFER>::Tvmult (
-  VECTOR2 &,
-  const VECTOR2 &) const
+PreconditionMG<dim, VectorType, TRANSFER>::Tvmult
+(OtherVectorType       &,
+ const OtherVectorType &) const
 {
   Assert(false, ExcNotImplemented());
 }
 
 
 template<int dim, typename VectorType, class TRANSFER>
-template<class VECTOR2>
+template<class OtherVectorType>
 void
-PreconditionMG<dim, VectorType, TRANSFER>::Tvmult_add (
-  VECTOR2 &,
-  const VECTOR2 &) const
+PreconditionMG<dim, VectorType, TRANSFER>::Tvmult_add
+(OtherVectorType       &,
+ const OtherVectorType &) const
 {
   Assert(false, ExcNotImplemented());
 }

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -60,7 +60,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Guido Kanschat, 1999 - 2005
  */
-template <class VECTOR>
+template <typename VectorType>
 class Multigrid : public Subscriptor
 {
 public:
@@ -77,8 +77,8 @@ public:
     f_cycle
   };
 
-  typedef VECTOR vector_type;
-  typedef const VECTOR const_vector_type;
+  typedef VectorType vector_type;
+  typedef const VectorType const_vector_type;
 
   /**
    * Constructor. The DoFHandler is used to determine the highest possible
@@ -90,27 +90,27 @@ public:
    * this type as late as possible.
    */
   template <int dim>
-  Multigrid(const DoFHandler<dim> &mg_dof_handler,
-            const MGMatrixBase<VECTOR> &matrix,
-            const MGCoarseGridBase<VECTOR> &coarse,
-            const MGTransferBase<VECTOR> &transfer,
-            const MGSmootherBase<VECTOR> &pre_smooth,
-            const MGSmootherBase<VECTOR> &post_smooth,
-            Cycle cycle = v_cycle);
+  Multigrid(const DoFHandler<dim>              &mg_dof_handler,
+            const MGMatrixBase<VectorType>     &matrix,
+            const MGCoarseGridBase<VectorType> &coarse,
+            const MGTransferBase<VectorType>   &transfer,
+            const MGSmootherBase<VectorType>   &pre_smooth,
+            const MGSmootherBase<VectorType>   &post_smooth,
+            Cycle                              cycle = v_cycle);
 
   /**
    * Experimental constructor for cases in which no DoFHandler is available.
    *
    * @warning Not intended for general use.
    */
-  Multigrid(const unsigned int minlevel,
-            const unsigned int maxlevel,
-            const MGMatrixBase<VECTOR> &matrix,
-            const MGCoarseGridBase<VECTOR> &coarse,
-            const MGTransferBase<VECTOR> &transfer,
-            const MGSmootherBase<VECTOR> &pre_smooth,
-            const MGSmootherBase<VECTOR> &post_smooth,
-            Cycle cycle = v_cycle);
+  Multigrid(const unsigned int                 minlevel,
+            const unsigned int                 maxlevel,
+            const MGMatrixBase<VectorType>     &matrix,
+            const MGCoarseGridBase<VectorType> &coarse,
+            const MGTransferBase<VectorType>   &transfer,
+            const MGSmootherBase<VectorType>   &pre_smooth,
+            const MGSmootherBase<VectorType>   &post_smooth,
+            Cycle                              cycle = v_cycle);
 
   /**
    * Reinit this class according to #minlevel and #maxlevel.
@@ -148,8 +148,8 @@ public:
    * <tt>edge_in</tt>. In particular, for symmetric operators, both arguments
    * can refer to the same matrix, saving assembling of one of them.
    */
-  void set_edge_matrices (const MGMatrixBase<VECTOR> &edge_out,
-                          const MGMatrixBase<VECTOR> &edge_in);
+  void set_edge_matrices (const MGMatrixBase<VectorType> &edge_out,
+                          const MGMatrixBase<VectorType> &edge_in);
 
   /**
    * Set additional matrices to correct residual computation at refinement
@@ -163,8 +163,8 @@ public:
    * <tt>edge_up</tt>. In particular, for symmetric operators, both arguments
    * can refer to the same matrix, saving assembling of one of them.
    */
-  void set_edge_flux_matrices (const MGMatrixBase<VECTOR> &edge_down,
-                               const MGMatrixBase<VECTOR> &edge_up);
+  void set_edge_flux_matrices (const MGMatrixBase<VectorType> &edge_down,
+                               const MGMatrixBase<VectorType> &edge_up);
 
   /**
    * Return the finest level for multigrid.
@@ -252,56 +252,56 @@ public:
    * Input vector for the cycle. Contains the defect of the outer method
    * projected to the multilevel vectors.
    */
-  MGLevelObject<VECTOR> defect;
+  MGLevelObject<VectorType> defect;
 
   /**
    * The solution update after the multigrid step.
    */
-  MGLevelObject<VECTOR> solution;
+  MGLevelObject<VectorType> solution;
 
 private:
   /**
    * Auxiliary vector.
    */
-  MGLevelObject<VECTOR> t;
+  MGLevelObject<VectorType> t;
 
   /**
    * Auxiliary vector for W- and F-cycles. Left uninitialized in V-cycle.
    */
-  MGLevelObject<VECTOR> defect2;
+  MGLevelObject<VectorType> defect2;
 
 
   /**
    * The matrix for each level.
    */
-  SmartPointer<const MGMatrixBase<VECTOR>,Multigrid<VECTOR> > matrix;
+  SmartPointer<const MGMatrixBase<VectorType>,Multigrid<VectorType> > matrix;
 
   /**
    * The matrix for each level.
    */
-  SmartPointer<const MGCoarseGridBase<VECTOR>,Multigrid<VECTOR> > coarse;
+  SmartPointer<const MGCoarseGridBase<VectorType>,Multigrid<VectorType> > coarse;
 
   /**
    * Object for grid tranfer.
    */
-  SmartPointer<const MGTransferBase<VECTOR>,Multigrid<VECTOR> > transfer;
+  SmartPointer<const MGTransferBase<VectorType>,Multigrid<VectorType> > transfer;
 
   /**
    * The pre-smoothing object.
    */
-  SmartPointer<const MGSmootherBase<VECTOR>,Multigrid<VECTOR> > pre_smooth;
+  SmartPointer<const MGSmootherBase<VectorType>,Multigrid<VectorType> > pre_smooth;
 
   /**
    * The post-smoothing object.
    */
-  SmartPointer<const MGSmootherBase<VECTOR>,Multigrid<VECTOR> > post_smooth;
+  SmartPointer<const MGSmootherBase<VectorType>,Multigrid<VectorType> > post_smooth;
 
   /**
    * Edge matrix from the interior of the refined part to the refinement edge.
    *
    * @note Only <tt>vmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VECTOR> > edge_out;
+  SmartPointer<const MGMatrixBase<VectorType> > edge_out;
 
   /**
    * Transpose edge matrix from the refinement edge to the interior of the
@@ -309,21 +309,21 @@ private:
    *
    * @note Only <tt>Tvmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VECTOR> > edge_in;
+  SmartPointer<const MGMatrixBase<VectorType> > edge_in;
 
   /**
    * Edge matrix from fine to coarse.
    *
    * @note Only <tt>vmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VECTOR>,Multigrid<VECTOR> > edge_down;
+  SmartPointer<const MGMatrixBase<VectorType>,Multigrid<VectorType> > edge_down;
 
   /**
    * Transpose edge matrix from coarse to fine.
    *
    * @note Only <tt>Tvmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VECTOR>,Multigrid<VECTOR> > edge_up;
+  SmartPointer<const MGMatrixBase<VectorType>,Multigrid<VectorType> > edge_up;
 
   /**
    * Level for debug output. Defaults to zero and can be set by set_debug().
@@ -339,13 +339,13 @@ private:
  * multi-level preconditioning and provide the standard interface for LAC
  * iterative methods.
  *
- * Furthermore, it needs functions <tt>void copy_to_mg(const VECTOR&)</tt> to
+ * Furthermore, it needs functions <tt>void copy_to_mg(const VectorType&)</tt> to
  * store @p src in the right hand side of the multi-level method and <tt>void
- * copy_from_mg(VECTOR&)</tt> to store the result of the v-cycle in @p dst.
+ * copy_from_mg(VectorType&)</tt> to store the result of the v-cycle in @p dst.
  *
  * @author Guido Kanschat, 1999, 2000, 2001, 2002
  */
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 class PreconditionMG : public Subscriptor
 {
 public:
@@ -353,9 +353,9 @@ public:
    * Constructor. Arguments are the multigrid object, pre-smoother, post-
    * smoother and coarse grid solver.
    */
-  PreconditionMG(const DoFHandler<dim>     &dof_handler,
-                 Multigrid<VECTOR>           &mg,
-                 const TRANSFER &transfer);
+  PreconditionMG(const DoFHandler<dim> &dof_handler,
+                 Multigrid<VectorType> &mg,
+                 const TRANSFER        &transfer);
 
   /**
    * Dummy function needed by other classes.
@@ -402,17 +402,17 @@ private:
   /**
    * Associated @p DoFHandler.
    */
-  SmartPointer<const DoFHandler<dim>,PreconditionMG<dim,VECTOR,TRANSFER> > dof_handler;
+  SmartPointer<const DoFHandler<dim>,PreconditionMG<dim,VectorType,TRANSFER> > dof_handler;
 
   /**
    * The multigrid object.
    */
-  SmartPointer<Multigrid<VECTOR>,PreconditionMG<dim,VECTOR,TRANSFER> > multigrid;
+  SmartPointer<Multigrid<VectorType>,PreconditionMG<dim,VectorType,TRANSFER> > multigrid;
 
   /**
    * Object for grid tranfer.
    */
-  SmartPointer<const TRANSFER,PreconditionMG<dim,VECTOR,TRANSFER> > transfer;
+  SmartPointer<const TRANSFER,PreconditionMG<dim,VectorType,TRANSFER> > transfer;
 };
 
 /*@}*/
@@ -421,15 +421,15 @@ private:
 /* --------------------------- inline functions --------------------- */
 
 
-template <class VECTOR>
+template <typename VectorType>
 template <int dim>
-Multigrid<VECTOR>::Multigrid (const DoFHandler<dim> &mg_dof_handler,
-                              const MGMatrixBase<VECTOR> &matrix,
-                              const MGCoarseGridBase<VECTOR> &coarse,
-                              const MGTransferBase<VECTOR> &transfer,
-                              const MGSmootherBase<VECTOR> &pre_smooth,
-                              const MGSmootherBase<VECTOR> &post_smooth,
-                              Cycle                         cycle)
+Multigrid<VectorType>::Multigrid (const DoFHandler<dim>          &mg_dof_handler,
+                              const MGMatrixBase<VectorType>     &matrix,
+                              const MGCoarseGridBase<VectorType> &coarse,
+                              const MGTransferBase<VectorType>   &transfer,
+                              const MGSmootherBase<VectorType>   &pre_smooth,
+                              const MGSmootherBase<VectorType>   &post_smooth,
+                              Cycle                              cycle)
   :
   cycle_type(cycle),
   minlevel(0),
@@ -450,20 +450,20 @@ Multigrid<VECTOR>::Multigrid (const DoFHandler<dim> &mg_dof_handler,
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 unsigned int
-Multigrid<VECTOR>::get_maxlevel () const
+Multigrid<VectorType>::get_maxlevel () const
 {
   return maxlevel;
 }
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 inline
 unsigned int
-Multigrid<VECTOR>::get_minlevel () const
+Multigrid<VectorType>::get_minlevel () const
 {
   return minlevel;
 }
@@ -472,28 +472,28 @@ Multigrid<VECTOR>::get_minlevel () const
 /* --------------------------- inline functions --------------------- */
 
 
-template<int dim, class VECTOR, class TRANSFER>
-PreconditionMG<dim, VECTOR, TRANSFER>
-::PreconditionMG(const DoFHandler<dim>      &dof_handler,
-                 Multigrid<VECTOR> &mg,
-                 const TRANSFER              &transfer)
+template<int dim, typename VectorType, class TRANSFER>
+PreconditionMG<dim, VectorType, TRANSFER>
+::PreconditionMG(const DoFHandler<dim>  &dof_handler,
+                 Multigrid<VectorType>  &mg,
+                 const TRANSFER         &transfer)
   :
   dof_handler(&dof_handler),
   multigrid(&mg),
   transfer(&transfer)
 {}
 
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 inline bool
-PreconditionMG<dim, VECTOR, TRANSFER>::empty () const
+PreconditionMG<dim, VectorType, TRANSFER>::empty () const
 {
   return false;
 }
 
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 template<class VECTOR2>
 void
-PreconditionMG<dim, VECTOR, TRANSFER>::vmult (
+PreconditionMG<dim, VectorType, TRANSFER>::vmult (
   VECTOR2 &dst,
   const VECTOR2 &src) const
 {
@@ -508,10 +508,10 @@ PreconditionMG<dim, VECTOR, TRANSFER>::vmult (
 }
 
 
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 template<class VECTOR2>
 void
-PreconditionMG<dim, VECTOR, TRANSFER>::vmult_add (
+PreconditionMG<dim, VectorType, TRANSFER>::vmult_add (
   VECTOR2 &dst,
   const VECTOR2 &src) const
 {
@@ -525,10 +525,10 @@ PreconditionMG<dim, VECTOR, TRANSFER>::vmult_add (
 }
 
 
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 template<class VECTOR2>
 void
-PreconditionMG<dim, VECTOR, TRANSFER>::Tvmult (
+PreconditionMG<dim, VectorType, TRANSFER>::Tvmult (
   VECTOR2 &,
   const VECTOR2 &) const
 {
@@ -536,10 +536,10 @@ PreconditionMG<dim, VECTOR, TRANSFER>::Tvmult (
 }
 
 
-template<int dim, class VECTOR, class TRANSFER>
+template<int dim, typename VectorType, class TRANSFER>
 template<class VECTOR2>
 void
-PreconditionMG<dim, VECTOR, TRANSFER>::Tvmult_add (
+PreconditionMG<dim, VectorType, TRANSFER>::Tvmult_add (
   VECTOR2 &,
   const VECTOR2 &) const
 {

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -424,12 +424,12 @@ private:
 template <typename VectorType>
 template <int dim>
 Multigrid<VectorType>::Multigrid (const DoFHandler<dim>          &mg_dof_handler,
-                              const MGMatrixBase<VectorType>     &matrix,
-                              const MGCoarseGridBase<VectorType> &coarse,
-                              const MGTransferBase<VectorType>   &transfer,
-                              const MGSmootherBase<VectorType>   &pre_smooth,
-                              const MGSmootherBase<VectorType>   &post_smooth,
-                              Cycle                              cycle)
+                                  const MGMatrixBase<VectorType>     &matrix,
+                                  const MGCoarseGridBase<VectorType> &coarse,
+                                  const MGTransferBase<VectorType>   &transfer,
+                                  const MGSmootherBase<VectorType>   &pre_smooth,
+                                  const MGSmootherBase<VectorType>   &post_smooth,
+                                  Cycle                              cycle)
   :
   cycle_type(cycle),
   minlevel(0),
@@ -529,7 +529,7 @@ template<int dim, typename VectorType, class TRANSFER>
 template<class OtherVectorType>
 void
 PreconditionMG<dim, VectorType, TRANSFER>::Tvmult
-(OtherVectorType       &,
+(OtherVectorType &,
  const OtherVectorType &) const
 {
   Assert(false, ExcNotImplemented());
@@ -540,7 +540,7 @@ template<int dim, typename VectorType, class TRANSFER>
 template<class OtherVectorType>
 void
 PreconditionMG<dim, VectorType, TRANSFER>::Tvmult_add
-(OtherVectorType       &,
+(OtherVectorType &,
  const OtherVectorType &) const
 {
   Assert(false, ExcNotImplemented());

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -24,15 +24,15 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <class VECTOR>
-Multigrid<VECTOR>::Multigrid (const unsigned int minlevel,
-                              const unsigned int maxlevel,
-                              const MGMatrixBase<VECTOR> &matrix,
-                              const MGCoarseGridBase<VECTOR> &coarse,
-                              const MGTransferBase<VECTOR> &transfer,
-                              const MGSmootherBase<VECTOR> &pre_smooth,
-                              const MGSmootherBase<VECTOR> &post_smooth,
-                              typename Multigrid<VECTOR>::Cycle cycle)
+template <typename VectorType>
+Multigrid<VectorType>::Multigrid (const unsigned int                    minlevel,
+                                  const unsigned int                    maxlevel,
+                                  const MGMatrixBase<VectorType>        &matrix,
+                                  const MGCoarseGridBase<VectorType>    &coarse,
+                                  const MGTransferBase<VectorType>      &transfer,
+                                  const MGSmootherBase<VectorType>      &pre_smooth,
+                                  const MGSmootherBase<VectorType>      &post_smooth,
+                                  typename Multigrid<VectorType>::Cycle cycle)
   :
   cycle_type(cycle),
   minlevel(minlevel),
@@ -54,10 +54,10 @@ Multigrid<VECTOR>::Multigrid (const unsigned int minlevel,
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::reinit(const unsigned int min_level,
-                          const unsigned int max_level)
+Multigrid<VectorType>::reinit (const unsigned int min_level,
+                               const unsigned int max_level)
 {
   minlevel=min_level;
   maxlevel=max_level;
@@ -65,9 +65,9 @@ Multigrid<VECTOR>::reinit(const unsigned int min_level,
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_maxlevel (const unsigned int l)
+Multigrid<VectorType>::set_maxlevel (const unsigned int l)
 {
   Assert (l <= maxlevel, ExcIndexRange(l,minlevel,maxlevel+1));
   Assert (l >= minlevel, ExcIndexRange(l,minlevel,maxlevel+1));
@@ -75,10 +75,10 @@ Multigrid<VECTOR>::set_maxlevel (const unsigned int l)
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_minlevel (const unsigned int l,
-                                 const bool relative)
+Multigrid<VectorType>::set_minlevel (const unsigned int l,
+                                     const bool relative)
 {
   Assert (l <= maxlevel, ExcIndexRange(l,minlevel,maxlevel+1));
   minlevel = (relative)
@@ -87,45 +87,45 @@ Multigrid<VECTOR>::set_minlevel (const unsigned int l,
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_cycle(typename Multigrid<VECTOR>::Cycle c)
+Multigrid<VectorType>::set_cycle(typename Multigrid<VectorType>::Cycle c)
 {
   cycle_type = c;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_debug (const unsigned int d)
+Multigrid<VectorType>::set_debug (const unsigned int d)
 {
   debug = d;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_edge_matrices (const MGMatrixBase<VECTOR> &down,
-                                      const MGMatrixBase<VECTOR> &up)
+Multigrid<VectorType>::set_edge_matrices (const MGMatrixBase<VectorType> &down,
+                                          const MGMatrixBase<VectorType> &up)
 {
   edge_out = &down;
   edge_in = &up;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::set_edge_flux_matrices (const MGMatrixBase<VECTOR> &down,
-                                           const MGMatrixBase<VECTOR> &up)
+Multigrid<VectorType>::set_edge_flux_matrices (const MGMatrixBase<VectorType> &down,
+                                               const MGMatrixBase<VectorType> &up)
 {
   edge_down = &down;
   edge_up = &up;
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::level_v_step(const unsigned int level)
+Multigrid<VectorType>::level_v_step (const unsigned int level)
 {
   if (debug>0)
     deallog << "V-cycle entering level " << level << std::endl;
@@ -243,10 +243,10 @@ Multigrid<VECTOR>::level_v_step(const unsigned int level)
 
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::level_step(const unsigned int level,
-                              Cycle cycle)
+Multigrid<VectorType>::level_step(const unsigned int level,
+                                  Cycle cycle)
 {
   char cychar = '?';
   switch (cycle)
@@ -373,9 +373,9 @@ Multigrid<VECTOR>::level_step(const unsigned int level,
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::cycle()
+Multigrid<VectorType>::cycle()
 {
   // The defect vector has been
   // initialized by copy_to_mg. Now
@@ -400,9 +400,9 @@ Multigrid<VECTOR>::cycle()
 }
 
 
-template <class VECTOR>
+template <typename VectorType>
 void
-Multigrid<VECTOR>::vcycle()
+Multigrid<VectorType>::vcycle()
 {
   // The defect vector has been
   // initialized by copy_to_mg. Now

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -638,10 +638,10 @@ public:
    * includes all of the usual vector types, but also IndexSet (see step-41
    * for a use of this).
    */
-  template <class VECTOR>
-  void add_data_vector (const VECTOR                   &data,
+  template <class VectorType>
+  void add_data_vector (const VectorType               &data,
                         const std::vector<std::string> &names,
-                        const DataVectorType            type = type_automatic,
+                        const DataVectorType           type = type_automatic,
                         const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation
                         = std::vector<DataComponentInterpretation::DataComponentInterpretation>());
 
@@ -661,10 +661,10 @@ public:
    * which FEValues can extract values on a cell using the
    * FEValuesBase::get_function_values() function.
    */
-  template <class VECTOR>
-  void add_data_vector (const VECTOR         &data,
+  template <class VectorType>
+  void add_data_vector (const VectorType     &data,
                         const std::string    &name,
-                        const DataVectorType  type = type_automatic,
+                        const DataVectorType type = type_automatic,
                         const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation
                         = std::vector<DataComponentInterpretation::DataComponentInterpretation>());
 
@@ -682,9 +682,9 @@ public:
    * represents dof data, the data vector type argument present in the other
    * methods above is skipped.
    */
-  template <class VECTOR>
+  template <class VectorType>
   void add_data_vector (const DH                       &dof_handler,
-                        const VECTOR                   &data,
+                        const VectorType               &data,
                         const std::vector<std::string> &names,
                         const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation
                         = std::vector<DataComponentInterpretation::DataComponentInterpretation>());
@@ -694,10 +694,10 @@ public:
    * This function is an abbreviation of the function above with only a scalar
    * @p dof_handler given and a single data name.
    */
-  template <class VECTOR>
-  void add_data_vector (const DH                       &dof_handler,
-                        const VECTOR                   &data,
-                        const std::string              &name,
+  template <class VectorType>
+  void add_data_vector (const DH          &dof_handler,
+                        const VectorType  &data,
+                        const std::string &name,
                         const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation
                         = std::vector<DataComponentInterpretation::DataComponentInterpretation>());
 
@@ -729,8 +729,8 @@ public:
    * error by declaring the data postprocessor variable before the DataOut
    * variable as objects are destroyed in reverse order of declaration.
    */
-  template <class VECTOR>
-  void add_data_vector (const VECTOR                           &data,
+  template <class VectorType>
+  void add_data_vector (const VectorType                             &data,
                         const DataPostprocessor<DH::space_dimension> &data_postprocessor);
 
   /**
@@ -739,9 +739,9 @@ public:
    * postprocessor can only read data from the given DoFHandler and solution
    * vector, not other solution vectors or DoFHandlers.
    */
-  template <class VECTOR>
-  void add_data_vector (const DH                               &dof_handler,
-                        const VECTOR                           &data,
+  template <class VectorType>
+  void add_data_vector (const DH                                     &dof_handler,
+                        const VectorType                             &data,
                         const DataPostprocessor<DH::space_dimension> &data_postprocessor);
 
   /**

--- a/include/deal.II/numerics/dof_output_operator.h
+++ b/include/deal.II/numerics/dof_output_operator.h
@@ -35,8 +35,8 @@ namespace Algorithms
    * An output operator writing a separate file in each step and writing the
    * vectors as finite element functions with respect to a given DoFHandler.
    */
-  template <class VECTOR, int dim, int spacedim=dim>
-  class DoFOutputOperator : public OutputOperator<VECTOR>
+  template <typename VectorType, int dim, int spacedim=dim>
+  class DoFOutputOperator : public OutputOperator<VectorType>
   {
   public:
     /*
@@ -53,12 +53,12 @@ namespace Algorithms
     void parse_parameters(ParameterHandler &param);
     void initialize (const DoFHandler<dim, spacedim> &dof_handler);
 
-    virtual OutputOperator<VECTOR> &
+    virtual OutputOperator<VectorType> &
     operator << (const AnyData &vectors);
 
   private:
     SmartPointer<const DoFHandler<dim, spacedim>,
-                 DoFOutputOperator<VECTOR, dim, spacedim> > dof;
+                 DoFOutputOperator<VectorType, dim, spacedim> > dof;
 
     const std::string filename_base;
     const unsigned int digits;
@@ -66,9 +66,9 @@ namespace Algorithms
     DataOut<dim> out;
   };
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   inline void
-  DoFOutputOperator<VECTOR, dim, spacedim>::initialize(const DoFHandler<dim, spacedim> &dof_handler)
+  DoFOutputOperator<VectorType, dim, spacedim>::initialize(const DoFHandler<dim, spacedim> &dof_handler)
   {
     dof = &dof_handler;
   }

--- a/include/deal.II/numerics/dof_output_operator.templates.h
+++ b/include/deal.II/numerics/dof_output_operator.templates.h
@@ -20,8 +20,8 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Algorithms
 {
-  template <class VECTOR, int dim, int spacedim>
-  DoFOutputOperator<VECTOR, dim, spacedim>::DoFOutputOperator (
+  template <typename VectorType, int dim, int spacedim>
+  DoFOutputOperator<VectorType, dim, spacedim>::DoFOutputOperator (
     const std::string filename_base,
     const unsigned int digits)
     :
@@ -32,23 +32,23 @@ namespace Algorithms
   }
 
 
-  template <class VECTOR, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   void
-  DoFOutputOperator<VECTOR, dim, spacedim>::parse_parameters(ParameterHandler &param)
+  DoFOutputOperator<VectorType, dim, spacedim>::parse_parameters(ParameterHandler &param)
   {
     out.parse_parameters(param);
   }
 
-  template <class VECTOR, int dim, int spacedim>
-  OutputOperator<VECTOR> &
-  DoFOutputOperator<VECTOR, dim, spacedim>::operator<<(
+  template <typename VectorType, int dim, int spacedim>
+  OutputOperator<VectorType> &
+  DoFOutputOperator<VectorType, dim, spacedim>::operator<<(
     const AnyData &data)
   {
     Assert ((dof!=0), ExcNotInitialized());
     out.attach_dof_handler (*dof);
     for (unsigned int i=0; i<data.size(); ++i)
       {
-        const VECTOR *p = data.try_read_ptr<VECTOR>(i);
+        const VectorType *p = data.try_read_ptr<VectorType>(i);
         if (p!=0)
           {
             out.add_data_vector (*p, data.name(i));

--- a/include/deal.II/numerics/dof_print_solver_step.h
+++ b/include/deal.II/numerics/dof_print_solver_step.h
@@ -49,8 +49,8 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup output
  * @author Guido Kanschat, 2000
  */
-template<int dim, class SOLVER, class VectorType = Vector<double> >
-class DoFPrintSolverStep : public SOLVER
+template<int dim, typename SolverType, class VectorType = Vector<double> >
+class DoFPrintSolverStep : public SolverType
 {
 public:
   /**
@@ -87,24 +87,24 @@ private:
 
 /* ----------------------- template functions --------------- */
 
-template<int dim, class SOLVER, class VectorType>
-DoFPrintSolverStep<dim, SOLVER, VectorType>::DoFPrintSolverStep
+template<int dim, typename SolverType, class VectorType>
+DoFPrintSolverStep<dim, SolverType, VectorType>::DoFPrintSolverStep
 (SolverControl            &control,
  VectorMemory<VectorType> &mem,
  DataOut<dim>             &data_out,
  const std::string        &basename)
-  : SOLVER (control, mem),
+  : SolverType (control, mem),
     out (data_out),
     basename (basename)
 {}
 
 
-template<int dim, class SOLVER, class VectorType>
+template<int dim, typename SolverType, class VectorType>
 void
-DoFPrintSolverStep<dim, SOLVER, VectorType>::print_vectors (const unsigned int step,
-                                                            const VectorType &x,
-                                                            const VectorType &r,
-                                                            const VectorType &d) const
+DoFPrintSolverStep<dim, SolverType, VectorType>::print_vectors (const unsigned int  step,
+                                                                const VectorType   &x,
+                                                                const VectorType   &r,
+                                                                const VectorType   &d) const
 {
   out.clear_data_vectors();
   out.add_data_vector(x, "solution");

--- a/include/deal.II/numerics/dof_print_solver_step.h
+++ b/include/deal.II/numerics/dof_print_solver_step.h
@@ -49,7 +49,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup output
  * @author Guido Kanschat, 2000
  */
-template<int dim, class SOLVER, class VECTOR = Vector<double> >
+template<int dim, class SOLVER, class VectorType = Vector<double> >
 class DoFPrintSolverStep : public SOLVER
 {
 public:
@@ -61,17 +61,17 @@ public:
    * produced for each iteration step.
    */
   DoFPrintSolverStep (SolverControl &control,
-                      VectorMemory<VECTOR> &mem,
-                      DataOut<dim> &data_out,
-                      const std::string &basename);
+                      VectorMemory<VectorType> &mem,
+                      DataOut<dim>             &data_out,
+                      const std::string        &basename);
 
   /**
    * Call-back function for the iterative method.
    */
   virtual void print_vectors (const unsigned int step,
-                              const VECTOR &x,
-                              const VECTOR &r,
-                              const VECTOR &d) const;
+                              const VectorType   &x,
+                              const VectorType   &r,
+                              const VectorType   &d) const;
 private:
   /**
    * Output object.
@@ -87,23 +87,24 @@ private:
 
 /* ----------------------- template functions --------------- */
 
-template<int dim, class SOLVER, class VECTOR>
-DoFPrintSolverStep<dim, SOLVER, VECTOR>::DoFPrintSolverStep (SolverControl &control,
-    VectorMemory<VECTOR> &mem,
-    DataOut<dim> &data_out,
-    const std::string &basename)
+template<int dim, class SOLVER, class VectorType>
+DoFPrintSolverStep<dim, SOLVER, VectorType>::DoFPrintSolverStep
+(SolverControl            &control,
+ VectorMemory<VectorType> &mem,
+ DataOut<dim>             &data_out,
+ const std::string        &basename)
   : SOLVER (control, mem),
     out (data_out),
     basename (basename)
 {}
 
 
-template<int dim, class SOLVER, class VECTOR>
+template<int dim, class SOLVER, class VectorType>
 void
-DoFPrintSolverStep<dim, SOLVER, VECTOR>::print_vectors (const unsigned int step,
-                                                        const VECTOR &x,
-                                                        const VECTOR &r,
-                                                        const VECTOR &d) const
+DoFPrintSolverStep<dim, SOLVER, VectorType>::print_vectors (const unsigned int step,
+                                                            const VectorType &x,
+                                                            const VectorType &r,
+                                                            const VectorType &d) const
 {
   out.clear_data_vectors();
   out.add_data_vector(x, "solution");

--- a/include/deal.II/numerics/dof_print_solver_step.h
+++ b/include/deal.II/numerics/dof_print_solver_step.h
@@ -101,10 +101,11 @@ DoFPrintSolverStep<dim, SolverType, VectorType>::DoFPrintSolverStep
 
 template<int dim, typename SolverType, class VectorType>
 void
-DoFPrintSolverStep<dim, SolverType, VectorType>::print_vectors (const unsigned int  step,
-                                                                const VectorType   &x,
-                                                                const VectorType   &r,
-                                                                const VectorType   &d) const
+DoFPrintSolverStep<dim, SolverType, VectorType>::print_vectors
+(const unsigned int  step,
+ const VectorType   &x,
+ const VectorType   &r,
+ const VectorType   &d) const
 {
   out.clear_data_vectors();
   out.add_data_vector(x, "solution");

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -161,7 +161,7 @@ namespace Functions
    */
   template <int dim,
             typename DH=DoFHandler<dim>,
-            typename VECTOR=Vector<double> >
+            typename VectorType=Vector<double> >
   class FEFieldFunction :  public Function<dim>
   {
   public:
@@ -174,7 +174,7 @@ namespace Functions
      * lay. Otherwise the standard Q1 mapping is used.
      */
     FEFieldFunction (const DH           &dh,
-                     const VECTOR       &data_vector,
+                     const VectorType   &data_vector,
                      const Mapping<dim> &mapping = StaticMappingQ1<dim>::mapping);
 
     /**
@@ -429,12 +429,12 @@ namespace Functions
     /**
      * Pointer to the dof handler.
      */
-    SmartPointer<const DH,FEFieldFunction<dim, DH, VECTOR> > dh;
+    SmartPointer<const DH,FEFieldFunction<dim, DH, VectorType> > dh;
 
     /**
      * A reference to the actual data vector.
      */
-    const VECTOR &data_vector;
+    const VectorType &data_vector;
 
     /**
      * A reference to the mapping being used.

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -31,10 +31,10 @@ DEAL_II_NAMESPACE_OPEN
 namespace Functions
 {
 
-  template <int dim, typename DH, typename VECTOR>
-  FEFieldFunction<dim, DH, VECTOR>::FEFieldFunction (const DH &mydh,
-                                                     const VECTOR &myv,
-                                                     const Mapping<dim> &mymapping)
+  template <int dim, typename DH, typename VectorType>
+  FEFieldFunction<dim, DH, VectorType>::FEFieldFunction (const DH           &mydh,
+                                                         const VectorType   &myv,
+                                                         const Mapping<dim> &mymapping)
     :
     Function<dim>(mydh.get_fe().n_components()),
     dh(&mydh, "FEFieldFunction"),
@@ -47,9 +47,9 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   set_active_cell(const typename DH::active_cell_iterator &newcell)
   {
     cell_hint.get() = newcell;
@@ -57,9 +57,9 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
-  void FEFieldFunction<dim, DH, VECTOR>::vector_value (const Point<dim> &p,
-                                                       Vector<double>   &values) const
+  template <int dim, typename DH, typename VectorType>
+  void FEFieldFunction<dim, DH, VectorType>::vector_value (const Point<dim> &p,
+                                                           Vector<double>   &values) const
   {
     Assert (values.size() == n_components,
             ExcDimensionMismatch(values.size(), n_components));
@@ -87,18 +87,18 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_values);
     fe_v.reinit(cell);
-    std::vector< Vector<typename VECTOR::value_type> >
-    vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
+    std::vector< Vector<typename VectorType::value_type> >
+    vvalues (1, Vector<typename VectorType::value_type>(values.size()));
     fe_v.get_function_values(data_vector, vvalues);
     values = vvalues[0];
   }
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   double
-  FEFieldFunction<dim, DH, VECTOR>::value (const Point<dim>   &p,
-                                           const unsigned int comp) const
+  FEFieldFunction<dim, DH, VectorType>::value (const Point<dim>   &p,
+                                               const unsigned int comp) const
   {
     Vector<double> values(n_components);
     vector_value(p, values);
@@ -107,9 +107,9 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   vector_gradient (const Point<dim>            &p,
                    std::vector<Tensor<1,dim> > &gradients) const
   {
@@ -143,17 +143,17 @@ namespace Functions
     // FIXME: we need a temp argument because get_function_values wants to put
     // its data into an object storing the correct scalar type, but this
     // function wants to return everything in a vector<double>
-    std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > > vgrads
-    (1,  std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components) );
+    std::vector< std::vector<Tensor<1,dim,typename VectorType::value_type> > > vgrads
+    (1,  std::vector<Tensor<1,dim,typename VectorType::value_type> >(n_components) );
     fe_v.get_function_gradients(data_vector, vgrads);
     gradients = std::vector<Tensor<1,dim> >(vgrads[0].begin(), vgrads[0].end());
   }
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   Tensor<1,dim>
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   gradient (const Point<dim>   &p,
             const unsigned int comp) const
   {
@@ -164,9 +164,9 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   vector_laplacian (const Point<dim> &p,
                     Vector<double>   &values) const
   {
@@ -196,16 +196,16 @@ namespace Functions
     FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
                        update_hessians);
     fe_v.reinit(cell);
-    std::vector< Vector<typename VECTOR::value_type> >
-    vvalues (1, Vector<typename VECTOR::value_type>(values.size()));
+    std::vector< Vector<typename VectorType::value_type> >
+    vvalues (1, Vector<typename VectorType::value_type>(values.size()));
     fe_v.get_function_laplacians(data_vector, vvalues);
     values = vvalues[0];
   }
 
 
 
-  template <int dim, typename DH, typename VECTOR>
-  double FEFieldFunction<dim, DH, VECTOR>::laplacian
+  template <int dim, typename DH, typename VectorType>
+  double FEFieldFunction<dim, DH, VectorType>::laplacian
   (const Point<dim>   &p, const unsigned int  comp) const
   {
     Vector<double> lap(n_components);
@@ -217,9 +217,9 @@ namespace Functions
   // Now the list versions
   // ==============================
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   vector_value_list (const std::vector<Point< dim > >     &points,
                      std::vector< Vector<double> > &values) const
   {
@@ -252,7 +252,7 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
+        std::vector< Vector<typename VectorType::value_type> > vvalues (nq, Vector<typename VectorType::value_type>(n_components));
         fe_v.get_present_fe_values ().get_function_values(data_vector, vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];
@@ -261,12 +261,12 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   value_list (const std::vector<Point< dim > > &points,
-              std::vector< double > &values,
-              const unsigned int  component) const
+              std::vector< double >            &values,
+              const unsigned int               component) const
   {
     Assert(points.size() == values.size(),
            ExcDimensionMismatch(points.size(), values.size()));
@@ -278,9 +278,9 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   vector_gradient_list (const std::vector<Point< dim > >     &points,
                         std::vector<
                         std::vector< Tensor<1,dim> > > &values) const
@@ -314,8 +314,8 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< std::vector<Tensor<1,dim,typename VECTOR::value_type> > >
-        vgrads (nq, std::vector<Tensor<1,dim,typename VECTOR::value_type> >(n_components));
+        std::vector< std::vector<Tensor<1,dim,typename VectorType::value_type> > >
+        vgrads (nq, std::vector<Tensor<1,dim,typename VectorType::value_type> >(n_components));
         fe_v.get_present_fe_values ().get_function_gradients(data_vector, vgrads);
         for (unsigned int q=0; q<nq; ++q)
           {
@@ -327,9 +327,9 @@ namespace Functions
       }
   }
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   gradient_list (const std::vector<Point< dim > > &points,
                  std::vector< Tensor<1,dim> > &values,
                  const unsigned int  component) const
@@ -344,9 +344,9 @@ namespace Functions
   }
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   vector_laplacian_list (const std::vector<Point< dim > >     &points,
                          std::vector< Vector<double> > &values) const
   {
@@ -379,16 +379,16 @@ namespace Functions
       {
         fe_v.reinit(cells[i], i, 0);
         const unsigned int nq = qpoints[i].size();
-        std::vector< Vector<typename VECTOR::value_type> > vvalues (nq, Vector<typename VECTOR::value_type>(n_components));
+        std::vector< Vector<typename VectorType::value_type> > vvalues (nq, Vector<typename VectorType::value_type>(n_components));
         fe_v.get_present_fe_values ().get_function_laplacians(data_vector, vvalues);
         for (unsigned int q=0; q<nq; ++q)
           values[maps[i][q]] = vvalues[q];
       }
   }
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   void
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   laplacian_list (const std::vector<Point< dim > > &points,
                   std::vector< double > &values,
                   const unsigned int  component) const
@@ -403,8 +403,8 @@ namespace Functions
 
 
 
-  template <int dim, typename DH, typename VECTOR>
-  unsigned int FEFieldFunction<dim, DH, VECTOR>::
+  template <int dim, typename DH, typename VectorType>
+  unsigned int FEFieldFunction<dim, DH, VectorType>::
   compute_point_locations(const std::vector<Point<dim> > &points,
                           std::vector<typename DH::active_cell_iterator > &cells,
                           std::vector<std::vector<Point<dim> > > &qpoints,
@@ -565,9 +565,9 @@ namespace Functions
   }
 
 
-  template <int dim, typename DH, typename VECTOR>
+  template <int dim, typename DH, typename VectorType>
   boost::optional<Point<dim> >
-  FEFieldFunction<dim, DH, VECTOR>::
+  FEFieldFunction<dim, DH, VectorType>::
   get_reference_coordinates (const typename DH::active_cell_iterator &cell,
                              const Point<dim>                        &point) const
   {

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -282,7 +282,7 @@ public:
 
 
   /**
-   * Put another mnemonic string (and hence @p VECTOR) into the class. This
+   * Put another mnemonic string (and hence @p VectorType) into the class. This
    * method adds storage space for variables equal to the number of true
    * values in component_mask. This also adds extra entries for points that
    * are already in the class, so @p add_field_name and @p add_points can be
@@ -292,7 +292,7 @@ public:
                       const ComponentMask &component_mask = ComponentMask());
 
   /**
-   * Put another mnemonic string (and hence @p VECTOR) into the class. This
+   * Put another mnemonic string (and hence @p VectorType) into the class. This
    * method adds storage space for n_components variables. This also adds
    * extra entries for points that are already in the class, so @p
    * add_field_name and @p add_points can be called in any order. This method
@@ -318,20 +318,20 @@ public:
 
 
   /**
-   * Extract values at the stored points from the VECTOR supplied and add them
-   * to the new dataset in vector_name. The component mask supplied when the
-   * field was added is used to select components to extract. If a @p
+   * Extract values at the stored points from the VectorType supplied and add
+   * them to the new dataset in vector_name. The component mask supplied when
+   * the field was added is used to select components to extract. If a @p
    * DoFHandler is used, one (and only one) evaluate_field method must be
    * called for each dataset (time step, iteration, etc) for each vector_name,
    * otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VECTOR>
+  template <class VectorType>
   void evaluate_field(const std::string &name,
-                      const VECTOR &solution);
+                      const VectorType  &solution);
 
 
   /**
-   * Compute values using a @p DataPostprocessor object with the @p VECTOR
+   * Compute values using a @p DataPostprocessor object with the @p VectorType
    * supplied and add them to the new dataset in vector_name. The
    * component_mask supplied when the field was added is used to select
    * components to extract from the @p DataPostprocessor return vector. This
@@ -347,26 +347,26 @@ public:
    * method must be called for each dataset (time step, iteration, etc) for
    * each vector_name, otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VECTOR>
+  template <class VectorType>
   void evaluate_field(const std::vector <std::string> &names,
-                      const VECTOR &solution,
-                      const DataPostprocessor<dim> &data_postprocessor,
-                      const Quadrature<dim> &quadrature);
+                      const VectorType                &solution,
+                      const DataPostprocessor<dim>    &data_postprocessor,
+                      const Quadrature<dim>           &quadrature);
 
   /**
    * Construct a std::vector <std::string> containing only vector_name and
    * call the above function. The above function is more efficient if multiple
    * fields use the same @p DataPostprocessor object.
    */
-  template <class VECTOR>
-  void evaluate_field(const std::string &name,
-                      const VECTOR &solution,
+  template <class VectorType>
+  void evaluate_field(const std::string            &name,
+                      const VectorType             &solution,
                       const DataPostprocessor<dim> &data_postprocessor,
-                      const Quadrature<dim> &quadrature);
+                      const Quadrature<dim>        &quadrature);
 
 
   /**
-   * Extract values at the points actually requested from the VECTOR supplied
+   * Extract values at the points actually requested from the VectorType supplied
    * and add them to the new dataset in vector_name. Unlike the other
    * evaluate_field methods this method does not care if the dof_handler has
    * been modified because it uses calls to @p VectorTools::point_value to
@@ -377,9 +377,9 @@ public:
    * called for each dataset (time step, iteration, etc) for each vector_name,
    * otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VECTOR>
+  template <class VectorType>
   void evaluate_field_at_requested_location(const std::string &name,
-                                            const VECTOR &solution);
+                                            const VectorType  &solution);
 
 
   /**

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -288,7 +288,7 @@ DEAL_II_NAMESPACE_OPEN
  * @author Ralf Hartmann, 1999, Oliver Kayser-Herold and Wolfgang Bangerth,
  * 2006, Wolfgang Bangerth 2014
  */
-template<int dim, typename VECTOR=Vector<double>, class DH=DoFHandler<dim> >
+template<int dim, typename VectorType=Vector<double>, class DH=DoFHandler<dim> >
 class SolutionTransfer
 {
 public:
@@ -323,13 +323,13 @@ public:
    * vectors that are to be interpolated onto the new (refined and/or
    * coarsenend) grid.
    */
-  void prepare_for_coarsening_and_refinement (const std::vector<VECTOR> &all_in);
+  void prepare_for_coarsening_and_refinement (const std::vector<VectorType> &all_in);
 
   /**
    * Same as previous function but for only one discrete function to be
    * interpolated.
    */
-  void prepare_for_coarsening_and_refinement (const VECTOR &in);
+  void prepare_for_coarsening_and_refinement (const VectorType &in);
 
   /**
    * This function interpolates the discrete function @p in, which is a vector
@@ -342,8 +342,8 @@ public:
    * is called and the refinement is executed before. Multiple calling of this
    * function is allowed. e.g. for interpolating several functions.
    */
-  void refine_interpolate (const VECTOR &in,
-                           VECTOR &out) const;
+  void refine_interpolate (const VectorType &in,
+                           VectorType       &out) const;
 
   /**
    * This function interpolates the discrete functions that are stored in @p
@@ -364,8 +364,8 @@ public:
    * the right size (@p n_dofs_refined). Otherwise an assertion will be
    * thrown.
    */
-  void interpolate (const std::vector<VECTOR> &all_in,
-                    std::vector<VECTOR>      &all_out) const;
+  void interpolate (const std::vector<VectorType> &all_in,
+                    std::vector<VectorType>       &all_out) const;
 
   /**
    * Same as the previous function. It interpolates only one function. It
@@ -376,8 +376,8 @@ public:
    * functions can be performed in one step by using <tt>interpolate (all_in,
    * all_out)</tt>
    */
-  void interpolate (const VECTOR &in,
-                    VECTOR       &out) const;
+  void interpolate (const VectorType &in,
+                    VectorType       &out) const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -418,7 +418,7 @@ private:
   /**
    * Pointer to the degree of freedom handler to work with.
    */
-  SmartPointer<const DH,SolutionTransfer<dim,VECTOR,DH> > dof_handler;
+  SmartPointer<const DH,SolutionTransfer<dim,VectorType,DH> > dof_handler;
 
   /**
    * Stores the number of DoFs before the refinement and/or coarsening.
@@ -468,7 +468,7 @@ private:
       indices_ptr(indices_ptr_in),
       dof_values_ptr (0),
       active_fe_index(active_fe_index_in) {};
-    Pointerstruct(std::vector<Vector<typename VECTOR::value_type> > *dof_values_ptr_in,
+    Pointerstruct(std::vector<Vector<typename VectorType::value_type> > *dof_values_ptr_in,
                   const unsigned int active_fe_index_in = 0) :
       indices_ptr (0),
       dof_values_ptr(dof_values_ptr_in),
@@ -476,7 +476,7 @@ private:
     std::size_t memory_consumption () const;
 
     std::vector<types::global_dof_index>    *indices_ptr;
-    std::vector<Vector<typename VECTOR::value_type> > *dof_values_ptr;
+    std::vector<Vector<typename VectorType::value_type> > *dof_values_ptr;
     unsigned int active_fe_index;
   };
 
@@ -492,7 +492,7 @@ private:
    * Is used for @p prepare_for_refining_and_coarsening The interpolated dof
    * values of all cells that'll be coarsened will be stored in this vector.
    */
-  std::vector<std::vector<Vector<typename VECTOR::value_type> > > dof_values_on_cell;
+  std::vector<std::vector<Vector<typename VectorType::value_type> > > dof_values_on_cell;
 };
 
 

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -595,8 +595,8 @@ namespace VectorTools
                 VectorType                      &vec,
                 const bool                      enforce_zero_boundary = false,
                 const Quadrature<dim-1>         &q_boundary = (dim > 1 ?
-                                                               QGauss<dim-1>(2) :
-                                                               Quadrature<dim-1>(0)),
+                                                              QGauss<dim-1>(2) :
+                                                              Quadrature<dim-1>(0)),
                 const bool                      project_to_boundary_first = false);
 
   /**
@@ -611,8 +611,8 @@ namespace VectorTools
                 VectorType                      &vec,
                 const bool                      enforce_zero_boundary = false,
                 const Quadrature<dim-1>         &q_boundary = (dim > 1 ?
-                                                        QGauss<dim-1>(2) :
-                                                        Quadrature<dim-1>(0)),
+                                                              QGauss<dim-1>(2) :
+                                                              Quadrature<dim-1>(0)),
                 const bool                      project_to_boundary_first = false);
 
   /**
@@ -644,8 +644,8 @@ namespace VectorTools
                 VectorType                         &vec,
                 const bool                         enforce_zero_boundary = false,
                 const hp::QCollection<dim-1>       &q_boundary = hp::QCollection<dim-1>(dim > 1 ?
-                                                                 QGauss<dim-1>(2) :
-                                                                 Quadrature<dim-1>(0)),
+                    QGauss<dim-1>(2) :
+                    Quadrature<dim-1>(0)),
                 const bool                         project_to_boundary_first = false);
 
   /**

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -400,20 +400,20 @@ namespace VectorTools
    * @todo The @p mapping argument should be replaced by a
    * hp::MappingCollection in case of a hp::DoFHandler.
    */
-  template <class VECTOR, int dim, int spacedim, template <int,int> class DH>
-  void interpolate (const Mapping<dim,spacedim>    &mapping,
-                    const DH<dim,spacedim>         &dof,
-                    const Function<spacedim,double>       &function,
-                    VECTOR                         &vec);
+  template <typename VectorType, int dim, int spacedim, template <int,int> class DH>
+  void interpolate (const Mapping<dim,spacedim>     &mapping,
+                    const DH<dim,spacedim>          &dof,
+                    const Function<spacedim,double> &function,
+                    VectorType                      &vec);
 
   /**
    * Calls the @p interpolate() function above with
    * <tt>mapping=MappingQGeneric1@<dim>@()</tt>.
    */
-  template <class VECTOR, class DH>
-  void interpolate (const DH              &dof,
-                    const Function<DH::space_dimension,double>   &function,
-                    VECTOR                &vec);
+  template <typename VectorType, class DH>
+  void interpolate (const DH                                   &dof,
+                    const Function<DH::space_dimension,double> &function,
+                    VectorType                                 &vec);
 
   /**
    * Interpolate different finite element spaces. The interpolation of vector
@@ -484,13 +484,14 @@ namespace VectorTools
    *
    * @author Valentin Zingan, 2013
    */
-  template<typename VECTOR, typename DH>
+  template<typename VectorType, typename DH>
   void
-  interpolate_based_on_material_id(const Mapping<DH::dimension, DH::space_dimension>                          &mapping,
-                                   const DH                                                                   &dof_handler,
-                                   const std::map< types::material_id, const Function<DH::space_dimension,double>* > &function_map,
-                                   VECTOR                                                                     &dst,
-                                   const ComponentMask                                                        &component_mask = ComponentMask());
+  interpolate_based_on_material_id
+  (const Mapping<DH::dimension, DH::space_dimension> &mapping,
+   const DH                                          &dof_handler,
+   const std::map< types::material_id, const Function<DH::space_dimension,double>* > &function_map,
+   VectorType                                        &dst,
+   const ComponentMask                               &component_mask = ComponentMask());
 
   /**
    * Gives the interpolation of a @p dof1-function @p u1 to a @p dof2-function
@@ -518,12 +519,12 @@ namespace VectorTools
    */
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class VECTOR>
+            typename VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
-                                 const VECTOR            &u1,
+                                 const VectorType        &u1,
                                  const DH<dim, spacedim> &dof2,
-                                 VECTOR                  &u2);
+                                 VectorType              &u2);
 
   /**
    * Gives the interpolation of a @p dof1-function @p u1 to a @p dof2-function
@@ -540,13 +541,13 @@ namespace VectorTools
    */
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class VECTOR>
+            typename VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
-                                 const VECTOR            &u1,
+                                 const VectorType        &u1,
                                  const DH<dim, spacedim> &dof2,
                                  const ConstraintMatrix  &constraints,
-                                 VECTOR                  &u2);
+                                 VectorType              &u2);
 
 
   /**
@@ -558,12 +559,12 @@ namespace VectorTools
    */
   template <int dim, int spacedim,
             template <int,int> class DH,
-            class VECTOR>
+            typename VectorType>
   void
   interpolate_to_different_mesh (const InterGridMap<DH<dim, spacedim> > &intergridmap,
-                                 const VECTOR                           &u1,
+                                 const VectorType                       &u1,
                                  const ConstraintMatrix                 &constraints,
-                                 VECTOR                                 &u2);
+                                 VectorType                             &u2);
 
   /**
    * Compute the projection of @p function to the finite element space.
@@ -585,67 +586,67 @@ namespace VectorTools
    * In 1d, the default value of the boundary quadrature formula is an invalid
    * object since integration on the boundary doesn't happen in 1d.
    */
-  template <int dim, class VECTOR, int spacedim>
-  void project (const Mapping<dim, spacedim>       &mapping,
-                const DoFHandler<dim,spacedim>    &dof,
-                const ConstraintMatrix   &constraints,
-                const Quadrature<dim>    &quadrature,
-                const Function<spacedim,double>      &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary = false,
-                const Quadrature<dim-1>  &q_boundary = (dim > 1 ?
-                                                        QGauss<dim-1>(2) :
-                                                        Quadrature<dim-1>(0)),
-                const bool                project_to_boundary_first = false);
+  template <int dim, typename VectorType, int spacedim>
+  void project (const Mapping<dim, spacedim>    &mapping,
+                const DoFHandler<dim,spacedim>  &dof,
+                const ConstraintMatrix          &constraints,
+                const Quadrature<dim>           &quadrature,
+                const Function<spacedim,double> &function,
+                VectorType                      &vec,
+                const bool                      enforce_zero_boundary = false,
+                const Quadrature<dim-1>         &q_boundary = (dim > 1 ?
+                                                               QGauss<dim-1>(2) :
+                                                               Quadrature<dim-1>(0)),
+                const bool                      project_to_boundary_first = false);
 
   /**
    * Calls the project() function above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
-  template <int dim, class VECTOR, int spacedim>
-  void project (const DoFHandler<dim,spacedim>    &dof,
-                const ConstraintMatrix   &constraints,
-                const Quadrature<dim>    &quadrature,
-                const Function<spacedim,double>      &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary = false,
-                const Quadrature<dim-1>  &q_boundary = (dim > 1 ?
+  template <int dim, typename VectorType, int spacedim>
+  void project (const DoFHandler<dim,spacedim>  &dof,
+                const ConstraintMatrix          &constraints,
+                const Quadrature<dim>           &quadrature,
+                const Function<spacedim,double> &function,
+                VectorType                      &vec,
+                const bool                      enforce_zero_boundary = false,
+                const Quadrature<dim-1>         &q_boundary = (dim > 1 ?
                                                         QGauss<dim-1>(2) :
                                                         Quadrature<dim-1>(0)),
-                const bool                project_to_boundary_first = false);
+                const bool                      project_to_boundary_first = false);
 
   /**
    * Same as above, but for arguments of type hp::DoFHandler,
    * hp::QuadratureCollection, hp::MappingCollection
    */
-  template <int dim, class VECTOR, int spacedim>
-  void project (const hp::MappingCollection<dim, spacedim>       &mapping,
-                const hp::DoFHandler<dim,spacedim>    &dof,
-                const ConstraintMatrix   &constraints,
-                const hp::QCollection<dim>    &quadrature,
-                const Function<spacedim,double>      &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary = false,
-                const hp::QCollection<dim-1>  &q_boundary = hp::QCollection<dim-1>(dim > 1 ?
-                                                            QGauss<dim-1>(2) :
-                                                            Quadrature<dim-1>(0)),
-                const bool                project_to_boundary_first = false);
+  template <int dim, typename VectorType, int spacedim>
+  void project (const hp::MappingCollection<dim, spacedim> &mapping,
+                const hp::DoFHandler<dim,spacedim>         &dof,
+                const ConstraintMatrix                     &constraints,
+                const hp::QCollection<dim>                 &quadrature,
+                const Function<spacedim,double>            &function,
+                VectorType                                 &vec,
+                const bool                                 enforce_zero_boundary = false,
+                const hp::QCollection<dim-1> &q_boundary = hp::QCollection<dim-1>(dim > 1 ?
+                                                           QGauss<dim-1>(2) :
+                                                           Quadrature<dim-1>(0)),
+                const bool                                 project_to_boundary_first = false);
 
   /**
    * Calls the project() function above, with a collection of
    * $Q_1$ mapping objects, i.e., with hp::StaticMappingQ1::mapping_collection.
    */
-  template <int dim, class VECTOR, int spacedim>
-  void project (const hp::DoFHandler<dim,spacedim>    &dof,
-                const ConstraintMatrix   &constraints,
-                const hp::QCollection<dim>    &quadrature,
-                const Function<spacedim,double>      &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary = false,
-                const hp::QCollection<dim-1>  &q_boundary = hp::QCollection<dim-1>(dim > 1 ?
-                                                            QGauss<dim-1>(2) :
-                                                            Quadrature<dim-1>(0)),
-                const bool                project_to_boundary_first = false);
+  template <int dim, typename VectorType, int spacedim>
+  void project (const hp::DoFHandler<dim,spacedim> &dof,
+                const ConstraintMatrix             &constraints,
+                const hp::QCollection<dim>         &quadrature,
+                const Function<spacedim,double>    &function,
+                VectorType                         &vec,
+                const bool                         enforce_zero_boundary = false,
+                const hp::QCollection<dim-1>       &q_boundary = hp::QCollection<dim-1>(dim > 1 ?
+                                                                 QGauss<dim-1>(2) :
+                                                                 Quadrature<dim-1>(0)),
+                const bool                         project_to_boundary_first = false);
 
   /**
    * Compute Dirichlet boundary conditions.  This function makes up a map of
@@ -1963,7 +1964,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void point_difference (const DoFHandler<dim,spacedim>  &dof,
                          const VectorType                &fe_function,
                          const Function<spacedim,double> &exact_solution,
@@ -1982,7 +1983,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void point_difference (const Mapping<dim, spacedim>    &mapping,
                          const DoFHandler<dim,spacedim>  &dof,
                          const VectorType                &fe_function,
@@ -2001,7 +2002,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const DoFHandler<dim,spacedim> &dof,
                const VectorType               &fe_function,
@@ -2014,7 +2015,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
                const VectorType                   &fe_function,
@@ -2036,7 +2037,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const DoFHandler<dim,spacedim> &dof,
                const VectorType               &fe_function,
@@ -2048,7 +2049,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
                const VectorType                   &fe_function,
@@ -2065,7 +2066,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
@@ -2079,7 +2080,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const hp::MappingCollection<dim, spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>         &dof,
@@ -2098,7 +2099,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const Mapping<dim,spacedim>    &mapping,
                const DoFHandler<dim,spacedim> &dof,
@@ -2111,7 +2112,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const hp::MappingCollection<dim,spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>        &dof,
@@ -2129,7 +2130,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const DoFHandler<dim,spacedim>    &dof,
                   const VectorType                  &fe_function,
@@ -2142,7 +2143,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const VectorType                   &fe_function,
@@ -2160,7 +2161,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
                   const VectorType               &fe_function,
@@ -2172,7 +2173,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const VectorType                   &fe_function,
@@ -2189,7 +2190,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const Mapping<dim, spacedim>      &mapping,
                   const DoFHandler<dim,spacedim>    &dof,
@@ -2203,7 +2204,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>         &dof,
@@ -2222,7 +2223,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const Mapping<dim,spacedim>    &mapping,
                   const DoFHandler<dim,spacedim> &dof,
@@ -2235,7 +2236,7 @@ namespace VectorTools
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::MappingCollection<dim,spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>        &dof,
@@ -2294,8 +2295,8 @@ namespace VectorTools
    * not equal to $(1,1,\ldots,1)^T$. For such elements, a different procedure
    * has to be used when subtracting the mean value.
    */
-  template <class VECTOR>
-  void subtract_mean_value(VECTOR                  &v,
+  template <typename VectorType>
+  void subtract_mean_value(VectorType              &v,
                            const std::vector<bool> &p_select = std::vector<bool>());
 
 
@@ -2321,7 +2322,7 @@ namespace VectorTools
    * Lagrangian elements. For all other elements, you will need to compute the
    * mean value and subtract it right inside the evaluation routine.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double compute_mean_value (const Mapping<dim, spacedim>   &mapping,
                              const DoFHandler<dim,spacedim> &dof,
                              const Quadrature<dim>          &quadrature,
@@ -2332,7 +2333,7 @@ namespace VectorTools
    * Calls the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double compute_mean_value (const DoFHandler<dim,spacedim> &dof,
                              const Quadrature<dim>          &quadrature,
                              const VectorType               &v,
@@ -2348,14 +2349,14 @@ namespace VectorTools
    * points of a FE_Q() finite element of the same degree as the
    * degree of the required components.
    *
-   * Curved manifold are respected, and the resulting VECTOR will be
+   * Curved manifold are respected, and the resulting VectorType will be
    * geometrically consistent. The resulting map is guaranteed to be
    * interpolatory at the support points of a FE_Q() finite element of
    * the same degree as the degree of the required components.
    *
    * If the underlying finite element is an FE_Q(1)^spacedim, then the
-   * resulting VECTOR is a finite element field representation of the vertices
-   * of the Triangulation.
+   * resulting @p VectorType is a finite element field representation of the
+   * vertices of the Triangulation.
    *
    * The optional ComponentMask argument can be used to specify what
    * components of the FiniteElement to use to describe the geometry. If no
@@ -2368,9 +2369,9 @@ namespace VectorTools
    *
    * @author Luca Heltai, 2015
    */
-  template<class DH, class VECTOR>
+  template<class DH, typename VectorType>
   void get_position_vector(const DH &dh,
-                           VECTOR &vector,
+                           VectorType &vector,
                            const ComponentMask &mask=ComponentMask());
 
   //@}

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -73,11 +73,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace VectorTools
 {
 
-  template <class VECTOR, int dim, int spacedim, template <int,int> class DH>
-  void interpolate (const Mapping<dim,spacedim>    &mapping,
-                    const DH<dim,spacedim>         &dof,
-                    const Function<spacedim>       &function,
-                    VECTOR                         &vec)
+  template <typename VectorType, int dim, int spacedim, template <int,int> class DH>
+  void interpolate (const Mapping<dim,spacedim> &mapping,
+                    const DH<dim,spacedim>      &dof,
+                    const Function<spacedim>    &function,
+                    VectorType                  &vec)
   {
     Assert (vec.size() == dof.n_dofs(),
             ExcDimensionMismatch (vec.size(), dof.n_dofs()));
@@ -269,10 +269,10 @@ namespace VectorTools
   }
 
 
-  template <class VECTOR, class DH>
-  void interpolate (const DH              &dof,
-                    const Function<DH::space_dimension>   &function,
-                    VECTOR                &vec)
+  template <typename VectorType, class DH>
+  void interpolate (const DH                            &dof,
+                    const Function<DH::space_dimension> &function,
+                    VectorType                          &vec)
   {
     interpolate(StaticMappingQ1<DH::dimension, DH::space_dimension>::mapping,
                 dof, function, vec);
@@ -332,12 +332,12 @@ namespace VectorTools
   }
 
 
-  template<typename VECTOR, typename DH>
+  template<typename VectorType, typename DH>
   void
   interpolate_based_on_material_id(const Mapping<DH::dimension, DH::space_dimension>                          &mapping,
                                    const DH                                                                   &dof,
                                    const std::map< types::material_id, const Function<DH::space_dimension>* > &function_map,
-                                   VECTOR                                                                     &dst,
+                                   VectorType                                                                 &dst,
                                    const ComponentMask                                                        &component_mask)
   {
     const unsigned int dim = DH::dimension;
@@ -541,9 +541,7 @@ namespace VectorTools
 
 
 
-  template <int dim, int spacedim,
-            template <int,int> class DH,
-            class VectorType>
+  template <int dim, int spacedim, template <int,int> class DH, typename VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
                                  const VectorType        &u1,
@@ -565,9 +563,7 @@ namespace VectorTools
 
 
 
-  template <int dim, int spacedim,
-            template <int,int> class DH,
-            class VectorType>
+  template <int dim, int spacedim, template <int,int> class DH, typename VectorType>
   void
   interpolate_to_different_mesh (const DH<dim, spacedim> &dof1,
                                  const VectorType        &u1,
@@ -605,9 +601,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, int spacedim,
-            template <int,int> class DH,
-            class VectorType>
+  template <int dim, int spacedim, template <int,int> class DH, typename VectorType>
   void
   interpolate_to_different_mesh (const InterGridMap<DH<dim, spacedim> > &intergridmap,
                                  const VectorType                       &u1,
@@ -682,10 +676,8 @@ namespace VectorTools
     /**
      * Compute the boundary values to be used in the project() functions.
      */
-    template <int dim, int spacedim,
-              template <int,int> class DH,
-              template <int,int> class M_or_MC,
-              template <int> class Q_or_QC>
+    template <int dim, int spacedim, template <int,int> class DH,
+              template <int,int> class M_or_MC, template <int> class Q_or_QC>
     void project_compute_b_v (const M_or_MC<dim, spacedim>   &mapping,
                               const DH<dim,spacedim> &dof,
                               const Function<spacedim> &function,
@@ -749,20 +741,17 @@ namespace VectorTools
     /**
      * Generic implementation of the project() function
      */
-    template <int dim, int spacedim,
-              class VectorType,
-              template <int,int> class DH,
-              template <int,int> class M_or_MC,
-              template <int> class Q_or_QC>
-    void do_project (const M_or_MC<dim, spacedim>   &mapping,
-                     const DH<dim,spacedim> &dof,
-                     const ConstraintMatrix   &constraints,
-                     const Q_or_QC<dim>       &quadrature,
-                     const Function<spacedim> &function,
-                     VectorType               &vec_result,
-                     const bool                enforce_zero_boundary,
-                     const Q_or_QC<dim-1>  &q_boundary,
-                     const bool                project_to_boundary_first)
+    template <int dim, int spacedim, typename VectorType, template <int,int> class DH,
+              template <int,int> class M_or_MC, template <int> class Q_or_QC>
+    void do_project (const M_or_MC<dim, spacedim> &mapping,
+                     const DH<dim,spacedim>       &dof,
+                     const ConstraintMatrix       &constraints,
+                     const Q_or_QC<dim>           &quadrature,
+                     const Function<spacedim>     &function,
+                     VectorType                   &vec_result,
+                     const bool                   enforce_zero_boundary,
+                     const Q_or_QC<dim-1>         &q_boundary,
+                     const bool                   project_to_boundary_first)
     {
       Assert (dof.get_fe().n_components() == function.n_components,
               ExcDimensionMismatch(dof.get_fe().n_components(),
@@ -842,16 +831,16 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VECTOR, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void project (const Mapping<dim, spacedim>   &mapping,
                 const DoFHandler<dim,spacedim> &dof,
-                const ConstraintMatrix   &constraints,
-                const Quadrature<dim>    &quadrature,
-                const Function<spacedim> &function,
-                VECTOR                   &vec_result,
-                const bool                enforce_zero_boundary,
-                const Quadrature<dim-1>  &q_boundary,
-                const bool                project_to_boundary_first)
+                const ConstraintMatrix         &constraints,
+                const Quadrature<dim>          &quadrature,
+                const Function<spacedim>       &function,
+                VectorType                     &vec_result,
+                const bool                     enforce_zero_boundary,
+                const Quadrature<dim-1>        &q_boundary,
+                const bool                     project_to_boundary_first)
   {
     do_project (mapping, dof, constraints, quadrature,
                 function, vec_result,
@@ -860,15 +849,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VECTOR, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void project (const DoFHandler<dim,spacedim> &dof,
-                const ConstraintMatrix   &constraints,
-                const Quadrature<dim>    &quadrature,
-                const Function<spacedim> &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary,
-                const Quadrature<dim-1>  &q_boundary,
-                const bool                project_to_boundary_first)
+                const ConstraintMatrix         &constraints,
+                const Quadrature<dim>          &quadrature,
+                const Function<spacedim>       &function,
+                VectorType                     &vec,
+                const bool                     enforce_zero_boundary,
+                const Quadrature<dim-1>        &q_boundary,
+                const bool                     project_to_boundary_first)
   {
     project(StaticMappingQ1<dim,spacedim>::mapping, dof, constraints, quadrature, function, vec,
             enforce_zero_boundary, q_boundary, project_to_boundary_first);
@@ -876,16 +865,16 @@ namespace VectorTools
 
 
 
-  template <int dim, class VECTOR, int spacedim>
-  void project (const hp::MappingCollection<dim, spacedim>   &mapping,
-                const hp::DoFHandler<dim,spacedim> &dof,
-                const ConstraintMatrix   &constraints,
-                const hp::QCollection<dim>    &quadrature,
-                const Function<spacedim> &function,
-                VECTOR                   &vec_result,
-                const bool                enforce_zero_boundary,
-                const hp::QCollection<dim-1>  &q_boundary,
-                const bool                project_to_boundary_first)
+  template <int dim, typename VectorType, int spacedim>
+  void project (const hp::MappingCollection<dim, spacedim> &mapping,
+                const hp::DoFHandler<dim,spacedim>         &dof,
+                const ConstraintMatrix                     &constraints,
+                const hp::QCollection<dim>                 &quadrature,
+                const Function<spacedim>                   &function,
+                VectorType                                 &vec_result,
+                const bool                                 enforce_zero_boundary,
+                const hp::QCollection<dim-1>               &q_boundary,
+                const bool                                 project_to_boundary_first)
   {
     do_project (mapping, dof, constraints, quadrature,
                 function, vec_result,
@@ -894,15 +883,15 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VECTOR, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void project (const hp::DoFHandler<dim,spacedim> &dof,
-                const ConstraintMatrix   &constraints,
-                const hp::QCollection<dim>    &quadrature,
-                const Function<spacedim> &function,
-                VECTOR                   &vec,
-                const bool                enforce_zero_boundary,
-                const hp::QCollection<dim-1>  &q_boundary,
-                const bool                project_to_boundary_first)
+                const ConstraintMatrix             &constraints,
+                const hp::QCollection<dim>         &quadrature,
+                const Function<spacedim>           &function,
+                VectorType                         &vec,
+                const bool                         enforce_zero_boundary,
+                const hp::QCollection<dim-1>       &q_boundary,
+                const bool                         project_to_boundary_first)
   {
     project(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
             dof, constraints, quadrature, function, vec,
@@ -1661,8 +1650,7 @@ namespace VectorTools
     // faces are points and it is far
     // easier to simply work on
     // individual vertices
-    template <class DH,
-              template <int,int> class M_or_MC>
+    template <class DH, template <int,int> class M_or_MC>
     static inline
     void do_interpolate_boundary_values (const M_or_MC<DH::dimension, DH::space_dimension> &,
                                          const DH                 &dof,
@@ -1744,9 +1732,7 @@ namespace VectorTools
     // dim_, it is clearly less specialized than the 1d function above and
     // whenever possible (i.e., if dim==1), the function template above
     // will be used
-    template <class DH,
-              template <int,int> class M_or_MC,
-              int dim_>
+    template <class DH, template <int,int> class M_or_MC, int dim_>
     static inline
     void
     do_interpolate_boundary_values (const M_or_MC<DH::dimension, DH::space_dimension> &mapping,
@@ -2153,10 +2139,8 @@ namespace VectorTools
 
   namespace
   {
-    template <int dim, int spacedim,
-              template <int,int> class DH,
-              template <int,int> class M_or_MC,
-              template <int> class Q_or_QC>
+    template <int dim, int spacedim, template <int,int> class DH,
+              template <int,int> class M_or_MC, template <int> class Q_or_QC>
     void
     do_project_boundary_values (const M_or_MC<dim, spacedim>   &mapping,
                                 const DH<dim, spacedim> &dof,
@@ -6541,7 +6525,7 @@ namespace VectorTools
 
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_difference (const DoFHandler<dim,spacedim> &dof,
                     const VectorType               &fe_function,
@@ -6558,7 +6542,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_difference (const Mapping<dim, spacedim>   &mapping,
                     const DoFHandler<dim,spacedim> &dof,
@@ -6604,7 +6588,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const DoFHandler<dim,spacedim> &dof,
                const VectorType               &fe_function,
@@ -6620,7 +6604,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
                const VectorType                   &fe_function,
@@ -6635,7 +6619,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const DoFHandler<dim,spacedim> &dof,
                const VectorType               &fe_function,
@@ -6648,7 +6632,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const hp::DoFHandler<dim,spacedim> &dof,
                const VectorType                   &fe_function,
@@ -6661,7 +6645,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
@@ -6702,7 +6686,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_value (const hp::MappingCollection<dim, spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>         &dof,
@@ -6742,7 +6726,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const Mapping<dim, spacedim>   &mapping,
                const DoFHandler<dim,spacedim> &dof,
@@ -6759,7 +6743,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   point_value (const hp::MappingCollection<dim, spacedim> &mapping,
                const hp::DoFHandler<dim,spacedim>         &dof,
@@ -6777,7 +6761,7 @@ namespace VectorTools
 
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const DoFHandler<dim,spacedim> &dof,
                   const VectorType               &fe_function,
@@ -6793,7 +6777,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const VectorType                   &fe_function,
@@ -6808,7 +6792,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const DoFHandler<dim,spacedim> &dof,
                   const VectorType               &fe_function,
@@ -6821,7 +6805,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::DoFHandler<dim,spacedim> &dof,
                   const VectorType                   &fe_function,
@@ -6834,7 +6818,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const Mapping<dim, spacedim>   &mapping,
                   const DoFHandler<dim,spacedim> &dof,
@@ -6876,7 +6860,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   void
   point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>         &dof,
@@ -6915,7 +6899,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const Mapping<dim, spacedim>   &mapping,
                   const DoFHandler<dim,spacedim> &dof,
@@ -6933,7 +6917,7 @@ namespace VectorTools
 
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   Tensor<1, spacedim, typename VectorType::value_type>
   point_gradient (const hp::MappingCollection<dim, spacedim> &mapping,
                   const hp::DoFHandler<dim,spacedim>         &dof,
@@ -6951,9 +6935,9 @@ namespace VectorTools
 
 
 
-  template <class VECTOR>
+  template <typename VectorType>
   void
-  subtract_mean_value(VECTOR                  &v,
+  subtract_mean_value(VectorType              &v,
                       const std::vector<bool> &p_select)
   {
     if (p_select.size() == 0)
@@ -6978,7 +6962,7 @@ namespace VectorTools
         Assert(p_select.size() == n,
                ExcDimensionMismatch(p_select.size(), n));
 
-        typename VECTOR::value_type s = 0.;
+        typename VectorType::value_type s = 0.;
         unsigned int counter = 0;
         for (unsigned int i=0; i<n; ++i)
           if (p_select[i])
@@ -7020,7 +7004,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   compute_mean_value (const Mapping<dim, spacedim>   &mapping,
                       const DoFHandler<dim,spacedim> &dof,
@@ -7087,7 +7071,7 @@ namespace VectorTools
   }
 
 
-  template <int dim, class VectorType, int spacedim>
+  template <int dim, typename VectorType, int spacedim>
   double
   compute_mean_value (const DoFHandler<dim,spacedim> &dof,
                       const Quadrature<dim>          &quadrature,
@@ -7098,9 +7082,9 @@ namespace VectorTools
   }
 
 
-  template<class DH, class VECTOR>
+  template<class DH, typename VectorType>
   void get_position_vector(const DH            &dh,
-                           VECTOR              &vector,
+                           VectorType          &vector,
                            const ComponentMask &mask)
   {
     AssertDimension(vector.size(), dh.n_dofs());

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2127,10 +2127,10 @@ namespace DataOutBase
 
 //----------------------------------------------------------------------//
 
-  template <int dim, int spacedim, typename STREAM>
+  template <int dim, int spacedim, typename StreamType>
   void
   write_nodes (const std::vector<Patch<dim,spacedim> > &patches,
-               STREAM &out)
+               StreamType                              &out)
   {
     Assert (dim<=3, ExcNotImplemented());
     unsigned int count = 0;
@@ -2168,10 +2168,10 @@ namespace DataOutBase
     out.flush_points ();
   }
 
-  template <int dim, int spacedim, typename STREAM>
+  template <int dim, int spacedim, typename StreamType>
   void
   write_cells (const std::vector<Patch<dim,spacedim> > &patches,
-               STREAM &out)
+               StreamType                              &out)
   {
     Assert (dim<=3, ExcNotImplemented());
     unsigned int count = 0;
@@ -2210,13 +2210,13 @@ namespace DataOutBase
   }
 
 
-  template <int dim, int spacedim, class STREAM>
+  template <int dim, int spacedim, class StreamType>
   void
-  write_data (
-    const std::vector<Patch<dim,spacedim> > &patches,
-    unsigned int n_data_sets,
-    const bool double_precision,
-    STREAM &out)
+  write_data
+  (const std::vector<Patch<dim,spacedim> > &patches,
+   unsigned int                             n_data_sets,
+   const bool                               double_precision,
+   StreamType                              &out)
   {
     Assert (dim<=3, ExcNotImplemented());
     unsigned int count = 0;

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -73,10 +73,10 @@ namespace internal
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 inline
 void
-TensorProductPolynomials<dim,POLY>::
+TensorProductPolynomials<dim,PolynomialType>::
 compute_index (const unsigned int i,
                unsigned int       (&indices)[(dim > 0 ? dim : 1)]) const
 {
@@ -87,9 +87,9 @@ compute_index (const unsigned int i,
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 void
-TensorProductPolynomials<dim,POLY>::output_indices(std::ostream &out) const
+TensorProductPolynomials<dim,PolynomialType>::output_indices(std::ostream &out) const
 {
   unsigned int ix[dim];
   for (unsigned int i=0; i<n_tensor_pols; ++i)
@@ -104,10 +104,10 @@ TensorProductPolynomials<dim,POLY>::output_indices(std::ostream &out) const
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 void
-TensorProductPolynomials<dim,POLY>::set_numbering(
-  const std::vector<unsigned int> &renumber)
+TensorProductPolynomials<dim,PolynomialType>::set_numbering
+(const std::vector<unsigned int> &renumber)
 {
   Assert(renumber.size()==index_map.size(),
          ExcDimensionMismatch(renumber.size(), index_map.size()));
@@ -131,10 +131,11 @@ TensorProductPolynomials<0,Polynomials::Polynomial<double> >
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 double
-TensorProductPolynomials<dim,POLY>::compute_value (const unsigned int i,
-                                                   const Point<dim> &p) const
+TensorProductPolynomials<dim,PolynomialType>::compute_value
+(const unsigned int  i,
+ const Point<dim>   &p) const
 {
   Assert(dim>0, ExcNotImplemented());
 
@@ -150,10 +151,10 @@ TensorProductPolynomials<dim,POLY>::compute_value (const unsigned int i,
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 Tensor<1,dim>
-TensorProductPolynomials<dim,POLY>::compute_grad (const unsigned int i,
-                                                  const Point<dim> &p) const
+TensorProductPolynomials<dim,PolynomialType>::compute_grad (const unsigned int  i,
+                                                            const Point<dim>   &p) const
 {
   unsigned int indices[dim];
   compute_index (i, indices);
@@ -186,10 +187,11 @@ TensorProductPolynomials<dim,POLY>::compute_grad (const unsigned int i,
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 Tensor<2,dim>
-TensorProductPolynomials<dim,POLY>::compute_grad_grad (const unsigned int i,
-                                                       const Point<dim> &p) const
+TensorProductPolynomials<dim,PolynomialType>::compute_grad_grad
+(const unsigned int  i,
+ const Point<dim>   &p) const
 {
   unsigned int indices[dim];
   compute_index (i, indices);
@@ -231,9 +233,9 @@ TensorProductPolynomials<dim,POLY>::compute_grad_grad (const unsigned int i,
 
 
 
-template <int dim, typename POLY>
+template <int dim, typename PolynomialType>
 void
-TensorProductPolynomials<dim,POLY>::
+TensorProductPolynomials<dim,PolynomialType>::
 compute (const Point<dim>            &p,
          std::vector<double>         &values,
          std::vector<Tensor<1,dim> > &grads,

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -43,8 +43,8 @@ namespace parallel
   namespace distributed
   {
 
-    template<int dim, typename VECTOR, class DH>
-    SolutionTransfer<dim, VECTOR, DH>::SolutionTransfer(const DH &dof)
+    template<int dim, typename VectorType, class DH>
+    SolutionTransfer<dim, VectorType, DH>::SolutionTransfer (const DH &dof)
       :
       dof_handler(&dof, typeid(*this).name())
     {
@@ -55,16 +55,16 @@ namespace parallel
 
 
 
-    template<int dim, typename VECTOR, class DH>
-    SolutionTransfer<dim, VECTOR, DH>::~SolutionTransfer()
+    template<int dim, typename VectorType, class DH>
+    SolutionTransfer<dim, VectorType, DH>::~SolutionTransfer ()
     {}
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    prepare_for_coarsening_and_refinement (const std::vector<const VECTOR *> &all_in)
+    SolutionTransfer<dim, VectorType, DH>::
+    prepare_for_coarsening_and_refinement (const std::vector<const VectorType *> &all_in)
     {
       input_vectors = all_in;
       register_data_attach( get_data_size() * input_vectors.size() );
@@ -72,10 +72,9 @@ namespace parallel
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    register_data_attach(const std::size_t size)
+    SolutionTransfer<dim, VectorType, DH>::register_data_attach (const std::size_t size)
     {
       Assert(size > 0, ExcMessage("Please transfer at least one vector!"));
 
@@ -88,7 +87,7 @@ namespace parallel
 
       offset
         = tria->register_data_attach(size,
-                                     std_cxx11::bind(&SolutionTransfer<dim, VECTOR, DH>::pack_callback,
+                                     std_cxx11::bind(&SolutionTransfer<dim, VectorType, DH>::pack_callback,
                                                      this,
                                                      std_cxx11::_1,
                                                      std_cxx11::_2,
@@ -98,53 +97,50 @@ namespace parallel
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    prepare_for_coarsening_and_refinement (const VECTOR &in)
+    SolutionTransfer<dim, VectorType, DH>::
+    prepare_for_coarsening_and_refinement (const VectorType &in)
     {
-      std::vector<const VECTOR *> all_in(1, &in);
+      std::vector<const VectorType *> all_in(1, &in);
       prepare_for_coarsening_and_refinement(all_in);
     }
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    prepare_serialization(const VECTOR &in)
+    SolutionTransfer<dim, VectorType, DH>::prepare_serialization (const VectorType &in)
     {
-      std::vector<const VECTOR *> all_in(1, &in);
+      std::vector<const VectorType *> all_in(1, &in);
       prepare_serialization(all_in);
     }
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    prepare_serialization(const std::vector<const VECTOR *> &all_in)
+    SolutionTransfer<dim, VectorType, DH>::prepare_serialization
+    (const std::vector<const VectorType *> &all_in)
     {
       prepare_for_coarsening_and_refinement (all_in);
     }
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    deserialize(VECTOR &in)
+    SolutionTransfer<dim, VectorType, DH>::deserialize (VectorType &in)
     {
-      std::vector<VECTOR *> all_in(1, &in);
+      std::vector<VectorType *> all_in(1, &in);
       deserialize(all_in);
     }
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    deserialize(std::vector<VECTOR *> &all_in)
+    SolutionTransfer<dim, VectorType, DH>::deserialize (std::vector<VectorType *> &all_in)
     {
       register_data_attach( get_data_size() * all_in.size() );
 
@@ -155,10 +151,9 @@ namespace parallel
     }
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    interpolate (std::vector<VECTOR *> &all_out)
+    SolutionTransfer<dim, VectorType, DH>::interpolate (std::vector<VectorType *> &all_out)
     {
       Assert(input_vectors.size()==all_out.size(),
              ExcDimensionMismatch(input_vectors.size(), all_out.size()) );
@@ -171,7 +166,7 @@ namespace parallel
       Assert (tria != 0, ExcInternalError());
 
       tria->notify_ready_to_unpack(offset,
-                                   std_cxx11::bind(&SolutionTransfer<dim, VECTOR, DH>::unpack_callback,
+                                   std_cxx11::bind(&SolutionTransfer<dim, VectorType, DH>::unpack_callback,
                                                    this,
                                                    std_cxx11::_1,
                                                    std_cxx11::_2,
@@ -179,7 +174,7 @@ namespace parallel
                                                    std_cxx11::ref(all_out)));
 
 
-      for (typename std::vector<VECTOR *>::iterator it=all_out.begin();
+      for (typename std::vector<VectorType *>::iterator it=all_out.begin();
            it !=all_out.end();
            ++it)
         (*it)->compress(::dealii::VectorOperation::insert);
@@ -189,72 +184,70 @@ namespace parallel
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    interpolate (VECTOR &out)
+    SolutionTransfer<dim, VectorType, DH>::interpolate (VectorType &out)
     {
-      std::vector<VECTOR *> all_out(1, &out);
+      std::vector<VectorType *> all_out(1, &out);
       interpolate(all_out);
     }
 
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     unsigned int
-    SolutionTransfer<dim, VECTOR, DH>::
-    get_data_size() const
+    SolutionTransfer<dim, VectorType, DH>::get_data_size() const
     {
       return sizeof(double)* DoFTools::max_dofs_per_cell(*dof_handler);
     }
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
+    SolutionTransfer<dim, VectorType, DH>::
     pack_callback(const typename Triangulation<dim,dim>::cell_iterator &cell_,
                   const typename Triangulation<dim,dim>::CellStatus /*status*/,
                   void *data)
     {
-      typename VECTOR::value_type *data_store = reinterpret_cast<typename VECTOR::value_type *>(data);
+      typename VectorType::value_type *data_store = reinterpret_cast<typename VectorType::value_type *>(data);
 
       typename DH::cell_iterator cell(*cell_, dof_handler);
 
       const unsigned int dofs_per_cell=cell->get_fe().dofs_per_cell;
-      ::dealii::Vector<typename VECTOR::value_type> dofvalues(dofs_per_cell);
-      for (typename std::vector<const VECTOR *>::iterator it=input_vectors.begin();
+      ::dealii::Vector<typename VectorType::value_type> dofvalues(dofs_per_cell);
+      for (typename std::vector<const VectorType *>::iterator it=input_vectors.begin();
            it !=input_vectors.end();
            ++it)
         {
           cell->get_interpolated_dof_values(*(*it), dofvalues);
-          Assert (typeid(typename VECTOR::value_type) == typeid(double), ExcNotImplemented());
-          std::memcpy(data_store, &dofvalues(0), sizeof(typename VECTOR::value_type)*dofs_per_cell);
+          Assert (typeid(typename VectorType::value_type) == typeid(double), ExcNotImplemented());
+          std::memcpy(data_store, &dofvalues(0), sizeof(typename VectorType::value_type)*dofs_per_cell);
           data_store += dofs_per_cell;
         }
     }
 
 
-    template<int dim, typename VECTOR, class DH>
+    template<int dim, typename VectorType, class DH>
     void
-    SolutionTransfer<dim, VECTOR, DH>::
-    unpack_callback(const typename Triangulation<dim,dim>::cell_iterator &cell_,
-                    const typename Triangulation<dim,dim>::CellStatus /*status*/,
-                    const void *data,
-                    std::vector<VECTOR *> &all_out)
+    SolutionTransfer<dim, VectorType, DH>::unpack_callback
+    (const typename Triangulation<dim,dim>::cell_iterator &cell_,
+     const typename Triangulation<dim,dim>::CellStatus    /*status*/,
+     const void                                           *data,
+     std::vector<VectorType *>                            &all_out)
     {
       typename DH::cell_iterator
       cell(*cell_, dof_handler);
 
       const unsigned int dofs_per_cell=cell->get_fe().dofs_per_cell;
-      ::dealii::Vector<typename VECTOR::value_type> dofvalues(dofs_per_cell);
-      const typename VECTOR::value_type *data_store = reinterpret_cast<const typename VECTOR::value_type *>(data);
+      ::dealii::Vector<typename VectorType::value_type> dofvalues(dofs_per_cell);
+      const typename VectorType::value_type *data_store = reinterpret_cast<const typename VectorType::value_type *>(data);
 
-      for (typename std::vector<VECTOR *>::iterator it = all_out.begin();
+      for (typename std::vector<VectorType *>::iterator it = all_out.begin();
            it != all_out.end();
            ++it)
         {
-          Assert (typeid(typename VECTOR::value_type) == typeid(double), ExcNotImplemented());
-          std::memcpy(&dofvalues(0), data_store, sizeof(typename VECTOR::value_type)*dofs_per_cell);
+          Assert (typeid(typename VectorType::value_type) == typeid(double), ExcNotImplemented());
+          std::memcpy(&dofvalues(0), data_store, sizeof(typename VectorType::value_type)*dofs_per_cell);
           cell->set_dof_values_by_interpolation(dofvalues, *(*it));
           data_store += dofs_per_cell;
         }

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -131,16 +131,17 @@ namespace
 
 
 
-template <class POLY, int dim, int spacedim>
-FE_PolyTensor<POLY,dim,spacedim>::FE_PolyTensor (const unsigned int degree,
-                                                 const FiniteElementData<dim> &fe_data,
-                                                 const std::vector<bool> &restriction_is_additive_flags,
-                                                 const std::vector<ComponentMask> &nonzero_components)
+template <class PolynomialType, int dim, int spacedim>
+FE_PolyTensor<PolynomialType,dim,spacedim>::FE_PolyTensor
+(const unsigned int                degree,
+ const FiniteElementData<dim>     &fe_data,
+ const std::vector<bool>          &restriction_is_additive_flags,
+ const std::vector<ComponentMask> &nonzero_components)
   :
   FiniteElement<dim,spacedim> (fe_data,
                                restriction_is_additive_flags,
                                nonzero_components),
-  poly_space(POLY(degree))
+  poly_space(PolynomialType(degree))
 {
   cached_point(0) = -1;
   // Set up the table converting
@@ -156,9 +157,10 @@ FE_PolyTensor<POLY,dim,spacedim>::FE_PolyTensor (const unsigned int degree,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 double
-FE_PolyTensor<POLY,dim,spacedim>::shape_value (const unsigned int, const Point<dim> &) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_value
+(const unsigned int, const Point<dim> &) const
 
 {
   typedef    FiniteElement<dim,spacedim> FEE;
@@ -168,11 +170,12 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_value (const unsigned int, const Point<d
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 double
-FE_PolyTensor<POLY,dim,spacedim>::shape_value_component (const unsigned int i,
-                                                         const Point<dim> &p,
-                                                         const unsigned int component) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_value_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   Assert (component < dim, ExcIndexRange (component, 0, dim));
@@ -198,10 +201,10 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_value_component (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<1,dim>
-FE_PolyTensor<POLY,dim,spacedim>::shape_grad (const unsigned int,
-                                              const Point<dim> &) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_grad (const unsigned int,
+                                                        const Point<dim> &) const
 {
   typedef    FiniteElement<dim,spacedim> FEE;
   Assert(false, typename FEE::ExcFENotPrimitive());
@@ -210,11 +213,12 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_grad (const unsigned int,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<1,dim>
-FE_PolyTensor<POLY,dim,spacedim>::shape_grad_component (const unsigned int i,
-                                                        const Point<dim> &p,
-                                                        const unsigned int component) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_grad_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   Assert (component < dim, ExcIndexRange (component, 0, dim));
@@ -241,9 +245,11 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_grad_component (const unsigned int i,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<2,dim>
-FE_PolyTensor<POLY,dim,spacedim>::shape_grad_grad (const unsigned int, const Point<dim> &) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_grad_grad
+(const unsigned int,
+ const Point<dim> &) const
 {
   typedef    FiniteElement<dim,spacedim> FEE;
   Assert(false, typename FEE::ExcFENotPrimitive());
@@ -252,11 +258,12 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_grad_grad (const unsigned int, const Poi
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 Tensor<2,dim>
-FE_PolyTensor<POLY,dim,spacedim>::shape_grad_grad_component (const unsigned int i,
-    const Point<dim> &p,
-    const unsigned int component) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::shape_grad_grad_component
+(const unsigned int  i,
+ const Point<dim>   &p,
+ const unsigned int  component) const
 {
   Assert (i<this->dofs_per_cell, ExcIndexRange(i,0,this->dofs_per_cell));
   Assert (component < dim, ExcIndexRange (component, 0, dim));
@@ -286,17 +293,18 @@ FE_PolyTensor<POLY,dim,spacedim>::shape_grad_grad_component (const unsigned int 
 // Fill data of FEValues
 //---------------------------------------------------------------------------
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
-                const CellSimilarity::Similarity                                     cell_similarity,
-                const Quadrature<dim>                                               &quadrature,
-                const Mapping<dim,spacedim>                                         &mapping,
-                const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
-                const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::
+fill_fe_values
+(const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+ const CellSimilarity::Similarity                                     cell_similarity,
+ const Quadrature<dim>                                               &quadrature,
+ const Mapping<dim,spacedim>                                         &mapping,
+ const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+ const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+ dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -755,17 +763,18 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator       
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
-                     const unsigned int                                                   face_no,
-                     const Quadrature<dim-1>                                             &quadrature,
-                     const Mapping<dim,spacedim>                                         &mapping,
-                     const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                     const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
-                     const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                     dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::
+fill_fe_face_values
+(const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+ const unsigned int                                                   face_no,
+ const Quadrature<dim-1>                                             &quadrature,
+ const Mapping<dim,spacedim>                                         &mapping,
+ const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+ const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+ dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -1214,18 +1223,19 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_PolyTensor<POLY,dim,spacedim>::
-fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
-                        const unsigned int                                                   face_no,
-                        const unsigned int                                                   sub_no,
-                        const Quadrature<dim-1>                                             &quadrature,
-                        const Mapping<dim,spacedim>                                         &mapping,
-                        const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
-                        const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
-                        const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
-                        dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::
+fill_fe_subface_values
+(const typename Triangulation<dim,spacedim>::cell_iterator           &cell,
+ const unsigned int                                                   face_no,
+ const unsigned int                                                   sub_no,
+ const Quadrature<dim-1>                                             &quadrature,
+ const Mapping<dim,spacedim>                                         &mapping,
+ const typename Mapping<dim,spacedim>::InternalDataBase              &mapping_internal,
+ const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
+ const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
+ dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const
 {
   // convert data object to internal
   // data for this class. fails with
@@ -1676,17 +1686,17 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyTensor<POLY,dim,spacedim>::requires_update_flags(const UpdateFlags flags) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   return update_once(flags) | update_each(flags);
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyTensor<POLY,dim,spacedim>::update_once (const UpdateFlags flags) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::update_once (const UpdateFlags flags) const
 {
   const bool values_once = (mapping_type == mapping_none);
 
@@ -1699,9 +1709,9 @@ FE_PolyTensor<POLY,dim,spacedim>::update_once (const UpdateFlags flags) const
 }
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
-FE_PolyTensor<POLY,dim,spacedim>::update_each (const UpdateFlags flags) const
+FE_PolyTensor<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -102,8 +102,8 @@ namespace FE_Q_Helper
  * A class with the same purpose as the similarly named class of the
  * Triangulation class. See there for more information.
  */
-template <class POLY, int xdim, int xspacedim>
-struct FE_Q_Base<POLY,xdim,xspacedim>::Implementation
+template <class PolynomialType, int xdim, int xspacedim>
+struct FE_Q_Base<PolynomialType,xdim,xspacedim>::Implementation
 {
   /**
    * Initialize the hanging node constraints matrices. Called from the
@@ -112,7 +112,7 @@ struct FE_Q_Base<POLY,xdim,xspacedim>::Implementation
   template <int spacedim>
   static
   void initialize_constraints (const std::vector<Point<1> > &,
-                               FE_Q_Base<POLY,1,spacedim> &)
+                               FE_Q_Base<PolynomialType,1,spacedim> &)
   {
     // no constraints in 1d
   }
@@ -121,12 +121,12 @@ struct FE_Q_Base<POLY,xdim,xspacedim>::Implementation
   template <int spacedim>
   static
   void initialize_constraints (const std::vector<Point<1> > &/*points*/,
-                               FE_Q_Base<POLY,2,spacedim> &fe)
+                               FE_Q_Base<PolynomialType,2,spacedim> &fe)
   {
     const unsigned int dim = 2;
 
     unsigned int q_deg = fe.degree;
-    if (types_are_equal<POLY, TensorProductPolynomialsBubbles<dim> >::value)
+    if (types_are_equal<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value)
       q_deg = fe.degree-1;
 
     // restricted to each face, the traces of the shape functions is an
@@ -228,12 +228,12 @@ struct FE_Q_Base<POLY,xdim,xspacedim>::Implementation
   template <int spacedim>
   static
   void initialize_constraints (const std::vector<Point<1> > &/*points*/,
-                               FE_Q_Base<POLY,3,spacedim> &fe)
+                               FE_Q_Base<PolynomialType,3,spacedim> &fe)
   {
     const unsigned int dim = 3;
 
     unsigned int q_deg = fe.degree;
-    if (types_are_equal<POLY,TensorProductPolynomialsBubbles<dim> >::value)
+    if (types_are_equal<PolynomialType,TensorProductPolynomialsBubbles<dim> >::value)
       q_deg = fe.degree-1;
 
     // For a detailed documentation of the interpolation see the
@@ -408,23 +408,24 @@ struct FE_Q_Base<POLY,xdim,xspacedim>::Implementation
 
 
 
-template <class POLY, int dim, int spacedim>
-FE_Q_Base<POLY,dim,spacedim>::FE_Q_Base (const POLY &poly_space,
-                                         const FiniteElementData<dim> &fe_data,
-                                         const std::vector<bool> &restriction_is_additive_flags)
+template <class PolynomialType, int dim, int spacedim>
+FE_Q_Base<PolynomialType,dim,spacedim>::FE_Q_Base
+(const PolynomialType         &poly_space,
+ const FiniteElementData<dim> &fe_data,
+ const std::vector<bool>      &restriction_is_additive_flags)
   :
-  FE_Poly<POLY,dim,spacedim>(poly_space, fe_data, restriction_is_additive_flags,
-                             std::vector<ComponentMask>(1, std::vector<bool>(1,true))),
-  q_degree (types_are_equal<POLY, TensorProductPolynomialsBubbles<dim> >::value
+  FE_Poly<PolynomialType,dim,spacedim>(poly_space, fe_data, restriction_is_additive_flags,
+                                       std::vector<ComponentMask>(1, std::vector<bool>(1,true))),
+  q_degree (types_are_equal<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value
             ?this->degree-1
             :this->degree)
 {}
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::initialize (const std::vector<Point<1> > &points)
+FE_Q_Base<PolynomialType,dim,spacedim>::initialize (const std::vector<Point<1> > &points)
 {
   Assert (points[0][0] == 0,
           ExcMessage ("The first support point has to be zero."));
@@ -465,15 +466,15 @@ FE_Q_Base<POLY,dim,spacedim>::initialize (const std::vector<Point<1> > &points)
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 get_interpolation_matrix (const FiniteElement<dim,spacedim> &x_source_fe,
-                          FullMatrix<double>       &interpolation_matrix) const
+                          FullMatrix<double>                &interpolation_matrix) const
 {
   // go through the list of elements we can interpolate from
-  if (const FE_Q_Base<POLY,dim,spacedim> *source_fe
-      = dynamic_cast<const FE_Q_Base<POLY,dim,spacedim>*>(&x_source_fe))
+  if (const FE_Q_Base<PolynomialType,dim,spacedim> *source_fe
+      = dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim>*>(&x_source_fe))
     {
       // ok, source is a Q element, so we will be able to do the work
       Assert (interpolation_matrix.m() == this->dofs_per_cell,
@@ -559,11 +560,11 @@ get_interpolation_matrix (const FiniteElement<dim,spacedim> &x_source_fe,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
-                               FullMatrix<double>       &interpolation_matrix) const
+                               FullMatrix<double>                &interpolation_matrix) const
 {
   Assert (dim > 1, ExcImpossibleInDim(1));
   get_subface_interpolation_matrix (source_fe, numbers::invalid_unsigned_int,
@@ -572,20 +573,20 @@ get_face_interpolation_matrix (const FiniteElement<dim,spacedim> &source_fe,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &x_source_fe,
-                                  const unsigned int        subface,
-                                  FullMatrix<double>       &interpolation_matrix) const
+                                  const unsigned int                 subface,
+                                  FullMatrix<double>                &interpolation_matrix) const
 {
   Assert (interpolation_matrix.m() == x_source_fe.dofs_per_face,
           ExcDimensionMismatch (interpolation_matrix.m(),
                                 x_source_fe.dofs_per_face));
 
   // see if source is a Q element
-  if (const FE_Q_Base<POLY,dim,spacedim> *source_fe
-      = dynamic_cast<const FE_Q_Base<POLY,dim,spacedim> *>(&x_source_fe))
+  if (const FE_Q_Base<PolynomialType,dim,spacedim> *source_fe
+      = dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim> *>(&x_source_fe))
     {
       // have this test in here since a table of size 2x0 reports its size as
       // 0x0
@@ -665,9 +666,9 @@ get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> &x_source_fe
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 bool
-FE_Q_Base<POLY,dim,spacedim>::hp_constraints_are_implemented () const
+FE_Q_Base<PolynomialType,dim,spacedim>::hp_constraints_are_implemented () const
 {
   return true;
 }
@@ -675,16 +676,16 @@ FE_Q_Base<POLY,dim,spacedim>::hp_constraints_are_implemented () const
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int> >
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing. in the first case, there should be
   // exactly one single DoF of each FE at a vertex, and they should have
   // identical value
-  if (dynamic_cast<const FE_Q_Base<POLY,dim,spacedim>*>(&fe_other) != 0)
+  if (dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim>*>(&fe_other) != 0)
     {
       return
         std::vector<std::pair<unsigned int, unsigned int> >
@@ -716,14 +717,15 @@ hp_vertex_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int> >
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing
-  if (const FE_Q_Base<POLY,dim,spacedim> *fe_q_other = dynamic_cast<const FE_Q_Base<POLY,dim,spacedim>*>(&fe_other))
+  if (const FE_Q_Base<PolynomialType,dim,spacedim> *fe_q_other
+      = dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim>*>(&fe_other))
     {
       // dofs are located along lines, so two dofs are identical if they are
       // located at identical positions. if we had only equidistant points, we
@@ -778,14 +780,15 @@ hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int> >
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 hp_quad_dof_identities (const FiniteElement<dim,spacedim>        &fe_other) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing
-  if (const FE_Q_Base<POLY,dim,spacedim> *fe_q_other = dynamic_cast<const FE_Q_Base<POLY,dim,spacedim>*>(&fe_other))
+  if (const FE_Q_Base<PolynomialType,dim,spacedim> *fe_q_other
+      = dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim>*>(&fe_other))
     {
       // this works exactly like the line case above, except that now we have
       // to have two indices i1, i2 and j1, j2 to characterize the dofs on the
@@ -844,13 +847,13 @@ hp_quad_dof_identities (const FiniteElement<dim,spacedim>        &fe_other) cons
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 FiniteElementDomination::Domination
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const
 {
-  if (const FE_Q_Base<POLY,dim,spacedim> *fe_q_other
-      = dynamic_cast<const FE_Q_Base<POLY,dim,spacedim>*>(&fe_other))
+  if (const FE_Q_Base<PolynomialType,dim,spacedim> *fe_q_other
+      = dynamic_cast<const FE_Q_Base<PolynomialType,dim,spacedim>*>(&fe_other))
     {
       if (this->degree < fe_q_other->degree)
         return FiniteElementDomination::this_element_dominates;
@@ -884,8 +887,9 @@ compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const
 
 
 
-template <class POLY, int dim, int spacedim>
-void FE_Q_Base<POLY,dim,spacedim>::initialize_unit_support_points (const std::vector<Point<1> > &points)
+template <class PolynomialType, int dim, int spacedim>
+void FE_Q_Base<PolynomialType,dim,spacedim>::initialize_unit_support_points
+(const std::vector<Point<1> > &points)
 {
   const std::vector<unsigned int> &index_map_inverse=
     this->poly_space.get_numbering_inverse();
@@ -900,8 +904,9 @@ void FE_Q_Base<POLY,dim,spacedim>::initialize_unit_support_points (const std::ve
 
 
 
-template <class POLY, int dim, int spacedim>
-void FE_Q_Base<POLY,dim,spacedim>::initialize_unit_face_support_points (const std::vector<Point<1> > &points)
+template <class PolynomialType, int dim, int spacedim>
+void FE_Q_Base<PolynomialType,dim,spacedim>::initialize_unit_face_support_points
+(const std::vector<Point<1> > &points)
 {
   // no faces in 1d, so nothing to do
   if (dim == 1)
@@ -923,9 +928,9 @@ void FE_Q_Base<POLY,dim,spacedim>::initialize_unit_face_support_points (const st
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::initialize_quad_dof_index_permutation ()
+FE_Q_Base<PolynomialType,dim,spacedim>::initialize_quad_dof_index_permutation ()
 {
   // for 1D and 2D, do nothing
   if (dim < 3)
@@ -990,9 +995,9 @@ FE_Q_Base<POLY,dim,spacedim>::initialize_quad_dof_index_permutation ()
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 unsigned int
-FE_Q_Base<POLY,dim,spacedim>::
+FE_Q_Base<PolynomialType,dim,spacedim>::
 face_to_cell_index (const unsigned int face_index,
                     const unsigned int face,
                     const bool face_orientation,
@@ -1111,9 +1116,9 @@ face_to_cell_index (const unsigned int face_index,
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 std::vector<unsigned int>
-FE_Q_Base<POLY,dim,spacedim>::get_dpo_vector(const unsigned int deg)
+FE_Q_Base<PolynomialType,dim,spacedim>::get_dpo_vector(const unsigned int deg)
 {
   AssertThrow(deg>0,ExcMessage("FE_Q needs to be of degree > 0."));
   std::vector<unsigned int> dpo(dim+1, 1U);
@@ -1124,18 +1129,19 @@ FE_Q_Base<POLY,dim,spacedim>::get_dpo_vector(const unsigned int deg)
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 void
-FE_Q_Base<POLY,dim,spacedim>::initialize_constraints (const std::vector<Point<1> > &points)
+FE_Q_Base<PolynomialType,dim,spacedim>::initialize_constraints
+(const std::vector<Point<1> > &points)
 {
   Implementation::initialize_constraints (points, *this);
 }
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 const FullMatrix<double> &
-FE_Q_Base<POLY,dim,spacedim>
+FE_Q_Base<PolynomialType,dim,spacedim>
 ::get_prolongation_matrix (const unsigned int child,
                            const RefinementCase<dim> &refinement_case) const
 {
@@ -1310,9 +1316,9 @@ FE_Q_Base<POLY,dim,spacedim>
 
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 const FullMatrix<double> &
-FE_Q_Base<POLY,dim,spacedim>
+FE_Q_Base<PolynomialType,dim,spacedim>
 ::get_restriction_matrix (const unsigned int child,
                           const RefinementCase<dim> &refinement_case) const
 {
@@ -1446,10 +1452,11 @@ FE_Q_Base<POLY,dim,spacedim>
 //---------------------------------------------------------------------------
 
 
-template <class POLY, int dim, int spacedim>
+template <class PolynomialType, int dim, int spacedim>
 bool
-FE_Q_Base<POLY,dim,spacedim>::has_support_on_face (const unsigned int shape_index,
-                                                   const unsigned int face_index) const
+FE_Q_Base<PolynomialType,dim,spacedim>::has_support_on_face
+(const unsigned int shape_index,
+ const unsigned int face_index) const
 {
   Assert (shape_index < this->dofs_per_cell,
           ExcIndexRange (shape_index, 0, this->dofs_per_cell));
@@ -1546,9 +1553,9 @@ FE_Q_Base<POLY,dim,spacedim>::has_support_on_face (const unsigned int shape_inde
 
 
 
-template <typename POLY, int dim, int spacedim>
+template <typename PolynomialType, int dim, int spacedim>
 std::pair<Table<2,bool>, std::vector<unsigned int> >
-FE_Q_Base<POLY,dim,spacedim>::get_constant_modes () const
+FE_Q_Base<PolynomialType,dim,spacedim>::get_constant_modes () const
 {
   Table<2,bool> constant_modes(1, this->dofs_per_cell);
   // We here just care for the constant mode due to the polynomial space

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -44,10 +44,10 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
-MappingFEField<dim,spacedim,VECTOR,DH>::InternalData::
-InternalData (const FiniteElement<dim,spacedim> &fe,
-              const ComponentMask mask)
+template<int dim, int spacedim, typename VectorType, class DH>
+MappingFEField<dim,spacedim,VectorType,DH>::InternalData::InternalData
+(const FiniteElement<dim,spacedim> &fe,
+ const ComponentMask                mask)
   :
   n_shape_functions (fe.dofs_per_cell),
   mask (mask),
@@ -57,10 +57,9 @@ InternalData (const FiniteElement<dim,spacedim> &fe,
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 std::size_t
-MappingFEField<dim,spacedim,VECTOR,DH>::InternalData::
-memory_consumption () const
+MappingFEField<dim,spacedim,VectorType,DH>::InternalData::memory_consumption () const
 {
   Assert (false, ExcNotImplemented());
   return 0;
@@ -68,11 +67,11 @@ memory_consumption () const
 
 
 
-template<int dim, int spacedim, class DH, class VECTOR>
+template<int dim, int spacedim, class DH, typename VectorType>
 double &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-shape (const unsigned int qpoint,
-       const unsigned int shape_nr)
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::shape
+(const unsigned int qpoint,
+ const unsigned int shape_nr)
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_values.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -81,11 +80,11 @@ shape (const unsigned int qpoint,
 }
 
 
-template<int dim, int spacedim, class DH, class VECTOR>
+template<int dim, int spacedim, class DH, typename VectorType>
 const Tensor<1,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-derivative (const unsigned int qpoint,
-            const unsigned int shape_nr) const
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr) const
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -95,11 +94,11 @@ derivative (const unsigned int qpoint,
 
 
 
-template<int dim, int spacedim, class DH, class VECTOR>
+template<int dim, int spacedim, class DH, typename VectorType>
 Tensor<1,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-derivative (const unsigned int qpoint,
-            const unsigned int shape_nr)
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr)
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -108,11 +107,11 @@ derivative (const unsigned int qpoint,
 }
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 const Tensor<2,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-second_derivative (const unsigned int qpoint,
-                   const unsigned int shape_nr) const
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::second_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr) const
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_second_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -122,11 +121,11 @@ second_derivative (const unsigned int qpoint,
 
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 Tensor<2,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-second_derivative (const unsigned int qpoint,
-                   const unsigned int shape_nr)
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::second_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr)
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_second_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -135,11 +134,11 @@ second_derivative (const unsigned int qpoint,
 }
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 const Tensor<3,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-third_derivative (const unsigned int qpoint,
-                  const unsigned int shape_nr) const
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::third_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr) const
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_third_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -149,11 +148,11 @@ third_derivative (const unsigned int qpoint,
 
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 Tensor<3,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-third_derivative (const unsigned int qpoint,
-                  const unsigned int shape_nr)
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::third_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr)
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_third_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -162,11 +161,11 @@ third_derivative (const unsigned int qpoint,
 }
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 const Tensor<4,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-fourth_derivative (const unsigned int qpoint,
-                   const unsigned int shape_nr) const
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::fourth_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr) const
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_fourth_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -176,11 +175,11 @@ fourth_derivative (const unsigned int qpoint,
 
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 Tensor<4,dim> &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::
-fourth_derivative (const unsigned int qpoint,
-                   const unsigned int shape_nr)
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::fourth_derivative
+(const unsigned int qpoint,
+ const unsigned int shape_nr)
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_fourth_derivatives.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -190,10 +189,11 @@ fourth_derivative (const unsigned int qpoint,
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
-MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const DH      &euler_dof_handler,
-                                                        const VECTOR  &euler_vector,
-                                                        const ComponentMask mask)
+template<int dim, int spacedim, typename VectorType, class DH>
+MappingFEField<dim,spacedim,VectorType,DH>::MappingFEField
+(const DH            &euler_dof_handler,
+ const VectorType    &euler_vector,
+ const ComponentMask  mask)
   :
   euler_vector(&euler_vector),
   fe(&euler_dof_handler.get_fe()),
@@ -212,8 +212,9 @@ MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const DH      &euler_dof
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
-MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const MappingFEField<dim,spacedim,VECTOR,DH> &mapping)
+template<int dim, int spacedim, typename VectorType, class DH>
+MappingFEField<dim,spacedim,VectorType,DH>::MappingFEField
+(const MappingFEField<dim,spacedim,VectorType,DH> &mapping)
   :
   euler_vector(mapping.euler_vector),
   fe(mapping.fe),
@@ -224,11 +225,12 @@ MappingFEField<dim,spacedim,VECTOR,DH>::MappingFEField (const MappingFEField<dim
 
 
 
-template<int dim, int spacedim, class DH, class VECTOR>
+template<int dim, int spacedim, class DH, typename VectorType>
 inline
 const double &
-MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::shape (const unsigned int qpoint,
-    const unsigned int shape_nr) const
+MappingFEField<dim,spacedim,DH,VectorType>::InternalData::shape
+(const unsigned int qpoint,
+ const unsigned int shape_nr) const
 {
   Assert(qpoint*n_shape_functions + shape_nr < shape_values.size(),
          ExcIndexRange(qpoint*n_shape_functions + shape_nr, 0,
@@ -238,19 +240,19 @@ MappingFEField<dim,spacedim,DH,VECTOR>::InternalData::shape (const unsigned int 
 
 
 
-template <int dim, int spacedim, class DH, class VECTOR>
+template <int dim, int spacedim, class DH, typename VectorType>
 bool
-MappingFEField<dim,spacedim,DH,VECTOR>::preserves_vertex_locations () const
+MappingFEField<dim,spacedim,DH,VectorType>::preserves_vertex_locations () const
 {
   return false;
 }
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
-compute_shapes_virtual (const std::vector<Point<dim> > &unit_points,
+MappingFEField<dim,spacedim,VectorType,DH>::
+compute_shapes_virtual (const std::vector<Point<dim> >                       &unit_points,
                         typename MappingFEField<dim, spacedim>::InternalData &data) const
 {
   const unsigned int n_points=unit_points.size();
@@ -280,9 +282,9 @@ compute_shapes_virtual (const std::vector<Point<dim> > &unit_points,
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 UpdateFlags
-MappingFEField<dim,spacedim,VECTOR,DH>::requires_update_flags (const UpdateFlags in) const
+MappingFEField<dim,spacedim,VectorType,DH>::requires_update_flags (const UpdateFlags in) const
 {
   // add flags if the respective quantities are necessary to compute
   // what we need. note that some flags appear in both conditions and
@@ -339,12 +341,13 @@ MappingFEField<dim,spacedim,VECTOR,DH>::requires_update_flags (const UpdateFlags
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::compute_data (const UpdateFlags      update_flags,
-                                                      const Quadrature<dim>  &q,
-                                                      const unsigned int     n_original_q_points,
-                                                      InternalData           &data) const
+MappingFEField<dim,spacedim,VectorType,DH>::compute_data
+(const UpdateFlags      update_flags,
+ const Quadrature<dim> &q,
+ const unsigned int     n_original_q_points,
+ InternalData          &data) const
 {
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values(). use the transitive hull of the required
@@ -390,12 +393,13 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_data (const UpdateFlags      upd
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::compute_face_data (const UpdateFlags update_flags,
-                                                           const Quadrature<dim> &q,
-                                                           const unsigned int n_original_q_points,
-                                                           InternalData &data) const
+MappingFEField<dim,spacedim,VectorType,DH>::compute_face_data
+(const UpdateFlags      update_flags,
+ const Quadrature<dim> &q,
+ const unsigned int     n_original_q_points,
+ InternalData          &data) const
 {
   compute_data (update_flags, q, n_original_q_points, data);
 
@@ -457,11 +461,11 @@ MappingFEField<dim,spacedim,VECTOR,DH>::compute_face_data (const UpdateFlags upd
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 typename
-MappingFEField<dim,spacedim,VECTOR,DH>::InternalData *
-MappingFEField<dim,spacedim,VECTOR,DH>::get_data (const UpdateFlags update_flags,
-                                                  const Quadrature<dim> &quadrature) const
+MappingFEField<dim,spacedim,VectorType,DH>::InternalData *
+MappingFEField<dim,spacedim,VectorType,DH>::get_data (const UpdateFlags      update_flags,
+                                                      const Quadrature<dim> &quadrature) const
 {
   InternalData *data = new InternalData(*fe, fe_mask);
   this->compute_data (update_flags, quadrature,
@@ -471,10 +475,11 @@ MappingFEField<dim,spacedim,VECTOR,DH>::get_data (const UpdateFlags update_flags
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 typename Mapping<dim,spacedim>::InternalDataBase *
-MappingFEField<dim,spacedim,VECTOR,DH>::get_face_data (const UpdateFlags update_flags,
-                                                       const Quadrature<dim-1>& quadrature) const
+MappingFEField<dim,spacedim,VectorType,DH>::get_face_data
+(const UpdateFlags        update_flags,
+ const Quadrature<dim-1> &quadrature) const
 {
   InternalData *data = new InternalData(*fe, fe_mask);
   const Quadrature<dim> q (QProjector<dim>::project_to_all_faces(quadrature));
@@ -485,10 +490,11 @@ MappingFEField<dim,spacedim,VECTOR,DH>::get_face_data (const UpdateFlags update_
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 typename Mapping<dim,spacedim>::InternalDataBase *
-MappingFEField<dim,spacedim,VECTOR,DH>::get_subface_data (const UpdateFlags update_flags,
-                                                          const Quadrature<dim-1>& quadrature) const
+MappingFEField<dim,spacedim,VectorType,DH>::get_subface_data
+(const UpdateFlags        update_flags,
+ const Quadrature<dim-1> &quadrature) const
 {
   InternalData *data = new InternalData(*fe, fe_mask);
   const Quadrature<dim> q (QProjector<dim>::project_to_all_subfaces(quadrature));
@@ -1267,9 +1273,9 @@ namespace internal
 
 // Note that the CellSimilarity flag is modifiable, since MappingFEField can need to
 // recalculate data even when cells are similar.
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 CellSimilarity::Similarity
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                 const CellSimilarity::Similarity                           cell_similarity,
                 const Quadrature<dim>                                     &quadrature,
@@ -1439,9 +1445,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                      const unsigned int                                         face_no,
                      const Quadrature<dim-1>                                   &quadrature,
@@ -1471,9 +1477,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                         const unsigned int                                         face_no,
                         const unsigned int                                         subface_no,
@@ -1507,7 +1513,7 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
 namespace
 {
-  template<int dim, int spacedim, int rank, class VECTOR, class DH>
+  template<int dim, int spacedim, int rank, typename VectorType, class DH>
   void
   transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
                    const MappingType                                        mapping_type,
@@ -1515,10 +1521,10 @@ namespace
                    VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
   {
     AssertDimension (input.size(), output.size());
-    Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData *>(&mapping_data) != 0),
+    Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData *>(&mapping_data) != 0),
             ExcInternalError());
-    const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData
-    &data = static_cast<const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData &>(mapping_data);
+    const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData
+    &data = static_cast<const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData &>(mapping_data);
 
     switch (mapping_type)
       {
@@ -1569,19 +1575,19 @@ namespace
   }
 
 
-  template<int dim, int spacedim, int rank, class VECTOR, class DH>
+  template<int dim, int spacedim, int rank, typename VectorType, class DH>
   void
-  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >    input,
-                               const MappingType                                                             mapping_type,
-                               const typename Mapping<dim,spacedim>::InternalDataBase                       &mapping_data,
-                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                          output)
+  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >  input,
+                               const MappingType                                                           mapping_type,
+                               const typename Mapping<dim,spacedim>::InternalDataBase                     &mapping_data,
+                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                        output)
   {
 
     AssertDimension (input.size(), output.size());
-    Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData *>(&mapping_data) != 0),
+    Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData *>(&mapping_data) != 0),
             ExcInternalError());
-    const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData
-    &data = static_cast<const typename MappingFEField<dim,spacedim,VECTOR,DH>::InternalData &>(mapping_data);
+    const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData
+    &data = static_cast<const typename MappingFEField<dim,spacedim,VectorType,DH>::InternalData &>(mapping_data);
 
     switch (mapping_type)
       {
@@ -1604,9 +1610,9 @@ namespace
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
@@ -1614,14 +1620,14 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
 {
   AssertDimension (input.size(), output.size());
 
-  transform_fields<dim,spacedim,1,VECTOR,DH>(input, mapping_type, mapping_data, output);
+  transform_fields<dim,spacedim,1,VectorType,DH>(input, mapping_type, mapping_data, output);
 }
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
            const MappingType                                                          mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
@@ -1629,14 +1635,14 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim> 
 {
   AssertDimension (input.size(), output.size());
 
-  transform_differential_forms<dim,spacedim,1,VECTOR,DH>(input, mapping_type, mapping_data, output);
+  transform_differential_forms<dim,spacedim,1,VectorType,DH>(input, mapping_type, mapping_data, output);
 }
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
            const MappingType,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
@@ -1652,9 +1658,9 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
            const MappingType                                                         mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
@@ -1702,9 +1708,9 @@ transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim>
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
            const MappingType                                     /*mapping_type*/,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
@@ -1722,11 +1728,11 @@ transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 Point<spacedim>
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                             const Point<dim>                                 &p) const
+                             const Point<dim>                                          &p) const
 {
 //  Use the get_data function to create an InternalData with data vectors of
 //  the right size and transformation shape values already computed at point
@@ -1741,9 +1747,9 @@ transform_unit_to_real_cell (const typename Triangulation<dim,spacedim>::cell_it
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 Point<spacedim>
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 do_transform_unit_to_real_cell (const InternalData &data) const
 {
   Point<spacedim> p_real;
@@ -1760,11 +1766,11 @@ do_transform_unit_to_real_cell (const InternalData &data) const
 
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 Point<dim>
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-                             const Point<spacedim>                            &p) const
+                             const Point<spacedim>                                     &p) const
 {
   // first a Newton iteration based on the real mapping. It uses the center
   // point of the cell as a starting point
@@ -1803,14 +1809,14 @@ transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_it
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 Point<dim>
-MappingFEField<dim,spacedim,VECTOR,DH>::
+MappingFEField<dim,spacedim,VectorType,DH>::
 do_transform_real_to_unit_cell
 (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
- const Point<spacedim>                            &p,
- const Point<dim>                                 &initial_p_unit,
- InternalData                                     &mdata) const
+ const Point<spacedim>                                     &p,
+ const Point<dim>                                          &initial_p_unit,
+ InternalData                                              &mdata) const
 {
   const unsigned int n_shapes=mdata.shape_values.size();
   (void)n_shapes;
@@ -1911,35 +1917,35 @@ failure:
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 unsigned int
-MappingFEField<dim,spacedim,VECTOR,DH>::get_degree() const
+MappingFEField<dim,spacedim,VectorType,DH>::get_degree() const
 {
   return fe->degree;
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 ComponentMask
-MappingFEField<dim,spacedim,VECTOR,DH>::get_component_mask() const
+MappingFEField<dim,spacedim,VectorType,DH>::get_component_mask() const
 {
   return this->fe_mask;
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 Mapping<dim,spacedim> *
-MappingFEField<dim,spacedim,VECTOR,DH>::clone () const
+MappingFEField<dim,spacedim,VectorType,DH>::clone () const
 {
-  return new MappingFEField<dim,spacedim,VECTOR,DH>(*this);
+  return new MappingFEField<dim,spacedim,VectorType,DH>(*this);
 }
 
 
-template<int dim, int spacedim, class VECTOR, class DH>
+template<int dim, int spacedim, typename VectorType, class DH>
 void
-MappingFEField<dim,spacedim,VECTOR,DH>::update_internal_dofs (
-  const typename Triangulation<dim,spacedim>::cell_iterator &cell,
-  const typename MappingFEField<dim, spacedim>::InternalData &data) const
+MappingFEField<dim,spacedim,VectorType,DH>::update_internal_dofs
+(const typename Triangulation<dim,spacedim>::cell_iterator  &cell,
+ const typename MappingFEField<dim, spacedim>::InternalData &data) const
 {
   Assert(euler_dof_handler != 0, ExcMessage("euler_dof_handler is empty"));
 

--- a/source/lac/block_matrix_array.cc
+++ b/source/lac/block_matrix_array.cc
@@ -26,8 +26,8 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <typename number, typename BLOCK_VECTOR>
-BlockMatrixArray<number,BLOCK_VECTOR>::Entry::Entry (const Entry &e)
+template <typename number, typename BlockVectorType>
+BlockMatrixArray<number,BlockVectorType>::Entry::Entry (const Entry &e)
   :
   row(e.row),
   col(e.col),
@@ -41,36 +41,36 @@ BlockMatrixArray<number,BLOCK_VECTOR>::Entry::Entry (const Entry &e)
 
 
 
-template <typename number, typename BLOCK_VECTOR>
-BlockMatrixArray<number,BLOCK_VECTOR>::Entry::~Entry ()
+template <typename number, typename BlockVectorType>
+BlockMatrixArray<number,BlockVectorType>::Entry::~Entry ()
 {
   if (matrix)
     delete matrix;
 }
 
 
-template <typename number, typename BLOCK_VECTOR>
-BlockMatrixArray<number,BLOCK_VECTOR>::BlockMatrixArray ()
+template <typename number, typename BlockVectorType>
+BlockMatrixArray<number,BlockVectorType>::BlockMatrixArray ()
   : block_rows (0),
     block_cols (0)
 {}
 
 
 
-template <typename number, typename BLOCK_VECTOR>
-BlockMatrixArray<number,BLOCK_VECTOR>::BlockMatrixArray (
-  const unsigned int n_block_rows,
-  const unsigned int n_block_cols)
+template <typename number, typename BlockVectorType>
+BlockMatrixArray<number,BlockVectorType>::BlockMatrixArray
+(const unsigned int n_block_rows,
+ const unsigned int n_block_cols)
   : block_rows (n_block_rows),
     block_cols (n_block_cols)
 {}
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::initialize (
-  const unsigned int n_block_rows,
-  const unsigned int n_block_cols)
+BlockMatrixArray<number,BlockVectorType>::initialize
+(const unsigned int n_block_rows,
+ const unsigned int n_block_cols)
 {
   block_rows = n_block_rows;
   block_cols = n_block_cols;
@@ -78,11 +78,11 @@ BlockMatrixArray<number,BLOCK_VECTOR>::initialize (
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::reinit (
-  const unsigned int n_block_rows,
-  const unsigned int n_block_cols)
+BlockMatrixArray<number,BlockVectorType>::reinit
+(const unsigned int n_block_rows,
+ const unsigned int n_block_cols)
 {
   clear();
   block_rows = n_block_rows;
@@ -91,27 +91,27 @@ BlockMatrixArray<number,BLOCK_VECTOR>::reinit (
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::clear ()
+BlockMatrixArray<number,BlockVectorType>::clear ()
 {
   entries.clear();
 }
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::vmult_add (BLOCK_VECTOR &dst,
-                                                  const BLOCK_VECTOR &src) const
+BlockMatrixArray<number,BlockVectorType>::vmult_add (BlockVectorType &dst,
+                                                     const BlockVectorType &src) const
 {
-  GrowingVectorMemory<typename BLOCK_VECTOR::BlockType > mem;
+  GrowingVectorMemory<typename BlockVectorType::BlockType > mem;
   Assert (dst.n_blocks() == block_rows,
           ExcDimensionMismatch(dst.n_blocks(), block_rows));
   Assert (src.n_blocks() == block_cols,
           ExcDimensionMismatch(src.n_blocks(), block_cols));
 
-  typename VectorMemory<typename BLOCK_VECTOR::BlockType >::Pointer p_aux(mem);
-  typename BLOCK_VECTOR::BlockType &aux = *p_aux;
+  typename VectorMemory<typename BlockVectorType::BlockType >::Pointer p_aux(mem);
+  typename BlockVectorType::BlockType &aux = *p_aux;
 
   typename std::vector<Entry>::const_iterator m = entries.begin();
   typename std::vector<Entry>::const_iterator end = entries.end();
@@ -130,10 +130,10 @@ BlockMatrixArray<number,BLOCK_VECTOR>::vmult_add (BLOCK_VECTOR &dst,
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::vmult (BLOCK_VECTOR &dst,
-                                              const BLOCK_VECTOR &src) const
+BlockMatrixArray<number,BlockVectorType>::vmult (BlockVectorType &dst,
+                                                 const BlockVectorType &src) const
 {
   dst = 0.;
   vmult_add (dst, src);
@@ -142,12 +142,12 @@ BlockMatrixArray<number,BLOCK_VECTOR>::vmult (BLOCK_VECTOR &dst,
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::Tvmult_add (BLOCK_VECTOR &dst,
-                                                   const BLOCK_VECTOR &src) const
+BlockMatrixArray<number,BlockVectorType>::Tvmult_add (BlockVectorType &dst,
+                                                      const BlockVectorType &src) const
 {
-  GrowingVectorMemory<typename BLOCK_VECTOR::BlockType > mem;
+  GrowingVectorMemory<typename BlockVectorType::BlockType > mem;
   Assert (dst.n_blocks() == block_cols,
           ExcDimensionMismatch(dst.n_blocks(), block_cols));
   Assert (src.n_blocks() == block_rows,
@@ -156,8 +156,8 @@ BlockMatrixArray<number,BLOCK_VECTOR>::Tvmult_add (BLOCK_VECTOR &dst,
   typename std::vector<Entry>::const_iterator m = entries.begin();
   typename std::vector<Entry>::const_iterator end = entries.end();
 
-  typename VectorMemory<typename BLOCK_VECTOR::BlockType >::Pointer p_aux(mem);
-  typename BLOCK_VECTOR::BlockType &aux = *p_aux;
+  typename VectorMemory<typename BlockVectorType::BlockType >::Pointer p_aux(mem);
+  typename BlockVectorType::BlockType &aux = *p_aux;
 
   for (; m != end ; ++m)
     {
@@ -172,10 +172,10 @@ BlockMatrixArray<number,BLOCK_VECTOR>::Tvmult_add (BLOCK_VECTOR &dst,
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockMatrixArray<number,BLOCK_VECTOR>::Tvmult (BLOCK_VECTOR &dst,
-                                               const BLOCK_VECTOR &src) const
+BlockMatrixArray<number,BlockVectorType>::Tvmult (BlockVectorType &dst,
+                                                  const BlockVectorType &src) const
 {
   dst = 0.;
   Tvmult_add (dst, src);
@@ -184,20 +184,20 @@ BlockMatrixArray<number,BLOCK_VECTOR>::Tvmult (BLOCK_VECTOR &dst,
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 number
-BlockMatrixArray<number,BLOCK_VECTOR>::matrix_scalar_product (
-  const BLOCK_VECTOR &u,
-  const BLOCK_VECTOR &v) const
+BlockMatrixArray<number,BlockVectorType>::matrix_scalar_product
+(const BlockVectorType &u,
+ const BlockVectorType &v) const
 {
-  GrowingVectorMemory<typename BLOCK_VECTOR::BlockType > mem;
+  GrowingVectorMemory<typename BlockVectorType::BlockType > mem;
   Assert (u.n_blocks() == block_rows,
           ExcDimensionMismatch(u.n_blocks(), block_rows));
   Assert (v.n_blocks() == block_cols,
           ExcDimensionMismatch(v.n_blocks(), block_cols));
 
-  typename VectorMemory<typename BLOCK_VECTOR::BlockType >::Pointer p_aux(mem);
-  typename BLOCK_VECTOR::BlockType &aux = *p_aux;
+  typename VectorMemory<typename BlockVectorType::BlockType >::Pointer p_aux(mem);
+  typename BlockVectorType::BlockType &aux = *p_aux;
 
   typename std::vector<Entry>::const_iterator m;
   typename std::vector<Entry>::const_iterator end = entries.end();
@@ -224,28 +224,28 @@ BlockMatrixArray<number,BLOCK_VECTOR>::matrix_scalar_product (
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 number
-BlockMatrixArray<number,BLOCK_VECTOR>::matrix_norm_square (
-  const BLOCK_VECTOR &u) const
+BlockMatrixArray<number,BlockVectorType>::matrix_norm_square
+(const BlockVectorType &u) const
 {
   return matrix_scalar_product(u,u);
 }
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 unsigned int
-BlockMatrixArray<number,BLOCK_VECTOR>::n_block_rows () const
+BlockMatrixArray<number,BlockVectorType>::n_block_rows () const
 {
   return block_rows;
 }
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 unsigned int
-BlockMatrixArray<number,BLOCK_VECTOR>::n_block_cols () const
+BlockMatrixArray<number,BlockVectorType>::n_block_cols () const
 {
   return block_cols;
 }
@@ -254,47 +254,47 @@ BlockMatrixArray<number,BLOCK_VECTOR>::n_block_cols () const
 
 //---------------------------------------------------------------------------
 
-template <typename number, typename BLOCK_VECTOR>
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::BlockTrianglePrecondition()
-  : BlockMatrixArray<number,BLOCK_VECTOR> (),
+template <typename number, typename BlockVectorType>
+BlockTrianglePrecondition<number,BlockVectorType>::BlockTrianglePrecondition()
+  : BlockMatrixArray<number,BlockVectorType> (),
     backward(false)
 {}
 
 
-template <typename number, typename BLOCK_VECTOR>
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::BlockTrianglePrecondition(
-  const unsigned int block_rows)
+template <typename number, typename BlockVectorType>
+BlockTrianglePrecondition<number,BlockVectorType>::BlockTrianglePrecondition
+(const unsigned int block_rows)
   :
-  BlockMatrixArray<number,BLOCK_VECTOR> (block_rows, block_rows),
+  BlockMatrixArray<number,BlockVectorType> (block_rows, block_rows),
   backward(false)
 {}
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::reinit (
-  const unsigned int n)
+BlockTrianglePrecondition<number,BlockVectorType>::reinit
+(const unsigned int n)
 {
-  BlockMatrixArray<number,BLOCK_VECTOR>::reinit(n,n);
+  BlockMatrixArray<number,BlockVectorType>::reinit(n,n);
 }
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::do_row (
-  BLOCK_VECTOR &dst,
-  size_type row_num) const
+BlockTrianglePrecondition<number,BlockVectorType>::do_row
+(BlockVectorType &dst,
+ size_type        row_num) const
 {
-  GrowingVectorMemory<typename BLOCK_VECTOR::BlockType > mem;
-  typename std::vector<typename BlockMatrixArray<number,BLOCK_VECTOR>::Entry>::const_iterator
+  GrowingVectorMemory<typename BlockVectorType::BlockType > mem;
+  typename std::vector<typename BlockMatrixArray<number,BlockVectorType>::Entry>::const_iterator
   m = this->entries.begin();
-  typename std::vector<typename BlockMatrixArray<number,BLOCK_VECTOR>::Entry>::const_iterator
+  typename std::vector<typename BlockMatrixArray<number,BlockVectorType>::Entry>::const_iterator
   end = this->entries.end();
-  std::vector<typename std::vector<typename BlockMatrixArray<number,BLOCK_VECTOR>::Entry>::const_iterator>
+  std::vector<typename std::vector<typename BlockMatrixArray<number,BlockVectorType>::Entry>::const_iterator>
   diagonals;
 
-  typename VectorMemory<typename BLOCK_VECTOR::BlockType >::Pointer p_aux(mem);
-  typename BLOCK_VECTOR::BlockType &aux = *p_aux;
+  typename VectorMemory<typename BlockVectorType::BlockType >::Pointer p_aux(mem);
+  typename BlockVectorType::BlockType &aux = *p_aux;
 
   aux.reinit(dst.block(row_num), true);
 
@@ -361,18 +361,18 @@ BlockTrianglePrecondition<number,BLOCK_VECTOR>::do_row (
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::vmult_add (
-  BLOCK_VECTOR &dst,
-  const BLOCK_VECTOR &src) const
+BlockTrianglePrecondition<number,BlockVectorType>::vmult_add
+(BlockVectorType       &dst,
+ const BlockVectorType &src) const
 {
   Assert (dst.n_blocks() == n_block_rows(),
           ExcDimensionMismatch(dst.n_blocks(), n_block_rows()));
   Assert (src.n_blocks() == n_block_cols(),
           ExcDimensionMismatch(src.n_blocks(), n_block_cols()));
 
-  BLOCK_VECTOR aux;
+  BlockVectorType aux;
   aux.reinit(dst);
   vmult(aux, src);
   dst.add(aux);
@@ -380,11 +380,11 @@ BlockTrianglePrecondition<number,BLOCK_VECTOR>::vmult_add (
 
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::vmult (
-  BLOCK_VECTOR &dst,
-  const BLOCK_VECTOR &src) const
+BlockTrianglePrecondition<number,BlockVectorType>::vmult
+(BlockVectorType       &dst,
+ const BlockVectorType &src) const
 {
   Assert (dst.n_blocks() == n_block_rows(),
           ExcDimensionMismatch(dst.n_blocks(), n_block_rows()));
@@ -406,21 +406,21 @@ BlockTrianglePrecondition<number,BLOCK_VECTOR>::vmult (
 
 }
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::Tvmult (
-  BLOCK_VECTOR &,
-  const BLOCK_VECTOR &) const
+BlockTrianglePrecondition<number,BlockVectorType>::Tvmult
+(BlockVectorType &,
+ const BlockVectorType &) const
 {
   Assert (false, ExcNotImplemented());
 }
 
 
-template <typename number, typename BLOCK_VECTOR>
+template <typename number, typename BlockVectorType>
 void
-BlockTrianglePrecondition<number,BLOCK_VECTOR>::Tvmult_add (
-  BLOCK_VECTOR &,
-  const BLOCK_VECTOR &) const
+BlockTrianglePrecondition<number,BlockVectorType>::Tvmult_add
+(BlockVectorType &,
+ const BlockVectorType &) const
 {
   Assert (false, ExcNotImplemented());
 }

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -489,19 +489,19 @@ SparseDirectUMFPACK::n () const
 
 
 // explicit instantiations for SparseMatrixUMFPACK
-#define InstantiateUMFPACK(MATRIX)                        \
-  template                                                \
-  void SparseDirectUMFPACK::factorize (const MATRIX &);   \
-  template                                                \
-  void SparseDirectUMFPACK::solve (const MATRIX   &,      \
-                                   Vector<double> &,      \
-                                   bool);                 \
-  template                                                \
-  void SparseDirectUMFPACK::solve (const MATRIX   &,      \
-                                   BlockVector<double> &, \
-                                   bool);                 \
-  template                                                \
-  void SparseDirectUMFPACK::initialize (const MATRIX &,   \
+#define InstantiateUMFPACK(MatrixType)                      \
+  template                                                  \
+  void SparseDirectUMFPACK::factorize (const MatrixType &); \
+  template                                                  \
+  void SparseDirectUMFPACK::solve (const MatrixType &,      \
+                                   Vector<double> &,        \
+                                   bool);                   \
+  template                                                  \
+  void SparseDirectUMFPACK::solve (const MatrixType &,      \
+                                   BlockVector<double> &,   \
+                                   bool);                   \
+  template                                                  \
+  void SparseDirectUMFPACK::initialize (const MatrixType &, \
                                         const AdditionalData);
 
 InstantiateUMFPACK(SparseMatrix<double>)

--- a/source/multigrid/mg_base.cc
+++ b/source/multigrid/mg_base.cc
@@ -27,23 +27,23 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <class VECTOR>
-MGTransferBase<VECTOR>::~MGTransferBase()
+template <typename VectorType>
+MGTransferBase<VectorType>::~MGTransferBase()
 {}
 
 
-template <class VECTOR>
-MGMatrixBase<VECTOR>::~MGMatrixBase()
+template <typename VectorType>
+MGMatrixBase<VectorType>::~MGMatrixBase()
 {}
 
 
-template <class VECTOR>
-MGSmootherBase<VECTOR>::~MGSmootherBase()
+template <typename VectorType>
+MGSmootherBase<VectorType>::~MGSmootherBase()
 {}
 
 
-template <class VECTOR>
-MGCoarseGridBase<VECTOR>::~MGCoarseGridBase()
+template <typename VectorType>
+MGCoarseGridBase<VectorType>::~MGCoarseGridBase()
 {}
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -42,35 +42,35 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template<class VECTOR>
-MGTransferPrebuilt<VECTOR>::MGTransferPrebuilt ()
+template<typename VectorType>
+MGTransferPrebuilt<VectorType>::MGTransferPrebuilt ()
 {}
 
 
-template<class VECTOR>
-MGTransferPrebuilt<VECTOR>::MGTransferPrebuilt (const ConstraintMatrix &c, const MGConstrainedDoFs &mg_c)
+template<typename VectorType>
+MGTransferPrebuilt<VectorType>::MGTransferPrebuilt (const ConstraintMatrix &c, const MGConstrainedDoFs &mg_c)
   :
   constraints(&c),
   mg_constrained_dofs(&mg_c)
 {}
 
 
-template <class VECTOR>
-MGTransferPrebuilt<VECTOR>::~MGTransferPrebuilt ()
+template <typename VectorType>
+MGTransferPrebuilt<VectorType>::~MGTransferPrebuilt ()
 {}
 
 
-template <class VECTOR>
-void MGTransferPrebuilt<VECTOR>::initialize_constraints (
-  const ConstraintMatrix &c, const MGConstrainedDoFs &mg_c)
+template <typename VectorType>
+void MGTransferPrebuilt<VectorType>::initialize_constraints
+(const ConstraintMatrix &c, const MGConstrainedDoFs &mg_c)
 {
   constraints = &c;
   mg_constrained_dofs = &mg_c;
 }
 
 
-template <class VECTOR>
-void MGTransferPrebuilt<VECTOR>::clear ()
+template <typename VectorType>
+void MGTransferPrebuilt<VectorType>::clear ()
 {
   sizes.resize(0);
   prolongation_matrices.resize(0);
@@ -85,11 +85,10 @@ void MGTransferPrebuilt<VECTOR>::clear ()
 }
 
 
-template <class VECTOR>
-void MGTransferPrebuilt<VECTOR>::prolongate (
-  const unsigned int to_level,
-  VECTOR            &dst,
-  const VECTOR      &src) const
+template <typename VectorType>
+void MGTransferPrebuilt<VectorType>::prolongate (const unsigned int to_level,
+                                                 VectorType        &dst,
+                                                 const VectorType  &src) const
 {
   Assert ((to_level >= 1) && (to_level<=prolongation_matrices.size()),
           ExcIndexRange (to_level, 1, prolongation_matrices.size()+1));
@@ -98,11 +97,10 @@ void MGTransferPrebuilt<VECTOR>::prolongate (
 }
 
 
-template <class VECTOR>
-void MGTransferPrebuilt<VECTOR>::restrict_and_add (
-  const unsigned int   from_level,
-  VECTOR       &dst,
-  const VECTOR &src) const
+template <typename VectorType>
+void MGTransferPrebuilt<VectorType>::restrict_and_add (const unsigned int from_level,
+                                                       VectorType        &dst,
+                                                       const VectorType  &src) const
 {
   Assert ((from_level >= 1) && (from_level<=prolongation_matrices.size()),
           ExcIndexRange (from_level, 1, prolongation_matrices.size()+1));
@@ -112,10 +110,10 @@ void MGTransferPrebuilt<VECTOR>::restrict_and_add (
 }
 
 
-template <typename VECTOR>
+template <typename VectorType>
 template <int dim, int spacedim>
-void MGTransferPrebuilt<VECTOR>::build_matrices (
-  const DoFHandler<dim,spacedim>  &mg_dof)
+void MGTransferPrebuilt<VectorType>::build_matrices
+(const DoFHandler<dim,spacedim>  &mg_dof)
 {
   const unsigned int n_levels      = mg_dof.get_tria().n_global_levels();
   const unsigned int dofs_per_cell = mg_dof.get_fe().dofs_per_cell;
@@ -140,9 +138,9 @@ void MGTransferPrebuilt<VECTOR>::build_matrices (
   for (unsigned int i=0; i<n_levels-1; ++i)
     {
       prolongation_sparsities.push_back
-      (std_cxx11::shared_ptr<typename internal::MatrixSelector<VECTOR>::Sparsity> (new typename internal::MatrixSelector<VECTOR>::Sparsity));
+      (std_cxx11::shared_ptr<typename internal::MatrixSelector<VectorType>::Sparsity> (new typename internal::MatrixSelector<VectorType>::Sparsity));
       prolongation_matrices.push_back
-      (std_cxx11::shared_ptr<typename internal::MatrixSelector<VECTOR>::Matrix> (new typename internal::MatrixSelector<VECTOR>::Matrix));
+      (std_cxx11::shared_ptr<typename internal::MatrixSelector<VectorType>::Matrix> (new typename internal::MatrixSelector<VectorType>::Matrix));
     }
 
   // two fields which will store the
@@ -209,11 +207,11 @@ void MGTransferPrebuilt<VECTOR>::build_matrices (
               }
           }
 
-      internal::MatrixSelector<VECTOR>::reinit(*prolongation_matrices[level],
-                                               *prolongation_sparsities[level],
-                                               level,
-                                               dsp,
-                                               mg_dof);
+      internal::MatrixSelector<VectorType>::reinit(*prolongation_matrices[level],
+                                                   *prolongation_sparsities[level],
+                                                   level,
+                                                   dsp,
+                                                   mg_dof);
       dsp.reinit(0,0);
 
       FullMatrix<double> prolongation;
@@ -284,11 +282,11 @@ namespace
   };
 }
 
-template <class VECTOR>
+template <typename VectorType>
 template <int dim, int spacedim>
 void
-MGTransferPrebuilt<VECTOR>::fill_and_communicate_copy_indices(
-  const DoFHandler<dim,spacedim> &mg_dof)
+MGTransferPrebuilt<VectorType>::fill_and_communicate_copy_indices
+(const DoFHandler<dim,spacedim> &mg_dof)
 {
   // Now we are filling the variables copy_indices*, which are essentially
   // maps from global to mgdof for each level stored as a std::vector of
@@ -473,9 +471,9 @@ MGTransferPrebuilt<VECTOR>::fill_and_communicate_copy_indices(
     std::sort(copy_indices_global_mine[level].begin(), copy_indices_global_mine[level].end(), compare);
 }
 
-template <class VECTOR>
+template <typename VectorType>
 void
-MGTransferPrebuilt<VECTOR>::print_matrices (std::ostream &os) const
+MGTransferPrebuilt<VectorType>::print_matrices (std::ostream &os) const
 {
   for (unsigned int level = 0; level<prolongation_matrices.size(); ++level)
     {
@@ -485,9 +483,9 @@ MGTransferPrebuilt<VECTOR>::print_matrices (std::ostream &os) const
     }
 }
 
-template <class VECTOR>
+template <typename VectorType>
 void
-MGTransferPrebuilt<VECTOR>::print_indices (std::ostream &os) const
+MGTransferPrebuilt<VectorType>::print_indices (std::ostream &os) const
 {
   for (unsigned int level = 0; level<copy_indices.size(); ++level)
     {

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -484,7 +484,7 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     DataEntry<DH,VectorType>::
     DataEntry (const DH                               *dofs,
                const VectorType                       *data,
@@ -497,7 +497,7 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     DataEntry<DH,VectorType>::
     DataEntry (const DH                                     *dofs,
                const VectorType                             *data,
@@ -510,10 +510,10 @@ namespace internal
 
     namespace
     {
-      template <class VectorType>
+      template <typename VectorType>
       double
-      get_vector_element (const VectorType &vector,
-                          const unsigned int cell_number)
+      get_vector_element (const VectorType   &vector,
+                          const unsigned int  cell_number)
       {
         return vector[cell_number];
       }
@@ -529,7 +529,7 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     double
     DataEntry<DH,VectorType>::
     get_cell_data_value (const unsigned int cell_number) const
@@ -539,11 +539,11 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                         std::vector<dealii::Vector<double> >    &patch_values_system) const
+    DataEntry<DH,VectorType>::get_function_values
+    (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
+     std::vector<dealii::Vector<double> >                  &patch_values_system) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -584,9 +584,9 @@ namespace internal
 
     template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_values (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                         std::vector<double>             &patch_values) const
+    DataEntry<DH,VectorType>::get_function_values
+    (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
+     std::vector<double>                                   &patch_values) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -623,11 +623,11 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                            std::vector<std::vector<Tensor<1,DH::space_dimension> > >   &patch_gradients_system) const
+    DataEntry<DH,VectorType>::get_function_gradients
+    (const FEValuesBase<DH::dimension,DH::space_dimension>     &fe_patch_values,
+     std::vector<std::vector<Tensor<1,DH::space_dimension> > > &patch_gradients_system) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -669,9 +669,9 @@ namespace internal
 
     template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_gradients (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                            std::vector<Tensor<1,DH::space_dimension> >       &patch_gradients) const
+    DataEntry<DH,VectorType>::get_function_gradients
+    (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
+     std::vector<Tensor<1,DH::space_dimension> >           &patch_gradients) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -709,11 +709,11 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                           std::vector<std::vector<Tensor<2,DH::space_dimension> > >   &patch_hessians_system) const
+    DataEntry<DH,VectorType>::get_function_hessians
+    (const FEValuesBase<DH::dimension,DH::space_dimension>     &fe_patch_values,
+     std::vector<std::vector<Tensor<2,DH::space_dimension> > > &patch_hessians_system) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -755,9 +755,9 @@ namespace internal
 
     template <class DH, typename VectorType>
     void
-    DataEntry<DH,VectorType>::
-    get_function_hessians (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
-                           std::vector<Tensor<2,DH::space_dimension> >       &patch_hessians) const
+    DataEntry<DH,VectorType>::get_function_hessians
+    (const FEValuesBase<DH::dimension,DH::space_dimension> &fe_patch_values,
+     std::vector<Tensor<2,DH::space_dimension> >           &patch_hessians) const
     {
       // FIXME: FEValuesBase gives us data in types that match that of
       // the solution vector. but this function needs to pass it back
@@ -804,7 +804,7 @@ namespace internal
 
 
 
-    template <class DH, class VectorType>
+    template <class DH, typename VectorType>
     void
     DataEntry<DH,VectorType>::clear ()
     {
@@ -868,10 +868,10 @@ attach_triangulation (const Triangulation<DH::dimension,DH::space_dimension> &tr
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
-add_data_vector (const VECTOR                             &vec,
+add_data_vector (const VectorType                         &vec,
                  const std::string                        &name,
                  const DataVectorType                      type,
                  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation)
@@ -907,10 +907,10 @@ add_data_vector (const VECTOR                             &vec,
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
-add_data_vector (const VECTOR                             &vec,
+add_data_vector (const VectorType                         &vec,
                  const std::vector<std::string>           &names,
                  const DataVectorType                      type,
                  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation_)
@@ -971,8 +971,8 @@ add_data_vector (const VECTOR                             &vec,
     }
 
   internal::DataOut::DataEntryBase<DH> *new_entry
-    = new internal::DataOut::DataEntry<DH,VECTOR>(dofs, &vec, names,
-                                                  data_component_interpretation);
+    = new internal::DataOut::DataEntry<DH,VectorType>(dofs, &vec, names,
+                                                      data_component_interpretation);
   if (actual_type == type_dof_data)
     dof_data.push_back (std_cxx11::shared_ptr<internal::DataOut::DataEntryBase<DH> >(new_entry));
   else
@@ -983,10 +983,10 @@ add_data_vector (const VECTOR                             &vec,
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
-add_data_vector (const VECTOR                           &vec,
+add_data_vector (const VectorType                       &vec,
                  const DataPostprocessor<DH::space_dimension> &data_postprocessor)
 {
   // this is a specialized version of the other function where we have a
@@ -1003,7 +1003,7 @@ add_data_vector (const VECTOR                           &vec,
                                                      dofs->get_tria().n_active_cells()));
 
   internal::DataOut::DataEntryBase<DH> *new_entry
-    = new internal::DataOut::DataEntry<DH,VECTOR>(dofs, &vec, &data_postprocessor);
+    = new internal::DataOut::DataEntry<DH,VectorType>(dofs, &vec, &data_postprocessor);
   dof_data.push_back (std_cxx11::shared_ptr<internal::DataOut::DataEntryBase<DH> >(new_entry));
 }
 
@@ -1011,11 +1011,11 @@ add_data_vector (const VECTOR                           &vec,
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
 add_data_vector (const DH                               &dof_handler,
-                 const VECTOR                           &vec,
+                 const VectorType                       &vec,
                  const DataPostprocessor<DH::space_dimension> &data_postprocessor)
 {
   // this is a specialized version of the other function where we have a
@@ -1026,7 +1026,7 @@ add_data_vector (const DH                               &dof_handler,
   AssertDimension (vec.size(), dof_handler.n_dofs());
 
   internal::DataOut::DataEntryBase<DH> *new_entry
-    = new internal::DataOut::DataEntry<DH,VECTOR>(&dof_handler, &vec, &data_postprocessor);
+    = new internal::DataOut::DataEntry<DH,VectorType>(&dof_handler, &vec, &data_postprocessor);
   dof_data.push_back (std_cxx11::shared_ptr<internal::DataOut::DataEntryBase<DH> >(new_entry));
 }
 
@@ -1034,11 +1034,11 @@ add_data_vector (const DH                               &dof_handler,
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
 add_data_vector (const DH                       &dof_handler,
-                 const VECTOR                   &data,
+                 const VectorType               &data,
                  const std::string              &name,
                  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation)
 {
@@ -1067,11 +1067,11 @@ add_data_vector (const DH                       &dof_handler,
 
 template <class DH,
           int patch_dim, int patch_space_dim>
-template <class VECTOR>
+template <typename VectorType>
 void
 DataOut_DoFData<DH,patch_dim,patch_space_dim>::
 add_data_vector (const DH                       &dof_handler,
-                 const VECTOR                   &data,
+                 const VectorType               &data,
                  const std::vector<std::string> &names,
                  const std::vector<DataComponentInterpretation::DataComponentInterpretation> &data_component_interpretation_)
 {
@@ -1098,8 +1098,8 @@ add_data_vector (const DH                       &dof_handler,
        (names.size(), DataComponentInterpretation::component_is_scalar));
 
   internal::DataOut::DataEntryBase<DH> *new_entry
-    = new internal::DataOut::DataEntry<DH,VECTOR>(&dof_handler, &data, names,
-                                                  data_component_interpretation);
+    = new internal::DataOut::DataEntry<DH,VectorType>(&dof_handler, &data, names,
+                                                      data_component_interpretation);
   dof_data.push_back (std_cxx11::shared_ptr<internal::DataOut::DataEntryBase<DH> >(new_entry));
 }
 

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -562,9 +562,9 @@ void PointValueHistory<dim>
 
 
 template <int dim>
-template <class VECTOR>
+template <typename VectorType>
 void PointValueHistory<dim>
-::evaluate_field (const std::string &vector_name, const VECTOR &solution)
+::evaluate_field (const std::string &vector_name, const VectorType &solution)
 {
   // must be closed to add data to internal
   // members.
@@ -615,9 +615,12 @@ void PointValueHistory<dim>
 
 
 template <int dim>
-template <class VECTOR>
+template <typename VectorType>
 void PointValueHistory<dim>
-::evaluate_field(const std::vector <std::string> &vector_names, const VECTOR &solution, const DataPostprocessor< dim> &data_postprocessor, const Quadrature<dim> &quadrature)
+::evaluate_field (const std::vector <std::string> &vector_names,
+                  const VectorType                &solution,
+                  const DataPostprocessor< dim>   &data_postprocessor,
+                  const Quadrature<dim>           &quadrature)
 {
   // must be closed to add data to internal
   // members.
@@ -658,9 +661,9 @@ void PointValueHistory<dim>
         {
           // Extract data for the
           // PostProcessor object
-          std::vector< typename VECTOR::value_type > uh (n_quadrature_points, 0.0);
-          std::vector< Tensor< 1, dim, typename VECTOR::value_type > > duh (n_quadrature_points, Tensor <1, dim, typename VECTOR::value_type> ());
-          std::vector< Tensor< 2, dim, typename VECTOR::value_type > > dduh (n_quadrature_points, Tensor <2, dim, typename VECTOR::value_type> ());
+          std::vector< typename VectorType::value_type > uh (n_quadrature_points, 0.0);
+          std::vector< Tensor< 1, dim, typename VectorType::value_type > > duh (n_quadrature_points, Tensor <1, dim, typename VectorType::value_type> ());
+          std::vector< Tensor< 2, dim, typename VectorType::value_type > > dduh (n_quadrature_points, Tensor <2, dim, typename VectorType::value_type> ());
           std::vector<Point<dim> > dummy_normals (1, Point<dim> ());
           std::vector<Point<dim> > evaluation_points;
           // at each point there is
@@ -691,7 +694,7 @@ void PointValueHistory<dim>
 
           // Call compute_derived_quantities_vector
           // or compute_derived_quantities_scalar
-          // TODO this function should also operate with typename VECTOR::value_type
+          // TODO this function should also operate with typename VectorType::value_type
           data_postprocessor.
           compute_derived_quantities_scalar(std::vector< double > (1, uh[selected_point]),
                                             std::vector< Tensor< 1, dim > > (1, Tensor< 1, dim >(duh[selected_point]) ),
@@ -704,9 +707,9 @@ void PointValueHistory<dim>
       else     // The case of a vector FE
         {
           // Extract data for the PostProcessor object
-          std::vector< Vector< typename VECTOR::value_type > > uh (n_quadrature_points, Vector <typename VECTOR::value_type> (n_components));
-          std::vector< std::vector< Tensor< 1, dim, typename VECTOR::value_type > > > duh (n_quadrature_points, std::vector< Tensor< 1, dim, typename VECTOR::value_type > > (n_components,  Tensor< 1, dim, typename VECTOR::value_type >()));
-          std::vector< std::vector< Tensor< 2, dim, typename VECTOR::value_type > > > dduh (n_quadrature_points, std::vector< Tensor< 2, dim, typename VECTOR::value_type > > (n_components,  Tensor< 2, dim, typename VECTOR::value_type >()));
+          std::vector< Vector< typename VectorType::value_type > > uh (n_quadrature_points, Vector <typename VectorType::value_type> (n_components));
+          std::vector< std::vector< Tensor< 1, dim, typename VectorType::value_type > > > duh (n_quadrature_points, std::vector< Tensor< 1, dim, typename VectorType::value_type > > (n_components,  Tensor< 1, dim, typename VectorType::value_type >()));
+          std::vector< std::vector< Tensor< 2, dim, typename VectorType::value_type > > > dduh (n_quadrature_points, std::vector< Tensor< 2, dim, typename VectorType::value_type > > (n_components,  Tensor< 2, dim, typename VectorType::value_type >()));
           std::vector<Point<dim> > dummy_normals  (1, Point<dim> ());
           std::vector<Point<dim> > evaluation_points;
           // at each point there is
@@ -739,9 +742,9 @@ void PointValueHistory<dim>
           // FIXME: We need tmp vectors below because the data
           // postprocessors are not equipped to deal with anything but
           // doubles (scalars and tensors).
-          const Vector< typename VECTOR::value_type >                        &uh_s   = uh[selected_point];
-          const std::vector< Tensor< 1, dim, typename VECTOR::value_type > > &duh_s  = duh[selected_point];
-          const std::vector< Tensor< 2, dim, typename VECTOR::value_type > > &dduh_s = dduh[selected_point];
+          const Vector< typename VectorType::value_type >                        &uh_s   = uh[selected_point];
+          const std::vector< Tensor< 1, dim, typename VectorType::value_type > > &duh_s  = duh[selected_point];
+          const std::vector< Tensor< 2, dim, typename VectorType::value_type > > &dduh_s = dduh[selected_point];
           std::vector< Tensor< 1, dim > > tmp_d (duh_s.size());
           for (unsigned int i = 0; i < duh_s.size(); i++)
             tmp_d[i] = duh_s[i];
@@ -794,9 +797,12 @@ void PointValueHistory<dim>
 
 
 template <int dim>
-template <class VECTOR>
+template <typename VectorType>
 void PointValueHistory<dim>
-::evaluate_field(const std::string &vector_name, const VECTOR &solution, const DataPostprocessor<dim> &data_postprocessor, const Quadrature<dim> &quadrature)
+::evaluate_field (const std::string            &vector_name,
+                  const VectorType             &solution,
+                  const DataPostprocessor<dim> &data_postprocessor,
+                  const Quadrature<dim>        &quadrature)
 {
   std::vector <std::string> vector_names;
   vector_names.push_back (vector_name);
@@ -806,9 +812,10 @@ void PointValueHistory<dim>
 
 
 template <int dim>
-template <class VECTOR>
+template <typename VectorType>
 void PointValueHistory<dim>
-::evaluate_field_at_requested_location(const std::string &vector_name, const VECTOR &solution)
+::evaluate_field_at_requested_location (const std::string &vector_name,
+                                        const VectorType  &solution)
 {
   // must be closed to add data to internal
   // members.
@@ -1349,4 +1356,3 @@ void PointValueHistory<dim>
 
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -34,8 +34,8 @@ DEAL_II_NAMESPACE_OPEN
 
 
 
-template<int dim, typename VECTOR, class DH>
-SolutionTransfer<dim, VECTOR, DH>::SolutionTransfer(const DH &dof)
+template<int dim, typename VectorType, class DH>
+SolutionTransfer<dim, VectorType, DH>::SolutionTransfer(const DH &dof)
   :
   dof_handler(&dof, typeid(*this).name()),
   n_dofs_old(0),
@@ -44,16 +44,16 @@ SolutionTransfer<dim, VECTOR, DH>::SolutionTransfer(const DH &dof)
 
 
 
-template<int dim, typename VECTOR, class DH>
-SolutionTransfer<dim, VECTOR, DH>::~SolutionTransfer()
+template<int dim, typename VectorType, class DH>
+SolutionTransfer<dim, VectorType, DH>::~SolutionTransfer()
 {
   clear ();
 }
 
 
 
-template<int dim, typename VECTOR, class DH>
-void SolutionTransfer<dim, VECTOR, DH>::clear ()
+template<int dim, typename VectorType, class DH>
+void SolutionTransfer<dim, VectorType, DH>::clear ()
 {
   indices_on_cell.clear();
   dof_values_on_cell.clear();
@@ -64,8 +64,8 @@ void SolutionTransfer<dim, VECTOR, DH>::clear ()
 
 
 
-template<int dim, typename VECTOR, class DH>
-void SolutionTransfer<dim, VECTOR, DH>::prepare_for_pure_refinement()
+template<int dim, typename VectorType, class DH>
+void SolutionTransfer<dim, VectorType, DH>::prepare_for_pure_refinement()
 {
   Assert(prepared_for!=pure_refinement, ExcAlreadyPrepForRef());
   Assert(prepared_for!=coarsening_and_refinement,
@@ -101,10 +101,10 @@ void SolutionTransfer<dim, VECTOR, DH>::prepare_for_pure_refinement()
 
 
 
-template<int dim, typename VECTOR, class DH>
+template<int dim, typename VectorType, class DH>
 void
-SolutionTransfer<dim, VECTOR, DH>::refine_interpolate(const VECTOR &in,
-                                                      VECTOR       &out) const
+SolutionTransfer<dim, VectorType, DH>::refine_interpolate (const VectorType &in,
+                                                           VectorType       &out) const
 {
   Assert(prepared_for==pure_refinement, ExcNotPrepared());
   Assert(in.size()==n_dofs_old, ExcDimensionMismatch(in.size(),n_dofs_old));
@@ -114,7 +114,7 @@ SolutionTransfer<dim, VECTOR, DH>::refine_interpolate(const VECTOR &in,
          ExcMessage ("Vectors cannot be used as input and output"
                      " at the same time!"));
 
-  Vector<typename VECTOR::value_type> local_values(0);
+  Vector<typename VectorType::value_type> local_values(0);
 
   typename DH::cell_iterator cell = dof_handler->begin(),
                              endc = dof_handler->end();
@@ -226,10 +226,10 @@ namespace internal
 
 
 
-template<int dim, typename VECTOR, class DH>
+template<int dim, typename VectorType, class DH>
 void
-SolutionTransfer<dim, VECTOR, DH>::
-prepare_for_coarsening_and_refinement(const std::vector<VECTOR> &all_in)
+SolutionTransfer<dim, VectorType, DH>::
+prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
 {
   Assert (prepared_for!=pure_refinement, ExcAlreadyPrepForRef());
   Assert (prepared_for!=coarsening_and_refinement,
@@ -281,9 +281,9 @@ prepare_for_coarsening_and_refinement(const std::vector<VECTOR> &all_in)
   std::vector<std::vector<types::global_dof_index> >(n_cells_to_stay_or_refine)
   .swap(indices_on_cell);
 
-  std::vector<std::vector<Vector<typename VECTOR::value_type> > >
+  std::vector<std::vector<Vector<typename VectorType::value_type> > >
   (n_coarsen_fathers,
-   std::vector<Vector<typename VECTOR::value_type> > (in_size))
+   std::vector<Vector<typename VectorType::value_type> > (in_size))
   .swap(dof_values_on_cell);
 
   Table<2,FullMatrix<double> > interpolation_hp;
@@ -353,8 +353,8 @@ prepare_for_coarsening_and_refinement(const std::vector<VECTOR> &all_in)
 
           const unsigned int dofs_per_cell=cell->get_dof_handler().get_fe()[target_fe_index].dofs_per_cell;
 
-          std::vector<Vector<typename VECTOR::value_type> >(in_size,
-                                                            Vector<typename VECTOR::value_type>(dofs_per_cell))
+          std::vector<Vector<typename VectorType::value_type> >(in_size,
+                                                                Vector<typename VectorType::value_type>(dofs_per_cell))
           .swap(dof_values_on_cell[n_cf]);
 
 
@@ -379,20 +379,20 @@ prepare_for_coarsening_and_refinement(const std::vector<VECTOR> &all_in)
 
 
 
-template<int dim, typename VECTOR, class DH>
+template<int dim, typename VectorType, class DH>
 void
-SolutionTransfer<dim, VECTOR, DH>::prepare_for_coarsening_and_refinement(const VECTOR &in)
+SolutionTransfer<dim, VectorType, DH>::prepare_for_coarsening_and_refinement (const VectorType &in)
 {
-  std::vector<VECTOR> all_in=std::vector<VECTOR>(1, in);
+  std::vector<VectorType> all_in=std::vector<VectorType>(1, in);
   prepare_for_coarsening_and_refinement(all_in);
 }
 
 
 
-template<int dim, typename VECTOR, class DH>
-void SolutionTransfer<dim, VECTOR, DH>::
-interpolate (const std::vector<VECTOR> &all_in,
-             std::vector<VECTOR>       &all_out) const
+template<int dim, typename VectorType, class DH>
+void SolutionTransfer<dim, VectorType, DH>::
+interpolate (const std::vector<VectorType> &all_in,
+             std::vector<VectorType>       &all_out) const
 {
   Assert(prepared_for==coarsening_and_refinement, ExcNotPrepared());
   const unsigned int size=all_in.size();
@@ -409,7 +409,7 @@ interpolate (const std::vector<VECTOR> &all_in,
              ExcMessage ("Vectors cannot be used as input and output"
                          " at the same time!"));
 
-  Vector<typename VECTOR::value_type> local_values;
+  Vector<typename VectorType::value_type> local_values;
   std::vector<types::global_dof_index> dofs;
 
   typename std::map<std::pair<unsigned int, unsigned int>, Pointerstruct>::const_iterator
@@ -418,7 +418,7 @@ interpolate (const std::vector<VECTOR> &all_in,
 
   Table<2,FullMatrix<double> > interpolation_hp;
   internal::extract_interpolation_matrices (*dof_handler, interpolation_hp);
-  Vector<typename VECTOR::value_type> tmp, tmp2;
+  Vector<typename VectorType::value_type> tmp, tmp2;
 
   typename DH::cell_iterator cell = dof_handler->begin(),
                              endc = dof_handler->end();
@@ -431,7 +431,7 @@ interpolate (const std::vector<VECTOR> &all_in,
           const std::vector<types::global_dof_index> *const indexptr
             =pointerstruct->second.indices_ptr;
 
-          const std::vector<Vector<typename VECTOR::value_type> > *const valuesptr
+          const std::vector<Vector<typename VectorType::value_type> > *const valuesptr
             =pointerstruct->second.dof_values_ptr;
 
           // cell stayed as it was or was refined
@@ -488,7 +488,7 @@ interpolate (const std::vector<VECTOR> &all_in,
                   // test we would have to
                   // store the fe_index of all
                   // cells
-                  const Vector<typename VECTOR::value_type> *data = 0;
+                  const Vector<typename VectorType::value_type> *data = 0;
                   const unsigned int active_fe_index = cell->active_fe_index();
                   if (active_fe_index != pointerstruct->second.active_fe_index)
                     {
@@ -518,18 +518,18 @@ interpolate (const std::vector<VECTOR> &all_in,
 
 
 
-template<int dim, typename VECTOR, class DH>
-void SolutionTransfer<dim, VECTOR, DH>::interpolate(const VECTOR &in,
-                                                    VECTOR       &out) const
+template<int dim, typename VectorType, class DH>
+void SolutionTransfer<dim, VectorType, DH>::interpolate (const VectorType &in,
+                                                         VectorType       &out) const
 {
   Assert (in.size()==n_dofs_old,
           ExcDimensionMismatch(in.size(), n_dofs_old));
   Assert (out.size()==dof_handler->n_dofs(),
           ExcDimensionMismatch(out.size(), dof_handler->n_dofs()));
 
-  std::vector<VECTOR> all_in(1);
+  std::vector<VectorType> all_in(1);
   all_in[0] = in;
-  std::vector<VECTOR> all_out(1);
+  std::vector<VectorType> all_out(1);
   all_out[0] = out;
   interpolate(all_in,
               all_out);
@@ -538,9 +538,9 @@ void SolutionTransfer<dim, VECTOR, DH>::interpolate(const VECTOR &in,
 
 
 
-template<int dim, typename VECTOR, class DH>
+template<int dim, typename VectorType, class DH>
 std::size_t
-SolutionTransfer<dim, VECTOR, DH>::memory_consumption () const
+SolutionTransfer<dim, VectorType, DH>::memory_consumption () const
 {
   // at the moment we do not include the memory
   // consumption of the cell_map as we have no
@@ -555,9 +555,9 @@ SolutionTransfer<dim, VECTOR, DH>::memory_consumption () const
 
 
 
-template<int dim, typename VECTOR, class DH>
+template<int dim, typename VectorType, class DH>
 std::size_t
-SolutionTransfer<dim, VECTOR, DH>::Pointerstruct::memory_consumption () const
+SolutionTransfer<dim, VectorType, DH>::Pointerstruct::memory_consumption () const
 {
   return sizeof(*this);
 }

--- a/tests/base/anisotropic_1.cc
+++ b/tests/base/anisotropic_1.cc
@@ -32,10 +32,10 @@
 using namespace Polynomials;
 
 
-template<int dim, class POLY1, class POLY2>
-void check_poly(const Point<dim> &x,
-                const POLY1      &p,
-                const POLY2      &q)
+template<int dim, class PolynomialType1, class PolynomialType2>
+void check_poly(const Point<dim>      &x,
+                const PolynomialType1 &p,
+                const PolynomialType2 &q)
 {
   const unsigned int n = p.n();
 

--- a/tests/base/polynomial_test.cc
+++ b/tests/base/polynomial_test.cc
@@ -33,9 +33,9 @@
 using namespace Polynomials;
 
 
-template<int dim, class POLY>
-void check_poly(const Point<dim> &x,
-                const POLY &p)
+template<int dim, class PolynomialType>
+void check_poly(const Point<dim>     &x,
+                const PolynomialType &p)
 {
   const unsigned int n = p.n();
   const double eps = 5.0e-15;

--- a/tests/base/polynomials_tensor.cc
+++ b/tests/base/polynomials_tensor.cc
@@ -30,9 +30,9 @@
 
 using namespace std;
 
-template<int dim, class POLY>
-void check_point (const Point<dim> &x,
-                  const POLY &p)
+template<int dim, class PolynomialType>
+void check_point (const Point<dim>     &x,
+                  const PolynomialType &p)
 {
   const unsigned int n = p.n();
   std::vector<Tensor<1,dim> > values(n);

--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -97,4 +97,3 @@ int main()
   PreconditionIdentity preconditioner;
   check_solve (solver, control, A,u,f, preconditioner);
 }
-

--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -37,9 +37,9 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -37,12 +37,14 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -37,11 +37,11 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -36,12 +36,14 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -36,11 +36,11 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -36,9 +36,9 @@
 #include <deal.II/lac/precondition.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -96,4 +96,3 @@ int main()
   PreconditionIdentity preconditioner;
   check_solve (solver, control, A,u,f, preconditioner);
 }
-

--- a/tests/bits/fe_tools_common.h
+++ b/tests/bits/fe_tools_common.h
@@ -76,17 +76,17 @@ output_matrix (const FullMatrix<double> &m)
 
 
 // output some indicators for a given vector
-template <class VECTOR>
+template <typename VectorType>
 void
-output_vector (const VECTOR &v)
+output_vector (const VectorType &v)
 {
   deallog << v.l1_norm() << ' ' << v.l2_norm() << ' ' << v.linfty_norm()
           << std::endl;
 
   // write out at most 20 equispaced
   // elements of the vector
-  for (unsigned int i=0; i<v.size(); i+=std::max(static_cast<typename VECTOR::size_type>(1),
-                                                 static_cast<typename VECTOR::size_type>(v.size()/20)))
+  for (unsigned int i=0; i<v.size(); i+=std::max(static_cast<typename VectorType::size_type>(1),
+                                                 static_cast<typename VectorType::size_type>(v.size()/20)))
     deallog << v(i) << ' ';
   deallog << std::endl;
 }

--- a/tests/gla/extract_subvector_to.cc
+++ b/tests/gla/extract_subvector_to.cc
@@ -15,7 +15,7 @@
 
 
 
-// test the various VECTOR::extract_subvector_to functions
+// test the various VectorType::extract_subvector_to functions
 
 #include "../tests.h"
 #include <deal.II/lac/generic_linear_algebra.h>

--- a/tests/gla/extract_subvector_to_parallel.cc
+++ b/tests/gla/extract_subvector_to_parallel.cc
@@ -15,7 +15,7 @@
 
 
 
-// test the various VECTOR::extract_subvector_to functions for
+// test the various extract_subvector_to functions for
 // parallel vectors and block vectors
 
 #include "../tests.h"

--- a/tests/integrators/assembler_simple_matrix_01.cc
+++ b/tests/integrators/assembler_simple_matrix_01.cc
@@ -35,8 +35,8 @@
 
 using namespace dealii;
 
-template <class DOFINFO, class MATRIX>
-void test(DOFINFO &info, MeshWorker::Assembler::MatrixSimple<MATRIX> &ass)
+template <class DOFINFO, typename MatrixType>
+void test(DOFINFO &info, MeshWorker::Assembler::MatrixSimple<MatrixType> &ass)
 {
   ass.initialize_info(info, false);
   deallog << "No faces" << std::endl;

--- a/tests/integrators/assembler_simple_matrix_01m.cc
+++ b/tests/integrators/assembler_simple_matrix_01m.cc
@@ -35,8 +35,8 @@
 
 using namespace dealii;
 
-template <class DOFINFO, class MATRIX>
-void test(DOFINFO &info, MeshWorker::Assembler::MatrixSimple<MATRIX> &ass)
+template <class DOFINFO, typename MatrixType>
+void test(DOFINFO &info, MeshWorker::Assembler::MatrixSimple<MatrixType> &ass)
 {
   ass.initialize_info(info, false);
   deallog << "No faces" << std::endl;

--- a/tests/integrators/assembler_simple_mgmatrix_01.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_01.cc
@@ -35,8 +35,8 @@
 
 using namespace dealii;
 
-template <class DOFINFO, class MATRIX>
-void test(DOFINFO &info, MeshWorker::Assembler::MGMatrixSimple<MATRIX> &ass)
+template <class DOFINFO, typename MatrixType>
+void test(DOFINFO &info, MeshWorker::Assembler::MGMatrixSimple<MatrixType> &ass)
 {
   ass.initialize_info(info, false);
   deallog << "No faces" << std::endl;

--- a/tests/lac/filtered_matrix.cc
+++ b/tests/lac/filtered_matrix.cc
@@ -25,21 +25,21 @@
 #include <fstream>
 
 
-template<class VECTOR>
-void test (const FilteredMatrix<VECTOR> &M)
+template<typename VectorType>
+void test (const FilteredMatrix<VectorType> &M)
 {
   deallog << "Iterator";
 
   unsigned int max = 0;
-  for (typename FilteredMatrix<VECTOR>::const_iterator i= M.begin();
+  for (typename FilteredMatrix<VectorType>::const_iterator i= M.begin();
        i != M.end(); ++i)
     {
       Assert(i->row() == i->column(), ExcInternalError());
       deallog << ' ' << i->row() << ':' << i->value();
       max = i->row();
     }
-  VECTOR v(max+1);
-  VECTOR w(max+1);
+  VectorType v(max+1);
+  VectorType w(max+1);
 
   for (unsigned int i=0; i<v.size(); ++i)
     v(i) = 31+i;

--- a/tests/lac/linear_operator_08.cc
+++ b/tests/lac/linear_operator_08.cc
@@ -49,38 +49,38 @@
 using namespace dealii;
 
 
-template<class PRECONDITIONER, class MATRIX, class VECTOR,
+template<class PRECONDITIONER, class MATRIX, typename VectorType,
          class ADDITIONAL_DATA = typename PRECONDITIONER::AdditionalData>
 void
 test_preconditioner (const MATRIX &A,
-                     const VECTOR &b,
+                     const VectorType &b,
                      const ADDITIONAL_DATA &data = ADDITIONAL_DATA())
 {
-  const auto lo_A = linear_operator<VECTOR>(A);
+  const auto lo_A = linear_operator<VectorType>(A);
 
   PRECONDITIONER preconditioner;
   preconditioner.initialize(A, data);
 
   SolverControl solver_control (100, 1.0e-10);
-  SolverCG<VECTOR> solver (solver_control);
+  SolverCG<VectorType> solver (solver_control);
 
   // Exact inverse
   const auto lo_A_inv = inverse_operator(lo_A,
                                          solver,
                                          preconditioner);
 
-  const VECTOR x = lo_A_inv*b;
+  const VectorType x = lo_A_inv*b;
 
   // Approximate inverse
   {
     // Using exemplar matrix
-    const auto lo_A_inv_approx = linear_operator<VECTOR>(A, preconditioner);
-    const VECTOR x_approx = lo_A_inv_approx*b;
+    const auto lo_A_inv_approx = linear_operator<VectorType>(A, preconditioner);
+    const VectorType x_approx = lo_A_inv_approx*b;
   }
   {
     // Stand-alone
-    const auto lo_A_inv_approx = linear_operator<VECTOR>(preconditioner);
-    const VECTOR x_approx = lo_A_inv_approx*b;
+    const auto lo_A_inv_approx = linear_operator<VectorType>(preconditioner);
+    const VectorType x_approx = lo_A_inv_approx*b;
   }
 }
 
@@ -193,16 +193,16 @@ public:
                               matrix.n_block_cols());
   }
 
-  template<typename VECTOR>
+  template<typename VectorType>
   void
-  vmult(VECTOR &dst, const VECTOR &src) const
+  vmult(VectorType &dst, const VectorType &src) const
   {
     dst = src;
   }
 
-  template<class VECTOR>
+  template<typename VectorType>
   void
-  Tvmult(VECTOR &dst, const VECTOR &src) const
+  Tvmult(VectorType &dst, const VectorType &src) const
   {
     dst = src;
   }

--- a/tests/lac/linear_operator_08.cc
+++ b/tests/lac/linear_operator_08.cc
@@ -49,10 +49,10 @@
 using namespace dealii;
 
 
-template<class PRECONDITIONER, class MATRIX, typename VectorType,
+template<class PRECONDITIONER, typename MatrixType, typename VectorType,
          class ADDITIONAL_DATA = typename PRECONDITIONER::AdditionalData>
 void
-test_preconditioner (const MATRIX &A,
+test_preconditioner (const MatrixType &A,
                      const VectorType &b,
                      const ADDITIONAL_DATA &data = ADDITIONAL_DATA())
 {

--- a/tests/lac/linear_operator_08.cc
+++ b/tests/lac/linear_operator_08.cc
@@ -129,7 +129,7 @@ test_preconditioner (const SparseMatrix<double> &A,
   }
 }
 
-template<class SOLVER>
+template<typename SolverType>
 void
 test_solver (const SparseMatrix<double> &A,
              const Vector<double> &b)
@@ -138,7 +138,7 @@ test_solver (const SparseMatrix<double> &A,
   {
     deallog.push("Standard solver");
     SolverControl solver_control (100, 1.0e-10);
-    SOLVER solver (solver_control);
+    SolverType solver (solver_control);
 
     PreconditionJacobi< SparseMatrix<double> > preconditioner;
     preconditioner.initialize(A);
@@ -156,7 +156,7 @@ test_solver (const SparseMatrix<double> &A,
     const auto lo_A = linear_operator(A);
 
     SolverControl solver_control (100, 1.0e-10);
-    SOLVER solver (solver_control);
+    SolverType solver (solver_control);
 
     PreconditionJacobi< SparseMatrix<double> > preconditioner;
     preconditioner.initialize(A);
@@ -322,7 +322,7 @@ int main()
     }
     deallog.pop();
 
-    // === SOLVERS ===
+    // === SolverTypes ===
     deallog << std::endl;
     deallog << "Solvers" << std::endl;
     deallog.push("Solvers");

--- a/tests/lac/solver.cc
+++ b/tests/lac/solver.cc
@@ -33,10 +33,13 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -50,10 +53,13 @@ check_solve( SOLVER &solver, const MATRIX &A,
     }
 }
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_Tsolve(SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_Tsolve (SOLVER             &solver,
+              const MATRIX       &A,
+              VectorType         &u,
+              VectorType         &f,
+              const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -286,4 +292,3 @@ int main()
       check_solve(rich,A,u,f,prec_psor);
     }
 }
-

--- a/tests/lac/solver.cc
+++ b/tests/lac/solver.cc
@@ -33,9 +33,9 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
@@ -53,9 +53,9 @@ check_solve (SOLVER             &solver,
     }
 }
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_Tsolve (SOLVER             &solver,
+check_Tsolve (SolverType         &solver,
               const MatrixType   &A,
               VectorType         &u,
               VectorType         &f,

--- a/tests/lac/solver.cc
+++ b/tests/lac/solver.cc
@@ -33,10 +33,10 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)
@@ -53,10 +53,10 @@ check_solve (SOLVER             &solver,
     }
 }
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_Tsolve (SOLVER             &solver,
-              const MATRIX       &A,
+              const MatrixType   &A,
               VectorType         &u,
               VectorType         &f,
               const PRECONDITION &P)

--- a/tests/lac/solver_02.cc
+++ b/tests/lac/solver_02.cc
@@ -32,7 +32,7 @@
 #include <deal.II/lac/precondition.h>
 #include <deal.II/base/point.h>
 
-template<class SOLVER>
+template<typename SolverType>
 void test()
 {
   const unsigned int size = 3;
@@ -50,7 +50,7 @@ void test()
   rhs(size-1)=1.0;
 
   SolverControl solvctrl(1000, 1e-12, true);
-  SOLVER solver(solvctrl);
+  SolverType solver(solvctrl);
 
   PreconditionIdentity precond;
   solver.solve(mat, solvec, rhs, precond);

--- a/tests/lac/solver_memorytest.cc
+++ b/tests/lac/solver_memorytest.cc
@@ -39,16 +39,16 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType>
+template<typename SolverType, typename MatrixType, typename VectorType>
 void
 check_solve (const MatrixType &A,
              VectorType       &u,
              VectorType       &f,
-             const typename SOLVER::AdditionalData &additional_data = typename SOLVER::AdditionalData())
+             const typename SolverType::AdditionalData &additional_data = typename SolverType::AdditionalData())
 {
   GrowingVectorMemory<> mem;
   SolverControl control(100, 1.e-3);
-  SOLVER solver(control, mem, additional_data);
+  SolverType solver(control, mem, additional_data);
   PreconditionIdentity prec_no;
   u = 0.;
   f = 0.;

--- a/tests/lac/solver_memorytest.cc
+++ b/tests/lac/solver_memorytest.cc
@@ -39,11 +39,11 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, typename VectorType>
+template<class SOLVER, typename MatrixType, typename VectorType>
 void
-check_solve (const MATRIX &A,
-             VectorType &u,
-             VectorType &f,
+check_solve (const MatrixType &A,
+             VectorType       &u,
+             VectorType       &f,
              const typename SOLVER::AdditionalData &additional_data = typename SOLVER::AdditionalData())
 {
   GrowingVectorMemory<> mem;

--- a/tests/lac/solver_memorytest.cc
+++ b/tests/lac/solver_memorytest.cc
@@ -39,10 +39,12 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, class VECTOR>
+template<class SOLVER, class MATRIX, typename VectorType>
 void
-check_solve( const MATRIX &A, VECTOR &u, VECTOR &f,
-             const typename SOLVER::AdditionalData &additional_data = typename SOLVER::AdditionalData() )
+check_solve (const MATRIX &A,
+             VectorType &u,
+             VectorType &f,
+             const typename SOLVER::AdditionalData &additional_data = typename SOLVER::AdditionalData())
 {
   GrowingVectorMemory<> mem;
   SolverControl control(100, 1.e-3);
@@ -102,4 +104,3 @@ int main()
     }
 
 }
-

--- a/tests/lac/solver_monitor.cc
+++ b/tests/lac/solver_monitor.cc
@@ -56,10 +56,13 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -140,4 +143,3 @@ int main()
         }
     }
 }
-

--- a/tests/lac/solver_monitor.cc
+++ b/tests/lac/solver_monitor.cc
@@ -56,10 +56,10 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)

--- a/tests/lac/solver_monitor.cc
+++ b/tests/lac/solver_monitor.cc
@@ -56,9 +56,9 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,

--- a/tests/lac/solver_monitor_disconnect.cc
+++ b/tests/lac/solver_monitor_disconnect.cc
@@ -57,10 +57,13 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -137,4 +140,3 @@ int main()
       cg_c1.disconnect();
     }
 }
-

--- a/tests/lac/solver_monitor_disconnect.cc
+++ b/tests/lac/solver_monitor_disconnect.cc
@@ -57,10 +57,10 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)

--- a/tests/lac/solver_monitor_disconnect.cc
+++ b/tests/lac/solver_monitor_disconnect.cc
@@ -57,9 +57,9 @@ SolverControl::State monitor_mean (const unsigned int    iteration,
 
 
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,

--- a/tests/lac/solver_relaxation_01.cc
+++ b/tests/lac/solver_relaxation_01.cc
@@ -31,10 +31,13 @@
 #include <deal.II/lac/solver_relaxation.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 double
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   double result = 0.;
   u = 0.;
@@ -176,4 +179,3 @@ int main()
       check_solve(rich,A,u,f,prec_psor);
     }
 }
-

--- a/tests/lac/solver_relaxation_01.cc
+++ b/tests/lac/solver_relaxation_01.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/solver_relaxation.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 double
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,

--- a/tests/lac/solver_relaxation_01.cc
+++ b/tests/lac/solver_relaxation_01.cc
@@ -31,10 +31,10 @@
 #include <deal.II/lac/solver_relaxation.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 double
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)

--- a/tests/lac/solver_relaxation_02.cc
+++ b/tests/lac/solver_relaxation_02.cc
@@ -32,10 +32,10 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 double
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)

--- a/tests/lac/solver_relaxation_02.cc
+++ b/tests/lac/solver_relaxation_02.cc
@@ -32,10 +32,13 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 double
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   double result = 0.;
   u = 0.;
@@ -151,4 +154,3 @@ int main()
         }
     }
 }
-

--- a/tests/lac/solver_relaxation_02.cc
+++ b/tests/lac/solver_relaxation_02.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 double
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,

--- a/tests/lac/solver_relaxation_03.cc
+++ b/tests/lac/solver_relaxation_03.cc
@@ -33,9 +33,9 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 double
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,

--- a/tests/lac/solver_relaxation_03.cc
+++ b/tests/lac/solver_relaxation_03.cc
@@ -33,10 +33,13 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 double
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve (SOLVER             &solver,
+             const MATRIX       &A,
+             VectorType         &u,
+             VectorType         &f,
+             const PRECONDITION &P)
 {
   double result = 0.;
   u = 0.;
@@ -207,4 +210,3 @@ int main()
         }
     }
 }
-

--- a/tests/lac/solver_relaxation_03.cc
+++ b/tests/lac/solver_relaxation_03.cc
@@ -33,10 +33,10 @@
 #include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/relaxation_block.h>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 double
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)

--- a/tests/lac/solver_selector_01.cc
+++ b/tests/lac/solver_selector_01.cc
@@ -26,9 +26,9 @@
 
 #include <fstream>
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, typename VectorType>
 void
-check(const MATRIX &A, const VECTOR &f)
+check (const MATRIX &A, const VectorType &f)
 {
   std::vector<std::string> names;
   names.push_back("cg");
@@ -38,11 +38,11 @@ check(const MATRIX &A, const VECTOR &f)
 
   ReductionControl cont1(100, 0., 1.e-4);
   SolverControl cont2(100, 1.e-7);
-  SolverSelector<VECTOR> solver;
+  SolverSelector<VectorType> solver;
   PreconditionSSOR<SparseMatrix<double> > pre;
   pre.initialize(A);
 
-  VECTOR u;
+  VectorType u;
   u.reinit(f);
 
   std::vector<std::string>::const_iterator name;

--- a/tests/lac/solver_selector_01.cc
+++ b/tests/lac/solver_selector_01.cc
@@ -26,9 +26,9 @@
 
 #include <fstream>
 
-template <class MATRIX, typename VectorType>
+template <typename MatrixType, typename VectorType>
 void
-check (const MATRIX &A, const VectorType &f)
+check (const MatrixType &A, const VectorType &f)
 {
   std::vector<std::string> names;
   names.push_back("cg");

--- a/tests/lac/solver_selector_02.cc
+++ b/tests/lac/solver_selector_02.cc
@@ -41,9 +41,9 @@ public:
 
 
 
-template <class MATRIX, class VECTOR>
+template <class MATRIX, typename VectorType>
 void
-check(const MATRIX &A, const VECTOR &f)
+check(const MATRIX &A, const VectorType &f)
 {
   std::vector<std::string> names;
   names.push_back("cg");
@@ -52,11 +52,11 @@ check(const MATRIX &A, const VECTOR &f)
   names.push_back("fgmres");
 
   MySolverControl mycont;
-  SolverSelector<VECTOR> solver;
+  SolverSelector<VectorType> solver;
   PreconditionSSOR<SparseMatrix<double> > pre;
   pre.initialize(A);
 
-  VECTOR u;
+  VectorType u;
   u.reinit(f);
 
   std::vector<std::string>::const_iterator name;

--- a/tests/lac/solver_selector_02.cc
+++ b/tests/lac/solver_selector_02.cc
@@ -41,9 +41,9 @@ public:
 
 
 
-template <class MATRIX, typename VectorType>
+template <typename MatrixType, typename VectorType>
 void
-check(const MATRIX &A, const VectorType &f)
+check(const MatrixType &A, const VectorType &f)
 {
   std::vector<std::string> names;
   names.push_back("cg");

--- a/tests/lac/solver_signals.cc
+++ b/tests/lac/solver_signals.cc
@@ -56,10 +56,13 @@ void output_eigenvalues(const std::vector<NUMBER> &eigenvalues,const std::string
   deallog << std::endl;
 }
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver, const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER             &solver,
+            const MATRIX       &A,
+            VectorType         &u,
+            VectorType         &f,
+            const PRECONDITION &P)
 {
   u = 0.;
   f = 1.;
@@ -134,4 +137,3 @@ int main()
     }
 
 }
-

--- a/tests/lac/solver_signals.cc
+++ b/tests/lac/solver_signals.cc
@@ -56,10 +56,10 @@ void output_eigenvalues(const std::vector<NUMBER> &eigenvalues,const std::string
   deallog << std::endl;
 }
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER             &solver,
-            const MATRIX       &A,
+            const MatrixType   &A,
             VectorType         &u,
             VectorType         &f,
             const PRECONDITION &P)

--- a/tests/lac/solver_signals.cc
+++ b/tests/lac/solver_signals.cc
@@ -56,9 +56,9 @@ void output_eigenvalues(const std::vector<NUMBER> &eigenvalues,const std::string
   deallog << std::endl;
 }
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER             &solver,
+check_solve(SolverType         &solver,
             const MatrixType   &A,
             VectorType         &u,
             VectorType         &f,

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -41,11 +41,11 @@
   deallog.pop(); \
   residuals.push_back(control.last_value())
 
-template<class MATRIX>
+template<typename MatrixType>
 void
-check_vmult_quadratic(std::vector<double> &residuals,
-                      const MATRIX &A,
-                      const char *prefix)
+check_vmult_quadratic (std::vector<double> &residuals,
+                       const MatrixType    &A,
+                       const char          *prefix)
 {
   deallog.push(prefix);
 
@@ -60,7 +60,7 @@ check_vmult_quadratic(std::vector<double> &residuals,
   const types::global_dof_index block_size = (types::global_dof_index) std::sqrt(A.n()+.3);
   const unsigned int n_blocks = A.n()/block_size;
 
-  typename PreconditionBlock<MATRIX, float>::AdditionalData
+  typename PreconditionBlock<MatrixType, float>::AdditionalData
   data(block_size, 1.2);
   std::vector<types::global_dof_index> perm(A.n());
   std::vector<types::global_dof_index> iperm(A.n());
@@ -72,22 +72,22 @@ check_vmult_quadratic(std::vector<double> &residuals,
       }
 
   PreconditionIdentity identity;
-  PreconditionJacobi<MATRIX> jacobi;
+  PreconditionJacobi<MatrixType> jacobi;
   jacobi.initialize(A, .5);
-  PreconditionSOR<MATRIX> sor;
+  PreconditionSOR<MatrixType> sor;
   sor.initialize(A, 1.2);
-//   PreconditionPSOR<MATRIX> psor;
+//   PreconditionPSOR<MatrixType> psor;
 //   psor.initialize(A, perm, iperm, 1.2);
-  PreconditionSSOR<MATRIX> ssor;
+  PreconditionSSOR<MatrixType> ssor;
   ssor.initialize(A, 1.2);
 
-  PreconditionBlockJacobi<MATRIX, float> block_jacobi;
+  PreconditionBlockJacobi<MatrixType, float> block_jacobi;
   block_jacobi.initialize(A, data);
-  PreconditionBlockSSOR<MATRIX, float> block_ssor;
+  PreconditionBlockSSOR<MatrixType, float> block_ssor;
   block_ssor.initialize(A, data);
-  PreconditionBlockSOR<MATRIX, float> block_sor;
+  PreconditionBlockSOR<MatrixType, float> block_sor;
   block_sor.initialize(A, data);
-  PreconditionBlockSOR<MATRIX, float> block_psor;
+  PreconditionBlockSOR<MatrixType, float> block_psor;
   block_psor.set_permutation(perm, iperm);
   block_psor.initialize(A, data);
 
@@ -160,18 +160,18 @@ check_vmult_quadratic(std::vector<double> &residuals,
 }
 
 
-template <class MATRIX>
+template <typename MatrixType>
 void
-check_iterator (const MATRIX &A)
+check_iterator (const MatrixType &A)
 {
 //  deallog.push("it");
 
-  typename MATRIX::const_iterator E = A.end();
+  typename MatrixType::const_iterator E = A.end();
 
   if (A.m() < 10)
     for (unsigned int r=0; r<A.m(); ++r)
       {
-        typename MATRIX::const_iterator b = A.begin(r);
+        typename MatrixType::const_iterator b = A.begin(r);
         if (b == E)
           deallog << "Final" << std::endl;
         else
@@ -180,7 +180,7 @@ check_iterator (const MATRIX &A)
                   << '\t' << b->column()
                   << '\t' << b->value()
                   << std::endl;
-        typename MATRIX::const_iterator e = A.end(r);
+        typename MatrixType::const_iterator e = A.end(r);
         if (e == E)
           deallog << "Final" << std::endl;
         else
@@ -188,17 +188,17 @@ check_iterator (const MATRIX &A)
                   << std::endl;
         deallog << "cols:";
 
-        for (typename MATRIX::const_iterator i=b; i!=e; ++i)
+        for (typename MatrixType::const_iterator i=b; i!=e; ++i)
           deallog << '\t' << ',' << i->column();
         deallog << std::endl;
       }
-  for (typename MATRIX::const_iterator i = A.begin(); i!= A.end(); ++i)
+  for (typename MatrixType::const_iterator i = A.begin(); i!= A.end(); ++i)
     deallog << '\t' << i->row()
             << '\t' << i->column()
             << '\t' << i->value()
             << std::endl;
   deallog << "Repeat row 2" << std::endl;
-  for (typename MATRIX::const_iterator i = A.begin(2); i!= A.end(2); ++i)
+  for (typename MatrixType::const_iterator i = A.begin(2); i!= A.end(2); ++i)
     deallog << '\t' << i->row()
             << '\t' << i->column()
             << '\t' << i->value()

--- a/tests/lac/testmatrix.h
+++ b/tests/lac/testmatrix.h
@@ -36,20 +36,20 @@ public:
   /**
    * Fill the matrix with values.
    */
-  template <typename MATRIX>
-  void five_point(MATRIX &, bool nonsymmetric = false) const;
+  template <typename MatrixType>
+  void five_point(MatrixType &, bool nonsymmetric = false) const;
 
   /**
    * Fill the matrix with values.
    */
-  template <typename MATRIX>
-  void nine_point(MATRIX &, bool nonsymmetric = false) const;
+  template <typename MatrixType>
+  void nine_point(MatrixType &, bool nonsymmetric = false) const;
 
   /**
    * Fill the matrix with values.
    */
-  template <typename MATRIX>
-  void upwind(MATRIX &, bool back = false) const;
+  template <typename MatrixType>
+  void upwind(MatrixType &, bool back = false) const;
 
   template <typename number>
   void gnuplot_print(std::ostream &, const Vector<number> &) const;
@@ -173,9 +173,9 @@ FDMatrix::nine_point_structure(SP &structure) const
 
 
 
-template<typename MATRIX>
+template<typename MatrixType>
 void
-FDMatrix::nine_point(MATRIX &A, bool) const
+FDMatrix::nine_point(MatrixType &A, bool) const
 {
   for (unsigned int i=0; i<=ny-2; i++)
     {
@@ -229,10 +229,10 @@ FDMatrix::nine_point(MATRIX &A, bool) const
     }
 }
 
-template<typename MATRIX>
+template<typename MatrixType>
 inline
 void
-FDMatrix::five_point(MATRIX &A, bool nonsymmetric) const
+FDMatrix::five_point(MatrixType &A, bool nonsymmetric) const
 {
   for (unsigned int i=0; i<=ny-2; i++)
     {
@@ -273,10 +273,10 @@ FDMatrix::five_point(MATRIX &A, bool nonsymmetric) const
 
 
 
-template<typename MATRIX>
+template<typename MatrixType>
 inline
 void
-FDMatrix::upwind(MATRIX &A, bool back) const
+FDMatrix::upwind(MatrixType &A, bool back) const
 {
   for (unsigned int i=0; i<=ny-2; i++)
     {

--- a/tests/lac/vector_memory.cc
+++ b/tests/lac/vector_memory.cc
@@ -24,27 +24,27 @@
 
 using namespace dealii;
 
-template<class VECTOR>
+template<typename VectorType>
 void
 test_leak()
 {
-  GrowingVectorMemory<VECTOR> mem;
-  VECTOR *v = mem.alloc();
+  GrowingVectorMemory<VectorType> mem;
+  VectorType *v = mem.alloc();
   v->reinit(5);
 }
 
 
-template<class VECTOR>
+template<typename VectorType>
 void
 test_stat()
 {
-  GrowingVectorMemory<VECTOR> mem(1, true);
-  VECTOR *v1 = mem.alloc();
-  VECTOR *v2 = mem.alloc();
-  VECTOR *v3 = mem.alloc();
-  VECTOR *v4 = mem.alloc();
-  VECTOR *v5 = mem.alloc();
-  VECTOR *v6 = mem.alloc();
+  GrowingVectorMemory<VectorType> mem(1, true);
+  VectorType *v1 = mem.alloc();
+  VectorType *v2 = mem.alloc();
+  VectorType *v3 = mem.alloc();
+  VectorType *v4 = mem.alloc();
+  VectorType *v5 = mem.alloc();
+  VectorType *v6 = mem.alloc();
   v1->reinit(5);
   v2->reinit(5);
   v3->reinit(5);

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER             &solver,
+check_solve (SolverType         &solver,
              const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
@@ -51,9 +51,9 @@ check_solve (SOLVER             &solver,
     }
 }
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_Tsolve (SOLVER             &solver,
+check_Tsolve (SolverType         &solver,
               const MatrixType   &A,
               VectorType         &u,
               VectorType         &f,

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -31,10 +31,10 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/precondition.h>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER             &solver,
-             const MATRIX       &A,
+             const MatrixType   &A,
              VectorType         &u,
              VectorType         &f,
              const PRECONDITION &P)
@@ -51,10 +51,10 @@ check_solve (SOLVER             &solver,
     }
 }
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_Tsolve (SOLVER             &solver,
-              const MATRIX       &A,
+              const MatrixType   &A,
               VectorType         &u,
               VectorType         &f,
               const PRECONDITION &P)

--- a/tests/matrix_free/inverse_mass_01.cc
+++ b/tests/matrix_free/inverse_mass_01.cc
@@ -39,7 +39,7 @@ std::ofstream logfile("output");
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
@@ -49,9 +49,9 @@ public:
   {};
 
   void
-  local_mass_operator (const MatrixFree<dim,Number>  &data,
-                       VECTOR       &dst,
-                       const VECTOR &src,
+  local_mass_operator (const MatrixFree<dim,Number>               &data,
+                       VectorType                                 &dst,
+                       const VectorType                           &src,
                        const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,1,Number> fe_eval (data);
@@ -70,9 +70,9 @@ public:
   }
 
   void
-  local_inverse_mass_operator (const MatrixFree<dim,Number>  &data,
-                               VECTOR       &dst,
-                               const VECTOR &src,
+  local_inverse_mass_operator (const MatrixFree<dim,Number>               &data,
+                               VectorType                                 &dst,
+                               const VectorType                           &src,
                                const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,1,Number> fe_eval (data);
@@ -91,19 +91,19 @@ public:
       }
   }
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType       &dst,
+              const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_mass_operator,
                     this, dst, src);
   };
 
-  void apply_inverse (VECTOR       &dst,
-                      const VECTOR &src) const
+  void apply_inverse (VectorType       &dst,
+                      const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_inverse_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_inverse_mass_operator,
                     this, dst, src);
   };
 

--- a/tests/matrix_free/inverse_mass_02.cc
+++ b/tests/matrix_free/inverse_mass_02.cc
@@ -39,7 +39,7 @@ std::ofstream logfile("output");
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
@@ -49,9 +49,9 @@ public:
   {};
 
   void
-  local_mass_operator (const MatrixFree<dim,Number>  &data,
-                       VECTOR       &dst,
-                       const VECTOR &src,
+  local_mass_operator (const MatrixFree<dim,Number>               &data,
+                       VectorType                                 &dst,
+                       const VectorType                           &src,
                        const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,dim,Number> fe_eval (data);
@@ -70,9 +70,9 @@ public:
   }
 
   void
-  local_inverse_mass_operator (const MatrixFree<dim,Number>  &data,
-                               VECTOR       &dst,
-                               const VECTOR &src,
+  local_inverse_mass_operator (const MatrixFree<dim,Number>               &data,
+                               VectorType                                 &dst,
+                               const VectorType                           &src,
                                const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,dim,Number> fe_eval (data);
@@ -91,19 +91,19 @@ public:
       }
   }
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType   &dst,
+              const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_mass_operator,
                     this, dst, src);
   };
 
-  void apply_inverse (VECTOR       &dst,
-                      const VECTOR &src) const
+  void apply_inverse (VectorType   &dst,
+                      const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_inverse_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_inverse_mass_operator,
                     this, dst, src);
   };
 

--- a/tests/matrix_free/inverse_mass_03.cc
+++ b/tests/matrix_free/inverse_mass_03.cc
@@ -40,7 +40,7 @@ std::ofstream logfile("output");
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
@@ -50,9 +50,9 @@ public:
   {};
 
   void
-  local_mass_operator (const MatrixFree<dim,Number>  &data,
-                       VECTOR       &dst,
-                       const VECTOR &src,
+  local_mass_operator (const MatrixFree<dim,Number>               &data,
+                       VectorType                                 &dst,
+                       const VectorType                           &src,
                        const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,3,Number> fe_eval (data);
@@ -77,9 +77,9 @@ public:
   }
 
   void
-  local_inverse_mass_operator (const MatrixFree<dim,Number>  &data,
-                               VECTOR       &dst,
-                               const VECTOR &src,
+  local_inverse_mass_operator (const MatrixFree<dim,Number>               &data,
+                               VectorType                                 &dst,
+                               const VectorType                           &src,
                                const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,3,Number> fe_eval (data);
@@ -104,19 +104,19 @@ public:
       }
   }
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType   &dst,
+              const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_mass_operator,
                     this, dst, src);
   };
 
-  void apply_inverse (VECTOR       &dst,
-                      const VECTOR &src) const
+  void apply_inverse (VectorType   &dst,
+                      const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_inverse_mass_operator,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_inverse_mass_operator,
                     this, dst, src);
   };
 

--- a/tests/matrix_free/matrix_vector_15.cc
+++ b/tests/matrix_free/matrix_vector_15.cc
@@ -41,21 +41,21 @@ std::ofstream logfile("output");
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
-  MatrixFreeTest(const DoFHandler<dim> &dof_handler,
+  MatrixFreeTest(const DoFHandler<dim>  &dof_handler,
                  const ConstraintMatrix &constraints)
     :
     dof_handler (dof_handler),
     constraints (constraints)
   {}
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType       &dst,
+              const VectorType &src) const
   {
-    VECTOR src_cpy = src;
+    VectorType src_cpy = src;
     constraints.distribute(src_cpy);
     FEEvaluation<dim,fe_degree,fe_degree+1,1,Number>
     fe_eval(dof_handler.get_fe(), QGauss<1>(fe_degree+1),

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -41,21 +41,21 @@ std::ofstream logfile("output");
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
-  MatrixFreeTest(const DoFHandler<dim> &dof_handler,
-                 const ConstraintMatrix &constraints)
+  MatrixFreeTest (const DoFHandler<dim>  &dof_handler,
+                  const ConstraintMatrix &constraints)
     :
     dof_handler (dof_handler),
     constraints (constraints)
   {}
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType       &dst,
+              const VectorType &src) const
   {
-    VECTOR src_cpy = src;
+    VectorType src_cpy = src;
     constraints.distribute(src_cpy);
     FEEvaluation<dim,fe_degree,fe_degree+1,dim,Number> fe_eval
     (dof_handler.get_fe(), QGauss<1>(fe_degree+1),

--- a/tests/matrix_free/matrix_vector_18.cc
+++ b/tests/matrix_free/matrix_vector_18.cc
@@ -42,7 +42,7 @@
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
@@ -50,20 +50,20 @@ public:
     data (data_in)
   {};
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType       &dst,
+              const VectorType &src) const
   {
     dst = 0;
-    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VECTOR>::local_operation,
+    data.cell_loop (&MatrixFreeTest<dim,fe_degree,Number,VectorType>::local_operation,
                     this, dst, src);
   };
 
 private:
   const MatrixFree<dim,Number> &data;
 
-  void local_operation (const MatrixFree<dim,Number> &data,
-                        VECTOR &out,
-                        const VECTOR &in,
+  void local_operation (const MatrixFree<dim,Number>               &data,
+                        VectorType                                 &out,
+                        const VectorType                           &in,
                         const std::pair<unsigned int,unsigned int> &cell_range) const
   {
     FEEvaluation<dim,fe_degree,fe_degree+1,1,Number> fe_eval (data);

--- a/tests/matrix_free/matrix_vector_18.cc
+++ b/tests/matrix_free/matrix_vector_18.cc
@@ -258,4 +258,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_mf.h
+++ b/tests/matrix_free/matrix_vector_mf.h
@@ -18,14 +18,14 @@
 #include <deal.II/lac/parallel_vector.h>
 
 
-template <int dim, int fe_degree, typename VECTOR>
+template <int dim, int fe_degree, typename VectorType>
 void
-helmholtz_operator (const MatrixFree<dim,typename VECTOR::value_type>  &data,
-                    VECTOR       &dst,
-                    const VECTOR &src,
-                    const std::pair<unsigned int,unsigned int> &cell_range)
+helmholtz_operator (const MatrixFree<dim,typename VectorType::value_type> &data,
+                    VectorType                                            &dst,
+                    const VectorType                                      &src,
+                    const std::pair<unsigned int,unsigned int>            &cell_range)
 {
-  typedef typename VECTOR::value_type Number;
+  typedef typename VectorType::value_type Number;
   FEEvaluation<dim,fe_degree,fe_degree+1,1,Number> fe_eval (data);
   const unsigned int n_q_points = fe_eval.n_q_points;
 
@@ -46,7 +46,7 @@ helmholtz_operator (const MatrixFree<dim,typename VECTOR::value_type>  &data,
 
 
 
-template <int dim, int fe_degree, typename Number, typename VECTOR=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
 class MatrixFreeTest
 {
 public:
@@ -56,15 +56,15 @@ public:
     data (data_in)
   {};
 
-  void vmult (VECTOR       &dst,
-              const VECTOR &src) const
+  void vmult (VectorType       &dst,
+              const VectorType &src) const
   {
     dst = 0;
-    const std_cxx11::function<void(const MatrixFree<dim,typename VECTOR::value_type> &,
-                                   VECTOR &,
-                                   const VECTOR &,
+    const std_cxx11::function<void(const MatrixFree<dim,typename VectorType::value_type> &,
+                                   VectorType &,
+                                   const VectorType &,
                                    const std::pair<unsigned int,unsigned int> &)>
-    wrap = helmholtz_operator<dim,fe_degree,VECTOR>;
+    wrap = helmholtz_operator<dim,fe_degree,VectorType>;
     data.cell_loop (wrap, dst, src);
   };
 

--- a/tests/matrix_free/matrix_vector_mf.h
+++ b/tests/matrix_free/matrix_vector_mf.h
@@ -71,7 +71,3 @@ public:
 private:
   const MatrixFree<dim,Number> &data;
 };
-
-
-
-

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -247,11 +247,11 @@ private:
 
 
 
-template <typename MATRIX>
+template <typename MatrixType>
 class MGTransferPrebuiltMF : public MGTransferPrebuilt<parallel::distributed::Vector<double> >
 {
 public:
-  MGTransferPrebuiltMF(const MGLevelObject<MATRIX> &laplace)
+  MGTransferPrebuiltMF(const MGLevelObject<MatrixType> &laplace)
     :
     laplace_operator (laplace)
   {};
@@ -273,18 +273,18 @@ public:
   }
 
 private:
-  const MGLevelObject<MATRIX> &laplace_operator;
+  const MGLevelObject<MatrixType> &laplace_operator;
 };
 
 
 
-template<typename MATRIX, typename Number>
+template<typename MatrixType, typename Number>
 class MGCoarseIterative : public MGCoarseGridBase<parallel::distributed::Vector<Number> >
 {
 public:
   MGCoarseIterative() {}
 
-  void initialize(const MATRIX &matrix)
+  void initialize(const MatrixType &matrix)
   {
     coarse_matrix = &matrix;
   }
@@ -298,7 +298,7 @@ public:
     solver_coarse.solve (*coarse_matrix, dst, src, PreconditionIdentity());
   }
 
-  const MATRIX *coarse_matrix;
+  const MatrixType *coarse_matrix;
 };
 
 

--- a/tests/multigrid/cycles.cc
+++ b/tests/multigrid/cycles.cc
@@ -73,7 +73,7 @@ void test_cycles(unsigned int minlevel, unsigned int maxlevel)
   mg::Matrix<VectorType> mgmatrix(level_matrices);
 
   Multigrid<VectorType> mg1(minlevel, maxlevel, mgmatrix, all, all, all, all,
-                        Multigrid<VectorType>::v_cycle);
+                            Multigrid<VectorType>::v_cycle);
   mg1.set_debug(3);
   for (unsigned int i=minlevel; i<=maxlevel; ++i)
     mg1.defect[i].reinit(N);

--- a/tests/multigrid/cycles.cc
+++ b/tests/multigrid/cycles.cc
@@ -32,35 +32,35 @@
 #include <fstream>
 
 #define N 3
-typedef Vector<double> VECTOR;
+typedef Vector<double> VectorType;
 
 class MGAll
   :
-  public MGSmootherBase<VECTOR>,
-  public MGTransferBase<VECTOR>,
-  public MGCoarseGridBase<VECTOR>
+  public MGSmootherBase<VectorType>,
+  public MGTransferBase<VectorType>,
+  public MGCoarseGridBase<VectorType>
 {
 public:
   virtual ~MGAll()
   {}
 
   virtual void smooth (const unsigned int,
-                       VECTOR &, const VECTOR &) const
+                       VectorType &, const VectorType &) const
   {}
 
   virtual void prolongate (const unsigned int,
-                           VECTOR &, const VECTOR &) const
+                           VectorType &, const VectorType &) const
   {}
 
   virtual void restrict_and_add (const unsigned int,
-                                 VECTOR &, const VECTOR &) const
+                                 VectorType &, const VectorType &) const
   {}
 
   virtual void clear ()
   {}
 
   virtual void operator() (const unsigned int,
-                           VECTOR &, const VECTOR &) const
+                           VectorType &, const VectorType &) const
   {}
 };
 
@@ -70,21 +70,21 @@ void test_cycles(unsigned int minlevel, unsigned int maxlevel)
   MGLevelObject<FullMatrix<double> > level_matrices(0, maxlevel);
   for (unsigned int i=0; i<=maxlevel; ++i)
     level_matrices[i].reinit(N, N);
-  mg::Matrix<VECTOR> mgmatrix(level_matrices);
+  mg::Matrix<VectorType> mgmatrix(level_matrices);
 
-  Multigrid<VECTOR> mg1(minlevel, maxlevel, mgmatrix, all, all, all, all,
-                        Multigrid<VECTOR>::v_cycle);
+  Multigrid<VectorType> mg1(minlevel, maxlevel, mgmatrix, all, all, all, all,
+                        Multigrid<VectorType>::v_cycle);
   mg1.set_debug(3);
   for (unsigned int i=minlevel; i<=maxlevel; ++i)
     mg1.defect[i].reinit(N);
   mg1.cycle();
   deallog << std::endl;
 
-  mg1.set_cycle(Multigrid<VECTOR>::w_cycle);
+  mg1.set_cycle(Multigrid<VectorType>::w_cycle);
   mg1.cycle();
   deallog << std::endl;
 
-  mg1.set_cycle(Multigrid<VECTOR>::f_cycle);
+  mg1.set_cycle(Multigrid<VectorType>::f_cycle);
   mg1.cycle();
 }
 

--- a/tests/multigrid/smoother_block.cc
+++ b/tests/multigrid/smoother_block.cc
@@ -121,12 +121,12 @@ ScalingMatrix<number>::Tvmult_add (VectorType &dst, const VectorType &src) const
 
 //----------------------------------------------------------------------//
 
-template<class MATRIX, class RELAX>
-void check_smoother(const MGLevelObject<MATRIX> &m,
+template<typename MatrixType, class RELAX>
+void check_smoother(const MGLevelObject<MatrixType> &m,
                     const MGLevelObject<RELAX> &r)
 {
   GrowingVectorMemory<BlockVector<double> > mem;
-  MGSmootherBlock<MATRIX, RELAX, double> smoother(mem);
+  MGSmootherBlock<MatrixType, RELAX, double> smoother(mem);
 
   smoother.initialize(m, r);
 

--- a/tests/multigrid/smoother_block.cc
+++ b/tests/multigrid/smoother_block.cc
@@ -43,8 +43,8 @@ public:
   /**
   * Apply preconditioner.
   */
-  template<class VECTOR>
-  void vmult (VECTOR &, const VECTOR &) const;
+  template<typename VectorType>
+  void vmult (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose
@@ -53,13 +53,13 @@ public:
    * the same as
    * vmult().
    */
-  template<class VECTOR>
-  void Tvmult (VECTOR &, const VECTOR &) const;
+  template<typename VectorType>
+  void Tvmult (VectorType &, const VectorType &) const;
   /**
    * Apply preconditioner, adding to the previous value.
    */
-  template<class VECTOR>
-  void vmult_add (VECTOR &, const VECTOR &) const;
+  template<typename VectorType>
+  void vmult_add (VectorType &, const VectorType &) const;
 
   /**
    * Apply transpose
@@ -68,8 +68,8 @@ public:
    * the same as
    * vmult_add().
    */
-  template<class VECTOR>
-  void Tvmult_add (VECTOR &, const VECTOR &) const;
+  template<typename VectorType>
+  void Tvmult_add (VectorType &, const VectorType &) const;
 
 private:
   number factor;
@@ -86,25 +86,25 @@ ScalingMatrix<number>::ScalingMatrix(number factor)
 
 
 template<typename number>
-template<class VECTOR>
+template<typename VectorType>
 inline void
-ScalingMatrix<number>::vmult (VECTOR &dst, const VECTOR &src) const
+ScalingMatrix<number>::vmult (VectorType &dst, const VectorType &src) const
 {
   dst.equ(factor, src);
 }
 
 template<typename number>
-template<class VECTOR>
+template<typename VectorType>
 inline void
-ScalingMatrix<number>::Tvmult (VECTOR &dst, const VECTOR &src) const
+ScalingMatrix<number>::Tvmult (VectorType &dst, const VectorType &src) const
 {
   dst.equ(factor, src);
 }
 
 template<typename number>
-template<class VECTOR>
+template<typename VectorType>
 inline void
-ScalingMatrix<number>::vmult_add (VECTOR &dst, const VECTOR &src) const
+ScalingMatrix<number>::vmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(factor, src);
 }
@@ -112,9 +112,9 @@ ScalingMatrix<number>::vmult_add (VECTOR &dst, const VECTOR &src) const
 
 
 template<typename number>
-template<class VECTOR>
+template<typename VectorType>
 inline void
-ScalingMatrix<number>::Tvmult_add (VECTOR &dst, const VECTOR &src) const
+ScalingMatrix<number>::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
   dst.add(factor, src);
 }

--- a/tests/multigrid/smoother_block.cc
+++ b/tests/multigrid/smoother_block.cc
@@ -217,4 +217,3 @@ int main()
 
   check();
 }
-

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -36,12 +36,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -99,4 +99,3 @@ int main(int argc, char **argv)
   GrowingVectorMemory<PETScWrappers::Vector>::release_unused_memory ();
 
 }
-

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -36,9 +36,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -36,11 +36,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -38,9 +38,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -38,11 +38,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -100,4 +100,3 @@ int main(int argc, char **argv)
   GrowingVectorMemory<PETScWrappers::Vector>::release_unused_memory ();
 
 }
-

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -38,12 +38,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -38,9 +38,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -38,11 +38,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -38,12 +38,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -101,4 +101,3 @@ int main(int argc, char **argv)
   GrowingVectorMemory<PETScWrappers::Vector>::release_unused_memory ();
 
 }
-

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -37,12 +37,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -37,11 +37,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -100,4 +100,3 @@ int main(int argc, char **argv)
   GrowingVectorMemory<PETScWrappers::Vector>::release_unused_memory ();
 
 }
-

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -37,9 +37,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -36,12 +36,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -99,4 +99,3 @@ int main(int argc, char **argv)
   GrowingVectorMemory<PETScWrappers::Vector>::release_unused_memory ();
 
 }
-

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -36,9 +36,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -36,11 +36,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -91,4 +91,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -94,4 +94,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -90,4 +90,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -93,4 +93,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -32,12 +32,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -32,11 +32,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -33,12 +33,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -33,9 +33,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -33,11 +33,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -94,4 +94,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -93,4 +93,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -32,12 +32,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -32,11 +32,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -99,4 +99,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -95,4 +95,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -35,9 +35,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -35,11 +35,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -96,4 +96,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -35,12 +35,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -92,4 +92,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -96,4 +96,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -89,4 +89,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER               &solver,
+check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve(SOLVER               &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -34,11 +34,11 @@
 template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER               &solver,
-             const SolverControl &solver_control,
-             const MATRIX        &A,
-             VectorType          &u,
-             VectorType          &f,
-             const PRECONDITION  &P)
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -31,9 +31,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve(SOLVER              &solver,
+check_solve(SolverType          &solver,
             const SolverControl &solver_control,
             const MatrixType    &A,
             VectorType          &u,

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -31,11 +31,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve(SOLVER              &solver,
             const SolverControl &solver_control,
-            const MATRIX        &A,
+            const MatrixType    &A,
             VectorType          &u,
             VectorType          &f,
             const PRECONDITION  &P)

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -31,12 +31,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
-             const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+check_solve(SOLVER              &solver,
+            const SolverControl &solver_control,
+            const MATRIX        &A,
+            VectorType          &u,
+            VectorType          &f,
+            const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -98,4 +98,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/slepc/solve_01.cc
+++ b/tests/slepc/solve_01.cc
@@ -35,9 +35,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType>
+template<typename SolverType, typename MatrixType, typename VectorType>
 void
-check_solve( SOLVER &solver,
+check_solve( SolverType &solver,
              const SolverControl &solver_control,
              const MatrixType &A, const MatrixType &B,
              std::vector<VectorType> &u, std::vector<PetscScalar > &v)

--- a/tests/slepc/solve_01.cc
+++ b/tests/slepc/solve_01.cc
@@ -35,11 +35,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType>
+template<class SOLVER, typename MatrixType, typename VectorType>
 void
 check_solve( SOLVER &solver,
              const SolverControl &solver_control,
-             const MATRIX &A, const MATRIX &B,
+             const MatrixType &A, const MatrixType &B,
              std::vector<VectorType> &u, std::vector<PetscScalar > &v)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;

--- a/tests/slepc/solve_01.cc
+++ b/tests/slepc/solve_01.cc
@@ -35,12 +35,12 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR>
+template<class SOLVER, class MATRIX, typename VectorType>
 void
 check_solve( SOLVER &solver,
              const SolverControl &solver_control,
              const MATRIX &A, const MATRIX &B,
-             std::vector<VECTOR> &u, std::vector<PetscScalar > &v)
+             std::vector<VectorType> &u, std::vector<PetscScalar > &v)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -35,11 +35,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType>
+template<class SOLVER, typename MatrixType, typename VectorType>
 void
 check_solve( SOLVER &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
+             const MatrixType &A,
              std::vector<VectorType> &u, std::vector<PetscScalar > &v)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -35,12 +35,12 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR>
+template<class SOLVER, class MATRIX, typename VectorType>
 void
 check_solve( SOLVER &solver,
              const SolverControl &solver_control,
              const MATRIX &A,
-             std::vector<VECTOR> &u, std::vector<PetscScalar > &v)
+             std::vector<VectorType> &u, std::vector<PetscScalar > &v)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -35,9 +35,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType>
+template<typename SolverType, typename MatrixType, typename VectorType>
 void
-check_solve( SOLVER &solver,
+check_solve( SolverType &solver,
              const SolverControl &solver_control,
              const MatrixType &A,
              std::vector<VectorType> &u, std::vector<PetscScalar > &v)

--- a/tests/slepc/testmatrix.h
+++ b/tests/slepc/testmatrix.h
@@ -29,8 +29,8 @@ public:
   /**
    * Fill the matrix with values.
    */
-  template <typename MATRIX>
-  void diag(MATRIX &) const;
+  template <typename MatrixType>
+  void diag(MatrixType &) const;
 
   template <typename number>
   void gnuplot_print(std::ostream &, const Vector<number> &) const;
@@ -75,10 +75,10 @@ FDDiagMatrix::diag_structure(SP &structure) const
 }
 
 
-template<typename MATRIX>
+template<typename MatrixType>
 inline
 void
-FDDiagMatrix::diag(MATRIX &A) const
+FDDiagMatrix::diag(MatrixType &A) const
 {
   for (unsigned int i=0; i<=ny-2; i++)
     {
@@ -131,8 +131,8 @@ public:
   /**
    * Fill the matrix with values.
    */
-  template <typename MATRIX>
-  void three_point(MATRIX &) const;
+  template <typename MatrixType>
+  void three_point(MatrixType &) const;
 
 private:
   /**
@@ -168,10 +168,10 @@ FD1DLaplaceMatrix::three_point_structure(SP &structure) const
 }
 
 
-template<typename MATRIX>
+template<typename MatrixType>
 inline
 void
-FD1DLaplaceMatrix::three_point(MATRIX &A) const
+FD1DLaplaceMatrix::three_point(MatrixType &A) const
 {
   for (unsigned int i=0; i<=n-2; i++)
     {

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -162,16 +162,16 @@ std::string unify_pretty_function (const std::string &text)
 /*
  * Test that a solver converged within a certain range of iteration steps.
  *
- * SOLVER_COMMAND is the command to issue, CONTROL_COMMAND a function call
+ * SolverType_COMMAND is the command to issue, CONTROL_COMMAND a function call
  * that returns the number of iterations (castable to unsigned int), and
  * MIN_ALLOWED, MAX_ALLOWED is the inclusive range of allowed iteration
  * steps.
  */
 
-#define check_solver_within_range(SOLVER_COMMAND, CONTROL_COMMAND, MIN_ALLOWED, MAX_ALLOWED) \
+#define check_solver_within_range(SolverType_COMMAND, CONTROL_COMMAND, MIN_ALLOWED, MAX_ALLOWED) \
   {                                                                              \
     const unsigned int previous_depth = deallog.depth_file(0);                   \
-    SOLVER_COMMAND;                                                              \
+    SolverType_COMMAND;                                                              \
     deallog.depth_file(previous_depth);                                          \
     const unsigned int steps = CONTROL_COMMAND;                                  \
     if (steps >= MIN_ALLOWED && steps <= MAX_ALLOWED)                            \

--- a/tests/trilinos/deal_solver_01.cc
+++ b/tests/trilinos/deal_solver_01.cc
@@ -37,11 +37,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/deal_solver_01.cc
+++ b/tests/trilinos/deal_solver_01.cc
@@ -37,9 +37,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_01.cc
+++ b/tests/trilinos/deal_solver_01.cc
@@ -37,12 +37,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -103,4 +105,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/deal_solver_02.cc
+++ b/tests/trilinos/deal_solver_02.cc
@@ -39,11 +39,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/deal_solver_02.cc
+++ b/tests/trilinos/deal_solver_02.cc
@@ -39,9 +39,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_02.cc
+++ b/tests/trilinos/deal_solver_02.cc
@@ -39,12 +39,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -104,4 +106,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -39,14 +39,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VectorType &u,
-             VectorType &f,
-             const PRECONDITION &P)
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -39,9 +39,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -39,12 +39,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER &solver,
              const SolverControl &solver_control,
              const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             VectorType &u,
+             VectorType &f,
+             const PRECONDITION &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -105,4 +107,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/deal_solver_04.cc
+++ b/tests/trilinos/deal_solver_04.cc
@@ -38,9 +38,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_04.cc
+++ b/tests/trilinos/deal_solver_04.cc
@@ -38,11 +38,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/deal_solver_04.cc
+++ b/tests/trilinos/deal_solver_04.cc
@@ -38,12 +38,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -104,4 +106,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/deal_solver_05.cc
+++ b/tests/trilinos/deal_solver_05.cc
@@ -37,11 +37,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/deal_solver_05.cc
+++ b/tests/trilinos/deal_solver_05.cc
@@ -37,9 +37,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_05.cc
+++ b/tests/trilinos/deal_solver_05.cc
@@ -37,12 +37,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -103,4 +105,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -37,11 +37,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -37,9 +37,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -37,12 +37,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -102,4 +104,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/solver_03.cc
+++ b/tests/trilinos/solver_03.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/solver_03.cc
+++ b/tests/trilinos/solver_03.cc
@@ -32,12 +32,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -98,4 +100,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/solver_03.cc
+++ b/tests/trilinos/solver_03.cc
@@ -32,11 +32,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/solver_05.cc
+++ b/tests/trilinos/solver_05.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/solver_05.cc
+++ b/tests/trilinos/solver_05.cc
@@ -32,12 +32,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -98,4 +100,3 @@ int main(int argc, char **argv)
     check_solve (solver, control, A,u,f, preconditioner);
   }
 }
-

--- a/tests/trilinos/solver_05.cc
+++ b/tests/trilinos/solver_05.cc
@@ -32,11 +32,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/trilinos/solver_07.cc
+++ b/tests/trilinos/solver_07.cc
@@ -32,12 +32,14 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
+template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
 void
-check_solve( SOLVER &solver,
+check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX &A,
-             VECTOR &u, VECTOR &f, const PRECONDITION &P)
+             const MATRIX        &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P)
 {
   deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
@@ -98,4 +100,3 @@ int main(int argc, char **argv)
   }
 
 }
-

--- a/tests/trilinos/solver_07.cc
+++ b/tests/trilinos/solver_07.cc
@@ -32,9 +32,9 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
+template<typename SolverType, typename MatrixType, typename VectorType, class PRECONDITION>
 void
-check_solve (SOLVER              &solver,
+check_solve (SolverType          &solver,
              const SolverControl &solver_control,
              const MatrixType    &A,
              VectorType          &u,

--- a/tests/trilinos/solver_07.cc
+++ b/tests/trilinos/solver_07.cc
@@ -32,11 +32,11 @@
 #include <deal.II/lac/vector_memory.h>
 #include <typeinfo>
 
-template<class SOLVER, class MATRIX, typename VectorType, class PRECONDITION>
+template<class SOLVER, typename MatrixType, typename VectorType, class PRECONDITION>
 void
 check_solve (SOLVER              &solver,
              const SolverControl &solver_control,
-             const MATRIX        &A,
+             const MatrixType    &A,
              VectorType          &u,
              VectorType          &f,
              const PRECONDITION  &P)

--- a/tests/umfpack/umfpack_04.cc
+++ b/tests/umfpack/umfpack_04.cc
@@ -44,8 +44,11 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>
 
-template <int dim, typename MATRIX, typename VectorType>
-void assemble_laplace (MATRIX &B, VectorType &bb, DoFHandler<dim> &dof_handler, FiniteElement<dim> &fe)
+template <int dim, typename MatrixType, typename VectorType>
+void assemble_laplace (MatrixType         &B,
+                       VectorType         &bb,
+                       DoFHandler<dim>    &dof_handler,
+                       FiniteElement<dim> &fe)
 {
   QGauss<dim>  quadrature_formula(2);
   FEValues<dim> fe_values (fe, quadrature_formula,

--- a/tests/umfpack/umfpack_04.cc
+++ b/tests/umfpack/umfpack_04.cc
@@ -44,8 +44,8 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>
 
-template <int dim, typename MATRIX, typename VECTOR>
-void assemble_laplace (MATRIX &B, VECTOR &bb, DoFHandler<dim> &dof_handler, FiniteElement<dim> &fe)
+template <int dim, typename MATRIX, typename VectorType>
+void assemble_laplace (MATRIX &B, VectorType &bb, DoFHandler<dim> &dof_handler, FiniteElement<dim> &fe)
 {
   QGauss<dim>  quadrature_formula(2);
   FEValues<dim> fe_values (fe, quadrature_formula,


### PR DESCRIPTION
This is the other part of #1777: besides not using class names as template arguments it would be nice if they were consistent across the library. I think we tentatively agreed there to prefer `VectorType` et al to all capital letter names (though it is not very hard to switch back if there is a preference for names like `VECTOR`).

Things remaining:
[ ] `RELAX` to `RelaxationType`
[ ] `DH` to DoFHandlerType
[ ] `SP` to SparsityPatternType