### PR TITLE
Minor multigrid cleanup

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -659,6 +659,8 @@ int main ()
     {
       using namespace Step16;
 
+      deallog.depth_console(2);
+
       LaplaceProblem<2> laplace_problem(1);
       laplace_problem.run ();
     }

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -935,6 +935,7 @@ int main()
       using namespace dealii;
       using namespace Step39;
 
+      deallog.depth_console(2);
       std::ofstream logfile("deallog");
       deallog.attach(logfile);
       FE_DGQ<2> fe1(3);

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -13,8 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
-#ifndef dealii__mg_constraints_h
-#define dealii__mg_constraints_h
+#ifndef dealii__mg_constrained_dofs_h
+#define dealii__mg_constrained_dofs_h
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/subscriptor.h>


### PR DESCRIPTION
We recently set the default depth for deallog to 0. The multigrid tutorials put all output through deallog, so set the level back to 2. (step-39 pipes the output to a log file, so it is not strictly necessary there, but a tutorial without any output at all still feels unusual.)