### PR TITLE
Improve line continuations

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -433,7 +433,7 @@ inconvenience this causes.
 
   <li> Improved: Allow continuation lines in ParameterHandler.
   <br>
-  (Alberto Sartori, 2015/09/04)
+  (Alberto Sartori, 2015/09/04, David Wells, 2016/01/18)
   </li>
 
   <li> Cleanup: The interface of Tensor<rank,dim,Number> has been cleaned

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1196,8 +1196,7 @@ namespace Patterns
  *
  *
  *     void LinEq::declare_parameters (ParameterHandler &prm) {
- *                                        // declare parameters for the linear
- *                                        // solver in a subsection
+ *       // declare parameters for the linear solver in a subsection
  *       prm.enter_subsection ("Linear solver");
  *       prm.declare_entry ("Solver",
  *                          "CG",
@@ -1221,7 +1220,7 @@ namespace Patterns
  *
  *
  *     void Problem::declare_parameters (ParameterHandler &prm) {
- *                                        // first some global parameter entries
+ *       // first some global parameter entries
  *       prm.declare_entry ("Output file",
  *                          "out",
  *                          Patterns::Anything(),
@@ -1235,8 +1234,7 @@ namespace Patterns
  *                          "Elasticity",
  *                          Patterns::Anything());
  *
- *                                        // declare parameters for the
- *                                        // first equation
+ *       // declare parameters for the first equation
  *       prm.enter_subsection ("Equation 1");
  *       prm.declare_entry ("Matrix type",
  *                          "Sparse",
@@ -1246,8 +1244,7 @@ namespace Patterns
  *       LinEq::declare_parameters (prm);  // for eq1
  *       prm.leave_subsection ();
  *
- *                                        // declare parameters for the
- *                                        // second equation
+ *       // declare parameters for the second equation
  *       prm.enter_subsection ("Equation 2");
  *       prm.declare_entry ("Matrix type",
  *                          "Sparse",
@@ -1258,24 +1255,22 @@ namespace Patterns
  *
  *
  *     void Problem::get_parameters (ParameterHandler &prm) {
- *                                        // entries of the problem class
+ *       // entries of the problem class
  *       outfile = prm.get ("Output file");
  *
  *       std::string equation1 = prm.get ("Equation 1"),
  *              equation2 = prm.get ("Equation 2");
  *
- *                                        // get parameters for the
- *                                        // first equation
+ *       // get parameters for the first equation
  *       prm.enter_subsection ("Equation 1");
  *       Matrix1 = prm.get ("Matrix type");
- *       eq1.get_parameters (prm);         // for eq1
+ *       eq1.get_parameters (prm); // for eq1
  *       prm.leave_subsection ();
  *
- *                                        // get parameters for the
- *                                        // second equation
+ *       // get parameters for the second equation
  *       prm.enter_subsection ("Equation 2");
  *       Matrix2 = prm.get ("Matrix type");
- *       eq2.get_parameters (prm);         // for eq2
+ *       eq2.get_parameters (prm); // for eq2
  *       prm.leave_subsection ();
  *
  *       std::cout << "  Problem: outfile=" << outfile << std::endl
@@ -1292,21 +1287,20 @@ namespace Patterns
  *
  *       p.declare_parameters (prm);
  *
- *                                        // read input from "prmtest.prm"; giving
- *                                        // argv[1] would also be a good idea
+ *       // read input from "prmtest.prm"; giving argv[1] would also be a
+ *       // good idea
  *       prm.read_input ("prmtest.prm");
  *
- *                                        // print parameters to std::cout as ASCII text
+ *       // print parameters to std::cout as ASCII text
  *       std::cout << std::endl << std::endl;
  *       prm.print_parameters (std::cout, ParameterHandler::Text);
  *
- *                                        // get parameters into the program
+ *       // get parameters into the program
  *       std::cout << std::endl << std::endl
  *                 << "Getting parameters:" << std::endl;
  *       p.get_parameters (prm);
  *
- *                                        // now run the program with these
- *                                        // input parameters
+ *       // now run the program with these input parameters
  *       p.do_something ();
  *     }
  *   @endcode
@@ -1314,13 +1308,13 @@ namespace Patterns
  *
  * This is the input file (named "prmtest.prm"):
  *   @code
- *                                 # first declare the types of equations
+ *     # first declare the types of equations
  *     set Equation 1 = Poisson
  *     set Equation 2 = Navier-Stokes
  *
  *     subsection Equation 1
  *       set Matrix type = Sparse
- *       subsection Linear solver    # parameters for linear solver 1
+ *       subsection Linear solver # parameters for linear solver 1
  *         set Solver                       = Gauss-Seidel
  *         set Maximum number of iterations = 40
  *       end

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1173,29 +1173,32 @@ namespace Patterns
  *
  *     using namespace dealii;
  *
- *     class LinEq {
- *       public:
- *         static void declare_parameters (ParameterHandler &prm);
- *         void get_parameters (ParameterHandler &prm);
- *       private:
- *         std::string Method;
- *         int    MaxIterations;
+ *     class LinEq
+ *     {
+ *     public:
+ *       static void declare_parameters (ParameterHandler &prm);
+ *       void get_parameters (ParameterHandler &prm);
+ *     private:
+ *       std::string Method;
+ *       int    MaxIterations;
  *     };
  *
  *
- *     class Problem {
- *       private:
- *         LinEq eq1, eq2;
- *         std::string Matrix1, Matrix2;
- *         std::string outfile;
- *       public:
- *         static void declare_parameters (ParameterHandler &prm);
- *         void get_parameters (ParameterHandler &prm);
+ *     class Problem
+ *     {
+ *     private:
+ *       LinEq eq1, eq2;
+ *       std::string Matrix1, Matrix2;
+ *       std::string outfile;
+ *     public:
+ *       static void declare_parameters (ParameterHandler &prm);
+ *       void get_parameters (ParameterHandler &prm);
  *     };
  *
  *
  *
- *     void LinEq::declare_parameters (ParameterHandler &prm) {
+ *     void LinEq::declare_parameters (ParameterHandler &prm)
+ *     {
  *       // declare parameters for the linear solver in a subsection
  *       prm.enter_subsection ("Linear solver");
  *       prm.declare_entry ("Solver",
@@ -1209,7 +1212,8 @@ namespace Patterns
  *     }
  *
  *
- *     void LinEq::get_parameters (ParameterHandler &prm) {
+ *     void LinEq::get_parameters (ParameterHandler &prm)
+ *     {
  *       prm.enter_subsection ("Linear solver");
  *       Method        = prm.get ("Solver");
  *       MaxIterations = prm.get_integer ("Maximum number of iterations");
@@ -1219,7 +1223,8 @@ namespace Patterns
  *
  *
  *
- *     void Problem::declare_parameters (ParameterHandler &prm) {
+ *     void Problem::declare_parameters (ParameterHandler &prm)
+ *     {
  *       // first some global parameter entries
  *       prm.declare_entry ("Output file",
  *                          "out",
@@ -1254,7 +1259,8 @@ namespace Patterns
  *     }
  *
  *
- *     void Problem::get_parameters (ParameterHandler &prm) {
+ *     void Problem::get_parameters (ParameterHandler &prm)
+ *     {
  *       // entries of the problem class
  *       outfile = prm.get ("Output file");
  *
@@ -1273,15 +1279,16 @@ namespace Patterns
  *       eq2.get_parameters (prm); // for eq2
  *       prm.leave_subsection ();
  *
- *       std::cout << "  Problem: outfile=" << outfile << std::endl
- *            << "           eq1="     << equation1 << ", eq2=" << equation2 << std::endl
- *            << "           Matrix1=" << Matrix1 << ", Matrix2=" << Matrix2 << std::endl;
+ *       std::cout << "  Problem: outfile=" << outfile << '\n'
+ *                 << "           eq1="     << equation1 << ", eq2=" << equation2 << '\n'
+ *                 << "           Matrix1=" << Matrix1 << ", Matrix2=" << Matrix2 << std::endl;
  *     }
  *
  *
  *
  *
- *     void main () {
+ *     int main ()
+ *     {
  *       ParameterHandler prm;
  *       Problem p;
  *
@@ -2051,41 +2058,45 @@ private:
  * is created which is then called. Taking the classes of the example for the
  * ParameterHandler class, the extended program would look like this:
  *   @code
- *     class HelperClass : public MultipleParameterLoop::UserClass {
- *       public:
- *         HelperClass ();
+ *     class HelperClass : public MultipleParameterLoop::UserClass
+ *     {
+ *     public:
+ *       HelperClass ();
  *
- *         virtual void create_new (const unsigned int run_no);
- *         virtual void run (ParameterHandler &prm);
+ *       virtual void create_new (const unsigned int run_no);
+ *       virtual void run (ParameterHandler &prm);
  *
- *         static void declare_parameters (ParameterHandler &prm);
- *       private:
- *         Problem *p;
+ *       static void declare_parameters (ParameterHandler &prm);
+ *     private:
+ *       std_cxx11::shared_ptr<Problem> p;
  *     };
  *
  *
  *     HelperClass::HelperClass () : p(0) {}
  *
  *
- *     void HelperClass::create_new (const unsigned int run_no) {
- *       if (p) delete p;
- *       p = new Problem;
+ *     void HelperClass::create_new (const unsigned int run_no)
+ *     {
+ *       p.reset(new Problem());
  *     }
  *
  *
- *     void HelperClass::declare_parameters (ParameterHandler &prm) {
+ *     void HelperClass::declare_parameters (ParameterHandler &prm)
+ *     {
  *       Problem::declare_parameters (prm);
  *     }
  *
  *
- *     void HelperClass::run (ParameterHandler &prm) {
+ *     void HelperClass::run (ParameterHandler &prm)
+ *     {
  *       p->get_parameters (prm);
  *       p->do_useful_work ();
  *     }
  *
  *
  *
- *     int main () {
+ *     int main ()
+ *     {
  *       class MultipleParameterLoop prm;
  *       HelperClass h;
  *       HelperClass::declare_parameters (prm);

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -32,18 +32,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-//TODO: Allow long input lines to be broken by appending a backslash character
-
-
-// public classes; to be declared below
-class ParameterHandler;
-class MultipleParameterLoop;
-
-
-
-// forward declaration
+// forward declarations for interfaces and friendship
 class LogStream;
-
+class MultipleParameterLoop;
 
 
 /**

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2264,30 +2264,23 @@ public:
    * from; this is only used when creating output for error messages.
    *
    * Return whether the read was successful.
+   *
+   * @note Of the three <tt>read_input</tt> functions implemented by
+   * ParameterHandler, this is the only one overridden with new behavior by
+   * this class. This is because the other two <tt>read_input</tt> functions
+   * just reformat their inputs and then call this version.
    */
   virtual bool read_input (std::istream &input,
                            const std::string &filename = "input file");
 
   /**
-   * Read input from a file the name of which is given. The PathSearch class
-   * "PARAMETERS" is used to find the file.
-   *
-   * Return whether the read was successful.
-   *
-   * Unless <tt>optional</tt> is <tt>true</tt>, this function will
-   * automatically generate the requested file with default values if the file
-   * did not exist. This file will not contain additional comments if
-   * <tt>write_stripped_file</tt> is <tt>true</tt>.
+   * Overriding virtual functions which are overloaded (like
+   * ParameterHandler::read_input, which has two different sets of input
+   * argument types) causes the non-overridden functions to be hidden. Get
+   * around this by explicitly using both variants of
+   * ParameterHandler::read_input and then overriding the one we care about.
    */
-  virtual bool read_input (const std::string &FileName,
-                           const bool optional = false,
-                           const bool write_stripped_file = false);
-
-  /**
-   * Read input from a string in memory. The lines in memory have to be
-   * separated by <tt>@\n</tt> characters.
-   */
-  virtual bool read_input_from_string (const char *s);
+  using ParameterHandler::read_input;
 
   /**
    * run the central loop.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1982,20 +1982,20 @@ private:
   std::string get_current_full_path (const std::string &name) const;
 
   /**
-   * Scan one line of input. <tt>input_filename</tt> and <tt>lineno</tt> are
-   * the name of the input file and the current number of the line presently
-   * scanned (for the logs if there are messages). Return <tt>false</tt> if
-   * line contained stuff that could not be understood, the uppermost
-   * subsection was to be left by an <tt>END</tt> or <tt>end</tt> statement, a
-   * value for a non-declared entry was given or the entry value did not match
-   * the regular expression. <tt>true</tt> otherwise.
+   * Scan one line of input. <tt>input_filename</tt> and <tt>current_line_n</tt>
+   * are the name of the input file and the current number of the line presently
+   * scanned (for the logs if there are messages). Return <tt>false</tt> if line
+   * contained stuff that could not be understood, the uppermost subsection was
+   * to be left by an <tt>END</tt> or <tt>end</tt> statement, a value for a
+   * non-declared entry was given or the entry value did not match the regular
+   * expression. <tt>true</tt> otherwise.
    *
    * The function modifies its argument, but also takes it by value, so the
    * caller's variable is not changed.
    */
   bool scan_line (std::string         line,
                   const std::string  &input_filename,
-                  const unsigned int  lineno);
+                  const unsigned int  current_line_n);
 
   friend class MultipleParameterLoop;
 };

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2820,28 +2820,6 @@ bool MultipleParameterLoop::read_input (std::istream &input,
 
 
 
-bool MultipleParameterLoop::read_input (const std::string &filename,
-                                        bool optional,
-                                        bool write_compact)
-{
-  return ParameterHandler::read_input (filename, optional, write_compact);
-  // don't call init_branches, since this read_input
-  // function calls
-  // MultipleParameterLoop::read_input(std::istream &, std::ostream &)
-  // which itself calls init_branches.
-}
-
-
-
-bool MultipleParameterLoop::read_input_from_string (const char *s)
-{
-  bool x = ParameterHandler::read_input (s);
-  init_branches ();
-  return x;
-}
-
-
-
 void MultipleParameterLoop::loop (MultipleParameterLoop::UserClass &uc)
 {
   for (unsigned int run_no=0; run_no<n_branches; ++run_no)

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1341,7 +1341,7 @@ bool ParameterHandler::read_input (std::istream &input,
   unsigned int current_line_n = 0;
   bool status = true;
 
-  while (getline (input, line))
+  while (std::getline (input, line))
     {
       ++current_line_n;
       status &= scan_line (line, filename, current_line_n);

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1338,13 +1338,13 @@ bool ParameterHandler::read_input (std::istream &input,
   std::vector<std::string> saved_path = subsection_path;
 
   std::string line;
-  int lineno=0;
+  unsigned int current_line_n = 0;
   bool status = true;
 
   while (getline (input, line))
     {
-      ++lineno;
-      status &= scan_line (line, filename, lineno);
+      ++current_line_n;
+      status &= scan_line (line, filename, current_line_n);
     }
 
   if (status && (saved_path != subsection_path))
@@ -2559,7 +2559,7 @@ ParameterHandler::log_parameters_section (LogStream &out)
 bool
 ParameterHandler::scan_line (std::string         line,
                              const std::string  &input_filename,
-                             const unsigned int  lineno)
+                             const unsigned int  current_line_n)
 {
   // if there is a comment, delete it
   if (line.find('#') != std::string::npos)
@@ -2588,7 +2588,7 @@ ParameterHandler::scan_line (std::string         line,
       // check whether subsection exists
       if (!entries->get_child_optional (get_current_full_path(subsection)))
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << ">: There is no such subsection to be entered: "
                     << demangle(get_current_full_path(subsection)) << std::endl;
@@ -2615,7 +2615,7 @@ ParameterHandler::scan_line (std::string         line,
 
       if (line.size()>0)
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << ">: invalid content after 'end'!" << std::endl;
           return false;
@@ -2623,7 +2623,7 @@ ParameterHandler::scan_line (std::string         line,
 
       if (subsection_path.size() == 0)
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << ">: There is no subsection to leave here!" << std::endl;
           return false;
@@ -2646,7 +2646,7 @@ ParameterHandler::scan_line (std::string         line,
       std::string::size_type pos = line.find("=");
       if (pos == std::string::npos)
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << ">: invalid format of set expression!" << std::endl;
           return false;
@@ -2663,7 +2663,7 @@ ParameterHandler::scan_line (std::string         line,
         {
           if (entries->get<std::string>(path + path_separator + "deprecation_status") == "true")
             {
-              std::cerr << "Warning in line <" << lineno
+              std::cerr << "Warning in line <" << current_line_n
                         << "> of file <" << input_filename
                         << ">: You are using the deprecated spelling <"
                         << entry_name
@@ -2689,7 +2689,7 @@ ParameterHandler::scan_line (std::string         line,
                 = entries->get<unsigned int> (path + path_separator + "pattern");
               if (!patterns[pattern_index]->match(entry_value))
                 {
-                  std::cerr << "Line <" << lineno
+                  std::cerr << "Line <" << current_line_n
                             << "> of file <" << input_filename
                             << ">:" << std::endl
                             << "    The entry value" << std::endl
@@ -2709,7 +2709,7 @@ ParameterHandler::scan_line (std::string         line,
         }
       else
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << ">: No such entry was declared:" << std::endl
                     << "    " << entry_name << std::endl
@@ -2735,7 +2735,7 @@ ParameterHandler::scan_line (std::string         line,
       // the remainder must then be a filename
       if (line.size() == 0)
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << "> is an include statement but does not name a file!"
                     << std::endl;
@@ -2746,7 +2746,7 @@ ParameterHandler::scan_line (std::string         line,
       std::ifstream input (line.c_str());
       if (!input)
         {
-          std::cerr << "Line <" << lineno
+          std::cerr << "Line <" << current_line_n
                     << "> of file <" << input_filename
                     << "> is an include statement but the file <"
                     << line << "> could not be opened!"
@@ -2759,7 +2759,7 @@ ParameterHandler::scan_line (std::string         line,
     }
 
   // this line matched nothing known
-  std::cerr << "Line <" << lineno
+  std::cerr << "Line <" << current_line_n
             << "> of file <" << input_filename
             << ">: This line matched nothing known ('set' or 'subsection' missing!?):" << std::endl
             << "    " << line << std::endl;

--- a/tests/bits/parameter_handler_backslash_01.cc
+++ b/tests/bits/parameter_handler_backslash_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,21 +26,34 @@ int main ()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  ParameterHandler prm;
-  prm.enter_subsection ("Testing");
-  prm.declare_entry ("Function",
-                     "a",
-                     Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
-  prm.leave_subsection ();
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
+      prm.leave_subsection ();
 
-  prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_01.prm");
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_01.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_01.prm");
+          prm.read_input(input_stream);
+        }
 
-  std::string list;
-  prm.enter_subsection ("Testing");
-  list = prm.get ("Function");
-  prm.leave_subsection ();
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("Function");
+      prm.leave_subsection ();
 
-  deallog << list << std::endl;
+      deallog << list << std::endl;
+    }
 
   return 0;
 }

--- a/tests/bits/parameter_handler_backslash_01.output
+++ b/tests/bits/parameter_handler_backslash_01.output
@@ -1,2 +1,3 @@
 
 DEAL::a, b, c
+DEAL::a, b, c

--- a/tests/bits/parameter_handler_backslash_02.cc
+++ b/tests/bits/parameter_handler_backslash_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,21 +26,34 @@ int main ()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  ParameterHandler prm;
-  prm.enter_subsection ("Testing");
-  prm.declare_entry ("Function",
-                     "a",
-                     Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
-  prm.leave_subsection ();
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
+      prm.leave_subsection ();
 
-  prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_02.prm");
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_02.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_02.prm");
+          prm.read_input(input_stream);
+        }
 
-  std::string list;
-  prm.enter_subsection ("Testing");
-  list = prm.get ("Function");
-  prm.leave_subsection ();
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("Function");
+      prm.leave_subsection ();
 
-  deallog << list << std::endl;
+      deallog << list << std::endl;
+    }
 
   return 0;
 }

--- a/tests/bits/parameter_handler_backslash_02.output
+++ b/tests/bits/parameter_handler_backslash_02.output
@@ -1,2 +1,3 @@
 
 DEAL::a,b,c
+DEAL::a,b,c

--- a/tests/bits/parameter_handler_backslash_03.cc
+++ b/tests/bits/parameter_handler_backslash_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,21 +26,35 @@ int main ()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  ParameterHandler prm;
-  prm.enter_subsection ("Testing");
-  prm.declare_entry ("Function",
-                     "a",
-                     Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
-  prm.leave_subsection ();
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
+      prm.leave_subsection ();
 
-  prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_03.prm");
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_03.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_03.prm");
+          prm.read_input(input_stream);
+        }
 
-  std::string list;
-  prm.enter_subsection ("Testing");
-  list = prm.get ("Function");
-  prm.leave_subsection ();
 
-  deallog << list << std::endl;
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("Function");
+      prm.leave_subsection ();
+
+      deallog << list << std::endl;
+    }
 
   return 0;
 }

--- a/tests/bits/parameter_handler_backslash_03.expect=diff.output
+++ b/tests/bits/parameter_handler_backslash_03.expect=diff.output
@@ -1,2 +1,3 @@
 
 DEAL::a, b, c
+DEAL::a, b, c

--- a/tests/bits/parameter_handler_backslash_04.cc
+++ b/tests/bits/parameter_handler_backslash_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,21 +26,35 @@ int main ()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  ParameterHandler prm;
-  prm.enter_subsection ("Testing");
-  prm.declare_entry ("Function",
-                     "a",
-                     Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
-  prm.leave_subsection ();
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
+      prm.leave_subsection ();
 
-  prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_04.prm");
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_04.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_04.prm");
+          prm.read_input(input_stream);
+        }
 
-  std::string list;
-  prm.enter_subsection ("Testing");
-  list = prm.get ("Function");
-  prm.leave_subsection ();
 
-  deallog << list << std::endl;
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("Function");
+      prm.leave_subsection ();
+
+      deallog << list << std::endl;
+    }
 
   return 0;
 }

--- a/tests/bits/parameter_handler_backslash_04.expect=diff.output
+++ b/tests/bits/parameter_handler_backslash_04.expect=diff.output
@@ -1,2 +1,3 @@
 
 DEAL::a, b, c
+DEAL::a, b, c

--- a/tests/bits/parameter_handler_backslash_05.cc
+++ b/tests/bits/parameter_handler_backslash_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2014 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,27 +26,41 @@ int main ()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  ParameterHandler prm;
-  prm.enter_subsection ("Testing");
-  prm.declare_entry ("Function_1",
-                     "a",
-                     Patterns::List(Patterns::Selection("a|b|c")));
-  prm.declare_entry ("Function_2",
-                     "d",
-                     Patterns::List(Patterns::Selection("d|e|f")));
-  prm.leave_subsection ();
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function_1",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c")));
+      prm.declare_entry ("Function_2",
+                         "d",
+                         Patterns::List(Patterns::Selection("d|e|f")));
+      prm.leave_subsection ();
 
-  prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_05.prm");
 
-  std::string list_1;
-  std::string list_2;
-  prm.enter_subsection ("Testing");
-  list_1 = prm.get ("Function_1");
-  list_2 = prm.get ("Function_2");
-  prm.leave_subsection ();
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_05.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_05.prm");
+          prm.read_input(input_stream);
+        }
 
-  deallog << list_1 << std::endl;
-  deallog << list_2 << std::endl;
+      std::string list_1;
+      std::string list_2;
+      prm.enter_subsection ("Testing");
+      list_1 = prm.get ("Function_1");
+      list_2 = prm.get ("Function_2");
+      prm.leave_subsection ();
+
+      deallog << list_1 << std::endl;
+      deallog << list_2 << std::endl;
+    }
 
   return 0;
 }

--- a/tests/bits/parameter_handler_backslash_05.expect=diff.output
+++ b/tests/bits/parameter_handler_backslash_05.expect=diff.output
@@ -1,3 +1,5 @@
 
 DEAL::a, b, c
 DEAL::d, e, f
+DEAL::a, b, c
+DEAL::d, e, f


### PR DESCRIPTION
The implementation in #1520 is correct, but it only handles one of two `read_input` functions. This PR moves all of the continuation line logic (from #1520) into the version of `read_input` that accepts a `std::istream` since the other two input functions ultimately call that one.

The first five commits are cosmetic; the substantial changes are in the last two.

I went ahead and added my name to the changelog entry from last time. @asartori86 is this okay?

Closes #333.