### PR TITLE
Fix some DoFHandlerType documentation.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1933,11 +1933,13 @@ namespace DoFTools
    * DoFTools::get_dofs_on_patch() will then help to make the connection
    * between global degrees of freedom and the local ones.
    *
-   * @tparam Container A type that is either DoFHandler or hp::DoFHandler. In
-   * C++, the compiler can not determine the type of <code>DoFHandlerType</code> from the
-   * function call. You need to specify it as an explicit template argument
-   * following the function name.
+   * @tparam DoFHandlerType A type that is either DoFHandler or
+   * hp::DoFHandler. In C++, the compiler can not determine the type of
+   * <code>DoFHandlerType</code> from the function call. You need to specify it
+   * as an explicit template argument following the function name.
+   *
    * @param patch A collection of cells within an object of type DoFHandlerType
+   *
    * @return The number of degrees of freedom associated with the cells of
    * this patch.
    *
@@ -1985,11 +1987,13 @@ namespace DoFTools
    * one considers the index into this array a local DoF index, then the local
    * system that results retains the block structure of the global system.
    *
-   * @tparam Container A type that is either DoFHandler or hp::DoFHandler. In
-   * C++, the compiler can not determine the type of <code>DoFHandlerType</code> from the
-   * function call. You need to specify it as an explicit template argument
-   * following the function name.
+   * @tparam DoFHandlerType A type that is either DoFHandler or
+   * hp::DoFHandler. In C++, the compiler can not determine the type of
+   * <code>DoFHandlerType</code> from the function call. You need to specify it
+   * as an explicit template argument following the function name.
+   *
    * @param patch A collection of cells within an object of type DoFHandlerType
+   *
    * @return A list of those global degrees of freedom located on the patch,
    * as defined above.
    *

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -558,7 +558,7 @@ namespace VectorTools
                                  VectorType                          &u2)
   {
     Assert(GridTools::have_same_coarse_mesh(dof1, dof2),
-           ExcMessage ("The two containers must represent triangulations that "
+           ExcMessage ("The two DoF handlers must represent triangulations that "
                        "have the same coarse meshes"));
 
     InterGridMap<DoFHandlerType<dim, spacedim> > intergridmap;
@@ -581,7 +581,7 @@ namespace VectorTools
                                  VectorType                          &u2)
   {
     Assert(GridTools::have_same_coarse_mesh(dof1, dof2),
-           ExcMessage ("The two containers must represent triangulations that "
+           ExcMessage ("The two DoF handlers must represent triangulations that "
                        "have the same coarse meshes"));
 
     InterGridMap<DoFHandlerType<dim, spacedim> > intergridmap;


### PR DESCRIPTION
These two functions reference `container` when they really meant to reference `DoFHandlerType` (that is the actual type name given in the template).