### PR TITLE
Mesh concept

### DIFF
--- a/doc/doxygen/headers/concepts.h
+++ b/doc/doxygen/headers/concepts.h
@@ -52,28 +52,6 @@
  *
  * <dl>
  *
- * <dt class="concepts">@anchor ConceptContainerType <b>ContainerType</b></dt>
- *
- * <dd>
-
- * There are several algorithms (e.g.,
- * GridTools::find_active_cell_around_point) in deal.II that can operate on
- * either a Triangulation or a DoFHandler, as both classes may be considered
- * to be collections of cells: see the @ref GlossMeshAsAContainer
- * "glossary entry" for a further discussion of this idea. %Functions that may
- * be called with either class indicate this by accepting a template parameter
- * like
- * @code
- * template <template <int, int> class Container>
- * @endcode
- * or
- * @code
- * template <typename Container>
- * @endcode
- * which is usually required to have a <code>typedef</code> named
- * <code>active_cell_iterator</code>.
- * </dd>
- *
  * <dt class="concepts">@anchor ConceptDoFHandlerType <b>DoFHandlerType</b></dt>
  *
  * <dd>
@@ -125,6 +103,27 @@
  * template concept. One can use the PointerMatrixAux class to implement
  * <code>vmult_add</code> and <code>Tvmult_add</code> instead of implementing
  * them manually.
+ * </dd>
+ *
+ * <dt class="concepts">@anchor ConceptMeshType <b>MeshType</b></dt>
+ *
+ * <dd>
+ * There are several algorithms (e.g.,
+ * GridTools::find_active_cell_around_point) in deal.II that can operate on
+ * either a Triangulation or a DoFHandler, as both classes may be considered
+ * to be collections of cells: see the @ref GlossMeshAsAContainer
+ * "glossary entry" for a further discussion of this idea. %Functions that may
+ * be called with either class indicate this by accepting a template parameter
+ * like
+ * @code
+ * template <template <int, int> class MeshType>
+ * @endcode
+ * or
+ * @code
+ * template <typename MeshType>
+ * @endcode
+ * which is usually required to have a <code>typedef</code> named
+ * <code>active_cell_iterator</code>.
  * </dd>
  *
  * <dt class="concepts">@anchor ConceptNumber <b>Number</b></dt>

--- a/doc/doxygen/headers/concepts.h
+++ b/doc/doxygen/headers/concepts.h
@@ -108,13 +108,36 @@
  * <dt class="concepts">@anchor ConceptMeshType <b>MeshType</b></dt>
  *
  * <dd>
- * There are several algorithms (e.g.,
- * GridTools::find_active_cell_around_point) in deal.II that can operate on
- * either a Triangulation or a DoFHandler, as both classes may be considered
- * to be collections of cells: see the @ref GlossMeshAsAContainer
- * "glossary entry" for a further discussion of this idea. %Functions that may
- * be called with either class indicate this by accepting a template parameter
- * like
+ * Meshes can be thought of as arrays of vertices and connectivities, but a
+ * more fruitful view is to consider them as <i>collections of cells</i>. In
+ * C++, collections are often called <i>containers</i> (typical containers are
+ * std::vector, std::list, etc.) and they are characterized by the ability to
+ * iterate over the elements of the collection. The <tt>MeshType</tt> concept
+ * refers to any container which defines appropriate methods (such as
+ * DoFHandler::begin_active()) and <tt>typedefs</tt> (such as
+ * DoFHandler::active_cell_iterator) for managing collections of cells.
+ *
+ * Triangulation&nnbsp;s, DoFHandler&nnbsp;s, and hp::DoFHandler&nnbsp;s may
+ * all be considered as containers of cells. In fact, the most important parts
+ * of the public interface of these classes consists simply of the ability to
+ * get iterators to their elements. Since these parts of the interface are
+ * generic, i.e., the functions have the same name in all classes, it is
+ * possible to write operations that do not actually care whether they work on
+ * a triangulation or a DoF handler object. Examples abound, for example, in
+ * the GridTools namespace, underlining the power of the abstraction that
+ * meshes and DoF handlers can all be considered simply as collections
+ * (containers) of cells.
+ *
+ * On the other hand, meshes are non-standard containers unlike std::vector or
+ * std::list in that they can be sliced several ways. For example, one can
+ * iterate over the subset of active cells or over all cells; likewise, cells
+ * are organized into levels and one can get iterator ranges for only the
+ * cells on one level. Generally, however, all classes that implement the
+ * containers-of-cells concept use the same function names to provide the same
+ * functionality.
+ *
+ * %Functions that may be called with either class indicate this by accepting
+ * a template parameter like
  * @code
  * template <template <int, int> class MeshType>
  * @endcode
@@ -122,8 +145,29 @@
  * @code
  * template <typename MeshType>
  * @endcode
- * which is usually required to have a <code>typedef</code> named
- * <code>active_cell_iterator</code>.
+ * The classes that satisfy this concept are collectively referred to as
+ * <em>mesh classes</em>. The exact definition of <tt>MeshType</tt> relies a
+ * lot on library internals, but it can be summarized as any class with the
+ * following properties:
+ * <ol>
+ *   <li>A <tt>typedef</tt> named <tt>active_cell_iterator</tt>.
+ *   </li>
+ *   <li>A method <tt>get_triangulation()</tt> which returns a reference to
+ *   the underlying geometrical description (one of the Triangulation classes)
+ *   of the collection of cells. If the mesh happens to be a Triangulation,
+ *   then the mesh just returns a reference to itself.
+ *   </li>
+ *   <li>A method <tt>begin_active()</tt> which returns an iterator pointing
+ *   to the first active cell.
+ *   </li>
+ *   <li>A static member value <tt>dimension</tt> containing the dimension in
+ *       which the object lives.
+ *   </li>
+ *   <li>A static member value <tt>space_dimension</tt> containing the dimension
+ *       of the object (e.g., a 2D surface in a 3D setting would have
+ *       <tt>space_dimension = 2</tt>).
+ *   </li>
+ * </ol>
  * </dd>
  *
  * <dt class="concepts">@anchor ConceptNumber <b>Number</b></dt>

--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1131,34 +1131,6 @@
  * </dd>
  *
  *
- * <dt class="glossary">@anchor GlossMeshAsAContainer <b>Meshes as containers</b></dt>
- * <dd>
- * Meshes can be thought of as arrays of vertices and connectivities, but a
- * more fruitful view is to consider them as <i>collections of cells</i>. In C++,
- * collections are often called <i>containers</i> (typical containers are std::vector,
- * std::list, etc.) and they are characterized by the ability iterate over the
- * elements of the collection.
- *
- * Triangulations and objects of type DoFHandler or hp::DoFHandler can all be
- * considered as containers of cells. In fact, the most important parts of the
- * public interface of these classes consists simply of the ability to get
- * iterators to their elements, using functions such as Triangulation::begin_active(),
- * Triangulation::end() and their counterparts in DoFHandler and hp::DoFHandler. Since
- * these parts of the interface are generic, i.e., the functions have the same name
- * in all classes, it is possible to write operations that do not actually care whether
- * they work on a triangulation or a DoF handler object. Examples about, for example,
- * in the GridTools namespace, underlining the power of the abstraction that meshes
- * and DoF handlers can all be considered simply as collections (containers) of cells.
- *
- * On the other hand, meshes are non-standard containers unlike std::vector or std::list
- * in that they can be sliced several ways. For example, one can iterate over the
- * subset of active cells or over all cells; likewise, cells are organized into levels
- * and one can get iterator ranges for only the cells on one level. Generally, however,
- * all classes that implement the containers-of-cells concept use the same function
- * names to provide the same functionality.
- * </dd>
- *
- *
  * <dt class="glossary">@anchor GlossMPICommunicator <b>MPI Communicator</b></dt>
  * <dd>
  * In the language of the Message Passing Interface (MPI), a communicator

--- a/doc/doxygen/headers/iterators.h
+++ b/doc/doxygen/headers/iterators.h
@@ -33,7 +33,7 @@ Basically, the template signature of TriaIterator is
 Conceptually, this type represents something like a pointer to an object
 represented by the <code>Accessor</code> class.  Usually, you will not use the
 actual class names spelled out directly, but employ one of the typedefs
-provided by the container classes, such as <code>typename
+provided by the mesh classes, such as <code>typename
 Triangulation::cell_iterator</code>. Before going into this, let us
 first discuss the concept of iterators, before delving into what the accessors
 do.
@@ -43,7 +43,7 @@ element using <tt>operator ++</tt>, and decremented to the previous element
 using <tt>operator --</tt>. One can also jump <tt>n</tt> elements ahead using
 the addition operator, <tt>it=it+n</tt>, and correspondingly to move a number
 of elements back. In addition, and keeping with the tradition of the standard
-template library, containers provide member functions <tt>begin()</tt> and
+template library, meshes provide member functions <tt>begin()</tt> and
 <tt>end()</tt> that provide the first element of a collection and a
 one-past-the-end iterator, respectively. Since there are a number of different
 iterators available, there is actually a whole family of such functions, such
@@ -269,12 +269,12 @@ of accessor classes:
 
 Except to look up member documentation, you will not usually have to deal with
 the actual class names listed above. Rather, one uses the typedefs provided by
-the container classes Triangulation, DoFHandler and hp::DoFHandler, as well
+the mesh classes Triangulation, DoFHandler and hp::DoFHandler, as well
 as the function that generate such objects:
 
 <table border=1>
   <tr>
-    <th>Container</th>
+    <th>Class</th>
     <th>cell_iterator type</th>
     <th>function call</th>
   </tr>
@@ -301,7 +301,7 @@ as the function that generate such objects:
 
 <table border=1>
   <tr>
-    <th>Container</th>
+    <th>Class</th>
     <th>face_iterator type</th>
     <th>function call</th>
   </tr>
@@ -330,7 +330,7 @@ Likewise, active iterators have the following properties:
 
 <table border=1>
   <tr>
-    <th>Container</th>
+    <th>Class</th>
     <th>cell_iterator type</th>
     <th>function call</th>
   </tr>
@@ -357,7 +357,7 @@ Likewise, active iterators have the following properties:
 
 <table border=1>
   <tr>
-    <th>Container</th>
+    <th>Class</th>
     <th>face_iterator type</th>
     <th>function call</th>
   </tr>
@@ -389,7 +389,7 @@ a hexahedron in 3d), there are corresponding types and calls like
 dimension independent geometric objects line, quad, and hex. These calls,
 just as the ones above, exist in active and non-active forms.
 
-The actual definition of all the typedefs local to the container classes are
+The actual definition of all the typedefs local to the mesh classes are
 stated in the
 
 - internal::Triangulation::Iterators<1,spacedim>,

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -308,7 +308,7 @@ inconvenience this causes.
   shadow class names. Additionally, template type names are now much more
   consistent across deal.II.
   <br>
-  (David Wells, 2015/10/18 - 2015/12/09)
+  (David Wells, 2015/10/18 - 2016/01/23)
   </li>
 
   <li> New: The WorkStream class's design and implementation are now much

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -178,9 +178,8 @@ namespace parallel
      * @ref distributed
      * documentation module, as well as the
      * @ref distributed_paper.
-     * See there for more information. This class satisfies the requirements
-     * outlined in
-     * @ref GlossMeshAsAContainer "Meshes as containers".
+     * See there for more information. This class satisfies the
+     * @ref ConceptMeshType "MeshType concept".
      *
      * @note This class does not support anisotropic refinement, because it
      * relies on the p4est library that does not support this. Attempts to

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -66,8 +66,9 @@ namespace internal
 
 /**
  * Manage the distribution and numbering of the degrees of freedom for non-
- * multigrid algorithms. This class satisfies the requirements outlined in
- * @ref GlossMeshAsAContainer "Meshes as containers".
+ * multigrid algorithms. This class satisfies the
+ * @ref ConceptMeshType "MeshType concept" requirements.
+ *
  * It is first used in the step-2 tutorial program.
  *
  * For each vertex, line, quad, etc, this class stores a list of the indices

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -48,7 +48,7 @@ namespace hp
   template <int dim, int spacedim> class MappingCollection;
 }
 class ConstraintMatrix;
-template <class GridClass> class InterGridMap;
+template <class MeshType> class InterGridMap;
 template <int dim, int spacedim> class Mapping;
 
 namespace GridTools

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -77,7 +77,8 @@ namespace GridGenerator
                    const bool                    colorize= false);
 
   /**
-   * \brief Mesh of a d-simplex with (d+1) vertices and mesh cells, resp.
+   * \brief %Triangulation of a d-simplex with (d+1) vertices and mesh cells,
+   * resp.
    *
    * The @p vertices argument contains a vector with all d+1 vertices of the
    * simplex. They must be given in an order such that the vectors from the
@@ -935,12 +936,12 @@ namespace GridGenerator
   // doing some contortion with the return type using the following
   // intermediate type. This is only used when using MS VC++ and uses
   // the direct way of doing it otherwise
-  template <template <int,int> class Container, int dim, int spacedim>
+  template <template <int,int> class MeshType, int dim, int spacedim>
   struct ExtractBoundaryMesh
   {
     typedef
-    std::map<typename Container<dim-1,spacedim>::cell_iterator,
-        typename Container<dim,spacedim>::face_iterator>
+    std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
+        typename MeshType<dim,spacedim>::face_iterator>
         return_type;
   };
 #endif
@@ -970,15 +971,14 @@ namespace GridGenerator
    * vertices.
    *
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
+   * @tparam MeshType A type that satisfies the requirements of a mesh
+   * container (see @ref GlossMeshAsAContainer "meshes as containers").
    * The map that is returned will be between cell iterators pointing into the
    * container describing the surface mesh and face iterators of the volume
-   * mesh container. If the Container argument is DoFHandler of
+   * mesh container. If the MeshType argument is DoFHandler of
    * hp::DoFHandler, then the function will re-build the triangulation
    * underlying the second argument and return a map between appropriate
-   * iterators into the Container arguments. However, the function will not
+   * iterators into the MeshType arguments. However, the function will not
    * actually distribute degrees of freedom on this newly created surface
    * mesh.
    * @tparam dim The dimension of the cells of the volume mesh. For example, if
@@ -1017,15 +1017,15 @@ namespace GridGenerator
    * accommodate different geometry descriptions in the case of curved
    * boundaries (but this is not currently implemented).
    */
-  template <template <int,int> class Container, int dim, int spacedim>
+  template <template <int,int> class MeshType, int dim, int spacedim>
 #ifndef _MSC_VER
-  std::map<typename Container<dim-1,spacedim>::cell_iterator,
-      typename Container<dim,spacedim>::face_iterator>
+  std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
+      typename MeshType<dim,spacedim>::face_iterator>
 #else
   typename ExtractBoundaryMesh<Container,dim,spacedim>::return_type
 #endif
-      extract_boundary_mesh (const Container<dim,spacedim> &volume_mesh,
-                             Container<dim-1,spacedim>     &surface_mesh,
+      extract_boundary_mesh (const MeshType<dim,spacedim>       &volume_mesh,
+                             MeshType<dim-1,spacedim>           &surface_mesh,
                              const std::set<types::boundary_id> &boundary_ids
                              = std::set<types::boundary_id>());
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -970,17 +970,16 @@ namespace GridGenerator
    * boundary object you may want to use to determine the location of new
    * vertices.
    *
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref ConceptMeshType "MeshType concept". The map that is returned will be
+   * between cell iterators pointing into the container describing the surface
+   * mesh and face iterators of the volume mesh container. If MeshType is
+   * DoFHandler or hp::DoFHandler, then the function will re-build the
+   * triangulation underlying the second argument and return a map between
+   * appropriate iterators into the MeshType arguments. However, the function
+   * will not actually distribute degrees of freedom on this newly created
+   * surface mesh.
    *
-   * @tparam MeshType A type that satisfies the requirements of a mesh
-   * container (see @ref GlossMeshAsAContainer "meshes as containers").
-   * The map that is returned will be between cell iterators pointing into the
-   * container describing the surface mesh and face iterators of the volume
-   * mesh container. If the MeshType argument is DoFHandler of
-   * hp::DoFHandler, then the function will re-build the triangulation
-   * underlying the second argument and return a map between appropriate
-   * iterators into the MeshType arguments. However, the function will not
-   * actually distribute degrees of freedom on this newly created surface
-   * mesh.
    * @tparam dim The dimension of the cells of the volume mesh. For example, if
    *   dim==2, then the cells are quadrilaterals that either live in the
    *   plane, or form a surface in a higher-dimensional space. The dimension

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -43,11 +43,11 @@ class SparsityPattern;
 
 namespace internal
 {
-  template<int dim, int spacedim, class Container>
+  template<int dim, int spacedim, class MeshType>
   class ActiveCellIterator
   {
   public:
-    typedef typename Container::active_cell_iterator type;
+    typedef typename MeshType::active_cell_iterator type;
   };
 
   template<int dim, int spacedim>
@@ -342,18 +342,17 @@ namespace GridTools
    * Find and return the number of the used vertex in a given mesh that is
    * located closest to a given point.
    *
-   * @param container A variable of a type that satisfies the requirements of
-   * a mesh container (see
-   * @ref GlossMeshAsAContainer).
+   * @param mesh A variable of a type that satisfies the requirements of
+   * a mesh container (see @ref GlossMeshAsAContainer).
    * @param p The point for which we want to find the closest vertex.
    * @return The index of the closest vertex found.
    *
    * @author Ralf B. Schulz, 2006
    */
-  template <int dim, template <int, int> class Container, int spacedim>
+  template <int dim, template <int, int> class MeshType, int spacedim>
   unsigned int
-  find_closest_vertex (const Container<dim, spacedim> &container,
-                       const Point<spacedim>     &p);
+  find_closest_vertex (const MeshType<dim, spacedim> &mesh,
+                       const Point<spacedim>         &p);
 
   /**
    * Find and return a vector of iterators to active cells that surround a
@@ -363,9 +362,8 @@ namespace GridTools
    * adjacent cells that are returned. However, it will always be either a
    * vertex of a cell or be a hanging node located on a face or an edge of it.
    *
-   * @param container A variable of a type that satisfies the requirements of
-   * a mesh container (see
-   * @ref GlossMeshAsAContainer).
+   * @param mesh A variable of a type that satisfies the requirements of
+   * the @ref GlossMeshAsAContainer "MeshType concept".
    * @param vertex_index The index of the vertex for which we try to find
    * adjacent cells.
    * @return A vector of cells that lie adjacent to the given vertex.
@@ -379,14 +377,14 @@ namespace GridTools
    * right thing with anisotropically refined meshes. It needs to be checked
    * for this case.
    */
-  template<int dim, template <int, int> class Container, int spacedim>
+  template<int dim, template <int, int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  std::vector<typename Container<dim, spacedim>::active_cell_iterator>
+  std::vector<typename MeshType<dim, spacedim>::active_cell_iterator>
 #else
-  std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type>
+  std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type>
 #endif
-  find_cells_adjacent_to_vertex (const Container<dim,spacedim> &container,
-                                 const unsigned int    vertex_index);
+  find_cells_adjacent_to_vertex (const MeshType<dim,spacedim> &container,
+                                 const unsigned int            vertex_index);
 
 
   /**
@@ -401,12 +399,10 @@ namespace GridTools
    * simultaneously delivers the local coordinate of the given point without
    * additional computational cost.
    *
-   * @param container A variable of a type that satisfies the requirements of
-   * a mesh container (see
-   * @ref GlossMeshAsAContainer).
+   * @param mesh A variable of a type that satisfies the requirements of
+   * the @ref GlossMeshAsAContainer "MeshType concept".
    * @param p The point for which we want to find the surrounding cell.
-   * @return An iterator into the mesh container that points to the
-   * surrounding cell.
+   * @return An iterator into the mesh that points to the surrounding cell.
    *
    * @note If the point requested does not lie in any of the cells of the mesh
    * given, then this function throws an exception of type
@@ -423,14 +419,14 @@ namespace GridTools
    * evaluating the solution) may not be possible and you will have to decide
    * what to do in that case.
    */
-  template <int dim, template <int,int> class Container, int spacedim>
+  template <int dim, template <int,int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  typename Container<dim,spacedim>::active_cell_iterator
+  typename MeshType<dim,spacedim>::active_cell_iterator
 #else
-  typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type
+  typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type
 #endif
-  find_active_cell_around_point (const Container<dim,spacedim>  &container,
-                                 const Point<spacedim> &p);
+  find_active_cell_around_point (const MeshType<dim,spacedim> &mesh,
+                                 const Point<spacedim>        &p);
 
   /**
    * Find and return an iterator to the active cell that surrounds a given
@@ -451,11 +447,10 @@ namespace GridTools
    *
    * @param mapping The mapping used to determine whether the given point is
    * inside a given cell.
-   * @param container A variable of a type that satisfies the requirements of
-   * a mesh container (see
-   * @ref GlossMeshAsAContainer).
+   * @param mesh A variable of a type that satisfies the requirements of
+   * the @ref GlossMeshAsAContainer "MeshType concept".
    * @param p The point for which we want to find the surrounding cell.
-   * @return An pair of an iterator into the mesh container that points to the
+   * @return An pair of an iterators into the mesh that points to the
    * surrounding cell, and of the coordinates of that point inside the cell in
    * the reference coordinates of that cell. This local position might be
    * located slightly outside an actual unit cell, due to numerical roundoff.
@@ -478,15 +473,15 @@ namespace GridTools
    * evaluating the solution) may not be possible and you will have to decide
    * what to do in that case.
    */
-  template <int dim, template<int, int> class Container, int spacedim>
+  template <int dim, template<int, int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  std::pair<typename Container<dim, spacedim>::active_cell_iterator, Point<dim> >
+  std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim> >
 #else
-  std::pair<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type, Point<dim> >
+  std::pair<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type, Point<dim> >
 #endif
-  find_active_cell_around_point (const Mapping<dim,spacedim>   &mapping,
-                                 const Container<dim,spacedim> &container,
-                                 const Point<spacedim>     &p);
+  find_active_cell_around_point (const Mapping<dim,spacedim>  &mapping,
+                                 const MeshType<dim,spacedim> &mesh,
+                                 const Point<spacedim>        &p);
 
   /**
    * A version of the previous function where we use that mapping on a given
@@ -511,9 +506,9 @@ namespace GridTools
    */
   template <int dim, int spacedim>
   std::pair<typename hp::DoFHandler<dim, spacedim>::active_cell_iterator, Point<dim> >
-  find_active_cell_around_point (const hp::MappingCollection<dim,spacedim>   &mapping,
-                                 const hp::DoFHandler<dim,spacedim> &container,
-                                 const Point<spacedim>     &p);
+  find_active_cell_around_point (const hp::MappingCollection<dim,spacedim> &mapping,
+                                 const hp::DoFHandler<dim,spacedim>        &mesh,
+                                 const Point<spacedim>                     &p);
 
   /**
    * Return a list of all descendants of the given cell that are active. For
@@ -524,42 +519,40 @@ namespace GridTools
    * If the current cell is already active, then the returned list is empty
    * (because the cell has no children that may be active).
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
-   * @param cell An iterator pointing to a cell of the mesh container.
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @param cell An iterator pointing to a cell of the mesh.
    * @return A list of active descendants of the given cell
    *
-   * @note Since in C++ the type of the Container template argument can not be
+   * @note Since in C++ the MeshType template argument can not be
    * deduced from a function call, you will have to specify it after the
    * function name, as for example in
    * @code
    *   GridTools::get_active_child_cells<DoFHandler<dim> > (cell)
    * @endcode
    */
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  get_active_child_cells (const typename Container::cell_iterator &cell);
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  get_active_child_cells (const typename MeshType::cell_iterator &cell);
 
   /**
    * Extract the active cells around a given cell @p cell and return them in
    * the vector @p active_neighbors.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
-   * @param[in] cell An iterator pointing to a cell of the mesh container.
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @param[in] cell An iterator pointing to a cell of the mesh.
    * @param[out] active_neighbors A list of active descendants of the given
    * cell
    */
-  template <class Container>
+  template <class MeshType>
   void
-  get_active_neighbors (const typename Container::active_cell_iterator        &cell,
-                        std::vector<typename Container::active_cell_iterator> &active_neighbors);
+  get_active_neighbors (const typename MeshType::active_cell_iterator        &cell,
+                        std::vector<typename MeshType::active_cell_iterator> &active_neighbors);
 
   /**
    * Extract and return the active cell layer around a subdomain (set of active
-   * cells) in the @p container (i.e. those that share a common set of vertices
+   * cells) in the @p mesh (i.e. those that share a common set of vertices
    * with the subdomain but are not a part of it).
    * Here, the "subdomain" consists of exactly all of those cells for which the
    * @p predicate returns @p true.
@@ -594,9 +587,9 @@ namespace GridTools
    * true only for locally owned cells. This means that the halo layer will
    * not contain any artificial cells.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see @ref GlossMeshAsAContainer).
-   * @param[in] container A mesh container (i.e. objects of type Triangulation,
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @param[in] mesh A mesh (i.e. objects of type Triangulation,
    * DoFHandler, or hp::DoFHandler).
    * @param[in] predicate A function  (or object of a type with an operator())
    * defining the subdomain around which the halo layer is to be extracted. It
@@ -606,10 +599,11 @@ namespace GridTools
    *
    * @author Jean-Paul Pelteret, Denis Davydov, Wolfgang Bangerth, 2015
    */
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  compute_active_cell_halo_layer (const Container                                                                    &container,
-                                  const std_cxx11::function<bool (const typename Container::active_cell_iterator &)> &predicate);
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  compute_active_cell_halo_layer
+  (const MeshType                                                                    &mesh,
+   const std_cxx11::function<bool (const typename MeshType::active_cell_iterator &)> &predicate);
 
   /**
    * Extract and return ghost cells which are the active cell layer
@@ -618,17 +612,17 @@ namespace GridTools
    * ghost cells on a processor, but for parallel::distributed::Triangulation
    * this will return all the ghost cells.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see @ref GlossMeshAsAContainer).
-   * @param[in] container A mesh container (i.e. objects of type Triangulation,
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @param[in] mesh A mesh (i.e. objects of type Triangulation,
    * DoFHandler, or hp::DoFHandler).
    * @return A list of ghost cells
    *
    * @author Jean-Paul Pelteret, Denis Davydov, Wolfgang Bangerth, 2015
    */
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  compute_ghost_cell_halo_layer (const Container &container);
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  compute_ghost_cell_halo_layer (const MeshType &mesh);
 
 
   /**
@@ -842,7 +836,7 @@ namespace GridTools
   /*@{*/
 
   /**
-   * Given two mesh containers (i.e. objects of type Triangulation,
+   * Given two meshes (i.e. objects of type Triangulation,
    * DoFHandler, or hp::DoFHandler) that are based on the same coarse mesh,
    * this function figures out a set of cells that are matched between the two
    * meshes and where at most one of the meshes is more refined on this cell.
@@ -866,15 +860,14 @@ namespace GridTools
    * does also not necessarily coincide with the order in which cells are
    * traversed in one, or both, of the meshes given as arguments.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
    */
-  template <typename Container>
-  std::list<std::pair<typename Container::cell_iterator,
-      typename Container::cell_iterator> >
-      get_finest_common_cells (const Container &mesh_1,
-                               const Container &mesh_2);
+  template <typename MeshType>
+  std::list<std::pair<typename MeshType::cell_iterator,
+      typename MeshType::cell_iterator> >
+      get_finest_common_cells (const MeshType &mesh_1,
+                               const MeshType &mesh_2);
 
   /**
    * Return true if the two triangulations are based on the same coarse mesh.
@@ -896,14 +889,13 @@ namespace GridTools
    * have_same_coarse_mesh for all types of containers representing
    * triangulations or the classes built on triangulations.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
    */
-  template <typename Container>
+  template <typename MeshType>
   bool
-  have_same_coarse_mesh (const Container &mesh_1,
-                         const Container &mesh_2);
+  have_same_coarse_mesh (const MeshType &mesh_1,
+                         const MeshType &mesh_2);
 
   /*@}*/
   /**
@@ -954,13 +946,12 @@ namespace GridTools
    * loops over all subfaces of current face adds the neighbors behind these
    * sub-faces to the list to be returned.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
-   * In C++, the compiler can not determine the type of <code>Container</code>
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
+   * In C++, The <code>MeshType</code> template argument can not be deduced
    * from the function call. You need to specify it as an explicit template
    * argument following the function name.
-   * @param[in] cell An iterator pointing to a cell of the mesh container.
+   * @param[in] cell An iterator pointing to a cell of the mesh.
    * @return A list of active cells that form the patch around the given cell
    *
    * @note Patches are often used in defining error estimators that require
@@ -978,9 +969,9 @@ namespace GridTools
    *
    * @author Arezou Ghesmati, Wolfgang Bangerth, 2014
    */
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  get_patch_around_cell(const typename Container::active_cell_iterator &cell);
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  get_patch_around_cell(const typename MeshType::active_cell_iterator &cell);
 
 
   /*@}*/
@@ -997,12 +988,12 @@ namespace GridTools
   // doing some contortion with the return type using the following
   // intermediate type. This is only used when using MS VC++ and uses
   // the direct way of doing it otherwise
-  template <template <int,int> class Container, int dim, int spacedim>
+  template <template <int,int> class MeshType, int dim, int spacedim>
   struct ExtractBoundaryMesh
   {
     typedef
-    std::map<typename Container<dim-1,spacedim>::cell_iterator,
-        typename Container<dim,spacedim>::face_iterator>
+    std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
+        typename MeshType<dim,spacedim>::face_iterator>
         return_type;
   };
 #endif
@@ -1147,7 +1138,7 @@ namespace GridTools
 
   /**
    * This function will collect periodic face pairs on the coarsest mesh
-   * level of the given @p container (a Triangulation or DoFHandler) and
+   * level of the given @p mesh (a Triangulation or DoFHandler) and
    * add them to the vector @p matched_pairs leaving the original contents
    * intact.
    *
@@ -1186,9 +1177,8 @@ namespace GridTools
    * and step-45). Second, @p matrix will be stored in the
    * PeriodicFacePair collection @p matched_pairs for further use.
    *
-   * @tparam Container A type that satisfies the requirements of a mesh
-   * container (see
-   * @ref GlossMeshAsAContainer).
+   * @tparam MeshType A type that satisfies the requirements of the
+   * @ref GlossMeshAsAContainer "MeshType concept".
    *
    * @note The created std::vector can be used in
    * DoFTools::make_periodicity_constraints() and in
@@ -1202,16 +1192,16 @@ namespace GridTools
    *
    * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
-  template <typename CONTAINER>
+  template <typename MeshType>
   void
   collect_periodic_faces
-  (const CONTAINER                                                   &container,
-   const types::boundary_id                                           b_id1,
-   const types::boundary_id                                           b_id2,
-   const int                                                          direction,
-   std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
-   const Tensor<1,CONTAINER::space_dimension>                        &offset = dealii::Tensor<1,CONTAINER::space_dimension>(),
-   const FullMatrix<double>                                          &matrix = FullMatrix<double>());
+  (const MeshType                            &mesh,
+   const types::boundary_id                   b_id1,
+   const types::boundary_id                   b_id2,
+   const int                                  direction,
+   std::vector<PeriodicFacePair<typename MeshType::cell_iterator> > &matched_pairs,
+   const Tensor<1,MeshType::space_dimension> &offset = dealii::Tensor<1,MeshType::space_dimension>(),
+   const FullMatrix<double>                  &matrix = FullMatrix<double>());
 
 
   /**
@@ -1236,15 +1226,15 @@ namespace GridTools
    *
    * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
-  template <typename CONTAINER>
+  template <typename MeshType>
   void
   collect_periodic_faces
-  (const CONTAINER                                                   &container,
-   const types::boundary_id                                           b_id,
-   const int                                                          direction,
-   std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
-   const dealii::Tensor<1,CONTAINER::space_dimension>                &offset = dealii::Tensor<1,CONTAINER::space_dimension>(),
-   const FullMatrix<double>                                          &matrix = FullMatrix<double>());
+  (const MeshType                                    &mesh,
+   const types::boundary_id                           b_id,
+   const int                                          direction,
+   std::vector<PeriodicFacePair<typename MeshType::cell_iterator> > &matched_pairs,
+   const dealii::Tensor<1,MeshType::space_dimension> &offset = dealii::Tensor<1,MeshType::space_dimension>(),
+   const FullMatrix<double>                          &matrix = FullMatrix<double>());
 
   /*@}*/
   /**
@@ -1461,11 +1451,11 @@ namespace GridTools
 
 
 
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  get_active_child_cells (const typename Container::cell_iterator &cell)
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  get_active_child_cells (const typename MeshType::cell_iterator &cell)
   {
-    std::vector<typename Container::active_cell_iterator> child_cells;
+    std::vector<typename MeshType::active_cell_iterator> child_cells;
 
     if (cell->has_children())
       {
@@ -1473,8 +1463,8 @@ namespace GridTools
              child<cell->n_children(); ++child)
           if (cell->child (child)->has_children())
             {
-              const std::vector<typename Container::active_cell_iterator>
-              children = get_active_child_cells<Container> (cell->child(child));
+              const std::vector<typename MeshType::active_cell_iterator>
+              children = get_active_child_cells<MeshType> (cell->child(child));
               child_cells.insert (child_cells.end(),
                                   children.begin(), children.end());
             }
@@ -1487,23 +1477,23 @@ namespace GridTools
 
 
 
-  template <class Container>
+  template <class MeshType>
   void
-  get_active_neighbors(const typename Container::active_cell_iterator        &cell,
-                       std::vector<typename Container::active_cell_iterator> &active_neighbors)
+  get_active_neighbors(const typename MeshType::active_cell_iterator        &cell,
+                       std::vector<typename MeshType::active_cell_iterator> &active_neighbors)
   {
     active_neighbors.clear ();
-    for (unsigned int n=0; n<GeometryInfo<Container::dimension>::faces_per_cell; ++n)
+    for (unsigned int n=0; n<GeometryInfo<MeshType::dimension>::faces_per_cell; ++n)
       if (! cell->at_boundary(n))
         {
-          if (Container::dimension == 1)
+          if (MeshType::dimension == 1)
             {
               // check children of neighbor. note
               // that in 1d children of the neighbor
               // may be further refined. In 1d the
               // case is simple since we know what
               // children bound to the present cell
-              typename Container::cell_iterator
+              typename MeshType::cell_iterator
               neighbor_child = cell->neighbor(n);
               if (!neighbor_child->active())
                 {

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -343,7 +343,7 @@ namespace GridTools
    * located closest to a given point.
    *
    * @param mesh A variable of a type that satisfies the requirements of
-   * a mesh container (see @ref GlossMeshAsAContainer).
+   * the @ref ConceptMeshType "MeshType concept".
    * @param p The point for which we want to find the closest vertex.
    * @return The index of the closest vertex found.
    *
@@ -363,7 +363,7 @@ namespace GridTools
    * vertex of a cell or be a hanging node located on a face or an edge of it.
    *
    * @param mesh A variable of a type that satisfies the requirements of
-   * the @ref GlossMeshAsAContainer "MeshType concept".
+   * the @ref ConceptMeshType "MeshType concept".
    * @param vertex_index The index of the vertex for which we try to find
    * adjacent cells.
    * @return A vector of cells that lie adjacent to the given vertex.
@@ -400,7 +400,7 @@ namespace GridTools
    * additional computational cost.
    *
    * @param mesh A variable of a type that satisfies the requirements of
-   * the @ref GlossMeshAsAContainer "MeshType concept".
+   * the @ref ConceptMeshType "MeshType concept".
    * @param p The point for which we want to find the surrounding cell.
    * @return An iterator into the mesh that points to the surrounding cell.
    *
@@ -448,7 +448,7 @@ namespace GridTools
    * @param mapping The mapping used to determine whether the given point is
    * inside a given cell.
    * @param mesh A variable of a type that satisfies the requirements of
-   * the @ref GlossMeshAsAContainer "MeshType concept".
+   * the @ref ConceptMeshType "MeshType concept".
    * @param p The point for which we want to find the surrounding cell.
    * @return An pair of an iterators into the mesh that points to the
    * surrounding cell, and of the coordinates of that point inside the cell in
@@ -520,7 +520,7 @@ namespace GridTools
    * (because the cell has no children that may be active).
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    * @param cell An iterator pointing to a cell of the mesh.
    * @return A list of active descendants of the given cell
    *
@@ -540,7 +540,7 @@ namespace GridTools
    * the vector @p active_neighbors.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    * @param[in] cell An iterator pointing to a cell of the mesh.
    * @param[out] active_neighbors A list of active descendants of the given
    * cell
@@ -588,7 +588,7 @@ namespace GridTools
    * not contain any artificial cells.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    * @param[in] mesh A mesh (i.e. objects of type Triangulation,
    * DoFHandler, or hp::DoFHandler).
    * @param[in] predicate A function  (or object of a type with an operator())
@@ -613,7 +613,7 @@ namespace GridTools
    * this will return all the ghost cells.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    * @param[in] mesh A mesh (i.e. objects of type Triangulation,
    * DoFHandler, or hp::DoFHandler).
    * @return A list of ghost cells
@@ -861,7 +861,7 @@ namespace GridTools
    * traversed in one, or both, of the meshes given as arguments.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    */
   template <typename MeshType>
   std::list<std::pair<typename MeshType::cell_iterator,
@@ -890,7 +890,7 @@ namespace GridTools
    * triangulations or the classes built on triangulations.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    */
   template <typename MeshType>
   bool
@@ -947,10 +947,10 @@ namespace GridTools
    * sub-faces to the list to be returned.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
-   * In C++, The <code>MeshType</code> template argument can not be deduced
-   * from the function call. You need to specify it as an explicit template
-   * argument following the function name.
+   * @ref ConceptMeshType "MeshType concept".
+   * In C++, the compiler can not determine <code>MeshType</code> from the
+   * function call. You need to specify it as an explicit template argument
+   * following the function name.
    * @param[in] cell An iterator pointing to a cell of the mesh.
    * @return A list of active cells that form the patch around the given cell
    *
@@ -1178,7 +1178,7 @@ namespace GridTools
    * PeriodicFacePair collection @p matched_pairs for further use.
    *
    * @tparam MeshType A type that satisfies the requirements of the
-   * @ref GlossMeshAsAContainer "MeshType concept".
+   * @ref ConceptMeshType "MeshType concept".
    *
    * @note The created std::vector can be used in
    * DoFTools::make_periodicity_constraints() and in

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -66,10 +66,10 @@ DEAL_II_NAMESPACE_OPEN
  * valid keys. For example, the mapping for the mother cell of cells 1 and 2
  * on the first grid will point to cell 1 on the second grid.
  *
- * The implementation of this class is such that not only cell iterators into
- * triangulations can be mapped, but also iterators into objects of type
- * DoFHandler or hp::DoFHandler. The extension to other classes offering
- * iterator functions and some minor additional requirements is simple.
+ * @tparam MeshType This class may be used with any class that satisfies the
+ * @ref GlossMeshAsAContainer "MeshType concept". The extension to other classes
+ * offering iterator functions and some minor additional requirements is
+ * simple.
  *
  * Note that this class could in principle be based on the C++
  * <tt>std::map<Key,Value></tt> data type. Instead, it uses another data
@@ -108,7 +108,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup grid
  * @author Wolfgang Bangerth, 1999
  */
-template <class GridClass>
+template <class MeshType>
 class InterGridMap : public Subscriptor
 {
 public:
@@ -116,7 +116,7 @@ public:
   /**
    * Typedef to the iterator type of the grid class under consideration.
    */
-  typedef typename GridClass::cell_iterator cell_iterator;
+  typedef typename MeshType::cell_iterator cell_iterator;
 
   /**
    * Constructor setting the class name arguments in the SmartPointer members.
@@ -126,8 +126,8 @@ public:
   /**
    * Create the mapping between the two grids.
    */
-  void make_mapping (const GridClass &source_grid,
-                     const GridClass &destination_grid);
+  void make_mapping (const MeshType &source_grid,
+                     const MeshType &destination_grid);
 
   /**
    * Access operator: give a cell on the source grid and receive the
@@ -145,12 +145,12 @@ public:
   /**
    * Return a pointer to the source grid.
    */
-  const GridClass &get_source_grid () const;
+  const MeshType &get_source_grid () const;
 
   /**
    * Return a pointer to the destination grid.
    */
-  const GridClass &get_destination_grid () const;
+  const MeshType &get_destination_grid () const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -179,12 +179,12 @@ private:
   /**
    * Store a pointer to the source grid.
    */
-  SmartPointer<const GridClass,InterGridMap<GridClass> > source_grid;
+  SmartPointer<const MeshType,InterGridMap<MeshType> > source_grid;
 
   /**
    * Likewise for the destination grid.
    */
-  SmartPointer<const GridClass,InterGridMap<GridClass> > destination_grid;
+  SmartPointer<const MeshType,InterGridMap<MeshType> > destination_grid;
 
   /**
    * Set the mapping for the pair of cells given. These shall match in level

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -67,7 +67,7 @@ DEAL_II_NAMESPACE_OPEN
  * on the first grid will point to cell 1 on the second grid.
  *
  * @tparam MeshType This class may be used with any class that satisfies the
- * @ref GlossMeshAsAContainer "MeshType concept". The extension to other classes
+ * @ref ConceptMeshType "MeshType concept". The extension to other classes
  * offering iterator functions and some minor additional requirements is
  * simple.
  *

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -434,9 +434,8 @@ namespace internal
  * dependent of the dimension and there only exist specialized versions for
  * distinct dimensions.
  *
- * This class satisfies the requirements outlined in
- * @ref GlossMeshAsAContainer "Meshes as containers".
- *
+ * This class satisfies the @ref ConceptMeshType "MeshType concept"
+ * requirements.
  *
  * <h3>Structure and iterators</h3>
  *
@@ -2817,8 +2816,8 @@ public:
    *
    * This doesn't seem to be very useful but allows to write code that
    * can access the underlying triangulation for anything that satisfies
-   * the @ref GlossMeshAsAContainer "MeshType as a container" concept (which
-   * may not only be a triangulation, but also a DoFHandler, for example).
+   * the @ref ConceptMeshType "MeshType concept" (which may not only be a
+   * triangulation, but also a DoFHandler, for example).
    */
   Triangulation<dim,spacedim> &
   get_triangulation ();

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2817,7 +2817,7 @@ public:
    *
    * This doesn't seem to be very useful but allows to write code that
    * can access the underlying triangulation for anything that satisfies
-   * the @ref GlossMeshAsAContainer "Mesh as a container" concept (which
+   * the @ref GlossMeshAsAContainer "MeshType as a container" concept (which
    * may not only be a triangulation, but also a DoFHandler, for example).
    */
   Triangulation<dim,spacedim> &

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -69,8 +69,8 @@ namespace hp
 
   /**
    * Manage the distribution and numbering of the degrees of freedom for hp-
-   * FEM algorithms. This class satisfies the requirements outlined in
-   * @ref GlossMeshAsAContainer "Meshes as containers".
+   * FEM algorithms. This class satisfies the
+   * @ref ConceptMeshType "MeshType concept" requirements.
    *
    * The purpose of this class is to allow for an enumeration of degrees of
    * freedom in the same way as the ::DoFHandler class, but it allows to use a

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4131,15 +4131,15 @@ namespace GridGenerator
 
 
 
-  template <template <int,int> class Container, int dim, int spacedim>
+  template <template <int,int> class MeshType, int dim, int spacedim>
 #ifndef _MSC_VER
-  std::map<typename Container<dim-1,spacedim>::cell_iterator,
-      typename Container<dim,spacedim>::face_iterator>
+  std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
+      typename MeshType<dim,spacedim>::face_iterator>
 #else
-  typename ExtractBoundaryMesh<Container,dim,spacedim>::return_type
+  typename ExtractBoundaryMesh<MeshType,dim,spacedim>::return_type
 #endif
-      extract_boundary_mesh (const Container<dim,spacedim> &volume_mesh,
-                             Container<dim-1,spacedim>     &surface_mesh,
+      extract_boundary_mesh (const MeshType<dim,spacedim>       &volume_mesh,
+                             MeshType<dim-1,spacedim>           &surface_mesh,
                              const std::set<types::boundary_id> &boundary_ids)
   {
 // This function works using the following assumption:
@@ -4147,15 +4147,15 @@ namespace GridGenerator
 //    the order of cells passed in using the CellData argument; also,
 //    that it will not reorder the vertices.
 
-    std::map<typename Container<dim-1,spacedim>::cell_iterator,
-        typename Container<dim,spacedim>::face_iterator>
+    std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
+        typename MeshType<dim,spacedim>::face_iterator>
         surface_to_volume_mapping;
 
     const unsigned int boundary_dim = dim-1; //dimension of the boundary mesh
 
     // First create surface mesh and mapping
     // from only level(0) cells of volume_mesh
-    std::vector<typename Container<dim,spacedim>::face_iterator>
+    std::vector<typename MeshType<dim,spacedim>::face_iterator>
     mapping;  // temporary map for level==0
 
 
@@ -4166,13 +4166,13 @@ namespace GridGenerator
 
     std::map<unsigned int,unsigned int> map_vert_index; //volume vertex indices to surf ones
 
-    for (typename Container<dim,spacedim>::cell_iterator
+    for (typename MeshType<dim,spacedim>::cell_iterator
          cell = volume_mesh.begin(0);
          cell != volume_mesh.end(0);
          ++cell)
       for (unsigned int i=0; i < GeometryInfo<dim>::faces_per_cell; ++i)
         {
-          const typename Container<dim,spacedim>::face_iterator
+          const typename MeshType<dim,spacedim>::face_iterator
           face = cell->face(i);
 
           if ( face->at_boundary()
@@ -4273,7 +4273,7 @@ namespace GridGenerator
     .create_triangulation (vertices, cells, subcell_data);
 
     // Make the actual mapping
-    for (typename Container<dim-1,spacedim>::active_cell_iterator
+    for (typename MeshType<dim-1,spacedim>::active_cell_iterator
          cell = surface_mesh.begin(0);
          cell!=surface_mesh.end(0); ++cell)
       surface_to_volume_mapping[cell] = mapping.at(cell->index());
@@ -4282,7 +4282,7 @@ namespace GridGenerator
       {
         bool changed = false;
 
-        for (typename Container<dim-1,spacedim>::active_cell_iterator
+        for (typename MeshType<dim-1,spacedim>::active_cell_iterator
              cell = surface_mesh.begin_active(); cell!=surface_mesh.end(); ++cell)
           if (surface_to_volume_mapping[cell]->has_children() == true )
             {
@@ -4295,7 +4295,7 @@ namespace GridGenerator
             const_cast<Triangulation<dim-1,spacedim>&>(surface_mesh.get_triangulation())
             .execute_coarsening_and_refinement();
 
-            for (typename Container<dim-1,spacedim>::cell_iterator
+            for (typename MeshType<dim-1,spacedim>::cell_iterator
                  surface_cell = surface_mesh.begin(); surface_cell!=surface_mesh.end(); ++surface_cell)
               for (unsigned int c=0; c<surface_cell->n_children(); c++)
                 if (surface_to_volume_mapping.find(surface_cell->child(c)) == surface_to_volume_mapping.end())

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -955,16 +955,16 @@ namespace GridTools
 
 
 
-  template <int dim, template <int, int> class Container, int spacedim>
+  template <int dim, template <int, int> class MeshType, int spacedim>
   unsigned int
-  find_closest_vertex (const Container<dim,spacedim> &container,
-                       const Point<spacedim> &p)
+  find_closest_vertex (const MeshType<dim,spacedim> &mesh,
+                       const Point<spacedim>        &p)
   {
     // first get the underlying
     // triangulation from the
-    // container and determine vertices
+    // mesh and determine vertices
     // and used vertices
-    const Triangulation<dim, spacedim> &tria = container.get_triangulation();
+    const Triangulation<dim, spacedim> &tria = mesh.get_triangulation();
 
     const std::vector< Point<spacedim> > &vertices = tria.get_vertices();
     const std::vector< bool       > &used     = tria.get_used_vertices();
@@ -998,31 +998,31 @@ namespace GridTools
   }
 
 
-  template<int dim, template<int, int> class Container, int spacedim>
+  template<int dim, template<int, int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  std::vector<typename Container<dim, spacedim>::active_cell_iterator>
+  std::vector<typename MeshType<dim, spacedim>::active_cell_iterator>
 #else
-  std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type>
+  std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type>
 #endif
-  find_cells_adjacent_to_vertex(const Container<dim,spacedim> &container,
-                                const unsigned int    vertex)
+  find_cells_adjacent_to_vertex(const MeshType<dim,spacedim> &mesh,
+                                const unsigned int            vertex)
   {
     // make sure that the given vertex is
     // an active vertex of the underlying
     // triangulation
-    Assert(vertex < container.get_triangulation().n_vertices(),
-           ExcIndexRange(0,container.get_triangulation().n_vertices(),vertex));
-    Assert(container.get_triangulation().get_used_vertices()[vertex],
+    Assert(vertex < mesh.get_triangulation().n_vertices(),
+           ExcIndexRange(0,mesh.get_triangulation().n_vertices(),vertex));
+    Assert(mesh.get_triangulation().get_used_vertices()[vertex],
            ExcVertexNotUsed(vertex));
 
     // use a set instead of a vector
     // to ensure that cells are inserted only
     // once
-    std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type> adjacent_cells;
+    std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type> adjacent_cells;
 
-    typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type
-    cell = container.begin_active(),
-    endc = container.end();
+    typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type
+    cell = mesh.begin_active(),
+    endc = mesh.end();
 
     // go through all active cells and look if the vertex is part of that cell
     //
@@ -1132,7 +1132,7 @@ next_cell:
 
     // return the result as a vector, rather than the set we built above
     return
-      std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type>
+      std::vector<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type>
       (adjacent_cells.begin(), adjacent_cells.end());
   }
 
@@ -1140,20 +1140,21 @@ next_cell:
 
   namespace
   {
-    template <int dim, template<int, int> class Container, int spacedim>
-    void find_active_cell_around_point_internal(const Container<dim,spacedim> &container,
+    template <int dim, template<int, int> class MeshType, int spacedim>
+    void find_active_cell_around_point_internal
+    (const MeshType<dim,spacedim> &mesh,
 #ifndef _MSC_VER
-                                                std::set<typename Container<dim, spacedim>::active_cell_iterator> &searched_cells,
-                                                std::set<typename Container<dim, spacedim>::active_cell_iterator> &adjacent_cells)
+     std::set<typename MeshType<dim, spacedim>::active_cell_iterator> &searched_cells,
+     std::set<typename MeshType<dim, spacedim>::active_cell_iterator> &adjacent_cells)
 #else
-                                                std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type> &searched_cells,
-                                                std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type> &adjacent_cells)
+     std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type> &searched_cells,
+     std::set<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type> &adjacent_cells)
 #endif
     {
 #ifndef _MSC_VER
-      typedef typename Container<dim, spacedim>::active_cell_iterator cell_iterator;
+      typedef typename MeshType<dim, spacedim>::active_cell_iterator cell_iterator;
 #else
-      typedef typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type cell_iterator;
+      typedef typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type cell_iterator;
 #endif
 
       // update the searched cells
@@ -1169,7 +1170,7 @@ next_cell:
       for (; cell != endc; ++cell)
         {
           std::vector<cell_iterator> active_neighbors;
-          get_active_neighbors<Container<dim, spacedim> >(*cell, active_neighbors);
+          get_active_neighbors<MeshType<dim, spacedim> >(*cell, active_neighbors);
           for (unsigned int i=0; i<active_neighbors.size(); ++i)
             if (searched_cells.find(active_neighbors[i]) == searched_cells.end())
               adjacent_cells_new.insert(active_neighbors[i]);
@@ -1184,8 +1185,8 @@ next_cell:
           // that the domain is disconnected. in that case,
           // choose the first previously untouched cell we
           // can find
-          cell_iterator it = container.begin_active();
-          for ( ; it!=container.end(); ++it)
+          cell_iterator it = mesh.begin_active();
+          for ( ; it!=mesh.end(); ++it)
             if (searched_cells.find(it) == searched_cells.end())
               {
                 adjacent_cells.insert(it);
@@ -1195,33 +1196,33 @@ next_cell:
     }
   }
 
-  template <int dim, template<int, int> class Container, int spacedim>
+  template <int dim, template<int, int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  typename Container<dim, spacedim>::active_cell_iterator
+  typename MeshType<dim, spacedim>::active_cell_iterator
 #else
-  typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type
+  typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type
 #endif
-  find_active_cell_around_point (const Container<dim,spacedim>  &container,
-                                 const Point<spacedim> &p)
+  find_active_cell_around_point (const MeshType<dim,spacedim> &mesh,
+                                 const Point<spacedim>        &p)
   {
     return
-      find_active_cell_around_point<dim,Container,spacedim>
+      find_active_cell_around_point<dim,MeshType,spacedim>
       (StaticMappingQ1<dim,spacedim>::mapping,
-       container, p).first;
+       mesh, p).first;
   }
 
 
-  template <int dim, template <int, int> class Container, int spacedim>
+  template <int dim, template <int, int> class MeshType, int spacedim>
 #ifndef _MSC_VER
-  std::pair<typename Container<dim, spacedim>::active_cell_iterator, Point<dim> >
+  std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim> >
 #else
-  std::pair<typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type, Point<dim> >
+  std::pair<typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type, Point<dim> >
 #endif
-  find_active_cell_around_point (const Mapping<dim,spacedim>   &mapping,
-                                 const Container<dim,spacedim> &container,
-                                 const Point<spacedim>     &p)
+  find_active_cell_around_point (const Mapping<dim,spacedim>  &mapping,
+                                 const MeshType<dim,spacedim> &mesh,
+                                 const Point<spacedim>        &p)
   {
-    typedef typename dealii::internal::ActiveCellIterator<dim, spacedim, Container<dim, spacedim> >::type active_cell_iterator;
+    typedef typename dealii::internal::ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim> >::type active_cell_iterator;
 
     // The best distance is set to the
     // maximum allowable distance from
@@ -1234,8 +1235,8 @@ next_cell:
     // Find closest vertex and determine
     // all adjacent cells
     std::vector<active_cell_iterator> adjacent_cells_tmp
-      = find_cells_adjacent_to_vertex(container,
-                                      find_closest_vertex(container, p));
+      = find_cells_adjacent_to_vertex(mesh,
+                                      find_closest_vertex(mesh, p));
 
     // Make sure that we have found
     // at least one cell adjacent to vertex.
@@ -1252,7 +1253,7 @@ next_cell:
     // the cell and have not searched
     // every cell in the triangulation,
     // we keep on looking.
-    const unsigned int n_active_cells = container.get_triangulation().n_active_cells();
+    const unsigned int n_active_cells = mesh.get_triangulation().n_active_cells();
     bool found = false;
     unsigned int cells_searched = 0;
     while (!found && cells_searched < n_active_cells)
@@ -1314,8 +1315,8 @@ next_cell:
         // is for.
         if (!found && cells_searched < n_active_cells)
           {
-            find_active_cell_around_point_internal<dim,Container,spacedim>
-            (container, searched_cells, adjacent_cells);
+            find_active_cell_around_point_internal<dim,MeshType,spacedim>
+            (mesh, searched_cells, adjacent_cells);
           }
       }
 
@@ -1330,11 +1331,11 @@ next_cell:
   template <int dim, int spacedim>
   std::pair<typename hp::DoFHandler<dim,spacedim>::active_cell_iterator, Point<dim> >
   find_active_cell_around_point (const hp::MappingCollection<dim,spacedim>   &mapping,
-                                 const hp::DoFHandler<dim,spacedim> &container,
+                                 const hp::DoFHandler<dim,spacedim> &mesh,
                                  const Point<spacedim>     &p)
   {
     Assert ((mapping.size() == 1) ||
-            (mapping.size() == container.get_fe().size()),
+            (mapping.size() == mesh.get_fe().size()),
             ExcMessage ("Mapping collection needs to have either size 1 "
                         "or size equal to the number of elements in "
                         "the FECollection."));
@@ -1346,7 +1347,7 @@ next_cell:
     //we use find_active_cell_around_point using only one
     //mapping.
     if (mapping.size() == 1)
-      best_cell = find_active_cell_around_point(mapping[0], container, p);
+      best_cell = find_active_cell_around_point(mapping[0], mesh, p);
     else
       {
 
@@ -1361,10 +1362,10 @@ next_cell:
 
         // Find closest vertex and determine
         // all adjacent cells
-        unsigned int vertex = find_closest_vertex(container, p);
+        unsigned int vertex = find_closest_vertex(mesh, p);
 
         std::vector<cell_iterator> adjacent_cells_tmp =
-          find_cells_adjacent_to_vertex(container, vertex);
+          find_cells_adjacent_to_vertex(mesh, vertex);
 
         // Make sure that we have found
         // at least one cell adjacent to vertex.
@@ -1380,7 +1381,7 @@ next_cell:
         // the cell and have not searched
         // every cell in the triangulation,
         // we keep on looking.
-        const unsigned int n_cells = container.get_triangulation().n_cells();
+        const unsigned int n_cells = mesh.get_triangulation().n_cells();
         bool found = false;
         unsigned int cells_searched = 0;
         while (!found && cells_searched < n_cells)
@@ -1437,7 +1438,7 @@ next_cell:
             if (!found && cells_searched < n_cells)
               {
                 find_active_cell_around_point_internal<dim,hp::DoFHandler,spacedim>
-                (container, searched_cells, adjacent_cells);
+                (mesh, searched_cells, adjacent_cells);
               }
 
           }
@@ -1453,11 +1454,11 @@ next_cell:
   namespace
   {
 
-    template<class Container>
+    template<class MeshType>
     bool
-    contains_locally_owned_cells (const std::vector<typename Container::active_cell_iterator> &cells)
+    contains_locally_owned_cells (const std::vector<typename MeshType::active_cell_iterator> &cells)
     {
-      for (typename std::vector<typename Container::active_cell_iterator>::const_iterator
+      for (typename std::vector<typename MeshType::active_cell_iterator>::const_iterator
            it = cells.begin(); it != cells.end(); ++it)
         {
           if ((*it)->is_locally_owned())
@@ -1466,11 +1467,11 @@ next_cell:
       return false;
     }
 
-    template<class Container>
+    template<class MeshType>
     bool
-    contains_artificial_cells (const std::vector<typename Container::active_cell_iterator> &cells)
+    contains_artificial_cells (const std::vector<typename MeshType::active_cell_iterator> &cells)
     {
-      for (typename std::vector<typename Container::active_cell_iterator>::const_iterator
+      for (typename std::vector<typename MeshType::active_cell_iterator>::const_iterator
            it = cells.begin(); it != cells.end(); ++it)
         {
           if ((*it)->is_artificial())
@@ -1483,33 +1484,34 @@ next_cell:
 
 
 
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  compute_active_cell_halo_layer (const Container                                                                    &container,
-                                  const std_cxx11::function<bool (const typename Container::active_cell_iterator &)> &predicate)
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  compute_active_cell_halo_layer
+  (const MeshType                                                                    &mesh,
+   const std_cxx11::function<bool (const typename MeshType::active_cell_iterator &)> &predicate)
   {
-    std::vector<typename Container::active_cell_iterator> active_halo_layer;
-    std::vector<bool> locally_active_vertices_on_subdomain (container.get_triangulation().n_vertices(),
+    std::vector<typename MeshType::active_cell_iterator> active_halo_layer;
+    std::vector<bool> locally_active_vertices_on_subdomain (mesh.get_triangulation().n_vertices(),
                                                             false);
 
     // Find the cells for which the predicate is true
     // These are the cells around which we wish to construct
     // the halo layer
-    for (typename Container::active_cell_iterator
-         cell = container.begin_active();
-         cell != container.end(); ++cell)
+    for (typename MeshType::active_cell_iterator
+         cell = mesh.begin_active();
+         cell != mesh.end(); ++cell)
       if (predicate(cell)) // True predicate --> Part of subdomain
-        for (unsigned int v=0; v<GeometryInfo<Container::dimension>::vertices_per_cell; ++v)
+        for (unsigned int v=0; v<GeometryInfo<MeshType::dimension>::vertices_per_cell; ++v)
           locally_active_vertices_on_subdomain[cell->vertex_index(v)] = true;
 
     // Find the cells that do not conform to the predicate
     // but share a vertex with the selected subdomain
     // These comprise the halo layer
-    for (typename Container::active_cell_iterator
-         cell = container.begin_active();
-         cell != container.end(); ++cell)
+    for (typename MeshType::active_cell_iterator
+         cell = mesh.begin_active();
+         cell != mesh.end(); ++cell)
       if (!predicate(cell)) // False predicate --> Potential halo cell
-        for (unsigned int v=0; v<GeometryInfo<Container::dimension>::vertices_per_cell; ++v)
+        for (unsigned int v=0; v<GeometryInfo<MeshType::dimension>::vertices_per_cell; ++v)
           if (locally_active_vertices_on_subdomain[cell->vertex_index(v)] == true)
             {
               active_halo_layer.push_back(cell);
@@ -1521,21 +1523,21 @@ next_cell:
 
 
 
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  compute_ghost_cell_halo_layer (const Container &container)
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  compute_ghost_cell_halo_layer (const MeshType &mesh)
   {
-    std_cxx11::function<bool (const typename Container::active_cell_iterator &)> predicate
+    std_cxx11::function<bool (const typename MeshType::active_cell_iterator &)> predicate
       = IteratorFilters::LocallyOwnedCell();
 
-    const std::vector<typename Container::active_cell_iterator>
-    active_halo_layer = compute_active_cell_halo_layer (container, predicate);
+    const std::vector<typename MeshType::active_cell_iterator>
+    active_halo_layer = compute_active_cell_halo_layer (mesh, predicate);
 
     // Check that we never return locally owned or artificial cells
     // What is left should only be the ghost cells
-    Assert(contains_locally_owned_cells<Container>(active_halo_layer) == false,
+    Assert(contains_locally_owned_cells<MeshType>(active_halo_layer) == false,
            ExcMessage("Halo layer contains locally owned cells"));
-    Assert(contains_artificial_cells<Container>(active_halo_layer) == false,
+    Assert(contains_artificial_cells<MeshType>(active_halo_layer) == false,
            ExcMessage("Halo layer contains artificial cells"));
 
     return active_halo_layer;
@@ -2097,14 +2099,14 @@ next_cell:
 
 
 
-  template <typename Container>
-  std::list<std::pair<typename Container::cell_iterator,
-      typename Container::cell_iterator> >
-      get_finest_common_cells (const Container &mesh_1,
-                               const Container &mesh_2)
+  template <typename MeshType>
+  std::list<std::pair<typename MeshType::cell_iterator,
+      typename MeshType::cell_iterator> >
+      get_finest_common_cells (const MeshType &mesh_1,
+                               const MeshType &mesh_2)
   {
     Assert (have_same_coarse_mesh (mesh_1, mesh_2),
-            ExcMessage ("The two containers must be represent triangulations that "
+            ExcMessage ("The two meshes must be represent triangulations that "
                         "have the same coarse meshes"));
 
     // the algorithm goes as follows:
@@ -2123,14 +2125,14 @@ next_cell:
     // the later on for further
     // consideration
     typedef
-    std::list<std::pair<typename Container::cell_iterator,
-        typename Container::cell_iterator> >
+    std::list<std::pair<typename MeshType::cell_iterator,
+        typename MeshType::cell_iterator> >
         CellList;
 
     CellList cell_list;
 
     // first push the coarse level cells
-    typename Container::cell_iterator
+    typename MeshType::cell_iterator
     cell_1 = mesh_1.begin(0),
     cell_2 = mesh_2.begin(0);
     for (; cell_1 != mesh_1.end(0); ++cell_1, ++cell_2)
@@ -2220,10 +2222,10 @@ next_cell:
 
 
 
-  template <typename Container>
+  template <typename MeshType>
   bool
-  have_same_coarse_mesh (const Container &mesh_1,
-                         const Container &mesh_2)
+  have_same_coarse_mesh (const MeshType &mesh_1,
+                         const MeshType &mesh_2)
   {
     return have_same_coarse_mesh (mesh_1.get_triangulation(),
                                   mesh_2.get_triangulation());
@@ -2827,18 +2829,18 @@ next_cell:
 
 
 
-  template <class Container>
-  std::vector<typename Container::active_cell_iterator>
-  get_patch_around_cell(const typename Container::active_cell_iterator &cell)
+  template <class MeshType>
+  std::vector<typename MeshType::active_cell_iterator>
+  get_patch_around_cell(const typename MeshType::active_cell_iterator &cell)
   {
     Assert (cell->is_locally_owned(),
             ExcMessage ("This function only makes sense if the cell for "
                         "which you are asking for a patch, is locally "
                         "owned."));
 
-    std::vector<typename Container::active_cell_iterator> patch;
+    std::vector<typename MeshType::active_cell_iterator> patch;
     patch.push_back (cell);
-    for (unsigned int face_number=0; face_number<GeometryInfo<Container::dimension>::faces_per_cell; ++face_number)
+    for (unsigned int face_number=0; face_number<GeometryInfo<MeshType::dimension>::faces_per_cell; ++face_number)
       if (cell->face(face_number)->at_boundary()==false)
         {
           if (cell->neighbor(face_number)->has_children() == false)
@@ -2847,7 +2849,7 @@ next_cell:
             // the neighbor is refined. in 2d/3d, we can simply ask for the children
             // of the neighbor because they can not be further refined and,
             // consequently, the children is active
-            if (Container::dimension > 1)
+            if (MeshType::dimension > 1)
               {
                 for (unsigned int subface=0; subface<cell->face(face_number)->n_children(); ++subface)
                   patch.push_back (cell->neighbor_child_on_subface (face_number, subface));
@@ -2856,7 +2858,7 @@ next_cell:
               {
                 // in 1d, we need to work a bit harder: iterate until we find
                 // the child by going from cell to child to child etc
-                typename Container::cell_iterator neighbor
+                typename MeshType::cell_iterator neighbor
                   = cell->neighbor (face_number);
                 while (neighbor->has_children())
                   neighbor = neighbor->child(1-face_number);
@@ -3124,19 +3126,19 @@ next_cell:
 
 
 
-  template<typename CONTAINER>
+  template<typename MeshType>
   void
   collect_periodic_faces
-  (const CONTAINER                            &container,
-   const types::boundary_id                   b_id1,
-   const types::boundary_id                   b_id2,
-   const int                                  direction,
-   std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
-   const Tensor<1,CONTAINER::space_dimension> &offset,
-   const FullMatrix<double>                   &matrix)
+  (const MeshType                        &mesh,
+   const types::boundary_id               b_id1,
+   const types::boundary_id               b_id2,
+   const int                              direction,
+   std::vector<PeriodicFacePair<typename MeshType::cell_iterator> > &matched_pairs,
+   const Tensor<1,MeshType::space_dimension> &offset,
+   const FullMatrix<double>              &matrix)
   {
-    static const int dim = CONTAINER::dimension;
-    static const int space_dim = CONTAINER::space_dimension;
+    static const int dim = MeshType::dimension;
+    static const int space_dim = MeshType::space_dimension;
     (void)dim;
     (void)space_dim;
     Assert (0<=direction && direction<space_dim,
@@ -3145,25 +3147,25 @@ next_cell:
     // Loop over all cells on the highest level and collect all boundary
     // faces belonging to b_id1 and b_id2:
 
-    std::set<std::pair<typename CONTAINER::cell_iterator, unsigned int> > pairs1;
-    std::set<std::pair<typename CONTAINER::cell_iterator, unsigned int> > pairs2;
+    std::set<std::pair<typename MeshType::cell_iterator, unsigned int> > pairs1;
+    std::set<std::pair<typename MeshType::cell_iterator, unsigned int> > pairs2;
 
-    for (typename CONTAINER::cell_iterator cell = container.begin(0);
-         cell != container.end(0); ++cell)
+    for (typename MeshType::cell_iterator cell = mesh.begin(0);
+         cell != mesh.end(0); ++cell)
       {
         for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
           {
-            const typename CONTAINER::face_iterator face = cell->face(i);
+            const typename MeshType::face_iterator face = cell->face(i);
             if (face->at_boundary() && face->boundary_id() == b_id1)
               {
-                const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair1
+                const std::pair<typename MeshType::cell_iterator, unsigned int> pair1
                   = std::make_pair(cell, i);
                 pairs1.insert(pair1);
               }
 
             if (face->at_boundary() && face->boundary_id() == b_id2)
               {
-                const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair2
+                const std::pair<typename MeshType::cell_iterator, unsigned int> pair2
                   = std::make_pair(cell, i);
                 pairs2.insert(pair2);
               }
@@ -3180,18 +3182,18 @@ next_cell:
 
 
 
-  template<typename CONTAINER>
+  template<typename MeshType>
   void
   collect_periodic_faces
-  (const CONTAINER                            &container,
-   const types::boundary_id                   b_id,
-   const int                                  direction,
-   std::vector<PeriodicFacePair<typename CONTAINER::cell_iterator> > &matched_pairs,
-   const Tensor<1,CONTAINER::space_dimension> &offset,
-   const FullMatrix<double>                   &matrix)
+  (const MeshType                        &mesh,
+   const types::boundary_id               b_id,
+   const int                              direction,
+   std::vector<PeriodicFacePair<typename MeshType::cell_iterator> > &matched_pairs,
+   const Tensor<1,MeshType::space_dimension> &offset,
+   const FullMatrix<double>              &matrix)
   {
-    static const int dim = CONTAINER::dimension;
-    static const int space_dim = CONTAINER::space_dimension;
+    static const int dim = MeshType::dimension;
+    static const int space_dim = MeshType::space_dimension;
     (void)dim;
     (void)space_dim;
     Assert (0<=direction && direction<space_dim,
@@ -3203,25 +3205,25 @@ next_cell:
     // Loop over all cells on the highest level and collect all boundary
     // faces 2*direction and 2*direction*1:
 
-    std::set<std::pair<typename CONTAINER::cell_iterator, unsigned int> > pairs1;
-    std::set<std::pair<typename CONTAINER::cell_iterator, unsigned int> > pairs2;
+    std::set<std::pair<typename MeshType::cell_iterator, unsigned int> > pairs1;
+    std::set<std::pair<typename MeshType::cell_iterator, unsigned int> > pairs2;
 
-    for (typename CONTAINER::cell_iterator cell = container.begin(0);
-         cell != container.end(0); ++cell)
+    for (typename MeshType::cell_iterator cell = mesh.begin(0);
+         cell != mesh.end(0); ++cell)
       {
-        const typename CONTAINER::face_iterator face_1 = cell->face(2*direction);
-        const typename CONTAINER::face_iterator face_2 = cell->face(2*direction+1);
+        const typename MeshType::face_iterator face_1 = cell->face(2*direction);
+        const typename MeshType::face_iterator face_2 = cell->face(2*direction+1);
 
         if (face_1->at_boundary() && face_1->boundary_id() == b_id)
           {
-            const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair1
+            const std::pair<typename MeshType::cell_iterator, unsigned int> pair1
               = std::make_pair(cell, 2*direction);
             pairs1.insert(pair1);
           }
 
         if (face_2->at_boundary() && face_2->boundary_id() == b_id)
           {
-            const std::pair<typename CONTAINER::cell_iterator, unsigned int> pair2
+            const std::pair<typename MeshType::cell_iterator, unsigned int> pair2
               = std::make_pair(cell, 2*direction+1);
             pairs2.insert(pair2);
           }

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -29,8 +29,8 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <class GridClass>
-InterGridMap<GridClass>::InterGridMap ()
+template <class MeshType>
+InterGridMap<MeshType>::InterGridMap ()
   :
   source_grid(0, typeid(*this).name()),
   destination_grid(0, typeid(*this).name())
@@ -39,9 +39,9 @@ InterGridMap<GridClass>::InterGridMap ()
 
 
 
-template <class GridClass>
-void InterGridMap<GridClass>::make_mapping (const GridClass &source_grid,
-                                            const GridClass &destination_grid)
+template <class MeshType>
+void InterGridMap<MeshType>::make_mapping (const MeshType &source_grid,
+                                           const MeshType &destination_grid)
 {
   // first delete all contents
   clear ();
@@ -50,7 +50,7 @@ void InterGridMap<GridClass>::make_mapping (const GridClass &source_grid,
   this->source_grid      = &source_grid;
   this->destination_grid = &destination_grid;
 
-  // then set up the containers from
+  // then set up the meshes from
   // scratch and fill them with end-iterators
   const unsigned int n_levels = source_grid.get_triangulation().n_levels();
   mapping.resize (n_levels);
@@ -96,10 +96,10 @@ void InterGridMap<GridClass>::make_mapping (const GridClass &source_grid,
 
 
 
-template <class GridClass>
+template <class MeshType>
 void
-InterGridMap<GridClass>::set_mapping (const cell_iterator &src_cell,
-                                      const cell_iterator &dst_cell)
+InterGridMap<MeshType>::set_mapping (const cell_iterator &src_cell,
+                                     const cell_iterator &dst_cell)
 {
   // first set the map for this cell
   mapping[src_cell->level()][src_cell->index()] = dst_cell;
@@ -109,14 +109,14 @@ InterGridMap<GridClass>::set_mapping (const cell_iterator &src_cell,
   if (src_cell->has_children() && dst_cell->has_children())
     {
       Assert(src_cell->n_children()==
-             GeometryInfo<GridClass::dimension>::max_children_per_cell,
+             GeometryInfo<MeshType::dimension>::max_children_per_cell,
              ExcNotImplemented());
       Assert(dst_cell->n_children()==
-             GeometryInfo<GridClass::dimension>::max_children_per_cell,
+             GeometryInfo<MeshType::dimension>::max_children_per_cell,
              ExcNotImplemented());
       Assert(src_cell->refinement_case()==dst_cell->refinement_case(),
              ExcNotImplemented());
-      for (unsigned int c=0; c<GeometryInfo<GridClass::dimension>::max_children_per_cell; ++c)
+      for (unsigned int c=0; c<GeometryInfo<MeshType::dimension>::max_children_per_cell; ++c)
         set_mapping (src_cell->child(c),
                      dst_cell->child(c));
     }
@@ -136,10 +136,10 @@ InterGridMap<GridClass>::set_mapping (const cell_iterator &src_cell,
 
 
 
-template <class GridClass>
+template <class MeshType>
 void
-InterGridMap<GridClass>::set_entries_to_cell (const cell_iterator &src_cell,
-                                              const cell_iterator &dst_cell)
+InterGridMap<MeshType>::set_entries_to_cell (const cell_iterator &src_cell,
+                                             const cell_iterator &dst_cell)
 {
   // first set the map for this cell
   mapping[src_cell->level()][src_cell->index()] = dst_cell;
@@ -153,9 +153,9 @@ InterGridMap<GridClass>::set_entries_to_cell (const cell_iterator &src_cell,
 }
 
 
-template <class GridClass>
-typename InterGridMap<GridClass>::cell_iterator
-InterGridMap<GridClass>::operator [] (const cell_iterator &source_cell) const
+template <class MeshType>
+typename InterGridMap<MeshType>::cell_iterator
+InterGridMap<MeshType>::operator [] (const cell_iterator &source_cell) const
 {
   Assert (source_cell.state() == IteratorState::valid,
           ExcInvalidKey (source_cell));
@@ -169,8 +169,8 @@ InterGridMap<GridClass>::operator [] (const cell_iterator &source_cell) const
 
 
 
-template <class GridClass>
-void InterGridMap<GridClass>::clear ()
+template <class MeshType>
+void InterGridMap<MeshType>::clear ()
 {
   mapping.clear ();
   source_grid      = 0;
@@ -179,27 +179,27 @@ void InterGridMap<GridClass>::clear ()
 
 
 
-template <class GridClass>
-const GridClass &
-InterGridMap<GridClass>::get_source_grid () const
+template <class MeshType>
+const MeshType &
+InterGridMap<MeshType>::get_source_grid () const
 {
   return *source_grid;
 }
 
 
 
-template <class GridClass>
-const GridClass &
-InterGridMap<GridClass>::get_destination_grid () const
+template <class MeshType>
+const MeshType &
+InterGridMap<MeshType>::get_destination_grid () const
 {
   return *destination_grid;
 }
 
 
 
-template <class GridClass>
+template <class MeshType>
 std::size_t
-InterGridMap<GridClass>::memory_consumption () const
+InterGridMap<MeshType>::memory_consumption () const
 {
   return (MemoryConsumption::memory_consumption (mapping) +
           MemoryConsumption::memory_consumption (source_grid) +


### PR DESCRIPTION
This PR consistently names 'the thing that `DoFHandler`s and `Triangulation`s are' as ~~`Mesh`~~ `MeshType`. I believe ~~`Mesh`~~ `MeshType` is an improvement over `Container` and `GridClass`, which are the two currently in use. If anyone has a better name I would like to hear it!

This PR also moves the discussion on 'Meshes as Containers' into `concepts.h`.