### PR TITLE
Fix doxygen markup.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -209,8 +209,7 @@ namespace DoFTools
   };
 
   /**
-   * @name Functions to support code that generically uses both DoFHandler and
-   * hp::DoFHandler
+   * @name Functions to support code that generically uses both DoFHandler and hp::DoFHandler
    * @{
    */
   /**
@@ -1185,8 +1184,7 @@ namespace DoFTools
    */
 
   /**
-   * @name Identifying subsets of degrees of freedom with particular
-   * properties
+   * @name Identifying subsets of degrees of freedom with particular properties
    * @{
    */
 


### PR DESCRIPTION
doxygen generates unpleasantly looking markup if the text that goes with a
'@name' tag is spread over two lines. Fix this.