### PR TITLE
Remove internal update_once/update_each functions

### DIFF
--- a/doc/doxygen/headers/update_flags.h
+++ b/doc/doxygen/headers/update_flags.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013, 2015 by the deal.II authors
+// Copyright (C) 2006 - 2013, 2015, 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -172,7 +172,7 @@
  * sufficient to evaluate the values of shape functions on a particular cell.)
  * 
  * To accommodate this structure, both mappings and finite element classes
- * internally split the update flags into two sets commonly referenced as
+ * may internally split the update flags into two sets commonly referenced as
  * <code>update_once</code> and <code>update_each</code>. The former contains
  * all those pieces of information that can be pre-computed once at the
  * time the FEValues object starts to interact with a mapping or
@@ -246,15 +246,11 @@
  * </ul>
  * 
  * This is, where the actual data fields for FEValues, stored in
- * FEValuesData objects is computed. These functions call the function in
- * Mapping first, such that all the mapping data required by the finite
- * element is available. Then, the FiniteElement function is called.
- * 
- * When this happens for the first time after initialization, all the
- * values specified by Mapping::InternalDataBase::update_once or
- * Mapping::InternalDataBase::update_each are filled. After that, only
- * the values specified by Mapping::InternalDataBase::update_each will be
- * updated.
+ * internal::FEValues::MappingRelatedData and
+ * internal::FEValues::FiniteElementRelatedData objects, are
+ * computed. These functions call the function in Mapping first, such
+ * that all the mapping data required by the finite element is
+ * available. Then, the FiniteElement function is called.
  * 
  * @ingroup feall
  */

--- a/doc/doxygen/headers/update_flags.h
+++ b/doc/doxygen/headers/update_flags.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2013, 2015, 2016 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -595,29 +595,9 @@ private:
    * within the constructor to be passed to the constructor of @p
    * FiniteElementData.
    */
-  static std::vector<unsigned int> get_dpo_vector (const unsigned int degree);
-
-  /**
-   * Given a set of flags indicating what quantities are requested from a @p
-   * FEValues object, return which of these can be precomputed once and for
-   * all. Often, the values of shape function at quadrature points can be
-   * precomputed, for example, in which case the return value of this function
-   * would be the logical and of the input @p flags and @p update_values.
-   *
-   * For the present kind of finite element, this is exactly the case.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * This is the opposite to the above function: given a set of flags
-   * indicating what we want to know, return which of these need to be
-   * computed each time we visit a new cell.
-   *
-   * If for the computation of one quantity something else is also required
-   * (for example, we often need the covariant transformation when gradients
-   * need to be computed), include this in the result as well.
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
+  static
+  std::vector<unsigned int>
+  get_dpo_vector (const unsigned int degree);
 
   /**
    * Degree of the polynomials.

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -257,7 +257,7 @@ protected:
     // generate a new data object and initialize some fields
     typename FiniteElement<1,spacedim>::InternalDataBase *data =
       new typename FiniteElement<1,spacedim>::InternalDataBase;
-    data->update_each = update_once(update_flags) | update_each(update_flags);  // FIX: only update_each required
+    data->update_each = requires_update_flags(update_flags);
 
     const unsigned int n_q_points = quadrature.size();
     AssertDimension(n_q_points, 1);
@@ -315,58 +315,13 @@ protected:
                           const typename FiniteElement<1,spacedim>::InternalDataBase        &fe_internal,
                           dealii::internal::FEValues::FiniteElementRelatedData<1, spacedim> &output_data) const;
 
-
-  /**
-   * Determine the values that need to be computed on the unit cell to be able
-   * to compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   * Therefore, the effect in this element is as follows: if
-   * <tt>update_values</tt> is set in <tt>flags</tt>, copy it to the result.
-   * All other flags of the result are cleared, since everything else must be
-   * computed for each cell.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * Determine the values that need to be computed on every cell to be able to
-   * compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   *
-   * The effect in this element is as follows:
-   * <ul>
-   *
-   * <li> if <tt>update_gradients</tt> is set, the result will contain
-   * <tt>update_gradients</tt> and <tt>update_covariant_transformation</tt>.
-   * The latter is required to transform the gradient on the unit cell to the
-   * real cell. Remark, that the action required by
-   * <tt>update_covariant_transformation</tt> is actually performed by the
-   * Mapping object used in conjunction with this finite element.
-   *
-   * <li> if <tt>update_hessians</tt> is set, the result will contain
-   * <tt>update_hessians</tt> and <tt>update_covariant_transformation</tt>.
-   * The rationale is the same as above and no higher derivatives of the
-   * transformation are required, since we use difference quotients for the
-   * actual computation.
-   *
-   * </ul>
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
-
 private:
   /**
    * Return vector with dofs per vertex, line, quad, hex.
    */
-  static std::vector<unsigned int> get_dpo_vector (const unsigned int deg);
+  static
+  std::vector<unsigned int>
+  get_dpo_vector (const unsigned int deg);
 };
 
 

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -58,12 +58,6 @@ DEAL_II_NAMESPACE_OPEN
  * FiniteElement classes which cannot be implemented by this class but are left
  * for implementation in derived classes.
  *
- * Furthermore, this class assumes that shape functions of the FiniteElement
- * under consideration do <em>not</em> depend on the actual shape of the cells
- * in real space, i.e. update_once() includes <tt>update_values</tt>. For
- * FiniteElements whose shape functions depend on the cells in real space, the
- * update_once() and update_each() functions must be overloaded.
- *
  * @todo Since nearly all functions for spacedim != dim are specialized, this
  * class needs cleaning up.
  *
@@ -233,7 +227,7 @@ protected:
     // generate a new data object and
     // initialize some fields
     InternalData *data = new InternalData;
-    data->update_each = update_each(update_flags) | update_once(update_flags);  // FIX: only update_each required
+    data->update_each = requires_update_flags(update_flags);
 
     const unsigned int n_q_points = quadrature.size();
 
@@ -363,52 +357,6 @@ protected:
                           const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
                           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
-
-  /**
-   * Determine the values that need to be computed on the unit cell to be able
-   * to compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   * Therefore, the effect in this element is as follows: if
-   * <tt>update_values</tt> is set in <tt>flags</tt>, copy it to the result.
-   * All other flags of the result are cleared, since everything else must be
-   * computed for each cell.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * Determine the values that need to be computed on every cell to be able to
-   * compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   *
-   * The effect in this element is as follows:
-   * <ul>
-   *
-   * <li> if <tt>update_gradients</tt> is set, the result will contain
-   * <tt>update_gradients</tt> and <tt>update_covariant_transformation</tt>.
-   * The latter is required to transform the gradient on the unit cell to the
-   * real cell. Remark, that the action required by
-   * <tt>update_covariant_transformation</tt> is actually performed by the
-   * Mapping object used in conjunction with this finite element.
-   *
-   * <li> if <tt>update_hessians</tt> is set, the result will contain
-   * <tt>update_hessians</tt> and <tt>update_covariant_transformation</tt>.
-   * The rationale is the same as above and no higher derivatives of the
-   * transformation are required, since we use difference quotients for the
-   * actual computation.
-   *
-   * </ul>
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
 
   /**
    * Fields of cell-independent data.

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -185,31 +185,10 @@ template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
 FE_Poly<PolynomialType,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 {
-  return update_once(flags) | update_each(flags);
-}
-
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_Poly<PolynomialType,dim,spacedim>::update_once (const UpdateFlags flags) const
-{
-  // for this kind of elements, only
-  // the values can be precomputed
-  // once and for all. set this flag
-  // if the values are requested at
-  // all
-  return (update_default | (flags & update_values));
-}
-
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_Poly<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
-{
   UpdateFlags out = update_default;
 
+  if (flags & update_values)
+    out |= update_values;
   if (flags & update_gradients)
     out |= update_gradients | update_covariant_transformation;
   if (flags & update_hessians)

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -49,12 +49,6 @@ DEAL_II_NAMESPACE_OPEN
  * which cannot be implemented by this class but are left for implementation
  * in derived classes.
  *
- * Furthermore, this class assumes that shape functions of the FiniteElement
- * under consideration do <em>not</em> depend on the actual shape of the cells
- * in real space, i.e. update_once() includes <tt>update_values</tt>. For
- * FiniteElements whose shape functions depend on the cells in real space, the
- * update_once() and update_each() functions must be overloaded.
- *
  * @author Guido Kanschat, 2009
  */
 template <class PolynomialType, int dim=PolynomialType::dimension+1, int spacedim=dim>
@@ -106,7 +100,7 @@ protected:
     // generate a new data object and
     // initialize some fields
     InternalData *data = new InternalData;
-    data->update_each = update_once(update_flags) | update_each(update_flags);  // FIX: only update_each required
+    data->update_each = requires_update_flags(update_flags);
 
     const unsigned int n_q_points = quadrature.size();
 
@@ -190,53 +184,6 @@ protected:
                           const dealii::internal::FEValues::MappingRelatedData<dim, spacedim> &mapping_data,
                           const typename FiniteElement<dim,spacedim>::InternalDataBase        &fe_internal,
                           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &output_data) const;
-
-  /**
-   * Determine the values that need to be computed on the unit cell to be able
-   * to compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   * Therefore, the effect in this element is as follows: if
-   * <tt>update_values</tt> is set in <tt>flags</tt>, copy it to the result.
-   * All other flags of the result are cleared, since everything else must be
-   * computed for each cell.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * Determine the values that need to be computed on every cell to be able to
-   * compute all values required by <tt>flags</tt>.
-   *
-   * For the purpose of this function, refer to the documentation in
-   * FiniteElement.
-   *
-   * This class assumes that shape functions of this FiniteElement do
-   * <em>not</em> depend on the actual shape of the cells in real space.
-   *
-   * The effect in this element is as follows:
-   * <ul>
-   *
-   * <li> if <tt>update_gradients</tt> is set, the result will contain
-   * <tt>update_gradients</tt> and <tt>update_covariant_transformation</tt>.
-   * The latter is required to transform the gradient on the unit cell to the
-   * real cell. Remark, that the action required by
-   * <tt>update_covariant_transformation</tt> is actually performed by the
-   * Mapping object used in conjunction with this finite element.
-   *
-   * <li> if <tt>update_hessians</tt> is set, the result will contain
-   * <tt>update_hessians</tt> and <tt>update_covariant_transformation</tt>.
-   * The rationale is the same as above and no higher derivatives of the
-   * transformation are required, since we use difference quotients for the
-   * actual computation.
-   *
-   * </ul>
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
-
 
   /**
    * Fields of cell-independent data.

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -53,23 +53,6 @@ template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
 FE_PolyFace<PolynomialType,dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 {
-  return update_once(flags) | update_each(flags);
-}
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_PolyFace<PolynomialType,dim,spacedim>::update_once (const UpdateFlags) const
-{
-  return update_default;
-}
-
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_PolyFace<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
-{
   UpdateFlags out = flags & update_values;
   if (flags & update_gradients)
     out |= update_gradients | update_covariant_transformation;

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -184,20 +184,6 @@ protected:
   MappingType mapping_type;
 
 
-  /**
-   * Given <tt>flags</tt>, determines the values which must be computed only
-   * for the reference cell. Make sure, that #mapping_type is set by the
-   * derived class, such that this function can operate correctly.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * Given <tt>flags</tt>, determines the values which must be computed in
-   * each cell cell. Make sure, that #mapping_type is set by the derived
-   * class, such that this function can operate correctly.
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
-
   /* NOTE: The following function has its definition inlined into the class declaration
      because we otherwise run into a compiler error with MS Visual Studio. */
   virtual
@@ -210,7 +196,7 @@ protected:
     // generate a new data object and
     // initialize some fields
     InternalData *data = new InternalData;
-    data->update_each = update_each(update_flags) | update_once(update_flags);  // FIX: only update_each required
+    data->update_each = requires_update_flags(update_flags);
 
     const unsigned int n_q_points = quadrature.size();
 

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -846,15 +846,6 @@ public:
   virtual std::size_t memory_consumption () const;
 
 protected:
-  /**
-   * Compute flags for initial update only.
-   */
-  UpdateFlags update_once (const UpdateFlags flags) const;
-
-  /**
-   * Compute flags for update on each cell.
-   */
-  UpdateFlags update_each (const UpdateFlags flags) const;
 
   /**
    * @p clone function instead of a copy constructor.

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -51,40 +51,12 @@ template <int,int> class FiniteElement;
  * You can select more than one flag by concatenation using the bitwise or
  * operator|(UpdateFlags,UpdateFlags).
  *
- * <h3>Generating the actual flags</h3>
+ * <h3>Use of these flags flags</h3>
  *
- * When given a set of UpdateFlags @p flags, the FEValues object must
- * determine, which values will have to be computed once only for the
- * reference cell and which values will have to be updated for each cell.
- * Here, it is important to note that in many cases, the FiniteElement will
- * require additional updates from the Mapping. To this end, several auxiliary
- * functions have been implemented:
- *
- * FiniteElement::update_once(flags) and FiniteElement::update_each(flags)
- * determine the values required by the FiniteElement once or on each cell.
- * The same functions exist in Mapping.
- *
- * Since the FiniteElement does not know if a value required from Mapping
- * should be computed once or for each cell,
- * FEValuesBase::compute_update_flags() is used to compute the union of all
- * values to be computed ever. It does this by first adding to the flags set
- * by the user all flags (once and each) added by the FiniteElement. This new
- * set of flags is then given to the Mapping and all flags required there are
- * added, again once and each.
- *
- * This union of all flags is given to Mapping::fill_fe_values() and
- * FiniteElement::fill_fe_values, where it is split again into the information
- * generated only once and the information that must be updated on each cell.
- *
- * The flags finally stored in FEValues then are the union of all the flags
- * required by the user, by FiniteElement and by Mapping, for computation once
- * or on each cell. Subsequent calls to the functions @p update_once and @p
- * update_each should just select among these flags, but should not add new
- * flags.
- *
- * The mechanism by which all this is accomplished is also discussed on the
- * page on
- * @ref UpdateFlags.
+ * More information on the use of this type both in user code as
+ * well as internally can be found in the documentation modules on
+ * @ref UpdateFlags "The interplay of UpdateFlags, Mapping, and FiniteElement in FEValues"
+ * and @ref FE_vs_Mapping_vs_FEValues "How Mapping, FiniteElement, and FEValues work together".
  */
 enum UpdateFlags
 {

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -239,28 +239,6 @@ template <int dim, int spacedim>
 UpdateFlags
 FE_DGPNonparametric<dim,spacedim>::requires_update_flags (const UpdateFlags flags) const
 {
-  return update_once(flags) | update_each(flags);
-}
-
-
-
-template <int dim, int spacedim>
-UpdateFlags
-FE_DGPNonparametric<dim,spacedim>::update_once (const UpdateFlags) const
-{
-  // for this kind of elements, only
-  // the values can be precomputed
-  // once and for all. set this flag
-  // if the values are requested at
-  // all
-  return update_default;
-}
-
-
-template <int dim, int spacedim>
-UpdateFlags
-FE_DGPNonparametric<dim,spacedim>::update_each (const UpdateFlags flags) const
-{
   UpdateFlags out = flags;
 
   if (flags & (update_values | update_gradients | update_hessians))
@@ -268,6 +246,7 @@ FE_DGPNonparametric<dim,spacedim>::update_each (const UpdateFlags flags) const
 
   return out;
 }
+
 
 
 //---------------------------------------------------------------------------
@@ -283,8 +262,9 @@ get_data (const UpdateFlags                                                    u
           dealii::internal::FEValues::FiniteElementRelatedData<dim, spacedim> &/*output_data*/) const
 {
   // generate a new data object
-  typename FiniteElement<dim,spacedim>::InternalDataBase *data = new typename FiniteElement<dim,spacedim>::InternalDataBase;
-  data->update_each = update_once(update_flags) | update_each(update_flags);   // FIX: only update_each required
+  typename FiniteElement<dim,spacedim>::InternalDataBase *data
+    = new typename FiniteElement<dim,spacedim>::InternalDataBase;
+  data->update_each = requires_update_flags(update_flags);
 
   // other than that, there is nothing we can add here as discussed
   // in the general documentation of this class

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -442,25 +442,7 @@ FE_FaceQ<1,spacedim>::get_constant_modes () const
 
 template <int spacedim>
 UpdateFlags
-FE_FaceQ<1,spacedim>::update_once (const UpdateFlags) const
-{
-  return update_default;
-}
-
-
-
-template <int spacedim>
-UpdateFlags
 FE_FaceQ<1,spacedim>::requires_update_flags (const UpdateFlags flags) const
-{
-  return update_once(flags) | update_each(flags);
-}
-
-
-
-template <int spacedim>
-UpdateFlags
-FE_FaceQ<1,spacedim>::update_each (const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
   if (flags & update_gradients)

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -1721,29 +1721,6 @@ template <class PolynomialType, int dim, int spacedim>
 UpdateFlags
 FE_PolyTensor<PolynomialType,dim,spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
-  return update_once(flags) | update_each(flags);
-}
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_PolyTensor<PolynomialType,dim,spacedim>::update_once (const UpdateFlags flags) const
-{
-  const bool values_once = (mapping_type == mapping_none);
-
-  UpdateFlags out = update_default;
-
-  if (values_once && (flags & update_values))
-    out |= update_values;
-
-  return out;
-}
-
-
-template <class PolynomialType, int dim, int spacedim>
-UpdateFlags
-FE_PolyTensor<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags) const
-{
   UpdateFlags out = update_default;
 
   switch (mapping_type)
@@ -1825,7 +1802,6 @@ FE_PolyTensor<PolynomialType,dim,spacedim>::update_each (const UpdateFlags flags
 
   return out;
 }
-
 
 
 // explicit instantiations


### PR DESCRIPTION
Sometime last fall, I replaces `update_once()` and `update_each()` in the finite element interface by a function `requires_update_flags()`. But a number of elements still retained these functions as internal functions (neither public, nor virtual). This patch gets rid of them.

Fixes #1974. In reference to #1198.