### PR TITLE
Change minimum parallel grainsize of vector to power of 2

### DIFF
--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -34,13 +34,13 @@ namespace internal
     // large to split the work load into
     // enough chunks and the problem becomes
     // badly balanced)
-    unsigned int minimum_parallel_grain_size = 1000;
+    unsigned int minimum_parallel_grain_size = 1024;
   }
 
 
   namespace SparseMatrix
   {
-    // set this value to 1/5 of the value of
+    // set this value to 1/4 of the value of
     // the minimum grain size of
     // vectors. this rests on the fact that
     // we have to do a lot more work per row
@@ -50,7 +50,7 @@ namespace internal
     // worth it any more for anything but
     // very small matrices that we don't care
     // that much about anyway.
-    unsigned int minimum_parallel_grain_size = 200;
+    unsigned int minimum_parallel_grain_size = 256;
   }
 }
 


### PR DESCRIPTION
By default, we align the data array of vectors at 64 byte boundaries (i.e., cache line size). When looking at some corner case, I realized that the entry points of the vector that TBB schedules were sometimes not aligned by the cache line size for 'float' vectors. Since we choose this number in an arbitrary way, I would recommend choosing it as a power of 2 (or at least divisible by 16).