### PR TITLE
Avoid using a deprecated function.

### DIFF
--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -351,7 +351,7 @@ namespace Step14
                << std::ends;
 
       std::ofstream out (filename.str().c_str());
-      GridOut().write_eps (dof_handler.get_tria(), out);
+      GridOut().write_eps (dof_handler.get_triangulation(), out);
     }
   }
 
@@ -2358,7 +2358,7 @@ namespace Step14
       // all off to WorkStream::run to compute the estimators for all
       // cells in parallel:
       error_indicators.reinit (DualSolver<dim>::dof_handler
-                               .get_tria().n_active_cells());
+                               .get_triangulation().n_active_cells());
 
       typedef
       std_cxx11::tuple<active_cell_iterator,Vector<float>::iterator>

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1018,9 +1018,9 @@ namespace Step9
                                 const Vector<double>  &solution,
                                 Vector<float>         &error_per_cell)
   {
-    Assert (error_per_cell.size() == dof_handler.get_tria().n_active_cells(),
+    Assert (error_per_cell.size() == dof_handler.get_triangulation().n_active_cells(),
             ExcInvalidVectorLength (error_per_cell.size(),
-                                    dof_handler.get_tria().n_active_cells()));
+                                    dof_handler.get_triangulation().n_active_cells()));
 
     typedef std_cxx11::tuple<typename DoFHandler<dim>::active_cell_iterator,Vector<float>::iterator>
     IteratorTuple;


### PR DESCRIPTION
The function DoFHandler::get_tria() was deprecated in #1970. This
patch avoids their use in the tutorials and instead uses the function's
replacement.