### PR TITLE
Provide and use signaling nans

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -451,6 +451,13 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: The constructor of SymmetricTensor that takes an array
+  of initializing elements led to a compiler error. This is now
+  fixed.
+  <br>
+  (Wolfgang Bangerth, 2015/11/28)
+  </li>
+
   <li> Fixed: parallel::distributed::Vector now detects if the size of MPI
   messages exceeds 2GB or if the local range exceeds the size of 32-bit
   integers and throws an exception informing about the unsupported sizes.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -167,6 +167,20 @@ inconvenience this causes.
 <a name="general"></a>
 <h3>General</h3>
 <ol>
+  <li> New: There is now a function template numbers::signaling_nan() that
+  is used to create invalid floating point objects. These objects can either
+  be scalars, or of type Tensor, SymmetricTensor, or DerivativeForm. The
+  content of these objects is a "signaling NaN" ("NaN" stands for "not a
+  number", and "signaling" implies that at least on platforms where this
+  is supported, any arithmetic operation using them terminates the program).
+  The purpose of this is to use them as markers for uninitialized objects
+  and arrays that are required to be filled in other places, and to trigger
+  an error when this later initialization does not happen before the first
+  use.
+  <br>
+  (Wolfgang Bangerth, Timo Heister, 2015/11/24)
+  </li>
+
   <li> Changed: The function FE_DGPNonparametric::shape_value() and similar
   functions in the same class returned values and derivatives of shape
   functions on the reference cell. However, this element is not defined

--- a/include/deal.II/base/signaling_nan.h
+++ b/include/deal.II/base/signaling_nan.h
@@ -1,0 +1,213 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2005 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__signaling_nan_h
+#define dealii__signaling_nan_h
+
+#include <deal.II/base/config.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/derivative_form.h>
+
+#include <limits>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace numbers
+{
+
+  namespace internal
+  {
+    /**
+     * A namespace for the implementation of functions that create
+     * signaling NaN objects. This is where the Utilities::signaling_nan()
+     * function calls into.
+     */
+    namespace SignalingNaN
+    {
+      /**
+       * A general template for classes that know how to initialize
+       * objects of type @p T with signaling NaNs to denote invalid
+       * values.
+       *
+       * The real implementation of this class happens in (partial)
+       * specializations for particular values of the template
+       * argument @p T.
+       */
+      template <typename T>
+      struct NaNInitializer;
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a @p float value equal to
+       * the invalid signaling NaN.
+       */
+      template <>
+      struct NaNInitializer<float>
+      {
+        static float invalid_element ()
+        {
+          return std::numeric_limits<float>::signaling_NaN();
+        }
+      };
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a @p double value equal to
+       * the invalid signaling NaN.
+       */
+      template <>
+      struct NaNInitializer<double>
+      {
+        static double invalid_element ()
+        {
+          return std::numeric_limits<double>::signaling_NaN();
+        }
+      };
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a Tensor<1,dim> value whose
+       * components are invalid signaling NaN values.
+       */
+      template <int dim, typename T>
+      struct NaNInitializer<Tensor<1,dim,T> >
+      {
+        static Tensor<1,dim,T> invalid_element ()
+        {
+          Tensor<1,dim,T> nan_tensor;
+
+          for (unsigned int i=0; i<dim; ++i)
+            nan_tensor[i] = NaNInitializer<T>::invalid_element();
+
+          return nan_tensor;
+        }
+      };
+
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a Tensor<rank,dim> value whose
+       * components are invalid signaling NaN values.
+       */
+      template <int rank, int dim, typename T>
+      struct NaNInitializer<Tensor<rank,dim,T> >
+      {
+        static Tensor<rank,dim,T> invalid_element ()
+        {
+          Tensor<rank,dim,T> nan_tensor;
+
+          // recursively initialize sub-tensors with invalid elements
+          for (unsigned int i=0; i<dim; ++i)
+            nan_tensor[i] = NaNInitializer<Tensor<rank-1,dim,T> >::invalid_element();
+
+          return nan_tensor;
+        }
+      };
+
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a SymmetricTensor<rank,dim>
+       * value whose components are invalid signaling NaN values.
+       */
+      template <int rank, int dim, typename T>
+      struct NaNInitializer<SymmetricTensor<rank,dim,T> >
+      {
+        static SymmetricTensor<rank,dim,T> invalid_element ()
+        {
+          // initialize symmetric tensors via the unrolled list of elements
+          T initializers[SymmetricTensor<rank,dim,T>::n_independent_components];
+          for (unsigned int i=0; i<SymmetricTensor<rank,dim,T>::n_independent_components; ++i)
+            initializers[i] = NaNInitializer<T>::invalid_element();
+
+          return SymmetricTensor<rank,dim,T>(initializers);
+        }
+      };
+
+
+
+      /**
+       * A specialization of the general NaNInitializer class that
+       * provides a function that returns a
+       * DerivativeForm<order,dim,spacedim> value whose components are
+       * invalid signaling NaN values.
+       */
+      template <int order, int dim, int spacedim, typename T>
+      struct NaNInitializer<DerivativeForm<order,dim,spacedim,T> >
+      {
+        static DerivativeForm<order,dim,spacedim,T> invalid_element ()
+        {
+          DerivativeForm<order,dim,spacedim,T> form;
+
+          // recursively initialize sub-tensors with invalid elements
+          for (unsigned int i=0; i<spacedim; ++i)
+            form[i] = NaNInitializer<Tensor<order,dim,T> >::invalid_element();
+
+          return form;
+        }
+      };
+    }
+  }
+
+
+
+
+  /**
+   * Provide an object of type @p T filled with a signaling NaN that
+   * will cause an exception when used in a computation. The content
+   * of these objects is a "signaling NaN" ("NaN" stands for "not a
+   * number", and "signaling" implies that at least on platforms where
+   * this is supported, any arithmetic operation using them terminates
+   * the program). The purpose of such objects is to use them as
+   * markers for uninitialized objects and arrays that are required to
+   * be filled in other places, and to trigger an error when this
+   * later initialization does not happen before the first use.
+   *
+   * @tparam T The type of the returned invalid object. This type can either
+   *   be a scalar, or of type Tensor, SymmetricTensor, or DerivativeForm.
+   *   Other types may be supported if there is a corresponding
+   *   specialization of the internal::SignalingNaN::NaNInitializer class
+   *   for this type.
+   *
+   * @note Because the type @p T is not used as a function argument, the
+   *   compiler cannot deduce it from the type of arguments. Consequently,
+   *   you have to provide it explicitly. For example, the line
+   *   @code
+   *     Tensor<1,dim> tensor = Utilities::signaling_nan<Tensor<1,dim> >();
+   *   @endcode
+   *   initializes a tensor with invalid values.
+   */
+  template <class T>
+  T
+  signaling_nan()
+  {
+    // dispatch to the classes in the internal namespace because there
+    // we can do partial specializations, which is not possible for
+    // template functions such as the current one
+    return internal::SignalingNaN::NaNInitializer<T>::invalid_element ();
+  }
+}
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -989,8 +989,13 @@ template <int rank, int dim, typename Number>
 inline
 SymmetricTensor<rank,dim,Number>::SymmetricTensor (const Number (&array) [n_independent_components])
   :
-  data (array)
-{}
+  data (*reinterpret_cast<const typename base_tensor_type::array_type *>(array))
+{
+  // ensure that the reinterpret_cast above actually works
+  Assert (sizeof(typename base_tensor_type::array_type)
+          == sizeof(array),
+          ExcInternalError());
+}
 
 
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
@@ -2127,40 +2128,51 @@ namespace internal
                                                   const UpdateFlags         flags)
     {
       if (flags & update_quadrature_points)
-        this->quadrature_points.resize(n_quadrature_points);
+        this->quadrature_points.resize(n_quadrature_points,
+                                       Point<spacedim>(numbers::signaling_nan<Tensor<1,spacedim> >()));
 
       if (flags & update_JxW_values)
-        this->JxW_values.resize(n_quadrature_points);
+        this->JxW_values.resize(n_quadrature_points,
+                                numbers::signaling_nan<double>());
 
       if (flags & update_jacobians)
-        this->jacobians.resize(n_quadrature_points);
+        this->jacobians.resize(n_quadrature_points,
+                               numbers::signaling_nan<DerivativeForm<1,dim,spacedim> >());
 
       if (flags & update_jacobian_grads)
-        this->jacobian_grads.resize(n_quadrature_points);
+        this->jacobian_grads.resize(n_quadrature_points,
+                                    numbers::signaling_nan<DerivativeForm<2,dim,spacedim> >());
 
       if (flags & update_jacobian_pushed_forward_grads)
-        this->jacobian_pushed_forward_grads.resize(n_quadrature_points);
+        this->jacobian_pushed_forward_grads.resize(n_quadrature_points,
+                                                   numbers::signaling_nan<Tensor<3,spacedim> >());
 
       if (flags & update_jacobian_2nd_derivatives)
-        this->jacobian_2nd_derivatives.resize(n_quadrature_points);
+        this->jacobian_2nd_derivatives.resize(n_quadrature_points,
+                                              numbers::signaling_nan<DerivativeForm<3,dim,spacedim> >());
 
       if (flags & update_jacobian_pushed_forward_2nd_derivatives)
-        this->jacobian_pushed_forward_2nd_derivatives.resize(n_quadrature_points);
+        this->jacobian_pushed_forward_2nd_derivatives.resize(n_quadrature_points,
+                                                             numbers::signaling_nan<Tensor<4,spacedim> >());
 
       if (flags & update_jacobian_3rd_derivatives)
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
       if (flags & update_jacobian_pushed_forward_3rd_derivatives)
-        this->jacobian_pushed_forward_3rd_derivatives.resize(n_quadrature_points);
+        this->jacobian_pushed_forward_3rd_derivatives.resize(n_quadrature_points,
+                                                             numbers::signaling_nan<Tensor<5,spacedim> >());
 
       if (flags & update_inverse_jacobians)
-        this->inverse_jacobians.resize(n_quadrature_points);
+        this->inverse_jacobians.resize(n_quadrature_points,
+                                       numbers::signaling_nan<DerivativeForm<1,spacedim,dim> >());
 
       if (flags & update_boundary_forms)
-        this->boundary_forms.resize(n_quadrature_points);
+        this->boundary_forms.resize(n_quadrature_points,
+                                    numbers::signaling_nan<Tensor<1,spacedim> >());
 
       if (flags & update_normal_vectors)
-        this->normal_vectors.resize(n_quadrature_points);
+        this->normal_vectors.resize(n_quadrature_points,
+                                    numbers::signaling_nan<Tensor<1,spacedim> >());
     }
 
 
@@ -2192,18 +2204,14 @@ namespace internal
                                                         const FiniteElement<dim,spacedim> &fe,
                                                         const UpdateFlags         flags)
     {
-
-      // initialize the table mapping
-      // from shape function number to
-      // the rows in the tables storing
-      // the data by shape function and
+      // initialize the table mapping from shape function number to
+      // the rows in the tables storing the data by shape function and
       // nonzero component
       this->shape_function_to_row_table
         = make_shape_function_to_row_table (fe);
 
-      // count the total number of non-zero
-      // components accumulated over all shape
-      // functions
+      // count the total number of non-zero components accumulated
+      // over all shape functions
       unsigned int n_nonzero_shape_components = 0;
       for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
         n_nonzero_shape_components += fe.n_nonzero_components (i);
@@ -2215,20 +2223,26 @@ namespace internal
       // that we will need to their
       // correct size
       if (flags & update_values)
-        this->shape_values.reinit(n_nonzero_shape_components,
-                                  n_quadrature_points);
+        {
+          this->shape_values.reinit(n_nonzero_shape_components,
+                                    n_quadrature_points);
+          this->shape_values.fill(numbers::signaling_nan<double>());
+        }
 
       if (flags & update_gradients)
         this->shape_gradients.resize (n_nonzero_shape_components,
-                                      std::vector<Tensor<1,spacedim> > (n_quadrature_points));
+                                      std::vector<Tensor<1,spacedim> > (n_quadrature_points,
+                                          numbers::signaling_nan<Tensor<1,spacedim> >()));
 
       if (flags & update_hessians)
         this->shape_hessians.resize (n_nonzero_shape_components,
-                                     std::vector<Tensor<2,spacedim> > (n_quadrature_points));
+                                     std::vector<Tensor<2,spacedim> > (n_quadrature_points,
+                                         numbers::signaling_nan<Tensor<2,spacedim> >()));
 
       if (flags & update_3rd_derivatives)
         this->shape_3rd_derivatives.resize (n_nonzero_shape_components,
-                                            std::vector<Tensor<3,spacedim> > (n_quadrature_points));
+                                            std::vector<Tensor<3,spacedim> > (n_quadrature_points,
+                                                numbers::signaling_nan<Tensor<3,spacedim> >()));
     }
 
 

--- a/tests/base/signaling_nan_derivative_form.cc
+++ b/tests/base/signaling_nan_derivative_form.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check numbers::signaling_nan<DerivativeForm>
+//
+// the test only checks that the function can be called. It would have
+// been nicer to output the tensors (which would also verify the
+// correct output type, as well as that indeed *each* element is
+// correctly filled), but outputting a sNaN triggers a floating point
+// exception as well
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/signaling_nan.h>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <fenv.h>
+
+
+
+template <typename T>
+void check ()
+{
+  numbers::signaling_nan<DerivativeForm<1,2,3,T> >();
+  numbers::signaling_nan<DerivativeForm<2,2,2,T> >();
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.depth_console(0);
+  deallog.threshold_double(1.e-10);
+
+  check<float> ();
+  check<double> ();
+
+  return 0;
+}
+
+

--- a/tests/base/signaling_nan_derivative_form.output
+++ b/tests/base/signaling_nan_derivative_form.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK

--- a/tests/base/signaling_nan_symmetric_tensor.cc
+++ b/tests/base/signaling_nan_symmetric_tensor.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check numbers::signaling_nan<SymmetricTensor>
+//
+// the test only checks that the function can be called. It would have
+// been nicer to output the tensors (which would also verify the
+// correct output type, as well as that indeed *each* element is
+// correctly filled), but outputting a sNaN triggers a floating point
+// exception as well
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/signaling_nan.h>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <fenv.h>
+
+
+template <typename T>
+void check ()
+{
+  numbers::signaling_nan<SymmetricTensor<2,2,T> >();
+  numbers::signaling_nan<SymmetricTensor<4,2,T> >();
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.depth_console(0);
+  deallog.threshold_double(1.e-10);
+
+  check<float> ();
+  check<double> ();
+
+  return 0;
+}
+
+

--- a/tests/base/signaling_nan_symmetric_tensor.output
+++ b/tests/base/signaling_nan_symmetric_tensor.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK

--- a/tests/base/signaling_nan_table.cc
+++ b/tests/base/signaling_nan_table.cc
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check Table<2,double> with elements numbers::signaling_nan<double>
+//
+// the test only checks that the function can be called. It would have
+// been nicer to output the tensors (which would also verify the
+// correct output type, as well as that indeed *each* element is
+// correctly filled), but outputting a sNaN triggers a floating point
+// exception as well
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/table.h>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <fenv.h>
+
+
+template <typename T>
+void check ()
+{
+  Table<2,T> t;
+  const T x = numbers::signaling_nan<double>();
+  const T array[6] = { x,x,x,x,x,x };
+
+  t.reinit (2,3, &x);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.depth_console(0);
+  deallog.threshold_double(1.e-10);
+
+  check<float> ();
+  check<double> ();
+
+  return 0;
+}
+

--- a/tests/base/signaling_nan_table.output
+++ b/tests/base/signaling_nan_table.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK

--- a/tests/base/signaling_nan_tensor.cc
+++ b/tests/base/signaling_nan_tensor.cc
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check numbers::signaling_nan<Tensor>
+//
+// the test only checks that the function can be called. It would have
+// been nicer to output the tensors (which would also verify the
+// correct output type, as well as that indeed *each* element is
+// correctly filled), but outputting a sNaN triggers a floating point
+// exception as well
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/signaling_nan.h>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <fenv.h>
+
+
+template <typename T>
+void check ()
+{
+  numbers::signaling_nan<Tensor<1,2,T> >();
+  numbers::signaling_nan<Tensor<2,2,T> >();
+  numbers::signaling_nan<Tensor<3,2,T> >();
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.depth_console(0);
+  deallog.threshold_double(1.e-10);
+
+  check<float> ();
+  check<double> ();
+
+  return 0;
+}
+

--- a/tests/base/signaling_nan_tensor.output
+++ b/tests/base/signaling_nan_tensor.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
This is an adaptation of @tjhei 's original patch to ASPECT (https://github.com/geodynamics/aspect/pull/441) that introduced the ability to initialize arrays to signaling NaNs. The idea is that this pre-sets uninitialized values to something that triggers a processor exception whenever this (uninitialized) data is accidentally used in any kind of arithmetic.

I generalized Timo's way of generating signaling NaNs a bit, doing away with the complete specializations of the function and instead allowing myself the luxury of partially specialized class templates. This is more extensible. 

The second commit uses this new facility to pre-set the elements of the various internal FEValues structures to these invalid values. This helped me find the issue addressed by #1908.

My test machine does not have sufficiently modern support for floating point exceptions, so they are switched off and I cannot see whether this patch actually triggers any of the exceptions this work hopes to capture. I suppose we will simply see what we find on other regression testers once this patch goes in. (Unless, of course, someone for whom `DEAL_II_HAVE_FP_EXCEPTIONS` is defined in `$build/include/deal.II/base/config.h` wants to run the testsuite with this patch.)