### PR TITLE
Provide serialization for long long TableEntry

### DIFF
--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -734,6 +734,11 @@ namespace internal
         char c = 's';
         ar &c & *p;
       }
+    else if (const unsigned long long int *p = boost::get<unsigned long long int>(&value))
+      {
+        char c = 'l';
+        ar &c & *p;
+      }
     else
       Assert (false, ExcInternalError());
   }
@@ -780,6 +785,14 @@ namespace internal
       case 's':
       {
         std::string val;
+        ar &val;
+        value = val;
+        break;
+      }
+
+      case 'l':
+      {
+        unsigned long long int val;
         ar &val;
         value = val;
         break;


### PR DESCRIPTION
This fixes serialization of `TableHandler` with `unsigned long long int` entries. If someone has a better suggestion for a type identifier than 'l', I am open for suggestions.