### PR TITLE
default cell numbers for hyper_shell in 3d

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -548,15 +548,25 @@ namespace GridGenerator
    * both the faces and the edges of these boundaries. If the flag is @p
    * false, both have indicator zero.
    *
+   * Attach a SphericalManifold for correct placement of vertices upon refinement
+   * and higher order mappings. Alternatively, attach a HyperShellBoundary to the
+   * inner and outer boundary.
+   *
    * In 2d, the number <tt>n_cells</tt> of elements for this initial
    * triangulation can be chosen arbitrarily. If the number of initial cells
    * is zero (as is the default), then it is computed adaptively such that the
    * resulting elements have the least aspect ratio.
    *
-   * In 3d, only certain numbers are allowed, 6 for a surface based on a
+   * In 3d, only certain numbers are allowed, 6 (or the default 0) for a surface based on a
    * hexahedron (i.e. 6 panels on the inner sphere extruded in radial
    * direction to form 6 cells), 12 for the rhombic dodecahedron, and 96 (see
-   * below). These give rise to the following meshes upon one refinement:
+   * below).
+   *
+   * While the SphericalManifold, that is demonstrated in the documentation of the
+   * @ref manifold "documentation module on manifolds", creates reasonable meshes
+   * for any number of @p n_cells, the situation is less than ideal when only attaching
+   * a HyperShellBoundary. Then, the 3d meshes give rise to the following meshes
+   * upon one refinement:
    *
    * @image html hypershell3d-6.png
    * @image html hypershell3d-12.png
@@ -579,13 +589,6 @@ namespace GridGenerator
    *
    * @image html hyper_shell_12_cut.png
    * @image html hyper_shell_96_cut.png
-   *
-   * A different way to approach the problem with distorted cells is to attach
-   * appropriate manifold descriptions to the geometry created by this
-   * function. In the current context, this would involve the
-   * SphericalManifold class. An example of how this works and what it leads
-   * to is shown in the documentation of the
-   * @ref manifold "documentation module on manifolds".
    *
    * @note This function is declared to exist for triangulations of all space
    * dimensions, but throws an error if called in 1d.

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3069,11 +3069,13 @@ namespace GridGenerator
                const Point<3> &p,
                const double inner_radius,
                const double outer_radius,
-               const unsigned int n,
+               const unsigned int n_cells,
                const bool colorize)
   {
     Assert ((inner_radius > 0) && (inner_radius < outer_radius),
             ExcInvalidRadii ());
+
+    const unsigned int n = (n_cells==0) ? 6 : n_cells;
 
     const double irad = inner_radius/std::sqrt(3.0);
     const double orad = outer_radius/std::sqrt(3.0);


### PR DESCRIPTION
- a default of n_cells=0 will now choose 6 coarse cells in 3d (instead
of throwing an exception)
- improve documentation