### PR TITLE
avoid warning about unused variable

### DIFF
--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -260,7 +260,7 @@ ArpackSolver::ArpackSolver (SolverControl &control,
 template <typename VectorType, typename MatrixType1,
           typename MatrixType2, typename INVERSE>
 inline
-void ArpackSolver::solve (const MatrixType1                  &system_matrix,
+void ArpackSolver::solve (const MatrixType1                  &/*system_matrix*/,
                           const MatrixType2                  &mass_matrix,
                           const INVERSE                      &inverse,
                           std::vector<std::complex<double> > &eigenvalues,


### PR DESCRIPTION
According to the [documentation](https://www.dealii.org/developer/doxygen/deal.II/classArpackSolver.html#ae49067a1359b8d6794b92e1d0b405df6) of ArpackSolver::solve the first parameter is
unused. Do not give it a name in the definition to avoid unused variable
warnings.

I do not use the ArpackSolver class but some application code included the header and I kept getting those warnings. This should be a simple fix but I do not really know why this parameter was introduced in the first place.