### PR TITLE
Parallel Multigrid deadlock

### DIFF
--- a/tests/multigrid/constrained_dofs_01.mpirun=3.output
+++ b/tests/multigrid/constrained_dofs_01.mpirun=3.output
@@ -26,11 +26,11 @@ DEAL:0::{[0,17], 21}
 DEAL:0::ok ok 
 DEAL:0::Level 3:
 DEAL:0::get_refinement_edge_indices:
-DEAL:0::{}
+DEAL:0::{0, 2, [6,7]}
 DEAL:0::get_boundary_indices:
-DEAL:0::{}
+DEAL:0::{[0,1]}
 DEAL:0::relevant:
-DEAL:0::{}
+DEAL:0::{[0,3], [6,7]}
 DEAL:0::ok ok 
 
 DEAL:1::FE_Q<2>(1)

--- a/tests/multigrid/transfer_04.with_trilinos=true.mpirun=2.output
+++ b/tests/multigrid/transfer_04.with_trilinos=true.mpirun=2.output
@@ -82,7 +82,7 @@ DEAL:1::cell=0_2:31 level_subdomain_id=1
 DEAL:1::cell=0_2:32 level_subdomain_id=1
 DEAL:1::cell=0_2:33 level_subdomain_id=1
 DEAL:1::cell=0_3:010 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:011 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:011 level_subdomain_id=0
 DEAL:1::cell=0_3:012 level_subdomain_id=4294967294
 DEAL:1::cell=0_3:013 level_subdomain_id=0
 DEAL:1::cell=0_3:030 level_subdomain_id=0
@@ -106,8 +106,8 @@ DEAL:1::cell=0_3:211 level_subdomain_id=1
 DEAL:1::cell=0_3:212 level_subdomain_id=1
 DEAL:1::cell=0_3:213 level_subdomain_id=1
 DEAL:1::cell=0_4:0320 level_subdomain_id=4294967294
-DEAL:1::cell=0_4:0321 level_subdomain_id=4294967294
-DEAL:1::cell=0_4:0322 level_subdomain_id=4294967294
-DEAL:1::cell=0_4:0323 level_subdomain_id=4294967294
+DEAL:1::cell=0_4:0321 level_subdomain_id=0
+DEAL:1::cell=0_4:0322 level_subdomain_id=0
+DEAL:1::cell=0_4:0323 level_subdomain_id=0
 DEAL:1::ok
 

--- a/tests/multigrid/transfer_04a.with_trilinos=true.mpirun=2.debug.output
+++ b/tests/multigrid/transfer_04a.with_trilinos=true.mpirun=2.debug.output
@@ -81,13 +81,13 @@ DEAL:1::cell=0_3:001 level_subdomain_id=4294967294
 DEAL:1::cell=0_3:002 level_subdomain_id=4294967294
 DEAL:1::cell=0_3:003 level_subdomain_id=4294967294
 DEAL:1::cell=0_3:010 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:011 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:012 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:013 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:011 level_subdomain_id=0
+DEAL:1::cell=0_3:012 level_subdomain_id=0
+DEAL:1::cell=0_3:013 level_subdomain_id=0
 DEAL:1::cell=0_3:020 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:021 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:022 level_subdomain_id=4294967294
-DEAL:1::cell=0_3:023 level_subdomain_id=4294967294
+DEAL:1::cell=0_3:021 level_subdomain_id=0
+DEAL:1::cell=0_3:022 level_subdomain_id=0
+DEAL:1::cell=0_3:023 level_subdomain_id=0
 copy_indices[1]	22	5
 copy_indices[1]	23	7
 copy_indices[1]	24	8

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2000 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Deadlock reported by Kronbichler (github
+// https://github.com/dealii/dealii/issues/2051) with 3 processes
+// in MgTransferPrebuilt
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/parallel_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/grid/grid_out.h>
+
+
+template <int dim>
+void check()
+{
+  FE_Q<dim> fe(1);
+
+  parallel::distributed::Triangulation<dim>
+  tr(MPI_COMM_WORLD,
+     Triangulation<dim>::limit_level_difference_at_vertices,
+     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::subdivided_hyper_cube (tr, 3);
+  for (unsigned int cycle=0; cycle<(dim == 2 ? 10 : 7); ++cycle)
+    {
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->vertex(0).norm() < 1e-10)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << " on "
+              << tr.n_global_levels() << " levels" << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      ConstraintMatrix hanging_node_constraints;
+      IndexSet relevant_dofs;
+      DoFTools::extract_locally_relevant_dofs(mgdof, relevant_dofs);
+      hanging_node_constraints.reinit(relevant_dofs);
+      DoFTools::make_hanging_node_constraints(mgdof, hanging_node_constraints);
+      hanging_node_constraints.close();
+
+      MGConstrainedDoFs mg_constrained_dofs;
+      ZeroFunction<dim> zero_function;
+      typename FunctionMap<dim>::type dirichlet_boundary;
+      dirichlet_boundary[0] = &zero_function;
+      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+
+      unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+
+      if (0)
+        {
+          std::ofstream grid_output (("out"+Utilities::to_string(myid)+".svg").c_str());
+          GridOut grid_out;
+          GridOutFlags::Svg flags;
+          flags.label_level_subdomain_id = true;
+          flags.coloring = GridOutFlags::Svg::level_subdomain_id;
+          flags.convert_level_number_to_height = true;
+          grid_out.set_flags(flags);
+
+          grid_out.write_svg (tr, grid_output);
+        }
+
+      MGTransferPrebuilt<parallel::distributed::Vector<double> >
+      transfer_ref(hanging_node_constraints, mg_constrained_dofs);
+      transfer_ref.build_matrices(mgdof);
+    }
+}
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+
+  check<2>();
+}

--- a/tests/multigrid/transfer_prebuilt_04.mpirun=2.output
+++ b/tests/multigrid/transfer_prebuilt_04.mpirun=2.output
@@ -1,0 +1,11 @@
+
+DEAL::no. cells: 12 on 2 levels
+DEAL::no. cells: 15 on 3 levels
+DEAL::no. cells: 18 on 4 levels
+DEAL::no. cells: 21 on 5 levels
+DEAL::no. cells: 24 on 6 levels
+DEAL::no. cells: 27 on 7 levels
+DEAL::no. cells: 30 on 8 levels
+DEAL::no. cells: 33 on 9 levels
+DEAL::no. cells: 36 on 10 levels
+DEAL::no. cells: 39 on 11 levels

--- a/tests/multigrid/transfer_prebuilt_04.mpirun=3.output
+++ b/tests/multigrid/transfer_prebuilt_04.mpirun=3.output
@@ -1,0 +1,11 @@
+
+DEAL::no. cells: 12 on 2 levels
+DEAL::no. cells: 15 on 3 levels
+DEAL::no. cells: 18 on 4 levels
+DEAL::no. cells: 21 on 5 levels
+DEAL::no. cells: 24 on 6 levels
+DEAL::no. cells: 27 on 7 levels
+DEAL::no. cells: 30 on 8 levels
+DEAL::no. cells: 33 on 9 levels
+DEAL::no. cells: 36 on 10 levels
+DEAL::no. cells: 39 on 11 levels


### PR DESCRIPTION
Level ghosts were not set up if neighbor is finer and we have no cells on that finest level. This causes a situation where Triangulation::level_ghost_owners is not symmetric causing a deadlock (and maybe also wrong information down the line). This causes a few test output changes.

Addresses #2051.