### PR TITLE
Fix output file.

### DIFF
--- a/tests/distributed_grids/intergrid_transfer_representation_parallel.mpirun=3.output
+++ b/tests/distributed_grids/intergrid_transfer_representation_parallel.mpirun=3.output
@@ -1,3 +1,4 @@
+
 DEAL:0:2d::Checking in 2 space dimensions
 DEAL:0:2d::---------------------------------------
 DEAL:0:2d::# dofs = 40


### PR DESCRIPTION
This fixes the distributed_grids/intergrid_transfer_representation_parallel.mpirun=3 that has been
failing for a long time already. It turns out that the output file was simply missing
a newline.