### PR TITLE
Use cell->active_cell_index() instead of the double-indexed loop.

### DIFF
--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1301,7 +1301,7 @@ namespace Step18
       typename Triangulation<dim>::active_cell_iterator
       cell = triangulation.begin_active(),
       endc = triangulation.end();
-      for (unsigned int index=0; cell!=endc; ++cell, ++index)
+      for (; cell!=endc; ++cell)
         if (cell->is_locally_owned() )
           {
             // On these cells, add up the stresses over all quadrature
@@ -1315,7 +1315,7 @@ namespace Step18
                 .old_stress;
 
             // ...then write the norm of the average to their destination:
-            norm_of_stress(index)
+            norm_of_stress(cell->active_cell_index())
               = (accumulated_stress /
                  quadrature_formula.size()).norm();
           }
@@ -1326,7 +1326,7 @@ namespace Step18
       // elements would not appear in the output file, that we would find out
       // by looking at the graphical output:
         else
-          norm_of_stress(index) = -1e+20;
+          norm_of_stress(cell->active_cell_index()) = -1e+20;
     }
     // Finally attach this vector as well to be treated for output:
     data_out.add_data_vector (norm_of_stress, "norm_of_stress");

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -382,8 +382,8 @@ namespace Step27
         typename hp::DoFHandler<dim>::active_cell_iterator
         cell = dof_handler.begin_active(),
         endc = dof_handler.end();
-        for (unsigned int index=0; cell!=endc; ++cell, ++index)
-          fe_degrees(index)
+        for (; cell!=endc; ++cell)
+          fe_degrees(cell->active_cell_index())
             = fe_collection[cell->active_fe_index()].degree;
       }
 
@@ -443,13 +443,13 @@ namespace Step27
         typename hp::DoFHandler<dim>::active_cell_iterator
         cell = dof_handler.begin_active(),
         endc = dof_handler.end();
-        for (unsigned int index=0; cell!=endc; ++cell, ++index)
+        for (; cell!=endc; ++cell)
           if (cell->refine_flag_set())
             {
               max_smoothness = std::max (max_smoothness,
-                                         smoothness_indicators(index));
+                                         smoothness_indicators(cell->active_cell_index()));
               min_smoothness = std::min (min_smoothness,
-                                         smoothness_indicators(index));
+                                         smoothness_indicators(cell->active_cell_index()));
             }
       }
       const float threshold_smoothness = (max_smoothness + min_smoothness) / 2;
@@ -466,10 +466,10 @@ namespace Step27
         typename hp::DoFHandler<dim>::active_cell_iterator
         cell = dof_handler.begin_active(),
         endc = dof_handler.end();
-        for (unsigned int index=0; cell!=endc; ++cell, ++index)
+        for (; cell!=endc; ++cell)
           if (cell->refine_flag_set()
               &&
-              (smoothness_indicators(index) > threshold_smoothness)
+              (smoothness_indicators(cell->active_cell_index()) > threshold_smoothness)
               &&
               (cell->active_fe_index()+1 < fe_collection.size()))
             {
@@ -753,7 +753,7 @@ namespace Step27
     typename hp::DoFHandler<dim>::active_cell_iterator
     cell = dof_handler.begin_active(),
     endc = dof_handler.end();
-    for (unsigned int index=0; cell!=endc; ++cell, ++index)
+    for (; cell!=endc; ++cell)
       {
         // Inside the loop, we first need to get the values of the local
         // degrees of freedom (which we put into the
@@ -829,7 +829,7 @@ namespace Step27
 
         // The final step is to compute the Sobolev index $s=\mu-\frac d2$ and
         // store it in the vector of estimated values for each cell:
-        smoothness_indicators(index) = mu - 1.*dim/2;
+        smoothness_indicators(cell->active_cell_index()) = mu - 1.*dim/2;
       }
   }
 }

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1093,10 +1093,10 @@ namespace Step28
     cell = triangulation.begin_active(),
     endc = triangulation.end();
 
-    for (unsigned int cell_index=0; cell!=endc; ++cell, ++cell_index)
-      if (error_indicators(cell_index) > refine_threshold)
+    for (; cell!=endc; ++cell)
+      if (error_indicators(cell->active_cell_index()) > refine_threshold)
         cell->set_refine_flag ();
-      else if (error_indicators(cell_index) < coarsen_threshold)
+      else if (error_indicators(cell->active_cell_index()) < coarsen_threshold)
         cell->set_coarsen_flag ();
 
     SolutionTransfer<dim> soltrans(dof_handler);

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -994,59 +994,56 @@ namespace Step46
     // more. The structure of these nested conditions is much the same as we
     // encountered when assembling interface terms in
     // <code>assemble_system</code>.
-    {
-      unsigned int cell_index = 0;
-      for (typename hp::DoFHandler<dim>::active_cell_iterator
-           cell = dof_handler.begin_active();
-           cell != dof_handler.end(); ++cell, ++cell_index)
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-          if (cell_is_in_solid_domain (cell))
-            {
-              if ((cell->at_boundary(f) == false)
+    for (typename hp::DoFHandler<dim>::active_cell_iterator
+         cell = dof_handler.begin_active();
+         cell != dof_handler.end(); ++cell)
+      for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        if (cell_is_in_solid_domain (cell))
+          {
+            if ((cell->at_boundary(f) == false)
+                &&
+                (((cell->neighbor(f)->level() == cell->level())
                   &&
-                  (((cell->neighbor(f)->level() == cell->level())
-                    &&
-                    (cell->neighbor(f)->has_children() == false)
-                    &&
-                    cell_is_in_fluid_domain (cell->neighbor(f)))
-                   ||
-                   ((cell->neighbor(f)->level() == cell->level())
-                    &&
-                    (cell->neighbor(f)->has_children() == true)
-                    &&
-                    (cell_is_in_fluid_domain (cell->neighbor_child_on_subface
-                                              (f, 0))))
-                   ||
-                   (cell->neighbor_is_coarser(f)
-                    &&
-                    cell_is_in_fluid_domain(cell->neighbor(f)))
-                  ))
-                estimated_error_per_cell(cell_index) = 0;
-            }
-          else
-            {
-              if ((cell->at_boundary(f) == false)
+                  (cell->neighbor(f)->has_children() == false)
                   &&
-                  (((cell->neighbor(f)->level() == cell->level())
-                    &&
-                    (cell->neighbor(f)->has_children() == false)
-                    &&
-                    cell_is_in_solid_domain (cell->neighbor(f)))
-                   ||
-                   ((cell->neighbor(f)->level() == cell->level())
-                    &&
-                    (cell->neighbor(f)->has_children() == true)
-                    &&
-                    (cell_is_in_solid_domain (cell->neighbor_child_on_subface
-                                              (f, 0))))
-                   ||
-                   (cell->neighbor_is_coarser(f)
-                    &&
-                    cell_is_in_solid_domain(cell->neighbor(f)))
-                  ))
-                estimated_error_per_cell(cell_index) = 0;
-            }
-    }
+                  cell_is_in_fluid_domain (cell->neighbor(f)))
+                 ||
+                 ((cell->neighbor(f)->level() == cell->level())
+                  &&
+                  (cell->neighbor(f)->has_children() == true)
+                  &&
+                  (cell_is_in_fluid_domain (cell->neighbor_child_on_subface
+                                            (f, 0))))
+                 ||
+                 (cell->neighbor_is_coarser(f)
+                  &&
+                  cell_is_in_fluid_domain(cell->neighbor(f)))
+                ))
+              estimated_error_per_cell(cell->active_cell_index()) = 0;
+          }
+        else
+          {
+            if ((cell->at_boundary(f) == false)
+                &&
+                (((cell->neighbor(f)->level() == cell->level())
+                  &&
+                  (cell->neighbor(f)->has_children() == false)
+                  &&
+                  cell_is_in_solid_domain (cell->neighbor(f)))
+                 ||
+                 ((cell->neighbor(f)->level() == cell->level())
+                  &&
+                  (cell->neighbor(f)->has_children() == true)
+                  &&
+                  (cell_is_in_solid_domain (cell->neighbor_child_on_subface
+                                            (f, 0))))
+                 ||
+                 (cell->neighbor_is_coarser(f)
+                  &&
+                  cell_is_in_solid_domain(cell->neighbor(f)))
+                ))
+              estimated_error_per_cell(cell->active_cell_index()) = 0;
+          }
 
     GridRefinement::refine_and_coarsen_fixed_number (triangulation,
                                                      estimated_error_per_cell,


### PR DESCRIPTION
#765 introduced CellAccessor::active_cell_index() and used it in a number of places
in the library. But there were locations in the tutorial that were not converted
as part of #765 that still needed to be addressed. This patch does this.

Fixes #761.