### PR TITLE
Introduce Triangulation::get_tria()

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -491,6 +491,14 @@ inconvenience this causes.
 
 
 <ol>
+  <li> New: There is now a function Triangulation::get_tria() that
+  allows writing code to get at the underlying triangulation for
+  everything that looks like a container, i.e., both Triangulation
+  or DoFHandler objects.
+  <br>
+  (Wolfgang Bangerth, 2015/12/07)
+  </li>
+
   <li> Improved: Many more functions in namespace GridTools and class
   InterGridMap are now consistely instantiated also for types
   parallel::distributed::Triangulation and parallel::shared::Triangulation.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -491,12 +491,19 @@ inconvenience this causes.
 
 
 <ol>
-  <li> New: There is now a function Triangulation::get_tria() that
+  <li> New: There is now a function Triangulation::get_triangulation() that
   allows writing code to get at the underlying triangulation for
   everything that looks like a container, i.e., both Triangulation
   or DoFHandler objects.
   <br>
-  (Wolfgang Bangerth, 2015/12/07)
+  (Wolfgang Bangerth, 2015/12/10)
+  </li>
+
+  <li> Deprecated: The functions DoFHandler::get_tria() and
+  hp::DoFHandler::get_tria() were deprecated. UseDoFHandler::get_triangulation() and
+  hp::DoFHandler::get_triangulation() instead.
+  <br>
+  (Wolfgang Bangerth, 2015/12/10)
   </li>
 
   <li> Improved: Many more functions in namespace GridTools and class

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -725,7 +725,7 @@ namespace internal
                  ?
                  typename
                  internal::Triangulation::Iterators<dim,spacedim>::
-                 raw_cell_iterator (&dof_handler.get_tria(),
+                 raw_cell_iterator (&dof_handler.get_triangulation(),
                                     obj_level,
                                     obj_index)->used()
                  :
@@ -733,7 +733,7 @@ namespace internal
                   ?
                   typename
                   internal::Triangulation::Iterators<dim,spacedim>::
-                  raw_line_iterator (&dof_handler.get_tria(),
+                  raw_line_iterator (&dof_handler.get_triangulation(),
                                      obj_level,
                                      obj_index)->used()
                   :
@@ -777,7 +777,7 @@ namespace internal
                  ?
                  typename
                  internal::Triangulation::Iterators<dim,spacedim>::
-                 raw_cell_iterator (&dof_handler.get_tria(),
+                 raw_cell_iterator (&dof_handler.get_triangulation(),
                                     obj_level,
                                     obj_index)->used()
                  :
@@ -785,7 +785,7 @@ namespace internal
                   ?
                   typename
                   internal::Triangulation::Iterators<dim,spacedim>::
-                  raw_line_iterator (&dof_handler.get_tria(),
+                  raw_line_iterator (&dof_handler.get_triangulation(),
                                      obj_level,
                                      obj_index)->used()
                   :

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -798,8 +798,15 @@ public:
 
   /**
    * Return a constant reference to the triangulation underlying this object.
+   *
+   * @deprecated Use get_triangulation() instead.
    */
-  const Triangulation<dim,spacedim> &get_tria () const;
+  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
+
+  /**
+   * Return a constant reference to the triangulation underlying this object.
+   */
+  const Triangulation<dim,spacedim> &get_triangulation () const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -1153,7 +1160,7 @@ template <int dim, int spacedim>
 const IndexSet &
 DoFHandler<dim, spacedim>::locally_owned_mg_dofs(const unsigned int level) const
 {
-  Assert(level < this->get_tria().n_global_levels(), ExcMessage("invalid level in locally_owned_mg_dofs"));
+  Assert(level < this->get_triangulation().n_global_levels(), ExcMessage("invalid level in locally_owned_mg_dofs"));
   return mg_number_cache[level].locally_owned_dofs;
 }
 
@@ -1176,7 +1183,7 @@ template <int dim, int spacedim>
 const std::vector<IndexSet> &
 DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor (const unsigned int level) const
 {
-  Assert(level < this->get_tria().n_global_levels(), ExcMessage("invalid level in locally_owned_mg_dofs_per_processor"));
+  Assert(level < this->get_triangulation().n_global_levels(), ExcMessage("invalid level in locally_owned_mg_dofs_per_processor"));
   return mg_number_cache[level].locally_owned_dofs_per_processor;
 }
 
@@ -1191,6 +1198,7 @@ DoFHandler<dim,spacedim>::get_fe () const
 }
 
 
+
 template <int dim, int spacedim>
 inline
 const Triangulation<dim,spacedim> &
@@ -1199,6 +1207,18 @@ DoFHandler<dim,spacedim>::get_tria () const
   Assert(tria != 0, ExcNotInitialized());
   return *tria;
 }
+
+
+
+template <int dim, int spacedim>
+inline
+const Triangulation<dim,spacedim> &
+DoFHandler<dim,spacedim>::get_triangulation () const
+{
+  Assert(tria != 0, ExcNotInitialized());
+  return *tria;
+}
+
 
 
 template <int dim, int spacedim>

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -756,7 +756,7 @@ namespace DoFRenumbering
    *   renumbered.
    *
    * @pre @p cell_order must have size
-   *   <code>dof_handler.get_tria().n_active_cells()</code>. Every active
+   *   <code>dof_handler.get_triangulation().n_active_cells()</code>. Every active
    *   cell iterator of that triangulation needs to be present in @p cell_order
    *   exactly once.
    */
@@ -790,7 +790,7 @@ namespace DoFRenumbering
    *   renumbered.
    *
    * @pre @p cell_order must have size
-   *   <code>dof_handler.get_tria().n_active_cells()</code>. Every active
+   *   <code>dof_handler.get_triangulation().n_active_cells()</code>. Every active
    *   cell iterator of that triangulation needs to be present in @p cell_order
    *   exactly once.
    * @post For each @p i between zero and <code>dof_handler.n_dofs()</code>,

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2821,14 +2821,14 @@ public:
    * may not only be a triangulation, but also a DoFHandler, for example).
    */
   Triangulation<dim,spacedim> &
-  get_tria ();
+  get_triangulation ();
 
   /**
    * Return a reference to the current object. This is the const-version
    * of the previous function.
    */
   const Triangulation<dim,spacedim> &
-  get_tria () const;
+  get_triangulation () const;
 
 
   /*

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1425,6 +1425,7 @@ public:
 
   typedef typename IteratorSelector::hex_iterator         hex_iterator;
   typedef typename IteratorSelector::active_hex_iterator  active_hex_iterator;
+
   /**
    * A structure that is used as an exception object by the
    * create_triangulation() function to indicate which cells among the coarse
@@ -2810,6 +2811,25 @@ public:
    * subdomain id of those cells that are owned by the current processor.
    */
   virtual types::subdomain_id locally_owned_subdomain () const;
+
+  /**
+   * Return a reference to the current object.
+   *
+   * This doesn't seem to be very useful but allows to write code that
+   * can access the underlying triangulation for anything that satisfies
+   * the @ref GlossMeshAsAContainer "Mesh as a container" concept (which
+   * may not only be a triangulation, but also a DoFHandler, for example).
+   */
+  Triangulation<dim,spacedim> &
+  get_tria ();
+
+  /**
+   * Return a reference to the current object. This is the const-version
+   * of the previous function.
+   */
+  const Triangulation<dim,spacedim> &
+  get_tria () const;
+
 
   /*
    * @}

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -985,7 +985,7 @@ namespace internal
  *           // with the triangulation that we want to be informed about
  *           // mesh refinement
  *           previous_cell = current_cell;
- *           previous_cell.get_tria().signals.post_refinement
+ *           previous_cell->get_triangulation().signals.post_refinement
  *             .connect (std_cxx11::bind (&FEValues<dim>::invalidate_previous_cell,
  *                                        std_cxx11::ref (*this)));
  *         }

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -592,10 +592,16 @@ namespace hp
     const hp::FECollection<dim,spacedim> &get_fe () const;
 
     /**
-     * Return a constant reference to the triangulation underlying this
-     * object.
+     * Return a constant reference to the triangulation underlying this object.
+     *
+     * @deprecated Use get_triangulation() instead.
      */
-    const Triangulation<dim,spacedim> &get_tria () const;
+    const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
+
+    /**
+     * Return a constant reference to the triangulation underlying this object.
+     */
+    const Triangulation<dim,spacedim> &get_triangulation () const;
 
     /**
      * Determine an estimate for the memory consumption (in bytes) of this
@@ -1010,6 +1016,7 @@ namespace hp
   }
 
 
+
   template<int dim, int spacedim>
   inline
   const Triangulation<dim,spacedim> &
@@ -1017,6 +1024,18 @@ namespace hp
   {
     return *tria;
   }
+
+
+
+  template<int dim, int spacedim>
+  inline
+  const Triangulation<dim,spacedim> &
+  DoFHandler<dim,spacedim>::get_triangulation () const
+  {
+    return *tria;
+  }
+
+
 
   template<int dim, int spacedim>
   inline

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1224,7 +1224,7 @@ MatrixFree<dim,Number>::get_cell_iterator(const unsigned int macro_cell_number,
   std::pair<unsigned int,unsigned int> index =
     cell_level_index[macro_cell_number*vectorization_length+vector_number];
   return typename DoFHandler<dim>::cell_iterator
-         (&dofh->get_tria(), index.first, index.second, dofh);
+         (&dofh->get_triangulation(), index.first, index.second, dofh);
 }
 
 
@@ -1252,7 +1252,7 @@ MatrixFree<dim,Number>::get_hp_cell_iterator(const unsigned int macro_cell_numbe
   std::pair<unsigned int,unsigned int> index =
     cell_level_index[macro_cell_number*vectorization_length+vector_number];
   return typename hp::DoFHandler<dim>::cell_iterator
-         (&dofh->get_tria(), index.first, index.second, dofh);
+         (&dofh->get_triangulation(), index.first, index.second, dofh);
 }
 
 

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -133,7 +133,7 @@ internal_reinit(const Mapping<dim>                          &mapping,
       AssertDimension (dof_handler.size(), locally_owned_set.size());
 
       // set variables that are independent of FE
-      internal::assert_communicator_equality (dof_handler[0]->get_tria(),
+      internal::assert_communicator_equality (dof_handler[0]->get_triangulation(),
                                               additional_data.mpi_communicator);
       size_info.communicator = additional_data.mpi_communicator;
       if (Utilities::MPI::job_supports_mpi() == true)
@@ -213,7 +213,7 @@ internal_reinit(const Mapping<dim>                          &mapping,
   // general case?
   if (additional_data.initialize_mapping == true)
     {
-      mapping_info.initialize (dof_handler[0]->get_tria(), cell_level_index,
+      mapping_info.initialize (dof_handler[0]->get_triangulation(), cell_level_index,
                                dof_info[0].cell_active_fe_index, mapping, quad,
                                additional_data.mapping_update_flags);
 
@@ -263,7 +263,7 @@ internal_reinit(const Mapping<dim>                            &mapping,
       AssertDimension (dof_handler.size(), locally_owned_set.size());
 
       // set variables that are independent of FE
-      internal::assert_communicator_equality (dof_handler[0]->get_tria(),
+      internal::assert_communicator_equality (dof_handler[0]->get_triangulation(),
                                               additional_data.mpi_communicator);
       size_info.communicator = additional_data.mpi_communicator;
       if (Utilities::MPI::job_supports_mpi() == true)
@@ -341,7 +341,7 @@ internal_reinit(const Mapping<dim>                            &mapping,
   // determined in @p extract_local_to_global_indices.
   if (additional_data.initialize_mapping == true)
     {
-      mapping_info.initialize (dof_handler[0]->get_tria(), cell_level_index,
+      mapping_info.initialize (dof_handler[0]->get_triangulation(), cell_level_index,
                                dof_info[0].cell_active_fe_index, mapping, quad,
                                additional_data.mapping_update_flags);
 
@@ -396,7 +396,7 @@ initialize_dof_handlers (const std::vector<const DoFHandler<dim>*> &dof_handler,
   const unsigned int n_mpi_procs = size_info.n_procs;
   const unsigned int my_pid = size_info.my_pid;
 
-  const Triangulation<dim> &tria = dof_handlers.dof_handler[0]->get_tria();
+  const Triangulation<dim> &tria = dof_handlers.dof_handler[0]->get_triangulation();
   if (level == numbers::invalid_unsigned_int)
     {
       if (n_mpi_procs == 1)
@@ -445,7 +445,7 @@ initialize_dof_handlers (const std::vector<const hp::DoFHandler<dim>*> &dof_hand
 
   // if we have no level given, use the same as for the standard DoFHandler,
   // otherwise we must loop through the respective level
-  const Triangulation<dim> &tria = dof_handler[0]->get_tria();
+  const Triangulation<dim> &tria = dof_handler[0]->get_triangulation();
 
   if (n_mpi_procs == 1)
     {
@@ -565,7 +565,7 @@ void MatrixFree<dim,Number>::initialize_indices
             {
               const DoFHandler<dim> *dofh = &*dof_handlers.dof_handler[no];
               typename DoFHandler<dim>::active_cell_iterator
-              cell_it (&dofh->get_tria(),
+              cell_it (&dofh->get_triangulation(),
                        cell_level_index[counter].first,
                        cell_level_index[counter].second,
                        dofh);
@@ -582,9 +582,9 @@ void MatrixFree<dim,Number>::initialize_indices
                    dof_handlers.level != numbers::invalid_unsigned_int)
             {
               const DoFHandler<dim> *dofh = dof_handlers.dof_handler[no];
-              AssertIndexRange (dof_handlers.level, dofh->get_tria().n_levels());
+              AssertIndexRange (dof_handlers.level, dofh->get_triangulation().n_levels());
               typename DoFHandler<dim>::cell_iterator
-              cell_it (&dofh->get_tria(),
+              cell_it (&dofh->get_triangulation(),
                        cell_level_index[counter].first,
                        cell_level_index[counter].second,
                        dofh);
@@ -601,7 +601,7 @@ void MatrixFree<dim,Number>::initialize_indices
               const hp::DoFHandler<dim> *dofh =
                 dof_handlers.hp_dof_handler[no];
               typename hp::DoFHandler<dim>::active_cell_iterator
-              cell_it (&dofh->get_tria(),
+              cell_it (&dofh->get_triangulation(),
                        cell_level_index[counter].first,
                        cell_level_index[counter].second,
                        dofh);

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -177,7 +177,7 @@ inline
 void
 MGConstrainedDoFs::initialize(const DoFHandler<dim,spacedim> &dof)
 {
-  const unsigned int nlevels = dof.get_tria().n_global_levels();
+  const unsigned int nlevels = dof.get_triangulation().n_global_levels();
 
   boundary_indices.resize(nlevels);
 

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -85,7 +85,7 @@ namespace
     const unsigned int n_target_blocks = max_block + 1;
 
     std::vector<std::vector<types::global_dof_index> >
-    ndofs(mg_dof.get_tria().n_levels(),
+    ndofs(mg_dof.get_triangulation().n_levels(),
           std::vector<types::global_dof_index>(n_target_blocks));
     MGTools::count_dofs_per_block (mg_dof, ndofs, target_component);
 
@@ -112,7 +112,7 @@ namespace
   {
     const parallel::Triangulation<dim,spacedim> *tria =
       (dynamic_cast<const parallel::Triangulation<dim,spacedim>*>
-       (&mg_dof.get_tria()));
+       (&mg_dof.get_triangulation()));
 
     for (unsigned int level=v.min_level();
          level<=v.max_level(); ++level)
@@ -142,7 +142,7 @@ namespace
   {
     const dealii::parallel::distributed::Triangulation<dim,spacedim> *tria =
       (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-       (&mg_dof.get_tria()));
+       (&mg_dof.get_triangulation()));
     AssertThrow(tria!=NULL, ExcMessage("multigrid with Trilinos vectors only works with distributed Triangulation!"));
 
 #ifdef DEAL_II_WITH_P4EST
@@ -179,7 +179,7 @@ MGTransferPrebuilt<VectorType>::copy_to_mg
   std::cout << "copy_to_mg src " << src.l2_norm() << std::endl;
   MPI_Barrier(MPI_COMM_WORLD);
 #endif
-  for (unsigned int level=mg_dof_handler.get_tria().n_global_levels(); level != 0;)
+  for (unsigned int level=mg_dof_handler.get_triangulation().n_global_levels(); level != 0;)
     {
       --level;
       VectorType &dst_level = dst[level];
@@ -238,7 +238,7 @@ MGTransferPrebuilt<VectorType>::copy_from_mg
   // have fine level basis
   // functions
   dst = 0;
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_global_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_global_levels(); ++level)
     {
 #ifdef DEBUG_OUTPUT
       MPI_Barrier(MPI_COMM_WORLD);
@@ -291,7 +291,7 @@ MGTransferPrebuilt<VectorType>::copy_from_mg_add
   // to the coarse level, but
   // have fine level basis
   // functions
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_global_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_global_levels(); ++level)
     {
       typedef std::vector<std::pair<types::global_dof_index, types::global_dof_index> >::const_iterator dof_pair_iterator;
 

--- a/include/deal.II/multigrid/mg_transfer_block.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_block.templates.h
@@ -44,7 +44,7 @@ MGTransferBlockSelect<number>::copy_from_mg (
   BlockVector<number2>                 &dst,
   const MGLevelObject<Vector<number> > &src) const
 {
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
     for (IT i= copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end(); ++i)
       dst.block(selected_block)(i->first) = src[level](i->second);
@@ -60,7 +60,7 @@ MGTransferBlockSelect<number>::copy_from_mg (
   Vector<number2>                      &dst,
   const MGLevelObject<Vector<number> > &src) const
 {
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
     for (IT i= copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end(); ++i)
       dst(i->first) = src[level](i->second);
@@ -76,7 +76,7 @@ MGTransferBlockSelect<number>::copy_from_mg_add (
   BlockVector<number2>                 &dst,
   const MGLevelObject<Vector<number> > &src) const
 {
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
     for (IT i= copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end(); ++i)
       dst.block(selected_block)(i->first) += src[level](i->second);
@@ -92,7 +92,7 @@ MGTransferBlockSelect<number>::copy_from_mg_add (
   Vector<number2>                      &dst,
   const MGLevelObject<Vector<number> > &src) const
 {
-  for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
     for (IT i= copy_indices[selected_block][level].begin();
          i != copy_indices[selected_block][level].end(); ++i)
       dst(i->first) += src[level](i->second);
@@ -122,7 +122,7 @@ MGTransferBlock<number>::copy_from_mg (
 {
   for (unsigned int block=0; block<selected.size(); ++block)
     if (selected[block])
-      for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+      for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
         for (IT i= copy_indices[block][level].begin();
              i != copy_indices[block][level].end(); ++i)
           dst.block(block)(i->first) = src[level].block(mg_block[block])(i->second);
@@ -140,7 +140,7 @@ MGTransferBlock<number>::copy_from_mg_add (
 {
   for (unsigned int block=0; block<selected.size(); ++block)
     if (selected[block])
-      for (unsigned int level=0; level<mg_dof_handler.get_tria().n_levels(); ++level)
+      for (unsigned int level=0; level<mg_dof_handler.get_triangulation().n_levels(); ++level)
         for (IT i= copy_indices[block][level].begin();
              i != copy_indices[block][level].end(); ++i)
           dst.block(block)(i->first) += src[level].block(mg_block[block])(i->second);

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -433,7 +433,7 @@ Multigrid<VectorType>::Multigrid (const DoFHandler<dim>          &mg_dof_handler
   :
   cycle_type(cycle),
   minlevel(0),
-  maxlevel(mg_dof_handler.get_tria().n_global_levels()-1),
+  maxlevel(mg_dof_handler.get_triangulation().n_global_levels()-1),
   defect(minlevel,maxlevel),
   solution(minlevel,maxlevel),
   t(minlevel,maxlevel),

--- a/include/deal.II/multigrid/sparse_matrix_collection.h
+++ b/include/deal.II/multigrid/sparse_matrix_collection.h
@@ -82,7 +82,7 @@ namespace mg
   void
   SparseMatrixCollection<number>::reinit(const DoFHandlerType &dof_handler)
   {
-    AssertIndexRange(sparsity.max_level(), dof_handler.get_tria().n_levels());
+    AssertIndexRange(sparsity.max_level(), dof_handler.get_triangulation().n_levels());
 
     for (unsigned int level=sparsity.min_level();
          level<=sparsity.max_level(); ++level)

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1058,24 +1058,24 @@ estimate (const Mapping<dim, spacedim>               &mapping,
 {
 #ifdef DEAL_II_WITH_P4EST
   if (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-      (&dof_handler.get_tria())
+      (&dof_handler.get_triangulation())
       != 0)
     Assert ((subdomain_id_ == numbers::invalid_subdomain_id)
             ||
             (subdomain_id_ ==
              dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>&>
-             (dof_handler.get_tria()).locally_owned_subdomain()),
+             (dof_handler.get_triangulation()).locally_owned_subdomain()),
             ExcMessage ("For parallel distributed triangulations, the only "
                         "valid subdomain_id that can be passed here is the "
                         "one that corresponds to the locally owned subdomain id."));
 
   const types::subdomain_id subdomain_id
     = ((dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-        (&dof_handler.get_tria())
+        (&dof_handler.get_triangulation())
         != 0)
        ?
        dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>&>
-       (dof_handler.get_tria()).locally_owned_subdomain()
+       (dof_handler.get_triangulation()).locally_owned_subdomain()
        :
        subdomain_id_);
 #else
@@ -1153,8 +1153,8 @@ estimate (const Mapping<dim, spacedim>               &mapping,
   // reserve one slot for each cell and set it to zero
   for (unsigned int n=0; n<n_solution_vectors; ++n)
     {
-      (*errors[n]).reinit (dof_handler.get_tria().n_active_cells());
-      for (unsigned int i=0; i<dof_handler.get_tria().n_active_cells(); ++i)
+      (*errors[n]).reinit (dof_handler.get_triangulation().n_active_cells());
+      for (unsigned int i=0; i<dof_handler.get_triangulation().n_active_cells(); ++i)
         (*errors[n])(i)=0;
     }
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -717,7 +717,7 @@ namespace VectorTools
             // function to hold on
             // all parts of the boundary
             const std::vector<types::boundary_id>
-            used_boundary_ids = dof.get_tria().get_boundary_ids();
+            used_boundary_ids = dof.get_triangulation().get_boundary_ids();
 
             typename FunctionMap<spacedim>::type boundary_functions;
             for (unsigned int i=0; i<used_boundary_ids.size(); ++i)
@@ -6388,7 +6388,7 @@ namespace VectorTools
                   ExcDimensionMismatch(weight->n_components, n_components));
         }
 
-      difference.reinit (dof.get_tria().n_active_cells());
+      difference.reinit (dof.get_triangulation().n_active_cells());
 
       switch (norm)
         {
@@ -7071,7 +7071,7 @@ namespace VectorTools
     // over the entire domain
     if (const parallel::Triangulation<dim,spacedim> *
         p_triangulation
-        = dynamic_cast<const parallel::Triangulation<dim,spacedim> *>(&dof.get_tria()))
+        = dynamic_cast<const parallel::Triangulation<dim,spacedim> *>(&dof.get_triangulation()))
       {
         // The type used to store the elements of the global vector may be a
         // real or a complex number. Do the global reduction always with real
@@ -7191,7 +7191,7 @@ namespace VectorTools
         // carefully selecting the right components.
 
         FESystem<dim,spacedim> feq(FE_Q<dim,spacedim>(degree), spacedim);
-        DoFHandlerType dhq(dh.get_tria());
+        DoFHandlerType dhq(dh.get_triangulation());
         dhq.distribute_dofs(feq);
         Vector<double> eulerq(dhq.n_dofs());
         const ComponentMask maskq(spacedim, true);

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -49,7 +49,7 @@ namespace parallel
       dof_handler(&dof, typeid(*this).name())
     {
       Assert (dynamic_cast<const parallel::distributed::Triangulation<dim>*>
-              (&dof_handler->get_tria()) != 0,
+              (&dof_handler->get_triangulation()) != 0,
               ExcMessage("parallel::distributed::SolutionTransfer requires a parallel::distributed::Triangulation object."));
     }
 
@@ -82,7 +82,7 @@ namespace parallel
       parallel::distributed::Triangulation<dim,DoFHandlerType::space_dimension> *tria
         = (dynamic_cast<parallel::distributed::Triangulation<dim,DoFHandlerType::space_dimension>*>
            (const_cast<dealii::Triangulation<dim,DoFHandlerType::space_dimension>*>
-            (&dof_handler->get_tria())));
+            (&dof_handler->get_triangulation())));
       Assert (tria != 0, ExcInternalError());
 
       offset
@@ -163,7 +163,7 @@ namespace parallel
       parallel::distributed::Triangulation<dim,DoFHandlerType::space_dimension> *tria
         = (dynamic_cast<parallel::distributed::Triangulation<dim,DoFHandlerType::space_dimension>*>
            (const_cast<dealii::Triangulation<dim,DoFHandlerType::space_dimension>*>
-            (&dof_handler->get_tria())));
+            (&dof_handler->get_triangulation())));
       Assert (tria != 0, ExcInternalError());
 
       tria->notify_ready_to_unpack(offset,

--- a/source/dofs/block_info.cc
+++ b/source/dofs/block_info.cc
@@ -37,7 +37,7 @@ BlockInfo::initialize(const DoFHandler<dim, spacedim> &dof, bool levels_only, bo
 
   if (!active_only && dof.has_level_dofs())
     {
-      std::vector<std::vector<types::global_dof_index> > sizes (dof.get_tria ().n_levels ());
+      std::vector<std::vector<types::global_dof_index> > sizes (dof.get_triangulation().n_levels ());
 
       for (unsigned int i = 0; i < sizes.size (); ++i)
         sizes[i].resize (dof.get_fe ().n_blocks ());

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -375,10 +375,10 @@ namespace internal
       static
       void reserve_space_mg (DoFHandler<1, spacedim> &dof_handler)
       {
-        Assert (dof_handler.get_tria ().n_levels () > 0, ExcMessage ("Invalid triangulation"));
+        Assert (dof_handler.get_triangulation().n_levels () > 0, ExcMessage ("Invalid triangulation"));
         dof_handler.clear_mg_space ();
 
-        const dealii::Triangulation<1, spacedim> &tria = dof_handler.get_tria ();
+        const dealii::Triangulation<1, spacedim> &tria = dof_handler.get_triangulation();
         const unsigned int &dofs_per_line = dof_handler.get_fe ().dofs_per_line;
         const unsigned int &n_levels = tria.n_levels ();
 
@@ -431,11 +431,11 @@ namespace internal
       static
       void reserve_space_mg (DoFHandler<2, spacedim> &dof_handler)
       {
-        Assert (dof_handler.get_tria ().n_levels () > 0, ExcMessage ("Invalid triangulation"));
+        Assert (dof_handler.get_triangulation().n_levels () > 0, ExcMessage ("Invalid triangulation"));
         dof_handler.clear_mg_space ();
 
         const dealii::FiniteElement<2, spacedim> &fe = dof_handler.get_fe ();
-        const dealii::Triangulation<2, spacedim> &tria = dof_handler.get_tria ();
+        const dealii::Triangulation<2, spacedim> &tria = dof_handler.get_triangulation();
         const unsigned int &n_levels = tria.n_levels ();
 
         for (unsigned int i = 0; i < n_levels; ++i)
@@ -490,11 +490,11 @@ namespace internal
       static
       void reserve_space_mg (DoFHandler<3, spacedim> &dof_handler)
       {
-        Assert (dof_handler.get_tria ().n_levels () > 0, ExcMessage ("Invalid triangulation"));
+        Assert (dof_handler.get_triangulation().n_levels () > 0, ExcMessage ("Invalid triangulation"));
         dof_handler.clear_mg_space ();
 
         const dealii::FiniteElement<3, spacedim> &fe = dof_handler.get_fe ();
-        const dealii::Triangulation<3, spacedim> &tria = dof_handler.get_tria ();
+        const dealii::Triangulation<3, spacedim> &tria = dof_handler.get_triangulation();
         const unsigned int &n_levels = tria.n_levels ();
 
         for (unsigned int i = 0; i < n_levels; ++i)
@@ -832,8 +832,8 @@ template <int dim, int spacedim>
 typename DoFHandler<dim,spacedim>::cell_iterator
 DoFHandler<dim,spacedim>::begin (const unsigned int level) const
 {
-  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_tria().begin(level);
-  if (cell == this->get_tria().end(level))
+  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_triangulation().begin(level);
+  if (cell == this->get_triangulation().end(level))
     return end(level);
   return cell_iterator (*cell, this);
 }
@@ -860,7 +860,7 @@ template <int dim, int spacedim>
 typename DoFHandler<dim,spacedim>::cell_iterator
 DoFHandler<dim,spacedim>::end () const
 {
-  return cell_iterator (&this->get_tria(),
+  return cell_iterator (&this->get_triangulation(),
                         -1,
                         -1,
                         this);
@@ -871,7 +871,7 @@ template <int dim, int spacedim>
 typename DoFHandler<dim,spacedim>::cell_iterator
 DoFHandler<dim,spacedim>::end (const unsigned int level) const
 {
-  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_tria().end(level);
+  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_triangulation().end(level);
   if (cell.state() != IteratorState::valid)
     return end();
   return cell_iterator (*cell, this);
@@ -882,7 +882,7 @@ template <int dim, int spacedim>
 typename DoFHandler<dim, spacedim>::active_cell_iterator
 DoFHandler<dim, spacedim>::end_active (const unsigned int level) const
 {
-  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_tria().end_active(level);
+  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_triangulation().end_active(level);
   if (cell.state() != IteratorState::valid)
     return active_cell_iterator(end());
   return active_cell_iterator (*cell, this);
@@ -896,8 +896,8 @@ DoFHandler<dim, spacedim>::begin_mg (const unsigned int level) const
 {
   // Assert(this->has_level_dofs(), ExcMessage("You can only iterate over mg "
   //     "levels if mg dofs got distributed."));
-  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_tria().begin(level);
-  if (cell == this->get_tria().end(level))
+  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_triangulation().begin(level);
+  if (cell == this->get_triangulation().end(level))
     return end_mg(level);
   return level_cell_iterator (*cell, this);
 }
@@ -909,7 +909,7 @@ DoFHandler<dim, spacedim>::end_mg (const unsigned int level) const
 {
   // Assert(this->has_level_dofs(), ExcMessage("You can only iterate over mg "
   //     "levels if mg dofs got distributed."));
-  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_tria().end(level);
+  typename Triangulation<dim,spacedim>::cell_iterator cell = this->get_triangulation().end(level);
   if (cell.state() != IteratorState::valid)
     return end();
   return level_cell_iterator (*cell, this);
@@ -920,7 +920,7 @@ template <int dim, int spacedim>
 typename DoFHandler<dim, spacedim>::level_cell_iterator
 DoFHandler<dim, spacedim>::end_mg () const
 {
-  return level_cell_iterator (&this->get_tria(), -1, -1, this);
+  return level_cell_iterator (&this->get_triangulation(), -1, -1, this);
 }
 
 
@@ -1427,8 +1427,8 @@ void DoFHandler<2>::renumber_dofs (const unsigned int  level,
     {
       // save user flags as they will be modified
       std::vector<bool> user_flags;
-      this->get_tria().save_user_flags(user_flags);
-      const_cast<Triangulation<2> &>(this->get_tria()).clear_user_flags ();
+      this->get_triangulation().save_user_flags(user_flags);
+      const_cast<Triangulation<2> &>(this->get_triangulation()).clear_user_flags ();
 
       // flag all lines adjacent to cells of the current
       // level, as those lines logically belong to the same
@@ -1448,7 +1448,7 @@ void DoFHandler<2>::renumber_dofs (const unsigned int  level,
               cell->line(l)->clear_user_flag();
             }
       // finally, restore user flags
-      const_cast<Triangulation<2> &>(this->get_tria()).load_user_flags (user_flags);
+      const_cast<Triangulation<2> &>(this->get_triangulation()).load_user_flags (user_flags);
     }
 
   for (std::vector<types::global_dof_index>::iterator i=mg_levels[level]->dof_object.dofs.begin();
@@ -1487,8 +1487,8 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
     {
       // save user flags as they will be modified
       std::vector<bool> user_flags;
-      this->get_tria().save_user_flags(user_flags);
-      const_cast<Triangulation<3> &>(this->get_tria()).clear_user_flags ();
+      this->get_triangulation().save_user_flags(user_flags);
+      const_cast<Triangulation<3> &>(this->get_triangulation()).clear_user_flags ();
 
       // flag all lines adjacent to cells of the current
       // level, as those lines logically belong to the same
@@ -1509,7 +1509,7 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
               cell->line(l)->clear_user_flag();
             }
       // finally, restore user flags
-      const_cast<Triangulation<3> &>(this->get_tria()).load_user_flags (user_flags);
+      const_cast<Triangulation<3> &>(this->get_triangulation()).load_user_flags (user_flags);
     }
 
   // QUAD DoFs
@@ -1517,8 +1517,8 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
     {
       // save user flags as they will be modified
       std::vector<bool> user_flags;
-      this->get_tria().save_user_flags(user_flags);
-      const_cast<Triangulation<3> &>(this->get_tria()).clear_user_flags ();
+      this->get_triangulation().save_user_flags(user_flags);
+      const_cast<Triangulation<3> &>(this->get_triangulation()).clear_user_flags ();
 
       // flag all quads adjacent to cells of the current
       // level, as those lines logically belong to the same
@@ -1538,7 +1538,7 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
               cell->quad(q)->clear_user_flag();
             }
       // finally, restore user flags
-      const_cast<Triangulation<3> &>(this->get_tria()).load_user_flags (user_flags);
+      const_cast<Triangulation<3> &>(this->get_triangulation()).load_user_flags (user_flags);
     }
 
   //HEX DoFs

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -231,7 +231,7 @@ namespace internal
                          DoFHandler<dim,spacedim> &dof_handler)
         {
           const dealii::Triangulation<dim,spacedim> &tria
-            = dof_handler.get_tria();
+            = dof_handler.get_triangulation();
           Assert (tria.n_levels() > 0, ExcMessage("Empty triangulation"));
 
           // Clear user flags because we will need them. But first we save
@@ -468,7 +468,7 @@ namespace internal
                                   const unsigned int level)
         {
           const dealii::Triangulation<dim,spacedim> &tria
-            = dof_handler.get_tria();
+            = dof_handler.get_triangulation();
           Assert (tria.n_levels() > 0, ExcMessage("Empty triangulation"));
           if (level>=tria.n_levels())
             return 0; //this is allowed for multigrid
@@ -558,7 +558,7 @@ namespace internal
               // invalid_dof_index:
               // check if this one
               // really is unused
-              Assert (dof_handler.get_tria()
+              Assert (dof_handler.get_triangulation()
                       .vertex_used((i-dof_handler.vertex_dofs.begin()) /
                                    dof_handler.selected_fe->dofs_per_vertex)
                       == false,
@@ -656,7 +656,7 @@ namespace internal
               // if index is invalid_dof_index:
               // check if this one really is
               // unused
-              Assert (dof_handler.get_tria()
+              Assert (dof_handler.get_triangulation()
                       .vertex_used((i-dof_handler.vertex_dofs.begin()) /
                                    dof_handler.selected_fe->dofs_per_vertex)
                       == false,
@@ -699,7 +699,7 @@ namespace internal
                           const unsigned int level,
                           const bool check_validity)
         {
-          if (level>=dof_handler.get_tria().n_levels())
+          if (level>=dof_handler.get_triangulation().n_levels())
             return;
           for (typename std::vector<typename DoFHandler<2,spacedim>::MGVertexDoFs>::iterator i=dof_handler.mg_vertex_dofs.begin();
                i!=dof_handler.mg_vertex_dofs.end(); ++i)
@@ -724,8 +724,8 @@ namespace internal
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
-              dof_handler.get_tria().save_user_flags(user_flags);
-              const_cast<dealii::Triangulation<2,spacedim> &>(dof_handler.get_tria()).clear_user_flags ();
+              dof_handler.get_triangulation().save_user_flags(user_flags);
+              const_cast<dealii::Triangulation<2,spacedim> &>(dof_handler.get_triangulation()).clear_user_flags ();
 
               // flag all lines adjacent to cells of the current
               // level, as those lines logically belong to the same
@@ -754,7 +754,7 @@ namespace internal
                       cell->line(l)->clear_user_flag();
                     }
               // finally, restore user flags
-              const_cast<dealii::Triangulation<2,spacedim> &>(dof_handler.get_tria()).load_user_flags (user_flags);
+              const_cast<dealii::Triangulation<2,spacedim> &>(dof_handler.get_triangulation()).load_user_flags (user_flags);
             }
 
           for (std::vector<types::global_dof_index>::iterator i=dof_handler.mg_levels[level]->dof_object.dofs.begin();
@@ -801,7 +801,7 @@ namespace internal
               // if index is invalid_dof_index:
               // check if this one really is
               // unused
-              Assert (dof_handler.get_tria()
+              Assert (dof_handler.get_triangulation()
                       .vertex_used((i-dof_handler.vertex_dofs.begin()) /
                                    dof_handler.selected_fe->dofs_per_vertex)
                       == false,
@@ -851,7 +851,7 @@ namespace internal
                           const unsigned int level,
                           const bool check_validity)
         {
-          if (level>=dof_handler.get_tria().n_levels())
+          if (level>=dof_handler.get_triangulation().n_levels())
             return;
           for (typename std::vector<typename DoFHandler<3,spacedim>::MGVertexDoFs>::iterator i=dof_handler.mg_vertex_dofs.begin();
                i!=dof_handler.mg_vertex_dofs.end(); ++i)
@@ -877,8 +877,8 @@ namespace internal
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
-              dof_handler.get_tria().save_user_flags(user_flags);
-              const_cast<dealii::Triangulation<3,spacedim> &>(dof_handler.get_tria()).clear_user_flags ();
+              dof_handler.get_triangulation().save_user_flags(user_flags);
+              const_cast<dealii::Triangulation<3,spacedim> &>(dof_handler.get_triangulation()).clear_user_flags ();
 
               // flag all lines adjacent to cells of the current level, as
               // those lines logically belong to the same level as the cell,
@@ -933,7 +933,7 @@ namespace internal
                     }
 
               // finally, restore user flags
-              const_cast<dealii::Triangulation<3,spacedim> &>(dof_handler.get_tria()).load_user_flags (user_flags);
+              const_cast<dealii::Triangulation<3,spacedim> &>(dof_handler.get_triangulation()).load_user_flags (user_flags);
             }
 
           for (std::vector<types::global_dof_index>::iterator i=dof_handler.mg_levels[level]->dof_object.dofs.begin();
@@ -1006,10 +1006,10 @@ namespace internal
       {
         std::vector<bool> user_flags;
 
-        dof_handler.get_tria().save_user_flags (user_flags);
-        const_cast<dealii::Triangulation<dim, spacedim>&>(dof_handler.get_tria()).clear_user_flags ();
+        dof_handler.get_triangulation().save_user_flags (user_flags);
+        const_cast<dealii::Triangulation<dim, spacedim>&>(dof_handler.get_triangulation()).clear_user_flags ();
 
-        for (unsigned int level = 0; level < dof_handler.get_tria().n_levels(); ++level)
+        for (unsigned int level = 0; level < dof_handler.get_triangulation().n_levels(); ++level)
           {
             types::global_dof_index next_free_dof = Implementation::distribute_dofs_on_level(0, numbers::invalid_subdomain_id, dof_handler, level);
 
@@ -1021,7 +1021,7 @@ namespace internal
             number_caches[level].n_locally_owned_dofs_per_processor.resize(1);
             number_caches[level].n_locally_owned_dofs_per_processor[0] = next_free_dof;
           }
-        const_cast<dealii::Triangulation<dim, spacedim>&>(dof_handler.get_tria()).load_user_flags (user_flags);
+        const_cast<dealii::Triangulation<dim, spacedim>&>(dof_handler.get_triangulation()).load_user_flags (user_flags);
       }
 
       template <int dim, int spacedim>
@@ -1073,11 +1073,11 @@ namespace internal
         // Namely, we first restore original partition (without artificial cells)
         // and then turn artificial cells on at the end of this function.
         const parallel::shared::Triangulation<dim, spacedim> *tr =
-          (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_tria ()));
+          (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()));
         Assert(tr != 0, ExcInternalError());
         typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator
-        cell = dof_handler.get_tria().begin_active(),
-        endc = dof_handler.get_tria().end();
+        cell = dof_handler.get_triangulation().begin_active(),
+        endc = dof_handler.get_triangulation().end();
         std::vector<types::subdomain_id> current_subdomain_ids(tr->n_active_cells());
         const std::vector<types::subdomain_id> &true_subdomain_ids = tr->get_true_subdomain_ids_of_cells();
         if (tr->with_artificial_cells())
@@ -1096,11 +1096,11 @@ namespace internal
             cell->set_subdomain_id(true_subdomain_ids[index]);
 
         number_cache.locally_owned_dofs_per_processor = DoFTools::locally_owned_dofs_per_subdomain (dof_handler);
-        number_cache.locally_owned_dofs = number_cache.locally_owned_dofs_per_processor[dof_handler.get_tria().locally_owned_subdomain()];
+        number_cache.locally_owned_dofs = number_cache.locally_owned_dofs_per_processor[dof_handler.get_triangulation().locally_owned_subdomain()];
         number_cache.n_locally_owned_dofs_per_processor.resize (number_cache.locally_owned_dofs_per_processor.size());
         for (unsigned int i = 0; i < number_cache.n_locally_owned_dofs_per_processor.size(); i++)
           number_cache.n_locally_owned_dofs_per_processor[i] = number_cache.locally_owned_dofs_per_processor[i].n_elements();
-        number_cache.n_locally_owned_dofs = number_cache.n_locally_owned_dofs_per_processor[dof_handler.get_tria().locally_owned_subdomain()];
+        number_cache.n_locally_owned_dofs = number_cache.n_locally_owned_dofs_per_processor[dof_handler.get_triangulation().locally_owned_subdomain()];
 
         // restore current subdomain ids
         cell = tr->begin_active();
@@ -1139,11 +1139,11 @@ namespace internal
         // Similar to distribute_dofs() we need to have a special treatment in
         // case artificial cells are present.
         const parallel::shared::Triangulation<dim, spacedim> *tr =
-          (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_tria ()));
+          (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()));
         Assert(tr != 0, ExcInternalError());
         typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator
-        cell = dof_handler.get_tria().begin_active(),
-        endc = dof_handler.get_tria().end();
+        cell = dof_handler.get_triangulation().begin_active(),
+        endc = dof_handler.get_triangulation().end();
         std::vector<types::subdomain_id> current_subdomain_ids(tr->n_active_cells());
         const std::vector<types::subdomain_id> &true_subdomain_ids = tr->get_true_subdomain_ids_of_cells();
         if (tr->with_artificial_cells())
@@ -1168,7 +1168,7 @@ namespace internal
             const unsigned int n_cpu = Utilities::MPI::n_mpi_processes (tr->get_communicator ());
             std::vector<types::global_dof_index> gathered_new_numbers (dof_handler.n_dofs (), 0);
             Assert(Utilities::MPI::this_mpi_process (tr->get_communicator ()) ==
-                   dof_handler.get_tria ().locally_owned_subdomain (),
+                   dof_handler.get_triangulation().locally_owned_subdomain (),
                    ExcInternalError())
 
             //gather new numbers among processors into one vector
@@ -1243,7 +1243,7 @@ namespace internal
         number_cache.locally_owned_dofs_per_processor =
           DoFTools::locally_owned_dofs_per_subdomain (dof_handler);
         number_cache.locally_owned_dofs =
-          number_cache.locally_owned_dofs_per_processor[dof_handler.get_tria ().locally_owned_subdomain ()];
+          number_cache.locally_owned_dofs_per_processor[dof_handler.get_triangulation().locally_owned_subdomain ()];
         // sequential renumbering returns a vector of size 1 here,
         // correct this:
         number_cache.n_locally_owned_dofs_per_processor.resize(number_cache.locally_owned_dofs_per_processor.size());
@@ -1252,7 +1252,7 @@ namespace internal
           number_cache.n_locally_owned_dofs_per_processor[i] = number_cache.locally_owned_dofs_per_processor[i].n_elements ();
 
         number_cache.n_locally_owned_dofs =
-          number_cache.n_locally_owned_dofs_per_processor[dof_handler.get_tria ().locally_owned_subdomain ()];
+          number_cache.n_locally_owned_dofs_per_processor[dof_handler.get_triangulation().locally_owned_subdomain ()];
 
         // restore artificial cells
         cell = tr->begin_active();
@@ -1739,7 +1739,7 @@ namespace internal
 
           const parallel::distributed::Triangulation< dim, spacedim > *tr
             = (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-               (&dof_handler.get_tria()));
+               (&dof_handler.get_triangulation()));
           Assert (tr != 0, ExcInternalError());
 
           // now collect cells and their
@@ -1866,7 +1866,7 @@ namespace internal
               for (unsigned int c=0; c<cells; ++c, dofs+=1+dofs[0])
                 {
                   typename DoFHandler<dim,spacedim>::level_cell_iterator
-                  cell (&dof_handler.get_tria(),
+                  cell (&dof_handler.get_triangulation(),
                         0,
                         p4est_tree_to_coarse_cell_permutation[treeindex[c]],
                         &dof_handler);
@@ -1970,7 +1970,7 @@ namespace internal
 
           const parallel::distributed::Triangulation< dim, spacedim > *tr
             = (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-               (&dof_handler.get_tria()));
+               (&dof_handler.get_triangulation()));
           Assert (tr != 0, ExcInternalError());
 
           // now collect cells and their
@@ -2048,7 +2048,7 @@ namespace internal
                     {
                       //artificial
                     }
-                  else if (cell->level_subdomain_id()==dof_handler.get_tria().locally_owned_subdomain())
+                  else if (cell->level_subdomain_id()==dof_handler.get_triangulation().locally_owned_subdomain())
                     {
                       //own
                       local_dof_indices.resize (cell->get_fe().dofs_per_cell);
@@ -2109,7 +2109,7 @@ namespace internal
               for (unsigned int c=0; c<cells; ++c, dofs+=1+dofs[0])
                 {
                   typename DoFHandler<dim,spacedim>::level_cell_iterator
-                  cell (&dof_handler.get_tria(),
+                  cell (&dof_handler.get_triangulation(),
                         0,
                         p4est_tree_to_coarse_cell_permutation[treeindex[c]],
                         &dof_handler);
@@ -2194,7 +2194,7 @@ namespace internal
         parallel::distributed::Triangulation< dim, spacedim > *tr
           = (dynamic_cast<parallel::distributed::Triangulation<dim,spacedim>*>
              (const_cast<dealii::Triangulation< dim, spacedim >*>
-              (&dof_handler.get_tria())));
+              (&dof_handler.get_triangulation())));
         Assert (tr != 0, ExcInternalError());
 
         const unsigned int
@@ -2416,7 +2416,7 @@ namespace internal
         parallel::distributed::Triangulation< dim, spacedim > *tr
           = (dynamic_cast<parallel::distributed::Triangulation<dim,spacedim>*>
              (const_cast<dealii::Triangulation< dim, spacedim >*>
-              (&dof_handler.get_tria())));
+              (&dof_handler.get_triangulation())));
         Assert (tr != 0, ExcInternalError());
 
         AssertThrow(
@@ -2427,7 +2427,7 @@ namespace internal
         const unsigned int
         n_cpus = Utilities::MPI::n_mpi_processes (tr->get_communicator());
 
-        unsigned int n_levels = Utilities::MPI::max(dof_handler.get_tria().n_levels(), tr->get_communicator());
+        unsigned int n_levels = Utilities::MPI::max(dof_handler.get_triangulation().n_levels(), tr->get_communicator());
 
         for (unsigned int level = 0; level < n_levels; ++level)
           {
@@ -2783,7 +2783,7 @@ namespace internal
           parallel::distributed::Triangulation< dim, spacedim > *tr
             = (dynamic_cast<parallel::distributed::Triangulation<dim,spacedim>*>
                (const_cast<dealii::Triangulation< dim, spacedim >*>
-                (&dof_handler.get_tria())));
+                (&dof_handler.get_triangulation())));
           Assert (tr != 0, ExcInternalError());
 
           std::vector<bool> user_flags;

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -529,7 +529,7 @@ namespace DoFRenumbering
 
     dof_handler.renumber_dofs (renumbering);
 
-    // for (unsigned int level=0;level<dof_handler.get_tria().n_levels();++level)
+    // for (unsigned int level=0;level<dof_handler.get_triangulation().n_levels();++level)
     //   if (dof_handler.n_dofs(level) != numbers::invalid_dof_index)
     //  component_wise(dof_handler, level, component_order_arg);
   }
@@ -752,7 +752,7 @@ namespace DoFRenumbering
 
     if (const parallel::Triangulation<dim,spacedim> *tria
         = (dynamic_cast<const parallel::Triangulation<dim,spacedim>*>
-           (&start->get_dof_handler().get_tria())))
+           (&start->get_dof_handler().get_triangulation())))
       {
 #ifdef DEAL_II_WITH_MPI
         std::vector<types::global_dof_index> local_dof_count(n_buckets);
@@ -1039,7 +1039,7 @@ namespace DoFRenumbering
 
     if (const parallel::Triangulation<dim,spacedim> *tria
         = (dynamic_cast<const parallel::Triangulation<dim,spacedim>*>
-           (&start->get_dof_handler().get_tria())))
+           (&start->get_dof_handler().get_triangulation())))
       {
 #ifdef DEAL_II_WITH_MPI
         std::vector<types::global_dof_index> local_dof_count(n_buckets);
@@ -1188,7 +1188,7 @@ namespace DoFRenumbering
 
     const parallel::distributed::Triangulation<dim> *tria
       = dynamic_cast<const parallel::distributed::Triangulation<dim>*>
-        (&dof_handler.get_tria());
+        (&dof_handler.get_triangulation());
 
     if (tria)
       {
@@ -1381,9 +1381,9 @@ namespace DoFRenumbering
    const DoFHandlerType                                                      &dof,
    const typename std::vector<typename DoFHandlerType::active_cell_iterator> &cells)
   {
-    Assert(cells.size() == dof.get_tria().n_active_cells(),
+    Assert(cells.size() == dof.get_triangulation().n_active_cells(),
            ExcDimensionMismatch(cells.size(),
-                                dof.get_tria().n_active_cells()));
+                                dof.get_triangulation().n_active_cells()));
 
     types::global_dof_index n_global_dofs = dof.n_dofs();
 
@@ -1469,9 +1469,9 @@ namespace DoFRenumbering
    const unsigned int                                                        level,
    const typename std::vector<typename DoFHandlerType::level_cell_iterator> &cells)
   {
-    Assert(cells.size() == dof.get_tria().n_cells(level),
+    Assert(cells.size() == dof.get_triangulation().n_cells(level),
            ExcDimensionMismatch(cells.size(),
-                                dof.get_tria().n_cells(level)));
+                                dof.get_triangulation().n_cells(level)));
     Assert (new_order.size() == dof.n_dofs(level),
             ExcDimensionMismatch(new_order.size(), dof.n_dofs(level)));
     Assert (reverse.size() == dof.n_dofs(level),
@@ -1527,7 +1527,7 @@ namespace DoFRenumbering
     if (dof_wise_renumbering == false)
       {
         std::vector<typename DoFHandlerType::active_cell_iterator> ordered_cells;
-        ordered_cells.reserve(dof.get_tria().n_active_cells());
+        ordered_cells.reserve(dof.get_triangulation().n_active_cells());
         const CompareDownstream<typename DoFHandlerType::active_cell_iterator,
               DoFHandlerType::space_dimension> comparator(direction);
 
@@ -1635,7 +1635,7 @@ namespace DoFRenumbering
     if (dof_wise_renumbering == false)
       {
         std::vector<typename DoFHandlerType::level_cell_iterator> ordered_cells;
-        ordered_cells.reserve (dof.get_tria().n_cells(level));
+        ordered_cells.reserve (dof.get_triangulation().n_cells(level));
         const CompareDownstream<typename DoFHandlerType::level_cell_iterator,
               DoFHandlerType::space_dimension> comparator(direction);
 
@@ -1794,7 +1794,7 @@ namespace DoFRenumbering
    const bool                                    counter)
   {
     std::vector<typename DoFHandlerType::active_cell_iterator> ordered_cells;
-    ordered_cells.reserve (dof.get_tria().n_active_cells());
+    ordered_cells.reserve (dof.get_triangulation().n_active_cells());
     internal::ClockCells<DoFHandlerType::space_dimension> comparator(center, counter);
 
     typename DoFHandlerType::active_cell_iterator p = dof.begin_active();
@@ -1820,7 +1820,7 @@ namespace DoFRenumbering
                      const bool                                    counter)
   {
     std::vector<typename DoFHandlerType::level_cell_iterator> ordered_cells;
-    ordered_cells.reserve(dof.get_tria().n_active_cells());
+    ordered_cells.reserve(dof.get_triangulation().n_active_cells());
     internal::ClockCells<DoFHandlerType::space_dimension> comparator(center, counter);
 
     typename DoFHandlerType::level_cell_iterator p = dof.begin(level);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -258,7 +258,7 @@ namespace DoFTools
   {
     const unsigned int dim = DoFHandlerType::dimension;
     const unsigned int spacedim = DoFHandlerType::space_dimension;
-    const Triangulation<dim,spacedim> &tria = dof_handler.get_tria();
+    const Triangulation<dim,spacedim> &tria = dof_handler.get_triangulation();
     (void)tria;
 
     AssertDimension (cell_data.size(), tria.n_active_cells());
@@ -522,7 +522,7 @@ namespace DoFTools
                          const std::set<types::boundary_id> &boundary_ids)
   {
     Assert ((dynamic_cast<const parallel::distributed::Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
-             (&dof_handler.get_tria())
+             (&dof_handler.get_triangulation())
              == 0),
             ExcMessage ("This function can not be used with distributed triangulations."
                         "See the documentation for more information."));
@@ -1005,7 +1005,7 @@ namespace DoFTools
         const types::subdomain_id id = cell->level_subdomain_id();
 
         // skip artificial and own cells (only look at ghost cells)
-        if (id == dof_handler.get_tria().locally_owned_subdomain()
+        if (id == dof_handler.get_triangulation().locally_owned_subdomain()
             || id == numbers::artificial_subdomain_id)
           continue;
 
@@ -1116,7 +1116,7 @@ namespace DoFTools
   get_active_fe_indices (const DoFHandlerType      &dof_handler,
                          std::vector<unsigned int> &active_fe_indices)
   {
-    AssertDimension (active_fe_indices.size(), dof_handler.get_tria().n_active_cells());
+    AssertDimension (active_fe_indices.size(), dof_handler.get_triangulation().n_active_cells());
 
     typename DoFHandlerType::active_cell_iterator
     cell = dof_handler.begin_active(),
@@ -1133,7 +1133,7 @@ namespace DoFTools
     // ask is for its locally owned subdomain
     Assert ((dynamic_cast<const parallel::distributed::
              Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> *>
-             (&dof_handler.get_tria()) == 0),
+             (&dof_handler.get_triangulation()) == 0),
             ExcMessage ("For parallel::distributed::Triangulation objects and "
                         "associated DoF handler objects, asking for any information "
                         "related to a subdomain other than the locally owned one does "
@@ -1192,7 +1192,7 @@ namespace DoFTools
     // ask is for its locally owned subdomain
     Assert ((dynamic_cast<const parallel::distributed::
              Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> *>
-             (&dof_handler.get_tria()) == 0),
+             (&dof_handler.get_triangulation()) == 0),
             ExcMessage ("For parallel::distributed::Triangulation objects and "
                         "associated DoF handler objects, asking for any information "
                         "related to a subdomain other than the locally owned one does "
@@ -1256,7 +1256,7 @@ namespace DoFTools
     // ask is for its locally owned subdomain
     Assert ((dynamic_cast<const parallel::distributed::
              Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> *>
-             (&dof_handler.get_tria()) == 0),
+             (&dof_handler.get_triangulation()) == 0),
             ExcMessage ("For parallel::distributed::Triangulation objects and "
                         "associated DoF handler objects, asking for any subdomain other "
                         "than the locally owned one does not make sense."));
@@ -1273,10 +1273,10 @@ namespace DoFTools
     // with possibly artifical cells, we need to take "true" subdomain IDs (i.e. without
     // artificial cells). Otherwise we are good to use subdomain_id as stored
     // in cell->subdomain_id().
-    std::vector<types::subdomain_id> cell_owners (dof_handler.get_tria().n_active_cells());
+    std::vector<types::subdomain_id> cell_owners (dof_handler.get_triangulation().n_active_cells());
     if (const parallel::shared::Triangulation<DoFHandlerType::dimension, DoFHandlerType::space_dimension>
         *tr = (dynamic_cast<const parallel::shared::Triangulation<DoFHandlerType::dimension,
-               DoFHandlerType::space_dimension>*> (&dof_handler.get_tria ())))
+               DoFHandlerType::space_dimension>*> (&dof_handler.get_triangulation())))
       {
         cell_owners = tr->get_true_subdomain_ids_of_cells();
         Assert (tr->get_true_subdomain_ids_of_cells().size() == tr->n_active_cells(),
@@ -1362,9 +1362,9 @@ namespace DoFTools
     // If we have a distributed::Triangulation only allow locally_owned
     // subdomain.
     Assert (
-      (dof_handler.get_tria().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof_handler.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
       ||
-      (subdomain == dof_handler.get_tria().locally_owned_subdomain()),
+      (subdomain == dof_handler.get_triangulation().locally_owned_subdomain()),
       ExcMessage ("For parallel::distributed::Triangulation objects and "
                   "associated DoF handler objects, asking for any subdomain other "
                   "than the locally owned one does not make sense."));
@@ -1429,8 +1429,8 @@ namespace DoFTools
       bool found = false;
       for (typename Triangulation<DoFHandlerType::dimension,
            DoFHandlerType::space_dimension>::active_cell_iterator
-           cell=dof_handler.get_tria().begin_active();
-           cell!=dof_handler.get_tria().end(); ++cell)
+           cell=dof_handler.get_triangulation().begin_active();
+           cell!=dof_handler.get_triangulation().end(); ++cell)
         if (cell->subdomain_id() == subdomain)
           {
             found = true;
@@ -1643,7 +1643,7 @@ namespace DoFTools
 
     if (const parallel::Triangulation<dim,spacedim> *tria
         = (dynamic_cast<const parallel::Triangulation<dim,spacedim>*>
-           (&dof_handler.get_tria())))
+           (&dof_handler.get_triangulation())))
       {
         std::vector<types::global_dof_index> local_dof_count = dofs_per_component;
 
@@ -1721,7 +1721,7 @@ namespace DoFTools
         // this information from all processors
         if (const parallel::Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> *tria
             = (dynamic_cast<const parallel::Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
-               (&dof_handler.get_tria())))
+               (&dof_handler.get_triangulation())))
           {
             std::vector<types::global_dof_index> local_dof_count = dofs_per_block;
             MPI_Allreduce ( &local_dof_count[0], &dofs_per_block[0],
@@ -1904,7 +1904,7 @@ namespace DoFTools
   {
     AssertDimension(support_points.size(), dof_handler.n_dofs());
     Assert ((dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-             (&dof_handler.get_tria())
+             (&dof_handler.get_triangulation())
              ==
              0),
             ExcMessage ("This function can not be used with distributed triangulations."
@@ -1928,7 +1928,7 @@ namespace DoFTools
   {
     AssertDimension(support_points.size(), dof_handler.n_dofs());
     Assert ((dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-             (&dof_handler.get_tria())
+             (&dof_handler.get_triangulation())
              ==
              0),
             ExcMessage ("This function can not be used with distributed triangulations."
@@ -2116,8 +2116,8 @@ namespace DoFTools
                            const bool            interior_dofs_only,
                            const bool            boundary_dofs)
   {
-    Assert(level > 0 && level < dof_handler.get_tria().n_levels(),
-           ExcIndexRange(level, 1, dof_handler.get_tria().n_levels()));
+    Assert(level > 0 && level < dof_handler.get_triangulation().n_levels(),
+           ExcIndexRange(level, 1, dof_handler.get_triangulation().n_levels()));
 
     typename DoFHandlerType::level_cell_iterator pcell = dof_handler.begin(level-1);
     typename DoFHandlerType::level_cell_iterator endc = dof_handler.end(level-1);
@@ -2188,16 +2188,16 @@ namespace DoFTools
 
     // Vector mapping from vertex index in the triangulation to consecutive
     // block indices on this level The number of cells at a vertex
-    std::vector<unsigned int> vertex_cell_count(dof_handler.get_tria().n_vertices(), 0);
+    std::vector<unsigned int> vertex_cell_count(dof_handler.get_triangulation().n_vertices(), 0);
 
     // Is a vertex at the boundary?
-    std::vector<bool> vertex_boundary(dof_handler.get_tria().n_vertices(), false);
+    std::vector<bool> vertex_boundary(dof_handler.get_triangulation().n_vertices(), false);
 
-    std::vector<unsigned int> vertex_mapping(dof_handler.get_tria().n_vertices(),
+    std::vector<unsigned int> vertex_mapping(dof_handler.get_triangulation().n_vertices(),
                                              numbers::invalid_unsigned_int);
 
     // Estimate for the number of dofs at this point
-    std::vector<unsigned int> vertex_dof_count(dof_handler.get_tria().n_vertices(), 0);
+    std::vector<unsigned int> vertex_dof_count(dof_handler.get_triangulation().n_vertices(), 0);
 
     // Identify all vertices active on this level and remember some data
     // about them

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -933,7 +933,7 @@ namespace DoFTools
                 //TODO[TL]: think about this in case of anisotropic
                 //refinement
 
-                Assert (dof_handler.get_tria().get_anisotropic_refinement_flag() ||
+                Assert (dof_handler.get_triangulation().get_anisotropic_refinement_flag() ||
                         ((this_face->child(0)->vertex_index(3) ==
                           this_face->child(1)->vertex_index(2)) &&
                          (this_face->child(0)->vertex_index(3) ==
@@ -2713,7 +2713,7 @@ namespace DoFTools
               {
                 const typename dealii::parallel::Triangulation<dim, spacedim> &tria =
                   dynamic_cast<const typename dealii::parallel::Triangulation<dim, spacedim>&>
-                  (coarse_to_fine_grid_map.get_destination_grid().get_tria ());
+                  (coarse_to_fine_grid_map.get_destination_grid().get_triangulation());
                 communicator = tria.get_communicator ();
                 is_called_in_parallel = true;
               }
@@ -2800,7 +2800,7 @@ namespace DoFTools
 
         // Try to find out whether the grids stem from the same coarse
         // grid. This is a rather crude test, but better than nothing
-        Assert (coarse_grid.get_tria().n_cells(0) == fine_grid.get_tria().n_cells(0),
+        Assert (coarse_grid.get_triangulation().n_cells(0) == fine_grid.get_triangulation().n_cells(0),
                 ExcGridsDontMatch());
 
         // check whether the map correlates the right objects

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -70,11 +70,11 @@ namespace DoFTools
     // subdomain. Not setting a subdomain is also okay, because we skip
     // ghost cells in the loop below.
     Assert (
-      (dof.get_tria().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
       ||
       (subdomain_id == numbers::invalid_subdomain_id)
       ||
-      (subdomain_id == dof.get_tria().locally_owned_subdomain()),
+      (subdomain_id == dof.get_triangulation().locally_owned_subdomain()),
       ExcMessage ("For parallel::distributed::Triangulation objects and "
                   "associated DoF handler objects, asking for any subdomain other "
                   "than the locally owned one does not make sense."));
@@ -134,11 +134,11 @@ namespace DoFTools
     // subdomain. Not setting a subdomain is also okay, because we skip
     // ghost cells in the loop below.
     Assert (
-      (dof.get_tria().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
       ||
       (subdomain_id == numbers::invalid_subdomain_id)
       ||
-      (subdomain_id == dof.get_tria().locally_owned_subdomain()),
+      (subdomain_id == dof.get_triangulation().locally_owned_subdomain()),
       ExcMessage ("For parallel::distributed::Triangulation objects and "
                   "associated DoF handler objects, asking for any subdomain other "
                   "than the locally owned one does not make sense."));
@@ -506,11 +506,11 @@ namespace DoFTools
     // subdomain. Not setting a subdomain is also okay, because we skip
     // ghost cells in the loop below.
     Assert (
-      (dof.get_tria().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
       ||
       (subdomain_id == numbers::invalid_subdomain_id)
       ||
-      (subdomain_id == dof.get_tria().locally_owned_subdomain()),
+      (subdomain_id == dof.get_triangulation().locally_owned_subdomain()),
       ExcMessage ("For parallel::distributed::Triangulation objects and "
                   "associated DoF handler objects, asking for any subdomain other "
                   "than the locally owned one does not make sense."));
@@ -1164,16 +1164,16 @@ namespace DoFTools
     // this function the Triangulation will be in the same state as it was
     // at the beginning of this function.
     std::vector<bool> user_flags;
-    dof.get_tria().save_user_flags(user_flags);
+    dof.get_triangulation().save_user_flags(user_flags);
     const_cast<Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &>
-    (dof.get_tria()).clear_user_flags ();
+    (dof.get_triangulation()).clear_user_flags ();
 
     internal::make_flux_sparsity_pattern (dof, sparsity,
                                           int_mask, flux_mask);
 
     // finally restore the user flags
     const_cast<Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &>
-    (dof.get_tria()).load_user_flags(user_flags);
+    (dof.get_triangulation()).load_user_flags(user_flags);
   }
 
 

--- a/source/fe/fe_tools_interpolate.cc
+++ b/source/fe/fe_tools_interpolate.cc
@@ -78,7 +78,7 @@ namespace FETools
                const ConstraintMatrix               &constraints,
                OutVector                            &u2)
   {
-    Assert(&dof1.get_tria()==&dof2.get_tria(), ExcTriangulationMismatch());
+    Assert(&dof1.get_triangulation()==&dof2.get_triangulation(), ExcTriangulationMismatch());
 
     Assert(u1.size()==dof1.n_dofs(),
            ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
@@ -137,7 +137,7 @@ namespace FETools
     // a cell, which this processor owns,
     // so we have to know the subdomain_id
     const types::subdomain_id subdomain_id =
-      dof1.get_tria().locally_owned_subdomain();
+      dof1.get_triangulation().locally_owned_subdomain();
 
     for (; cell1!=endc1; ++cell1, ++cell2)
       if ((cell1->subdomain_id() == subdomain_id)
@@ -283,7 +283,7 @@ namespace FETools
     Vector<typename OutVector::value_type> u1_int_local(dofs_per_cell1);
 
     const types::subdomain_id subdomain_id =
-      dof1.get_tria().locally_owned_subdomain();
+      dof1.get_triangulation().locally_owned_subdomain();
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator cell = dof1.begin_active(),
                                                             endc = dof1.end();
@@ -351,7 +351,7 @@ namespace FETools
     Vector<typename OutVector::value_type> u1_int_local(DoFTools::max_dofs_per_cell(dof1));
 
     const types::subdomain_id subdomain_id =
-      dof1.get_tria().locally_owned_subdomain();
+      dof1.get_triangulation().locally_owned_subdomain();
 
     typename DoFHandlerType<dim>::active_cell_iterator cell = dof1.begin_active(),
                                                        endc = dof1.end();
@@ -595,7 +595,7 @@ namespace FETools
     Vector<typename OutVector::value_type> u1_diff_local(dofs_per_cell);
 
     const types::subdomain_id subdomain_id =
-      dof1.get_tria().locally_owned_subdomain();
+      dof1.get_triangulation().locally_owned_subdomain();
 
     FullMatrix<double> difference_matrix(dofs_per_cell, dofs_per_cell);
     get_interpolation_difference_matrix(dof1.get_fe(), fe2,
@@ -701,7 +701,7 @@ namespace FETools
                   const DoFHandler<dim,spacedim> &dof2,
                   OutVector &u2)
   {
-    Assert(&dof1.get_tria()==&dof2.get_tria(), ExcTriangulationMismatch());
+    Assert(&dof1.get_triangulation()==&dof2.get_triangulation(), ExcTriangulationMismatch());
     Assert(dof1.get_fe().n_components() == dof2.get_fe().n_components(),
            ExcDimensionMismatch(dof1.get_fe().n_components(), dof2.get_fe().n_components()));
     Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
@@ -760,7 +760,7 @@ namespace FETools
   {
     Assert(dof1.get_fe().n_components() == dof2.get_fe().n_components(),
            ExcDimensionMismatch(dof1.get_fe().n_components(), dof2.get_fe().n_components()));
-    Assert(&dof1.get_tria()==&dof2.get_tria(), ExcTriangulationMismatch());
+    Assert(&dof1.get_triangulation()==&dof2.get_triangulation(), ExcTriangulationMismatch());
     Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
     Assert(u2.size()==dof2.n_dofs(), ExcDimensionMismatch(u2.size(), dof2.n_dofs()));
 
@@ -784,7 +784,7 @@ namespace FETools
     }
 
     // then traverse grid bottom up
-    for (unsigned int level=0; level<dof1.get_tria().n_levels()-1; ++level)
+    for (unsigned int level=0; level<dof1.get_triangulation().n_levels()-1; ++level)
       {
         typename DoFHandler<dim,spacedim>::cell_iterator cell=dof2.begin(level),
                                                          endc=dof2.end(level);

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4129,71 +4129,6 @@ namespace GridGenerator
 
 
 
-  // This anonymous namespace contains utility functions to extract the
-  // triangulation from any container such as DoFHandler
-  // and the like
-  namespace
-  {
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const parallel::distributed::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const parallel::shared::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, template<int, int> class Container, int spacedim>
-    const Triangulation<dim,spacedim> &
-    get_tria(const Container<dim,spacedim> &container)
-    {
-      return container.get_tria();
-    }
-
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(parallel::distributed::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(parallel::shared::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, template<int, int> class Container, int spacedim>
-    const Triangulation<dim,spacedim> &
-    get_tria(Container<dim,spacedim> &container)
-    {
-      return container.get_tria();
-    }
-  }
-
-
-
   template <template <int,int> class Container, int dim, int spacedim>
 #ifndef _MSC_VER
   std::map<typename Container<dim-1,spacedim>::cell_iterator,
@@ -4222,7 +4157,7 @@ namespace GridGenerator
     mapping;  // temporary map for level==0
 
 
-    std::vector< bool > touched (get_tria(volume_mesh).n_vertices(), false);
+    std::vector< bool > touched (volume_mesh.get_tria().n_vertices(), false);
     std::vector< CellData< boundary_dim > > cells;
     SubCellData                             subcell_data;
     std::vector< Point<spacedim> >          vertices;
@@ -4332,7 +4267,7 @@ namespace GridGenerator
 
     // create level 0 surface triangulation
     Assert (cells.size() > 0, ExcMessage ("No boundary faces selected"));
-    const_cast<Triangulation<dim-1,spacedim>&>(get_tria(surface_mesh))
+    const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_tria())
     .create_triangulation (vertices, cells, subcell_data);
 
     // Make the actual mapping
@@ -4355,7 +4290,7 @@ namespace GridGenerator
 
         if (changed)
           {
-            const_cast<Triangulation<dim-1,spacedim>&>(get_tria(surface_mesh))
+            const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_tria())
             .execute_coarsening_and_refinement();
 
             for (typename Container<dim-1,spacedim>::cell_iterator

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4157,7 +4157,7 @@ namespace GridGenerator
     mapping;  // temporary map for level==0
 
 
-    std::vector< bool > touched (volume_mesh.get_tria().n_vertices(), false);
+    std::vector< bool > touched (volume_mesh.get_triangulation().n_vertices(), false);
     std::vector< CellData< boundary_dim > > cells;
     SubCellData                             subcell_data;
     std::vector< Point<spacedim> >          vertices;
@@ -4267,7 +4267,7 @@ namespace GridGenerator
 
     // create level 0 surface triangulation
     Assert (cells.size() > 0, ExcMessage ("No boundary faces selected"));
-    const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_tria())
+    const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_triangulation())
     .create_triangulation (vertices, cells, subcell_data);
 
     // Make the actual mapping
@@ -4290,7 +4290,7 @@ namespace GridGenerator
 
         if (changed)
           {
-            const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_tria())
+            const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_triangulation())
             .execute_coarsening_and_refinement();
 
             for (typename Container<dim-1,spacedim>::cell_iterator

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -61,72 +61,6 @@ DEAL_II_NAMESPACE_OPEN
 namespace GridTools
 {
 
-  // This anonymous namespace contains utility functions to extract the
-  // triangulation from any container such as DoFHandler and the like
-  namespace
-  {
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const parallel::distributed::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    const Triangulation<dim, spacedim> &
-    get_tria(const parallel::shared::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-
-    template<int dim, template<int, int> class Container, int spacedim>
-    const Triangulation<dim,spacedim> &
-    get_tria(const Container<dim,spacedim> &container)
-    {
-      return container.get_tria();
-    }
-
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(parallel::distributed::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-    template<int dim, int spacedim>
-    Triangulation<dim, spacedim> &
-    get_tria(parallel::shared::Triangulation<dim, spacedim> &tria)
-    {
-      return tria;
-    }
-
-
-    template<int dim, template<int, int> class Container, int spacedim>
-    const Triangulation<dim,spacedim> &
-    get_tria(Container<dim,spacedim> &container)
-    {
-      return container.get_tria();
-    }
-  }
-
-
-
   template <int dim, int spacedim>
   double
   diameter (const Triangulation<dim, spacedim> &tria)
@@ -1030,7 +964,7 @@ namespace GridTools
     // triangulation from the
     // container and determine vertices
     // and used vertices
-    const Triangulation<dim, spacedim> &tria = get_tria(container);
+    const Triangulation<dim, spacedim> &tria = container.get_tria();
 
     const std::vector< Point<spacedim> > &vertices = tria.get_vertices();
     const std::vector< bool       > &used     = tria.get_used_vertices();
@@ -1076,9 +1010,9 @@ namespace GridTools
     // make sure that the given vertex is
     // an active vertex of the underlying
     // triangulation
-    Assert(vertex < get_tria(container).n_vertices(),
-           ExcIndexRange(0,get_tria(container).n_vertices(),vertex));
-    Assert(get_tria(container).get_used_vertices()[vertex],
+    Assert(vertex < container.get_tria().n_vertices(),
+           ExcIndexRange(0,container.get_tria().n_vertices(),vertex));
+    Assert(container.get_tria().get_used_vertices()[vertex],
            ExcVertexNotUsed(vertex));
 
     // use a set instead of a vector
@@ -1318,7 +1252,7 @@ next_cell:
     // the cell and have not searched
     // every cell in the triangulation,
     // we keep on looking.
-    const unsigned int n_active_cells = get_tria(container).n_active_cells();
+    const unsigned int n_active_cells = container.get_tria().n_active_cells();
     bool found = false;
     unsigned int cells_searched = 0;
     while (!found && cells_searched < n_active_cells)
@@ -1446,7 +1380,7 @@ next_cell:
         // the cell and have not searched
         // every cell in the triangulation,
         // we keep on looking.
-        const unsigned int n_cells =get_tria(container).n_cells();
+        const unsigned int n_cells = container.get_tria().n_cells();
         bool found = false;
         unsigned int cells_searched = 0;
         while (!found && cells_searched < n_cells)
@@ -1555,7 +1489,7 @@ next_cell:
                                   const std_cxx11::function<bool (const typename Container::active_cell_iterator &)> &predicate)
   {
     std::vector<typename Container::active_cell_iterator> active_halo_layer;
-    std::vector<bool> locally_active_vertices_on_subdomain (get_tria(container).n_vertices(),
+    std::vector<bool> locally_active_vertices_on_subdomain (container.get_tria().n_vertices(),
                                                             false);
 
     // Find the cells for which the predicate is true
@@ -2291,8 +2225,8 @@ next_cell:
   have_same_coarse_mesh (const Container &mesh_1,
                          const Container &mesh_2)
   {
-    return have_same_coarse_mesh (get_tria(mesh_1),
-                                  get_tria(mesh_2));
+    return have_same_coarse_mesh (mesh_1.get_tria(),
+                                  mesh_2.get_tria());
   }
 
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -964,7 +964,7 @@ namespace GridTools
     // triangulation from the
     // container and determine vertices
     // and used vertices
-    const Triangulation<dim, spacedim> &tria = container.get_tria();
+    const Triangulation<dim, spacedim> &tria = container.get_triangulation();
 
     const std::vector< Point<spacedim> > &vertices = tria.get_vertices();
     const std::vector< bool       > &used     = tria.get_used_vertices();
@@ -1010,9 +1010,9 @@ namespace GridTools
     // make sure that the given vertex is
     // an active vertex of the underlying
     // triangulation
-    Assert(vertex < container.get_tria().n_vertices(),
-           ExcIndexRange(0,container.get_tria().n_vertices(),vertex));
-    Assert(container.get_tria().get_used_vertices()[vertex],
+    Assert(vertex < container.get_triangulation().n_vertices(),
+           ExcIndexRange(0,container.get_triangulation().n_vertices(),vertex));
+    Assert(container.get_triangulation().get_used_vertices()[vertex],
            ExcVertexNotUsed(vertex));
 
     // use a set instead of a vector
@@ -1252,7 +1252,7 @@ next_cell:
     // the cell and have not searched
     // every cell in the triangulation,
     // we keep on looking.
-    const unsigned int n_active_cells = container.get_tria().n_active_cells();
+    const unsigned int n_active_cells = container.get_triangulation().n_active_cells();
     bool found = false;
     unsigned int cells_searched = 0;
     while (!found && cells_searched < n_active_cells)
@@ -1380,7 +1380,7 @@ next_cell:
         // the cell and have not searched
         // every cell in the triangulation,
         // we keep on looking.
-        const unsigned int n_cells = container.get_tria().n_cells();
+        const unsigned int n_cells = container.get_triangulation().n_cells();
         bool found = false;
         unsigned int cells_searched = 0;
         while (!found && cells_searched < n_cells)
@@ -1489,7 +1489,7 @@ next_cell:
                                   const std_cxx11::function<bool (const typename Container::active_cell_iterator &)> &predicate)
   {
     std::vector<typename Container::active_cell_iterator> active_halo_layer;
-    std::vector<bool> locally_active_vertices_on_subdomain (container.get_tria().n_vertices(),
+    std::vector<bool> locally_active_vertices_on_subdomain (container.get_triangulation().n_vertices(),
                                                             false);
 
     // Find the cells for which the predicate is true
@@ -2225,8 +2225,8 @@ next_cell:
   have_same_coarse_mesh (const Container &mesh_1,
                          const Container &mesh_2)
   {
-    return have_same_coarse_mesh (mesh_1.get_tria(),
-                                  mesh_2.get_tria());
+    return have_same_coarse_mesh (mesh_1.get_triangulation(),
+                                  mesh_2.get_triangulation());
   }
 
 

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -29,54 +29,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace
-{
-// helper function to acquire the number of levels within a grid
-  template <class GridClass>
-  unsigned int
-  get_n_levels (const GridClass &grid)
-  {
-    // all objects we deal with are able
-    // to deliver a pointer to the
-    // underlying triangulation.
-    //
-    // for the triangulation as GridClass
-    // of this object, there is a
-    // specialization of this function
-    return grid.get_tria().n_levels();
-  }
-
-
-// specialization for triangulation classes
-  template <int dim, int spacedim>
-  unsigned int
-  get_n_levels (const Triangulation<dim, spacedim> &grid)
-  {
-    // if GridClass==Triangulation, then
-    // we can ask directly.
-    return grid.n_levels();
-  }
-
-  template <int dim, int spacedim>
-  unsigned int
-  get_n_levels (const parallel::distributed::Triangulation<dim, spacedim> &grid)
-  {
-    // if GridClass==Triangulation, then
-    // we can ask directly.
-    return grid.n_levels();
-  }
-
-  template <int dim, int spacedim>
-  unsigned int
-  get_n_levels (const parallel::shared::Triangulation<dim, spacedim> &grid)
-  {
-    // if GridClass==Triangulation, then
-    // we can ask directly.
-    return grid.n_levels();
-  }
-}
-
-
 template <class GridClass>
 InterGridMap<GridClass>::InterGridMap ()
   :
@@ -100,7 +52,7 @@ void InterGridMap<GridClass>::make_mapping (const GridClass &source_grid,
 
   // then set up the containers from
   // scratch and fill them with end-iterators
-  const unsigned int n_levels = get_n_levels(source_grid);
+  const unsigned int n_levels = source_grid.get_tria().n_levels();
   mapping.resize (n_levels);
   for (unsigned int level=0; level<n_levels; ++level)
     {

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -52,7 +52,7 @@ void InterGridMap<GridClass>::make_mapping (const GridClass &source_grid,
 
   // then set up the containers from
   // scratch and fill them with end-iterators
-  const unsigned int n_levels = source_grid.get_tria().n_levels();
+  const unsigned int n_levels = source_grid.get_triangulation().n_levels();
   mapping.resize (n_levels);
   for (unsigned int level=0; level<n_levels; ++level)
     {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11575,7 +11575,7 @@ Triangulation<dim,spacedim>::locally_owned_subdomain () const
 
 template <int dim, int spacedim>
 Triangulation<dim,spacedim> &
-Triangulation<dim,spacedim>::get_tria ()
+Triangulation<dim,spacedim>::get_triangulation ()
 {
   return *this;
 }
@@ -11584,7 +11584,7 @@ Triangulation<dim,spacedim>::get_tria ()
 
 template <int dim, int spacedim>
 const Triangulation<dim,spacedim> &
-Triangulation<dim,spacedim>::get_tria () const
+Triangulation<dim,spacedim>::get_triangulation () const
 {
   return *this;
 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11574,6 +11574,24 @@ Triangulation<dim,spacedim>::locally_owned_subdomain () const
 
 
 template <int dim, int spacedim>
+Triangulation<dim,spacedim> &
+Triangulation<dim,spacedim>::get_tria ()
+{
+  return *this;
+}
+
+
+
+template <int dim, int spacedim>
+const Triangulation<dim,spacedim> &
+Triangulation<dim,spacedim>::get_tria () const
+{
+  return *this;
+}
+
+
+
+template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::execute_coarsening_and_refinement ()
 {

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1705,7 +1705,7 @@ namespace hp
   typename DoFHandler<dim,spacedim>::cell_iterator
   DoFHandler<dim, spacedim>::begin(const unsigned int level) const
   {
-    return cell_iterator (*this->get_tria().begin(level),
+    return cell_iterator (*this->get_triangulation().begin(level),
                           this);
   }
 
@@ -1731,7 +1731,7 @@ namespace hp
   typename DoFHandler<dim,spacedim>::cell_iterator
   DoFHandler<dim,spacedim>::end () const
   {
-    return cell_iterator (&this->get_tria(),
+    return cell_iterator (&this->get_triangulation(),
                           -1,
                           -1,
                           this);
@@ -1742,7 +1742,7 @@ namespace hp
   typename DoFHandler<dim,spacedim>::cell_iterator
   DoFHandler<dim,spacedim>::end (const unsigned int level) const
   {
-    return (level == this->get_tria().n_levels()-1 ?
+    return (level == this->get_triangulation().n_levels()-1 ?
             end() :
             begin (level+1));
   }
@@ -1752,7 +1752,7 @@ namespace hp
   typename DoFHandler<dim, spacedim>::active_cell_iterator
   DoFHandler<dim, spacedim>::end_active (const unsigned int level) const
   {
-    return (level == this->get_tria().n_levels()-1 ?
+    return (level == this->get_triangulation().n_levels()-1 ?
             active_cell_iterator(end()) :
             begin_active (level+1));
   }
@@ -2254,8 +2254,8 @@ namespace hp
     // we will mark lines that we have already treated, so first save and clear
     // the user flags on lines and later restore them
     std::vector<bool> user_flags;
-    this->get_tria().save_user_flags_line(user_flags);
-    const_cast<Triangulation<dim,spacedim> &>(this->get_tria()).clear_user_flags_line ();
+    this->get_triangulation().save_user_flags_line(user_flags);
+    const_cast<Triangulation<dim,spacedim> &>(this->get_triangulation()).clear_user_flags_line ();
 
     // An implementation of the algorithm described in the hp paper, including
     // the modification mentioned later in the "complications in 3-d" subsections
@@ -2433,7 +2433,7 @@ namespace hp
           }
 
     // finally restore the user flags
-    const_cast<Triangulation<dim,spacedim> &>(this->get_tria())
+    const_cast<Triangulation<dim,spacedim> &>(this->get_triangulation())
     .load_user_flags_line(user_flags);
   }
 
@@ -2465,8 +2465,8 @@ namespace hp
     // on quads and later restore
     // them
     std::vector<bool> user_flags;
-    this->get_tria().save_user_flags_quad(user_flags);
-    const_cast<Triangulation<dim,spacedim> &>(this->get_tria()).clear_user_flags_quad ();
+    this->get_triangulation().save_user_flags_quad(user_flags);
+    const_cast<Triangulation<dim,spacedim> &>(this->get_triangulation()).clear_user_flags_quad ();
 
     // An implementation of the
     // algorithm described in the hp
@@ -2558,7 +2558,7 @@ namespace hp
           }
 
     // finally restore the user flags
-    const_cast<Triangulation<dim,spacedim> &>(this->get_tria())
+    const_cast<Triangulation<dim,spacedim> &>(this->get_triangulation())
     .load_user_flags_quad(user_flags);
   }
 
@@ -2720,7 +2720,7 @@ namespace hp
     number_cache.n_locally_owned_dofs = number_cache.n_global_dofs;
 
     if (dynamic_cast<const parallel::shared::Triangulation< dim, spacedim >*>
-        (&this->get_tria())
+        (&this->get_triangulation())
         == 0)
       {
         number_cache.locally_owned_dofs

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -123,7 +123,7 @@ namespace MGTools
     // flags. Since we restore them in
     // the end, this cast is safe.
     Triangulation<dim,spacedim> &user_flags_triangulation =
-      const_cast<Triangulation<dim,spacedim>&> (dofs.get_tria());
+      const_cast<Triangulation<dim,spacedim>&> (dofs.get_triangulation());
     user_flags_triangulation.save_user_flags(old_flags);
     user_flags_triangulation.clear_user_flags();
 
@@ -297,7 +297,7 @@ namespace MGTools
     // flags. Since we restore them in
     // the end, this cast is safe.
     Triangulation<dim,spacedim> &user_flags_triangulation =
-      const_cast<Triangulation<dim,spacedim>&> (dofs.get_tria());
+      const_cast<Triangulation<dim,spacedim>&> (dofs.get_triangulation());
     user_flags_triangulation.save_user_flags(old_flags);
     user_flags_triangulation.clear_user_flags();
 
@@ -553,8 +553,8 @@ namespace MGTools
     typename DoFHandlerType::cell_iterator cell = dof.begin(level),
                                            endc = dof.end(level);
     for (; cell!=endc; ++cell)
-      if (dof.get_tria().locally_owned_subdomain()==numbers::invalid_subdomain_id
-          || cell->level_subdomain_id()==dof.get_tria().locally_owned_subdomain())
+      if (dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
+          || cell->level_subdomain_id()==dof.get_triangulation().locally_owned_subdomain())
         {
           cell->get_mg_dof_indices (dofs_on_this_cell);
           // make sparsity pattern for this cell
@@ -641,8 +641,8 @@ namespace MGTools
                                    SparsityPatternType            &sparsity,
                                    const unsigned int              level)
   {
-    Assert ((level>=1) && (level<dof.get_tria().n_global_levels()),
-            ExcIndexRange(level, 1, dof.get_tria().n_global_levels()));
+    Assert ((level>=1) && (level<dof.get_triangulation().n_global_levels()),
+            ExcIndexRange(level, 1, dof.get_triangulation().n_global_levels()));
 
     const types::global_dof_index fine_dofs = dof.n_dofs(level);
     const types::global_dof_index coarse_dofs = dof.n_dofs(level-1);
@@ -749,8 +749,8 @@ namespace MGTools
     // same state as it was at the
     // beginning of this function.
     std::vector<bool> user_flags;
-    dof.get_tria().save_user_flags(user_flags);
-    const_cast<Triangulation<dim,spacedim> &>(dof.get_tria()).clear_user_flags ();
+    dof.get_triangulation().save_user_flags(user_flags);
+    const_cast<Triangulation<dim,spacedim> &>(dof.get_triangulation()).clear_user_flags ();
 
     for (; cell!=endc; ++cell)
       {
@@ -872,7 +872,7 @@ namespace MGTools
       }
 
     // finally restore the user flags
-    const_cast<Triangulation<dim,spacedim> &>(dof.get_tria()).load_user_flags(user_flags);
+    const_cast<Triangulation<dim,spacedim> &>(dof.get_triangulation()).load_user_flags(user_flags);
   }
 
 
@@ -888,8 +888,8 @@ namespace MGTools
     const unsigned int n_comp = fe.n_components();
     (void)n_comp;
 
-    Assert ((level>=1) && (level<dof.get_tria().n_global_levels()),
-            ExcIndexRange(level, 1, dof.get_tria().n_global_levels()));
+    Assert ((level>=1) && (level<dof.get_triangulation().n_global_levels()),
+            ExcIndexRange(level, 1, dof.get_triangulation().n_global_levels()));
 
     const types::global_dof_index fine_dofs = dof.n_dofs(level);
     const types::global_dof_index coarse_dofs = dof.n_dofs(level-1);
@@ -970,7 +970,7 @@ namespace MGTools
   {
     const FiniteElement<dim> &fe = dof_handler.get_fe();
     const unsigned int n_components = fe.n_components();
-    const unsigned int nlevels = dof_handler.get_tria().n_global_levels();
+    const unsigned int nlevels = dof_handler.get_triangulation().n_global_levels();
 
     Assert (result.size() == nlevels,
             ExcDimensionMismatch(result.size(), nlevels));
@@ -1072,7 +1072,7 @@ namespace MGTools
   {
     const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe = dof_handler.get_fe();
     const unsigned int n_blocks = fe.n_blocks();
-    const unsigned int n_levels = dof_handler.get_tria().n_global_levels();
+    const unsigned int n_levels = dof_handler.get_triangulation().n_global_levels();
 
     AssertDimension (dofs_per_block.size(), n_levels);
 
@@ -1186,7 +1186,7 @@ namespace MGTools
     if (function_map.size() == 0)
       return;
 
-    const unsigned int n_levels = dof.get_tria().n_global_levels();
+    const unsigned int n_levels = dof.get_triangulation().n_global_levels();
 
     (void)n_levels;
 
@@ -1212,7 +1212,7 @@ namespace MGTools
         endc = dof.end();
         for (; cell!=endc; ++cell)
           {
-            if (dof.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+            if (dof.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
                 && cell->level_subdomain_id()==numbers::artificial_subdomain_id)
               continue;
             const FiniteElement<dim> &fe = cell->get_fe();
@@ -1246,7 +1246,7 @@ namespace MGTools
         cell = dof.begin(),
         endc = dof.end();
         for (; cell!=endc; ++cell)
-          if (dof.get_tria().locally_owned_subdomain()==numbers::invalid_subdomain_id
+          if (dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
               || cell->level_subdomain_id()!=numbers::artificial_subdomain_id)
             for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
                  ++face_no)
@@ -1395,14 +1395,14 @@ namespace MGTools
                      std::vector<IndexSet> &boundary_indices,
                      const ComponentMask &component_mask)
   {
-    Assert (boundary_indices.size() == dof.get_tria().n_global_levels(),
+    Assert (boundary_indices.size() == dof.get_triangulation().n_global_levels(),
             ExcDimensionMismatch (boundary_indices.size(),
-                                  dof.get_tria().n_global_levels()));
+                                  dof.get_triangulation().n_global_levels()));
 
     std::vector<std::set<types::global_dof_index> >
-    my_boundary_indices (dof.get_tria().n_global_levels());
+    my_boundary_indices (dof.get_triangulation().n_global_levels());
     make_boundary_list (dof, function_map, my_boundary_indices, component_mask);
-    for (unsigned int i=0; i<dof.get_tria().n_global_levels(); ++i)
+    for (unsigned int i=0; i<dof.get_triangulation().n_global_levels(); ++i)
       {
         boundary_indices[i] = IndexSet (dof.n_dofs(i));
         boundary_indices[i].add_indices (my_boundary_indices[i].begin(),
@@ -1416,9 +1416,9 @@ namespace MGTools
   extract_non_interface_dofs (const DoFHandler<dim,spacedim> &mg_dof_handler,
                               std::vector<std::set<types::global_dof_index> >  &non_interface_dofs)
   {
-    Assert (non_interface_dofs.size() == mg_dof_handler.get_tria().n_global_levels(),
+    Assert (non_interface_dofs.size() == mg_dof_handler.get_triangulation().n_global_levels(),
             ExcDimensionMismatch (non_interface_dofs.size(),
-                                  mg_dof_handler.get_tria().n_global_levels()));
+                                  mg_dof_handler.get_triangulation().n_global_levels()));
 
     const FiniteElement<dim,spacedim> &fe = mg_dof_handler.get_fe();
 
@@ -1435,8 +1435,8 @@ namespace MGTools
 
     for (; cell!=endc; ++cell)
       {
-        if (mg_dof_handler.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
-            && cell->level_subdomain_id()!=mg_dof_handler.get_tria().locally_owned_subdomain())
+        if (mg_dof_handler.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+            && cell->level_subdomain_id()!=mg_dof_handler.get_triangulation().locally_owned_subdomain())
           continue;
 
         std::fill (cell_dofs.begin(), cell_dofs.end(), false);
@@ -1485,9 +1485,9 @@ namespace MGTools
   extract_inner_interface_dofs (const DoFHandler<dim,spacedim> &mg_dof_handler,
                                 std::vector<IndexSet>  &interface_dofs)
   {
-    Assert (interface_dofs.size() == mg_dof_handler.get_tria().n_global_levels(),
+    Assert (interface_dofs.size() == mg_dof_handler.get_triangulation().n_global_levels(),
             ExcDimensionMismatch (interface_dofs.size(),
-                                  mg_dof_handler.get_tria().n_global_levels()));
+                                  mg_dof_handler.get_triangulation().n_global_levels()));
 
     std::vector<std::vector<types::global_dof_index> >
     tmp_interface_dofs(interface_dofs.size());
@@ -1508,7 +1508,7 @@ namespace MGTools
       {
         // Do not look at artificial level cells (in a serial computation we
         // need to ignore the level_subdomain_id() because it is never set).
-        if (mg_dof_handler.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+        if (mg_dof_handler.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
             && cell->level_subdomain_id()==numbers::artificial_subdomain_id)
           continue;
 
@@ -1526,7 +1526,7 @@ namespace MGTools
                 neighbor = cell->neighbor(face_nr);
 
                 // only process cell pairs if one or both of them are owned by me (ignore if running in serial)
-                if (mg_dof_handler.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+                if (mg_dof_handler.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
                     &&
                     neighbor->level_subdomain_id()==numbers::artificial_subdomain_id)
                   continue;
@@ -1555,7 +1555,7 @@ namespace MGTools
           }
       }
 
-    for (unsigned int l=0; l<mg_dof_handler.get_tria().n_global_levels(); ++l)
+    for (unsigned int l=0; l<mg_dof_handler.get_triangulation().n_global_levels(); ++l)
       {
         interface_dofs[l].clear();
         std::sort(tmp_interface_dofs[l].begin(), tmp_interface_dofs[l].end());

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -63,7 +63,7 @@ namespace
     if (ndofs.size() == 0)
       {
         std::vector<std::vector<types::global_dof_index> >
-        new_dofs(mg_dof.get_tria().n_levels(),
+        new_dofs(mg_dof.get_triangulation().n_levels(),
                  std::vector<types::global_dof_index>(selected.size()));
         std::swap(ndofs, new_dofs);
         MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -109,7 +109,7 @@ namespace
     if (ndofs.size() == 0)
       {
         std::vector<std::vector<types::global_dof_index> >
-        new_dofs(mg_dof.get_tria().n_levels(),
+        new_dofs(mg_dof.get_triangulation().n_levels(),
                  std::vector<types::global_dof_index>(selected.size()));
         std::swap(ndofs, new_dofs);
         MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -138,7 +138,7 @@ MGTransferBlockSelect<number>::copy_to_mg (
   // first, since only one block is
   // selected.
   bool first = true;
-  for (unsigned int level=mg_dof_handler.get_tria().n_levels(); level != 0;)
+  for (unsigned int level=mg_dof_handler.get_triangulation().n_levels(); level != 0;)
     {
       --level;
       for (IT i= copy_indices[selected_block][level].begin();
@@ -165,7 +165,7 @@ MGTransferBlockSelect<number>::copy_to_mg (
   // multilevel block is always the
   // first, since only one block is selected.
   bool first = true;
-  for (unsigned int level=mg_dof_handler.get_tria().n_levels(); level != 0;)
+  for (unsigned int level=mg_dof_handler.get_triangulation().n_levels(); level != 0;)
     {
       --level;
       for (IT i= copy_indices[selected_block][level].begin();
@@ -189,7 +189,7 @@ MGTransferBlock<number>::copy_to_mg (
 {
   reinit_vector_by_blocks(mg_dof_handler, dst, selected, sizes);
   bool first = true;
-  for (unsigned int level=mg_dof_handler.get_tria().n_levels(); level != 0;)
+  for (unsigned int level=mg_dof_handler.get_triangulation().n_levels(); level != 0;)
     {
       --level;
       for (unsigned int block=0; block<selected.size(); ++block)
@@ -213,7 +213,7 @@ void MGTransferBlockBase::build_matrices (
   const FiniteElement<dim> &fe = mg_dof.get_fe();
   const unsigned int n_blocks  = fe.n_blocks();
   const unsigned int dofs_per_cell = fe.dofs_per_cell;
-  const unsigned int n_levels      = mg_dof.get_tria().n_levels();
+  const unsigned int n_levels      = mg_dof.get_triangulation().n_levels();
 
   Assert (selected.size() == n_blocks,
           ExcDimensionMismatch(selected.size(), n_blocks));
@@ -480,7 +480,7 @@ void MGTransferBlockSelect<number>::build_matrices (
   std::vector<types::global_dof_index> global_dof_indices (fe.dofs_per_cell);
   std::vector<types::global_dof_index> level_dof_indices  (fe.dofs_per_cell);
 
-  for (int level=dof.get_tria().n_levels()-1; level>=0; --level)
+  for (int level=dof.get_triangulation().n_levels()-1; level>=0; --level)
     {
       typename DoFHandler<dim,spacedim>::active_cell_iterator
       level_cell = mg_dof.begin_active(level);
@@ -567,7 +567,7 @@ void MGTransferBlock<number>::build_matrices (
   std::vector<std::vector<types::global_dof_index> > temp_copy_indices (n_blocks);
   std::vector<types::global_dof_index> global_dof_indices (fe.dofs_per_cell);
   std::vector<types::global_dof_index> level_dof_indices  (fe.dofs_per_cell);
-  for (int level=dof.get_tria().n_levels()-1; level>=0; --level)
+  for (int level=dof.get_triangulation().n_levels()-1; level>=0; --level)
     {
       typename DoFHandler<dim,spacedim>::active_cell_iterator
       level_cell = mg_dof.begin_active(level);

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -125,7 +125,7 @@ namespace
     if (ndofs.size() == 0)
       {
         std::vector<std::vector<types::global_dof_index> >
-        new_dofs(mg_dof.get_tria().n_levels(),
+        new_dofs(mg_dof.get_triangulation().n_levels(),
                  std::vector<types::global_dof_index>(target_component.size()));
         std::swap(ndofs, new_dofs);
         MGTools::count_dofs_per_block (mg_dof, ndofs, target_component);
@@ -194,7 +194,7 @@ namespace
     if (ndofs.size() == 0)
       {
         std::vector<std::vector<types::global_dof_index> >
-        new_dofs(mg_dof.get_tria().n_levels(),
+        new_dofs(mg_dof.get_triangulation().n_levels(),
                  std::vector<types::global_dof_index>(target_component.size()));
         std::swap(ndofs, new_dofs);
         MGTools::count_dofs_per_block (mg_dof, ndofs,
@@ -220,7 +220,7 @@ MGTransferSelect<number>::do_copy_to_mg (
 {
   dst=0;
 
-  Assert(sizes.size()==mg_dof_handler.get_tria().n_levels(),
+  Assert(sizes.size()==mg_dof_handler.get_triangulation().n_levels(),
          ExcMatricesNotBuilt());
 
   reinit_vector_by_components(mg_dof_handler, dst,
@@ -239,7 +239,7 @@ MGTransferSelect<number>::do_copy_to_mg (
   // already have built.
 
   bool first = true;
-  for (unsigned int level=mg_dof_handler.get_tria().n_levels(); level!=0;)
+  for (unsigned int level=mg_dof_handler.get_triangulation().n_levels(); level!=0;)
     {
       --level;
 
@@ -318,7 +318,7 @@ void MGTransferComponentBase::build_matrices (
   const unsigned int n_components  =
     *std::max_element(mg_target_component.begin(), mg_target_component.end()) + 1;
   const unsigned int dofs_per_cell = fe.dofs_per_cell;
-  const unsigned int n_levels      = mg_dof.get_tria().n_levels();
+  const unsigned int n_levels      = mg_dof.get_triangulation().n_levels();
 
   Assert (mg_component_mask.represents_n_components(fe.n_components()),
           ExcMessage ("Component mask has wrong size."));
@@ -506,7 +506,7 @@ void MGTransferComponentBase::build_matrices (
   if (boundary_indices.size() != 0)
     {
       std::vector<std::vector<types::global_dof_index> >
-      dofs_per_component(mg_dof.get_tria().n_levels(),
+      dofs_per_component(mg_dof.get_triangulation().n_levels(),
                          std::vector<types::global_dof_index>(n_components));
 
       MGTools::count_dofs_per_block (mg_dof, dofs_per_component, mg_target_component);
@@ -612,8 +612,8 @@ void MGTransferSelect<number>::build_matrices (
 
   MGTransferComponentBase::build_matrices (dof, mg_dof);
 
-  interface_dofs.resize(mg_dof.get_tria().n_levels());
-  for (unsigned int l=0; l<mg_dof.get_tria().n_levels(); ++l)
+  interface_dofs.resize(mg_dof.get_triangulation().n_levels());
+  for (unsigned int l=0; l<mg_dof.get_triangulation().n_levels(); ++l)
     {
       interface_dofs[l].clear();
       interface_dofs[l].set_size(mg_dof.n_dofs(l));
@@ -625,7 +625,7 @@ void MGTransferSelect<number>::build_matrices (
   std::vector<types::global_dof_index> temp_copy_indices;
   std::vector<types::global_dof_index> global_dof_indices (fe.dofs_per_cell);
   std::vector<types::global_dof_index> level_dof_indices  (fe.dofs_per_cell);
-  for (int level=dof.get_tria().n_levels()-1; level>=0; --level)
+  for (int level=dof.get_triangulation().n_levels()-1; level>=0; --level)
     {
       copy_to_and_from_indices[level].clear();
       typename DoFHandler<dim,spacedim>::active_cell_iterator

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -115,7 +115,7 @@ template <int dim, int spacedim>
 void MGTransferPrebuilt<VectorType>::build_matrices
 (const DoFHandler<dim,spacedim>  &mg_dof)
 {
-  const unsigned int n_levels      = mg_dof.get_tria().n_global_levels();
+  const unsigned int n_levels      = mg_dof.get_triangulation().n_global_levels();
   const unsigned int dofs_per_cell = mg_dof.get_fe().dofs_per_cell;
 
   sizes.resize(n_levels);
@@ -173,8 +173,8 @@ void MGTransferPrebuilt<VectorType>::build_matrices
       for (typename DoFHandler<dim,spacedim>::cell_iterator cell=mg_dof.begin(level);
            cell != mg_dof.end(level); ++cell)
         if (cell->has_children() &&
-            ( mg_dof.get_tria().locally_owned_subdomain()==numbers::invalid_subdomain_id
-              || cell->level_subdomain_id()==mg_dof.get_tria().locally_owned_subdomain()
+            ( mg_dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
+              || cell->level_subdomain_id()==mg_dof.get_triangulation().locally_owned_subdomain()
             ))
           {
             cell->get_mg_dof_indices (dof_indices_parent);
@@ -220,8 +220,8 @@ void MGTransferPrebuilt<VectorType>::build_matrices
       for (typename DoFHandler<dim,spacedim>::cell_iterator cell=mg_dof.begin(level);
            cell != mg_dof.end(level); ++cell)
         if (cell->has_children() &&
-            (mg_dof.get_tria().locally_owned_subdomain()==numbers::invalid_subdomain_id
-             || cell->level_subdomain_id()==mg_dof.get_tria().locally_owned_subdomain())
+            (mg_dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
+             || cell->level_subdomain_id()==mg_dof.get_triangulation().locally_owned_subdomain())
            )
           {
             cell->get_mg_dof_indices (dof_indices_parent);
@@ -301,7 +301,7 @@ MGTransferPrebuilt<VectorType>::fill_and_communicate_copy_indices
   // that will be copied into copy_indices_level_mine
   std::vector<DoFPair> send_data_temp;
 
-  const unsigned int n_levels = mg_dof.get_tria().n_global_levels();
+  const unsigned int n_levels = mg_dof.get_triangulation().n_global_levels();
   copy_indices.resize(n_levels);
   copy_indices_global_mine.resize(n_levels);
   copy_indices_level_mine.resize(n_levels);
@@ -326,7 +326,7 @@ MGTransferPrebuilt<VectorType>::fill_and_communicate_copy_indices
 
       for (; level_cell!=level_end; ++level_cell)
         {
-          if (mg_dof.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+          if (mg_dof.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
               &&  (level_cell->level_subdomain_id()==numbers::artificial_subdomain_id
                    ||  level_cell->subdomain_id()==numbers::artificial_subdomain_id)
              )
@@ -376,7 +376,7 @@ MGTransferPrebuilt<VectorType>::fill_and_communicate_copy_indices
 
   const dealii::parallel::distributed::Triangulation<dim,spacedim> *tria =
     (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-     (&mg_dof.get_tria()));
+     (&mg_dof.get_triangulation()));
   AssertThrow(send_data_temp.size()==0 || tria!=NULL, ExcMessage("parallel Multigrid only works with a distributed Triangulation!"));
 
 #ifdef DEAL_II_WITH_MPI

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -861,7 +861,7 @@ attach_dof_handler (const DoFHandlerType &d)
 
   triangulation = SmartPointer<const Triangulation<DoFHandlerType::dimension,
   DoFHandlerType::space_dimension> >
-  (&d.get_tria(), typeid(*this).name());
+  (&d.get_triangulation(), typeid(*this).name());
   dofs = SmartPointer<const DoFHandlerType>(&d, typeid(*this).name());
 }
 
@@ -1019,7 +1019,7 @@ add_data_vector (const VectorType                       &vec,
   Assert (vec.size() == dofs->n_dofs(),
           Exceptions::DataOut::ExcInvalidVectorSize (vec.size(),
                                                      dofs->n_dofs(),
-                                                     dofs->get_tria().n_active_cells()));
+                                                     dofs->get_triangulation().n_active_cells()));
 
   internal::DataOut::DataEntryBase<DoFHandlerType> *new_entry
     = new internal::DataOut::DataEntry<DoFHandlerType,VectorType>(dofs, &vec, &data_postprocessor);
@@ -1100,9 +1100,9 @@ add_data_vector
   // together with its DoFHandler. if we do, we know that we have
   // type_dof_data, which makes things a bit simpler
   if (triangulation == 0)
-    triangulation = SmartPointer<const Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> >(&dof_handler.get_tria(), typeid(*this).name());
+    triangulation = SmartPointer<const Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> >(&dof_handler.get_triangulation(), typeid(*this).name());
 
-  Assert (&dof_handler.get_tria() == triangulation,
+  Assert (&dof_handler.get_triangulation() == triangulation,
           ExcMessage("The triangulation attached to the DoFHandler does not "
                      "match with the one set previously"));
 

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -142,7 +142,7 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
   // is cell vector: we only need one
   // name
   if ((n_components == 1) ||
-      (vec.size() == dof_handler->get_tria().n_active_cells()))
+      (vec.size() == dof_handler->get_triangulation().n_active_cells()))
     {
       names.resize (1, name);
     }
@@ -172,7 +172,7 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
           Exceptions::DataOut::ExcNoDoFHandlerSelected ());
   // either cell data and one name,
   // or dof data and n_components names
-  Assert (((vec.size() == dof_handler->get_tria().n_active_cells()) &&
+  Assert (((vec.size() == dof_handler->get_triangulation().n_active_cells()) &&
            (names.size() == 1))
           ||
           ((vec.size() == dof_handler->n_dofs()) &&
@@ -205,13 +205,13 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
       // n_dofs==n_cells, so only
       // bomb out if the next if
       // statement will not be run
-      if (dof_handler->n_dofs() != dof_handler->get_tria().n_active_cells())
+      if (dof_handler->n_dofs() != dof_handler->get_triangulation().n_active_cells())
         Assert (false, ExcVectorNotDeclared (names[0]));
     }
 
   // search cell data
   if ((vec.size() != dof_handler->n_dofs()) ||
-      (dof_handler->n_dofs() == dof_handler->get_tria().n_active_cells()))
+      (dof_handler->n_dofs() == dof_handler->get_triangulation().n_active_cells()))
     {
       typename std::vector<DataVector>::iterator data_vector=cell_data.begin();
       for (; data_vector!=cell_data.end(); ++data_vector)

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -973,9 +973,9 @@ namespace DerivativeApproximation
                             const unsigned int                  component,
                             Vector<float>                      &derivative_norm)
     {
-      Assert (derivative_norm.size() == dof_handler.get_tria().n_active_cells(),
+      Assert (derivative_norm.size() == dof_handler.get_triangulation().n_active_cells(),
               ExcVectorLengthVsNActiveCells (derivative_norm.size(),
-                                             dof_handler.get_tria().n_active_cells()));
+                                             dof_handler.get_triangulation().n_active_cells()));
       Assert (component < dof_handler.get_fe().n_components(),
               ExcIndexRange (component, 0, dof_handler.get_fe().n_components()));
 

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -221,24 +221,24 @@ estimate (const Mapping<1,spacedim>                  &mapping,
 {
 #ifdef DEAL_II_WITH_P4EST
   if (dynamic_cast<const parallel::distributed::Triangulation<1,spacedim>*>
-      (&dof_handler.get_tria())
+      (&dof_handler.get_triangulation())
       != 0)
     Assert ((subdomain_id_ == numbers::invalid_subdomain_id)
             ||
             (subdomain_id_ ==
              dynamic_cast<const parallel::distributed::Triangulation<1,spacedim>&>
-             (dof_handler.get_tria()).locally_owned_subdomain()),
+             (dof_handler.get_triangulation()).locally_owned_subdomain()),
             ExcMessage ("For parallel distributed triangulations, the only "
                         "valid subdomain_id that can be passed here is the "
                         "one that corresponds to the locally owned subdomain id."));
 
   const types::subdomain_id subdomain_id
     = ((dynamic_cast<const parallel::distributed::Triangulation<1,spacedim>*>
-        (&dof_handler.get_tria())
+        (&dof_handler.get_triangulation())
         != 0)
        ?
        dynamic_cast<const parallel::distributed::Triangulation<1,spacedim>&>
-       (dof_handler.get_tria()).locally_owned_subdomain()
+       (dof_handler.get_triangulation()).locally_owned_subdomain()
        :
        subdomain_id_);
 #else
@@ -295,7 +295,7 @@ estimate (const Mapping<1,spacedim>                  &mapping,
 
   // reserve one slot for each cell and set it to zero
   for (unsigned int n=0; n<n_solution_vectors; ++n)
-    (*errors[n]).reinit (dof_handler.get_tria().n_active_cells());
+    (*errors[n]).reinit (dof_handler.get_triangulation().n_active_cells());
 
   // fields to get the gradients on the present and the neighbor cell.
   //

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -93,7 +93,7 @@ PointValueHistory<dim>::PointValueHistory (const DoFHandler<dim> &dof_handler,
     = std::vector<std::vector <double> > (n_indep, std::vector <double> (0));
   indep_names = std::vector <std::string> ();
 
-  tria_listener = dof_handler.get_tria().signals.any_change.connect (std_cxx11::bind (&PointValueHistory<dim>::tria_change_listener,
+  tria_listener = dof_handler.get_triangulation().signals.any_change.connect (std_cxx11::bind (&PointValueHistory<dim>::tria_change_listener,
                   std_cxx11::ref(*this)));
 }
 
@@ -123,7 +123,7 @@ PointValueHistory<dim>::PointValueHistory (const PointValueHistory &point_value_
   // Presume subscribe new instance?
   if (have_dof_handler)
     {
-      tria_listener = dof_handler->get_tria().signals.any_change.connect (std_cxx11::bind     (&PointValueHistory<dim>::tria_change_listener,
+      tria_listener = dof_handler->get_triangulation().signals.any_change.connect (std_cxx11::bind     (&PointValueHistory<dim>::tria_change_listener,
                       std_cxx11::ref(*this)));
     }
 }
@@ -155,7 +155,7 @@ PointValueHistory<dim>::operator= (const PointValueHistory &point_value_history)
   // Presume subscribe new instance?
   if (have_dof_handler)
     {
-      tria_listener = dof_handler->get_tria().signals.any_change.connect (std_cxx11::bind     (&PointValueHistory<dim>::tria_change_listener,
+      tria_listener = dof_handler->get_triangulation().signals.any_change.connect (std_cxx11::bind     (&PointValueHistory<dim>::tria_change_listener,
                       std_cxx11::ref(*this)));
     }
 

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -73,7 +73,7 @@ void SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_for_pure_refinem
 
   clear();
 
-  const unsigned int n_active_cells = dof_handler->get_tria().n_active_cells();
+  const unsigned int n_active_cells = dof_handler->get_triangulation().n_active_cells();
   n_dofs_old=dof_handler->n_dofs();
 
   // efficient reallocation of indices_on_cell
@@ -243,7 +243,7 @@ prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
 
   clear();
 
-  const unsigned int n_active_cells = dof_handler->get_tria().n_active_cells();
+  const unsigned int n_active_cells = dof_handler->get_triangulation().n_active_cells();
   (void)n_active_cells;
   n_dofs_old = dof_handler->n_dofs();
 

--- a/tests/bits/data_out_07.cc
+++ b/tests/bits/data_out_07.cc
@@ -32,7 +32,7 @@ check_this (const DoFHandler<dim> &dof_handler,
             const Vector<double>  &v_cell)
 {
   DataOut<dim> data_out;
-  data_out.attach_triangulation (dof_handler.get_tria());
+  data_out.attach_triangulation (dof_handler.get_triangulation());
   data_out.add_data_vector (v_cell, "cell_data");
   data_out.build_patches ();
 

--- a/tests/bits/data_out_common.h
+++ b/tests/bits/data_out_common.h
@@ -90,7 +90,7 @@ check (const FiniteElement<dim> &fe,
   Vector<double> v_node (dof_handler.n_dofs());
   for (unsigned int i=0; i<v_node.size(); ++i) v_node(i) = i;
 
-  Vector<double> v_cell (dof_handler.get_tria().n_active_cells());
+  Vector<double> v_cell (dof_handler.get_triangulation().n_active_cells());
   for (unsigned int i=0; i<v_cell.size(); ++i) v_cell(i) = i;
 
   // call main function in .cc files

--- a/tests/bits/dof_tools_06.cc
+++ b/tests/bits/dof_tools_06.cc
@@ -30,7 +30,7 @@ check_this (const DoFHandler<dim> &dof_handler)
 {
   std::vector<bool> dofs(dof_handler.n_dofs());
 
-  for (unsigned int level=0; level<dof_handler.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<dof_handler.get_triangulation().n_levels(); ++level)
     {
       DoFTools::extract_subdomain_dofs (dof_handler,
                                         level,

--- a/tests/bits/dof_tools_13.cc
+++ b/tests/bits/dof_tools_13.cc
@@ -35,7 +35,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   if (dof_handler.get_fe().is_primitive() == false)
     return;
 
-  Vector<double> cell_data (dof_handler.get_tria().n_active_cells());
+  Vector<double> cell_data (dof_handler.get_triangulation().n_active_cells());
   for (unsigned int i=0; i<cell_data.size(); ++i)
     cell_data(i) = i;
 

--- a/tests/bits/dof_tools_13a.cc
+++ b/tests/bits/dof_tools_13a.cc
@@ -41,7 +41,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   if (dof_handler.get_fe().is_primitive() == false)
     return;
 
-  Vector<double> cell_data (dof_handler.get_tria().n_active_cells());
+  Vector<double> cell_data (dof_handler.get_triangulation().n_active_cells());
   for (unsigned int i=0; i<cell_data.size(); ++i)
     cell_data(i) = i;
 

--- a/tests/bits/dof_tools_19.cc
+++ b/tests/bits/dof_tools_19.cc
@@ -78,7 +78,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   cm.distribute (solution);
 
   // Evaluate error
-  Vector<double> cellwise_errors (dof_handler.get_tria ().n_active_cells());
+  Vector<double> cellwise_errors (dof_handler.get_triangulation ().n_active_cells());
   VectorTools::integrate_difference (dof_handler, solution, test_func,
                                      cellwise_errors, quadrature,
                                      VectorTools::L2_norm);

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -265,7 +265,7 @@ namespace Evaluation
              << ".eps"
              << std::ends;
 
-    GridOut().write_eps (dof_handler.get_tria(),
+    GridOut().write_eps (dof_handler.get_triangulation(),
                          deallog.get_file_stream());
   }
 }
@@ -1682,7 +1682,7 @@ namespace LaplaceSolver
         face_integrals[cell->face(face_no)] = -1e20;
 
     error_indicators.reinit (dual_solver.dof_handler
-                             .get_tria().n_active_cells());
+                             .get_triangulation().n_active_cells());
 
     const unsigned int n_threads = MultithreadInfo::n_threads();
     for (unsigned int i=0; i<n_threads; ++i)

--- a/tests/codim_one/surface.cc
+++ b/tests/codim_one/surface.cc
@@ -90,7 +90,7 @@ void test(std::string filename)
   deallog<<"Approximate measure of hyper sphere = "<<area<<std::endl;
   deallog<<"Error = "<<std::fabs(dim*2*numbers::PI-area)<<std::endl;
   deallog << "Average error in norms: "
-          << ( normals/dof_handler.get_tria().n_active_cells()
+          << ( normals/dof_handler.get_triangulation().n_active_cells()
                /fe_values.n_quadrature_points)
           << std::endl;
 

--- a/tests/dofs/accessor_01.cc
+++ b/tests/dofs/accessor_01.cc
@@ -44,7 +44,7 @@ template <typename DoFHandlerType>
 void test_in_dim(const DoFHandlerType &d1, const DoFHandlerType &d2)
 {
   typename DoFHandlerType::active_cell_iterator a = d1.begin_active();
-  typename DoFHandlerType::cell_iterator l = d1.begin(d1.get_tria().n_levels()-1);
+  typename DoFHandlerType::cell_iterator l = d1.begin(d1.get_triangulation().n_levels()-1);
 
   deallog << "a " << a << std::endl
           << "l " << l << std::endl;

--- a/tests/dofs/accessor_02.cc
+++ b/tests/dofs/accessor_02.cc
@@ -44,7 +44,7 @@ template <typename DoFHandlerType>
 void test_in_dim(const DoFHandlerType &d1, const DoFHandlerType &d2)
 {
   typename DoFHandlerType::active_cell_iterator a = d1.begin_active();
-  typename DoFHandlerType::cell_iterator l = d1.begin(d1.get_tria().n_levels()-1);
+  typename DoFHandlerType::cell_iterator l = d1.begin(d1.get_triangulation().n_levels()-1);
 
   deallog << "a " << a << std::endl
           << "l " << l << std::endl;

--- a/tests/dofs/dof_renumbering.cc
+++ b/tests/dofs/dof_renumbering.cc
@@ -116,7 +116,7 @@ check_renumbering(DoFHandler<dim> &mgdof, bool discontinuous)
   print_dofs (dof);
 
   // Check level ordering
-  for (unsigned int level=0; level<dof.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<dof.get_triangulation().n_levels(); ++level)
     {
       print_dofs (mgdof, level);
 

--- a/tests/dofs/dof_renumbering_02.cc
+++ b/tests/dofs/dof_renumbering_02.cc
@@ -123,7 +123,7 @@ check_renumbering(DoFHandler<dim> &mgdof)
   DoFRenumbering::downstream(dof, direction);
   print_dofs (dof);
   // Check level ordering
-  for (unsigned int level=0; level<dof.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<dof.get_triangulation().n_levels(); ++level)
     {
       deallog << "Level " << level << std::endl;
       DoFRenumbering::downstream(mgdof, level, direction);
@@ -134,7 +134,7 @@ check_renumbering(DoFHandler<dim> &mgdof)
   DoFRenumbering::downstream(dof, direction, true);
   print_dofs (dof);
   // Check level ordering
-  for (unsigned int level=0; level<dof.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<dof.get_triangulation().n_levels(); ++level)
     {
       deallog << "Level " << level << std::endl;
       DoFRenumbering::downstream(mgdof, level, direction, true);

--- a/tests/dofs/dof_renumbering_07.cc
+++ b/tests/dofs/dof_renumbering_07.cc
@@ -78,7 +78,7 @@ check_renumbering(DoFHandler<dim> &dof)
   deallog << element.get_name() << std::endl;
 
   DoFRenumbering::boost::Cuthill_McKee(dof);
-  for (unsigned int level=0; level<dof.get_tria().n_levels(); ++level)
+  for (unsigned int level=0; level<dof.get_triangulation().n_levels(); ++level)
     DoFRenumbering::Cuthill_McKee(dof, level);
   print_dofs (dof);
 }

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -265,7 +265,7 @@ namespace Evaluation
              << ".eps"
              << std::ends;
 
-    GridOut().write_eps (dof_handler.get_tria(),
+    GridOut().write_eps (dof_handler.get_triangulation(),
                          deallog.get_file_stream());
   }
 }
@@ -1682,7 +1682,7 @@ namespace LaplaceSolver
         face_integrals[cell->face(face_no)] = -1e20;
 
     error_indicators.reinit (dual_solver.dof_handler
-                             .get_tria().n_active_cells());
+                             .get_triangulation().n_active_cells());
 
     const unsigned int n_threads = MultithreadInfo::n_threads();
     Threads::ThreadGroup<> threads;

--- a/tests/fail/rt_crash_01.cc
+++ b/tests/fail/rt_crash_01.cc
@@ -75,7 +75,7 @@ check_this (const DoFHandler<dim> &dof_handler)
             ExcInternalError());
 
   // Evaluate error
-  Vector<double> cellwise_errors (dof_handler.get_tria ().n_active_cells());
+  Vector<double> cellwise_errors (dof_handler.get_triangulation ().n_active_cells());
   VectorTools::integrate_difference (dof_handler, solution, test_func,
                                      cellwise_errors, quadrature,
                                      VectorTools::L2_norm);

--- a/tests/grid/grid_tools_halo_layer_04.cc
+++ b/tests/grid/grid_tools_halo_layer_04.cc
@@ -46,7 +46,7 @@ template <int dim>
 void
 write_vtk (const hp::DoFHandler<dim> &dof_handler, const std::string filename)
 {
-  Vector<double> active_fe_index (dof_handler.get_tria().n_active_cells());
+  Vector<double> active_fe_index (dof_handler.get_triangulation().n_active_cells());
   int count = 0;
   typename hp::DoFHandler<dim>::active_cell_iterator
   cell = dof_handler.begin_active(),

--- a/tests/grid/grid_tools_halo_layer_05.cc
+++ b/tests/grid/grid_tools_halo_layer_05.cc
@@ -46,7 +46,7 @@ template <int dim>
 void
 write_vtk (const hp::DoFHandler<dim> &dof_handler, const std::string filename)
 {
-  Vector<double> active_fe_index (dof_handler.get_tria().n_active_cells());
+  Vector<double> active_fe_index (dof_handler.get_triangulation().n_active_cells());
   int count = 0;
   typename hp::DoFHandler<dim>::active_cell_iterator
   cell = dof_handler.begin_active(),

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -132,7 +132,7 @@ void assemble_mg_matrix(DoFHandler<dim> &dof_handler,
     dof_handler.begin_mg(), dof_handler.end_mg(),
     dof_info, info_box, matrix_integrator, assembler);
 
-  const unsigned int nlevels = dof_handler.get_tria().n_levels();
+  const unsigned int nlevels = dof_handler.get_triangulation().n_levels();
   for (unsigned int level=0; level<nlevels; ++level)
     {
       for (unsigned int i=0; i<dof_handler.n_dofs(level); ++i)

--- a/tests/integrators/cells_and_faces_01.cc
+++ b/tests/integrators/cells_and_faces_01.cc
@@ -93,8 +93,8 @@ test_mesh(DoFHandler<dim> &mgdofs)
   BlockVector<double> faces(n_functionals);
   for (unsigned int i=0; i<n_functionals; ++i)
     {
-      cells.block(i).reinit(dofs.get_tria().n_cells());
-      faces.block(i).reinit(dofs.get_tria().n_faces());
+      cells.block(i).reinit(dofs.get_triangulation().n_cells());
+      faces.block(i).reinit(dofs.get_triangulation().n_faces());
     }
   cells.collect_sizes();
   faces.collect_sizes();

--- a/tests/integrators/mesh_worker_02.cc
+++ b/tests/integrators/mesh_worker_02.cc
@@ -224,7 +224,7 @@ test_simple(DoFHandler<dim> &mgdofs)
   MGLevelObject<SparseMatrix<double> > mg_matrix_dg_up;
   MGLevelObject<SparseMatrix<double> > mg_matrix_dg_down;
 
-  const unsigned int n_levels = mgdofs.get_tria().n_levels();
+  const unsigned int n_levels = mgdofs.get_triangulation().n_levels();
 
   mg_sparsity.resize(0, n_levels-1);
   mg_sparsity_dg_interface.resize(0, n_levels-1);

--- a/tests/integrators/mesh_worker_03.cc
+++ b/tests/integrators/mesh_worker_03.cc
@@ -237,7 +237,7 @@ test_simple(DoFHandler<dim> &mgdofs)
   MGLevelObject<SparseMatrix<double> > mg_matrix_dg_up;
   MGLevelObject<SparseMatrix<double> > mg_matrix_dg_down;
 
-  const unsigned int n_levels = mgdofs.get_tria().n_levels();
+  const unsigned int n_levels = mgdofs.get_triangulation().n_levels();
 
   mg_sparsity.resize(0, n_levels-1);
   mg_sparsity_dg_interface.resize(0, n_levels-1);

--- a/tests/matrix_free/copy.cc
+++ b/tests/matrix_free/copy.cc
@@ -72,7 +72,7 @@ void sub_test()
                                                 constraints);
       constraints.close();
 
-      //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+      //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
       //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
       //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -218,7 +218,7 @@ void do_test (const DoFHandler<dim> &dof,
 {
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
   // use this for info on problem
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/get_functions_gl.cc
+++ b/tests/matrix_free/get_functions_gl.cc
@@ -53,7 +53,7 @@ void test ()
   constraints.close();
 
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/get_functions_mappingq.cc
+++ b/tests/matrix_free/get_functions_mappingq.cc
@@ -54,7 +54,7 @@ void test ()
   // get_functions_common, but here we have to
   // manually choose another mapping
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/get_functions_q_hierarchical.cc
+++ b/tests/matrix_free/get_functions_q_hierarchical.cc
@@ -55,7 +55,7 @@ void test ()
   constraints.close();
 
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/get_functions_rect.cc
+++ b/tests/matrix_free/get_functions_rect.cc
@@ -76,7 +76,7 @@ void test ()
   // get_functions_common, but here we have to
   // manually choose non-rectangular tests.
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/get_values_plain.cc
+++ b/tests/matrix_free/get_values_plain.cc
@@ -107,7 +107,7 @@ void do_test (const DoFHandler<dim> &dof,
               const ConstraintMatrix &constraints)
 {
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/matrix_vector_15.cc
+++ b/tests/matrix_free/matrix_vector_15.cc
@@ -95,7 +95,7 @@ void do_test (const DoFHandler<dim> &dof,
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
   if (parallel_option > 0)
     deallog << "Parallel option: " << parallel_option << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -96,7 +96,7 @@ void do_test (const DoFHandler<dim>  &dof,
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
   if (parallel_option > 0)
     deallog << "Parallel option: " << parallel_option << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/matrix_vector_common.h
+++ b/tests/matrix_free/matrix_vector_common.h
@@ -47,7 +47,7 @@ void do_test (const DoFHandler<dim> &dof,
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
   if (parallel_option > 0)
     deallog << "Parallel option: " << parallel_option << std::endl;
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -158,7 +158,7 @@ void test ()
   sparsity.copy_from (csp);
   SparseMatrix<double> system_matrix (sparsity);
 
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -53,7 +53,7 @@ void test ()
                                             constraints);
   constraints.close ();
 
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   // set up MatrixFree

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -113,7 +113,7 @@ void do_test (const DoFHandler<dim> &dof,
               const ConstraintMatrix &constraints)
 {
   // use this for info on problem
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -81,7 +81,7 @@ public:
         endc = dof_handler.end(level);
         for (; cell!=endc; ++cell)
           {
-            if (dof_handler.get_tria().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+            if (dof_handler.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
                 && cell->level_subdomain_id()==numbers::artificial_subdomain_id)
               continue;
             const FiniteElement<dim> &fe = cell->get_fe();
@@ -339,8 +339,8 @@ void do_test (const DoFHandler<dim>  &dof,
   typedef LaplaceOperator<dim,fe_degree,n_q_points_1d,number> LevelMatrixType;
 
   MGLevelObject<LevelMatrixType> mg_matrices;
-  mg_matrices.resize(0, dof.get_tria().n_levels()-1);
-  for (unsigned int level = 0; level<dof.get_tria().n_levels(); ++level)
+  mg_matrices.resize(0, dof.get_triangulation().n_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_levels(); ++level)
     {
       mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
     }
@@ -356,8 +356,8 @@ void do_test (const DoFHandler<dim>  &dof,
   mg_smoother;
 
   MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
-  smoother_data.resize(0, dof.get_tria().n_levels()-1);
-  for (unsigned int level = 0; level<dof.get_tria().n_levels(); ++level)
+  smoother_data.resize(0, dof.get_triangulation().n_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_levels(); ++level)
     {
       smoother_data[level].smoothing_range = 15.;
       smoother_data[level].degree = 5;

--- a/tests/matrix_free/thread_correctness.cc
+++ b/tests/matrix_free/thread_correctness.cc
@@ -75,7 +75,7 @@ void sub_test()
                                                 constraints);
       constraints.close();
 
-      //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+      //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
       //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
       //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -135,7 +135,7 @@ void do_test (const unsigned int parallel_option)
                                             constraints);
   constraints.close ();
 
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells() << std::endl;
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells() << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 

--- a/tests/matrix_free/update_mapping_only.cc
+++ b/tests/matrix_free/update_mapping_only.cc
@@ -45,7 +45,7 @@ void test ()
 
   deallog << "Testing " << dof.get_fe().get_name() << std::endl;
   // use this for info on problem
-  //std::cout << "Number of cells: " << dof.get_tria().n_active_cells()
+  //std::cout << "Number of cells: " << dof.get_triangulation().n_active_cells()
   //          << std::endl;
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
@@ -64,7 +64,7 @@ void test ()
   constraints.distribute(solution);
 
   FESystem<dim> fe_sys(dof.get_fe(), dim);
-  DoFHandler<dim> dofh_eulerian(dof.get_tria());
+  DoFHandler<dim> dofh_eulerian(dof.get_triangulation());
   dofh_eulerian.distribute_dofs(fe_sys);
 
   MatrixFree<dim,double> mf_data;

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -121,7 +121,7 @@ void initialize (const DoFHandler<dim> &dof,
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
   std::vector<types::global_dof_index> face_indices(dofs_per_face);
 
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       for (typename DoFHandler<dim>::cell_iterator
            cell = dof.begin_mg(l);
@@ -153,7 +153,7 @@ void print (const DoFHandler<dim> &dof,
 {
   const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       deallog << std::endl;
       deallog << "Level " << l << std::endl;

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -121,7 +121,7 @@ void initialize (const DoFHandler<dim> &dof,
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
   std::vector<types::global_dof_index> face_indices(dofs_per_face);
 
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       for (typename DoFHandler<dim>::cell_iterator
            cell = dof.begin_mg(l);
@@ -153,7 +153,7 @@ void print (const DoFHandler<dim> &dof,
 {
   const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       deallog << std::endl;
       deallog << "Level " << l << std::endl;

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -136,7 +136,7 @@ void print(const DoFHandler<dim> &dof, std::vector<std::vector<bool> > &interfac
 {
   const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
   std::vector<unsigned int> dof_indices(dofs_per_cell);
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       deallog << std::endl;
       deallog << "Level " << l << std::endl;

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -164,7 +164,7 @@ void print(const DoFHandler<dim> &dof, std::vector<std::vector<bool> > &interfac
 {
   const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       deallog << std::endl;
       deallog << "Level " << l << std::endl;

--- a/tests/multigrid/transfer_03.cc
+++ b/tests/multigrid/transfer_03.cc
@@ -131,7 +131,7 @@ void print (const DoFHandler<dim> &dof,
 {
   const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
-  for (unsigned int l=0; l<dof.get_tria().n_levels(); ++l)
+  for (unsigned int l=0; l<dof.get_triangulation().n_levels(); ++l)
     {
       deallog << std::endl;
       deallog << "Level " << l << std::endl;

--- a/tests/multigrid/transfer_block.cc
+++ b/tests/multigrid/transfer_block.cc
@@ -58,7 +58,7 @@ reinit_vector_by_blocks (
   if (ndofs.size() == 0)
     {
       std::vector<std::vector<types::global_dof_index> >
-      new_dofs(mg_dof.get_tria().n_levels(),
+      new_dofs(mg_dof.get_triangulation().n_levels(),
                std::vector<types::global_dof_index>(selected.size()));
       std::swap(ndofs, new_dofs);
       MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -105,7 +105,7 @@ void check_block(const FiniteElement<dim> &fe,
 
   for (unsigned int l=0; l<tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l);
-  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_tria().n_levels(),
+  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_triangulation().n_levels(),
                                                               std::vector<types::global_dof_index>(fe.n_blocks()));
   MGTools::count_dofs_per_block(mgdof, mg_ndofs);
 

--- a/tests/multigrid/transfer_block_select.cc
+++ b/tests/multigrid/transfer_block_select.cc
@@ -57,7 +57,7 @@ reinit_vector_by_blocks (
   if (ndofs.size() == 0)
     {
       std::vector<std::vector<types::global_dof_index> >
-      new_dofs(mg_dof.get_tria().n_levels(),
+      new_dofs(mg_dof.get_triangulation().n_levels(),
                std::vector<types::global_dof_index>(selected.size()));
       std::swap(ndofs, new_dofs);
       MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -91,7 +91,7 @@ void check_select(const FiniteElement<dim> &fe, unsigned int selected)
 
   for (unsigned int l=0; l<tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l);
-  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_tria().n_levels(),
+  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_triangulation().n_levels(),
                                                               std::vector<types::global_dof_index>(fe.n_blocks()));
   MGTools::count_dofs_per_block(mgdof, mg_ndofs);
 

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -60,7 +60,7 @@ reinit_vector_by_blocks (
   if (ndofs.size() == 0)
     {
       std::vector<std::vector<types::global_dof_index> >
-      new_dofs(mg_dof.get_tria().n_levels(),
+      new_dofs(mg_dof.get_triangulation().n_levels(),
                std::vector<types::global_dof_index>(selected.size()));
       std::swap(ndofs, new_dofs);
       MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -92,7 +92,7 @@ reinit_vector_by_blocks (
   if (ndofs.size() == 0)
     {
       std::vector<std::vector<types::global_dof_index> >
-      new_dofs(mg_dof.get_tria().n_levels(),
+      new_dofs(mg_dof.get_triangulation().n_levels(),
                std::vector<types::global_dof_index>(selected.size()));
       std::swap(ndofs, new_dofs);
       MGTools::count_dofs_per_block (mg_dof, ndofs);
@@ -148,7 +148,7 @@ void check_block(const FiniteElement<dim> &fe)
   // Store sizes
   vector<types::global_dof_index> ndofs(fe.n_blocks());
   DoFTools::count_dofs_per_block(mgdof, ndofs);
-  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_tria().n_levels(),
+  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_triangulation().n_levels(),
                                                               std::vector<types::global_dof_index>(fe.n_blocks()));
   MGTools::count_dofs_per_block(mgdof, mg_ndofs);
 

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -67,7 +67,7 @@ void check_select(const FiniteElement<dim> &fe,
   for (unsigned int l=0; l<tr.n_levels(); ++l)
     DoFRenumbering::component_wise(mgdof, l, mg_target_component);
 
-  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_tria().n_levels());
+  std::vector<std::vector<types::global_dof_index> > mg_ndofs(mgdof.get_triangulation().n_levels());
   MGTools::count_dofs_per_component(mgdof, mg_ndofs, true, mg_target_component);
 
   deallog << "Global  dofs:";

--- a/tests/trilinos/mg_transfer_prebuilt_01.cc
+++ b/tests/trilinos/mg_transfer_prebuilt_01.cc
@@ -45,7 +45,7 @@ reinit_vector (const dealii::DoFHandler<dim,spacedim> &mg_dof,
 {
   const dealii::parallel::distributed::Triangulation<dim,spacedim> *tria =
     (dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
-     (&mg_dof.get_tria()));
+     (&mg_dof.get_triangulation()));
   AssertThrow(tria!=NULL, ExcMessage("multigrid with Trilinos vectors only works with distributed Triangulation!"));
 
   for (unsigned int level=v.min_level();


### PR DESCRIPTION
As @drwells correctly points out in #1968, one can write more generic code by introducing a function `Triangulation::get_tria()` that simply returns a reference to itself. This patch does so and then deletes some 200 lines of workarounds for the previous lack of this function.

This fixes #1968.