### PR TITLE
Do some work in get_data instead of fill_fe_values

### DIFF
--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -254,11 +254,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
 
   const UpdateFlags flags(fe_data.update_each);
 
-  if (flags & update_values)
-    for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      for (unsigned int i=0; i<quadrature.size(); ++i)
-        output_data.shape_values(k,i) = fe_data.shape_values[k][i];
-
+  // transform gradients and higher derivatives. there is nothing to do
+  // for values since we already emplaced them into output_data when
+  // we were in get_data()
   if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
       mapping.transform (fe_data.shape_gradients[k],
@@ -329,6 +327,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
 
   const UpdateFlags flags(fe_data.update_each);
 
+  // transform gradients and higher derivatives. we also have to copy
+  // the values (unlike in the case of fill_fe_values()) since
+  // we need to take into account the offsets
   if (flags & update_values)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
       for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -408,6 +409,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
   const UpdateFlags flags(fe_data.update_each);
 
+  // transform gradients and higher derivatives. we also have to copy
+  // the values (unlike in the case of fill_fe_values()) since
+  // we need to take into account the offsets
   if (flags & update_values)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
       for (unsigned int i=0; i<quadrature.size(); ++i)

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -49,10 +49,9 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (fe_data.update_each & update_values)
-        for (unsigned int i=0; i<quadrature.size(); ++i)
-          output_data.shape_values(k,i) = fe_data.shape_values[k][i];
-
+      // transform gradients and higher derivatives. there is nothing to do
+      // for values since we already emplaced them into output_data when
+      // we were in get_data()
       if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
@@ -107,10 +106,9 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (fe_data.update_each & update_values)
-        for (unsigned int i=0; i<quadrature.size(); ++i)
-          output_data.shape_values(k,i) = fe_data.shape_values[k][i];
-
+      // transform gradients and higher derivatives. there is nothing to do
+      // for values since we already emplaced them into output_data when
+      // we were in get_data()
       if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
@@ -166,10 +164,9 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (fe_data.update_each & update_values)
-        for (unsigned int i=0; i<quadrature.size(); ++i)
-          output_data.shape_values(k,i) = fe_data.shape_values[k][i];
-
+      // transform gradients and higher derivatives. there is nothing to do
+      // for values since we already emplaced them into output_data when
+      // we were in get_data()
       if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,
@@ -220,11 +217,9 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
 
   for (unsigned int k=0; k<this->dofs_per_cell; ++k)
     {
-      if (fe_data.update_each & update_values)
-        for (unsigned int i=0; i<quadrature.size(); ++i)
-          output_data.shape_values(k,i) = fe_data.shape_values[k][i];
-
-
+      // transform gradients and higher derivatives. there is nothing to do
+      // for values since we already emplaced them into output_data when
+      // we were in get_data()
       if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
         mapping.transform (fe_data.shape_gradients[k],
                            mapping_covariant,


### PR DESCRIPTION
This addresses #1824 for the FE_Poly class. My goal is to do as much work as possible already in `FE_Poly::get_data()`, rather than wait for `FE_Poly::fill_fe_values()`. It turns out, however, that there is not actually very much that can already be done: one can put the values of the shape functions into the output array when working on cells, and that's it. Derivatives of course have to be transformed, so there is nothing we can do. And when looking at values on faces, we build a table in `get_data()` that contains the values on *all* faces, but we later only want those on *one* face, and so have to copy from the scratch array to the final destination a subset (with an offset), so we can't put the final results into the output structure already in `get_data()`. A bit disappointing. At the same time, copying *values* is likely so cheap compared to transforming derivatives that it's not worth fretting over.

It turns out that we duplicate code multiple times between fe_poly.templates.h and fe_poly.cc for the fill_fe_values() functions and their specializations. I don't want to see right now what the cause for this is, so I'll leave this alone (noting that it cost me a couple of hours of debugging to realize why my code didn't work as expected, before I found the duplication and applied the same patch there too). But I'll throw in a second comment that switches loops and if-statements in the same way we had previously done in #1821.

In reference to #1198.