### PR TITLE
Fix quadratic complexity of p::d::Tria::fill_vertices_with_ghost_neighbors

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -451,6 +451,16 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Improved: The method
+  parallel::distributed::Triangulation::fill_vertices_with_ghost_neighbors
+  that is used for distributing DoFs on parallel triangulations previously
+  exhibited quadratic complexity in the number of coarse grid cells. This has
+  been changed into linear complexity calls (apart from a few issues
+  inside p4est).
+  <br>
+  (Martin Kronbichler, 2015/12/05)
+  </li>
+
   <li> Fixed: The constructor of SymmetricTensor that takes an array
   of initializing elements led to a compiler error. This is now
   fixed.

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4810,8 +4810,8 @@ namespace parallel
     {
       int i, l = quad.level;
       int child_id;
-      const std::vector<types::global_dof_index> perm = triangulation->get_p4est_tree_to_coarse_cell_permutation ();
-      types::global_dof_index dealii_index = perm[treeidx];
+      types::global_dof_index dealii_index =
+        triangulation->get_p4est_tree_to_coarse_cell_permutation()[treeidx];
 
       for (i = 0; i < l; i++)
         {


### PR DESCRIPTION
On a 3D mesh with 533k coarse cells (run with MPI), the DoFHandler::distribute_dofs call was very slow. A breakdown of times (steps 1-4 inside dof_handler_policy) showed the following behavior (release build):
```
DH distribute own dofs 0.079838
DH mark local indices/kill non-owned dofs 0.0376949
DH renumber/shift local dofs 0.0248921
DH fill_vertices_with_ghost_neighbors 186.323
DH communicate dof indices 45.3166
```
This is pretty bad and the reason was that for each possible ghost cell we copied the whole array of cell indices from p4est. (The function spent 10^12 instructions in memmove because we used to create a std::vector of indices in every call.) But we pass the array in `get_p4est_tree_to_coarse_cell_permutation()` by reference, so no need for this quadratic complexity.
