### PR TITLE
Avoid C++11-isms in tests

### DIFF
--- a/tests/base/tensor_mixing_types_02.cc
+++ b/tests/base/tensor_mixing_types_02.cc
@@ -30,9 +30,15 @@ int main ()
   double d_scalar = 10.;
   std::complex<double> c_scalar = 10.;
 
-  Tensor<1,2,float>                 f1 = { {1., 2.} };
-  Tensor<1,2,double>                d1 = { {4., 8.} };
-  Tensor<1,2,std::complex<double> > c1 = { {16., 32.} };
+  Tensor<1,2,float>                 f1;
+  f1[0] = 1.;
+  f1[1] = 2.;
+  Tensor<1,2,double>                d1;
+  d1[0] = 4.;
+  d1[1] = 8.;
+  Tensor<1,2,std::complex<double> > c1;
+  c1[0] = 16.;
+  c1[1] = 32.;
 
   deallog << f1 + d1 << std::endl;
   deallog << f1 - d1 << std::endl;

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -366,9 +366,9 @@ namespace Step22
       GridTools::collect_periodic_faces(
         dof_handler, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
-      DoFTools::make_periodicity_constraints<DoFHandler<dim>>(
-                                                             periodicity_vector, constraints, fe.component_mask(velocities),
-                                                             first_vector_components);
+      DoFTools::make_periodicity_constraints<DoFHandler<dim> >(
+        periodicity_vector, constraints, fe.component_mask(velocities),
+        first_vector_components);
 #endif
     }
 


### PR DESCRIPTION
Fixes most tests listed here:
http://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=896
(The sacado_product_type_0{4,5} tests also listed there are probably due to a Trilinos version too old (11.4) - the error messages are not really helpful and thus I don't think it's worth fixing.)