### PR TITLE
Fix markup of references.

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -792,7 +792,7 @@
  * namespace and the techniques used in step-40.
  *
  * The full reference for the paper is as follows:
- * @code
+ * @code{.bib}
 @Article{BBHK11,
   author =       {Wolfgang Bangerth and Carsten Burstedde and Timo Heister
                   and Martin Kronbichler},
@@ -981,7 +981,7 @@
  * elements.
  *
  * The full reference for this paper is as follows:
- * @code
+ * @code{.bib}
 @Article{BK07,
   author =       {Wolfgang Bangerth and Oliver Kayser-Herold},
   title =        {Data Structures and Requirements for hp Finite Element
@@ -1169,15 +1169,15 @@
  * methods.
  *
  * The full reference for this paper is as follows:
- * @code
+ * @code{.bib}
 @article{janssen2011adaptive,
-  title={Adaptive Multilevel Methods with Local Smoothing for H\^{}1-and H\^{}curl-Conforming High Order Finite Element Methods},
-  author={Janssen, B{\"a}rbel and Kanschat, Guido},
-  journal={SIAM Journal on Scientific Computing},
-  volume={33},
-  number={4},
-  pages={2095--2114},
-  year={2011},
+  title=    {Adaptive Multilevel Methods with Local Smoothing for H^1- and H^{curl}-Conforming High Order Finite Element Methods},
+  author=   {Janssen, B{\"a}rbel and Kanschat, Guido},
+  journal=  {SIAM Journal on Scientific Computing},
+  volume=   {33},
+  number=   {4},
+  pages=    {2095--2114},
+  year=     {2011},
   publisher={SIAM}}
  * @endcode
  * See 
@@ -1494,7 +1494,7 @@
  *   of implementing it. It also compares the performance of different implementations.
  *
  * The full reference for this paper is as follows:
- * @code
+ * @code{.bib}
 @Article{TKB16,
   author =       {Bruno Turcksin and Martin Kronbichler and Wolfgang Bangerth},
   title =        {\textit{WorkStream} -- a design pattern for multicore-enabled finite element computations},

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -75,7 +75,7 @@ namespace hp
  *
  * The full reference for the paper in which this error estimator is defined
  * is as follows:
- * @code
+ * @code{.bib}
  * @Article{KGZB83,
  *   author =       {Kelly, D. W. and {De S. R. Gago}, J. P. and Zienkiewicz, O. C.
  *                   and Babu\v{s}ka, I.},


### PR DESCRIPTION
doxygen interpreted our bibtex-references as C++ code which led
to funny HTML markup. Fortunately, there is a way to tell
doxygen to interpret the code block as just some piece of text
it will not understand regardless of how hard it tries.