### PR TITLE
fix trilinos warning

### DIFF
--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -183,6 +183,7 @@ namespace TrilinosWrappers
     if (constant_modes_dimension > 0)
       {
         const size_type global_size = n_global_rows(matrix);
+        (void)global_length; // work around compiler warning about unused function in release mode
         Assert (global_size ==
                 static_cast<size_type>(global_length(distributed_constant_modes)),
                 ExcDimensionMismatch(global_size,


### PR DESCRIPTION
Fixes:

```
dealii/source/lac/trilinos_precondition_ml.cc:46:9: warning: ‘int dealii::TrilinosWrappers::{anonymous}::global_length(const Epetra_MultiVector&)’ defined but not used [-Wunused-function]
      int global_length (const Epetra_MultiVector &vector)
``` 