### PR TITLE
Remove an unused argument of FiniteElementData.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,15 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Changed: The constructor of FiniteElementData had a last argument
+  <code>n_blocks</code> that was not actually used by the class to
+  initialize anything. It has been removed. In addition, the default
+  constructor of FiniteElementData has also been removed given that it
+  only creates a dysfunctional element.
+  <br>
+  (Wolfgang Bangerth, 2016/01/23).
+  </li>
+
   <li> Rework: SLEPcWrappers were reworked to allow usage of PETSc solvers
   and preconditioners inside SLEPc's eigensolvers. To that end extra methods
   were introduced to PETSc wrappers. Moreover, initialization of the
@@ -48,7 +57,7 @@ inconvenience this causes.
   (Denis Davydov, 2015/12/29).
   </li>
 
-  <li> Removed the deprecated Operator class in the Algorithms namespace.
+  <li> Removed: The deprecated Operator class in the Algorithms namespace.
   <br>
   (Timo Heister, 2015/12/21)
   </li>

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -340,14 +340,11 @@ public:
    *   $H_\text{div}$ conforming; finally, completely discontinuous
    *   elements (implemented by the FE_DGQ class) are only $L_2$
    *   conforming.
-   *
-   * @param[in] n_blocks obsolete and ignored.
    */
   FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
                      const unsigned int               n_components,
                      const unsigned int               degree,
-                     const Conformity                 conformity = unknown,
-                     const unsigned int               n_blocks = numbers::invalid_unsigned_int);
+                     const Conformity                 conformity = unknown);
 
   /**
    * Number of dofs per vertex.

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -311,13 +311,6 @@ public:
   BlockIndices block_indices_data;
 
   /**
-   * Default constructor. Constructs an element with no dofs. Checking
-   * n_dofs_per_cell() is therefore a good way to check if something went
-   * wrong.
-   */
-  FiniteElementData ();
-
-  /**
    * Constructor, computing all necessary values from the distribution of dofs
    * to geometrical objects.
    *

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -30,7 +30,7 @@ FE_DGVector<PolynomialType,dim,spacedim>::FE_DGVector (
   FE_PolyTensor<PolynomialType, dim, spacedim>(
     deg,
     FiniteElementData<dim>(
-      get_dpo_vector(deg), dim, deg+1, FiniteElementData<dim>::L2, 1),
+      get_dpo_vector(deg), dim, deg+1, FiniteElementData<dim>::L2),
     std::vector<bool>(PolynomialType::compute_n_pols(deg), true),
     std::vector<ComponentMask>(PolynomialType::compute_n_pols(deg),
                                ComponentMask(dim,true)))

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -45,7 +45,7 @@ FE_ABF<dim>::FE_ABF (const unsigned int deg)
   FE_PolyTensor<PolynomialsABF<dim>, dim> (
     deg,
     FiniteElementData<dim>(get_dpo_vector(deg),
-                           dim, deg+1, FiniteElementData<dim>::Hdiv, 1),
+                           dim, deg+1, FiniteElementData<dim>::Hdiv),
     std::vector<bool>(PolynomialsABF<dim>::compute_n_pols(deg), true),
     std::vector<ComponentMask>(PolynomialsABF<dim>::compute_n_pols(deg),
                                std::vector<bool>(dim,true))),

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -39,7 +39,7 @@ FE_BDM<dim>::FE_BDM (const unsigned int deg)
   FE_PolyTensor<PolynomialsBDM<dim>, dim> (
     deg,
     FiniteElementData<dim>(get_dpo_vector(deg),
-                           dim, deg+1, FiniteElementData<dim>::Hdiv, 1),
+                           dim, deg+1, FiniteElementData<dim>::Hdiv),
     get_ria_vector (deg),
     std::vector<ComponentMask>(PolynomialsBDM<dim>::compute_n_pols(deg),
                                std::vector<bool>(dim,true)))

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -23,8 +23,7 @@ FiniteElementData<dim>::
 FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
                    const unsigned int n_components,
                    const unsigned int degree,
-                   const Conformity conformity,
-                   const unsigned int)
+                   const Conformity conformity)
   :
   dofs_per_vertex(dofs_per_object[0]),
   dofs_per_line(dofs_per_object[1]),

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -18,28 +18,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<int dim>
-FiniteElementData<dim>::FiniteElementData ()
-  :
-  dofs_per_vertex(0),
-  dofs_per_line(0),
-  dofs_per_quad(0),
-  dofs_per_hex(0),
-  first_line_index(0),
-  first_quad_index(0),
-  first_hex_index(0),
-  first_face_line_index(0),
-  first_face_quad_index(0),
-  dofs_per_face(0),
-  dofs_per_cell (0),
-  components(0),
-  degree(0),
-  conforming_space(unknown),
-  cached_primitivity(false)
-{}
-
-
-
 template <int dim>
 FiniteElementData<dim>::
 FiniteElementData (const std::vector<unsigned int> &dofs_per_object,

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -46,7 +46,7 @@ FE_Nedelec<dim>::FE_Nedelec (const unsigned int p) :
   FE_PolyTensor<PolynomialsNedelec<dim>, dim>
   (p,
    FiniteElementData<dim> (get_dpo_vector (p), dim, p + 1,
-                           FiniteElementData<dim>::Hcurl, 1),
+                           FiniteElementData<dim>::Hcurl),
    std::vector<bool> (PolynomialsNedelec<dim>::compute_n_pols (p), true),
    std::vector<ComponentMask>
    (PolynomialsNedelec<dim>::compute_n_pols (p),

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -45,7 +45,7 @@ FE_RaviartThomas<dim>::FE_RaviartThomas (const unsigned int deg)
   FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim> (
     deg,
     FiniteElementData<dim>(get_dpo_vector(deg),
-                           dim, deg+1, FiniteElementData<dim>::Hdiv, 1),
+                           dim, deg+1, FiniteElementData<dim>::Hdiv),
     std::vector<bool>(PolynomialsRaviartThomas<dim>::compute_n_pols(deg), true),
     std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::compute_n_pols(deg),
                                std::vector<bool>(dim,true)))

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -38,7 +38,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal (const unsigned int deg)
   FE_PolyTensor<PolynomialsRaviartThomas<dim>, dim> (
     deg,
     FiniteElementData<dim>(get_dpo_vector(deg),
-                           dim, deg+1, FiniteElementData<dim>::Hdiv, 1),
+                           dim, deg+1, FiniteElementData<dim>::Hdiv),
     get_ria_vector (deg),
     std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::compute_n_pols(deg),
                                std::vector<bool>(dim,true)))

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -2449,8 +2449,6 @@ FESystem<dim,spacedim>::multiply_dof_numbers (
 
   unsigned int degree = 0; // degree is the maximal degree of the components
 
-  unsigned int summed_multiplicities = 0;
-
   for (unsigned int i=0; i<fes.size(); i++)
     if (multiplicities[i]>0)
       {
@@ -2462,8 +2460,6 @@ FESystem<dim,spacedim>::multiply_dof_numbers (
         multiplied_n_components+=fes[i]->n_components() * multiplicities[i];
 
         degree = std::max(degree, fes[i]->tensor_degree() );
-
-        summed_multiplicities += multiplicities[i];
       }
 
   // assume conformity of the first finite element and then take away
@@ -2497,8 +2493,7 @@ FESystem<dim,spacedim>::multiply_dof_numbers (
   return FiniteElementData<dim> (dpo,
                                  multiplied_n_components,
                                  degree,
-                                 total_conformity,
-                                 summed_multiplicities);
+                                 total_conformity);
 }
 
 


### PR DESCRIPTION
As pointed out in #1378, the value of the last argument of FiniteElementData was unused by this
class, but several derived classes passed something down anyway. Fix this by simply
removing the argument and adjusting the calling sites. This fixes #1378.

While I was there I also removed the default constructor of FiniteElementData.
It creates an object that is not functional, so there is no point in keeping
it around. It turns out that it is also never used.