### PR TITLE
Always inline some tensor functions.

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -30,7 +30,9 @@
 #   DEAL_II_HAVE_LIBSTDCXX_DEMANGLER
 #   DEAL_II_COMPILER_HAS_ATTRIBUTE_PRETTY_FUNCTION
 #   DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED
+#   DEAL_II_COMPILER_HAS_ATTRIBUTE_ALWAYS_INLINE
 #   DEAL_II_DEPRECATED
+#   DEAL_II_ALWAYS_INLINE
 #   DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
 #   DEAL_II_COMPILER_HAS_FUSE_LD_GOLD
 #
@@ -313,6 +315,24 @@ IF(DEAL_II_COMPILER_HAS_ATTRIBUTE_DEPRECATED)
   SET(DEAL_II_DEPRECATED "__attribute__((deprecated))")
 ELSE()
   SET(DEAL_II_DEPRECATED " ")
+ENDIF()
+
+
+#
+# Do a similar check with the always_inline attribute on functions.
+#
+CHECK_CXX_SOURCE_COMPILES(
+  "
+          __attribute__((always_inline)) int fn () { return 0; }
+          int main () { return fn(); }
+  "
+  DEAL_II_COMPILER_HAS_ATTRIBUTE_ALWAYS_INLINE
+  )
+
+IF(DEAL_II_COMPILER_HAS_ATTRIBUTE_ALWAYS_INLINE)
+  SET(DEAL_II_ALWAYS_INLINE "__attribute__((always_inline))")
+ELSE()
+  SET(DEAL_II_ALWAYS_INLINE " ")
 ENDIF()
 
 

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -213,6 +213,13 @@ inconvenience this causes.
   (Wolfgang Bangerth, 2016/01/07)
   </li>
 
+  <li> New: deal.II now provides a string <code>DEAL_II_ALWAYS_INLINE</code>
+  that, when supported by the compiler, can be used to annotate functions
+  to ensure that the compiler always inlines them.
+  <br>
+  (Matthias Maier, Wolfgang Bangerth, 2016/01/07)
+  </li>
+
   <li> New: constrained_linear_operator() and constrained_right_hand_side()
   provide a generic mechanism of applying constraints to a LinearOperator.
   A detailed explanation with example code is given in the @ref constraints

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -86,6 +86,7 @@
 #cmakedefine DEAL_II_HAVE_LIBSTDCXX_DEMANGLER
 #cmakedefine __PRETTY_FUNCTION__ @__PRETTY_FUNCTION__@
 #cmakedefine DEAL_II_DEPRECATED @DEAL_II_DEPRECATED@
+#cmakedefine DEAL_II_ALWAYS_INLINE @DEAL_II_ALWAYS_INLINE@
 #cmakedefine DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -843,6 +843,7 @@ namespace internal
   namespace TensorSubscriptor
   {
     template <typename ArrayElementType, int dim>
+    inline __attribute__((always_inline))
     ArrayElementType &
     subscript (ArrayElementType *values,
                const unsigned int i,
@@ -868,7 +869,7 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-inline
+inline __attribute__((always_inline))
 typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 {
@@ -877,7 +878,7 @@ Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 
 
 template <int rank_, int dim, typename Number>
-inline
+inline __attribute__((always_inline))
 const typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
 {
@@ -1467,7 +1468,7 @@ operator- (const Tensor<rank,dim,Number> &p, const Tensor<rank,dim,OtherNumber> 
  */
 template <int rank_1, int rank_2, int dim,
           typename Number, typename OtherNumber>
-inline
+inline __attribute__((always_inline))
 typename Tensor<rank_1 + rank_2 - 2, dim, typename ProductType<Number, OtherNumber>::type>::tensor_type
 operator * (const Tensor<rank_1, dim, Number> &src1,
             const Tensor<rank_2, dim, OtherNumber> &src2)

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -843,7 +843,7 @@ namespace internal
   namespace TensorSubscriptor
   {
     template <typename ArrayElementType, int dim>
-    inline __attribute__((always_inline))
+    inline DEAL_II_ALWAYS_INLINE
     ArrayElementType &
     subscript (ArrayElementType *values,
                const unsigned int i,
@@ -869,7 +869,7 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-inline __attribute__((always_inline))
+inline DEAL_II_ALWAYS_INLINE
 typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 {
@@ -878,7 +878,7 @@ Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 
 
 template <int rank_, int dim, typename Number>
-inline __attribute__((always_inline))
+inline DEAL_II_ALWAYS_INLINE
 const typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
 {
@@ -1468,7 +1468,7 @@ operator- (const Tensor<rank,dim,Number> &p, const Tensor<rank,dim,OtherNumber> 
  */
 template <int rank_1, int rank_2, int dim,
           typename Number, typename OtherNumber>
-inline __attribute__((always_inline))
+inline DEAL_II_ALWAYS_INLINE
 typename Tensor<rank_1 + rank_2 - 2, dim, typename ProductType<Number, OtherNumber>::type>::tensor_type
 operator * (const Tensor<rank_1, dim, Number> &src1,
             const Tensor<rank_2, dim, OtherNumber> &src2)

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -183,7 +183,7 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int index, int rank, typename T>
-  internal::ReorderedIndexView<index, rank, T>
+  __attribute__((always_inline)) internal::ReorderedIndexView<index, rank, T>
   reordered_index_view(T &t)
   {
 #ifdef DEAL_II_WITH_CXX11
@@ -264,7 +264,7 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int no_contr, int rank_1, int rank_2, int dim, typename T1, typename T2, typename T3>
-  void contract(T1 &result, const T2 &left, const T3 &right)
+  __attribute__((always_inline)) void contract(T1 &result, const T2 &left, const T3 &right)
   {
 #ifdef DEAL_II_WITH_CXX11
     static_assert(rank_1 >= no_contr, "The rank of the left tensor must be "
@@ -393,7 +393,7 @@ namespace TensorAccessors
       value_type;
 
       // Recurse by applying index j directly:
-      inline
+      inline __attribute__((always_inline))
       value_type operator[](unsigned int j) const
       {
         return value_type(t_[j]);
@@ -422,7 +422,7 @@ namespace TensorAccessors
 
       typedef StoreIndex<rank - 1, internal::Identity<T> > value_type;
 
-      inline
+      inline __attribute__((always_inline))
       value_type operator[](unsigned int j) const
       {
         return value_type(Identity<T>(t_), j);
@@ -443,7 +443,8 @@ namespace TensorAccessors
 
       typedef typename ReferenceType<typename ValueType<T>::value_type>::type value_type;
 
-      inline value_type operator[](unsigned int j) const
+      inline __attribute__((always_inline))
+      value_type operator[](unsigned int j) const
       {
         return t_[j];
       }
@@ -465,7 +466,7 @@ namespace TensorAccessors
 
       typedef typename ValueType<T>::value_type return_type;
 
-      inline
+      inline __attribute__((always_inline))
       typename ReferenceType<return_type>::type apply(unsigned int j) const
       {
         return t_[j];
@@ -491,7 +492,7 @@ namespace TensorAccessors
 
       typedef StoreIndex<rank - 1, StoreIndex<rank, S> > value_type;
 
-      inline
+      inline __attribute__((always_inline))
       value_type operator[](unsigned int j) const
       {
         return value_type(*this, j);
@@ -523,7 +524,8 @@ namespace TensorAccessors
       typedef typename ValueType<typename S::return_type>::value_type return_type;
       typedef return_type value_type;
 
-      inline return_type &operator[](unsigned int j) const
+      inline __attribute__((always_inline))
+      return_type &operator[](unsigned int j) const
       {
         return s_.apply(j)[i_];
       }
@@ -593,7 +595,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline static
+      inline __attribute__((always_inline)) static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         for (unsigned int i = 0; i < dim; ++i)
@@ -621,7 +623,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline static
+      inline __attribute__((always_inline)) static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         for (unsigned int i = 0; i < dim; ++i)
@@ -649,7 +651,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline static
+      inline __attribute__((always_inline)) static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         result = Contract2<no_contr, dim>::template contract2<T1>(left, right);
@@ -665,7 +667,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline static
+      inline __attribute__((always_inline)) static
       T1 contract2(const T2 &left, const T3 &right)
       {
         T1 result = T1();
@@ -683,7 +685,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline static
+      inline __attribute__((always_inline)) static
       T1 contract2(const T2 &left, const T3 &right)
       {
         return left * right;

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2015 by the deal.II authors
+// Copyright (C) 1998 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -183,7 +183,8 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int index, int rank, typename T>
-  DEAL_II_ALWAYS_INLINE internal::ReorderedIndexView<index, rank, T>
+  inline DEAL_II_ALWAYS_INLINE
+  internal::ReorderedIndexView<index, rank, T>
   reordered_index_view(T &t)
   {
 #ifdef DEAL_II_WITH_CXX11
@@ -264,7 +265,8 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int no_contr, int rank_1, int rank_2, int dim, typename T1, typename T2, typename T3>
-  DEAL_II_ALWAYS_INLINE void contract(T1 &result, const T2 &left, const T3 &right)
+  inline DEAL_II_ALWAYS_INLINE
+  void contract(T1 &result, const T2 &left, const T3 &right)
   {
 #ifdef DEAL_II_WITH_CXX11
     static_assert(rank_1 >= no_contr, "The rank of the left tensor must be "

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -183,7 +183,7 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int index, int rank, typename T>
-  __attribute__((always_inline)) internal::ReorderedIndexView<index, rank, T>
+  DEAL_II_ALWAYS_INLINE internal::ReorderedIndexView<index, rank, T>
   reordered_index_view(T &t)
   {
 #ifdef DEAL_II_WITH_CXX11
@@ -264,7 +264,7 @@ namespace TensorAccessors
    * @author Matthias Maier, 2015
    */
   template <int no_contr, int rank_1, int rank_2, int dim, typename T1, typename T2, typename T3>
-  __attribute__((always_inline)) void contract(T1 &result, const T2 &left, const T3 &right)
+  DEAL_II_ALWAYS_INLINE void contract(T1 &result, const T2 &left, const T3 &right)
   {
 #ifdef DEAL_II_WITH_CXX11
     static_assert(rank_1 >= no_contr, "The rank of the left tensor must be "
@@ -393,7 +393,7 @@ namespace TensorAccessors
       value_type;
 
       // Recurse by applying index j directly:
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       value_type operator[](unsigned int j) const
       {
         return value_type(t_[j]);
@@ -422,7 +422,7 @@ namespace TensorAccessors
 
       typedef StoreIndex<rank - 1, internal::Identity<T> > value_type;
 
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       value_type operator[](unsigned int j) const
       {
         return value_type(Identity<T>(t_), j);
@@ -443,7 +443,7 @@ namespace TensorAccessors
 
       typedef typename ReferenceType<typename ValueType<T>::value_type>::type value_type;
 
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       value_type operator[](unsigned int j) const
       {
         return t_[j];
@@ -466,7 +466,7 @@ namespace TensorAccessors
 
       typedef typename ValueType<T>::value_type return_type;
 
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       typename ReferenceType<return_type>::type apply(unsigned int j) const
       {
         return t_[j];
@@ -492,7 +492,7 @@ namespace TensorAccessors
 
       typedef StoreIndex<rank - 1, StoreIndex<rank, S> > value_type;
 
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       value_type operator[](unsigned int j) const
       {
         return value_type(*this, j);
@@ -524,7 +524,7 @@ namespace TensorAccessors
       typedef typename ValueType<typename S::return_type>::value_type return_type;
       typedef return_type value_type;
 
-      inline __attribute__((always_inline))
+      inline DEAL_II_ALWAYS_INLINE
       return_type &operator[](unsigned int j) const
       {
         return s_.apply(j)[i_];
@@ -595,7 +595,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline __attribute__((always_inline)) static
+      inline DEAL_II_ALWAYS_INLINE static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         for (unsigned int i = 0; i < dim; ++i)
@@ -623,7 +623,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline __attribute__((always_inline)) static
+      inline DEAL_II_ALWAYS_INLINE static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         for (unsigned int i = 0; i < dim; ++i)
@@ -651,7 +651,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline __attribute__((always_inline)) static
+      inline DEAL_II_ALWAYS_INLINE static
       void contract(T1 &result, const T2 &left, const T3 &right)
       {
         result = Contract2<no_contr, dim>::template contract2<T1>(left, right);
@@ -667,7 +667,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline __attribute__((always_inline)) static
+      inline DEAL_II_ALWAYS_INLINE static
       T1 contract2(const T2 &left, const T3 &right)
       {
         T1 result = T1();
@@ -685,7 +685,7 @@ namespace TensorAccessors
     {
     public:
       template<typename T1, typename T2, typename T3>
-      inline __attribute__((always_inline)) static
+      inline DEAL_II_ALWAYS_INLINE static
       T1 contract2(const T2 &left, const T3 &right)
       {
         return left * right;


### PR DESCRIPTION
This drastically reduces the time in assembly in ASPECT:
```
DEBUG:
| Assemble Stokes system          |         8 |      38.3s |        27% |
| Assemble temperature system     |         8 |      51.4s |        36% |
| Build Stokes preconditioner     |         3 |      13.8s |       9.7% |
| Build temperature preconditioner|         8 |     0.192s |      0.13% |
| Solve Stokes system             |         8 |      12.3s |       8.6% |

DEBUG WITH PATCH:
| Assemble Stokes system          |         8 |      30.8s |        25% |
| Assemble temperature system     |         8 |      41.7s |        34% |
| Build Stokes preconditioner     |         3 |      12.1s |       9.9% |
| Build temperature preconditioner|         8 |     0.192s |      0.16% |
| Solve Stokes system             |         8 |      12.2s |        10% |
```
(Run with 16 processors, using the testcase discussed in https://github.com/geodynamics/aspect/pull/654 .)

There are no significant differences in release mode with this patch,
as probably expected.