### PR TITLE
Fix AlignedVector for classes that do not implement copy assignment

### DIFF
--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1902,11 +1902,24 @@ TableBase<N,T>::reinit (const TableIndices<N> &new_sizes,
       return;
     }
 
-  // if new size is nonzero: if necessary allocate additional memory, and if
-  // not fast resize, zero out all values/default initialize them)
-  values.resize_fast (new_size);
+  // adjust values field. If it was empty before, we can simply call resize(),
+  // which can set all the data fields. Otherwise, select the fast resize and
+  // manually fill in all the elements as required by the design of this
+  // class. (Selecting another code for the empty case ensures that we touch
+  // the memory only once for non-trivial classes that need to initialize the
+  // memory also in resize_fast.)
   if (!omit_default_initialization)
-    values.fill(T());
+    {
+      if (values.empty())
+        values.resize(new_size, T());
+      else
+        {
+          values.resize_fast(new_size);
+          values.fill(T());
+        }
+    }
+  else
+    values.resize_fast (new_size);
 }
 
 

--- a/tests/base/table_06.output
+++ b/tests/base/table_06.output
@@ -1,8 +1,6 @@
 
 DEAL::Construct object
 DEAL::Destruct with size 0
-DEAL::Construct object
-DEAL::Destruct with size 0
 DEAL::Resize vector to 2
 DEAL::Resize vector to 2
 DEAL::Destruct with size 2
@@ -12,8 +10,6 @@ DEAL::Resize vector to 2
 DEAL::Resize vector to 3
 DEAL::Construct object
 DEAL::Destruct with size 3
-DEAL::Destruct with size 0
-DEAL::Construct object
 DEAL::Destruct with size 0
 DEAL::Construct object
 DEAL::Destruct with size 0


### PR DESCRIPTION
Fixes a few failing tests due to my recent change a89bad2: AlignedVector should work for classes that do not define the copy assignment operator (in analogy to std::vector). We need to distinguish copy constructor and copy assignment operator in `internal::AlignedVectorMove` by a template parameter.

Moreover, this PR also includes a minor speedup for Table of non-trivial types (e.g. `Table<2,Tensor<...>>`). The implementation introduced by a89bad2 would initialize the memory twice in the constructor, once for resize_fast and once for fill. In case the data field was empty before, we can avoid one such operation.