### PR TITLE
Make instantiation of functions more uniform.

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -70,10 +70,18 @@ DOFHANDLER_TEMPLATES := { DoFHandler;
                           hp::DoFHandler }
 
 TRIANGULATION_AND_DOFHANDLER_TEMPLATES := { Triangulation;
+                                            parallel::shared::Triangulation;
+                                            parallel::distributed::Triangulation;
                                             DoFHandler;
                                             hp::DoFHandler }
 
+SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
+                                              DoFHandler<deal_II_dimension, deal_II_space_dimension>;
+                                              hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> }
+
 TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
+                                   parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension>;
+                                   parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;
                                    DoFHandler<deal_II_dimension, deal_II_space_dimension>;
                                    hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> }
 

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -482,7 +482,15 @@ inconvenience this causes.
 
 
 <ol>
-  <li> Improved: both versions of distribute_sparsity_pattern are now plain, not
+  <li> Improved: Many more functions in namespace GridTools and class
+  InterGridMap are now consistely instantiated also for types
+  parallel::distributed::Triangulation and parallel::shared::Triangulation.
+  <br>
+  (Wolfgang Bangerth, 2015/12/07)
+  </li>
+
+  <li> Improved: Both versions of SparsityTools::distribute_sparsity_pattern()
+  are now plain, not
   template, functions. This is not a breaking change because each function was
   instantiated for exactly one template argument.
   <br>

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -23,6 +23,7 @@
 #include <deal.II/grid/intergrid_map.h>
 
 #include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 
 #include <iostream>
 #include <cmath>
@@ -4147,6 +4148,13 @@ namespace GridGenerator
       return tria;
     }
 
+    template<int dim, int spacedim>
+    const Triangulation<dim, spacedim> &
+    get_tria(const parallel::shared::Triangulation<dim, spacedim> &tria)
+    {
+      return tria;
+    }
+
     template<int dim, template<int, int> class Container, int spacedim>
     const Triangulation<dim,spacedim> &
     get_tria(const Container<dim,spacedim> &container)
@@ -4165,6 +4173,13 @@ namespace GridGenerator
     template<int dim, int spacedim>
     Triangulation<dim, spacedim> &
     get_tria(parallel::distributed::Triangulation<dim, spacedim> &tria)
+    {
+      return tria;
+    }
+
+    template<int dim, int spacedim>
+    Triangulation<dim, spacedim> &
+    get_tria(parallel::shared::Triangulation<dim, spacedim> &tria)
     {
       return tria;
     }

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -52,7 +52,7 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
   template
     std::list<std::pair<X::cell_iterator, X::cell_iterator> >
     get_finest_common_cells (const X &mesh_1,
-                               const X &mesh_2);
+                             const X &mesh_2);
 
 
   template
@@ -65,76 +65,16 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
   #endif
 }
 
-// now also instantiate these functions for parallel::shared::Triangulation
+// now also instantiate a few additional functions for parallel::distributed::Triangulation
 for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
 {
 
 #if deal_II_dimension <= deal_II_space_dimension
   namespace GridTools \{
-
-  template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
-    compute_active_cell_halo_layer (const parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                    const std_cxx11::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension,
-                                                                                                               parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type&)> &);
-  \}
-
-#endif
-}
-
-
-// now also instantiate these functions for parallel::distributed::Triangulation
-for (deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
-{
-
-#if deal_II_dimension <= deal_II_space_dimension
-  namespace GridTools \{
-
-  template
-    unsigned int
-    find_closest_vertex (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-                         const Point<deal_II_space_dimension> &);
-
-  template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
-    find_cells_adjacent_to_vertex(const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-                                  const unsigned int);
-  template
-    dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type
-    find_active_cell_around_point (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-                                   const Point<deal_II_space_dimension> &p);
-
-  template
-    std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type, Point<deal_II_dimension> >
-    find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-                                   const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &,
-                                   const Point<deal_II_space_dimension> &);
-
-  template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
-    compute_active_cell_halo_layer (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                    const std_cxx11::function<bool (const dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension,
-                                                                                                               parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type&)> &);
-
-  template
-    std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> >::type>
-    compute_ghost_cell_halo_layer (const parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
   template
   std::map<unsigned int,types::global_vertex_index>
   compute_local_to_global_vertex_index_map(const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation);
-
-  template
-    std::list<std::pair<parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator, parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator> >
-    get_finest_common_cells (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_1,
-                               const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
-
-
-  template
-    bool
-    have_same_coarse_mesh (const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_1,
-                           const parallel::distributed::Triangulation<deal_II_dimension,deal_II_space_dimension> &mesh_2);
-
   \}
 
   #endif
@@ -301,7 +241,13 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
   }
 
 
-for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
+// instantiate the following functions only for the "sequential" containers. this
+// is a misnomer here, however: the point is simply that we only instantiate
+// these functions for certain *iterator* types, and the iterator types are
+// the same for sequential and parallel containers; consequently, we get duplicate
+// instantiation errors if we instantiate for *all* container types, rather than
+// only the sequential ones
+for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II_space_dimension : SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
   namespace GridTools \{

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -22,6 +22,8 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/intergrid_map.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -45,10 +47,28 @@ namespace
   }
 
 
-// specialization for grid==tria
+// specialization for triangulation classes
   template <int dim, int spacedim>
   unsigned int
   get_n_levels (const Triangulation<dim, spacedim> &grid)
+  {
+    // if GridClass==Triangulation, then
+    // we can ask directly.
+    return grid.n_levels();
+  }
+
+  template <int dim, int spacedim>
+  unsigned int
+  get_n_levels (const parallel::distributed::Triangulation<dim, spacedim> &grid)
+  {
+    // if GridClass==Triangulation, then
+    // we can ask directly.
+    return grid.n_levels();
+  }
+
+  template <int dim, int spacedim>
+  unsigned int
+  get_n_levels (const parallel::shared::Triangulation<dim, spacedim> &grid)
   {
     // if GridClass==Triangulation, then
     // we can ask directly.


### PR DESCRIPTION
Specifically, allow the script to also instantiate for parallel distributed
and shared Triangulation classes. This also allows to significantly
simplify the list of explicit instantiations for GridTools.


This fixes #1958.