### PR TITLE
Remove references to the pre-historic parallel::distributed::DoFHandler.

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1316,8 +1316,7 @@
  *
  * On the other hand, for programs that are parallelized using MPI but
  * where meshes are held distributed across several processors using
- * the parallel::distributed::Triangulation and
- * parallel::distributed::DoFHandler classes, the subdomain id of
+ * the parallel::distributed::Triangulation class, the subdomain id of
  * cells is tied to the processor that owns the cell. In other words,
  * querying the subdomain id of a cell tells you if the cell is owned
  * by the current processor (i.e. if <code>cell-@>subdomain_id() ==

--- a/examples/step-40/doc/intro.dox
+++ b/examples/step-40/doc/intro.dox
@@ -69,7 +69,7 @@ but apart from that all of its workings are hidden under the surface
 of deal.II.
 
 In essence, what the parallel::distributed::Triangulation class and
-associated parallel::distributed::DoFHandler objects do is to split
+code inside the DoFHandler class do is to split
 the global mesh so that every processor only stores a small bit it
 "owns" along with one layer of "ghost" cells that surround the ones it
 owns. What happens in the rest of the domain on which we want to solve

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -175,9 +175,18 @@ public:
   /**
    * Constructor. The supplied IndexSet defines which indices might be
    * constrained inside this ConstraintMatrix. In a calculation with a
-   * parallel::distributed::DoFHandler one should use locally_relevant_dofs.
-   * The IndexSet allows the ConstraintMatrix to save memory. Otherwise
-   * internal data structures for all possible indices will be created.
+   * DoFHandler object based on parallel::distributed::Triangulation
+   * or parallel::shared::Triangulation, one should use the set of locally
+   * relevant dofs (see @ref GlossLocallyRelevenDof).
+   *
+   * The given IndexSet allows the ConstraintMatrix to save memory by just not
+   * caring about degrees of freedom that are not of importance to the
+   * current processor. Alternatively, if no such IndexSet is provided,
+   * internal data structures for <i>all</i> possible indices will be created,
+   * leading to memory consumption on every processor that is proportional to
+   * the <i>overall</i> size of the problem, not just proportional to the
+   * size of the portion of the overall problem that is handled by the current
+   * processor.
    */
   explicit ConstraintMatrix (const IndexSet &local_constraints = IndexSet());
 


### PR DESCRIPTION
Also augment the documentation of one function.

This fixes #2018.