### PR TITLE
disable gcc warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -283,6 +283,7 @@ _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")       \
 _Pragma("GCC diagnostic ignored \"-Wunused-function\"")          \
 _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")          \
+_Pragma("GCC diagnostic ignored \"-Wtype-limits\"")              \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"") \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")     \

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -20,9 +20,11 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
```
In file included from /usr/include/c++/4.8/cassert:43:0,
                 from /ssd/libs-
candi/boost_1_60_0/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp:6,
                 from /ssd/libs-
candi/boost_1_60_0/include/boost/property_tree/detail/json_parser/read.hpp:14,
                 from /ssd/libs-
candi/boost_1_60_0/include/boost/property_tree/json_parser.hpp:16,
                 from /ssd/deal-git/source/base/parameter_handler.cc:26:
/ssd/libs-
candi/boost_1_60_0/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp:
In member function ‘char
boost::property_tree::json_parser::detail::utf8_utf8_encoding::to_internal_trivial(char)
const’:
/ssd/libs-
candi/boost_1_60_0/include/boost/property_tree/detail/json_parser/narrow_encoding.hpp:71:25:
warning: comparison is always true due to limited range of data type
[-Wtype-limits]
             assert(c <= 0x7f);
```
```
/ssd/libs-
candi/trilinos-12.6.1-Source/include/Amesos2_Superludist_FunctionMap.hpp:71:125:
warning: enumeral and non-enumeral type in conditional expression
[enabled by default]
((ds)==SLUD::ROW) ? 'R' : ((ds)=='C') ? SLUD::COL : SLUD::BOTH)
```