### PR TITLE
remove PetscScalar() from PArpack test which does not use PETSc

### DIFF
--- a/tests/arpack/step-36_parpack_trilinos.cc
+++ b/tests/arpack/step-36_parpack_trilinos.cc
@@ -249,7 +249,7 @@ void test ()
     std::vector<std::complex<double> > lambda(eigenfunctions.size());
 
     for (unsigned int i=0; i < eigenvalues.size(); i++)
-      eigenfunctions[i] = PetscScalar();
+      eigenfunctions[i] = 0.;
 
     SolverControl solver_control     (dof_handler.n_dofs(), 1e-9,/*log_history*/false,/*log_results*/false);
     SolverControl solver_control_lin (dof_handler.n_dofs(), 1e-10,/*log_history*/false,/*log_results*/false);


### PR DESCRIPTION
subj.

should fix [this test error](http://cdash.kyomu.43-1.org/testDetails.php?test=265111&build=106).