### PR TITLE
Add a missing PETScWrappers label.

### DIFF
--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -452,6 +452,7 @@ namespace PETScWrappers
   /**
    * An implementation of the solver interface using the PETSc GMRES solver.
    *
+   * @ingroup PETScWrappers
    * @author Wolfgang Bangerth, 2004
    */
   class SolverGMRES : public SolverBase


### PR DESCRIPTION
For some reason the `PETSc` `GMRES` solver is not on this list.