### PR TITLE
Skip whitespace at the start of continuing lines.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -885,9 +885,11 @@ inconvenience this causes.
   (Timo Heister, 2015/09/05)
   </li>
 
-  <li> Improved: Allow continuation lines in ParameterHandler.
+  <li> Improved: Allow continuation lines in ParameterHandler. Any line in a
+  parameter file ending with a <tt>\\</tt> will now be combined with the next
+  line; see ParameterHandler's documentation for more information.
   <br>
-  (Alberto Sartori, 2015/09/04, David Wells, 2016/01/18)
+  (Alberto Sartori, 2015/09/04, David Wells, 2016/01/18-2016/01/28)
   </li>
 
   <li> New: There is now a function SparsityPattern::print_svg() which prints the sparsity of the matrix

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1496,6 +1496,8 @@ namespace Patterns
  *
  * @ingroup input
  * @author Wolfgang Bangerth, October 1997, revised February 1998, 2010, 2011
+ * @author Alberto Sartori, 2015
+ * @author David Wells, 2016
  */
 class ParameterHandler : public Subscriptor
 {

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1016,8 +1016,11 @@ namespace Patterns
  *
  * Comments starting with \# are skipped.
  *
- * Continuation lines are allowed by means of the character <tt>\\</tt>,
- * which must be the last character of the line.
+ * Continuation lines are allowed by means of the character <tt>\\</tt>, which
+ * must be the last character (aside from whitespace, which is ignored) of the
+ * line. When a line is a continuation (i.e., the previous line ended in a
+ * <tt>\\</tt>), then, unlike the default behavior of the <tt>C</tt>
+ * preprocessor, all whitespace at the beginning of the line is ignored.
  *
  * We propose to use the following scheme to name entries: start the first
  * word with a capital letter and use lowercase letters further on. The same

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1381,6 +1381,13 @@ bool ParameterHandler::read_input (std::istream &input,
         }
     }
 
+  // While it does not make much sense for anyone to actually do this, allow
+  // the last line to end in a backslash.
+  if (is_concatenated)
+    {
+      status &= scan_line (fully_concatenated_line, filename, current_line_n);
+    }
+
   if (status && (saved_path != subsection_path))
     {
       std::cerr << "Unbalanced 'subsection'/'end' in file <" << filename

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1346,6 +1346,9 @@ bool ParameterHandler::read_input (std::istream &input,
   while (std::getline (input, input_line))
     {
       ++current_line_n;
+      // Trim the whitespace at the ends of the line here instead of in
+      // scan_line. This makes the continuation line logic a lot simpler.
+      input_line = Utilities::trim (input_line);
 
       // check whether or not the current line should be joined with the next
       // line before calling scan_line.

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1350,12 +1350,12 @@ bool ParameterHandler::read_input (std::istream &input,
       // scan_line. This makes the continuation line logic a lot simpler.
       input_line = Utilities::trim (input_line);
 
-      // check whether or not the current line should be joined with the next
+      // Check whether or not the current line should be joined with the next
       // line before calling scan_line.
       if (input_line.length() != 0 &&
           input_line.find_last_of('\\') == input_line.length() - 1)
         {
-          input_line.erase(input_line.length() - 1); // remove the last '\'
+          input_line.erase (input_line.length() - 1); // remove the last '\'
           is_concatenated = true;
 
           fully_concatenated_line += input_line;
@@ -1367,7 +1367,7 @@ bool ParameterHandler::read_input (std::istream &input,
           fully_concatenated_line += input_line;
           is_concatenated = false;
         }
-      // finally, if neither the previous nor current lines are continuations,
+      // Finally, if neither the previous nor current lines are continuations,
       // then the current input line is entirely concatenated.
       else
         {

--- a/tests/bits/parameter_handler_backslash_01.cc
+++ b/tests/bits/parameter_handler_backslash_01.cc
@@ -19,6 +19,16 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * Test that ParameterHandler can read parameters of the form
+ *
+ *     set Function = a, \
+ *                    b, \
+ *                    c
+ *
+ * correctly. The main point of this test is to exercise the
+ * backslash-handling part of ParameterHandler.
+ */
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_02.cc
+++ b/tests/bits/parameter_handler_backslash_02.cc
@@ -19,6 +19,18 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * Test that ParameterHandler can read parameters of the form
+ *
+ *     set Function = a,\
+ *                    \
+ *                    b,\
+ *     \
+ *                    c
+ *
+ * correctly. This tests how ParameterHandler handles lines that are blank
+ * aside from whitespace and a continuation ('\') character.
+ */
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_03.cc
+++ b/tests/bits/parameter_handler_backslash_03.cc
@@ -19,6 +19,14 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * Test that ParameterHandler does not join lines for things like
+ *
+ *     set Function = a,\ # first term
+ *                    b
+ *
+ * since there are non-whitespace characters after the '\'.
+ */
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_04.cc
+++ b/tests/bits/parameter_handler_backslash_04.cc
@@ -19,6 +19,12 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * Test that ParameterHandler does *not* join lines for things like
+ *
+ *      set Function = a,\ b,
+ *                     c
+ */
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_05.cc
+++ b/tests/bits/parameter_handler_backslash_05.cc
@@ -19,6 +19,17 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * Test that ParameterHandler will stop a line continuation if a completely
+ * blank line follows one with a '\', such as
+ *
+ *     set Function_1 = a, \
+ *
+ *                      b, \
+ *                      c
+ *
+ * This should *not* be parsed as 'Function_1 = a, b, c'.
+ */
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_06.cc
+++ b/tests/bits/parameter_handler_backslash_06.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("Function",
+                         "a",
+                         Patterns::List(Patterns::Selection("a|b|c|d|e|f|g|h")));
+      prm.leave_subsection ();
+
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_06.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_06.prm");
+          prm.read_input(input_stream);
+        }
+
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("Function");
+      prm.leave_subsection ();
+
+      deallog << list << std::endl;
+    }
+
+  return 0;
+}

--- a/tests/bits/parameter_handler_backslash_06.cc
+++ b/tests/bits/parameter_handler_backslash_06.cc
@@ -14,6 +14,11 @@
 // ---------------------------------------------------------------------
 
 
+/*
+ * Test that ParameterHandler will ignore whitespace characters following a
+ * '\' character when joining lines.
+ */
+
 #include "../tests.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/parameter_handler.h>

--- a/tests/bits/parameter_handler_backslash_06.output
+++ b/tests/bits/parameter_handler_backslash_06.output
@@ -1,0 +1,3 @@
+
+DEAL::a, b, c
+DEAL::a, b, c

--- a/tests/bits/parameter_handler_backslash_07.cc
+++ b/tests/bits/parameter_handler_backslash_07.cc
@@ -19,6 +19,18 @@
 #include <deal.II/base/parameter_handler.h>
 #include <fstream>
 
+/*
+ * If a parameter file line ends in a '\', then the whitespace at at the
+ * beginning of the next line is ignored when joining the lines. For example,
+ * the input
+ *
+ *      set value = val\
+ *                  u\
+ *                  e
+ *
+ * is parsed as 'set value = value'.
+ */
+
 
 int main ()
 {

--- a/tests/bits/parameter_handler_backslash_07.cc
+++ b/tests/bits/parameter_handler_backslash_07.cc
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("value", "value", Patterns::Anything());
+      prm.leave_subsection ();
+
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_07.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_07.prm");
+          prm.read_input(input_stream);
+        }
+
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("value");
+      prm.leave_subsection ();
+
+      deallog << list << std::endl;
+    }
+
+  return 0;
+}

--- a/tests/bits/parameter_handler_backslash_07.output
+++ b/tests/bits/parameter_handler_backslash_07.output
@@ -1,0 +1,3 @@
+
+DEAL::value
+DEAL::value

--- a/tests/bits/parameter_handler_backslash_08.cc
+++ b/tests/bits/parameter_handler_backslash_08.cc
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+
+/*
+ * Test that the last line in a parameter file can end in a '\' with no ill
+ * effect.
+ */
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      ParameterHandler prm;
+      prm.enter_subsection ("Testing");
+      prm.declare_entry ("value", "value", Patterns::Anything());
+      prm.leave_subsection ();
+
+      // test both relevant read_input functions
+      if (i == 0)
+        {
+          prm.read_input(SOURCE_DIR "/prm/parameter_handler_backslash_08.prm");
+        }
+      else
+        {
+          std::ifstream input_stream
+          (SOURCE_DIR "/prm/parameter_handler_backslash_08.prm");
+          prm.read_input(input_stream);
+        }
+
+      std::string list;
+      prm.enter_subsection ("Testing");
+      list = prm.get ("value");
+      prm.leave_subsection ();
+
+      deallog << list << std::endl;
+    }
+
+  return 0;
+}

--- a/tests/bits/parameter_handler_backslash_08.output
+++ b/tests/bits/parameter_handler_backslash_08.output
@@ -1,0 +1,3 @@
+
+DEAL::value
+DEAL::value

--- a/tests/bits/prm/parameter_handler_backslash_06.prm
+++ b/tests/bits/prm/parameter_handler_backslash_06.prm
@@ -1,0 +1,7 @@
+# Whitespace characters after '\'s are ignored.
+#----------------------------------------------
+subsection Testing # note the spaces and tab at the end of the next line.
+  set Function = a,\      	
+                 b,\
+                 c
+end

--- a/tests/bits/prm/parameter_handler_backslash_07.prm
+++ b/tests/bits/prm/parameter_handler_backslash_07.prm
@@ -1,0 +1,7 @@
+# whitespace at the beginning of a line is always ignored.
+#---------------------------------------------------------
+subsection Testing
+  set value = val\
+              u\
+              e
+end

--- a/tests/bits/prm/parameter_handler_backslash_08.prm
+++ b/tests/bits/prm/parameter_handler_backslash_08.prm
@@ -1,0 +1,5 @@
+# Allow the last line to end with a '\'.
+#---------------------------------------
+subsection Testing
+  set value = value
+end\


### PR DESCRIPTION
This addresses #2098 with the following behavior:

1. If anything  follows a `\` then the lines are not joined. @asartori86 pointed out that this is how the code used to work (before #2078) so I think it is the right place to begin a discussion (I also think it is the right choice, but I am interested to hear other perspectives).
2. #2098 should be fixed by removing whitespace at the beginning of each line before any lines are joined or `scan_line` is called.