### PR TITLE
Initialize the last non-const field of FiniteElementData from constructor arguments

### DIFF
--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -308,7 +308,7 @@ public:
    * element. For an element which is not an FESystem, this contains only a
    * single block with length #dofs_per_cell.
    */
-  BlockIndices block_indices_data;
+  const BlockIndices block_indices_data;
 
   /**
    * Constructor, computing all necessary values from the distribution of dofs
@@ -340,11 +340,19 @@ public:
    *   $H_\text{div}$ conforming; finally, completely discontinuous
    *   elements (implemented by the FE_DGQ class) are only $L_2$
    *   conforming.
+   *
+   * @param[in] block_indices An argument that describes how the base elements
+   *   of a finite element are grouped. The default value constructs a single
+   *   block that consists of all @p dofs_per_cell degrees of freedom. This
+   *   is appropriate for all "atomic" elements (including non-primitive ones)
+   *   and these can therefore omit this argument. On the other hand, composed
+   *   elements such as FESystem will want to pass a different value here.
    */
   FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
                      const unsigned int               n_components,
                      const unsigned int               degree,
-                     const Conformity                 conformity = unknown);
+                     const Conformity                 conformity = unknown,
+                     const BlockIndices              &block_indices = BlockIndices());
 
   /**
    * Number of dofs per vertex.

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -74,7 +74,8 @@ public:
   /**
    * Specialized constructor for a structure with blocks of equal size.
    */
-  explicit BlockIndices(const unsigned int n_blocks, const size_type block_size = 0);
+  explicit BlockIndices(const unsigned int n_blocks,
+                        const size_type block_size = 0);
 
   /**
    * Reinitialize the number of blocks and assign each block the same number
@@ -259,9 +260,8 @@ BlockIndices::BlockIndices ()
 
 
 inline
-BlockIndices::BlockIndices (
-  const unsigned int n_blocks,
-  const size_type block_size)
+BlockIndices::BlockIndices (const unsigned int n_blocks,
+                            const size_type block_size)
   :
   n_blocks(n_blocks),
   start_indices(n_blocks+1)

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -21,9 +21,10 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim>
 FiniteElementData<dim>::
 FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
-                   const unsigned int n_components,
-                   const unsigned int degree,
-                   const Conformity conformity)
+                   const unsigned int               n_components,
+                   const unsigned int               degree,
+                   const Conformity                 conformity,
+                   const BlockIndices              &block_indices)
   :
   dofs_per_vertex(dofs_per_object[0]),
   dofs_per_line(dofs_per_object[1]),
@@ -56,7 +57,11 @@ FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
   components(n_components),
   degree(degree),
   conforming_space(conformity),
-  block_indices_data(1, dofs_per_cell)
+  block_indices_data(block_indices.size() == 0
+                     ?
+                     BlockIndices(1, dofs_per_cell)
+                     :
+                     block_indices)
 {
   Assert(dofs_per_object.size()==dim+1, ExcDimensionMismatch(dofs_per_object.size()-1,dim));
 }


### PR DESCRIPTION
`FiniteElementData` had a single non-`const` member variable left that is initialized to something that's reasonable for almost all derived classes in the constructor, but later overwritten in `FESystem` that needs a different value.

This patch makes the member `const`, provides the constructor with a (defaulted) argument of the appropriate type, and makes sure that `FESystem` computes the appropriate value during initialization of member variables already, rather than a later point in the constructor.

Fixes #2104. In reference to #1198.