### PR TITLE
Remove whitespace in get fe by name

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -845,7 +845,8 @@ namespace FETools
 
   /**
    * Parse the name of a finite element and generate a finite element object
-   * accordingly.
+   * accordingly. The parser ignores space characters between words (things
+   * matching the regular expression [A-Za-z0-9_]).
    *
    * The name must be in the form which is returned by the
    * FiniteElement::get_name function, where dimension template parameters

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -50,6 +50,7 @@
 
 #include <deal.II/base/index_set.h>
 
+#include <cctype>
 #include <iostream>
 
 
@@ -1547,10 +1548,27 @@ namespace FETools
   FiniteElement<dim, spacedim> *
   get_fe_by_name (const std::string &parameter_name)
   {
+    std::string name = Utilities::trim(parameter_name);
+    std::size_t index = 1;
+    // remove spaces that are not between two word (things that match the
+    // regular expression [A-Za-z0-9_]) characters.
+    while (2 < name.size() && index < name.size() - 1)
+      {
+        if (name[index] == ' ' &&
+            (!(std::isalnum(name[index - 1]) || name[index - 1] == '_') ||
+             !(std::isalnum(name[index + 1]) || name[index + 1] == '_')))
+          {
+            name.erase(index, 1);
+          }
+        else
+          {
+            ++index;
+          }
+      }
+
     // Create a version of the name
     // string where all template
     // parameters are eliminated.
-    std::string name = parameter_name;
     for (unsigned int pos1 = name.find('<');
          pos1 < name.size();
          pos1 = name.find('<'))

--- a/tests/fe/get_fe_from_name_01.cc
+++ b/tests/fe/get_fe_from_name_01.cc
@@ -75,7 +75,7 @@ int main ()
 
   // gen.generate("FE_Q_Hierarchical(1)");
   // gen.generate("FE_DGPNonparametric(1)");
-  gen.generate("FE_DGQ(1)");
+  gen.generate("FE_DGQ     (1)");
   gen.generate("FE_Q(1)");
 
   // gen.generate("FE_Q_Hierarchical(2)");
@@ -95,7 +95,7 @@ int main ()
 
   // gen.generate("FESystem[FE_Q_Hierarchical(1)^2-FE_DGQ(1)]");
   // gen.generate("FESystem[FE_DGPNonparametric(1)^2-FE_DGQ(1)]");
-  gen.generate("FESystem[FE_DGQ(1)^2-FE_DGQ(1)]");
+  gen.generate("      FESystem[FE_DGQ(1)^2     -FE_DGQ(1)]");
   gen.generate("FESystem[FE_Q(1)^2-FE_DGQ(1)]");
 
 

--- a/tests/fe/get_fe_from_name_01.output
+++ b/tests/fe/get_fe_from_name_01.output
@@ -1,5 +1,5 @@
 
-DEAL::Read FE_DGQ(1)
+DEAL::Read FE_DGQ     (1)
 DEAL::Generated :
 DEAL::FE_DGQ<1>(1)
 DEAL::FE_DGQ<2>(1)
@@ -31,7 +31,7 @@ DEAL::FE_Q<3>(2)
 DEAL::FE_Q<1,2>(2)
 DEAL::FE_Q<1,3>(2)
 DEAL::FE_Q<2,3>(2)
-DEAL::Read FESystem[FE_DGQ(1)^2-FE_DGQ(1)]
+DEAL::Read       FESystem[FE_DGQ(1)^2     -FE_DGQ(1)]
 DEAL::Generated :
 DEAL::FESystem<1>[FE_DGQ<1>(1)^2-FE_DGQ<1>(1)]
 DEAL::FESystem<2>[FE_DGQ<2>(1)^2-FE_DGQ<2>(1)]


### PR DESCRIPTION
This should close #2099. It fixes the issue in #2098, where `get_fe_by_name` choked if the string contained unexpected whitespace.