### PR TITLE
Also install a code gallery page if not found during cmake time.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -155,15 +155,20 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     LIST(APPEND _doxygen_input
       ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/${_step}.h
       )
-    LIST(APPEND _doxygen_input
-      ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
-      )
   ENDFOREACH()
-
-  LIST(APPEND _doxygen_depend
-    ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
-    )
 ENDIF()
+
+
+# always make the doxygen run depend on the code-gallery.h file
+# (whether generated from the code gallery or copied from
+# no-code-gallery.h; both happen in code-gallery/CMakeLists.txt)
+LIST(APPEND _doxygen_input
+  ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
+)
+LIST(APPEND _doxygen_depend
+  ${CMAKE_CURRENT_BINARY_DIR}/code-gallery/code-gallery.h
+)
+
 
 TO_STRING(_doxygen_image_path_string ${_doxygen_image_path})
 TO_STRING(_doxygen_input_string ${_doxygen_input})

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -199,6 +199,7 @@ ADD_CUSTOM_COMMAND(
     ${CMAKE_CURRENT_BINARY_DIR}/options.dox
     ${CMAKE_CURRENT_BINARY_DIR}/header.html
     ${CMAKE_CURRENT_BINARY_DIR}/footer.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml
     ${_doxygen_depend}
   COMMENT "Generating documentation via doxygen."
   VERBATIM

--- a/doc/doxygen/DoxygenLayout.xml
+++ b/doc/doxygen/DoxygenLayout.xml
@@ -3,7 +3,10 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="user" visible="yes" title="Tutorial" url="@ref Tutorial" />
+    <tab type="usergroup" title="Tutorial">
+      <tab type="user" visible="yes" title="Tutorial" url="@ref Tutorial" />
+      <tab type="user" visible="yes" title="Code gallery" url="@ref CodeGallery" />
+    </tab>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>

--- a/doc/doxygen/DoxygenLayout.xml
+++ b/doc/doxygen/DoxygenLayout.xml
@@ -3,10 +3,8 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="usergroup" title="Tutorial">
-      <tab type="user" visible="yes" title="Tutorial" url="@ref Tutorial" />
-      <tab type="user" visible="yes" title="Code gallery" url="@ref CodeGallery" />
-    </tab>
+    <tab type="user" visible="yes" title="Tutorial" url="@ref Tutorial" />
+    <tab type="user" visible="yes" title="Code gallery" url="@ref CodeGallery" />
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -126,6 +126,16 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
   ENDFOREACH()
 
 ELSE()
-  MESSAGE(STATUS "Generating the code-gallery documentation is only possible if the code gallery exists in ${DEAL_II_CODE_GALLERY_DIRECTORY}.")
+
+  # no copy of the code gallery is available. say so. but also
+  # install a file that creates a doxygen page we can link to
+  # nonetheless, so we don't get bad doxygen references
+  MESSAGE(STATUS "Setting up code gallery documentation.")
+  MESSAGE(STATUS "  Skipping as no code gallery exists in ${DEAL_II_CODE_GALLERY_DIRECTORY}.")
+
+  FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/no-code-gallery.h
+       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  FILE(RENAME ${CMAKE_CURRENT_BINARY_DIR}/no-code-gallery.h
+       ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
 ENDIF()
 

--- a/doc/doxygen/code-gallery/code-gallery.h.in
+++ b/doc/doxygen/code-gallery/code-gallery.h.in
@@ -26,7 +26,7 @@
  * Instructions for obtaining the code gallery programs can be found at
  * http://dealii.org/code-gallery.html .
  *
- * @note The programs that form part of the code gallery are contributed by
+ * @warning The programs that form part of the code gallery are contributed by
  *   others and are not part of deal.II itself. The deal.II authors make
  *   no assurances that these programs are documented in any reasonable way,
  *   nor that the programs are in fact correct. Please contact the authors

--- a/doc/doxygen/code-gallery/no-code-gallery.h
+++ b/doc/doxygen/code-gallery/no-code-gallery.h
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+/**
+ * @page CodeGallery The deal.II code gallery
+ *
+ * In order to create pages for the code gallery, there needs to be a
+ * version of the code gallery checked out alongside the other
+ * top-level directories in the <code>deal.II/</code> directory. No
+ * such copy was found when configuring your version of deal.II.
+ *
+ * Instructions for obtaining the code gallery can be found at
+ * http://dealii.org/code-gallery.html .
+ */


### PR DESCRIPTION
This makes sure that we always have a doxygen target to link to available. The target
page may simply say that the code gallery was not available.

In reference to #1314.