### PR TITLE
Detemplate distribute sparsity pattern

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -469,6 +469,13 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Improved: both versions of distribute_sparsity_pattern are now plain, not
+  template, functions. This is not a breaking change because each function was
+  instantiated for exactly one template argument.
+  <br>
+  (David Wells, 2015/12/06)
+  </li>
+
   <li> Improved: The method
   parallel::distributed::Triangulation::fill_vertices_with_ghost_neighbors()
   that is used for distributing DoFs on parallel triangulations previously

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -174,21 +174,23 @@ namespace SparsityTools
   /**
    * Communicate rows in a dynamic sparsity pattern over MPI.
    *
-   * @param dsp is a dynamic sparsity pattern that has been built locally and
-   * for which we need to exchange entries with other processors to make sure
-   * that each processor knows all the elements of the rows of a matrix it
-   * stores and that may eventually be written to. This sparsity pattern will
-   * be changed as a result of this function: All entries in rows that belong
-   * to a different processor are sent to them and added there.
+   * @param dsp A dynamic sparsity pattern that has been built locally and for
+   * which we need to exchange entries with other processors to make sure that
+   * each processor knows all the elements of the rows of a matrix it stores
+   * and that may eventually be written to. This sparsity pattern will be
+   * changed as a result of this function: All entries in rows that belong to
+   * a different processor are sent to them and added there.
    *
-   * @param rows_per_cpu determines ownership of rows.
+   * @param rows_per_cpu A vector containing the number of of rows per CPU for
+   * determining ownership. This is typically the value returned by
+   * DoFHandler::locally_owned_dofs_per_processor.
    *
-   * @param mpi_comm is the MPI communicator that is shared between the
-   * processors that all participate in this operation.
+   * @param mpi_comm The MPI communicator shared between the processors that
+   * participate in this operation.
    *
-   * @param myrange indicates the range of elements stored locally and should
-   * be the one used in the constructor of the DynamicSparsityPattern.  This
-   * should be the locally relevant set.  Only rows contained in myrange are
+   * @param myrange The range of elements stored locally. This should be the
+   * one used in the constructor of the DynamicSparsityPattern, and should
+   * also be the locally relevant set. Only rows contained in myrange are
    * checked in dsp for transfer. This function needs to be used with
    * PETScWrappers::MPI::SparseMatrix for it to work correctly in a parallel
    * computation.
@@ -200,10 +202,13 @@ namespace SparsityTools
    const IndexSet                                       &myrange);
 
   /**
-   * similar to the function above, but for BlockDynamicSparsityPattern
-   * instead. @p owned_set_per_cpu is typically
-   * DoFHandler::locally_owned_dofs_per_processor and @p myrange is
-   * locally_relevant_dofs.
+   * Similar to the function above, but for BlockDynamicSparsityPattern
+   * instead.
+
+   * @param owned_set_per_cpu Typically the value given by
+   * DoFHandler::locally_owned_dofs_per_processor.
+   *
+   * @param myrange Typically the locally relevant DoFs.
    */
   void distribute_sparsity_pattern
   (BlockDynamicSparsityPattern &dsp,

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -19,8 +19,9 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern.h>
 
 #include <vector>
 
@@ -171,14 +172,14 @@ namespace SparsityTools
 
 #ifdef DEAL_II_WITH_MPI
   /**
-   * Communicate rows in a compressed sparsity pattern over MPI.
+   * Communicate rows in a dynamic sparsity pattern over MPI.
    *
-   * @param dsp is the sparsity pattern that has been built locally and for
-   * which we need to exchange entries with other processors to make sure that
-   * each processor knows all the elements of the rows of a matrix it stores
-   * and that may eventually be written to. This sparsity pattern will be
-   * changed as a result of this function: All entries in rows that belong to
-   * a different processor are sent to them and added there.
+   * @param dsp is a dynamic sparsity pattern that has been built locally and
+   * for which we need to exchange entries with other processors to make sure
+   * that each processor knows all the elements of the rows of a matrix it
+   * stores and that may eventually be written to. This sparsity pattern will
+   * be changed as a result of this function: All entries in rows that belong
+   * to a different processor are sent to them and added there.
    *
    * @param rows_per_cpu determines ownership of rows.
    *
@@ -192,23 +193,23 @@ namespace SparsityTools
    * PETScWrappers::MPI::SparseMatrix for it to work correctly in a parallel
    * computation.
    */
-  template <class DSP_t>
-  void distribute_sparsity_pattern(DSP_t &dsp,
-                                   const std::vector<typename DSP_t::size_type> &rows_per_cpu,
-                                   const MPI_Comm &mpi_comm,
-                                   const IndexSet &myrange);
+  void distribute_sparsity_pattern
+  (DynamicSparsityPattern                               &dsp,
+   const std::vector<DynamicSparsityPattern::size_type> &rows_per_cpu,
+   const MPI_Comm                                       &mpi_comm,
+   const IndexSet                                       &myrange);
 
   /**
-   * similar to the function above, but includes support for
-   * BlockDynamicSparsityPattern. @p owned_set_per_cpu is typically
-   * DoFHandler::locally_owned_dofs_per_processor and @p myrange are
+   * similar to the function above, but for BlockDynamicSparsityPattern
+   * instead. @p owned_set_per_cpu is typically
+   * DoFHandler::locally_owned_dofs_per_processor and @p myrange is
    * locally_relevant_dofs.
    */
-  template <class DSP_t>
-  void distribute_sparsity_pattern(DSP_t &dsp,
-                                   const std::vector<IndexSet> &owned_set_per_cpu,
-                                   const MPI_Comm &mpi_comm,
-                                   const IndexSet &myrange);
+  void distribute_sparsity_pattern
+  (BlockDynamicSparsityPattern &dsp,
+   const std::vector<IndexSet> &owned_set_per_cpu,
+   const MPI_Comm              &mpi_comm,
+   const IndexSet              &myrange);
 
 #endif
 

--- a/tests/mpi/distribute_sp_01.cc
+++ b/tests/mpi/distribute_sp_01.cc
@@ -57,10 +57,10 @@ void test_mpi()
   for (unsigned int i=0; i<n; ++i)
     csp.add(i, myid);
 
-  SparsityTools::distribute_sparsity_pattern<>(csp,
-                                               rows_per_cpu,
-                                               MPI_COMM_WORLD,
-                                               locally_rel);
+  SparsityTools::distribute_sparsity_pattern(csp,
+                                             rows_per_cpu,
+                                             MPI_COMM_WORLD,
+                                             locally_rel);
   /*  {
       std::ofstream f((std::string("after")+Utilities::int_to_string(myid)).c_str());
       csp.print(f);

--- a/tests/mpi/distribute_sp_02.cc
+++ b/tests/mpi/distribute_sp_02.cc
@@ -66,10 +66,10 @@ void test_mpi()
       deallog << "size: " << csp.n_rows() << "x" << csp.n_cols() << std::endl;
     }
 
-  SparsityTools::distribute_sparsity_pattern<>(csp,
-                                               locally_owned_dofs_per_cpu,
-                                               MPI_COMM_WORLD,
-                                               locally_rel);
+  SparsityTools::distribute_sparsity_pattern(csp,
+                                             locally_owned_dofs_per_cpu,
+                                             MPI_COMM_WORLD,
+                                             locally_rel);
   /*  {
       std::ofstream f((std::string("after")+Utilities::int_to_string(myid)).c_str());
       csp.print(f);
@@ -115,10 +115,10 @@ void test_mpi()
     locally_owned_dofs_per_cpu2[i].add_range((i)*num_local, (i+1)*num_local);
 
 
-  SparsityTools::distribute_sparsity_pattern<>(csp,
-                                               locally_owned_dofs_per_cpu2,
-                                               MPI_COMM_WORLD,
-                                               locally_rel);
+  SparsityTools::distribute_sparsity_pattern(csp,
+                                             locally_owned_dofs_per_cpu2,
+                                             MPI_COMM_WORLD,
+                                             locally_rel);
 
   if (myid==0)
     {


### PR DESCRIPTION
As was noted in the discussion in #1941: these functions are currently templates on the sparsity pattern type, but are only instantiated (in the `.cc` file) for exactly one sparsity pattern type each. Therefore they do not really need to be template functions. 