### PR TITLE
hp::FECollection new constructors added

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -68,6 +68,50 @@ namespace hp
     explicit FECollection (const FiniteElement<dim,spacedim> &fe);
 
     /**
+     * Constructor. This constructor creates a FECollection from two
+     * finite elements.
+     */
+    FECollection (const FiniteElement<dim,spacedim> &fe1,
+                  const FiniteElement<dim,spacedim> &fe2);
+
+    /**
+     * Constructor. This constructor creates a FECollection from three
+     * finite elements.
+     */
+    FECollection (const FiniteElement<dim,spacedim> &fe1,
+                  const FiniteElement<dim,spacedim> &fe2,
+                  const FiniteElement<dim,spacedim> &fe3);
+
+    /**
+     * Constructor. This constructor creates a FECollection from four
+     * finite elements.
+     */
+    FECollection (const FiniteElement<dim,spacedim> &fe1,
+                  const FiniteElement<dim,spacedim> &fe2,
+                  const FiniteElement<dim,spacedim> &fe3,
+                  const FiniteElement<dim,spacedim> &fe4);
+
+    /**
+     * Constructor. This constructor creates a FECollection from five
+     * finite elements.
+     */
+    FECollection (const FiniteElement<dim,spacedim> &fe1,
+                  const FiniteElement<dim,spacedim> &fe2,
+                  const FiniteElement<dim,spacedim> &fe3,
+                  const FiniteElement<dim,spacedim> &fe4,
+                  const FiniteElement<dim,spacedim> &fe5);
+
+    /**
+     * Constructor. Same as above but for any number of elements. Pointers
+     * to the elements are passed in a vector to this constructor.
+     * As above, the finite element objects pointed to by the argument are
+     * not actually used other than to create copies internally. Consequently,
+     * you can delete these pointers immediately again after calling this
+     * constructor.
+     */
+    FECollection (const std::vector<const FiniteElement<dim,spacedim>*> &fes);
+
+    /**
      * Copy constructor.
      */
     FECollection (const FECollection<dim,spacedim> &fe_collection);

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -101,6 +101,71 @@ namespace hp
 
 
   template <int dim, int spacedim>
+  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
+                                            const FiniteElement<dim,spacedim> &fe2)
+  {
+    push_back(fe1);
+    push_back(fe2);
+  }
+
+
+
+  template <int dim, int spacedim>
+  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
+                                            const FiniteElement<dim,spacedim> &fe2,
+                                            const FiniteElement<dim,spacedim> &fe3)
+  {
+    push_back(fe1);
+    push_back(fe2);
+    push_back(fe3);
+  }
+
+
+
+  template <int dim, int spacedim>
+  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
+                                            const FiniteElement<dim,spacedim> &fe2,
+                                            const FiniteElement<dim,spacedim> &fe3,
+                                            const FiniteElement<dim,spacedim> &fe4)
+  {
+    push_back(fe1);
+    push_back(fe2);
+    push_back(fe3);
+    push_back(fe4);
+  }
+
+
+
+  template <int dim, int spacedim>
+  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
+                                            const FiniteElement<dim,spacedim> &fe2,
+                                            const FiniteElement<dim,spacedim> &fe3,
+                                            const FiniteElement<dim,spacedim> &fe4,
+                                            const FiniteElement<dim,spacedim> &fe5)
+  {
+    push_back(fe1);
+    push_back(fe2);
+    push_back(fe3);
+    push_back(fe4);
+    push_back(fe5);
+  }
+
+
+
+  template <int dim, int spacedim>
+  FECollection<dim,spacedim>::
+  FECollection (const std::vector<const FiniteElement<dim,spacedim>*>  &fes)
+  {
+    Assert (fes.size() > 0,
+            ExcMessage ("Need to pass at least one finite element."));
+
+    for (unsigned int i = 0; i < fes.size(); ++i)
+      push_back(*fes[i]);
+  }
+
+
+
+  template <int dim, int spacedim>
   FECollection<dim,spacedim>::
   FECollection (const FECollection<dim,spacedim> &fe_collection)
     :


### PR DESCRIPTION
Addition of constructors which allow the creation of an hp::FECollection from multiple base finite elements.
The new constructors for hp::FECollection could be useful if one needs to fully define the collection within the initialization list of a class. In that case the construction + push_back method can't be used.
The implementation of the constructors follows the style used in FESystem.