### PR TITLE
Add alternate output files.

### DIFF
--- a/tests/slepc/solve_01.output.2
+++ b/tests/slepc/solve_01.output.2
@@ -1,0 +1,30 @@
+
+DEAL::Size 46 Unknowns 2025
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers17SolverKrylovSchurE
+DEAL::Convergence step 23 value 0
+DEAL::Solver stopped after 23 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers13SolverArnoldiE
+DEAL::Convergence step 74 value 0
+DEAL::Solver stopped after 74 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers13SolverLanczosE
+DEAL::Convergence step 77 value 0
+DEAL::Solver stopped after 77 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers25SolverGeneralizedDavidsonE
+DEAL::Solver stopped after 277 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers20SolverJacobiDavidsonE
+DEAL::Solver stopped after 43 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers25SolverGeneralizedDavidsonE
+DEAL::Solver stopped after 583 iterations
+DEAL::Eigenvalues: 29.73524, 29.67536, 29.58873, 29.46785
+DEAL::

--- a/tests/slepc/solve_04.output.2
+++ b/tests/slepc/solve_04.output.2
@@ -1,0 +1,33 @@
+
+DEAL::Size 31 Unknowns 30
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers17SolverKrylovSchurE
+DEAL::Convergence step 5 value 0
+DEAL::Solver stopped after 5 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers13SolverArnoldiE
+DEAL::Convergence step 22 value 0
+DEAL::Solver stopped after 22 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers13SolverLanczosE
+DEAL::Convergence step 23 value 0
+DEAL::Solver stopped after 23 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers25SolverGeneralizedDavidsonE
+DEAL::Convergence step 120 value 0
+DEAL::Solver stopped after 120 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers20SolverJacobiDavidsonE
+DEAL::Convergence step 435 value 0
+DEAL::Solver stopped after 435 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::
+DEAL::Solver type: N6dealii13SLEPcWrappers25SolverGeneralizedDavidsonE
+DEAL::Convergence step 145 value 0
+DEAL::Solver stopped after 145 iterations
+DEAL::Eigenvalues: 3.98974, 3.95906, 3.90828, 3.83792
+DEAL::


### PR DESCRIPTION
This allows the 'tester' machine to successfully pass these two tests.