### PR TITLE
fix several scary MPI bugs

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7082,7 +7082,7 @@ namespace VectorTools
         double my_values[3] = { mean_double.real(), mean_double.imag(), area };
         double global_values[3];
 
-        MPI_Allreduce (&my_values, &global_values, 3, MPI_DOUBLE,
+        MPI_Allreduce (my_values, global_values, 3, MPI_DOUBLE,
                        MPI_SUM,
                        p_triangulation->get_communicator());
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6173,7 +6173,7 @@ void DataOutInterface<dim,spacedim>::write_vtu_in_parallel (const char *filename
       MPI_File_write(fh, const_cast<char *>(ss.str().c_str()), header_size, MPI_CHAR, MPI_STATUS_IGNORE);
     }
 
-  MPI_Bcast(&header_size, 1, MPI_INT, 0, comm);
+  MPI_Bcast(&header_size, 1, MPI_UNSIGNED, 0, comm);
 
   MPI_File_seek_shared( fh, header_size, MPI_SEEK_SET );
   {

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -96,7 +96,7 @@ namespace
 
     // compute the minimum on
     // processor zero
-    MPI_Reduce (&comp, &result, 2, MPI_DOUBLE,
+    MPI_Reduce (comp, result, 2, MPI_DOUBLE,
                 MPI_MIN, 0, mpi_communicator);
 
     // make sure only processor zero


### PR DESCRIPTION
I am surprised the code in question used to work at all because we are just
overwriting random memory. I detected those using clang's argument type
warnings and extensible clang type annotation within MPICH.