### PR TITLE
[WIP] Add unchecked indices

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -264,6 +264,12 @@ inconvenience this causes.
   <br>
   (Wolfgang Bangerth, 2015/11/20)
   </li>
+  
+  <li> New: There is now a class UncheckedIndex that is used in some of the
+  Tensor interfaces to avoid redundant index checks.
+  <br>
+  (Wolfgang Bangerth, 2015/11/19)
+  </li>
 
   <li> Fixed: Trilinos ML preconditioner is now deterministic when using
   version 12.4 or newer.

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1182,20 +1182,20 @@ namespace internal
     switch (dim)
       {
       case 1:
-        return data[0] * sdata[0];
+        return data[unchecked_index(0u)] * sdata[unchecked_index(0u)];
       case 2:
-        return (data[0] * sdata[0] +
-                data[1] * sdata[1] +
-                2*data[2] * sdata[2]);
+        return (data[unchecked_index(0u)] * sdata[unchecked_index(0u)] +
+                data[unchecked_index(1u)] * sdata[unchecked_index(1u)] +
+                2*data[unchecked_index(2u)] * sdata[unchecked_index(2u)]);
       default:
         // Start with the non-diagonal part to avoid some multiplications by
         // 2.
-        Number sum = data[dim] * sdata[dim];
+        Number sum = data[unchecked_index<unsigned int>(dim)] * sdata[unchecked_index<unsigned int>(dim)];
         for (unsigned int d=dim+1; d<(dim*(dim+1)/2); ++d)
-          sum += data[d] * sdata[d];
+          sum += data[unchecked_index(d)] * sdata[unchecked_index(d)];
         sum *= 2.;
         for (unsigned int d=0; d<dim; ++d)
-          sum += data[d] * sdata[d];
+          sum += data[unchecked_index(d)] * sdata[unchecked_index(d)];
         return sum;
       }
   }
@@ -1210,9 +1210,9 @@ namespace internal
   {
     const unsigned int data_dim =
       SymmetricTensorAccessors::StorageType<2,dim,Number>::n_independent_components;
-    Number tmp [data_dim];
+    Number tmp[data_dim];
     for (unsigned int i=0; i<data_dim; ++i)
-      tmp[i] = perform_double_contraction<dim,Number>(data[i], sdata);
+      tmp[i] = perform_double_contraction<dim,Number>(data[unchecked_index(i)], sdata);
     return dealii::SymmetricTensor<2,dim,Number>(tmp);
   }
 
@@ -1228,9 +1228,9 @@ namespace internal
     for (unsigned int i=0; i<tmp.dimension; ++i)
       {
         for (unsigned int d=0; d<dim; ++d)
-          tmp[i] += data[d] * sdata[d][i];
+          tmp[unchecked_index(i)] += data[unchecked_index(d)] * sdata[unchecked_index(d)][unchecked_index(i)];
         for (unsigned int d=dim; d<(dim*(dim+1)/2); ++d)
-          tmp[i] += 2 * data[d] * sdata[d][i];
+          tmp[unchecked_index(i)] += 2 * data[unchecked_index(d)] * sdata[unchecked_index(d)][unchecked_index(i)];
       }
     return tmp;
   }
@@ -1250,9 +1250,9 @@ namespace internal
       for (unsigned int j=0; j<data_dim; ++j)
         {
           for (unsigned int d=0; d<dim; ++d)
-            tmp[i][j] += data[i][d] * sdata[d][j];
+            tmp[unchecked_index(i)][unchecked_index(j)] += data[unchecked_index(i)][unchecked_index(d)] * sdata[unchecked_index(d)][unchecked_index(j)];
           for (unsigned int d=dim; d<(dim*(dim+1)/2); ++d)
-            tmp[i][j] += 2 * data[i][d] * sdata[d][j];
+            tmp[unchecked_index(i)][unchecked_index(j)] += 2 * data[unchecked_index(i)][unchecked_index(d)] * sdata[unchecked_index(d)][unchecked_index(j)];
         }
     return tmp;
   }

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1412,7 +1412,7 @@ operator * (const Tensor<rank,dim,Number> &t,
   // recurse over the base objects
   Tensor<rank,dim,typename ProductType<Number,OtherNumber>::type> tt;
   for (unsigned int d=0; d<dim; ++d)
-    tt[d] = t[d] * factor;
+    tt[unchecked_index(d)] = t[unchecked_index(d)] * factor;
   return tt;
 }
 
@@ -1458,7 +1458,7 @@ operator / (const Tensor<rank,dim,Number> &t,
   // recurse over the base objects
   Tensor<rank,dim,typename ProductType<Number,OtherNumber>::type> tt;
   for (unsigned int d=0; d<dim; ++d)
-    tt[d] = t[d] / factor;
+    tt[unchecked_index(d)] = t[unchecked_index(d)] / factor;
   return tt;
 }
 
@@ -1800,8 +1800,8 @@ cross_product_2d (const Tensor<1,dim,Number> &src)
 
   Tensor<1, dim, Number> result;
 
-  result[0] = src[1];
-  result[1] = -src[0];
+  result[unchecked_index(0u)] = src[unchecked_index(1u)];
+  result[unchecked_index(1u)] = -src[unchecked_index(0u)];
 
   return result;
 }
@@ -1827,9 +1827,9 @@ cross_product_3d (const Tensor<1,dim,Number> &src1,
 
   Tensor<1, dim, Number> result;
 
-  result[0] = src1[1]*src2[2] - src1[2]*src2[1];
-  result[1] = src1[2]*src2[0] - src1[0]*src2[2];
-  result[2] = src1[0]*src2[1] - src1[1]*src2[0];
+  result[unchecked_index(0u)] = src1[unchecked_index(1u)]*src2[unchecked_index(2u)] - src1[unchecked_index(2u)]*src2[unchecked_index(1u)];
+  result[unchecked_index(1u)] = src1[unchecked_index(2u)]*src2[unchecked_index(0u)] - src1[unchecked_index(0u)]*src2[unchecked_index(2u)];
+  result[unchecked_index(2u)] = src1[unchecked_index(0u)]*src2[unchecked_index(1u)] - src1[unchecked_index(1u)]*src2[unchecked_index(0u)];
 
   return result;
 }

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/tensor_accessors.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/unchecked_index.h>
 
 #include <cmath>
 #include <ostream>
@@ -411,6 +412,22 @@ public:
    * Read-only access operator.
    */
   const value_type &operator[](const unsigned int i) const;
+
+  /**
+   * Read-Write access operator. This variation of operator[] does not
+   * check for validity of the index, even in debug mode. You should
+   * only use it in places where you know for other reasons that the
+   * index is correct.
+   */
+  value_type &operator [] (const UncheckedIndex<unsigned int> &i);
+
+  /**
+   * Read-only access operator. This variation of operator[] does not
+   * check for validity of the index, even in debug mode. You should
+   * only use it in places where you know for other reasons that the
+   * index is correct.
+   */
+  const value_type &operator[](const UncheckedIndex<unsigned int> &i) const;
 
   /**
    * Read access using TableIndices <tt>indices</tt>
@@ -842,6 +859,19 @@ namespace internal
 {
   namespace TensorSubscriptor
   {
+    template <typename ArrayElementType>
+    ArrayElementType &
+    subscript (ArrayElementType *,
+               const unsigned int,
+               dealii::internal::int2type<0>)
+    {
+      Assert (false,
+              ExcMessage("It is not possible to access elements of tensors of size zero."));
+      static ArrayElementType dummy_value;
+      return dummy_value;
+    }
+
+
     template <typename ArrayElementType, int dim>
     ArrayElementType &
     subscript (ArrayElementType *values,
@@ -853,10 +883,32 @@ namespace internal
     }
 
 
-    template <typename ArrayElementType>
+    template <typename ArrayElementType, int dim>
+    ArrayElementType &
+    subscript (ArrayElementType *values,
+               const UncheckedIndex<unsigned int> &i,
+               dealii::internal::int2type<dim>)
+    {
+      return values[i.value()];
+    }
+
+
+    template <typename ArrayElementType, typename IndexType>
     ArrayElementType &
     subscript (ArrayElementType *,
                const unsigned int,
+               dealii::internal::int2type<0>)
+    {
+      Assert(false, ExcMessage("Cannot access elements of an object of type Tensor<rank,0,Number>."));
+      static ArrayElementType t;
+      return t;
+    }
+
+
+    template <typename ArrayElementType, typename IndexType>
+    ArrayElementType &
+    subscript (ArrayElementType *,
+               const UncheckedIndex<unsigned int> &,
                dealii::internal::int2type<0>)
     {
       Assert(false, ExcMessage("Cannot access elements of an object of type Tensor<rank,0,Number>."));
@@ -880,6 +932,24 @@ template <int rank_, int dim, typename Number>
 inline
 const typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
+{
+  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
+}
+
+
+template <int rank_, int dim, typename Number>
+inline
+typename Tensor<rank_,dim,Number>::value_type &
+Tensor<rank_,dim,Number>::operator[] (const UncheckedIndex<unsigned int> &i)
+{
+  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
+}
+
+
+template <int rank_, int dim, typename Number>
+inline
+const typename Tensor<rank_,dim,Number>::value_type &
+Tensor<rank_,dim,Number>::operator[] (const UncheckedIndex<unsigned int> &i) const
 {
   return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
 }
@@ -1171,9 +1241,9 @@ template <int rank_, int dim, typename Number>
 inline
 std::ostream &operator << (std::ostream &out, const Tensor<rank_,dim,Number> &p)
 {
-  for (unsigned int i = 0; i < dim; ++i)
+  for (unsigned int i=0; i<dim; ++i)
     {
-      out << p[i];
+      out << p[unchecked_index(i)];
       if (i != dim - 1)
         out << ' ';
     }
@@ -1408,7 +1478,7 @@ operator+ (const Tensor<rank,dim,Number> &p, const Tensor<rank,dim,OtherNumber> 
   Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type> tmp (p);
 
   for (unsigned int i=0; i<dim; ++i)
-    tmp[i] += q[i];
+    tmp[unchecked_index(i)] += q[unchecked_index(i)];
 
   return tmp;
 }
@@ -1429,7 +1499,7 @@ operator- (const Tensor<rank,dim,Number> &p, const Tensor<rank,dim,OtherNumber> 
   Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type> tmp (p);
 
   for (unsigned int i=0; i<dim; ++i)
-    tmp[i] -= q[i];
+    tmp[unchecked_index(i)] -= q[unchecked_index(i)];
 
   return tmp;
 }
@@ -1791,11 +1861,11 @@ Number determinant (const Tensor<2,dim,Number> &t)
       Tensor<2,dim-1,Number> minor;
       for (unsigned int i=0; i<dim-1; ++i)
         for (unsigned int j=0; j<dim-1; ++j)
-          minor[i][j] = t[i][j<k ? j : j+1];
+          minor[unchecked_index(i)][unchecked_index(j)] = t[unchecked_index(i)][unchecked_index(j<k ? j : j+1)];
 
       const Number cofactor = ((k % 2 == 0) ? -1. : 1.) * determinant(minor);
 
-      det += t[dim-1][k] * cofactor;
+      det += t[unchecked_index<unsigned int>(dim-1)][unchecked_index(k)] * cofactor;
     }
 
   return ((dim % 2 == 0) ? 1. : -1.) * det;
@@ -1810,7 +1880,7 @@ template <typename Number>
 inline
 Number determinant (const Tensor<2,1,Number> &t)
 {
-  return t[0][0];
+  return t[unchecked_index(0U)][unchecked_index(0U)];
 }
 
 
@@ -1824,9 +1894,9 @@ Number determinant (const Tensor<2,1,Number> &t)
 template <int dim, typename Number>
 Number trace (const Tensor<2,dim,Number> &d)
 {
-  Number t=d[0][0];
+  Number t=d[unchecked_index(0U)][unchecked_index(0U)];
   for (unsigned int i=1; i<dim; ++i)
-    t += d[i][i];
+    t += d[unchecked_index(i)][unchecked_index(i)];
   return t;
 }
 
@@ -1849,41 +1919,41 @@ invert (const Tensor<2,dim,Number> &t)
   switch (dim)
     {
     case 1:
-      return_tensor[0][0] = 1.0/t[0][0];
+      return_tensor[0][0] = 1.0/t[unchecked_index(0U)][unchecked_index(0U)];
       break;
 
     case 2:
       // this is Maple output,
       // thus a bit unstructured
     {
-      const Number det = t[0][0]*t[1][1]-t[1][0]*t[0][1];
+      const Number det = t[unchecked_index(0U)][unchecked_index(0U)]*t[unchecked_index(1U)][unchecked_index(1U)]-t[unchecked_index(1U)][unchecked_index(0U)]*t[unchecked_index(0U)][unchecked_index(1U)];
       const Number t4 = 1.0/det;
-      return_tensor[0][0] = t[1][1]*t4;
-      return_tensor[0][1] = -t[0][1]*t4;
-      return_tensor[1][0] = -t[1][0]*t4;
-      return_tensor[1][1] = t[0][0]*t4;
+      return_tensor[0][0] = t[unchecked_index(1U)][unchecked_index(1U)]*t4;
+      return_tensor[0][1] = -t[unchecked_index(0U)][unchecked_index(1U)]*t4;
+      return_tensor[1][0] = -t[unchecked_index(1U)][unchecked_index(0U)]*t4;
+      return_tensor[1][1] = t[unchecked_index(0U)][unchecked_index(0U)]*t4;
       break;
     }
 
     case 3:
     {
-      const Number t4 = t[0][0]*t[1][1],
-                   t6 = t[0][0]*t[1][2],
-                   t8 = t[0][1]*t[1][0],
-                   t00 = t[0][2]*t[1][0],
-                   t01 = t[0][1]*t[2][0],
-                   t04 = t[0][2]*t[2][0],
-                   det = (t4*t[2][2]-t6*t[2][1]-t8*t[2][2]+
-                          t00*t[2][1]+t01*t[1][2]-t04*t[1][1]),
+      const Number t4 = t[unchecked_index(0U)][unchecked_index(0U)]*t[unchecked_index(1U)][unchecked_index(1U)],
+                   t6 = t[unchecked_index(0U)][unchecked_index(0U)]*t[unchecked_index(1U)][unchecked_index(2U)],
+                   t8 = t[unchecked_index(0U)][unchecked_index(1U)]*t[unchecked_index(1U)][unchecked_index(0U)],
+                   t00 = t[unchecked_index(0U)][unchecked_index(2U)]*t[unchecked_index(1U)][unchecked_index(0U)],
+                   t01 = t[unchecked_index(0U)][unchecked_index(1U)]*t[unchecked_index(2U)][unchecked_index(0U)],
+                   t04 = t[unchecked_index(0U)][unchecked_index(2U)]*t[unchecked_index(2U)][unchecked_index(0U)],
+                   det = (t4*t[unchecked_index(2U)][unchecked_index(2U)]-t6*t[unchecked_index(2U)][unchecked_index(1U)]-t8*t[unchecked_index(2U)][unchecked_index(2U)]+
+                          t00*t[unchecked_index(2U)][unchecked_index(1U)]+t01*t[unchecked_index(1U)][unchecked_index(2U)]-t04*t[unchecked_index(1U)][unchecked_index(1U)]),
                          t07 = 1.0/det;
-      return_tensor[0][0] = (t[1][1]*t[2][2]-t[1][2]*t[2][1])*t07;
-      return_tensor[0][1] = (t[0][2]*t[2][1]-t[0][1]*t[2][2])*t07;
-      return_tensor[0][2] = (t[0][1]*t[1][2]-t[0][2]*t[1][1])*t07;
-      return_tensor[1][0] = (t[1][2]*t[2][0]-t[1][0]*t[2][2])*t07;
-      return_tensor[1][1] = (t[0][0]*t[2][2]-t04)*t07;
+      return_tensor[0][0] = (t[unchecked_index(1U)][unchecked_index(1U)]*t[unchecked_index(2U)][unchecked_index(2U)]-t[unchecked_index(1U)][unchecked_index(2U)]*t[unchecked_index(2U)][unchecked_index(1U)])*t07;
+      return_tensor[0][1] = (t[unchecked_index(0U)][unchecked_index(2U)]*t[unchecked_index(2U)][unchecked_index(1U)]-t[unchecked_index(0U)][unchecked_index(1U)]*t[unchecked_index(2U)][unchecked_index(2U)])*t07;
+      return_tensor[0][2] = (t[unchecked_index(0U)][unchecked_index(1U)]*t[unchecked_index(1U)][unchecked_index(2U)]-t[unchecked_index(0U)][unchecked_index(2U)]*t[unchecked_index(1U)][unchecked_index(1U)])*t07;
+      return_tensor[1][0] = (t[unchecked_index(1U)][unchecked_index(2U)]*t[unchecked_index(2U)][unchecked_index(0U)]-t[unchecked_index(1U)][unchecked_index(0U)]*t[unchecked_index(2U)][unchecked_index(2U)])*t07;
+      return_tensor[1][1] = (t[unchecked_index(0U)][unchecked_index(0U)]*t[unchecked_index(2U)][unchecked_index(2U)]-t04)*t07;
       return_tensor[1][2] = (t00-t6)*t07;
-      return_tensor[2][0] = (t[1][0]*t[2][1]-t[1][1]*t[2][0])*t07;
-      return_tensor[2][1] = (t01-t[0][0]*t[2][1])*t07;
+      return_tensor[2][0] = (t[unchecked_index(1U)][unchecked_index(0U)]*t[unchecked_index(2U)][unchecked_index(1U)]-t[unchecked_index(1U)][unchecked_index(1U)]*t[unchecked_index(2U)][unchecked_index(0U)])*t07;
+      return_tensor[2][1] = (t01-t[unchecked_index(0U)][unchecked_index(0U)]*t[unchecked_index(2U)][unchecked_index(1U)])*t07;
       return_tensor[2][2] = (t4-t8)*t07;
 
       break;
@@ -1913,12 +1983,12 @@ transpose (const Tensor<2,dim,Number> &t)
   Tensor<2, dim, Number> tt;
   for (unsigned int i=0; i<dim; ++i)
     {
-      tt[i][i] = t[i][i];
+      tt[unchecked_index(i)][unchecked_index(i)] = t[unchecked_index(i)][unchecked_index(i)];
       for (unsigned int j=i+1; j<dim; ++j)
         {
-          tt[i][j] = t[j][i];
-          tt[j][i] = t[i][j];
-        };
+          tt[unchecked_index(i)][unchecked_index(j)] = t[unchecked_index(j)][unchecked_index(i)];
+          tt[unchecked_index(j)][unchecked_index(i)] = t[unchecked_index(i)][unchecked_index(j)];
+        }
     }
   return tt;
 }
@@ -1941,7 +2011,7 @@ l1_norm (const Tensor<2,dim,Number> &t)
     {
       double sum = 0;
       for (unsigned int i=0; i<dim; ++i)
-        sum += std::fabs(t[i][j]);
+        sum += std::fabs(t[unchecked_index(i)][unchecked_index(j)]);
 
       if (sum > max)
         max = sum;
@@ -1968,7 +2038,7 @@ linfty_norm (const Tensor<2,dim,Number> &t)
     {
       double sum = 0;
       for (unsigned int j=0; j<dim; ++j)
-        sum += std::fabs(t[i][j]);
+        sum += std::fabs(t[unchecked_index(i)][unchecked_index(j)]);
 
       if (sum > max)
         max = sum;

--- a/include/deal.II/base/unchecked_index.h
+++ b/include/deal.II/base/unchecked_index.h
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__unchecked_index_h
+#define dealii__unchecked_index_h
+
+
+#include <deal.II/base/config.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/**
+ * A class that is used in place of regular indices in places where you
+ * want to avoid index checks even in debug mode because you are sure
+ * that the indices are correct. This class is supported in indexing
+ * operators, i.e., <code>operator[]</code>, by the Tensor and
+ * SymmetricTensor classes.
+ *
+ * In general, it is a bad idea to elide index checks because index
+ * checks are among the most frequent bugs in codes. Furthermore, the
+ * index checks deal.II performs are only enabled in debug, but not
+ * in release mode, and consequently won't slow down large computations
+ * after you have already debugged your program and switched to
+ * release mode. However, there are cases in the innermost loops where
+ * you are certain that indices are correct and where index checks
+ * would be performed so many times that they slow down programs in
+ * debug mode to an undue degree. An example would be if you
+ * implemented the assembly loop of a Laplace solver in the following
+ * way (a small variation of the loop in step-4, where the innermost
+ * loop is in fact hidden behind the <code>operator*</code> of the
+ * Tensor class):
+ * @code
+ *  for (unsigned int q_index=0; q_index<n_q_points; ++q_index)
+ *    for (unsigned int i=0; i<dofs_per_cell; ++i)
+ *      for (unsigned int j=0; j<dofs_per_cell; ++j)
+ *        {
+ *          const Tensor<1,dim> grad_phi_i = fe_values.shape_grad (i, q_index);
+ *          const Tensor<1,dim> grad_phi_j = fe_values.shape_grad (j, q_index);
+ *
+ *          double grad_i_times_grad_j = 0;
+ *          for (unsigned int d=0; d<dim; ++d)
+ *            grad_i_times_grad_j += grad_phi_i[d] * grad_phi_j[d];  // ***
+ *
+ *          cell_matrix(i,j) += (grad_i_times_grad_j *
+ *                               fe_values.JxW (q_index));
+ *      }
+ * @endcode
+ * Here, we compute the dot product $\nabla\varphi_i \cdot \nabla\varphi_j$
+ * using a loop over the <code>dim</code> elements of the tensors, both
+ * of which are of type Tensor<1,dim> and thus have exactly <code>dim</code>
+ * elements. In other words, we are not accessing <i>any</i> tensor element
+ * in the marked line, but elements whose indices we very carefully control
+ * and whose values are well known from the loop in the line immediately
+ * above. Consequently, there is no risk that the indices could be invalid,
+ * and the repeated index checks performed by <code>operator[]</code> (of which
+ * there are
+ * <code>n_q_points * dofs_per_cell * dofs_per_cell * dim</code>) are not
+ * necessary after the code has been debugged; given their frequency, they
+ * do however slow down the overall assembly loop in significant ways.
+ *
+ * This class avoids the dilemma by offering the following alternative syntax:
+ * @code
+ *          double grad_i_times_grad_j = 0;
+ *          for (unsigned int d=0; d<dim; ++d)
+ *            grad_i_times_grad_j += grad_phi_i[unchecked_index(d)] *
+ *                                   grad_phi_j[unchecked_index(d)];
+ *      }
+ * @endcode
+ * Here, the function unchecked_index() returns an object of type
+ * UncheckedIndex, and there is an overload of Tensor::operator[]
+ * that accepts such objects, returning the requested element without
+ * performing the index check.
+ *
+ * Obviously, such unchecked index accesses are almost never a good idea
+ * and should only be used in very closely controlled contexts. In
+ * practice, this means that they should only be used in a very small
+ * number of primitives inside the library itself.
+ *
+ *
+ * @author Wolfgang Bangerth, 2015
+ */
+template <typename IndexType>
+class UncheckedIndex
+{
+public:
+  /**
+   * Construct an UncheckedIndex object that wraps the given index.
+   */
+  UncheckedIndex (const IndexType index);
+
+  /**
+   * Return the wrapped index set by the constructor.
+   */
+  IndexType value() const;
+
+private:
+  /**
+   * The value of the wrapped index.
+   */
+  const IndexType index;
+};
+
+
+
+/**
+ * Create an UncheckedIndex object with the same index type as the
+ * argument given to this function.
+ *
+ * @param index The desired index.
+ * @return An UncheckedIndex object that simply wraps @p index.
+ */
+template <typename IndexType>
+UncheckedIndex<IndexType>
+unchecked_index (const IndexType index)
+{
+  return UncheckedIndex<IndexType>(index);
+}
+
+
+
+// ----------- inline functions ---------------
+
+template <typename IndexType>
+inline
+UncheckedIndex<IndexType>::UncheckedIndex (const IndexType index)
+  :
+  index (index)
+{}
+
+
+
+template <typename IndexType>
+inline
+IndexType
+UncheckedIndex<IndexType>::value () const
+{
+  return index;
+}
+
+
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
In ASPECT, we have a situation where matrix assembly simply takes too long in debug mode, and the cause is repeated tensor contractions, see https://github.com/geodynamics/aspect/pull/654 . This patch tries to address this by providing a basis for ways to avoid index checks.

The idea is that in many of the operations that work on tensors (say, the dot product), we have code that looks like this:
```
  Tensor<1,dim> a,b;
  ...
  for (unsigned int d=0; d<dim; ++d)
    result += a[d] * b[d];
```
Here, using `operator[]` on `a` and `b` incurs an index check via an assertion. That's of course good in general, but in this particular case, we know for sure that the index only runs from zero to dim, and so all of these checks will succeed.

This patch introduces a data type `UncheckedIndex` (and a function `unchecked_index` that creates such objects) so that one can write
```
  Tensor<1,dim> a,b;
  ...
  for (unsigned int d=0; d<dim; ++d)
    result += a[unchecked_index(d)] * b[unchecked_index(d)];
```
and overloads for `Tensor::operator[]` to use such indices and then elide the index check. I'm not proposing that users use this in their own codes, but that we use it internally in places where we can be pretty sure.

What do you all think?
