### PR TITLE
Fix error messages.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -994,8 +994,8 @@ namespace internal
                     << "The input data for creating a triangulation contained "
                     << "information about a line with indices "
                     << arg1 << " and " << arg2
-                    << "that is supposed to have boundary indicator "
-                    << arg3
+                    << " that is described to have boundary indicator "
+                    << (int)arg3
                     << ". However, this is an internal line not located on the "
                     << "boundary. You cannot assign a boundary indicator to it."
                     << std::endl
@@ -1025,8 +1025,8 @@ namespace internal
                     << "The input data for creating a triangulation contained "
                     << "information about a quad with indices "
                     << arg1 << ", " << arg2 << ", " << arg3 << ", and " << arg4
-                    << "that is supposed to have boundary indicator "
-                    << arg5
+                    << " that is described to have boundary indicator "
+                    << (int)arg5
                     << ". However, this is an internal quad not located on the "
                     << "boundary. You cannot assign a boundary indicator to it."
                     << std::endl


### PR DESCRIPTION
There was a space  missing in a couple of places, but more importantly we cannot
directly output objects of type types::boundary_id (==char). They need to be cast
to integers to yield something useful.