### PR TITLE
fix METIS partitioning with too many processors

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -213,6 +213,12 @@ inconvenience this causes.
 <a name="general"></a>
 <h3>General</h3>
 <ol>
+  <li> Fixed: Partitioning using METIS now works correctly with more
+  domains than cells.
+  <br>
+  (Timo Heister, 2016/01/26)
+  </li>
+
   <li> New: The documentation of step-17 has been completely rewritten,
   and many aspects of how one has to think when writing parallel programs
   have been much better documented now.

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -57,7 +57,7 @@ namespace SparsityTools
                                  sparsity_pattern.n_rows()));
 
     // check for an easy return
-    if (n_partitions == 1)
+    if (n_partitions == 1 || (sparsity_pattern.n_rows()==1))
       {
         std::fill_n (partition_indices.begin(), partition_indices.size(), 0U);
         return;

--- a/tests/metis/metis_04.cc
+++ b/tests/metis/metis_04.cc
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check GridTools::partition_triangulation with too many subdomains
+
+#include "../tests.h"
+#include <deal.II/lac/vector.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/numerics/data_out.h>
+#include <fstream>
+#include <iomanip>
+
+
+template <int dim>
+void test ()
+{
+  Triangulation<dim> triangulation;
+  GridGenerator::hyper_cube (triangulation);
+  triangulation.refine_global (1);
+  {
+    triangulation.begin_active()->set_refine_flag();
+    triangulation.execute_coarsening_and_refinement ();
+  }
+
+  for (unsigned int procs=1; procs<20; ++procs)
+    {
+      deallog << " procs = " << procs << std::endl;
+      GridTools::partition_triangulation (procs, triangulation);
+      {
+        typename Triangulation<dim>::active_cell_iterator cell = triangulation.begin_active();
+        for (; cell!=triangulation.end(); ++cell)
+          {
+            deallog << cell->subdomain_id() << " ";
+          }
+        deallog << std::endl;
+      }
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main ()
+{
+  initlog();
+
+  test<2> ();
+}

--- a/tests/metis/metis_04.output
+++ b/tests/metis/metis_04.output
@@ -14,27 +14,27 @@ DEAL::1 3 0 5 1 5 2
 DEAL:: procs = 7
 DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 8
-DEAL::1 5 0 7 3 4 2 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 9
-DEAL::3 3 3 3 3 3 3 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 10
-DEAL::4 4 4 4 4 4 4 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 11
-DEAL::10 10 10 10 10 10 10 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 12
-DEAL::11 11 11 11 11 11 11 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 13
-DEAL::2 2 2 2 2 2 2 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 14
-DEAL::9 9 9 9 9 9 9 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 15
-DEAL::6 6 6 6 6 6 6 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 16
-DEAL::7 7 7 7 7 7 7 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 17
-DEAL::7 7 7 7 7 7 7 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 18
-DEAL::8 8 8 8 8 8 8 
+DEAL::2 3 0 6 2 5 4 
 DEAL:: procs = 19
-DEAL::8 8 8 8 8 8 8 
+DEAL::2 3 0 6 2 5 4 
 DEAL::OK

--- a/tests/metis/metis_04.output
+++ b/tests/metis/metis_04.output
@@ -1,0 +1,40 @@
+
+DEAL:: procs = 1
+DEAL::0 0 0 0 0 0 0 
+DEAL:: procs = 2
+DEAL::0 1 0 1 0 1 0 
+DEAL:: procs = 3
+DEAL::0 1 0 2 2 1 1 
+DEAL:: procs = 4
+DEAL::0 2 0 3 1 2 1 
+DEAL:: procs = 5
+DEAL::1 3 0 2 2 4 3 
+DEAL:: procs = 6
+DEAL::1 3 0 5 1 5 2 
+DEAL:: procs = 7
+DEAL::2 3 0 6 2 5 4 
+DEAL:: procs = 8
+DEAL::1 5 0 7 3 4 2 
+DEAL:: procs = 9
+DEAL::3 3 3 3 3 3 3 
+DEAL:: procs = 10
+DEAL::4 4 4 4 4 4 4 
+DEAL:: procs = 11
+DEAL::10 10 10 10 10 10 10 
+DEAL:: procs = 12
+DEAL::11 11 11 11 11 11 11 
+DEAL:: procs = 13
+DEAL::2 2 2 2 2 2 2 
+DEAL:: procs = 14
+DEAL::9 9 9 9 9 9 9 
+DEAL:: procs = 15
+DEAL::6 6 6 6 6 6 6 
+DEAL:: procs = 16
+DEAL::7 7 7 7 7 7 7 
+DEAL:: procs = 17
+DEAL::7 7 7 7 7 7 7 
+DEAL:: procs = 18
+DEAL::8 8 8 8 8 8 8 
+DEAL:: procs = 19
+DEAL::8 8 8 8 8 8 8 
+DEAL::OK


### PR DESCRIPTION
If you have more processors than cells to partition, METIS will behave
in a weird and undesired way:
- at some point all subdomains land on a single processor
- METIS produces an error message
  "***Cannot bisect a graph with 0 vertices!"