### PR TITLE
fix test codim_one/error_estimator_02

### DIFF
--- a/tests/codim_one/error_estimator_02.cc
+++ b/tests/codim_one/error_estimator_02.cc
@@ -72,7 +72,7 @@ public:
                         const unsigned int  component) const
   {
     double val = 0.0;
-    if (abs(p(1)-1.0)<1e-5)
+    if (std::abs(p(1)-1.0)<1e-5)
       val = 2.0;
 
     deallog << "evaluate normal derivative at " << p << " with value " << val << std::endl;


### PR DESCRIPTION
fixes dealii/tests/codim_one/error_estimator_02.cc:75:9: warning: using
integer absolute value function 'abs' when argument is of floating point
type [-Wabsolute-value]
    if (abs(p(1)-1.0)<1e-5)