### PR TITLE
Remove the DEAL_II_LIBLAPACK_NOQUERYMODE check.

### DIFF
--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -635,11 +635,15 @@ LAPACKFullMatrix<number>::compute_eigenvalues(const bool right,
   const char *const jobvr = (right) ? (&V) : (&N);
   const char *const jobvl = (left)  ? (&V) : (&N);
 
-  // The LAPACK routine DGEEV requires a sufficient large workspace variable,
-  // minimum requirement is
-  //    work.size>=4*nn.
-  // However, to improve performance, a somewhat larger workspace may be
-  // needed.
+  /*
+   * The LAPACK routine xGEEV requires a sufficiently large work array; the
+   * minimum requirement is
+   *
+   * work.size >= 4*nn.
+   *
+   * However, for better performance, a larger work array may be needed. The
+   * first call determines the optimal work size and the second does the work.
+   */
   lwork = -1;
   work.resize(1);
 
@@ -701,11 +705,15 @@ LAPACKFullMatrix<number>::compute_eigenvalues_symmetric(const number        lowe
   std::vector<int> ifail(static_cast<size_type> (nn));
 
 
-  // The LAPACK routine ?SYEVX requires a sufficient large workspace variable,
-  // minimum requirement is
-  //    work.size>=3*nn-1.
-  // However, to improve performance, a somewhat larger workspace may be
-  // needed.
+  /*
+   * The LAPACK routine xSYEVX requires a sufficiently large work array; the
+   * minimum requirement is
+   *
+   * work.size >= 8*nn.
+   *
+   * However, for better performance, a larger work array may be needed. The
+   * first call determines the optimal work size and the second does the work.
+   */
   work.resize(1);
 
   syevx (jobz, range,
@@ -789,11 +797,15 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   std::vector<int> ifail(static_cast<size_type> (nn));
 
 
-  // The LAPACK routine ?SYGVX requires a sufficient large workspace variable,
-  // minimum requirement is
-  //    work.size>=3*nn-1.
-  // However, to improve performance, a somewhat larger workspace may be
-  // needed.
+  /*
+   * The LAPACK routine xSYGVX requires a sufficiently large work array; the
+   * minimum requirement is
+   *
+   * work.size >= 8*nn.
+   *
+   * However, for better performance, a larger work array may be needed. The
+   * first call determines the optimal work size and the second does the work.
+   */
   work.resize(1);
 
   sygvx (&itype, jobz, range, uplo, &nn, values_A, &nn,
@@ -868,11 +880,15 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
   const char *const jobz = (eigenvectors.size() > 0) ? (&V) : (&N);
   const char *const uplo = (&U);
 
-  // The LAPACK routine DSYGV requires a sufficient large workspace variable,
-  // minimum requirement is
-  //    work.size>=3*nn-1.
-  // However, to improve performance, a somewhat larger workspace may be
-  // needed.
+  /*
+   * The LAPACK routine xSYGV requires a sufficiently large work array; the
+   * minimum requirement is
+   *
+   * work.size >= 3*nn - 1.
+   *
+   * However, for better performance, a larger work array may be needed. The
+   * first call determines the optimal work size and the second does the work.
+   */
   work.resize(1);
 
   sygv (&itype, jobz, uplo, &nn, values_A, &nn,

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -869,7 +869,7 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
          ExcMessage ("eigenvectors.size() > matrix.n_cols()"));
 
   wr.resize(nn);
-  wi.resize(nn); //This is set purley for consistency reasons with the
+  wi.resize(nn); //This is set purely for consistency reasons with the
   //eigenvalues() function.
 
   number *values_A = const_cast<number *> (&this->values[0]);

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -22,6 +22,8 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 
+#include <boost/math/special_functions/round.hpp>
+
 #include <iostream>
 #include <iomanip>
 
@@ -503,7 +505,7 @@ LAPACKFullMatrix<number>::compute_svd()
         &work[0], &lwork, &ipiv[0], &info);
   AssertThrow (info==0, LAPACKSupport::ExcErrorCode("gesdd", info));
   // Now resize work array and
-  lwork = static_cast<int>(work[0] + .5);
+  lwork = boost::math::iround(work[0]);
 
   work.resize(lwork);
   // Do the actual SVD.
@@ -655,7 +657,7 @@ LAPACKFullMatrix<number>::compute_eigenvalues(const bool right,
   // for work, everything else would not be acceptable.
   Assert (info == 0, ExcInternalError());
   // Allocate working array according to suggestion.
-  lwork = (int) (work[0]+.1);
+  lwork = boost::math::iround(work[0]);
 
   // resize workspace array
   work.resize((size_type ) lwork);
@@ -727,7 +729,7 @@ LAPACKFullMatrix<number>::compute_eigenvalues_symmetric(const number        lowe
   // for work, everything else would not be acceptable.
   Assert (info == 0, ExcInternalError());
   // Allocate working array according to suggestion.
-  lwork = (int) (work[0]+.1);
+  lwork = boost::math::iround(work[0]);
   work.resize(static_cast<size_type> (lwork));
 
   // Finally compute the eigenvalues.
@@ -817,7 +819,7 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric(
   // for work, everything else would not be acceptable.
   Assert (info == 0, ExcInternalError());
   // Allocate working array according to suggestion.
-  lwork = (int) (work[0]+.1);
+  lwork = boost::math::iround(work[0]);
 
   // resize workspace arrays
   work.resize(static_cast<size_type> (lwork));
@@ -898,7 +900,7 @@ LAPACKFullMatrix<number>::compute_generalized_eigenvalues_symmetric (
   // for work, everything else would not be acceptable.
   Assert (info == 0, ExcInternalError());
   // Allocate working array according to suggestion.
-  lwork = (int) (work[0]+.1);
+  lwork = boost::math::iround(work[0]);
 
   // resize workspace array
   work.resize((size_type) lwork);


### PR DESCRIPTION
This is another option that did not survive the CMake port. I am *pretty sure* that the problem this used to solve is no longer a problem.