### PR TITLE
Populate Tvmult and Tvmult_add of an inverse_operator correctly

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -526,6 +526,12 @@ inconvenience this causes.
 
 
 <ol>
+  <li> Fixed: inverse_operator() now populates <code>Tvmult</code> and
+  <code>Tvmult_add</code> correctly.
+  <br>
+  (Jean-Paul Pelteret, David Wells, Matthias Maier, 2015/12/30)
+  </li>
+
   <li> Fixed: Now all members in the class SparseMatrixEZ are initialized
   correctly in the constructor. This was causing random crashes before.
   <br>

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -664,7 +664,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
     solver.solve(transpose_operator(op), v, u, preconditioner);
   };
 
-  return_op.Tvmult =
+  return_op.Tvmult_add =
     [op, &solver, &preconditioner](Vector &v, const Vector &u)
   {
     static GrowingVectorMemory<typename Solver::vector_type> vector_memory;

--- a/tests/lac/linear_operator_08a.cc
+++ b/tests/lac/linear_operator_08a.cc
@@ -70,15 +70,15 @@ int main()
   for (unsigned int j = 0; j < 1000; ++j)
     {
       // test Tvmult:
-      residual = lo_A_inv_t * b;
+      residual = lo_A_inv_t *b;
       residual -= answer;
       if (residual.l2_norm() > 1e-10)
-          ++n_mistakes;
+        ++n_mistakes;
 
       // test Tvmult_add:
-      residual = lo_A_inv_t * b - answer;
+      residual = lo_A_inv_t *b - answer;
       if (residual.l2_norm() > 1e-10)
-          ++n_mistakes;
+        ++n_mistakes;
     }
 
   deallog.depth_file(3);

--- a/tests/lac/linear_operator_08a.cc
+++ b/tests/lac/linear_operator_08a.cc
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Verify that Tvmult of an inverse_operator works correctly.
+
+#include "../tests.h"
+
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/packaged_operation.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+
+using namespace dealii;
+
+int main()
+{
+  initlog();
+
+  Vector<double> answer(2);
+  answer[0] = 0.25;
+  answer[1] = 0.25;
+
+  SparsityPattern sparsity_pattern(2, 2, 1);
+  sparsity_pattern.add(0, 0);
+  sparsity_pattern.add(1, 1);
+  sparsity_pattern.compress();
+
+  SparseMatrix<double> A(sparsity_pattern);
+  A.set(0, 0, 4.0);
+  A.set(1, 1, 4.0);
+
+  Vector<double> b(2);
+  b[0] = 1.0;
+  b[1] = 1.0;
+
+  const auto lo_A = linear_operator(A);
+
+  // As we all remember from numerical analysis class, CG will converge in
+  // at most two iterations
+  SolverControl solver_control_A (2, 1.0e-15);
+
+  SolverCG<Vector<double>> solver_A(solver_control_A);
+  PreconditionIdentity preconditioner_A;
+
+  const auto lo_A_inv = inverse_operator(lo_A, solver_A, preconditioner_A);
+  const auto lo_A_inv_t = transpose_operator(lo_A_inv);
+
+  deallog.depth_file(0);
+
+  unsigned int n_mistakes {0};
+
+  Vector<double> residual; // keep storage location to trigger bug.
+
+  for (unsigned int j = 0; j < 1000; ++j)
+    {
+      // test Tvmult:
+      residual = lo_A_inv_t * b;
+      residual -= answer;
+      if (residual.l2_norm() > 1e-10)
+          ++n_mistakes;
+
+      // test Tvmult_add:
+      residual = lo_A_inv_t * b - answer;
+      if (residual.l2_norm() > 1e-10)
+          ++n_mistakes;
+    }
+
+  deallog.depth_file(3);
+
+  deallog << "number of mistakes: " << n_mistakes << std::endl;
+  if (n_mistakes != 0)
+    deallog << "Ooops!" << std::endl;
+}

--- a/tests/lac/linear_operator_08a.with_cxx11=on.output
+++ b/tests/lac/linear_operator_08a.with_cxx11=on.output
@@ -1,0 +1,2 @@
+
+DEAL::number of mistakes: 0


### PR DESCRIPTION
Fix a typo in linear_operator.h: The transpose operation function-object
Tvmult was accidentally overwritten by Tvmult_add (and the latter left
uninitialized).

Closes #2008