### PR TITLE
Hook in code gallery 3

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -155,7 +155,14 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     LIST(APPEND _doxygen_input
       ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/${_step}.h
       )
+    LIST(APPEND _doxygen_input
+      ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
+      )
   ENDFOREACH()
+
+  LIST(APPEND _doxygen_depend
+    ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
+    )
 ENDIF()
 
 TO_STRING(_doxygen_image_path_string ${_doxygen_image_path})

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -124,6 +124,7 @@ LIST(APPEND _doxygen_depend
   ${CMAKE_CURRENT_BINARY_DIR}/tutorial/tutorial.h
   )
 
+# find all tutorial programs so we can add dependencies as appropriate
 FILE(GLOB _deal_ii_steps
   ${CMAKE_SOURCE_DIR}/examples/step-*
   )
@@ -136,6 +137,26 @@ FOREACH(_step ${_deal_ii_steps})
     ${CMAKE_CURRENT_BINARY_DIR}/tutorial/${_step}.h
     )
 ENDFOREACH()
+
+# Also find all code gallery programs (if available) for the same reason.
+# The logic here follows the same as in code-gallery/CMakeLists.txt
+SET_IF_EMPTY(DEAL_II_CODE_GALLERY_DIRECTORY ${CMAKE_SOURCE_DIR}/code-gallery)
+IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
+  FILE(GLOB _code_gallery_names
+       "${DEAL_II_CODE_GALLERY_DIRECTORY}/*/doc/author")
+  STRING(REGEX REPLACE "/+doc/+author" "" _code_gallery_names "${_code_gallery_names}")
+
+  FOREACH(_step ${_code_gallery_names})
+    GET_FILENAME_COMPONENT(_step "${_step}" NAME)
+
+    LIST(APPEND _doxygen_depend
+      ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/${_step}.h
+      )
+    LIST(APPEND _doxygen_input
+      ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/${_step}.h
+      )
+  ENDFOREACH()
+ENDIF()
 
 TO_STRING(_doxygen_image_path_string ${_doxygen_image_path})
 TO_STRING(_doxygen_input_string ${_doxygen_input})
@@ -162,6 +183,7 @@ ADD_CUSTOM_COMMAND(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS
     tutorial
+    code-gallery
     ${CMAKE_CURRENT_BINARY_DIR}/options.dox
     ${CMAKE_CURRENT_BINARY_DIR}/header.html
     ${CMAKE_CURRENT_BINARY_DIR}/footer.html

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -44,8 +44,32 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
        "${DEAL_II_CODE_GALLERY_DIRECTORY}/*/doc/author")
   STRING(REGEX REPLACE "/+doc/+author" "" _code_gallery_names "${_code_gallery_names}")
 
-  # Now set up targets for each of the code gallery programs
+  FOREACH(_step ${_code_gallery_names})
+    GET_FILENAME_COMPONENT(_step "${_step}" NAME)
+    LIST(APPEND _code_gallery_names_sans_dir "${_step}")
+  ENDFOREACH()
 
+  # Describe how to build code-gallery.h:
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+    COMMAND ${PERL_EXECUTABLE}
+    ARGS
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/code-gallery.pl
+      ${CMAKE_CURRENT_SOURCE_DIR}/code-gallery.h.in
+      ${DEAL_II_CODE_GALLERY_DIRECTORY}
+      ${_code_gallery_names_sans_dir}
+      > ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+    DEPENDS
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/code-gallery.pl
+      ${CMAKE_CURRENT_SOURCE_DIR}/code-gallery.h.in
+      ${_code_gallery_names}
+    )
+  ADD_CUSTOM_TARGET(build_code-gallery_h
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
+  ADD_DEPENDENCIES(code-gallery build_code-gallery_h)
+
+
+  # Now set up targets for each of the code gallery programs
   FOREACH(_step ${_code_gallery_names})
     GET_FILENAME_COMPONENT(_step "${_step}" NAME)
     MESSAGE(STATUS "  Setting up ${_step}")

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -46,7 +46,35 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
 
   # Now set up targets for each of the code gallery programs
 
-  # ...TODO...
+  FOREACH(_step ${_code_gallery_names})
+    GET_FILENAME_COMPONENT(_step "${_step}" NAME)
+    MESSAGE(STATUS "  Setting up ${_step}")
+
+    # get all source files so we can properly describe the dependencies
+    FILE(GLOB_RECURSE _src_files *)
+
+    ADD_CUSTOM_COMMAND(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
+      COMMAND ${PERL_EXECUTABLE}
+      ARGS
+        ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/make_gallery.pl
+        ${_step} ${CMAKE_SOURCE_DIR}
+        > ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
+      WORKING_DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS
+        ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/make_gallery.pl
+        ${_src_files}
+      )
+
+    ADD_CUSTOM_TARGET(code-gallery_${_step}
+      DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
+      )
+    ADD_DEPENDENCIES(code-gallery code-gallery_${_step})
+
+
+  ENDFOREACH()
 
 ELSE()
   MESSAGE(STATUS "Generating the code-gallery documentation is only possible if the code gallery exists in ${DEAL_II_CODE_GALLERY_DIRECTORY}.")

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -50,15 +50,27 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     GET_FILENAME_COMPONENT(_step "${_step}" NAME)
     MESSAGE(STATUS "  Setting up ${_step}")
 
-    # get all source files so we can properly describe the dependencies
-    FILE(GLOB_RECURSE _src_files *)
+    # Get all source files so we can let the perl script work on
+    # them and so we properly describe the dependencies. exclude
+    # meta-files necessary to describe each code gallery project
+    FILE(GLOB_RECURSE _src_files
+         ${DEAL_II_CODE_GALLERY_DIRECTORY}/${_step}/*)
+    STRING(REPLACE "${DEAL_II_CODE_GALLERY_DIRECTORY}/${_step}/" "" _relative_src_files
+           "${_src_files}")
+    LIST(REMOVE_ITEM _relative_src_files doc/author)
+    LIST(REMOVE_ITEM _relative_src_files doc/tooltip)
+    LIST(REMOVE_ITEM _relative_src_files doc/dependencies)
+    LIST(REMOVE_ITEM _relative_src_files doc/builds-on)
 
     ADD_CUSTOM_COMMAND(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
       COMMAND ${PERL_EXECUTABLE}
       ARGS
         ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/make_gallery.pl
-        ${_step} ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR} 
+        ${_step} 
+        ${DEAL_II_CODE_GALLERY_DIRECTORY}/${_step}
+        ${_relative_src_files} 
         > ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
       WORKING_DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR}
@@ -67,6 +79,18 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
         ${_src_files}
       )
 
+    # Copy files of interest (non-metadata) to the build directory
+    # so we can link to them, and schedule them for installation
+    FILE(COPY ${DEAL_II_CODE_GALLERY_DIRECTORY}/${_step}
+         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/
+         PATTERN REGEX "doc/tooltip|doc/dependencies|doc/builds-on" EXCLUDE)
+    INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_step}
+            DESTINATION ${DEAL_II_DOCHTML_RELDIR}/doxygen/code-gallery
+            COMPONENT documentation
+           )
+
+    # Create a target for this program and add it to the top-level
+    # target of this directory
     ADD_CUSTOM_TARGET(code-gallery_${_step}
       DEPENDS
         ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2015 by the deal.II Authors
+## Copyright (C) 2015, 2016 by the deal.II Authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -76,6 +76,7 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
         ${CMAKE_CURRENT_BINARY_DIR}
       DEPENDS
         ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/make_gallery.pl
+        ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/program2doxygen
         ${_src_files}
       )
 

--- a/doc/doxygen/code-gallery/code-gallery.h.in
+++ b/doc/doxygen/code-gallery/code-gallery.h.in
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+/**
+ * @page CodeGallery The deal.II code gallery
+ *
+ * The deal.II code gallery contains a collection of programs based on deal.II
+ * that were contributed by others to serve as starting points for more complex
+ * applications. The code gallery is an extension of the @ref Tutorial "tutorial"
+ * in that the programs are intended to show how applications can be
+ * implemented with deal.II, but without the requirement to have these code
+ * documented at the same, extensive level as used in the tutorial.
+ * Instructions for obtaining the code gallery programs can be found at
+ * http://dealii.org/code-gallery.html .
+ *
+ * @note The programs that form part of the code gallery are contributed by
+ *   others and are not part of deal.II itself. The deal.II authors make
+ *   no assurances that these programs are documented in any reasonable way,
+ *   nor that the programs are in fact correct. Please contact the authors
+ *   of the code gallery programs if you have questions.
+ *
+ * The code gallery currently consists of the following programs (with
+ * connections to other programs shown in the graph on the
+ * @ref TutorialConnectionGraph "tutorial page"):
+ *
+@@GALLERY_LIST@@
+ */

--- a/doc/doxygen/scripts/code-gallery.pl
+++ b/doc/doxygen/scripts/code-gallery.pl
@@ -1,0 +1,56 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2016 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+use strict;
+
+my $gallery_file = shift;
+open GALLERY, "<$gallery_file";
+
+my $gallery_dir = shift;
+
+
+# Print the first part of gallery.h.in up until the point where we
+# find the line with '@@GALLERY_LIST@@'
+while (my $line = <GALLERY>)
+{
+  last if($line =~ m/\@\@GALLERY_LIST\@\@/);
+  print $line;
+}
+
+# print the list of code gallery programs as a descriptor/description
+# list
+print "<dl>\n";
+foreach my $gallery (sort @ARGV)
+{
+    my $gallery_underscore = $gallery;
+    $gallery_underscore    =~ s/-/_/;
+    print "  <dt><b>\@ref code_gallery_${gallery_underscore} \"$gallery\"</b></dt>\n";
+    print "    <dd>\n";
+    open TOOLTIP, "<$gallery_dir/$gallery/doc/tooltip";
+    while (my $line = <TOOLTIP>) {
+        print "      $line";
+    }
+    print "    </dd>\n";
+    print "\n";
+}
+print "</dl>\n";
+
+
+# Then print the rest of code-gallery.h.in
+while (my $line = <GALLERY>)
+{
+  print $line;
+}
+close GALLERY;

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -114,13 +114,30 @@ if (@picture_files)
 foreach my $file (@src_files)
 { 
     # just copy markdown files as-is, but make sure we update links
+    # that may be inlined. doxygen doesn't seem to understand the
+    # ```...``` form of offset commands, so keep track of that as
+    # well
     if ($file =~ /.*\.(md|markdown)/)
     {
         print "<a name=\"ann-$file\"></a>\n";
         print "<h1>Annotated version of $file</h1>\n";
 
         open MD, "<$gallery_dir/$file";
-        while ($line = <MD>) {
+        my $incode = 0;
+        while ($line = <MD>) 
+        {
+            # replace ``` markdown commands by doxygen equivalents
+            while ($line =~ m/```/)
+            {
+                if ($incode == 0) {
+                    $line =~ s/```/\@code{.sh}/;
+                    $incode = 1;
+                } else {
+                    $line =~ s/```/\@endcode/;
+                    $incode = 0;
+                }
+            }
+
             # update markdown links of the form "[text](./filename)"
             $line =~ s/(\[.*\])\(.\//\1\(..\/code-gallery\/$gallery\//g;
             print "$line";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -58,7 +58,7 @@ foreach my $file (@src_files)
   print "- <a href=\"../code-gallery/$gallery/$file\">$file</a>\n";
   if ($file =~ /.*\.(md|markdown|cc|cpp|cxx|c\+\+|h|hh|hxx)/) 
   {
-      print "  (see <a href=\"#ann-$file\">below</a> for an annotated version)\n";
+      print "  (<a href=\"#ann-$file\">annotated version</a>)\n";
   }
 }
 print "\n";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -56,6 +56,10 @@ This program consists of the following files (click to inspect):
 foreach my $file (@src_files)
 { 
   print "- <a href=\"../code-gallery/$gallery/$file\">$file</a>\n";
+  if ($file =~ /.*\.(md|markdown|cc|cpp|cxx|c\+\+|h|hh|hxx)/) 
+  {
+      print "  (see <a href=\"#ann-$file\">below</a> for an annotated version)\n";
+  }
 }
 print "\n";
 
@@ -73,7 +77,7 @@ foreach my $file (@src_files)
 
 if (@picture_files)
 {
-    print "<h2>Pictures from this code gallery program:</h2>\n";
+    print "<h1>Pictures from this code gallery program</h1>\n";
     print "<p align=\"center\">\n";
     print "<table>\n";
 
@@ -96,6 +100,39 @@ if (@picture_files)
 
     print "</table>\n";
     print "</p>\n";
+}
+
+
+# Then go through the list of files again and see which ones we can
+# annotate and copy into the current document
+foreach my $file (@src_files)
+{ 
+    # just copy markdown files as-is, but make sure we update links
+    if ($file =~ /.*\.(md|markdown)/)
+    {
+        print "<a name=\"ann-$file\"></a>\n";
+        print "<h1>Annotated version of $file</h1>\n";
+
+        open MD, "<$gallery_dir/$file";
+        while ($line = <MD>) {
+            # update markdown links of the form "[text](./filename)"
+            $line =~ s/(\[.*\])\(.\//\1\(..\/code-gallery\/$gallery\//g;
+            print "$line";
+        }
+
+        print "\n\n";
+    }
+
+    # annotate source files
+    if ($file =~ /.*\.(cc|cpp|cxx|c\+\+|h|hh|hxx)/)
+    {
+        print "<a name=\"ann-$file\"></a>\n";
+        print "<h1>Annotated version of $file</h1>\n";
+
+        system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen", "$gallery_dir/$file";
+
+        print "\n\n";
+    }
 }
 
 

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -13,27 +13,50 @@
 ##
 ## ---------------------------------------------------------------------
 
-if ($#ARGV != 1) {
-  print "\nUsage: make_gallery.pl gallery cmake_source_dir\n";
+if ($#ARGV < 1) {
+  print "\nUsage: make_gallery.pl cmake_source_dir gallery_name gallery_dir gallery_src_files...\n";
   exit;
 }
 
-$gallery=$ARGV[0];
-$gallery_underscore=$gallery;
-$gallery_underscore=~ s/-/_/;
+my $cmake_source_dir = shift(@ARGV);
 
-$cmake_source_dir=$ARGV[1];
+my $gallery = shift(@ARGV);
+my $gallery_underscore = $gallery;
+$gallery_underscore    =~ s/-/_/;
+
+my $gallery_dir = shift(@ARGV);
+my $author_file = "$gallery_dir/doc/author";
+
+my @src_files = @ARGV;
+
+# read the names of authors; escape '<' and '>' as they
+# appear in the email address. also trim trailing space and
+# newlines
+open AUTHORS, "<$author_file";
+my $authors = <AUTHORS>;
+$authors    =~ s/</&lt;/g; 
+$authors    =~ s/>/&gt;/g; 
+$authors    =~ s/\s*$//g;
 
 print
 "/**
   * \@page code_gallery_$gallery_underscore The $gallery code gallery program
 \@htmlonly
-<table class=\"tutorial\" width=\"50%\">
-<tr><th colspan=\"2\"><b><small>Table of contents</small></b></th></tr>
-<tr><td width=\"50%\" valign=\"top\">
+<p align=\"center\"> 
+  This program was contributed by $authors.
+  <br>
+  It comes without any warranty or support by its authors or the authors of deal.II.
+</p>
+
 \@endhtmlonly
+
+This program consists of the following files (click to inspect):
 ";
 
-print
-"*/
-";
+foreach my $file (@src_files)
+{ 
+  print "- <a href=\"../code-gallery/$gallery/$file\">$file</a>\n";
+}
+print "\n";
+
+print "*/\n";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -1,0 +1,39 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2013, 2015 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+if ($#ARGV != 1) {
+  print "\nUsage: make_gallery.pl gallery cmake_source_dir\n";
+  exit;
+}
+
+$gallery=$ARGV[0];
+$gallery_underscore=$gallery;
+$gallery_underscore=~ s/-/_/;
+
+$cmake_source_dir=$ARGV[1];
+
+print
+"/**
+  * \@page code_gallery_$gallery_underscore The $gallery code gallery program
+\@htmlonly
+<table class=\"tutorial\" width=\"50%\">
+<tr><th colspan=\"2\"><b><small>Table of contents</small></b></th></tr>
+<tr><td width=\"50%\" valign=\"top\">
+\@endhtmlonly
+";
+
+print
+"*/
+";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013, 2015 by the deal.II authors
+## Copyright (C) 2013, 2015, 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -59,4 +59,45 @@ foreach my $file (@src_files)
 }
 print "\n";
 
+
+# Next go through the list of files and see whether any of these are
+# pictures we could show here:
+my @picture_files;
+foreach my $file (@src_files)
+{ 
+    if ($file =~ /.*\.(png|jpg|gif|svg)/)
+    {
+        push @picture_files, $file;
+    }
+}
+
+if (@picture_files)
+{
+    print "<h2>Pictures from this code gallery program:</h2>\n";
+    print "<p align=\"center\">\n";
+    print "<table>\n";
+
+    # print four pictures per row
+    while (@picture_files)
+    {
+        print "     <tr>\n";
+        for my $i (0 .. 3)
+        {
+            if (@picture_files) 
+            {
+                print "       <td>\n";
+                my $pic = pop(@picture_files);
+                print "         <img width=\"250\" src=\"../code-gallery/$gallery/$pic\">\n";
+                print "       </td>\n";
+            }
+        }
+        print "     </tr>\n";
+    }
+
+    print "</table>\n";
+    print "</p>\n";
+}
+
+
+# end the doxygen input file
 print "*/\n";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -56,7 +56,8 @@ print
 
 \@endhtmlonly
 
-This program consists of the following files (click to inspect):
+This program is part of the \@ref CodeGallery \"deal.II code gallery\" and
+consists of the following files (click to inspect):
 ";
 
 foreach my $file (@src_files)

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -27,7 +27,13 @@ $gallery_underscore    =~ s/-/_/;
 my $gallery_dir = shift(@ARGV);
 my $author_file = "$gallery_dir/doc/author";
 
-my @src_files = @ARGV;
+# next get the source files. sort all markdown files
+# first so that we get to show them first. this makes
+# sense because markdown files typically provide
+# overview information
+my @src_files = grep { $_ =~ m/.*\.(md|markdown)/ } @ARGV;
+push @src_files, sort(grep { !($_ =~ m/.*\.(md|markdown)/) }@ARGV);
+
 
 # read the names of authors; escape '<' and '>' as they
 # appear in the email address. also trim trailing space and

--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013 by the deal.II authors
+## Copyright (C) 2013, 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -56,6 +56,8 @@ print
 
 system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors", "$cmake_source_dir/examples/$step/doc/intro.dox";
 
+print " * <a name=\"CommProg\"></a>\n";
+print " * <h1> The commented program</h1>\n";
 system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen", "$cmake_source_dir/examples/$step/$step.cc";
 
 system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors", "$cmake_source_dir/examples/$step/doc/results.dox";

--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -14,12 +14,17 @@
 ## ---------------------------------------------------------------------
 
 
-# ignore comments at the start of the program. this includes subversion
-# tags and copyright notices.
-$_ = <>;
-while ( m!^/\*!  ||  m!\s*\*! || m/^$/ ) {
-    $_ = <>;
+# skip header lines at the top of the file, such as copyright notices 
+# and license information, if the file is a step-xx.cc tutorial. don't
+# skip for other files such as code-gallery files
+if ($ARGV[0] =~ /step-\d+.cc/)
+{
+  $_ = <>;
+  while ( m!^/\*!  ||  m!\s*\*! || m/^$/ ) {
+      $_ = <>;
+  }
 }
+
 
 # have three states, in which the program can be:
 # comment-mode, program-mode and skip-mode

--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2006 - 2015 by the deal.II authors
+## Copyright (C) 2006 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -13,9 +13,6 @@
 ##
 ## ---------------------------------------------------------------------
 
-
-print " * <a name=\"CommProg\"></a>\n";
-print " * <h1> The commented program</h1>\n";
 
 # ignore comments at the start of the program. this includes subversion
 # tags and copyright notices.

--- a/doc/doxygen/tutorial/CMakeLists.txt
+++ b/doc/doxygen/tutorial/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II Authors
+## Copyright (C) 2012 - 2016 by the deal.II Authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -113,6 +113,10 @@ FOREACH(_step ${_deal_ii_steps})
       ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS
       ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/make_step.pl
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/intro2toc
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/create_anchors
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/program2doxygen
+      ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/program2doxyplain
       ${CMAKE_SOURCE_DIR}/examples/${_step}/${_step}.cc
       ${CMAKE_SOURCE_DIR}/examples/${_step}/doc/intro.dox
       ${CMAKE_SOURCE_DIR}/examples/${_step}/doc/results.dox

--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -43,9 +43,6 @@
  *     synopsis of each program.
  *   <li> or <b><a href="#topic">grouped by topic</a></b>.
  * </ol>
- * Some of the programs also jointly form
- * the <a href="../../doxygen/deal.II/group__geodynamics.html">geodynamics
- * demonstration suite</a>.
  *
  * The programs are in the <code>examples/</code> directory of your local
  * deal.II installation. After compiling the library itself, if you go into
@@ -56,7 +53,15 @@
  * different directories are based on the 
  * <a href="../../users/cmakelists.html" target="_top">small program Makefile template</a>.
  *
+ * @note Some of the tutorial programs also jointly form
+ *   the <a href="../../doxygen/deal.II/group__geodynamics.html">geodynamics
+ *   demonstration suite</a>. More, often more complex but less well documented,
+ *   deal.II-based programs than the ones that form the tutorial can also be
+ *   found in the @ref CodeGallery .
+ *
+ *
  * <a name="graph"></a>
+ * @anchor TutorialConnectionGraph
  * <h3>Connections between tutorial programs</h3>
  *
  * The following graph shows the connections between tutorial programs and


### PR DESCRIPTION
This finishes the bulk of the work still required for #1314. In particular it creates a complete page for each code gallery program (that is now linked to properly from the tutorial page). Each page contains a list of files that make up this program, contains a gallery of pictures found in the gallery directory, and then contains annotated versions of all markdown and .cc/h source files.

What is missing is a doxygen page that outlines all code gallery programs as a list, with links to the complete page for each program.