### PR TITLE
Add a missing space to an exception message.

### DIFF
--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1508,7 +1508,7 @@ public:
                   int, int,
                   << "You are trying to access the matrix entry with index <"
                   << arg1 << ',' << arg2
-                  << ">, but this entry does not exist in the sparsity pattern"
+                  << ">, but this entry does not exist in the sparsity pattern "
                   "of this matrix."
                   "\n\n"
                   "The most common cause for this problem is that you used "


### PR DESCRIPTION
I noticed this ages ago but kept forgetting to fix it.