### PR TITLE
Minor changes to Tensor class

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -198,6 +198,12 @@ inconvenience this causes.
 <a name="general"></a>
 <h3>General</h3>
 <ol>
+  <li> Fixed: Tensor::operator[] that takes TableIndices as a parameter no
+  longer returns by value, but rather by reference.
+  <br>
+  (Jean-Paul Pelteret, 2016/01/08)
+  </li>
+
   <li> New: constrained_linear_operator() and constrained_right_hand_side()
   provide a generic mechanism of applying constraints to a LinearOperator.
   A detailed explanation with example code is given in the @ref constraints

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -199,7 +199,9 @@ inconvenience this causes.
 <h3>General</h3>
 <ol>
   <li> Fixed: Tensor::operator[] that takes TableIndices as a parameter no
-  longer returns by value, but rather by reference.
+  longer returns by value, but rather by reference. Tensor::operator<< for
+  dim==0 now accesses values by reference instead of making a copy. This is
+  useful when non-trivial number types are stored.
   <br>
   (Jean-Paul Pelteret, 2016/01/08)
   </li>

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1192,7 +1192,7 @@ template <int dim, typename Number>
 inline
 std::ostream &operator << (std::ostream &out, const Tensor<0,dim,Number> &p)
 {
-  out << static_cast<Number>(p);
+  out << static_cast<const Number &>(p);
   return out;
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -415,7 +415,7 @@ public:
   /**
    * Read access using TableIndices <tt>indices</tt>
    */
-  Number operator [] (const TableIndices<rank_> &indices) const;
+  const Number &operator [] (const TableIndices<rank_> &indices) const;
 
   /**
    * Read and write access using TableIndices <tt>indices</tt>
@@ -887,7 +887,7 @@ Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
 
 template <int rank_, int dim, typename Number>
 inline
-Number
+const Number &
 Tensor<rank_,dim,Number>::operator[] (const TableIndices<rank_> &indices) const
 {
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<rank_,0,Number>"));


### PR DESCRIPTION
One of the access operators returned by value, instead of by reference. This is now fixed.

The bitwise shift left operator for dim==0 now accesses values by reference instead of making a copy. This is useful when non-trivial number types (e.g. auto-differentiable) are stored.

Output of `make setup_tests_base && ctest -j8 -R "tensor"` is `100% tests passed, 0 tests failed out of 124`.