### PR TITLE
Do not run into an unused block of code

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -6020,9 +6020,11 @@ namespace internal
                 if (integrate_grad == true)
                   eval.template gradients<0,false,true> (gradients_quad[c][0], temp1);
                 eval.template values<1,false,false>(temp1, temp2);
-                eval.template values<0,false,false> (gradients_quad[c][d1], temp1);
                 if (integrate_grad == true)
-                  eval.template gradients<1,false,true>(temp1, temp2);
+                  {
+                    eval.template values<0,false,false> (gradients_quad[c][d1], temp1);
+                    eval.template gradients<1,false,true>(temp1, temp2);
+                  }
                 eval.template values<2,false,false> (temp2, values_dofs[c]);
               }
             else if (integrate_grad == true)


### PR DESCRIPTION
The code below triggered a floating point exception in debug mode in some cases. The problem was that the `eval.template values<0,false,false>` part of the code should only be evaluated when gradients are requested because the `gradients_quad` field contains uninitialized variables if no gradient was requested. And an uninitialized variable can be `nan` that triggers the FPE. (The FPE only appeared in debug mode because the compiler optimizes away the unused code since `temp1` is not used if `integrate_grad==false`.)