### PR TITLE
Change the exception type to avoid the compiler warning

### DIFF
--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -230,10 +230,10 @@ private:
                   << "Maximum number " << arg1
                   << " of iterations reached.");
 
-  DeclException1 (ExcArpackNoShifts, int,
-                  << "No shifts could be applied during implicit"
-                  << " Arnoldi update, try increasing the number of"
-                  << " Arnoldi vectors.");
+  DeclExceptionMsg (ExcArpackNoShifts,
+                    "No shifts could be applied during implicit"
+                    " Arnoldi update, try increasing the number of"
+                    " Arnoldi vectors.");
 };
 
 
@@ -515,7 +515,7 @@ void ArpackSolver::solve (const MatrixType1                  &system_matrix,
         }
       else if (info == 3)
         {
-          Assert (false, ExcArpackNoShifts(1));
+          Assert (false, ExcArpackNoShifts());
         }
       else if (info!=0)
         {


### PR DESCRIPTION
There was a wrongly declared exception in the arpack interface which caused compiler warnings.

This pull request addresses issue #1156 in at least this respect, but does not close it.