### PR TITLE
MSVC fix for fe_evaluation

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -4098,13 +4098,13 @@ FEEvaluationAccess<dim,dim,Number>
 
 template <int dim, typename Number>
 inline
-Tensor<1,dim==2?1:dim,VectorizedArray<Number> >
+Tensor<1,(dim==2?1:dim),VectorizedArray<Number> >
 FEEvaluationAccess<dim,dim,Number>
 ::get_curl (const unsigned int q_point) const
 {
   // copy from generic function into dim-specialization function
   const Tensor<2,dim,VectorizedArray<Number> > grad = get_gradient(q_point);
-  Tensor<1,dim==2?1:dim,VectorizedArray<Number> > curl;
+  Tensor<1,(dim==2?1:dim),VectorizedArray<Number> > curl;
   switch (dim)
     {
     case 1:


### PR DESCRIPTION
It looks like MSVC struggles with operator? in template parameters unless you wrap them in parenthesis.

See http://cdash.kyomu.43-1.org/testDetails.php?test=27194494&build=14752