### PR TITLE
fix uninitialized members in SparseMatrixEZ

### DIFF
--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -86,7 +86,7 @@ template<typename number> class FullMatrix;
  * If the rows are expected to be filled more or less from first to last,
  * using a @p default_row_length of zero may not be such a bad idea.
  *
- * The name of this matrix is in reverence to a publication of the Internal
+ * The name of this matrix is in reference to a publication of the Internal
  * Revenue Service of the United States of America. I hope some other aliens
  * will appreciate it. By the way, the suffix makes sense by pronouncing it
  * the American way.

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -31,9 +31,10 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 SparseMatrixEZ<number>::SparseMatrixEZ()
-{
-  n_columns = 0;
-}
+  : n_columns (0),
+    increment (1),
+    saved_default_row_length (0)
+{}
 
 
 template <typename number>


### PR DESCRIPTION
An uninitialized member would cause random crashes in
tests/lac/sparse_matrices_ez as documented by valgrind:

==31301== Conditional jump or move depends on uninitialised value(s)
==31301==    at 0xB0C4614:
dealii::SparseMatrixEZ<float>::reinit(unsigned int, unsigned int,
unsigned int, unsigned int, unsigned int) (stl_vector.h:666)
==31301==    by 0x40F45C: main (sparse_matrix_ez.h:1400)