### PR TITLE
Add another compatibility function, improve documentation

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -184,9 +184,9 @@ inconvenience this causes.
 <h3>General</h3>
 <ol>
   <li> New: OpenCASCADE::read_IGES() and OpenCASCADE::read_STEP() have
-  been unified in behaviour, and now they allow to extract *all* elements of 
-  the IGES and STEP files instead of only the faces. This allows the 
-  use of iges files describing edges only to be used as input for some of 
+  been unified in behaviour, and now they allow to extract *all* elements of
+  the IGES and STEP files instead of only the faces. This allows the
+  use of iges files describing edges only to be used as input for some of
   the OpenCASCADE Manifold wrappers.
   <br>
   (Luca Heltai, 2015/12/13)
@@ -526,6 +526,12 @@ inconvenience this causes.
   hp::DoFHandler::get_triangulation() instead.
   <br>
   (Wolfgang Bangerth, 2015/12/10)
+  </li>
+
+  <li> New: parallel::distributed::Vector has now a method to return a shared
+  pointer to the underlying partitioner object.
+  <br>
+  (Martin Kronbichler, 2015/12/07)
   </li>
 
   <li> Improved: Many more functions in namespace GridTools and class

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -144,12 +144,12 @@ namespace parallel
      *
      * This vector class is based on two different number types for indexing.
      * The so-called global index type encodes the overall size of the vector.
-     * Its type is types::global_dof_index. The largest possible
-     * value is <code>2^32-1</code> or approximately four billion in case 64
-     * bit integers are disabled at configuration of deal.II (default case) or
+     * Its type is types::global_dof_index. The largest possible value is
+     * <code>2^32-1</code> or approximately 4 billion in case 64 bit integers
+     * are disabled at configuration of deal.II (default case) or
      * <code>2^64-1</code> or approximately <code>10^19</code> if 64 bit
-     * integers are enabled (see the glossary entry on
-     * @ref GlobalDoFIndex for further information).
+     * integers are enabled (see the glossary entry on @ref GlobalDoFIndex for
+     * further information).
      *
      * The second relevant index type is the local index used within one MPI
      * rank. As opposed to the global index, the implementation assumes 32-bit
@@ -984,13 +984,23 @@ namespace parallel
       const MPI_Comm &get_mpi_communicator () const;
 
       /**
+       * Return the MPI partitioner that describes the parallel layout of the
+       * vector. This object can be used to initialize another vector with the
+       * respective reinit() call, for additional queries regarding the
+       * parallel communication, or the compatibility of partitioners.
+       */
+      std_cxx11::shared_ptr<const Utilities::MPI::Partitioner>
+      get_partitioner () const;
+
+      /**
        * Checks whether the given partitioner is compatible with the
        * partitioner used for this vector. Two partitioners are compatible if
        * they have the same local size and the same ghost indices. They do not
-       * necessarily need to be the same data field. This is a local operation
-       * only, i.e., if only some processors decide that the partitioning is
-       * not compatible, only these processors will return @p false, whereas
-       * the other processors will return @p true.
+       * necessarily need to be the same data field of the shared
+       * pointer. This is a local operation only, i.e., if only some
+       * processors decide that the partitioning is not compatible, only these
+       * processors will return @p false, whereas the other processors will
+       * return @p true.
        */
       bool
       partitioners_are_compatible (const Utilities::MPI::Partitioner &part) const;
@@ -2385,6 +2395,16 @@ namespace parallel
     Vector<Number>::get_mpi_communicator() const
     {
       return partitioner->get_communicator();
+    }
+
+
+
+    template <typename Number>
+    inline
+    std_cxx11::shared_ptr<const Utilities::MPI::Partitioner>
+    Vector<Number>::get_partitioner () const
+    {
+      return partitioner;
     }
 
 #endif  // ifndef DOXYGEN

--- a/tests/mpi/parallel_vector_17.cc
+++ b/tests/mpi/parallel_vector_17.cc
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2011 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check parallel::distributed::Vector::partitioners_are_compatible and
+// partitioners_are_globally_compatible
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+
+void test ()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  if (myid==0) deallog << "numproc=" << numproc << std::endl;
+
+
+  // all processors own 2 elements
+  IndexSet local_owned(numproc*2);
+  local_owned.add_range(myid*2,myid*2+2);
+  IndexSet local_relevant(local_owned.size());
+  local_relevant = local_owned;
+  local_relevant.add_range(1,2);
+
+  parallel::distributed::Vector<double> v1, v2, v3, v4, v5, v6;
+  v1.reinit(local_owned, MPI_COMM_WORLD);
+  v2.reinit(local_owned, local_relevant, MPI_COMM_WORLD);
+  v3.reinit(local_owned, local_relevant, MPI_COMM_WORLD);
+  v4.reinit(v3);
+  IndexSet local_owned_5(numproc*3);
+  local_owned_5.add_range(myid*3,myid*3+3);
+  v5.reinit(local_owned_5, MPI_COMM_WORLD);
+
+  // create sub-communicator on two processors
+  MPI_Comm newcomm;
+  MPI_Comm_split(MPI_COMM_WORLD, myid/2, myid%2, &newcomm);
+  IndexSet local_owned_b(6);
+  if (myid<2)
+    local_owned_b.add_range(myid*3,myid*3+3);
+  v6.reinit(local_owned_b, newcomm);
+
+  deallog << "local compatibility  v1-v2: "
+          << v1.partitioners_are_compatible(*v2.get_partitioner()) << " "
+          << v2.partitioners_are_compatible(*v1.get_partitioner()) << std::endl;
+  deallog << "global compatibility v1-v2: "
+          << v1.partitioners_are_globally_compatible(*v2.get_partitioner()) << " "
+          << v2.partitioners_are_globally_compatible(*v1.get_partitioner()) << std::endl;
+  deallog << "local compatibility  v2-v3: "
+          << v2.partitioners_are_compatible(*v3.get_partitioner()) << " "
+          << v3.partitioners_are_compatible(*v2.get_partitioner()) << std::endl;
+  deallog << "global compatibility v2-v3: "
+          << v2.partitioners_are_globally_compatible(*v3.get_partitioner()) << " "
+          << v3.partitioners_are_globally_compatible(*v2.get_partitioner()) << std::endl;
+  deallog << "local compatibility  v3-v4: "
+          << v4.partitioners_are_compatible(*v3.get_partitioner()) << " "
+          << v3.partitioners_are_compatible(*v4.get_partitioner()) << std::endl;
+  deallog << "global compatibility v3-v4: "
+          << v4.partitioners_are_globally_compatible(*v3.get_partitioner()) << " "
+          << v3.partitioners_are_globally_compatible(*v4.get_partitioner()) << std::endl;
+  deallog << "local compatibility  v4-v5: "
+          << v4.partitioners_are_compatible(*v5.get_partitioner()) << " "
+          << v5.partitioners_are_compatible(*v4.get_partitioner()) << std::endl;
+  deallog << "global compatibility v4-v5: "
+          << v4.partitioners_are_globally_compatible(*v5.get_partitioner()) << " "
+          << v5.partitioners_are_globally_compatible(*v4.get_partitioner()) << std::endl;
+  deallog << "local compatibility  v5-v6: "
+          << v6.partitioners_are_compatible(*v5.get_partitioner()) << " "
+          << v5.partitioners_are_compatible(*v6.get_partitioner()) << std::endl;
+  deallog << "global compatibility v5-v6: "
+          << v6.partitioners_are_globally_compatible(*v5.get_partitioner()) << " "
+          << v5.partitioners_are_globally_compatible(*v6.get_partitioner()) << std::endl;
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+  MPILogInitAll log;
+
+  test();
+
+}

--- a/tests/mpi/parallel_vector_17.mpirun=3.output
+++ b/tests/mpi/parallel_vector_17.mpirun=3.output
@@ -1,0 +1,36 @@
+
+DEAL:0::numproc=3
+DEAL:0::local compatibility  v1-v2: 1 1
+DEAL:0::global compatibility v1-v2: 0 0
+DEAL:0::local compatibility  v2-v3: 1 1
+DEAL:0::global compatibility v2-v3: 1 1
+DEAL:0::local compatibility  v3-v4: 1 1
+DEAL:0::global compatibility v3-v4: 1 1
+DEAL:0::local compatibility  v4-v5: 0 0
+DEAL:0::global compatibility v4-v5: 0 0
+DEAL:0::local compatibility  v5-v6: 0 0
+DEAL:0::global compatibility v5-v6: 0 0
+
+DEAL:1::local compatibility  v1-v2: 0 0
+DEAL:1::global compatibility v1-v2: 0 0
+DEAL:1::local compatibility  v2-v3: 1 1
+DEAL:1::global compatibility v2-v3: 1 1
+DEAL:1::local compatibility  v3-v4: 1 1
+DEAL:1::global compatibility v3-v4: 1 1
+DEAL:1::local compatibility  v4-v5: 0 0
+DEAL:1::global compatibility v4-v5: 0 0
+DEAL:1::local compatibility  v5-v6: 0 0
+DEAL:1::global compatibility v5-v6: 0 0
+
+
+DEAL:2::local compatibility  v1-v2: 0 0
+DEAL:2::global compatibility v1-v2: 0 0
+DEAL:2::local compatibility  v2-v3: 1 1
+DEAL:2::global compatibility v2-v3: 1 1
+DEAL:2::local compatibility  v3-v4: 1 1
+DEAL:2::global compatibility v3-v4: 1 1
+DEAL:2::local compatibility  v4-v5: 0 0
+DEAL:2::global compatibility v4-v5: 0 0
+DEAL:2::local compatibility  v5-v6: 0 0
+DEAL:2::global compatibility v5-v6: 0 0
+


### PR DESCRIPTION
I improved the documentation regarding the 32-bit limit of local size in parallel::distributed::Vector.

In addition, I added another function for checking compatibility between vectors. There was previously a check for the compatibility of the underlying partitioner which checks if the local range and the ghost indices are the same (this is used for asserting the correct layout inside MatrixFree where the we work in the local index space augmented by certain ghost indices). In some of my applications I need to make this assertion on the level of two vectors to reset a vector in case the layout is different. Note that the partitioner is not accessible from the outside and I don't want to change that.