### PR TITLE
Matrix-free level transfer for geometric multigrid

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -198,6 +198,14 @@ inconvenience this causes.
 <a name="general"></a>
 <h3>General</h3>
 <ol>
+  <li> New: The new class MGTransferMatrixFree implements multigrid level
+  transfer using local polynomial embedding and restriction with tensor
+  product evaluation techniques. This is a faster and less memory-demanding
+  alternative to MGTransferPrebuilt.
+  <br>
+  (Martin Kronbichler, 2016/01/20)
+  </li>
+
   <li> New: hp::FECollection now has constructors which take
   multiple finite elements as arguments.
   <br>

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -314,25 +314,25 @@ namespace internal
         for (unsigned int q=0; q<stride; ++q)
           {
             shape_val_evenodd[i*stride+q] =
-              0.5 * (shape_values[i*n_q_points_1d+q] +
-                     shape_values[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_values[i*n_q_points_1d+q] +
+                             shape_values[i*n_q_points_1d+n_q_points_1d-1-q]);
             shape_val_evenodd[(fe_degree-i)*stride+q] =
-              0.5 * (shape_values[i*n_q_points_1d+q] -
-                     shape_values[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_values[i*n_q_points_1d+q] -
+                             shape_values[i*n_q_points_1d+n_q_points_1d-1-q]);
 
             shape_gra_evenodd[i*stride+q] =
-              0.5 * (shape_gradients[i*n_q_points_1d+q] +
-                     shape_gradients[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_gradients[i*n_q_points_1d+q] +
+                             shape_gradients[i*n_q_points_1d+n_q_points_1d-1-q]);
             shape_gra_evenodd[(fe_degree-i)*stride+q] =
-              0.5 * (shape_gradients[i*n_q_points_1d+q] -
-                     shape_gradients[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_gradients[i*n_q_points_1d+q] -
+                             shape_gradients[i*n_q_points_1d+n_q_points_1d-1-q]);
 
             shape_hes_evenodd[i*stride+q] =
-              0.5 * (shape_hessians[i*n_q_points_1d+q] +
-                     shape_hessians[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_hessians[i*n_q_points_1d+q] +
+                             shape_hessians[i*n_q_points_1d+n_q_points_1d-1-q]);
             shape_hes_evenodd[(fe_degree-i)*stride+q] =
-              0.5 * (shape_hessians[i*n_q_points_1d+q] -
-                     shape_hessians[i*n_q_points_1d+n_q_points_1d-1-q]);
+              Number(0.5) * (shape_hessians[i*n_q_points_1d+q] -
+                             shape_hessians[i*n_q_points_1d+n_q_points_1d-1-q]);
           }
       if (fe_degree % 2 == 0)
         for (unsigned int q=0; q<stride; ++q)

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -1,0 +1,232 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__mg_transfer_matrix_free_h
+#define dealii__mg_transfer_matrix_free_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/multigrid/mg_base.h>
+#include <deal.II/multigrid/mg_constrained_dofs.h>
+#include <deal.II/base/mg_level_object.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/matrix_free/shape_info.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/*!@addtogroup mg */
+/*@{*/
+
+/**
+ * Implementation of the MGTransferBase interface for which the transfer
+ * operations is implemented in a matrix-free way based on the interpolation
+ * matrices of the underlying finite element. This requires considerably less
+ * memory than MGTransferPrebuilt and can also be considerably faster than
+ * that variant.
+ *
+ * This class currently only works for tensor-product finite elements based on
+ * FE_Q and FE_DGQ elements, including systems involving multiple components
+ * of one of these elements. Systems with different elements or other elements
+ * are currently not implemented.
+ *
+ * @author Martin Kronbichler
+ * @date 2016
+ */
+template <int dim, typename Number>
+class MGTransferMatrixFree : public MGLevelGlobalTransfer<parallel::distributed::Vector<Number> >
+{
+public:
+  /**
+   * Constructor without constraint matrices. Use this constructor only with
+   * discontinuous finite elements or with no local refinement.
+   */
+  MGTransferMatrixFree ();
+
+  /**
+   * Constructor with constraints. Equivalent to the default constructor
+   * followed by initialize_constraints().
+   */
+  MGTransferMatrixFree (const MGConstrainedDoFs &mg_constrained_dofs);
+
+  /**
+   * Destructor.
+   */
+  virtual ~MGTransferMatrixFree ();
+
+  /**
+   * Initialize the constraints to be used in build().
+   */
+  void initialize_constraints (const MGConstrainedDoFs &mg_constrained_dofs);
+
+  /**
+   * Reset the object to the state it had right after the default constructor.
+   */
+  void clear ();
+
+  /**
+   * Actually build the information for the prolongation for each level.
+   */
+  void build (const DoFHandler<dim,dim> &mg_dof);
+
+  /**
+   * Prolongate a vector from level <tt>to_level-1</tt> to level
+   * <tt>to_level</tt> using the embedding matrices of the underlying finite
+   * element. The previous content of <tt>dst</tt> is overwritten.
+   *
+   * @arg src is a vector with as many elements as there are degrees of
+   * freedom on the coarser level involved.
+   *
+   * @arg dst has as many elements as there are degrees of freedom on the
+   * finer level.
+   */
+  virtual void prolongate (const unsigned int                           to_level,
+                           parallel::distributed::Vector<Number>       &dst,
+                           const parallel::distributed::Vector<Number> &src) const;
+
+  /**
+   * Restrict a vector from level <tt>from_level</tt> to level
+   * <tt>from_level-1</tt> using the transpose operation of the @p prolongate
+   * method. If the region covered by cells on level <tt>from_level</tt> is
+   * smaller than that of level <tt>from_level-1</tt> (local refinement), then
+   * some degrees of freedom in <tt>dst</tt> are active and will not be
+   * altered. For the other degrees of freedom, the result of the restriction
+   * is added.
+   *
+   * @arg src is a vector with as many elements as there are degrees of
+   * freedom on the finer level involved.
+   *
+   * @arg dst has as many elements as there are degrees of freedom on the
+   * coarser level.
+   */
+  virtual void restrict_and_add (const unsigned int from_level,
+                                 parallel::distributed::Vector<Number>       &dst,
+                                 const parallel::distributed::Vector<Number> &src) const;
+
+  /**
+   * Finite element does not provide prolongation matrices.
+   */
+  DeclException0(ExcNoProlongation);
+
+  /**
+   * Memory used by this object.
+   */
+  std::size_t memory_consumption () const;
+
+private:
+
+  /**
+   * Stores the degree of the finite element contained in the DoFHandler
+   * passed to build(). The selection of the computational kernel is based on
+   * this number.
+   */
+  unsigned int fe_degree;
+
+  /**
+   * Stores whether the element is continuous and there is a joint degree of
+   * freedom in the center of the 1D line.
+   */
+  bool element_is_continuous;
+
+  /**
+   * Stores the number of components in the finite element contained in the
+   * DoFHandler passed to build().
+   */
+  unsigned int n_components;
+
+  /**
+   * Stores the number of degrees of freedom on all child cells. It is
+   * <tt>2<sup>dim</sup>*fe.dofs_per_cell</tt> for DG elements and somewhat
+   * less for continuous elements.
+   */
+  unsigned int n_child_cell_dofs;
+
+  /**
+   * Holds the indices for cells on a given level, extracted from DoFHandler
+   * for fast access. All DoF indices on a given level are stored as a plain
+   * array (since this class assumes constant DoFs per cell). To index into
+   * this array, use the cell number times dofs_per_cell.
+   *
+   * This array first is arranged such that all locally owned level cells come
+   * first (found in the variable n_owned_level_cells) and then other cells
+   * necessary for the transfer to the next level.
+   */
+  std::vector<std::vector<unsigned int> > level_dof_indices;
+
+  /**
+   * Stores the connectivity from parent to child cell numbers.
+   */
+  std::vector<std::vector<std::pair<unsigned int,unsigned int> > > parent_child_connect;
+
+  /**
+   * Stores the number of cells owned on a given process (sets the bounds for
+   * the worker loops).
+   */
+  std::vector<unsigned int> n_owned_level_cells;
+
+  /**
+   * Holds the one-dimensional embedding (prolongation) matrix from mother
+   * element to the children.
+   */
+  internal::MatrixFreeFunctions::ShapeInfo<Number> shape_info;
+
+  /**
+   * Holds the temporary values for the tensor evaluation
+   */
+  mutable AlignedVector<VectorizedArray<Number> > evaluation_data;
+
+  /**
+   * For continuous elements, restriction is not additive and we need to
+   * weight the result at the end of prolongation (and at the start of
+   * restriction) by the valence of the degrees of freedom, i.e., on how many
+   * elements they appear. We store the data in vectorized form to allow for
+   * cheap access. Moreover, we utilize the fact that we only need to store
+   * <tt>3<sup>dim</sup></tt> indices.
+   */
+  std::vector<AlignedVector<VectorizedArray<Number> > > weights_on_refined;
+
+  /**
+   * Stores the local indices of Dirichlet boundary conditions on cells.
+   */
+  std::vector<std::vector<std::vector<unsigned short> > > dirichlet_indices;
+
+  /**
+   * Performs templated prolongation operation
+   */
+  template <int degree>
+  void do_prolongate_add(const unsigned int                           to_level,
+                         parallel::distributed::Vector<Number>       &dst,
+                         const parallel::distributed::Vector<Number> &src) const;
+
+  /**
+   * Performs templated restriction operation
+   */
+  template <int degree>
+  void do_restrict_add(const unsigned int                           from_level,
+                       parallel::distributed::Vector<Number>       &dst,
+                       const parallel::distributed::Vector<Number> &src) const;
+};
+
+
+/*@}*/
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -90,10 +90,10 @@ public:
    * <tt>to_level</tt> using the embedding matrices of the underlying finite
    * element. The previous content of <tt>dst</tt> is overwritten.
    *
-   * @arg src is a vector with as many elements as there are degrees of
+   * @param src is a vector with as many elements as there are degrees of
    * freedom on the coarser level involved.
    *
-   * @arg dst has as many elements as there are degrees of freedom on the
+   * @param dst has as many elements as there are degrees of freedom on the
    * finer level.
    */
   virtual void prolongate (const unsigned int                           to_level,
@@ -102,17 +102,17 @@ public:
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
-   * <tt>from_level-1</tt> using the transpose operation of the @p prolongate
+   * <tt>from_level-1</tt> using the transpose operation of the prolongate()
    * method. If the region covered by cells on level <tt>from_level</tt> is
    * smaller than that of level <tt>from_level-1</tt> (local refinement), then
    * some degrees of freedom in <tt>dst</tt> are active and will not be
    * altered. For the other degrees of freedom, the result of the restriction
    * is added.
    *
-   * @arg src is a vector with as many elements as there are degrees of
+   * @param src is a vector with as many elements as there are degrees of
    * freedom on the finer level involved.
    *
-   * @arg dst has as many elements as there are degrees of freedom on the
+   * @param dst has as many elements as there are degrees of freedom on the
    * coarser level.
    */
   virtual void restrict_and_add (const unsigned int from_level,
@@ -170,13 +170,13 @@ private:
   std::vector<std::vector<unsigned int> > level_dof_indices;
 
   /**
-   * Stores the connectivity from parent to child cell numbers.
+   * Stores the connectivity from parent to child cell numbers for each level.
    */
   std::vector<std::vector<std::pair<unsigned int,unsigned int> > > parent_child_connect;
 
   /**
    * Stores the number of cells owned on a given process (sets the bounds for
-   * the worker loops).
+   * the worker loops) for each level.
    */
   std::vector<unsigned int> n_owned_level_cells;
 
@@ -198,11 +198,16 @@ private:
    * elements they appear. We store the data in vectorized form to allow for
    * cheap access. Moreover, we utilize the fact that we only need to store
    * <tt>3<sup>dim</sup></tt> indices.
+   *
+   * Data is organized in terms of each level (outer vector) and the cells on
+   * each level (inner vector).
    */
   std::vector<AlignedVector<VectorizedArray<Number> > > weights_on_refined;
 
   /**
-   * Stores the local indices of Dirichlet boundary conditions on cells.
+   * Stores the local indices of Dirichlet boundary conditions on cells for
+   * all levels (outer index), the cells within the levels (second index), and
+   * the indices on the cell (inner index).
    */
   std::vector<std::vector<std::vector<unsigned short> > > dirichlet_indices;
 

--- a/source/matrix_free/matrix_free.cc
+++ b/source/matrix_free/matrix_free.cc
@@ -26,5 +26,6 @@ DEAL_II_NAMESPACE_OPEN
 
 template struct internal::MatrixFreeFunctions::ShapeInfo<double>;
 template struct internal::MatrixFreeFunctions::ShapeInfo<float>;
+template struct internal::MatrixFreeFunctions::ShapeInfo<long double>;
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -39,6 +39,8 @@ for (deal_II_dimension : DIMENSIONS)
   template void internal::MatrixFreeFunctions::ShapeInfo<float>::reinit
   <deal_II_dimension>(const Quadrature<1> &, const FiniteElement
                       <deal_II_dimension,deal_II_dimension> &, const unsigned int);
+  template void internal::MatrixFreeFunctions::ShapeInfo<long double>::reinit
+  <deal_II_dimension>(const Quadrature<1> &, const FiniteElement
+                      <deal_II_dimension,deal_II_dimension> &, const unsigned int);
 #endif
 }
-

--- a/source/multigrid/CMakeLists.txt
+++ b/source/multigrid/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(_src
   mg_tools.cc
   mg_transfer_block.cc
   mg_transfer_component.cc
+  mg_transfer_matrix_free.cc
   mg_transfer_prebuilt.cc
   multigrid.cc
   )
@@ -31,6 +32,7 @@ SET(_inst
   mg_tools.inst.in
   mg_transfer_block.inst.in
   mg_transfer_component.inst.in
+  mg_transfer_matrix_free.inst.in
   mg_transfer_prebuilt.inst.in
   multigrid.inst.in
   )

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -1,0 +1,942 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/function.h>
+
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_tools.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+#include <deal.II/matrix_free/shape_info.h>
+#include <deal.II/matrix_free/fe_evaluation.h>
+
+#include <algorithm>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+template<int dim, typename Number>
+MGTransferMatrixFree<dim,Number>::MGTransferMatrixFree ()
+  :
+  fe_degree(0),
+  element_is_continuous(false),
+  n_components(0),
+  n_child_cell_dofs(0)
+{}
+
+
+
+template<int dim, typename Number>
+MGTransferMatrixFree<dim,Number>::MGTransferMatrixFree (const MGConstrainedDoFs &mg_c)
+  :
+  fe_degree(0),
+  element_is_continuous(false),
+  n_components(0),
+  n_child_cell_dofs(0)
+{
+  this->mg_constrained_dofs = &mg_c;
+}
+
+
+
+template <int dim, typename Number>
+MGTransferMatrixFree<dim,Number>::~MGTransferMatrixFree ()
+{}
+
+
+
+template <int dim, typename Number>
+void MGTransferMatrixFree<dim,Number>::initialize_constraints
+(const MGConstrainedDoFs &mg_c)
+{
+  this->mg_constrained_dofs = &mg_c;
+}
+
+
+
+template <int dim, typename Number>
+void MGTransferMatrixFree<dim,Number>::clear ()
+{
+  this->MGLevelGlobalTransfer<parallel::distributed::Vector<Number> >::clear();
+  fe_degree = 0;
+  element_is_continuous = false;
+  n_components = 0;
+  n_child_cell_dofs = 0;
+  level_dof_indices.clear();
+  parent_child_connect.clear();
+  n_owned_level_cells.clear();
+  shape_info = internal::MatrixFreeFunctions::ShapeInfo<Number>();
+  evaluation_data.clear();
+  weights_on_refined.clear();
+}
+
+
+
+namespace
+{
+  // given the collection of child cells in lexicographic ordering as seen
+  // from the parent, compute the first index of the given child
+  template <int dim>
+  unsigned int
+  compute_shift_within_children(const unsigned int child,
+                                const unsigned int fe_shift_1d,
+                                const unsigned int fe_degree)
+  {
+    // we put the degrees of freedom of all child cells in
+    // lexicographic ordering
+    unsigned int c_tensor_index[dim];
+    unsigned int tmp = child;
+    for (unsigned int d=0; d<dim; ++d)
+      {
+        c_tensor_index[d] = tmp % 2;
+        tmp /= 2;
+      }
+    const unsigned int n_child_dofs_1d = fe_degree + 1 + fe_shift_1d;
+    unsigned int factor = 1;
+    unsigned int shift = fe_shift_1d * c_tensor_index[0];
+    for (unsigned int d=1; d<dim; ++d)
+      {
+        factor *= n_child_dofs_1d;
+        shift = shift + factor * fe_shift_1d * c_tensor_index[d];
+      }
+    return shift;
+  }
+
+
+
+  // puts the indices on the given child cell in lexicographic ordering with
+  // respect to the collection of all child cells as seen from the parent
+  template <int dim>
+  void add_child_indices(const unsigned int child,
+                         const unsigned int fe_shift_1d,
+                         const unsigned int fe_degree,
+                         const std::vector<unsigned int> &lexicographic_numbering,
+                         const std::vector<types::global_dof_index> &local_dof_indices,
+                         types::global_dof_index *target_indices)
+  {
+    const unsigned int n_child_dofs_1d = fe_degree + 1 + fe_shift_1d;
+    const unsigned int shift =
+      compute_shift_within_children<dim>(child, fe_shift_1d, fe_degree);
+    const unsigned int n_components =
+      local_dof_indices.size()/Utilities::fixed_power<dim>(fe_degree+1);
+    types::global_dof_index *indices = target_indices + shift;
+    const unsigned int n_scalar_cell_dofs = Utilities::fixed_power<dim>(n_child_dofs_1d);
+    for (unsigned int c=0, m=0; c<n_components; ++c)
+      for (unsigned int k=0; k<(dim>2 ? (fe_degree+1) : 1); ++k)
+        for (unsigned int j=0; j<(dim>1 ? (fe_degree+1) : 1); ++j)
+          for (unsigned int i=0; i<(fe_degree+1); ++i, ++m)
+            {
+              const unsigned int index = c*n_scalar_cell_dofs+k*n_child_dofs_1d*
+                                         n_child_dofs_1d+j*n_child_dofs_1d+i;
+              Assert(indices[index] == numbers::invalid_dof_index ||
+                     indices[index] == local_dof_indices[lexicographic_numbering[m]],
+                     ExcInternalError());
+              indices[index] = local_dof_indices[lexicographic_numbering[m]];
+            }
+  }
+
+
+
+  // initialize the vectors needed for the transfer (and merge with the
+  // content in copy_indices_global_mine)
+  template <typename Number>
+  void
+  reinit_ghosted_vector(const IndexSet &locally_owned,
+                        std::vector<types::global_dof_index> &ghosted_level_dofs,
+                        const MPI_Comm &communicator,
+                        parallel::distributed::Vector<Number> &ghosted_level_vector,
+                        std::vector<std::pair<unsigned int,unsigned int> > &copy_indices_global_mine)
+  {
+    std::sort(ghosted_level_dofs.begin(), ghosted_level_dofs.end());
+    IndexSet ghosted_dofs(locally_owned.size());
+    ghosted_dofs.add_indices(ghosted_level_dofs.begin(),
+                             std::unique(ghosted_level_dofs.begin(),
+                                         ghosted_level_dofs.end()));
+    ghosted_dofs.compress();
+
+    // Add possible ghosts from the previous content in the vector
+    if (ghosted_level_vector.size() == locally_owned.size())
+      {
+        // shift the local number of the copy indices according to the new
+        // partitioner that we are going to use for the vector
+        const std_cxx11::shared_ptr<const Utilities::MPI::Partitioner> part
+          = ghosted_level_vector.get_partitioner();
+        ghosted_dofs.add_indices(part->ghost_indices());
+        for (unsigned int i=0; i<copy_indices_global_mine.size(); ++i)
+          copy_indices_global_mine[i].second =
+            locally_owned.n_elements() +
+            ghosted_dofs.index_within_set(part->local_to_global(copy_indices_global_mine[i].second));
+      }
+    ghosted_level_vector.reinit(locally_owned, ghosted_dofs, communicator);
+  }
+
+  // Transform the ghost indices to local index space for the vector
+  void
+  copy_indices_to_mpi_local_numbers(const Utilities::MPI::Partitioner &part,
+                                    const std::vector<types::global_dof_index> &mine,
+                                    const std::vector<types::global_dof_index> &remote,
+                                    std::vector<unsigned int> &localized_indices)
+  {
+    localized_indices.resize(mine.size()+remote.size(),
+                             numbers::invalid_unsigned_int);
+    for (unsigned int i=0; i<mine.size(); ++i)
+      if (mine[i] != numbers::invalid_dof_index)
+        localized_indices[i] = part.global_to_local(mine[i]);
+
+    for (unsigned int i=0; i<remote.size(); ++i)
+      if (remote[i] != numbers::invalid_dof_index)
+        localized_indices[i+mine.size()] = part.global_to_local(remote[i]);
+  }
+}
+
+
+
+template <int dim, typename Number>
+void MGTransferMatrixFree<dim,Number>::build
+(const DoFHandler<dim,dim>  &mg_dof)
+{
+  this->fill_and_communicate_copy_indices(mg_dof);
+
+  // we collect all child DoFs of a mother cell together. For faster
+  // tensorized operations, we align the degrees of freedom
+  // lexicographically. We distinguish FE_Q elements and FE_DGQ elements
+
+  const Triangulation<dim> &tria = mg_dof.get_triangulation();
+
+  // ---------------------------- 1. Extract 1D info about the finite element
+  // step 1.1: create a 1D copy of the finite element from FETools where we
+  // substitute the template argument
+  AssertDimension(mg_dof.get_fe().n_base_elements(), 1);
+  std::string fe_name = mg_dof.get_fe().base_element(0).get_name();
+  {
+    const std::size_t template_starts = fe_name.find_first_of('<');
+    Assert (fe_name[template_starts+1] == (dim==1?'1':(dim==2?'2':'3')),
+            ExcInternalError());
+    fe_name[template_starts+1] = '1';
+  }
+  std_cxx11::shared_ptr<FiniteElement<1> > fe_1d
+  (FETools::get_fe_from_name<1>(fe_name));
+  const FiniteElement<1> &fe = *fe_1d;
+  unsigned int n_child_dofs_1d = numbers::invalid_unsigned_int;
+
+  {
+    // currently, we have only FE_Q and FE_DGQ type elements implemented
+    n_components = mg_dof.get_fe().element_multiplicity(0);
+    AssertDimension(Utilities::fixed_power<dim>(fe.dofs_per_cell)*n_components,
+                    mg_dof.get_fe().dofs_per_cell);
+    AssertDimension(fe.degree, mg_dof.get_fe().degree);
+    fe_degree = fe.degree;
+    element_is_continuous = fe.dofs_per_vertex > 0;
+    Assert(fe.dofs_per_vertex < 2, ExcNotImplemented());
+
+    // step 1.2: get renumbering of 1D basis functions to lexicographic
+    // numbers. The distinction according to fe.dofs_per_vertex is to support
+    // both continuous and discontinuous bases.
+    std::vector<unsigned int> renumbering(fe.dofs_per_cell);
+    {
+      AssertIndexRange(fe.dofs_per_vertex, 2);
+      renumbering[0] = 0;
+      for (unsigned int i=0; i<fe.dofs_per_line; ++i)
+        renumbering[i+fe.dofs_per_vertex] =
+          GeometryInfo<1>::vertices_per_cell*fe.dofs_per_vertex + i;
+      if (fe.dofs_per_vertex > 0)
+        renumbering[fe.dofs_per_cell-fe.dofs_per_vertex] = fe.dofs_per_vertex;
+    }
+
+    // step 1.3: create a 1D quadrature formula from the finite element that
+    // collects the support points of the basis functions on the two children.
+    std::vector<Point<1> > basic_support_points = fe.get_unit_support_points();
+    Assert(fe.dofs_per_vertex == 0 || fe.dofs_per_vertex == 1,
+           ExcNotImplemented());
+    std::vector<Point<1> > points_refined(fe.dofs_per_vertex > 0 ?
+                                          (2 * fe.dofs_per_cell - 1) :
+                                          (2 * fe.dofs_per_cell));
+    const unsigned int shift = fe.dofs_per_cell - fe.dofs_per_vertex;
+    for (unsigned int c=0; c<GeometryInfo<1>::max_children_per_cell; ++c)
+      for (unsigned int j=0; j<basic_support_points.size(); ++j)
+        points_refined[shift*c+j][0] =
+          c*0.5 + 0.5 * basic_support_points[renumbering[j]][0];
+
+    n_child_dofs_1d = points_refined.size();
+    n_child_cell_dofs = n_components*Utilities::fixed_power<dim>(n_child_dofs_1d);
+
+    // step 1.4: evaluate the polynomials and store the data in ShapeInfo
+    const Quadrature<1> quadrature(points_refined);
+    shape_info.reinit(quadrature, mg_dof.get_fe(), 0);
+
+    for (unsigned int c=0; c<GeometryInfo<1>::max_children_per_cell; ++c)
+      for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
+        for (unsigned int j=0; j<fe.dofs_per_cell; ++j)
+          Assert(std::abs(shape_info.shape_values[i*n_child_dofs_1d+j+c*shift][0] -
+                          fe.get_prolongation_matrix(c)(renumbering[j],renumbering[i]))
+                 < std::max(2.*(double)std::numeric_limits<Number>::epsilon(),1e-12),
+                 ExcInternalError());
+  }
+
+  // -------------- 2. Extract and match dof indices between child and parent
+  const unsigned int n_levels = tria.n_global_levels();
+  level_dof_indices.resize(n_levels);
+  parent_child_connect.resize(n_levels-1);
+  n_owned_level_cells.resize(n_levels-1);
+  std::vector<std::vector<unsigned int> > coarse_level_indices(n_levels-1);
+  for (unsigned int level=0; level<std::min(tria.n_levels(),n_levels-1); ++level)
+    coarse_level_indices[level].resize(tria.n_raw_cells(level),
+                                       numbers::invalid_unsigned_int);
+  std::vector<types::global_dof_index> local_dof_indices(mg_dof.get_fe().dofs_per_cell);
+  dirichlet_indices.resize(n_levels-1);
+
+  // We use the vectors stored ghosted_level_vector in the base class for
+  // keeping ghosted transfer indices. To avoid keeping two very similar
+  // vectors, we merge them here.
+  if (this->ghosted_level_vector.max_level() != n_levels-1)
+    this->ghosted_level_vector.resize(0, n_levels-1);
+
+  for (unsigned int level=n_levels-1; level > 0; --level)
+    {
+      unsigned int counter = 0;
+      std::vector<types::global_dof_index> global_level_dof_indices;
+      std::vector<types::global_dof_index> global_level_dof_indices_remote;
+      std::vector<types::global_dof_index> ghosted_level_dofs;
+      std::vector<types::global_dof_index> global_level_dof_indices_l0;
+      std::vector<types::global_dof_index> ghosted_level_dofs_l0;
+
+      // step 2.1: loop over the cells on the coarse side
+      for (typename DoFHandler<dim>::cell_iterator cell = mg_dof.begin(level-1);
+           cell != mg_dof.end(level-1); ++cell)
+        {
+          // need to look into a cell if it has children and it is locally owned
+          if (!cell->has_children())
+            continue;
+
+          bool consider_cell = false;
+          if (tria.locally_owned_subdomain()==numbers::invalid_subdomain_id
+              || cell->level_subdomain_id()==tria.locally_owned_subdomain()
+             )
+            consider_cell = true;
+
+          // due to the particular way we store DoF indices (via children), we
+          // also need to add the DoF indices for coarse cells where we own at
+          // least one child
+          bool cell_is_remote = !consider_cell;
+          for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
+            if (cell->child(c)->level_subdomain_id()==tria.locally_owned_subdomain())
+              consider_cell = true;
+
+          if (!consider_cell)
+            continue;
+
+          // step 2.2: loop through children and append the dof indices to the
+          // appropriate list. We need separate lists for the owned coarse
+          // cell case (which will be part of restriction/prolongation between
+          // level-1 and level) and the remote case (which needs to store DoF
+          // indices for the operations between level and level+1).
+          AssertDimension(cell->n_children(),
+                          GeometryInfo<dim>::max_children_per_cell);
+          std::vector<types::global_dof_index> &next_indices =
+            cell_is_remote ? global_level_dof_indices_remote : global_level_dof_indices;
+          const std::size_t start_index = next_indices.size();
+          next_indices.resize(start_index + n_child_cell_dofs,
+                              numbers::invalid_dof_index);
+          for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
+            {
+              if (cell_is_remote && cell->child(c)->level_subdomain_id() !=
+                  tria.locally_owned_subdomain())
+                continue;
+              cell->child(c)->get_mg_dof_indices(local_dof_indices);
+
+              const IndexSet &owned_level_dofs = mg_dof.locally_owned_mg_dofs(level);
+              for (unsigned int i=0; i<local_dof_indices.size(); ++i)
+                if (!owned_level_dofs.is_element(local_dof_indices[i]))
+                  ghosted_level_dofs.push_back(local_dof_indices[i]);
+
+              add_child_indices<dim>(c, fe.dofs_per_cell - fe.dofs_per_vertex,
+                                     fe.degree, shape_info.lexicographic_numbering,
+                                     local_dof_indices,
+                                     &next_indices[start_index]);
+
+              // step 2.3 store the connectivity to the parent
+              if (cell->child(c)->has_children() &&
+                  (tria.locally_owned_subdomain()==numbers::invalid_subdomain_id
+                   || cell->child(c)->level_subdomain_id()==tria.locally_owned_subdomain()
+                  ))
+                {
+                  const unsigned int child_index = coarse_level_indices[level][cell->child(c)->index()];
+                  AssertIndexRange(child_index, parent_child_connect[level].size());
+                  unsigned int parent_index = counter;
+                  // remote cells, i.e., cells where we work on a further
+                  // level but are not treated on the current level, need to
+                  // be placed at the end of the list; however, we do not yet
+                  // know the exact position in the array, so shift their
+                  // parent index by the number of cells so we can set the
+                  // correct number after the end of this loop
+                  if (cell_is_remote)
+                    parent_index = start_index/n_child_cell_dofs + tria.n_cells(level);
+                  parent_child_connect[level][child_index] =
+                    std::make_pair(parent_index, c);
+                  AssertIndexRange(mg_dof.get_fe().dofs_per_cell,
+                                   static_cast<unsigned short>(-1));
+
+                  // set Dirichlet boundary conditions (as a list of
+                  // constrained DoFs) for the child
+                  if (this->mg_constrained_dofs != 0)
+                    for (unsigned int i=0; i<mg_dof.get_fe().dofs_per_cell; ++i)
+                      if (this->mg_constrained_dofs->is_boundary_index(level, local_dof_indices[shape_info.lexicographic_numbering[i]]))
+                        dirichlet_indices[level][child_index].push_back(i);
+                }
+            }
+          if (!cell_is_remote)
+            {
+              AssertIndexRange(static_cast<unsigned int>(cell->index()),
+                               coarse_level_indices[level-1].size());
+              coarse_level_indices[level-1][cell->index()] = counter++;
+            }
+
+          // step 2.4: include indices for the coarsest cells. we still insert
+          // the indices as if they were from a child in order to use the same
+          // code (the coarsest level does not matter much in terms of memory,
+          // so we gain in code simplicity)
+          if (level == 1 && !cell_is_remote)
+            {
+              cell->get_mg_dof_indices(local_dof_indices);
+
+              const IndexSet &owned_level_dofs_l0 = mg_dof.locally_owned_mg_dofs(0);
+              for (unsigned int i=0; i<local_dof_indices.size(); ++i)
+                if (!owned_level_dofs_l0.is_element(local_dof_indices[i]))
+                  ghosted_level_dofs_l0.push_back(local_dof_indices[i]);
+
+              const std::size_t start_index = global_level_dof_indices_l0.size();
+              global_level_dof_indices_l0.resize(start_index+n_child_cell_dofs,
+                                                 numbers::invalid_dof_index);
+              add_child_indices<dim>(0, fe.dofs_per_cell - fe.dofs_per_vertex,
+                                     fe.degree, shape_info.lexicographic_numbering,
+                                     local_dof_indices,
+                                     &global_level_dof_indices_l0[start_index]);
+
+              dirichlet_indices[0].push_back(std::vector<unsigned short>());
+              if (this->mg_constrained_dofs != 0)
+                for (unsigned int i=0; i<mg_dof.get_fe().dofs_per_cell; ++i)
+                  if (this->mg_constrained_dofs->is_boundary_index(0, local_dof_indices[shape_info.lexicographic_numbering[i]]))
+                    dirichlet_indices[0].back().push_back(i);
+            }
+        }
+
+      // step 2.5: store information about the current level and prepare the
+      // Dirichlet indices and parent-child relationship for the next coarser
+      // level
+      AssertDimension(counter*n_child_cell_dofs, global_level_dof_indices.size());
+      n_owned_level_cells[level-1] = counter;
+      dirichlet_indices[level-1].resize(counter);
+      parent_child_connect[level-1].
+      resize(counter, std::make_pair(numbers::invalid_unsigned_int,
+                                     numbers::invalid_unsigned_int));
+
+      // step 2.6: put the cells with remotely owned parent to the end of the
+      // list (these are needed for the transfer from level to level+1 but not
+      // for the transfer from level-1 to level).
+      if (level < n_levels-1)
+        for (std::vector<std::pair<unsigned int,unsigned int> >::iterator
+             i=parent_child_connect[level].begin(); i!=parent_child_connect[level].end(); ++i)
+          if (i->first >= tria.n_cells(level))
+            {
+              i->first -= tria.n_cells(level);
+              i->first += counter;
+            }
+
+      // step 2.7: Initialize the ghosted vector
+      const parallel::Triangulation<dim,dim> *ptria =
+        (dynamic_cast<const parallel::Triangulation<dim,dim>*> (&tria));
+      const MPI_Comm communicator =
+        ptria != 0 ? ptria->get_communicator() : MPI_COMM_SELF;
+
+      reinit_ghosted_vector(mg_dof.locally_owned_mg_dofs(level),
+                            ghosted_level_dofs, communicator,
+                            this->ghosted_level_vector[level],
+                            this->copy_indices_global_mine[level]);
+
+      copy_indices_to_mpi_local_numbers(*this->ghosted_level_vector[level].get_partitioner(),
+                                        global_level_dof_indices,
+                                        global_level_dof_indices_remote,
+                                        level_dof_indices[level]);
+
+      // step 2.8: Initialize the ghosted vector for level 0
+      if (level == 1)
+        {
+          for (unsigned int i = 0; i<parent_child_connect[0].size(); ++i)
+            parent_child_connect[0][i] = std::make_pair(i, 0U);
+
+          reinit_ghosted_vector(mg_dof.locally_owned_mg_dofs(0),
+                                ghosted_level_dofs_l0, communicator,
+                                this->ghosted_level_vector[0],
+                                this->copy_indices_global_mine[0]);
+
+          copy_indices_to_mpi_local_numbers(*this->ghosted_level_vector[0].get_partitioner(),
+                                            global_level_dof_indices_l0,
+                                            std::vector<types::global_dof_index>(),
+                                            level_dof_indices[0]);
+        }
+    }
+
+  // ------------------------ 3. compute weights to make restriction additive
+  //
+  // get the valence of the individual components and compute the weights as
+  // the inverse of the valence
+  weights_on_refined.resize(n_levels);
+  for (unsigned int level = 1; level<n_levels; ++level)
+    {
+      this->ghosted_level_vector[level] = 0;
+      for (unsigned int c=0; c<n_owned_level_cells[level-1]; ++c)
+        for (unsigned int j=0; j<n_child_cell_dofs; ++j)
+          this->ghosted_level_vector[level].local_element(level_dof_indices[level][n_child_cell_dofs*c+j]) += Number(1.);
+      this->ghosted_level_vector[level].compress(VectorOperation::add);
+      this->ghosted_level_vector[level].update_ghost_values();
+
+      const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;
+      std::vector<unsigned int> degree_to_3 (n_child_dofs_1d);
+      degree_to_3[0] = 0;
+      for (unsigned int i=1; i<n_child_dofs_1d-1; ++i)
+        degree_to_3[i] = 1;
+      degree_to_3.back() = 2;
+
+      // we only store 3^dim weights because all dofs on a line have the same
+      // valence, and all dofs on a quad have the same valence.
+      weights_on_refined[level].resize(((n_owned_level_cells[level-1]+vec_size-1)/vec_size)*Utilities::fixed_power<dim>(3));
+      for (unsigned int c=0; c<n_owned_level_cells[level-1]; ++c)
+        {
+          const unsigned int comp = c/vec_size;
+          const unsigned int v = c%vec_size;
+
+          for (unsigned int k=0, m=0; k<(dim>2 ? n_child_dofs_1d : 1); ++k)
+            for (unsigned int j=0; j<(dim>1 ? n_child_dofs_1d : 1); ++j)
+              {
+                unsigned int shift = 9*degree_to_3[k] + 3*degree_to_3[j];
+                for (unsigned int i=0; i<n_child_dofs_1d; ++i, ++m)
+                  weights_on_refined[level][comp*Utilities::fixed_power<dim>(3)+shift+degree_to_3[i]][v] = Number(1.)/
+                      this->ghosted_level_vector[level].local_element(level_dof_indices[level][n_child_cell_dofs*c+m]);
+              }
+        }
+    }
+
+  evaluation_data.resize(3*n_child_cell_dofs);
+}
+
+
+
+template <int dim, typename Number>
+void MGTransferMatrixFree<dim,Number>
+::prolongate (const unsigned int                           to_level,
+              parallel::distributed::Vector<Number>       &dst,
+              const parallel::distributed::Vector<Number> &src) const
+{
+  Assert ((to_level >= 1) && (to_level<=level_dof_indices.size()),
+          ExcIndexRange (to_level, 1, level_dof_indices.size()+1));
+
+  AssertDimension(this->ghosted_level_vector[to_level].local_size(),
+                  dst.local_size());
+  AssertDimension(this->ghosted_level_vector[to_level-1].local_size(),
+                  src.local_size());
+
+  this->ghosted_level_vector[to_level-1] = src;
+  this->ghosted_level_vector[to_level-1].update_ghost_values();
+  this->ghosted_level_vector[to_level] = 0.;
+
+  // the implementation in do_prolongate_add is templated in the degree of the
+  // element (for efficiency reasons), so we need to find the appropriate
+  // kernel here...
+  if (fe_degree == 0)
+    do_prolongate_add<0>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 1)
+    do_prolongate_add<1>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 2)
+    do_prolongate_add<2>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 3)
+    do_prolongate_add<3>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 4)
+    do_prolongate_add<4>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 5)
+    do_prolongate_add<5>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 6)
+    do_prolongate_add<6>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 7)
+    do_prolongate_add<7>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 8)
+    do_prolongate_add<8>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 9)
+    do_prolongate_add<9>(to_level, this->ghosted_level_vector[to_level],
+                         this->ghosted_level_vector[to_level-1]);
+  else if (fe_degree == 10)
+    do_prolongate_add<10>(to_level, this->ghosted_level_vector[to_level],
+                          this->ghosted_level_vector[to_level-1]);
+  else
+    AssertThrow(false, ExcNotImplemented("Only degrees 0 up to 10 implemented."));
+
+  this->ghosted_level_vector[to_level].compress(VectorOperation::add);
+  dst = this->ghosted_level_vector[to_level];
+}
+
+
+
+template <int dim, typename Number>
+void MGTransferMatrixFree<dim,Number>
+::restrict_and_add (const unsigned int                           from_level,
+                    parallel::distributed::Vector<Number>       &dst,
+                    const parallel::distributed::Vector<Number> &src) const
+{
+  Assert ((from_level >= 1) && (from_level<=level_dof_indices.size()),
+          ExcIndexRange (from_level, 1, level_dof_indices.size()+1));
+
+  AssertDimension(this->ghosted_level_vector[from_level].local_size(),
+                  src.local_size());
+  AssertDimension(this->ghosted_level_vector[from_level-1].local_size(),
+                  dst.local_size());
+
+  this->ghosted_level_vector[from_level] = src;
+  this->ghosted_level_vector[from_level].update_ghost_values();
+  this->ghosted_level_vector[from_level-1] = 0.;
+
+  if (fe_degree == 0)
+    do_restrict_add<0>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 1)
+    do_restrict_add<1>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 2)
+    do_restrict_add<2>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 3)
+    do_restrict_add<3>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 4)
+    do_restrict_add<4>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 5)
+    do_restrict_add<5>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 6)
+    do_restrict_add<6>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 7)
+    do_restrict_add<7>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 8)
+    do_restrict_add<8>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 9)
+    do_restrict_add<9>(from_level, this->ghosted_level_vector[from_level-1],
+                       this->ghosted_level_vector[from_level]);
+  else if (fe_degree == 10)
+    do_restrict_add<10>(from_level, this->ghosted_level_vector[from_level-1],
+                        this->ghosted_level_vector[from_level]);
+  else
+    AssertThrow(false, ExcNotImplemented("Only degrees 0 up to 10 implemented."));
+
+  this->ghosted_level_vector[from_level-1].compress(VectorOperation::add);
+  dst += this->ghosted_level_vector[from_level-1];
+}
+
+
+
+namespace
+{
+  template <int dim, typename Eval, typename Number, bool prolongate>
+  void
+  perform_tensorized_op(const Eval &evaluator,
+                        const unsigned int n_child_cell_dofs,
+                        const unsigned int n_components,
+                        AlignedVector<VectorizedArray<Number> > &evaluation_data)
+  {
+    AssertDimension(n_components * Eval::n_q_points, n_child_cell_dofs);
+    VectorizedArray<Number> *t0 = &evaluation_data[0];
+    VectorizedArray<Number> *t1 = &evaluation_data[n_child_cell_dofs];
+    VectorizedArray<Number> *t2 = &evaluation_data[2*n_child_cell_dofs];
+
+    for (unsigned int c=0; c<n_components; ++c)
+      {
+        // for the prolongate case, we go from dofs (living on the parent cell) to
+        // quads (living on all children) in the FEEvaluation terminology
+        if (dim == 1)
+          evaluator.template values<0,prolongate,false>(t0, t2);
+        else if (dim == 2)
+          {
+            evaluator.template values<0,prolongate,false>(t0, t1);
+            evaluator.template values<1,prolongate,false>(t1, t2);
+          }
+        else if (dim == 3)
+          {
+            evaluator.template values<0,prolongate,false>(t0, t2);
+            evaluator.template values<1,prolongate,false>(t2, t1);
+            evaluator.template values<2,prolongate,false>(t1, t2);
+          }
+        else
+          Assert(false, ExcNotImplemented());
+        if (prolongate)
+          {
+            t0 += Eval::dofs_per_cell;
+            t2 += Eval::n_q_points;
+          }
+        else
+          {
+            t0 += Eval::n_q_points;
+            t2 += Eval::dofs_per_cell;
+          }
+      }
+  }
+
+  template <int dim, int degree, typename Number>
+  void weight_dofs_on_child (const VectorizedArray<Number> *weights,
+                             const unsigned int n_components,
+                             VectorizedArray<Number> *data)
+  {
+    Assert(degree > 0, ExcNotImplemented());
+    const unsigned int loop_length = 2*degree+1;
+    unsigned int degree_to_3 [loop_length];
+    degree_to_3[0] = 0;
+    for (unsigned int i=1; i<loop_length-1; ++i)
+      degree_to_3[i] = 1;
+    degree_to_3[loop_length-1] = 2;
+    for (unsigned int c=0; c<n_components; ++c)
+      for (unsigned int k=0; k<(dim>2 ? loop_length : 1); ++k)
+        for (unsigned int j=0; j<(dim>1 ? loop_length : 1); ++j)
+          {
+            const unsigned int shift = 9*degree_to_3[k] + 3*degree_to_3[j];
+            data[0] *= weights[shift];
+            for (unsigned int i=1; i<loop_length-1; ++i)
+              data[i] *= weights[shift+1];
+            data[loop_length-1] *= weights[shift+2];
+            data += loop_length;
+          }
+  }
+}
+
+
+
+template <int dim, typename Number>
+template <int degree>
+void MGTransferMatrixFree<dim,Number>
+::do_prolongate_add (const unsigned int                           to_level,
+                     parallel::distributed::Vector<Number>       &dst,
+                     const parallel::distributed::Vector<Number> &src) const
+{
+  const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;
+  const unsigned int n_child_dofs_1d = 2*(fe_degree+1) - element_is_continuous;
+  const unsigned int n_scalar_cell_dofs = Utilities::fixed_power<dim>(n_child_dofs_1d);
+  const unsigned int three_to_dim = Utilities::fixed_int_power<3,dim>::value;
+
+  for (unsigned int cell=0; cell < n_owned_level_cells[to_level-1];
+       cell += vec_size)
+    {
+      const unsigned int n_chunks = cell+vec_size > n_owned_level_cells[to_level-1] ?
+                                    n_owned_level_cells[to_level-1] - cell : vec_size;
+
+      // read from source vector
+      for (unsigned int v=0; v<n_chunks; ++v)
+        {
+          const unsigned int shift = compute_shift_within_children<dim>
+                                     (parent_child_connect[to_level-1][cell+v].second,
+                                      degree+1-element_is_continuous, degree);
+          const unsigned int *indices = &level_dof_indices[to_level-1][parent_child_connect[to_level-1][cell+v].first*n_child_cell_dofs+shift];
+          for (unsigned int c=0, m=0; c<n_components; ++c)
+            {
+              for (unsigned int k=0; k<(dim>2 ? (degree+1) : 1); ++k)
+                for (unsigned int j=0; j<(dim>1 ? (degree+1) : 1); ++j)
+                  for (unsigned int i=0; i<(degree+1); ++i, ++m)
+                    evaluation_data[m][v] =
+                      src.local_element(indices[c*n_scalar_cell_dofs +
+                                                k*n_child_dofs_1d*n_child_dofs_1d+
+                                                j*n_child_dofs_1d+i]);
+
+              // apply Dirichlet boundary conditions on parent cell
+              for (std::vector<unsigned short>::const_iterator i=dirichlet_indices[to_level-1][cell+v].begin(); i!=dirichlet_indices[to_level-1][cell+v].end(); ++i)
+                evaluation_data[*i][v] = 0.;
+            }
+        }
+
+      // perform tensorized operation
+      Assert(shape_info.element_type ==
+             internal::MatrixFreeFunctions::tensor_symmetric, ExcNotImplemented());
+      if (element_is_continuous)
+        {
+          AssertDimension(shape_info.shape_val_evenodd.size(),
+                          (degree+1)*(degree+1));
+          typedef internal::EvaluatorTensorProduct<internal::evaluate_evenodd,dim,degree,2*degree+1,VectorizedArray<Number> > Evaluator;
+          Evaluator evaluator(shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd);
+          perform_tensorized_op<dim,Evaluator,Number,true>(evaluator,
+                                                           n_child_cell_dofs,
+                                                           n_components,
+                                                           evaluation_data);
+          weight_dofs_on_child<dim,degree,Number>(&weights_on_refined[to_level][(cell/vec_size)*three_to_dim],
+                                                  n_components,
+                                                  &evaluation_data[2*n_child_cell_dofs]);
+        }
+      else
+        {
+          AssertDimension(shape_info.shape_val_evenodd.size(),
+                          (degree+1)*(degree+1));
+          typedef internal::EvaluatorTensorProduct<internal::evaluate_evenodd,dim,degree,2*degree+2,VectorizedArray<Number> > Evaluator;
+          Evaluator evaluator(shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd);
+          perform_tensorized_op<dim,Evaluator,Number,true>(evaluator,
+                                                           n_child_cell_dofs,
+                                                           n_components,
+                                                           evaluation_data);
+        }
+
+      // write into dst vector
+      const unsigned int *indices = &level_dof_indices[to_level][cell*
+                                                                 n_child_cell_dofs];
+      for (unsigned int v=0; v<n_chunks; ++v)
+        {
+          for (unsigned int i=0; i<n_child_cell_dofs; ++i)
+            dst.local_element(indices[i]) += evaluation_data[2*n_child_cell_dofs+i][v];
+          indices += n_child_cell_dofs;
+        }
+    }
+}
+
+
+
+template <int dim, typename Number>
+template <int degree>
+void MGTransferMatrixFree<dim,Number>
+::do_restrict_add (const unsigned int                           from_level,
+                   parallel::distributed::Vector<Number>       &dst,
+                   const parallel::distributed::Vector<Number> &src) const
+{
+  const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;
+  const unsigned int n_child_dofs_1d = 2*(fe_degree+1) - element_is_continuous;
+  const unsigned int n_scalar_cell_dofs = Utilities::fixed_power<dim>(n_child_dofs_1d);
+  const unsigned int three_to_dim = Utilities::fixed_int_power<3,dim>::value;
+
+  for (unsigned int cell=0; cell < n_owned_level_cells[from_level-1];
+       cell += vec_size)
+    {
+      const unsigned int n_chunks = cell+vec_size > n_owned_level_cells[from_level-1] ?
+                                    n_owned_level_cells[from_level-1] - cell : vec_size;
+
+      // read from source vector
+      {
+        const unsigned int *indices = &level_dof_indices[from_level][cell*
+                                      n_child_cell_dofs];
+        for (unsigned int v=0; v<n_chunks; ++v)
+          {
+            for (unsigned int i=0; i<n_child_cell_dofs; ++i)
+              evaluation_data[i][v] = src.local_element(indices[i]);
+            indices += n_child_cell_dofs;
+          }
+      }
+
+      // perform tensorized operation
+      Assert(shape_info.element_type ==
+             internal::MatrixFreeFunctions::tensor_symmetric, ExcNotImplemented());
+      if (element_is_continuous)
+        {
+          AssertDimension(shape_info.shape_val_evenodd.size(),
+                          (degree+1)*(degree+1));
+          typedef internal::EvaluatorTensorProduct<internal::evaluate_evenodd,dim,degree,2*degree+1,VectorizedArray<Number> > Evaluator;
+          Evaluator evaluator(shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd);
+          weight_dofs_on_child<dim,degree,Number>(&weights_on_refined[from_level][(cell/vec_size)*three_to_dim],
+                                                  n_components,
+                                                  &evaluation_data[0]);
+          perform_tensorized_op<dim,Evaluator,Number,false>(evaluator,
+                                                            n_child_cell_dofs,
+                                                            n_components,
+                                                            evaluation_data);
+        }
+      else
+        {
+          AssertDimension(shape_info.shape_val_evenodd.size(),
+                          (degree+1)*(degree+1));
+          typedef internal::EvaluatorTensorProduct<internal::evaluate_evenodd,dim,degree,2*degree+2,VectorizedArray<Number> > Evaluator;
+          Evaluator evaluator(shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd,
+                              shape_info.shape_val_evenodd);
+          perform_tensorized_op<dim,Evaluator,Number,false>(evaluator,
+                                                            n_child_cell_dofs,
+                                                            n_components,
+                                                            evaluation_data);
+        }
+
+      // write into dst vector
+      for (unsigned int v=0; v<n_chunks; ++v)
+        {
+          const unsigned int shift = compute_shift_within_children<dim>
+                                     (parent_child_connect[from_level-1][cell+v].second,
+                                      degree+1-element_is_continuous, degree);
+          AssertIndexRange(parent_child_connect[from_level-1][cell+v].first*
+                           n_child_cell_dofs+n_child_cell_dofs-1,
+                           level_dof_indices[from_level-1].size());
+          const unsigned int *indices = &level_dof_indices[from_level-1][parent_child_connect[from_level-1][cell+v].first*n_child_cell_dofs+shift];
+          for (unsigned int c=0, m=0; c<n_components; ++c)
+            {
+              // apply Dirichlet boundary conditions on parent cell
+              for (std::vector<unsigned short>::const_iterator i=dirichlet_indices[from_level-1][cell+v].begin(); i!=dirichlet_indices[from_level-1][cell+v].end(); ++i)
+                evaluation_data[2*n_child_cell_dofs+(*i)][v] = 0.;
+
+              for (unsigned int k=0; k<(dim>2 ? (degree+1) : 1); ++k)
+                for (unsigned int j=0; j<(dim>1 ? (degree+1) : 1); ++j)
+                  for (unsigned int i=0; i<(degree+1); ++i, ++m)
+                    dst.local_element(indices[c*n_scalar_cell_dofs +
+                                              k*n_child_dofs_1d*n_child_dofs_1d+
+                                              j*n_child_dofs_1d+i])
+                    += evaluation_data[2*n_child_cell_dofs+m][v];
+            }
+        }
+    }
+}
+
+
+
+template <int dim, typename Number>
+std::size_t
+MGTransferMatrixFree<dim,Number>::memory_consumption() const
+{
+  std::size_t memory = MGLevelGlobalTransfer<parallel::distributed::Vector<Number> >::memory_consumption();
+  memory += MemoryConsumption::memory_consumption(level_dof_indices);
+  memory += MemoryConsumption::memory_consumption(parent_child_connect);
+  memory += MemoryConsumption::memory_consumption(n_owned_level_cells);
+  memory += shape_info.memory_consumption();
+  memory += MemoryConsumption::memory_consumption(evaluation_data);
+  memory += MemoryConsumption::memory_consumption(weights_on_refined);
+  memory += MemoryConsumption::memory_consumption(dirichlet_indices);
+  return memory;
+}
+
+
+// explicit instantiation
+#include "mg_transfer_matrix_free.inst"
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -340,7 +340,10 @@ void MGTransferMatrixFree<dim,Number>::build
           bool cell_is_remote = !consider_cell;
           for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
             if (cell->child(c)->level_subdomain_id()==tria.locally_owned_subdomain())
-              consider_cell = true;
+              {
+                consider_cell = true;
+                break;
+              }
 
           if (!consider_cell)
             continue;

--- a/source/multigrid/mg_transfer_matrix_free.inst.in
+++ b/source/multigrid/mg_transfer_matrix_free.inst.in
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2014 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
+  {
+    template class MGTransferMatrixFree< deal_II_dimension, S1 >;
+  }

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -338,8 +338,8 @@ void do_test (const DoFHandler<dim>  &dof)
   typedef LaplaceOperator<dim,fe_degree,n_q_points_1d,number> LevelMatrixType;
 
   MGLevelObject<LevelMatrixType> mg_matrices;
-  mg_matrices.resize(0, dof.get_triangulation().n_levels()-1);
-  for (unsigned int level = 0; level<dof.get_triangulation().n_levels(); ++level)
+  mg_matrices.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
     {
       mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
     }
@@ -355,8 +355,8 @@ void do_test (const DoFHandler<dim>  &dof)
   mg_smoother;
 
   MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
-  smoother_data.resize(0, dof.get_triangulation().n_levels()-1);
-  for (unsigned int level = 0; level<dof.get_triangulation().n_levels(); ++level)
+  smoother_data.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
     {
       smoother_data[level].smoothing_range = 15.;
       smoother_data[level].degree = 5;

--- a/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
@@ -1,0 +1,580 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014-2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// same test as parallel_multigrid_adaptive but using but using adaptive
+// meshes with hanging nodes (doing local smoothing)
+
+#include "../tests.h"
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/multigrid/multigrid.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/mg_coarse.h>
+#include <deal.II/multigrid/mg_smoother.h>
+#include <deal.II/multigrid/mg_matrix.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/fe_evaluation.h>
+
+std::ofstream logfile("output");
+
+
+template <int dim, int fe_degree, int n_q_points_1d = fe_degree+1, typename number=double>
+class LaplaceOperator : public Subscriptor
+{
+public:
+  typedef number value_type;
+
+  LaplaceOperator() {};
+
+
+  void initialize (const Mapping<dim> &mapping,
+                   const DoFHandler<dim> &dof_handler,
+                   const MGConstrainedDoFs &mg_constrained_dofs,
+                   const typename FunctionMap<dim>::type &dirichlet_boundary,
+                   const unsigned int level = numbers::invalid_unsigned_int)
+  {
+    const QGauss<1> quad (n_q_points_1d);
+    typename MatrixFree<dim,number>::AdditionalData addit_data;
+    addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
+    addit_data.tasks_block_size = 3;
+    addit_data.level_mg_handler = level;
+    addit_data.mpi_communicator = MPI_COMM_WORLD;
+    ConstraintMatrix constraints;
+    if (level == numbers::invalid_unsigned_int)
+      {
+        IndexSet relevant_dofs;
+        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        constraints.reinit(relevant_dofs);
+        DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+        VectorTools::interpolate_boundary_values(dof_handler, dirichlet_boundary,
+                                                 constraints);
+      }
+    else
+      {
+        IndexSet relevant_dofs;
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level,
+                                                      relevant_dofs);
+        constraints.reinit(relevant_dofs);
+        constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
+
+        std::vector<types::global_dof_index> interface_indices;
+        mg_constrained_dofs.get_refinement_edge_indices(level).fill_index_vector(interface_indices);
+        edge_constrained_indices.clear();
+        edge_constrained_indices.reserve(interface_indices.size());
+        edge_constrained_values.resize(interface_indices.size());
+        const IndexSet &locally_owned = dof_handler.locally_owned_mg_dofs(level);
+        for (unsigned int i=0; i<interface_indices.size(); ++i)
+          if (locally_owned.is_element(interface_indices[i]))
+            edge_constrained_indices.push_back(locally_owned.index_within_set(interface_indices[i]));
+        have_interface_matrices = Utilities::MPI::max((unsigned int)edge_constrained_indices.size(), MPI_COMM_WORLD) > 0;
+      }
+    constraints.close();
+
+    data.reinit (mapping, dof_handler, constraints, quad, addit_data);
+
+    if (level != numbers::invalid_unsigned_int)
+      compute_inverse_diagonal();
+  }
+
+  void vmult(parallel::distributed::Vector<number> &dst,
+             const parallel::distributed::Vector<number> &src) const
+  {
+    dst = 0;
+    vmult_add(dst, src);
+  }
+
+  void Tvmult(parallel::distributed::Vector<number> &dst,
+              const parallel::distributed::Vector<number> &src) const
+  {
+    dst = 0;
+    vmult_add(dst, src);
+  }
+
+  void Tvmult_add(parallel::distributed::Vector<number> &dst,
+                  const parallel::distributed::Vector<number> &src) const
+  {
+    vmult_add(dst, src);
+  }
+
+  void vmult_add(parallel::distributed::Vector<number> &dst,
+                 const parallel::distributed::Vector<number> &src) const
+  {
+    Assert(src.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+    Assert(dst.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+
+    // set zero Dirichlet values on the input vector (and remember the src and
+    // dst values because we need to reset them at the end)
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        edge_constrained_values[i] =
+          std::pair<number,number>(src.local_element(edge_constrained_indices[i]),
+                                   dst.local_element(edge_constrained_indices[i]));
+        const_cast<parallel::distributed::Vector<number>&>(src).local_element(edge_constrained_indices[i]) = 0.;
+      }
+
+    data.cell_loop (&LaplaceOperator::local_apply,
+                    this, dst, src);
+
+    const std::vector<unsigned int> &
+    constrained_dofs = data.get_constrained_dofs();
+    for (unsigned int i=0; i<constrained_dofs.size(); ++i)
+      dst.local_element(constrained_dofs[i]) += src.local_element(constrained_dofs[i]);
+
+    // reset edge constrained values, multiply by unit matrix and add into
+    // destination
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        const_cast<parallel::distributed::Vector<number>&>(src).local_element(edge_constrained_indices[i]) = edge_constrained_values[i].first;
+        dst.local_element(edge_constrained_indices[i]) = edge_constrained_values[i].second + edge_constrained_values[i].first;
+      }
+  }
+
+  void vmult_interface_down(parallel::distributed::Vector<number> &dst,
+                            const parallel::distributed::Vector<number> &src) const
+  {
+    Assert(src.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+    Assert(dst.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+
+    dst = 0;
+
+    if (!have_interface_matrices)
+      return;
+
+    // set zero Dirichlet values on the input vector (and remember the src and
+    // dst values because we need to reset them at the end)
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        const double src_val = src.local_element(edge_constrained_indices[i]);
+        const_cast<parallel::distributed::Vector<number>&>(src).local_element(edge_constrained_indices[i]) = 0.;
+        edge_constrained_values[i] = std::pair<number,number>(src_val,
+                                                              dst.local_element(edge_constrained_indices[i]));
+      }
+
+    data.cell_loop (&LaplaceOperator::local_apply,
+                    this, dst, src);
+
+    unsigned int c=0;
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        for ( ; c<edge_constrained_indices[i]; ++c)
+          dst.local_element(c) = 0.;
+        ++c;
+
+        // reset the src values
+        const_cast<parallel::distributed::Vector<number>&>(src).local_element(edge_constrained_indices[i]) = edge_constrained_values[i].first;
+      }
+    for ( ; c<dst.local_size(); ++c)
+      dst.local_element(c) = 0.;
+  }
+
+  void vmult_interface_up(parallel::distributed::Vector<number> &dst,
+                          const parallel::distributed::Vector<number> &src) const
+  {
+    Assert(src.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+    Assert(dst.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner), ExcInternalError());
+
+    dst = 0;
+
+    if (!have_interface_matrices)
+      return;
+
+    parallel::distributed::Vector<number> src_cpy (src);
+    unsigned int c=0;
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        for ( ; c<edge_constrained_indices[i]; ++c)
+          src_cpy.local_element(c) = 0.;
+        ++c;
+      }
+    for ( ; c<src_cpy.local_size(); ++c)
+      src_cpy.local_element(c) = 0.;
+
+    data.cell_loop (&LaplaceOperator::local_apply,
+                    this, dst, src_cpy);
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        dst.local_element(edge_constrained_indices[i]) = 0.;
+      }
+  }
+
+  types::global_dof_index m() const
+  {
+    return data.get_vector_partitioner()->size();
+  }
+
+  types::global_dof_index n() const
+  {
+    return data.get_vector_partitioner()->size();
+  }
+
+  number el (const unsigned int row,  const unsigned int col) const
+  {
+    AssertThrow(false, ExcMessage("Matrix-free does not allow for entry access"));
+    return number();
+  }
+
+  void
+  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  {
+    if (!vector.partitioners_are_compatible(*data.get_dof_info(0).vector_partitioner))
+      data.initialize_dof_vector(vector);
+    Assert(vector.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner),
+           ExcInternalError());
+  }
+
+  const parallel::distributed::Vector<number> &
+  get_matrix_diagonal_inverse() const
+  {
+    Assert(inverse_diagonal_entries.size() > 0, ExcNotInitialized());
+    return inverse_diagonal_entries;
+  }
+
+
+private:
+  void
+  local_apply (const MatrixFree<dim,number>                &data,
+               parallel::distributed::Vector<number>       &dst,
+               const parallel::distributed::Vector<number> &src,
+               const std::pair<unsigned int,unsigned int>  &cell_range) const
+  {
+    FEEvaluation<dim,fe_degree,n_q_points_1d,1,number> phi (data);
+
+    for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
+      {
+        phi.reinit (cell);
+        phi.read_dof_values(src);
+        phi.evaluate (false,true,false);
+        for (unsigned int q=0; q<phi.n_q_points; ++q)
+          phi.submit_gradient (phi.get_gradient(q), q);
+        phi.integrate (false,true);
+        phi.distribute_local_to_global (dst);
+      }
+  }
+
+  void
+  compute_inverse_diagonal ()
+  {
+    data.initialize_dof_vector(inverse_diagonal_entries);
+    unsigned int dummy;
+    data.cell_loop (&LaplaceOperator::local_diagonal_cell,
+                    this, inverse_diagonal_entries, dummy);
+
+    const std::vector<unsigned int> &
+    constrained_dofs = data.get_constrained_dofs();
+    for (unsigned int i=0; i<constrained_dofs.size(); ++i)
+      inverse_diagonal_entries.local_element(constrained_dofs[i]) = 1.;
+    for (unsigned int i=0; i<edge_constrained_indices.size(); ++i)
+      {
+        inverse_diagonal_entries.local_element(edge_constrained_indices[i]) = 1.;
+      }
+
+
+    for (unsigned int i=0; i<inverse_diagonal_entries.local_size(); ++i)
+      if (std::abs(inverse_diagonal_entries.local_element(i)) > 1e-10)
+        inverse_diagonal_entries.local_element(i) = 1./inverse_diagonal_entries.local_element(i);
+      else
+        inverse_diagonal_entries.local_element(i) = 1.;
+  }
+
+  void
+  local_diagonal_cell (const MatrixFree<dim,number>                &data,
+                       parallel::distributed::Vector<number>       &dst,
+                       const unsigned int &,
+                       const std::pair<unsigned int,unsigned int>  &cell_range) const
+  {
+    FEEvaluation<dim,fe_degree,n_q_points_1d,1,number> phi (data);
+
+    for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
+      {
+        phi.reinit (cell);
+
+        VectorizedArray<number> local_diagonal_vector[phi.tensor_dofs_per_cell];
+        for (unsigned int i=0; i<phi.dofs_per_cell; ++i)
+          {
+            for (unsigned int j=0; j<phi.dofs_per_cell; ++j)
+              phi.begin_dof_values()[j] = VectorizedArray<number>();
+            phi.begin_dof_values()[i] = 1.;
+            phi.evaluate (false,true,false);
+            for (unsigned int q=0; q<phi.n_q_points; ++q)
+              phi.submit_gradient (phi.get_gradient(q), q);
+            phi.integrate (false,true);
+            local_diagonal_vector[i] = phi.begin_dof_values()[i];
+          }
+        for (unsigned int i=0; i<phi.tensor_dofs_per_cell; ++i)
+          phi.begin_dof_values()[i] = local_diagonal_vector[i];
+        phi.distribute_local_to_global (dst);
+      }
+  }
+
+  MatrixFree<dim,number> data;
+  parallel::distributed::Vector<number> inverse_diagonal_entries;
+  std::vector<unsigned int> edge_constrained_indices;
+  mutable std::vector<std::pair<number,number> > edge_constrained_values;
+  bool have_interface_matrices;
+};
+
+
+
+template <typename LAPLACEOPERATOR>
+class MGInterfaceMatrix : public Subscriptor
+{
+public:
+  void initialize (const LAPLACEOPERATOR &laplace)
+  {
+    this->laplace = &laplace;
+  }
+
+  void vmult (parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> &dst,
+              const parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> &src) const
+  {
+    laplace->vmult_interface_down(dst, src);
+  }
+
+  void Tvmult (parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> &dst,
+               const parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> &src) const
+  {
+    laplace->vmult_interface_up(dst, src);
+  }
+
+private:
+  SmartPointer<const LAPLACEOPERATOR> laplace;
+};
+
+
+
+template <int dim, typename LAPLACEOPERATOR>
+class MGTransferMF : public MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>
+{
+public:
+  MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace,
+               const MGConstrainedDoFs &mg_constrained_dofs)
+    :
+    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>(mg_constrained_dofs),
+    laplace_operator (laplace)
+  {
+  }
+
+  /**
+   * Overload copy_to_mg from MGTransferPrebuilt to get the vectors compatible
+   * with MatrixFree and bypass the crude vector initialization in
+   * MGTransferPrebuilt
+   */
+  template <class InVector, int spacedim>
+  void
+  copy_to_mg (const DoFHandler<dim,spacedim> &mg_dof_handler,
+              MGLevelObject<parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> > &dst,
+              const InVector &src) const
+  {
+    for (unsigned int level=dst.min_level();
+         level<=dst.max_level(); ++level)
+      laplace_operator[level].initialize_dof_vector(dst[level]);
+    MGLevelGlobalTransfer<parallel::distributed::Vector<typename LAPLACEOPERATOR::value_type> >::
+    copy_to_mg(mg_dof_handler, dst, src);
+  }
+
+private:
+  const MGLevelObject<LAPLACEOPERATOR> &laplace_operator;
+};
+
+
+
+template<typename MatrixType, typename Number>
+class MGCoarseIterative : public MGCoarseGridBase<parallel::distributed::Vector<Number> >
+{
+public:
+  MGCoarseIterative() {}
+
+  void initialize(const MatrixType &matrix)
+  {
+    coarse_matrix = &matrix;
+  }
+
+  virtual void operator() (const unsigned int   level,
+                           parallel::distributed::Vector<Number> &dst,
+                           const parallel::distributed::Vector<Number> &src) const
+  {
+    ReductionControl solver_control (1e4, 1e-50, 1e-10);
+    SolverCG<parallel::distributed::Vector<Number> > solver_coarse (solver_control);
+    solver_coarse.solve (*coarse_matrix, dst, src, PreconditionIdentity());
+  }
+
+  const MatrixType *coarse_matrix;
+};
+
+
+
+
+template <int dim, int fe_degree, int n_q_points_1d, typename number>
+void do_test (const DoFHandler<dim>  &dof)
+{
+  deallog << "Testing " << dof.get_fe().get_name();
+  deallog << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
+
+  ConstraintMatrix hanging_node_constraints;
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  hanging_node_constraints.reinit(locally_relevant_dofs);
+  DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
+  hanging_node_constraints.close();
+
+  MGConstrainedDoFs mg_constrained_dofs;
+  ZeroFunction<dim> zero_function;
+  typename FunctionMap<dim>::type dirichlet_boundary;
+  dirichlet_boundary[0] = &zero_function;
+  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+
+  MappingQ<dim> mapping(fe_degree+1);
+  LaplaceOperator<dim,fe_degree,n_q_points_1d,double> fine_matrix;
+  fine_matrix.initialize(mapping, dof, mg_constrained_dofs, dirichlet_boundary,
+                         numbers::invalid_unsigned_int);
+
+  parallel::distributed::Vector<double> in, sol;
+  fine_matrix.initialize_dof_vector(in);
+  fine_matrix.initialize_dof_vector(sol);
+
+  // set constant rhs vector
+  for (unsigned int i=0; i<in.local_size(); ++i)
+    if (!hanging_node_constraints.is_constrained(in.get_partitioner()->local_to_global(i)))
+      in.local_element(i) = 1.;
+
+  // set up multigrid in analogy to step-37
+  typedef LaplaceOperator<dim,fe_degree,n_q_points_1d,number> LevelMatrixType;
+
+  MGLevelObject<LevelMatrixType> mg_matrices;
+  mg_matrices.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
+    {
+      mg_matrices[level].initialize(mapping, dof, mg_constrained_dofs,
+                                    dirichlet_boundary, level);
+    }
+  MGLevelObject<MGInterfaceMatrix<LevelMatrixType> > mg_interface_matrices;
+  mg_interface_matrices.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level=0; level<dof.get_triangulation().n_global_levels(); ++level)
+    mg_interface_matrices[level].initialize(mg_matrices[level]);
+
+  MGTransferMF<dim,LevelMatrixType> mg_transfer(mg_matrices,
+                                                mg_constrained_dofs);
+  mg_transfer.build(dof);
+
+  MGCoarseIterative<LevelMatrixType,number> mg_coarse;
+  mg_coarse.initialize(mg_matrices[0]);
+
+  typedef PreconditionChebyshev<LevelMatrixType,parallel::distributed::Vector<number> > SMOOTHER;
+  MGSmootherPrecondition<LevelMatrixType, SMOOTHER, parallel::distributed::Vector<number> >
+  mg_smoother;
+
+  MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
+  smoother_data.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
+    {
+      smoother_data[level].smoothing_range = 15.;
+      smoother_data[level].degree = 5;
+      smoother_data[level].eig_cg_n_iterations = 15;
+      smoother_data[level].matrix_diagonal_inverse =
+        mg_matrices[level].get_matrix_diagonal_inverse();
+    }
+
+  // temporarily disable deallog for the setup of the preconditioner that
+  // involves a CG solver for eigenvalue estimation
+  deallog.depth_file(0);
+  mg_smoother.initialize(mg_matrices, smoother_data);
+
+  mg::Matrix<parallel::distributed::Vector<number> >
+  mg_matrix(mg_matrices);
+  mg::Matrix<parallel::distributed::Vector<number> >
+  mg_interface(mg_interface_matrices);
+
+  Multigrid<parallel::distributed::Vector<number> > mg(dof,
+                                                       mg_matrix,
+                                                       mg_coarse,
+                                                       mg_transfer,
+                                                       mg_smoother,
+                                                       mg_smoother);
+  mg.set_edge_matrices(mg_interface, mg_interface);
+  PreconditionMG<dim, parallel::distributed::Vector<number>,
+                 MGTransferMF<dim,LevelMatrixType> >
+                 preconditioner(dof, mg, mg_transfer);
+
+  {
+    // avoid output from inner (coarse-level) solver
+    deallog.depth_file(2);
+    ReductionControl control(30, 1e-20, 1e-7);
+    SolverCG<parallel::distributed::Vector<double> > solver(control);
+    solver.solve(fine_matrix, sol, in, preconditioner);
+  }
+}
+
+
+
+template <int dim, int fe_degree, typename Number>
+void test ()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                                 dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(8-2*dim);
+  const unsigned int n_runs = fe_degree == 1 ? 6-dim : 5-dim;
+  for (unsigned int i=0; i<n_runs; ++i)
+    {
+      for (typename Triangulation<dim>::active_cell_iterator cell=tria.begin_active();
+           cell != tria.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            (cell->center().norm() < 0.5 && (cell->level() < 5 ||
+                                             cell->center().norm() > 0.45)
+             ||
+             (dim == 2 && cell->center().norm() > 1.2)))
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+      FE_Q<dim> fe (fe_degree);
+      DoFHandler<dim> dof (tria);
+      dof.distribute_dofs(fe);
+      dof.distribute_mg_dofs(fe);
+
+      do_test<dim, fe_degree, fe_degree+1, Number> (dof);
+    }
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+
+  mpi_initlog();
+  deallog.threshold_double(1e-9);
+
+  test<2,1,double>();
+  test<2,3,float>();
+  test<3,1,double>();
+  test<3,2,float>();
+}

--- a/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014-2015 by the deal.II authors
+// Copyright (C) 2014-2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -12,7 +12,6 @@
 // the top level of the deal.II distribution.
 //
 // ---------------------------------------------------------------------
-
 
 
 // same test as parallel_multigrid_adaptive but using but using adaptive
@@ -43,8 +42,6 @@
 
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
-
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, int n_q_points_1d = fe_degree+1, typename number=double>

--- a/tests/matrix_free/parallel_multigrid_adaptive_mf.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_mf.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -1,0 +1,49 @@
+
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 507
+DEAL:cg::Starting value 21.9317
+DEAL:cg::Convergence step 5 value 7.81205e-07
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 881
+DEAL:cg::Starting value 27.7669
+DEAL:cg::Convergence step 6 value 9.24482e-07
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 2147
+DEAL:cg::Starting value 43.2551
+DEAL:cg::Convergence step 6 value 1.14520e-06
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 6517
+DEAL:cg::Starting value 76.9220
+DEAL:cg::Convergence step 6 value 1.55925e-06
+DEAL::Testing FE_Q<2>(3)
+DEAL::Number of degrees of freedom: 4259
+DEAL:cg::Starting value 64.2573
+DEAL:cg::Convergence step 5 value 1.14788e-06
+DEAL::Testing FE_Q<2>(3)
+DEAL::Number of degrees of freedom: 7457
+DEAL:cg::Starting value 83.1084
+DEAL:cg::Convergence step 5 value 6.03076e-06
+DEAL::Testing FE_Q<2>(3)
+DEAL::Number of degrees of freedom: 18535
+DEAL:cg::Starting value 130.977
+DEAL:cg::Convergence step 5 value 4.58984e-06
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 186
+DEAL:cg::Starting value 12.3693
+DEAL:cg::Convergence step 3 value 8.40297e-08
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 648
+DEAL:cg::Starting value 21.1424
+DEAL:cg::Convergence step 7 value 4.98971e-07
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 2930
+DEAL:cg::Starting value 47.1699
+DEAL:cg::Convergence step 7 value 1.64836e-06
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 1106
+DEAL:cg::Starting value 30.8707
+DEAL:cg::Convergence step 5 value 5.33421e-08
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 4268
+DEAL:cg::Starting value 57.4891
+DEAL:cg::Convergence step 8 value 7.61055e-07

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -1,0 +1,433 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014-2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// same test as parallel_multigrid but using matrix-free transfer operations
+// (and including single-precision multigrid preconditioning)
+
+#include "../tests.h"
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/multigrid/multigrid.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+#include <deal.II/multigrid/mg_tools.h>
+#include <deal.II/multigrid/mg_coarse.h>
+#include <deal.II/multigrid/mg_smoother.h>
+#include <deal.II/multigrid/mg_matrix.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/fe_evaluation.h>
+
+std::ofstream logfile("output");
+
+
+template <int dim, int fe_degree, int n_q_points_1d = fe_degree+1, typename number=double>
+class LaplaceOperator : public Subscriptor
+{
+public:
+  typedef number value_type;
+
+  LaplaceOperator() {};
+
+  void initialize (const Mapping<dim> &mapping,
+                   const DoFHandler<dim> &dof_handler,
+                   const std::set<types::boundary_id> &dirichlet_boundaries,
+                   const unsigned int level = numbers::invalid_unsigned_int)
+  {
+    const QGauss<1> quad (n_q_points_1d);
+    typename MatrixFree<dim,number>::AdditionalData addit_data;
+    addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
+    addit_data.level_mg_handler = level;
+    addit_data.mpi_communicator = MPI_COMM_WORLD;
+
+    // extract the constraints due to Dirichlet boundary conditions
+    ConstraintMatrix constraints;
+    ZeroFunction<dim> zero;
+    typename FunctionMap<dim>::type functions;
+    for (std::set<types::boundary_id>::const_iterator it=dirichlet_boundaries.begin();
+         it != dirichlet_boundaries.end(); ++it)
+      functions[*it] = &zero;
+    if (level == numbers::invalid_unsigned_int)
+      VectorTools::interpolate_boundary_values(dof_handler, functions, constraints);
+    else
+      {
+        std::vector<types::global_dof_index> local_dofs;
+        typename DoFHandler<dim>::cell_iterator
+        cell = dof_handler.begin(level),
+        endc = dof_handler.end(level);
+        for (; cell!=endc; ++cell)
+          {
+            if (dof_handler.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
+                && cell->level_subdomain_id()==numbers::artificial_subdomain_id)
+              continue;
+            const FiniteElement<dim> &fe = cell->get_fe();
+            local_dofs.resize(fe.dofs_per_face);
+
+            for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
+                 ++face_no)
+              if (cell->at_boundary(face_no) == true)
+                {
+                  const typename DoFHandler<dim>::face_iterator
+                  face = cell->face(face_no);
+                  const types::boundary_id bi = face->boundary_id();
+                  if (functions.find(bi) != functions.end())
+                    {
+                      face->get_mg_dof_indices(level, local_dofs);
+                      for (unsigned int i=0; i<fe.dofs_per_face; ++i)
+                        constraints.add_line(local_dofs[i]);
+                    }
+                }
+          }
+      }
+    constraints.close();
+
+    data.reinit (mapping, dof_handler, constraints, quad, addit_data);
+
+    compute_inverse_diagonal();
+  }
+
+  void vmult(parallel::distributed::Vector<number> &dst,
+             const parallel::distributed::Vector<number> &src) const
+  {
+    dst = 0;
+    vmult_add(dst, src);
+  }
+
+  void Tvmult(parallel::distributed::Vector<number> &dst,
+              const parallel::distributed::Vector<number> &src) const
+  {
+    dst = 0;
+    vmult_add(dst, src);
+  }
+
+  void Tvmult_add(parallel::distributed::Vector<number> &dst,
+                  const parallel::distributed::Vector<number> &src) const
+  {
+    vmult_add(dst, src);
+  }
+
+  void vmult_add(parallel::distributed::Vector<number> &dst,
+                 const parallel::distributed::Vector<number> &src) const
+  {
+    data.cell_loop (&LaplaceOperator::local_apply,
+                    this, dst, src);
+
+    const std::vector<unsigned int> &
+    constrained_dofs = data.get_constrained_dofs();
+    for (unsigned int i=0; i<constrained_dofs.size(); ++i)
+      dst.local_element(constrained_dofs[i]) += src.local_element(constrained_dofs[i]);
+  }
+
+  types::global_dof_index m() const
+  {
+    return data.get_vector_partitioner()->size();
+  }
+
+  types::global_dof_index n() const
+  {
+    return data.get_vector_partitioner()->size();
+  }
+
+  number el (const unsigned int row,  const unsigned int col) const
+  {
+    AssertThrow(false, ExcMessage("Matrix-free does not allow for entry access"));
+    return number();
+  }
+
+  void
+  initialize_dof_vector(parallel::distributed::Vector<number> &vector) const
+  {
+    if (!vector.partitioners_are_compatible(*data.get_dof_info(0).vector_partitioner))
+      data.initialize_dof_vector(vector);
+    Assert(vector.partitioners_are_globally_compatible(*data.get_dof_info(0).vector_partitioner),
+           ExcInternalError());
+  }
+
+  const parallel::distributed::Vector<number> &
+  get_matrix_diagonal_inverse() const
+  {
+    Assert(inverse_diagonal_entries.size() > 0, ExcNotInitialized());
+    return inverse_diagonal_entries;
+  }
+
+
+private:
+  void
+  local_apply (const MatrixFree<dim,number>                &data,
+               parallel::distributed::Vector<number>       &dst,
+               const parallel::distributed::Vector<number> &src,
+               const std::pair<unsigned int,unsigned int>  &cell_range) const
+  {
+    FEEvaluation<dim,fe_degree,n_q_points_1d,1,number> phi (data);
+
+    for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
+      {
+        phi.reinit (cell);
+        phi.read_dof_values(src);
+        phi.evaluate (false,true,false);
+        for (unsigned int q=0; q<phi.n_q_points; ++q)
+          phi.submit_gradient (phi.get_gradient(q), q);
+        phi.integrate (false,true);
+        phi.distribute_local_to_global (dst);
+      }
+  }
+
+  void
+  compute_inverse_diagonal ()
+  {
+    data.initialize_dof_vector(inverse_diagonal_entries);
+    unsigned int dummy;
+    data.cell_loop (&LaplaceOperator::local_diagonal_cell,
+                    this, inverse_diagonal_entries, dummy);
+
+    for (unsigned int i=0; i<inverse_diagonal_entries.local_size(); ++i)
+      if (std::abs(inverse_diagonal_entries.local_element(i)) > 1e-10)
+        inverse_diagonal_entries.local_element(i) = 1./inverse_diagonal_entries.local_element(i);
+      else
+        inverse_diagonal_entries.local_element(i) = 1.;
+  }
+
+  void
+  local_diagonal_cell (const MatrixFree<dim,number>                &data,
+                       parallel::distributed::Vector<number>       &dst,
+                       const unsigned int &,
+                       const std::pair<unsigned int,unsigned int>  &cell_range) const
+  {
+    FEEvaluation<dim,fe_degree,n_q_points_1d,1,number> phi (data);
+
+    for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
+      {
+        phi.reinit (cell);
+
+        VectorizedArray<number> local_diagonal_vector[phi.tensor_dofs_per_cell];
+        for (unsigned int i=0; i<phi.dofs_per_cell; ++i)
+          {
+            for (unsigned int j=0; j<phi.dofs_per_cell; ++j)
+              phi.begin_dof_values()[j] = VectorizedArray<number>();
+            phi.begin_dof_values()[i] = 1.;
+            phi.evaluate (false,true,false);
+            for (unsigned int q=0; q<phi.n_q_points; ++q)
+              phi.submit_gradient (phi.get_gradient(q), q);
+            phi.integrate (false,true);
+            local_diagonal_vector[i] = phi.begin_dof_values()[i];
+          }
+        for (unsigned int i=0; i<phi.tensor_dofs_per_cell; ++i)
+          phi.begin_dof_values()[i] = local_diagonal_vector[i];
+        phi.distribute_local_to_global (dst);
+      }
+  }
+
+  MatrixFree<dim,number> data;
+  parallel::distributed::Vector<number> inverse_diagonal_entries;
+};
+
+
+
+template <int dim, typename MatrixType>
+class MGTransferPrebuiltMF : public MGTransferMatrixFree<dim, typename MatrixType::value_type>
+{
+public:
+  MGTransferPrebuiltMF(const MGLevelObject<MatrixType> &laplace,
+                       const MGConstrainedDoFs &mg_constrained_dofs)
+    :
+    MGTransferMatrixFree<dim, typename MatrixType::value_type>(mg_constrained_dofs),
+    laplace_operator (laplace)
+  {};
+
+  /**
+   * Overload copy_to_mg from MGTransferPrebuilt to get the vectors compatible
+   * with MatrixFree and bypass the crude initialization in MGTransferPrebuilt
+   */
+  template <class InVector, int spacedim>
+  void
+  copy_to_mg (const DoFHandler<dim,spacedim> &mg_dof,
+              MGLevelObject<parallel::distributed::Vector<typename MatrixType::value_type> > &dst,
+              const InVector &src) const
+  {
+    for (unsigned int level=dst.min_level();
+         level<=dst.max_level(); ++level)
+      laplace_operator[level].initialize_dof_vector(dst[level]);
+    MGLevelGlobalTransfer<parallel::distributed::Vector<typename MatrixType::value_type> >::copy_to_mg(mg_dof, dst, src);
+  }
+
+private:
+  const MGLevelObject<MatrixType> &laplace_operator;
+};
+
+
+
+template<typename MatrixType, typename Number>
+class MGCoarseIterative : public MGCoarseGridBase<parallel::distributed::Vector<Number> >
+{
+public:
+  MGCoarseIterative() {}
+
+  void initialize(const MatrixType &matrix)
+  {
+    coarse_matrix = &matrix;
+  }
+
+  virtual void operator() (const unsigned int   level,
+                           parallel::distributed::Vector<Number> &dst,
+                           const parallel::distributed::Vector<Number> &src) const
+  {
+    ReductionControl solver_control (1e4, 1e-50, 1e-10);
+    SolverCG<parallel::distributed::Vector<Number> > solver_coarse (solver_control);
+    solver_coarse.solve (*coarse_matrix, dst, src, PreconditionIdentity());
+  }
+
+  const MatrixType *coarse_matrix;
+};
+
+
+
+
+template <int dim, int fe_degree, int n_q_points_1d, typename number>
+void do_test (const DoFHandler<dim>  &dof)
+{
+  deallog << "Testing " << dof.get_fe().get_name();
+  deallog << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
+
+  MappingQ<dim> mapping(fe_degree+1);
+  LaplaceOperator<dim,fe_degree,n_q_points_1d,double> fine_matrix;
+  std::set<types::boundary_id> dirichlet_boundaries;
+  dirichlet_boundaries.insert(0);
+  fine_matrix.initialize(mapping, dof, dirichlet_boundaries);
+
+  parallel::distributed::Vector<double> in, sol;
+  fine_matrix.initialize_dof_vector(in);
+  fine_matrix.initialize_dof_vector(sol);
+
+  // set constant rhs vector
+  in = 1.;
+
+  // set up multigrid in analogy to step-37
+  typedef LaplaceOperator<dim,fe_degree,n_q_points_1d,number> LevelMatrixType;
+
+  MGLevelObject<LevelMatrixType> mg_matrices;
+  mg_matrices.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
+    {
+      mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
+    }
+
+  MGConstrainedDoFs mg_constrained_dofs;
+  ZeroFunction<dim> zero_function;
+  typename FunctionMap<dim>::type dirichlet_boundary;
+  dirichlet_boundary[0] = &zero_function;
+  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+
+  MGTransferPrebuiltMF<dim,LevelMatrixType> mg_transfer(mg_matrices, mg_constrained_dofs);
+  mg_transfer.build(dof);
+
+  MGCoarseIterative<LevelMatrixType,number> mg_coarse;
+  mg_coarse.initialize(mg_matrices[0]);
+
+  typedef PreconditionChebyshev<LevelMatrixType,parallel::distributed::Vector<number> > SMOOTHER;
+  MGSmootherPrecondition<LevelMatrixType, SMOOTHER, parallel::distributed::Vector<number> >
+  mg_smoother;
+
+  MGLevelObject<typename SMOOTHER::AdditionalData> smoother_data;
+  smoother_data.resize(0, dof.get_triangulation().n_global_levels()-1);
+  for (unsigned int level = 0; level<dof.get_triangulation().n_global_levels(); ++level)
+    {
+      smoother_data[level].smoothing_range = 15.;
+      smoother_data[level].degree = 5;
+      smoother_data[level].eig_cg_n_iterations = 15;
+      smoother_data[level].matrix_diagonal_inverse =
+        mg_matrices[level].get_matrix_diagonal_inverse();
+    }
+
+  // temporarily disable deallog for the setup of the preconditioner that
+  // involves a CG solver for eigenvalue estimation
+  deallog.depth_file(0);
+  mg_smoother.initialize(mg_matrices, smoother_data);
+
+  mg::Matrix<parallel::distributed::Vector<number> >
+  mg_matrix(mg_matrices);
+
+  Multigrid<parallel::distributed::Vector<number> > mg(dof,
+                                                       mg_matrix,
+                                                       mg_coarse,
+                                                       mg_transfer,
+                                                       mg_smoother,
+                                                       mg_smoother);
+  PreconditionMG<dim, parallel::distributed::Vector<number>,
+                 MGTransferPrebuiltMF<dim,LevelMatrixType> >
+                 preconditioner(dof, mg, mg_transfer);
+
+  {
+    // avoid output from inner (coarse-level) solver
+    deallog.depth_file(2);
+    ReductionControl control(30, 1e-20, 1e-7);
+    SolverCG<parallel::distributed::Vector<double> > solver(control);
+    solver.solve(fine_matrix, sol, in, preconditioner);
+  }
+}
+
+
+
+template <int dim, int fe_degree, typename number>
+void test ()
+{
+  for (unsigned int i=5; i<8; ++i)
+    {
+      parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                                     dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::hyper_cube (tria);
+      tria.refine_global(i-dim);
+
+      FE_Q<dim> fe (fe_degree);
+      DoFHandler<dim> dof (tria);
+      dof.distribute_dofs(fe);
+      dof.distribute_mg_dofs(fe);
+
+      do_test<dim, fe_degree, fe_degree+1, number> (dof);
+    }
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+
+  mpi_initlog();
+  deallog.threshold_double(1e-9);
+
+  {
+    test<2,1,double>();
+    test<2,2,float>();
+
+    test<3,1,double>();
+    test<3,2,float>();
+
+  }
+}

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014-2015 by the deal.II authors
+// Copyright (C) 2014-2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -12,7 +12,6 @@
 // the top level of the deal.II distribution.
 //
 // ---------------------------------------------------------------------
-
 
 
 // same test as parallel_multigrid but using matrix-free transfer operations
@@ -43,8 +42,6 @@
 
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
-
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, int n_q_points_1d = fe_degree+1, typename number=double>

--- a/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -1,0 +1,49 @@
+
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 81
+DEAL:cg::Starting value 9.00000
+DEAL:cg::Convergence step 3 value 3.51892e-08
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 289
+DEAL:cg::Starting value 17.0000
+DEAL:cg::Convergence step 3 value 3.00255e-08
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 1089
+DEAL:cg::Starting value 33.0000
+DEAL:cg::Convergence step 3 value 1.23434e-06
+DEAL::Testing FE_Q<2>(2)
+DEAL::Number of degrees of freedom: 289
+DEAL:cg::Starting value 17.0000
+DEAL:cg::Convergence step 3 value 2.83605e-07
+DEAL::Testing FE_Q<2>(2)
+DEAL::Number of degrees of freedom: 1089
+DEAL:cg::Starting value 33.0000
+DEAL:cg::Convergence step 3 value 7.10474e-07
+DEAL::Testing FE_Q<2>(2)
+DEAL::Number of degrees of freedom: 4225
+DEAL:cg::Starting value 65.0000
+DEAL:cg::Convergence step 3 value 1.70919e-06
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 125
+DEAL:cg::Starting value 11.1803
+DEAL:cg::Convergence step 3 value 0
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 729
+DEAL:cg::Starting value 27.0000
+DEAL:cg::Convergence step 3 value 1.30226e-07
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 4913
+DEAL:cg::Starting value 70.0928
+DEAL:cg::Convergence step 3 value 1.26015e-07
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 729
+DEAL:cg::Starting value 27.0000
+DEAL:cg::Convergence step 3 value 2.86664e-08
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 4913
+DEAL:cg::Starting value 70.0928
+DEAL:cg::Convergence step 3 value 1.13132e-06
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 35937
+DEAL:cg::Starting value 189.571
+DEAL:cg::Convergence step 3 value 5.57593e-06

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -87,7 +87,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -105,7 +105,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -128,7 +128,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with uniform meshes for FE_Q
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_Q<dim> fe(QGaussLobatto<1>(fe_degree+1));
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 2, 3, 4, 5, 6, 8};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 3-dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      ConstraintMatrix hanging_node_constraints;
+      MGConstrainedDoFs mg_constrained_dofs;
+      ZeroFunction<dim> zero_function;
+      typename FunctionMap<dim>::type dirichlet_boundary;
+      dirichlet_boundary[0] = &zero_function;
+      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> >
+      transfer_ref(hanging_node_constraints, mg_constrained_dofs);
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/multigrid/transfer_matrix_free_01.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -37,7 +37,7 @@ void check(const unsigned int fe_degree)
   deallog << "FE: " << fe.get_name() << std::endl;
 
   // run a few different sizes...
-  unsigned int sizes [] = {1, 2, 3, 4};
+  unsigned int sizes [] = {1, 2, 3};
   for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
     {
       unsigned int n_refinements = 0;
@@ -48,7 +48,7 @@ void check(const unsigned int fe_degree)
             n_refinements += 1;
             n_subdiv /= 2;
           }
-      n_refinements += 6-2*dim;
+      n_refinements += 3-dim;
       if (fe_degree < 3)
         n_refinements += 1;
 
@@ -154,7 +154,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -113,7 +113,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -131,7 +131,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -1,0 +1,166 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with adaptive meshes for FE_Q
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_Q<dim> fe(QGaussLobatto<1>(fe_degree+1));
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 2, 3, 4};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 6-2*dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() < 0.5)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.3 && cell->center().norm() < 0.4)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.33 && cell->center().norm() < 0.37)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      ConstraintMatrix hanging_node_constraints;
+      IndexSet relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(mgdof, relevant_dofs);
+      hanging_node_constraints.reinit(relevant_dofs);
+      DoFTools::make_hanging_node_constraints(mgdof, hanging_node_constraints);
+      hanging_node_constraints.close();
+
+      MGConstrainedDoFs mg_constrained_dofs;
+      ZeroFunction<dim> zero_function;
+      typename FunctionMap<dim>::type dirichlet_boundary;
+      dirichlet_boundary[0] = &zero_function;
+      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> >
+      transfer_ref(hanging_node_constraints, mg_constrained_dofs);
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,95 +1,5 @@
 
 DEAL::FE: FE_Q<2>(1)
-DEAL::no. cells: 250
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 868
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
-DEAL::
-DEAL::FE: FE_Q<2>(QGaussLobatto(4))
 DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -144,14 +54,27 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 34
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -162,10 +85,20 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 141
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
 DEAL::
 DEAL::FE: FE_Q<3>(1)
 DEAL::no. cells: 15
@@ -207,26 +140,6 @@ DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
 DEAL::FE: FE_Q<3>(QGaussLobatto(4))
 DEAL::no. cells: 1
 DEAL::
@@ -249,7 +162,8 @@ DEAL::Diff restrict add l2: 0
 DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::
-DEAL::no. cells: 694
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
@@ -266,7 +180,6 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::FE: FE_Q<2>(2)
 DEAL::no. cells: 250
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -287,14 +200,12 @@ DEAL::Diff restrict add l5: 0
 DEAL::Diff restrict     l6: 0
 DEAL::Diff restrict add l6: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::no. cells: 510
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -305,56 +216,6 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
 DEAL::
 DEAL::FE: FE_Q<3>(2)
 DEAL::no. cells: 15
@@ -395,24 +256,4 @@ DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
-DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
 DEAL::

--- a/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,418 @@
+
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,95 +1,5 @@
 
 DEAL::FE: FE_Q<2>(1)
-DEAL::no. cells: 250
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 868
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
-DEAL::
-DEAL::FE: FE_Q<2>(QGaussLobatto(4))
 DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -144,14 +54,27 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 34
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -162,10 +85,20 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 141
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
 DEAL::
 DEAL::FE: FE_Q<3>(1)
 DEAL::no. cells: 15
@@ -207,26 +140,6 @@ DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
 DEAL::FE: FE_Q<3>(QGaussLobatto(4))
 DEAL::no. cells: 1
 DEAL::
@@ -249,7 +162,8 @@ DEAL::Diff restrict add l2: 0
 DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::
-DEAL::no. cells: 694
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
@@ -266,7 +180,6 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::FE: FE_Q<2>(2)
 DEAL::no. cells: 250
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -287,14 +200,12 @@ DEAL::Diff restrict add l5: 0
 DEAL::Diff restrict     l6: 0
 DEAL::Diff restrict add l6: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::no. cells: 510
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -305,56 +216,6 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
 DEAL::
 DEAL::FE: FE_Q<3>(2)
 DEAL::no. cells: 15
@@ -395,24 +256,4 @@ DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
-DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
 DEAL::

--- a/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_02.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,0 +1,418 @@
+
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -90,7 +90,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -108,7 +108,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -131,7 +131,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with adaptive meshes for FE_Q (similar to
+// transfer_matrix_free_02 but on a different mesh refining into a corner)
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_Q<dim> fe(QGaussLobatto<1>(fe_degree+1));
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  parallel::distributed::Triangulation<dim>
+  tr(MPI_COMM_WORLD,
+     Triangulation<dim>::limit_level_difference_at_vertices,
+     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::subdivided_hyper_cube (tr, 3);
+  for (unsigned int cycle=0; cycle<(dim == 2 ? 10 : 7); ++cycle)
+    {
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->vertex(0).norm() < 1e-10)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << " on "
+              << tr.n_global_levels() << " levels" << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      ConstraintMatrix hanging_node_constraints;
+      IndexSet relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(mgdof, relevant_dofs);
+      hanging_node_constraints.reinit(relevant_dofs);
+      DoFTools::make_hanging_node_constraints(mgdof, hanging_node_constraints);
+      hanging_node_constraints.close();
+
+      MGConstrainedDoFs mg_constrained_dofs;
+      ZeroFunction<dim> zero_function;
+      typename FunctionMap<dim>::type dirichlet_boundary;
+      dirichlet_boundary[0] = &zero_function;
+      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> >
+      transfer_ref(hanging_node_constraints, mg_constrained_dofs);
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_03.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_03.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,4 +1,4 @@
-JobId mklap4 Mon Jan 11 11:42:13 2016
+
 DEAL::FE: FE_Q<2>(1)
 DEAL::no. cells: 12 on 2 levels
 DEAL::Diff prolongate   l1: 0

--- a/tests/multigrid/transfer_matrix_free_03.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_03.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,0 +1,856 @@
+JobId mklap4 Mon Jan 11 11:42:13 2016
+DEAL::FE: FE_Q<2>(1)
+DEAL::no. cells: 12 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 15 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 18 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 21 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 24 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 27 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 30 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 33 on 9 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::no. cells: 36 on 10 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::
+DEAL::no. cells: 39 on 11 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff prolongate   l10: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::Diff restrict     l10: 0
+DEAL::Diff restrict add l10: 0
+DEAL::
+DEAL::FE: FE_Q<2>(QGaussLobatto(4))
+DEAL::no. cells: 12 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 15 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 18 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 21 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 24 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 27 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 30 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 33 on 9 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::no. cells: 36 on 10 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::
+DEAL::no. cells: 39 on 11 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff prolongate   l10: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::Diff restrict     l10: 0
+DEAL::Diff restrict add l10: 0
+DEAL::
+DEAL::FE: FE_Q<3>(1)
+DEAL::no. cells: 34 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 41 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 48 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 55 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 62 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 69 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 76 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_Q<3>(QGaussLobatto(4))
+DEAL::no. cells: 34 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 41 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 48 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 55 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 62 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 69 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 76 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_Q<2>(2)
+DEAL::no. cells: 12 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 15 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 18 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 21 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 24 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 27 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 30 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 33 on 9 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::no. cells: 36 on 10 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::
+DEAL::no. cells: 39 on 11 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff prolongate   l9: 0
+DEAL::Diff prolongate   l10: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::Diff restrict     l9: 0
+DEAL::Diff restrict add l9: 0
+DEAL::Diff restrict     l10: 0
+DEAL::Diff restrict add l10: 0
+DEAL::
+DEAL::FE: FE_Q<3>(2)
+DEAL::no. cells: 34 on 2 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 41 on 3 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 48 on 4 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 55 on 5 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 62 on 6 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 69 on 7 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 76 on 8 levels
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -121,7 +121,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -80,7 +80,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -98,7 +98,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with uniform meshes for FE_DGQ (except for the different
+// element and no constraints the same test as transfer_matrix_free_01)
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_DGQArbitraryNodes<dim> fe(QGaussLobatto<1>(fe_degree+1));
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 2, 3, 4, 5, 6, 8};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 3-dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> > transfer_ref;
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer;
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_DGQ<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_DGQ<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -1,0 +1,364 @@
+
+DEAL::FE: FE_DGQ<2>(1)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 4
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 36
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 100
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(1)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 27
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 125
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 16
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 144
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 256
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 400
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 576
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1024
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(2)
+DEAL::no. cells: 8
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 64
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 216
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 512
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 1000
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::
+DEAL::no. cells: 1728
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 4096
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with adaptive meshes for FE_DGQ (except for the different
+// element and no constraints the same test as transfer_matrix_free_01)
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_DGQArbitraryNodes<dim> fe(QGaussLobatto<1>(fe_degree+1));
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 2, 3, 4};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 6-2*dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() < 0.5)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.3 && cell->center().norm() < 0.4)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.33 && cell->center().norm() < 0.37)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> > transfer_ref;
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer;
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -37,7 +37,7 @@ void check(const unsigned int fe_degree)
   deallog << "FE: " << fe.get_name() << std::endl;
 
   // run a few different sizes...
-  unsigned int sizes [] = {1, 2, 3, 4};
+  unsigned int sizes [] = {1, 2, 3};
   for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
     {
       unsigned int n_refinements = 0;
@@ -48,7 +48,7 @@ void check(const unsigned int fe_degree)
             n_refinements += 1;
             n_subdiv /= 2;
           }
-      n_refinements += 6-2*dim;
+      n_refinements += 3-dim;
       if (fe_degree < 3)
         n_refinements += 1;
 
@@ -140,7 +140,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -99,7 +99,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -117,7 +117,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,95 +1,5 @@
 
 DEAL::FE: FE_DGQ<2>(1)
-DEAL::no. cells: 250
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 868
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
-DEAL::
-DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
 DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -144,14 +54,27 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 34
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -162,10 +85,20 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 141
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
 DEAL::
 DEAL::FE: FE_DGQ<3>(1)
 DEAL::no. cells: 15
@@ -207,26 +140,6 @@ DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
 DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
 DEAL::no. cells: 1
 DEAL::
@@ -249,7 +162,8 @@ DEAL::Diff restrict add l2: 0
 DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::
-DEAL::no. cells: 694
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
@@ -266,7 +180,6 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::FE: FE_DGQ<2>(2)
 DEAL::no. cells: 250
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -287,14 +200,12 @@ DEAL::Diff restrict add l5: 0
 DEAL::Diff restrict     l6: 0
 DEAL::Diff restrict add l6: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::no. cells: 510
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -305,56 +216,6 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
 DEAL::
 DEAL::FE: FE_DGQ<3>(2)
 DEAL::no. cells: 15
@@ -395,24 +256,4 @@ DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
-DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
 DEAL::

--- a/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,418 @@
+
+DEAL::FE: FE_DGQ<2>(1)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(1)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(2)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,95 +1,5 @@
 
 DEAL::FE: FE_DGQ<2>(1)
-DEAL::no. cells: 250
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 868
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
-DEAL::
-DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
 DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -144,14 +54,27 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 34
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -162,10 +85,20 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 141
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
 DEAL::
 DEAL::FE: FE_DGQ<3>(1)
 DEAL::no. cells: 15
@@ -207,26 +140,6 @@ DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
 DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
 DEAL::no. cells: 1
 DEAL::
@@ -249,7 +162,8 @@ DEAL::Diff restrict add l2: 0
 DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::
-DEAL::no. cells: 694
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 88
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
@@ -266,7 +180,6 @@ DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
 DEAL::
-DEAL::FE: FE_DGQ<2>(2)
 DEAL::no. cells: 250
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
@@ -287,14 +200,12 @@ DEAL::Diff restrict add l5: 0
 DEAL::Diff restrict     l6: 0
 DEAL::Diff restrict add l6: 0
 DEAL::
-DEAL::no. cells: 868
+DEAL::no. cells: 510
 DEAL::Diff prolongate   l1: 0
 DEAL::Diff prolongate   l2: 0
 DEAL::Diff prolongate   l3: 0
 DEAL::Diff prolongate   l4: 0
 DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
 DEAL::Diff restrict     l1: 0
 DEAL::Diff restrict add l1: 0
 DEAL::Diff restrict     l2: 0
@@ -305,56 +216,6 @@ DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
 DEAL::Diff restrict     l5: 0
 DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::
-DEAL::no. cells: 1887
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::
-DEAL::no. cells: 3388
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff prolongate   l7: 0
-DEAL::Diff prolongate   l8: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
-DEAL::Diff restrict     l7: 0
-DEAL::Diff restrict add l7: 0
-DEAL::Diff restrict     l8: 0
-DEAL::Diff restrict add l8: 0
 DEAL::
 DEAL::FE: FE_DGQ<3>(2)
 DEAL::no. cells: 15
@@ -395,24 +256,4 @@ DEAL::Diff restrict     l3: 0
 DEAL::Diff restrict add l3: 0
 DEAL::Diff restrict     l4: 0
 DEAL::Diff restrict add l4: 0
-DEAL::
-DEAL::no. cells: 3599
-DEAL::Diff prolongate   l1: 0
-DEAL::Diff prolongate   l2: 0
-DEAL::Diff prolongate   l3: 0
-DEAL::Diff prolongate   l4: 0
-DEAL::Diff prolongate   l5: 0
-DEAL::Diff prolongate   l6: 0
-DEAL::Diff restrict     l1: 0
-DEAL::Diff restrict add l1: 0
-DEAL::Diff restrict     l2: 0
-DEAL::Diff restrict add l2: 0
-DEAL::Diff restrict     l3: 0
-DEAL::Diff restrict add l3: 0
-DEAL::Diff restrict     l4: 0
-DEAL::Diff restrict add l4: 0
-DEAL::Diff restrict     l5: 0
-DEAL::Diff restrict add l5: 0
-DEAL::Diff restrict     l6: 0
-DEAL::Diff restrict add l6: 0
 DEAL::

--- a/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_05.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,0 +1,418 @@
+
+DEAL::FE: FE_DGQ<2>(1)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<2>(QGaussLobatto(4))
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(1)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FE_DGQArbitraryNodes<3>(QGaussLobatto(4))
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQ<2>(2)
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 868
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 3388
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff prolongate   l7: 0
+DEAL::Diff prolongate   l8: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::Diff restrict     l7: 0
+DEAL::Diff restrict add l7: 0
+DEAL::Diff restrict     l8: 0
+DEAL::Diff restrict add l8: 0
+DEAL::
+DEAL::FE: FE_DGQ<3>(2)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 3599
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -115,7 +115,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.prolongate(level, v2, v1);
           transfer_ref.prolongate(level, v3, v1_cpy);
@@ -133,7 +133,7 @@ void check(const unsigned int fe_degree)
           v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
           for (unsigned int i=0; i<v1.local_size(); ++i)
-            v1.local_element(i) = (double)rand()/RAND_MAX;
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
           v1_cpy = v1;
           transfer.restrict_and_add(level, v2, v1);
           transfer_ref.restrict_and_add(level, v3, v1_cpy);

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with adaptive meshes for FESystem(FE_Q,2). Same as
+// transfer_matrix_free_02 but using two components (and fewer meshes).
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FESystem<dim> fe (FE_Q<dim>(QGaussLobatto<1>(fe_degree+1)), 2);
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 3};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 6-2*dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() < 0.5)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.3 && cell->center().norm() < 0.4)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.33 && cell->center().norm() < 0.37)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      ConstraintMatrix hanging_node_constraints;
+      IndexSet relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(mgdof, relevant_dofs);
+      hanging_node_constraints.reinit(relevant_dofs);
+      DoFTools::make_hanging_node_constraints(mgdof, hanging_node_constraints);
+      hanging_node_constraints.close();
+
+      MGConstrainedDoFs mg_constrained_dofs;
+      ZeroFunction<dim> zero_function;
+      typename FunctionMap<dim>::type dirichlet_boundary;
+      dirichlet_boundary[0] = &zero_function;
+      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+
+      // build reference
+      MGTransferPrebuilt<parallel::distributed::Vector<double> >
+      transfer_ref(hanging_node_constraints, mg_constrained_dofs);
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          parallel::distributed::Vector<Number> v1, v2;
+          parallel::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -156,7 +156,8 @@ void check(const unsigned int fe_degree)
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2,double>(1);

--- a/tests/multigrid/transfer_matrix_free_06.with_mpi=true.with_p4est=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_06.with_mpi=true.with_p4est=true.mpirun=5.output
@@ -1,0 +1,178 @@
+
+DEAL::FE: FESystem<2>[FE_Q<2>(1)^2]
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FESystem<2>[FE_Q<2>(QGaussLobatto(4))^2]
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(1)^2]
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(QGaussLobatto(4))^2]
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FESystem<2>[FE_Q<2>(2)^2]
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 1887
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::FE: FESystem<3>[FE_Q<3>(2)^2]
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::


### PR DESCRIPTION
This patch implements matrix-free level transfer operators for geometric multigrid. The implementation in the new class `MGTransferMatrixFree` supports the vector type `parallel::distributed::Vector<Number>`. Combined with matrix-free smoothers (such as `tests/matrix_free/parallel_multigrid`), this considerably improves performance of geometric multigrid as compared to `MGTransferPrebuilt`, in particular for polynomial degrees larger than 2. For Q3 elements in 3D, the solver is about twice as fast (based on doubles) or three times as fast (when using single precision for the MG preconditioner).

Here is some data on 32 procs on Q2 in 3D (relative iterative tolerance 1e-12, 5 iterations, Chebyshev smoother of degree 4):
```
level  cells     dofs    Sol time
    4     4096     35937   0.0067
    5    32768    274625   0.0178
    6   262144   2146689   0.1023
    7  2097152  16974593   0.9047
    5  4096000  33076161   1.7681
    6  7077888  57066625   3.0245
    5 11239424  90518849   4.7244
    8 16777216 135005697   7.0059
```

This was the old data with matrix-based transfer and where I had to copy some data between double and float rather than doing everything in the v-cycle in float as enabled by this PR (otherwise the same problem):
```
level  cells     dofs    Sol time
    4     4096     35937   0.0077
    5    32768    274625   0.0240
    6   262144   2146689   0.1692
    7  2097152  16974593   1.4932
    5  4096000  33076161   2.9941
    6  7077888  57066625   5.0973
    5 11239424  90518849   8.0122
    8 16777216 135005697  12.7230
```

An second positive aspect is that the maximum memory (whole-program VmRSS) per proc at 32 procs with 135m DoFs (or 4m DoFs per core), was 2.9G on the matrix-based algorithm, whereas I measured 1.3G for the fully matrix-free algorithm. For Q3 in 3D, I can compute five times as large problems with the same memory. (Of course, if you have a global matrix for the problem, you will hardly notice this difference because the matrix takes so much more memory.)

This patch is tested on various processor counts and for various problems (I will continue to evaluate it during the next days). I think this is ready for inclusion in the 8.4 release since it merely adds functionality and does not interfere with anything else. But if anyone sees reasons not to include it in 8.4, I'm open to discuss.

There is one issue that I observed when working on this case: There is a bug in the new test `multigrid/tranfer_matrix_free_03.mpirun=5` (this the mesh configuration reported in #2051) and it currently runs into a timeout. But I hope that I or @tjhei will be able to fix that issue.