### PR TITLE
Convert the VectorSlice argument of Mapping::transform to ArrayView.

### DIFF
--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/array_view.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -64,20 +65,34 @@ public:
               unsigned int length);
 
   /**
+   * Conversion operator to an ArrayView object that represents
+   * an array of non-const elements pointing to the same location
+   * as the current object.
+   */
+  operator ArrayView<typename VectorType::value_type *> ();
+
+  /**
+   * Conversion operator to an ArrayView object that represents
+   * an array of const elements pointing to the same location
+   * as the current object.
+   */
+  operator ArrayView<const typename VectorType::value_type *> () const;
+
+  /**
    * Return the length of the slice using the same interface as
    * <tt>std::vector</tt>.
    */
   unsigned int size() const;
 
   /**
-   * Access an element of the slice using the same interface as
-   * <tt>std::vector</tt>.
+   * Return a reference to the $i$th element of the range
+   * represented by the current object.
    */
   typename VectorType::reference operator[] (unsigned int i);
 
   /**
-   * Access an element of a constant slice using the same interface as
-   * <tt>std::vector</tt>.
+   * Return a @p const reference to the $i$th element of the range
+   * represented by the current object.
    */
   typename VectorType::const_reference operator[] (unsigned int i) const;
 
@@ -185,6 +200,22 @@ unsigned int
 VectorSlice<VectorType>::size() const
 {
   return length;
+}
+
+
+template <typename VectorType>
+VectorSlice<VectorType>::
+operator ArrayView<typename VectorType::value_type *> ()
+{
+  return ArrayView<typename VectorType::value_type *> (&v[start], length);
+}
+
+
+template <typename VectorType>
+VectorSlice<VectorType>::
+operator ArrayView<const typename VectorType::value_type *> () const
+{
+  return ArrayView<const typename VectorType::value_type *> (&v[start], length);
 }
 
 

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -259,18 +259,18 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
   // we were in get_data()
   if (flags & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (fe_data.shape_gradients[k],
+      mapping.transform (make_array_view(fe_data.shape_gradients[k]),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_hessians[k],
+        mapping.transform (make_array_view(fe_data.shape_hessians[k]),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -283,10 +283,10 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
   if (flags & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_3rd_derivatives[k],
+        mapping.transform (make_array_view(fe_data.shape_3rd_derivatives[k]),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);
@@ -337,20 +337,19 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
 
   if (flags & update_gradients)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
+      mapping.transform (ArrayView<const Tensor<1,dim> >(&fe_data.shape_gradients[k][offset], quadrature.size()),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (flags & update_hessians)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (make_slice(fe_data.shape_hessians[k],
-                                      offset,
-                                      quadrature.size()),
+        mapping.transform (ArrayView<const Tensor<2,dim> >(&fe_data.shape_hessians[k][offset],
+                                                           quadrature.size()),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -363,17 +362,18 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator  
   if (flags & update_3rd_derivatives)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (make_slice(fe_data.shape_3rd_derivatives[k],
-                                      offset,
-                                      quadrature.size()),
+        mapping.transform (ArrayView<const Tensor<3,dim> >(&fe_data.shape_3rd_derivatives[k][offset],
+                                                           quadrature.size()),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);
     }
 }
+
+
 
 template <class PolynomialType, int dim, int spacedim>
 void
@@ -419,20 +419,20 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
   if (flags & update_gradients)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (make_slice(fe_data.shape_gradients[k], offset, quadrature.size()),
+      mapping.transform (ArrayView<const Tensor<1,dim> >(&fe_data.shape_gradients[k][offset],
+                                                         quadrature.size()),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (flags & update_hessians)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (make_slice(fe_data.shape_hessians[k],
-                                      offset,
-                                      quadrature.size()),
+        mapping.transform (ArrayView<const Tensor<2,dim> >(&fe_data.shape_hessians[k][offset],
+                                                           quadrature.size()),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -445,12 +445,11 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
   if (flags & update_3rd_derivatives)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (make_slice(fe_data.shape_3rd_derivatives[k],
-                                      offset,
-                                      quadrature.size()),
+        mapping.transform (ArrayView<const Tensor<3,dim> >(&fe_data.shape_3rd_derivatives[k][offset],
+                                                           quadrature.size()),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/std_cxx11/array.h>
-#include <deal.II/base/vector_slice.h>
+#include <deal.II/base/array_view.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/fe/fe_update_flags.h>
 
@@ -962,16 +962,15 @@ public:
    *   this object also represents with respect to which cell the transformation
    *   should be applied to.
    * @param[out] output An array (or part of an array) into which the transformed
-   *   objects should be placed.
+   *   objects should be placed. (Note that the array view is @p const, but the
+   *   tensors it points to are not.)
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+  transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const = 0;
-
-
+             const ArrayView<Tensor<1,spacedim> >                   &output) const = 0;
 
   /**
    * Transform a field of differential forms from the reference cell to the
@@ -1015,15 +1014,15 @@ public:
    *   this object also represents with respect to which cell the transformation
    *   should be applied to.
    * @param[out] output An array (or part of an array) into which the transformed
-   *   objects should be placed.
+   *   objects should be placed. (Note that the array view is @p const, but the
+   *   tensors it points to are not.)
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<1, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >                            output) const = 0;
-
+  transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<2,spacedim> >                     &output) const = 0;
 
   /**
    * Transform a tensor field from the reference cell to the physical cell.
@@ -1074,14 +1073,15 @@ public:
    *   this object also represents with respect to which cell the transformation
    *   should be applied to.
    * @param[out] output An array (or part of an array) into which the transformed
-   *   objects should be placed.
+   *   objects should be placed. (Note that the array view is @p const, but the
+   *   tensors it points to are not.)
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+  transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const = 0;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const = 0;
 
   /**
    * Transform a tensor field from the reference cell to the physical cell.
@@ -1118,14 +1118,15 @@ public:
    *   this object also represents with respect to which cell the transformation
    *   should be applied to.
    * @param[out] output An array (or part of an array) into which the transformed
-   *   objects should be placed.
+   *   objects should be placed. (Note that the array view is @p const, but the
+   *   tensors it points to are not.)
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const = 0;
+  transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<3,spacedim> >                     &output) const = 0;
 
   /**
    * Transform a field of 3-differential forms from the reference cell to the
@@ -1176,10 +1177,10 @@ public:
    */
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+  transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const = 0;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const = 0;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -94,42 +94,42 @@ public:
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+  transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-             const MappingType                                                       type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                 &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const;
+  transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<2,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+  transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
+  transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<3,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+  transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -160,42 +160,42 @@ public:
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+  transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > > input,
-             const MappingType                                                        type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                  &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >                           output) const;
+  transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<2,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+  transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
+  transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<3,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+  transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const;
 
   /**
    * @}

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -153,45 +153,45 @@ public:
   transform_real_to_unit_cell (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                                const Point<spacedim>                                     &p) const;
 
-  // for documentation, see the base classes
+  // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+  transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
-
-  // for documentation, see the base classes
-  virtual
-  void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim, spacedim> > > input,
-             const MappingType                                                        type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                  &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >                           output) const;
-
-  // for documentation, see the base classes
-  virtual
-  void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
-             const MappingType                                       type,
-             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
+  transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<2,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+  transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const;
+
+  // for documentation, see the Mapping base class
+  virtual
+  void
+  transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<3,spacedim> >                     &output) const;
+
+  // for documentation, see the Mapping base class
+  virtual
+  void
+  transform (const ArrayView<const Tensor<3, dim> >                 &input,
+             const MappingType                                       type,
+             const typename Mapping<dim,spacedim>::InternalDataBase &internal,
+             const ArrayView<Tensor<3,spacedim> >                   &output) const;
 
   /**
    * Return a pointer to a copy of the present object. The caller of this copy

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -152,42 +152,42 @@ public:
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+  transform (const ArrayView<const Tensor<1,dim> >                  &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const;
+             const ArrayView<Tensor<1,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-             const MappingType                                                       type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                 &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const;
+  transform (const ArrayView<const DerivativeForm<1, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<2,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+  transform (const ArrayView<const Tensor<2, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const;
+             const ArrayView<Tensor<2,spacedim> >                   &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-             const MappingType                                                         type,
-             const typename Mapping<dim,spacedim>::InternalDataBase                   &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const;
+  transform (const ArrayView<const DerivativeForm<2, dim, spacedim> > &input,
+             const MappingType                                         type,
+             const typename Mapping<dim,spacedim>::InternalDataBase   &internal,
+             const ArrayView<Tensor<3,spacedim> >                     &output) const;
 
   // for documentation, see the Mapping base class
   virtual
   void
-  transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
+  transform (const ArrayView<const Tensor<3, dim> >                 &input,
              const MappingType                                       type,
              const typename Mapping<dim,spacedim>::InternalDataBase &internal,
-             VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const;
+             const ArrayView<Tensor<3,spacedim> >                   &output) const;
 
   /**
    * @}

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -52,18 +52,18 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
   // we were in get_data()
   if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (fe_data.shape_gradients[k],
+      mapping.transform (make_array_view(fe_data.shape_gradients[k]),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_hessians[k],
+        mapping.transform (make_array_view(fe_data.shape_hessians[k]),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -76,10 +76,10 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
   if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_3rd_derivatives[k],
+        mapping.transform (make_array_view(fe_data.shape_3rd_derivatives[k]),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);
@@ -111,18 +111,18 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
   // we were in get_data()
   if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (fe_data.shape_gradients[k],
+      mapping.transform (make_array_view(fe_data.shape_gradients[k]),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_hessians[k],
+        mapping.transform (make_array_view(fe_data.shape_hessians[k]),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -135,10 +135,10 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
   if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_3rd_derivatives[k],
+        mapping.transform (make_array_view(fe_data.shape_3rd_derivatives[k]),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);
@@ -171,18 +171,18 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
   // we were in get_data()
   if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (fe_data.shape_gradients[k],
+      mapping.transform (make_array_view(fe_data.shape_gradients[k]),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_hessians[k],
+        mapping.transform (make_array_view(fe_data.shape_hessians[k]),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -195,10 +195,10 @@ fill_fe_values (const Triangulation<1,2>::cell_iterator &,
   if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_3rd_derivatives[k],
+        mapping.transform (make_array_view(fe_data.shape_3rd_derivatives[k]),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);
@@ -226,18 +226,18 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
   // we were in get_data()
   if (fe_data.update_each & update_gradients && cell_similarity != CellSimilarity::translation)
     for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-      mapping.transform (fe_data.shape_gradients[k],
+      mapping.transform (make_array_view(fe_data.shape_gradients[k]),
                          mapping_covariant,
                          mapping_internal,
-                         output_data.shape_gradients[k]);
+                         make_array_view(output_data.shape_gradients[k]));
 
   if (fe_data.update_each & update_hessians && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_hessians[k],
+        mapping.transform (make_array_view(fe_data.shape_hessians[k]),
                            mapping_covariant_gradient,
                            mapping_internal,
-                           output_data.shape_hessians[k]);
+                           make_array_view(output_data.shape_hessians[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         for (unsigned int i=0; i<quadrature.size(); ++i)
@@ -250,10 +250,10 @@ fill_fe_values (const Triangulation<2,3>::cell_iterator &,
   if (fe_data.update_each & update_3rd_derivatives && cell_similarity != CellSimilarity::translation)
     {
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
-        mapping.transform (fe_data.shape_3rd_derivatives[k],
+        mapping.transform (make_array_view(fe_data.shape_3rd_derivatives[k]),
                            mapping_covariant_hessian,
                            mapping_internal,
-                           output_data.shape_3rd_derivatives[k]);
+                           make_array_view(output_data.shape_3rd_derivatives[k]));
 
       for (unsigned int k=0; k<this->dofs_per_cell; ++k)
         correct_third_derivatives(output_data, mapping_data, quadrature.size(), k);

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -364,10 +364,10 @@ fill_fe_values
             case mapping_covariant:
             case mapping_contravariant:
             {
-              mapping.transform (fe_data.shape_values[i],
+              mapping.transform (make_array_view(fe_data.shape_values[i]),
                                  mapping_type,
                                  mapping_internal,
-                                 fe_data.transformed_shape_values);
+                                 make_array_view(fe_data.transformed_shape_values));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
@@ -379,10 +379,10 @@ fill_fe_values
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-              mapping.transform (fe_data.shape_values[i],
+              mapping.transform (make_array_view(fe_data.shape_values[i]),
                                  mapping_piola,
                                  mapping_internal,
-                                 fe_data.transformed_shape_values);
+                                 make_array_view(fe_data.transformed_shape_values));
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_values(first+d,k)
@@ -392,10 +392,10 @@ fill_fe_values
 
             case mapping_nedelec:
             {
-              mapping.transform (fe_data.shape_values[i],
+              mapping.transform (make_array_view(fe_data.shape_values[i]),
                                  mapping_covariant,
                                  mapping_internal,
-                                 fe_data.transformed_shape_values);
+                                 make_array_view(fe_data.transformed_shape_values));
 
               for (unsigned int k = 0; k < n_q_points; ++k)
                 for (unsigned int d = 0; d < dim; ++d)
@@ -423,10 +423,10 @@ fill_fe_values
             {
             case mapping_none:
             {
-              mapping.transform (fe_data.shape_grads[i],
+              mapping.transform (make_array_view(fe_data.shape_grads[i]),
                                  mapping_covariant,
                                  mapping_internal,
-                                 fe_data.transformed_shape_grads);
+                                 make_array_view(fe_data.transformed_shape_grads));
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_gradients[first+d][k] = fe_data.transformed_shape_grads[k][d];
@@ -434,10 +434,10 @@ fill_fe_values
             }
             case mapping_covariant:
             {
-              mapping.transform (fe_data.shape_grads[i],
+              mapping.transform (make_array_view(fe_data.shape_grads[i]),
                                  mapping_covariant_gradient,
                                  mapping_internal,
-                                 fe_data.transformed_shape_grads);
+                                 make_array_view(fe_data.transformed_shape_grads));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -455,10 +455,10 @@ fill_fe_values
             {
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k] = fe_data.shape_grads[i][k];
-              mapping.transform (fe_data.untransformed_shape_grads,
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads),
                                  mapping_contravariant_gradient,
                                  mapping_internal,
-                                 fe_data.transformed_shape_grads);
+                                 make_array_view(fe_data.transformed_shape_grads));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -478,10 +478,10 @@ fill_fe_values
             {
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k] = fe_data.shape_grads[i][k];
-              mapping.transform (fe_data.untransformed_shape_grads,
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads),
                                  mapping_piola_gradient,
                                  mapping_internal,
-                                 fe_data.transformed_shape_grads);
+                                 make_array_view(fe_data.transformed_shape_grads));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -514,10 +514,10 @@ fill_fe_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k] = fe_data.shape_grads[i][k];
 
-              mapping.transform (fe_data.untransformed_shape_grads,
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads),
                                  mapping_covariant_gradient,
                                  mapping_internal,
-                                 fe_data.transformed_shape_grads);
+                                 make_array_view(fe_data.transformed_shape_grads));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -553,8 +553,10 @@ fill_fe_values
             case mapping_none:
             {
 
-              mapping.transform(fe_data.shape_grad_grads[i], mapping_covariant_gradient,
-                                mapping_internal, fe_data.transformed_shape_hessians);
+              mapping.transform(make_array_view(fe_data.shape_grad_grads[i]),
+                                mapping_covariant_gradient,
+                                mapping_internal,
+                                make_array_view(fe_data.transformed_shape_hessians));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -575,9 +577,9 @@ fill_fe_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k] = fe_data.shape_grad_grads[i][k];
 
-              mapping.transform(fe_data.untransformed_shape_hessian_tensors,
+              mapping.transform(make_array_view(fe_data.untransformed_shape_hessian_tensors),
                                 mapping_covariant_hessian, mapping_internal,
-                                fe_data.transformed_shape_hessians);
+                                make_array_view(fe_data.transformed_shape_hessians));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -609,9 +611,10 @@ fill_fe_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k] = fe_data.shape_grad_grads[i][k];
 
-              mapping.transform(fe_data.untransformed_shape_hessian_tensors, mapping_contravariant_hessian,
-                                mapping_internal, fe_data.transformed_shape_hessians
-                               );
+              mapping.transform(make_array_view(fe_data.untransformed_shape_hessian_tensors),
+                                mapping_contravariant_hessian,
+                                mapping_internal,
+                                make_array_view(fe_data.transformed_shape_hessians));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -652,9 +655,10 @@ fill_fe_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k] = fe_data.shape_grad_grads[i][k];
 
-              mapping.transform(fe_data.untransformed_shape_hessian_tensors, mapping_piola_hessian,
-                                mapping_internal, fe_data.transformed_shape_hessians
-                               );
+              mapping.transform(make_array_view(fe_data.untransformed_shape_hessian_tensors),
+                                mapping_piola_hessian,
+                                mapping_internal,
+                                make_array_view(fe_data.transformed_shape_hessians));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -714,9 +718,9 @@ fill_fe_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k] = fe_data.shape_grad_grads[i][k];
 
-              mapping.transform(fe_data.untransformed_shape_hessian_tensors,
+              mapping.transform(make_array_view(fe_data.untransformed_shape_hessian_tensors),
                                 mapping_covariant_hessian, mapping_internal,
-                                fe_data.transformed_shape_hessians);
+                                make_array_view(fe_data.transformed_shape_hessians));
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -831,11 +835,9 @@ fill_fe_face_values
             case mapping_covariant:
             case mapping_contravariant:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values(fe_data.transformed_shape_values, offset, n_q_points);
-              // Use auxiliary vector
-              // for transformation
-              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
+              mapping.transform (make_array_view(fe_data.shape_values[i], offset, n_q_points),
                                  mapping_type,
                                  mapping_internal,
                                  transformed_shape_values);
@@ -849,10 +851,9 @@ fill_fe_face_values
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values(fe_data.transformed_shape_values, offset, n_q_points);
-
-              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
+              mapping.transform (make_array_view(fe_data.shape_values[i], offset, n_q_points),
                                  mapping_piola,
                                  mapping_internal,
                                  transformed_shape_values);
@@ -865,10 +866,9 @@ fill_fe_face_values
 
             case mapping_nedelec:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values(fe_data.transformed_shape_values, offset, n_q_points);
-
-              mapping.transform (make_slice (fe_data.shape_values[i], offset, n_q_points),
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
+              mapping.transform (make_array_view (fe_data.shape_values[i], offset, n_q_points),
                                  mapping_covariant,
                                  mapping_internal,
                                  transformed_shape_values);
@@ -888,14 +888,13 @@ fill_fe_face_values
 
       if (fe_data.update_each & update_gradients)
         {
-          VectorSlice< std::vector<Tensor<2,spacedim> > >
-          transformed_shape_grads (fe_data.transformed_shape_grads, offset, n_q_points);
-
           switch (mapping_type)
             {
             case mapping_none:
             {
-              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+              const ArrayView<Tensor<2,spacedim> > transformed_shape_grads
+                = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
+              mapping.transform (make_array_view(fe_data.shape_grads[i], offset, n_q_points),
                                  mapping_covariant,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -907,7 +906,9 @@ fill_fe_face_values
 
             case mapping_covariant:
             {
-              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+              const ArrayView<Tensor<2,spacedim> > transformed_shape_grads
+                = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
+              mapping.transform (make_array_view(fe_data.shape_grads[i], offset, n_q_points),
                                  mapping_covariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -923,11 +924,14 @@ fill_fe_face_values
                   output_data.shape_gradients[first+d][k] = transformed_shape_grads[k][d];
               break;
             }
+
             case mapping_contravariant:
             {
+              const ArrayView<Tensor<2,spacedim> > transformed_shape_grads
+                = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
-              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_contravariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -944,12 +948,15 @@ fill_fe_face_values
 
               break;
             }
+
             case mapping_raviart_thomas:
             case mapping_piola:
             {
+              const ArrayView<Tensor<2,spacedim> > transformed_shape_grads
+                = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
-              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_piola_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -986,7 +993,9 @@ fill_fe_face_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
-              mapping.transform (make_slice (fe_data.untransformed_shape_grads, offset, n_q_points),
+              const ArrayView<Tensor<2,spacedim> > transformed_shape_grads
+                = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
+              mapping.transform (make_array_view (fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_covariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1011,19 +1020,17 @@ fill_fe_face_values
         }
 
       if (fe_data.update_each & update_hessians)
-
         {
-
-          VectorSlice< std::vector<Tensor<3,spacedim> > > transformed_shape_hessians (fe_data.transformed_shape_hessians, offset, n_q_points);
-
           switch (mapping_type)
             {
             case mapping_none:
             {
-
-              mapping.transform(make_slice (fe_data.shape_grad_grads[i], offset, n_q_points),
-                                mapping_covariant_gradient, mapping_internal, transformed_shape_hessians
-                               );
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.shape_grad_grads[i], offset, n_q_points),
+                                mapping_covariant_gradient,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1040,12 +1047,15 @@ fill_fe_face_values
             }
             case mapping_covariant:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_covariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_covariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1071,14 +1081,18 @@ fill_fe_face_values
               break;
 
             }
+
             case mapping_contravariant:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_contravariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_contravariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1110,17 +1124,20 @@ fill_fe_face_values
                   output_data.shape_hessians[first+d][k] = transformed_shape_hessians[k][d];
 
               break;
-
             }
+
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_piola_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_piola_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1171,17 +1188,19 @@ fill_fe_face_values
                   output_data.shape_hessians[first+d][k] = fe_data.sign_change[i] * transformed_shape_hessians[k][d];
 
               break;
-
             }
 
             case mapping_nedelec:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_covariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_covariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1205,7 +1224,6 @@ fill_fe_face_values
                   output_data.shape_hessians[first+d][k] = fe_data.sign_change[i] * transformed_shape_hessians[k][d];
 
               break;
-
             }
 
             default:
@@ -1296,12 +1314,9 @@ fill_fe_subface_values
             case mapping_covariant:
             case mapping_contravariant:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values (fe_data.transformed_shape_values, offset, n_q_points);
-
-              // Use auxiliary vector for
-              // transformation
-              mapping.transform (make_slice(fe_data.shape_values[i], offset, n_q_points),
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
+              mapping.transform (make_array_view(fe_data.shape_values[i], offset, n_q_points),
                                  mapping_type,
                                  mapping_internal,
                                  transformed_shape_values);
@@ -1312,26 +1327,30 @@ fill_fe_subface_values
 
               break;
             }
+
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values (fe_data.transformed_shape_values, offset, n_q_points);
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
 
-              mapping.transform(make_slice(fe_data.shape_values[i], offset, n_q_points),
-                                mapping_piola, mapping_internal, transformed_shape_values);
+              mapping.transform(make_array_view(fe_data.shape_values[i], offset, n_q_points),
+                                mapping_piola,
+                                mapping_internal,
+                                transformed_shape_values);
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<dim; ++d)
                   output_data.shape_values(first+d,k)
                     = fe_data.sign_change[i] * transformed_shape_values[k][d];
               break;
             }
+
             case mapping_nedelec:
             {
-              VectorSlice< std::vector<Tensor<1,spacedim> > >
-              transformed_shape_values (fe_data.transformed_shape_values, offset, n_q_points);
+              const ArrayView<Tensor<1,spacedim> > transformed_shape_values
+                = make_array_view(fe_data.transformed_shape_values, offset, n_q_points);
 
-              mapping.transform (make_slice (fe_data.shape_values[i], offset, n_q_points),
+              mapping.transform (make_array_view (fe_data.shape_values[i], offset, n_q_points),
                                  mapping_covariant,
                                  mapping_internal,
                                  transformed_shape_values);
@@ -1343,6 +1362,7 @@ fill_fe_subface_values
 
               break;
             }
+
             default:
               Assert(false, ExcNotImplemented());
             }
@@ -1350,13 +1370,13 @@ fill_fe_subface_values
 
       if (fe_data.update_each & update_gradients)
         {
-          VectorSlice< std::vector<Tensor<2, spacedim > > >
-          transformed_shape_grads (fe_data.transformed_shape_grads, offset, n_q_points);
+          const ArrayView<Tensor<2, spacedim> > transformed_shape_grads
+            = make_array_view(fe_data.transformed_shape_grads, offset, n_q_points);
           switch (mapping_type)
             {
             case mapping_none:
             {
-              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.shape_grads[i], offset, n_q_points),
                                  mapping_covariant,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1368,7 +1388,7 @@ fill_fe_subface_values
 
             case mapping_covariant:
             {
-              mapping.transform (make_slice(fe_data.shape_grads[i], offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.shape_grads[i], offset, n_q_points),
                                  mapping_covariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1391,7 +1411,7 @@ fill_fe_subface_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
-              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_contravariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1415,7 +1435,7 @@ fill_fe_subface_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
-              mapping.transform (make_slice(fe_data.untransformed_shape_grads, offset, n_q_points),
+              mapping.transform (make_array_view(fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_piola_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1450,7 +1470,7 @@ fill_fe_subface_values
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_grads[k+offset] = fe_data.shape_grads[i][k+offset];
 
-              mapping.transform (make_slice (fe_data.untransformed_shape_grads, offset, n_q_points),
+              mapping.transform (make_array_view (fe_data.untransformed_shape_grads, offset, n_q_points),
                                  mapping_covariant_gradient,
                                  mapping_internal,
                                  transformed_shape_grads);
@@ -1475,19 +1495,16 @@ fill_fe_subface_values
         }
 
       if (fe_data.update_each & update_hessians)
-
         {
-
-          VectorSlice< std::vector<Tensor<3,dim> > > transformed_shape_hessians (fe_data.transformed_shape_hessians, offset, n_q_points);
-
           switch (mapping_type)
             {
             case mapping_none:
             {
-
-              mapping.transform(make_slice (fe_data.shape_grad_grads[i], offset, n_q_points),
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.shape_grad_grads[i], offset, n_q_points),
                                 mapping_covariant_gradient, mapping_internal,
-                                transformed_shape_hessians );
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1504,12 +1521,15 @@ fill_fe_subface_values
             }
             case mapping_covariant:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_covariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_covariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1535,14 +1555,18 @@ fill_fe_subface_values
               break;
 
             }
+
             case mapping_contravariant:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_contravariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_contravariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1576,15 +1600,19 @@ fill_fe_subface_values
               break;
 
             }
+
             case mapping_raviart_thomas:
             case mapping_piola:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_piola_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_piola_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)
@@ -1639,12 +1667,15 @@ fill_fe_subface_values
 
             case mapping_nedelec:
             {
-
               for (unsigned int k=0; k<n_q_points; ++k)
                 fe_data.untransformed_shape_hessian_tensors[k+offset] = fe_data.shape_grad_grads[i][k+offset];
 
-              mapping.transform(make_slice (fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
-                                mapping_covariant_hessian, mapping_internal, transformed_shape_hessians);
+              const ArrayView<Tensor<3,spacedim> > transformed_shape_hessians
+                = make_array_view(fe_data.transformed_shape_hessians, offset, n_q_points);
+              mapping.transform(make_array_view(fe_data.untransformed_shape_hessian_tensors, offset, n_q_points),
+                                mapping_covariant_hessian,
+                                mapping_internal,
+                                transformed_shape_hessians);
 
               for (unsigned int k=0; k<n_q_points; ++k)
                 for (unsigned int d=0; d<spacedim; ++d)

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3415,14 +3415,15 @@ FEValuesBase<dim,spacedim>::get_normal_vectors () const
 
 template <int dim, int spacedim>
 void
-FEValuesBase<dim,spacedim>::transform (
-  std::vector<Tensor<1,spacedim> > &transformed,
-  const std::vector<Tensor<1,dim> > &original,
-  MappingType type) const
+FEValuesBase<dim,spacedim>::
+transform (std::vector<Tensor<1,spacedim> > &transformed,
+           const std::vector<Tensor<1,dim> > &original,
+           MappingType type) const
 {
-  VectorSlice<const std::vector<Tensor<1,dim> > > src(original);
-  VectorSlice<std::vector<Tensor<1,spacedim> > > dst(transformed);
-  mapping->transform(src, type,*mapping_data, dst);
+  mapping->transform(make_array_view(original),
+                     type,
+                     *mapping_data,
+                     make_array_view(transformed));
 }
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -613,10 +613,10 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 template<int dim, int spacedim>
 void
 MappingCartesian<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+transform (const ArrayView<const Tensor<1,dim> >                  &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
+           const ArrayView<Tensor<1,spacedim> >                   &output) const
 {
   AssertDimension (input.size(), output.size());
   Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
@@ -668,10 +668,10 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
 template<int dim, int spacedim>
 void
 MappingCartesian<dim,spacedim>::
-transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-           const MappingType                                                       mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                 &mapping_data,
-           VectorSlice<std::vector<Tensor<2,spacedim> > >                          output) const
+transform (const ArrayView<const DerivativeForm<1, dim,spacedim> > &input,
+           const MappingType                                        mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
+           const ArrayView<Tensor<2,spacedim> >                    &output) const
 {
   AssertDimension (input.size(), output.size());
   Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
@@ -769,10 +769,10 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> >
 template<int dim, int spacedim>
 void
 MappingCartesian<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+transform (const ArrayView<const Tensor<2, dim> >                 &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<2, spacedim> > >         output) const
+           const ArrayView<Tensor<2, spacedim> >                  &output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -870,10 +870,10 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
 template<int dim, int spacedim>
 void
 MappingCartesian<dim,spacedim>::
-transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-           const MappingType                                                         mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
+transform (const ArrayView<const  DerivativeForm<2, dim, spacedim> > &input,
+           const MappingType                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_data,
+           const ArrayView<Tensor<3,spacedim> >                      &output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -908,10 +908,10 @@ transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim>
 template<int dim, int spacedim>
 void
 MappingCartesian<dim,spacedim>::
-transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
+transform (const ArrayView<const  Tensor<3,dim> >                 &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
+           const ArrayView<Tensor<3,spacedim> >                   &output) const
 {
 
   AssertDimension (input.size(), output.size());

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1097,10 +1097,10 @@ namespace internal
                     data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d].size(),
                     ExcInternalError());
 
-            mapping.transform (data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d],
+            mapping.transform (make_array_view(data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d]),
                                mapping_contravariant,
                                data,
-                               data.aux[d]);
+                               make_array_view(data.aux[d]));
           }
 
         // if dim==spacedim, we can use the unit tangentials to compute the
@@ -1515,10 +1515,10 @@ namespace
 {
   template<int dim, int spacedim, int rank, typename VectorType, typename DoFHandlerType>
   void
-  transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
+  transform_fields(const ArrayView<const Tensor<rank,dim> >                &input,
                    const MappingType                                        mapping_type,
                    const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-                   VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
+                   const ArrayView<Tensor<rank,spacedim> >                 &output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::InternalData *>(&mapping_data) != 0),
@@ -1578,10 +1578,10 @@ namespace
   template<int dim, int spacedim, int rank, typename VectorType, typename DoFHandlerType>
   void
   transform_differential_forms
-  (const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > >  input,
-   const MappingType                                                           mapping_type,
-   const typename Mapping<dim,spacedim>::InternalDataBase                     &mapping_data,
-   VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                        output)
+  (const ArrayView<const DerivativeForm<rank, dim,spacedim> >  &input,
+   const MappingType                                            mapping_type,
+   const typename Mapping<dim,spacedim>::InternalDataBase      &mapping_data,
+   const ArrayView<Tensor<rank+1, spacedim> >                  &output)
   {
 
     AssertDimension (input.size(), output.size());
@@ -1614,10 +1614,10 @@ namespace
 template<int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::
-transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+transform (const ArrayView<const Tensor<1,dim> >                  &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
+           const ArrayView<Tensor<1,spacedim> >                   &output) const
 {
   AssertDimension (input.size(), output.size());
 
@@ -1629,10 +1629,10 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
 template<int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::
-transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
-           const MappingType                                                          mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
-           VectorSlice<std::vector<Tensor<2,spacedim> > >                             output) const
+transform (const ArrayView<const DerivativeForm<1, dim ,spacedim> > &input,
+           const MappingType                                         mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase   &mapping_data,
+           const ArrayView<Tensor<2,spacedim> >                     &output) const
 {
   AssertDimension (input.size(), output.size());
 
@@ -1644,10 +1644,10 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim> 
 template<int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::
-transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
-           const MappingType,
+transform (const ArrayView<const Tensor<2, dim> >                 &input,
+           const MappingType                                       ,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const
+           const ArrayView<Tensor<2,spacedim> >                   &output) const
 {
   (void)input;
   (void)output;
@@ -1662,12 +1662,11 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
 template<int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::
-transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-           const MappingType                                                         mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
+transform (const ArrayView<const DerivativeForm<2, dim, spacedim> >  &input,
+           const MappingType                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_data,
+           const ArrayView<Tensor<3,spacedim> >                      &output) const
 {
-
   AssertDimension (input.size(), output.size());
   Assert (dynamic_cast<const InternalData *>(&mapping_data) != 0,
           ExcInternalError());
@@ -1712,10 +1711,10 @@ transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim>
 template<int dim, int spacedim, typename VectorType, typename DoFHandlerType>
 void
 MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::
-transform (const VectorSlice<const std::vector< Tensor<3,dim> > >  input,
+transform (const ArrayView<const Tensor<3,dim> >                  &input,
            const MappingType                                     /*mapping_type*/,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
+           const ArrayView<Tensor<3,spacedim> >                   &output) const
 {
 
   (void)input;

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -345,13 +345,14 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 }
 
 
+
 template<int dim, int spacedim>
 void
 MappingQ<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
+transform (const ArrayView<const Tensor<1,dim> >                  &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<1,spacedim> > >          output) const
+           const ArrayView<Tensor<1,spacedim> >                   &output) const
 {
   AssertDimension (input.size(), output.size());
   Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
@@ -372,10 +373,10 @@ transform (const VectorSlice<const std::vector<Tensor<1,dim> > >   input,
 template<int dim, int spacedim>
 void
 MappingQ<dim,spacedim>::
-transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim>  > >  input,
-           const MappingType                                                          mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
-           VectorSlice<std::vector<Tensor<2,spacedim> > >                             output) const
+transform (const ArrayView<const DerivativeForm<1, dim ,spacedim> >  &input,
+           const MappingType                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_data,
+           const ArrayView<Tensor<2,spacedim> >                      &output) const
 {
   AssertDimension (input.size(), output.size());
   Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
@@ -390,14 +391,63 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim ,spacedim> 
     // otherwise use the full mapping
     qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
 }
+
+
+
+template<int dim, int spacedim>
+void
+MappingQ<dim,spacedim>::
+transform (const ArrayView<const Tensor<2, dim> >                 &input,
+           const MappingType                                       mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+           const ArrayView<Tensor<2,spacedim> >                   &output) const
+{
+  AssertDimension (input.size(), output.size());
+  Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
+           != 0),
+          ExcInternalError());
+  const InternalData *data = dynamic_cast<const InternalData *>(&mapping_data);
+
+  // check whether we should in fact work on the Q1 portion of it
+  if (data->use_mapping_q1_on_current_cell)
+    q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
+  else
+    // otherwise use the full mapping
+    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+}
+
+
+
+template<int dim, int spacedim>
+void
+MappingQ<dim,spacedim>::
+transform (const ArrayView<const DerivativeForm<2, dim ,spacedim> >  &input,
+           const MappingType                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_data,
+           const ArrayView<Tensor<3,spacedim> >                      &output) const
+{
+  AssertDimension (input.size(), output.size());
+  Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
+           != 0),
+          ExcInternalError());
+  const InternalData *data = dynamic_cast<const InternalData *>(&mapping_data);
+
+  // check whether we should in fact work on the Q1 portion of it
+  if (data->use_mapping_q1_on_current_cell)
+    q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
+  else
+    // otherwise use the full mapping
+    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
+}
+
 
 
 template<int dim, int spacedim>
 void MappingQ<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
+transform (const ArrayView<const Tensor<3, dim> >                 &input,
            const MappingType                                       mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<2,spacedim> > >          output) const
+           const ArrayView<Tensor<3,spacedim> >                   &output) const
 {
   AssertDimension (input.size(), output.size());
   Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
@@ -413,51 +463,6 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >  input,
     qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
 }
 
-
-
-template<int dim, int spacedim>
-void
-MappingQ<dim,spacedim>::
-transform (const VectorSlice<const std::vector<DerivativeForm<2, dim ,spacedim>  > >  input,
-           const MappingType                                                          mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >                             output) const
-{
-  AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
-           != 0),
-          ExcInternalError());
-  const InternalData *data = dynamic_cast<const InternalData *>(&mapping_data);
-
-  // check whether we should in fact work on the Q1 portion of it
-  if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
-  else
-    // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
-}
-
-
-template<int dim, int spacedim>
-void MappingQ<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<3, dim> > >  input,
-           const MappingType                                       mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >          output) const
-{
-  AssertDimension (input.size(), output.size());
-  Assert ((dynamic_cast<const typename MappingQ<dim,spacedim>::InternalData *> (&mapping_data)
-           != 0),
-          ExcInternalError());
-  const InternalData *data = dynamic_cast<const InternalData *>(&mapping_data);
-
-  // check whether we should in fact work on the Q1 portion of it
-  if (data->use_mapping_q1_on_current_cell)
-    q1_mapping->transform (input, mapping_type, *data->mapping_q1_data, output);
-  else
-    // otherwise use the full mapping
-    qp_mapping->transform(input, mapping_type, *data->mapping_qp_data, output);
-}
 
 
 template<int dim, int spacedim>

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2744,10 +2744,10 @@ namespace internal
                       data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d].size(),
                       ExcInternalError());
 
-              mapping.transform (data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d],
+              mapping.transform (make_array_view(data.unit_tangentials[face_no+GeometryInfo<dim>::faces_per_cell*d]),
                                  mapping_contravariant,
                                  data,
-                                 data.aux[d]);
+                                 make_array_view(data.aux[d]));
             }
 
           // if dim==spacedim, we can use the unit tangentials to compute the
@@ -2998,10 +2998,10 @@ namespace
 {
   template <int dim, int spacedim, int rank>
   void
-  transform_fields(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
-                   const MappingType                                        mapping_type,
-                   const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-                   VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
+  transform_fields(const ArrayView<const Tensor<rank,dim> >               &input,
+                   const MappingType                                       mapping_type,
+                   const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
+                   const ArrayView<Tensor<rank,spacedim> >                &output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -3061,10 +3061,10 @@ namespace
 
   template <int dim, int spacedim, int rank>
   void
-  transform_gradients(const VectorSlice<const std::vector<Tensor<rank,dim> > > input,
+  transform_gradients(const ArrayView<const Tensor<rank,dim> >                &input,
                       const MappingType                                        mapping_type,
                       const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-                      VectorSlice<std::vector<Tensor<rank,spacedim> > >        output)
+                      const ArrayView<Tensor<rank,spacedim> >                 &output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -3142,10 +3142,10 @@ namespace
 
   template <int dim, int spacedim>
   void
-  transform_hessians(const VectorSlice<const std::vector<Tensor<3,dim> > >   input,
+  transform_hessians(const ArrayView<const Tensor<3,dim> >                  &input,
                      const MappingType                                       mapping_type,
                      const typename Mapping<dim,spacedim>::InternalDataBase &mapping_data,
-                     VectorSlice<std::vector<Tensor<3,spacedim> > >          output)
+                     const ArrayView<Tensor<3,spacedim> >                   &output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -3284,10 +3284,10 @@ namespace
 
   template<int dim, int spacedim, int rank>
   void
-  transform_differential_forms(const VectorSlice<const std::vector<DerivativeForm<rank, dim,spacedim> > > input,
-                               const MappingType                                                          mapping_type,
-                               const typename Mapping<dim,spacedim>::InternalDataBase                    &mapping_data,
-                               VectorSlice<std::vector<Tensor<rank+1, spacedim> > >                       output)
+  transform_differential_forms(const ArrayView<const DerivativeForm<rank, dim,spacedim> >   &input,
+                               const MappingType                                             mapping_type,
+                               const typename Mapping<dim,spacedim>::InternalDataBase       &mapping_data,
+                               const ArrayView<Tensor<rank+1, spacedim> >                   &output)
   {
     AssertDimension (input.size(), output.size());
     Assert ((dynamic_cast<const typename MappingQGeneric<dim,spacedim>::InternalData *>(&mapping_data) != 0),
@@ -3318,10 +3318,10 @@ namespace
 template<int dim, int spacedim>
 void
 MappingQGeneric<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<1, dim> > >   input,
+transform (const ArrayView<const Tensor<1, dim> >                  &input,
            const MappingType                                        mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-           VectorSlice<std::vector<Tensor<1, spacedim> > >          output) const
+           const ArrayView<Tensor<1, spacedim> >                   &output) const
 {
   transform_fields(input, mapping_type, mapping_data, output);
 }
@@ -3331,10 +3331,10 @@ transform (const VectorSlice<const std::vector<Tensor<1, dim> > >   input,
 template<int dim, int spacedim>
 void
 MappingQGeneric<dim,spacedim>::
-transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> > > input,
-           const MappingType                                                       mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                 &mapping_data,
-           VectorSlice<std::vector<Tensor<2, spacedim> > >                         output) const
+transform (const ArrayView<const DerivativeForm<1, dim,spacedim> >  &input,
+           const MappingType                                         mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase   &mapping_data,
+           const ArrayView<Tensor<2, spacedim> >                    &output) const
 {
   transform_differential_forms(input, mapping_type, mapping_data, output);
 }
@@ -3344,10 +3344,10 @@ transform (const VectorSlice<const std::vector<DerivativeForm<1, dim,spacedim> >
 template<int dim, int spacedim>
 void
 MappingQGeneric<dim,spacedim>::
-transform (const VectorSlice<const std::vector<Tensor<2, dim> > >   input,
+transform (const ArrayView<const Tensor<2, dim> >                  &input,
            const MappingType                                        mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-           VectorSlice<std::vector<Tensor<2, spacedim> > >          output) const
+           const ArrayView<Tensor<2, spacedim> >                   &output) const
 {
   switch (mapping_type)
     {
@@ -3370,10 +3370,10 @@ transform (const VectorSlice<const std::vector<Tensor<2, dim> > >   input,
 template<int dim, int spacedim>
 void
 MappingQGeneric<dim,spacedim>::
-transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim> > > input,
-           const MappingType                                                         mapping_type,
-           const typename Mapping<dim,spacedim>::InternalDataBase                   &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >                            output) const
+transform (const ArrayView<const  DerivativeForm<2, dim, spacedim> > &input,
+           const MappingType                                          mapping_type,
+           const typename Mapping<dim,spacedim>::InternalDataBase    &mapping_data,
+           const ArrayView<Tensor<3,spacedim> >                      &output) const
 {
 
   AssertDimension (input.size(), output.size());
@@ -3419,10 +3419,10 @@ transform (const VectorSlice<const std::vector< DerivativeForm<2, dim, spacedim>
 template<int dim, int spacedim>
 void
 MappingQGeneric<dim,spacedim>::
-transform (const VectorSlice<const std::vector< Tensor<3,dim> > >   input,
+transform (const ArrayView<const  Tensor<3,dim> >                  &input,
            const MappingType                                        mapping_type,
            const typename Mapping<dim,spacedim>::InternalDataBase  &mapping_data,
-           VectorSlice<std::vector<Tensor<3,spacedim> > >           output) const
+           const ArrayView<Tensor<3,spacedim> >                    &output) const
 {
   switch (mapping_type)
     {


### PR DESCRIPTION
This will allow to change the underlying data type in which the data is stored because
ArrayView does not actually store this, in contrast to VectorSlice.

This patch is backward incompatible. However, this area has already been incompatibly changed
in recent months as part of my #1198 work. This should get me half-way to what is necessary to address #1241.