### PR TITLE
Remove two exceptions that are not used in deal.II any more.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2075,19 +2075,6 @@ public:
    */
   DeclException0 (ExcInterpolationNotImplemented);
 
-  /**
-   * Exception
-   *
-   * @ingroup Exceptions
-   */
-  DeclException0 (ExcBoundaryFaceUsed);
-  /**
-   * Exception
-   *
-   * @ingroup Exceptions
-   */
-  DeclException0 (ExcJacobiDeterminantHasWrongSign);
-
 protected:
 
   /**


### PR DESCRIPTION
I found this looking into #512. Also in reference to #610.