### PR TITLE
build_test fixes for MSVC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 /tests/run_test.cmake -export-ignore
 .gitattributes export-ignore
 .travis.yml export-ignore
+/cmake/scripts/run_test.sh text eol=lf
+/tests/**/*output text eol=lf

--- a/bundled/boost-1.56.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.56.0/include/boost/config/compiler/visualc.hpp
@@ -263,7 +263,8 @@
 
 //
 // last known and checked version is 18.00.20827.3 (VC12 RC, aka 2013 RC):
-#if (_MSC_VER > 1800 && _MSC_FULL_VER > 180020827)
+// tjhei: change 180020827 to 190023506 (vs 2015 update 1)
+#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190023506)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -76,7 +76,7 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
     ENDIF()
     FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/run_target.cmake
       "SET(ENV{PATH} \"${CMAKE_CURRENT_BINARY_DIR}${_delim}${DEAL_II_PATH}/${DEAL_II_EXECUTABLE_RELDIR}${_delim}\$ENV{PATH}\")\n"
-      "EXECUTE_PROCESS(COMMAND ${TARGET_RUN}\n"
+      "EXECUTE_PROCESS(COMMAND ${CMAKE_BUILD_TYPE}\\\\${TARGET_RUN}\n"
       "  RESULT_VARIABLE _return_value\n"
       "  )\n"
       "IF(NOT \"\${_return_value}\" STREQUAL \"0\")\n"

--- a/cmake/scripts/normalize.pl
+++ b/cmake/scripts/normalize.pl
@@ -23,6 +23,9 @@
 #  small doubles
 #
 
+# Convert windows to unix line endings. This is necessary to be able to run
+# the testsuite on windows (using cygwin's diff/perl)
+s/\r$//;
 
 # Remove JobID
 

--- a/cmake/scripts/run_test.cmake
+++ b/cmake/scripts/run_test.cmake
@@ -53,7 +53,8 @@ IF("${EXPECT}" STREQUAL "")
 ENDIF()
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND}
-  --build ${BINARY_DIR} --target ${TRGT}
+  --build . --target ${TRGT}
+  WORKING_DIRECTORY ${BINARY_DIR}
   RESULT_VARIABLE _result_code # ignored ;-)
   OUTPUT_VARIABLE _output
   )

--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -87,7 +87,7 @@ diff() {
     # is found (including the main comparison file).
     #
     case ${NUMDIFF_EXECUTABLE} in
-      *numdiff)
+      *numdiff*)
         ${NUMDIFF_EXECUTABLE} -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
                               "${file}" output > diff${variant}
         ;;

--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -818,7 +818,7 @@ MAKEOPTS
 <pre>
 mkdir dealii/build
 cd dealii/build
-ctest -j4 -S ../cmake/scripts/run_buildtest.cmake
+ctest -j4 -S ../tests/run_buildtest.cmake
 </pre>
     </p>
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1602,7 +1602,12 @@ private:
   template <typename,bool> friend class SparseMatrixIterators::Iterator;
   template <typename,bool> friend class SparseMatrixIterators::Accessor;
 
+#ifndef DEAL_II_MSVC
+  // Visual studio is choking on the following friend declaration, probably
+  // because Reference is only defined in a specialization. It looks like
+  // the library is compiling without this line, though.
   template <typename number2> friend class SparseMatrixIterators::Accessor<number2, false>::Reference;
+#endif
 };
 
 #ifndef DOXYGEN

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -82,6 +82,30 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_EXECUTABLE_RELDIR}"
     )
 
+  # Under Windows (MSVC) cmake will always generate multi-configuration
+  # projects. When building on the command line with 'cmake --build .',
+  # release and debug builds of the library are done with the default 'Debug'
+  # configuration. This causes the debug and release .lib to be built inside
+  # ./lib/Debug/. This is not very pretty and confuses example/test projects,
+  # so we just hard-wire the location here. We only really need to set static
+  # lib locations for _DEBUG (no support for dynamic linking, _RELEASE will be
+  # ignored), but we do it anyhow.
+  IF (DEAL_II_MSVC)
+    SET_PROPERTY(TARGET ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX} PROPERTY
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
+      )
+    SET_PROPERTY(TARGET ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX} PROPERTY
+      ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
+      )
+    SET_PROPERTY(TARGET ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX} PROPERTY
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
+      )
+    SET_PROPERTY(TARGET ${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX} PROPERTY
+      ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
+      )
+  ENDIF()
+
+
   TARGET_LINK_LIBRARIES(${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX}
     ${DEAL_II_LIBRARIES_${build}}
     ${DEAL_II_LIBRARIES}

--- a/tests/build_tests/CMakeLists.txt
+++ b/tests/build_tests/CMakeLists.txt
@@ -117,7 +117,7 @@ FOREACH(_step_full ${_steps})
       ADD_CUSTOM_COMMAND(OUTPUT ${_step_dir}/configure_output
         COMMAND rm -f ${_step_dir}/failing_configure_output
         COMMAND ${CMAKE_COMMAND}
-          -DDEAL_II_DIR=${DEAL_II_DIR} -DCMAKE_BUILD_TYPE=${_build} .
+          -DDEAL_II_DIR=${DEAL_II_DIR} -DCMAKE_BUILD_TYPE=${_build} -G ${CMAKE_GENERATOR} .
           > ${_step_dir}/configure_output 2>&1
           || (mv ${_step_dir}/configure_output
                  ${_step_dir}/failing_configure_output
@@ -128,11 +128,21 @@ FOREACH(_step_full ${_steps})
           ${DEAL_II_PATH}/${DEAL_II_PROJECT_CONFIG_RELDIR}/${DEAL_II_PACKAGE_NAME}Config.cmake
         )
 
+
+      # MSVC needs to know if we are compiling the debug or release configuration right now:
+      IF(MSVC AND ("${_build}" STREQUAL "RELEASE"))
+        SET(_magic1 "--config")
+        SET(_magic2 "Release")
+      ELSE()
+        SET(_magic1 "")
+        SET(_magic2 "")
+      ENDIF()
+
       # And a rule on how to build the example step:
       ADD_CUSTOM_COMMAND(OUTPUT ${_step_dir}/build_output
         COMMAND test ! -f ${_step_dir}/configure_output
           || (rm -f ${_step_dir}/failing_build_output
-              && ${CMAKE_COMMAND} --build ${_step_dir} --target all
+              && ${CMAKE_COMMAND} --build . ${_magic1} ${_magic2}
               > ${_step_dir}/build_output 2>&1)
           || (mv ${_step_dir}/build_output
                  ${_step_dir}/failing_build_output
@@ -152,7 +162,7 @@ FOREACH(_step_full ${_steps})
       ADD_CUSTOM_COMMAND(OUTPUT ${_step_dir}/run_output
         COMMAND test ! -f ${_step_dir}/build_output
           || (rm -f ${_step_dir}/failing_run_output
-             && ${CMAKE_COMMAND} --build ${_step_dir} --target run
+             && ${CMAKE_COMMAND} --build .  --target run ${_magic1} ${_magic2}
              > ${_step_dir}/run_output 2>&1)
           || (mv ${_step_dir}/run_output
                  ${_step_dir}/failing_run_output

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -43,6 +43,20 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #endif
 
 
+#ifdef DEAL_II_MSVC
+// Under windows tests will hang and show a debugging dialog box from the
+// debug CRT if an exception is encountered. Disable this:
+#include <stdlib.h>
+
+struct DisableWindowsDebugRuntimeDialog
+{
+  DisableWindowsDebugRuntimeDialog ()
+  {
+    _set_abort_behavior( 0, _WRITE_ABORT_MSG);
+  }
+} deal_II_windows_crt_dialog;
+#endif
+
 // implicitly use the deal.II namespace everywhere, without us having to say
 // so in each and every testcase
 using namespace dealii;


### PR DESCRIPTION
    - fix path in documentation
    - remove friend declaration MSVC chokes on
    - fix unittest scripts (line endings)
    - whitelist MSVC 2015 update 1 in bundled boost
    - fix run target in examples
    - do not specify target "all"
    - cmake --build can not have a relative directory on windows
    - need to specify build configuration
    - need to pass generator along
    - disable CRT debug dialog box in tests