### PR TITLE
improve PETSc sparse_matrix constructor error msg

### DIFF
--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -399,7 +399,25 @@ namespace PETScWrappers
       Assert(local_rows.is_contiguous() && local_columns.is_contiguous(),
              ExcMessage("PETSc only supports contiguous row/column ranges"));
 
-
+#ifdef DEBUG
+      {
+        // check indexsets
+        types::global_dof_index row_owners = Utilities::MPI::sum(local_rows.n_elements(), communicator);
+        types::global_dof_index col_owners = Utilities::MPI::sum(local_columns.n_elements(), communicator);
+        Assert(row_owners == sparsity_pattern.n_rows(),
+               ExcMessage(std::string("Each row has to be owned by exactly one owner (n_rows()=")
+                          + Utilities::to_string(sparsity_pattern.n_rows())
+                          + " but sum(local_rows.n_elements())="
+                          + Utilities::to_string(row_owners)
+                          + ")"));
+        Assert(col_owners == sparsity_pattern.n_cols(),
+               ExcMessage(std::string("Each column has to be owned by exactly one owner (n_cols()=")
+                          + Utilities::to_string(sparsity_pattern.n_cols())
+                          + " but sum(local_columns.n_elements())="
+                          + Utilities::to_string(col_owners)
+                          + ")"));
+      }
+#endif
 
 
       // create the matrix. We do not set row length but set the


### PR DESCRIPTION
If you construct a PETSc sparse matrix with invalid IndexSets for local
rows/columns, you only get a cryptic PETSc error code. This commit adds
a check in debug mode with a helpful error message.