### PR TITLE
Fix a typo in a CMake check.

### DIFF
--- a/bundled/boost-1.56.0/libs/iostreams/src/CMakeLists.txt
+++ b/bundled/boost-1.56.0/libs/iostreams/src/CMakeLists.txt
@@ -26,7 +26,7 @@ SET(src_boost_iostreams
     zlib.cpp
     )
 
-IF(DEALII_WITH_BZIP2)
+IF(DEAL_II_WITH_BZIP2)
   LIST(APPEND src_boost_iostreams bzip2.cpp)
 ELSE()
   MESSAGE(STATUS "BOOST::Iostreams will not support bz2'ed streams because libbz2 or its header files could not be found")


### PR DESCRIPTION
The correct `CMake` variable is `DEAL_II_WITH_BZIP2`, not `DEALII_WITH_BZIP2`.