### PR TITLE
[8.4] take over #2168: fix link

### DIFF
--- a/doc/developers/porting.html
+++ b/doc/developers/porting.html
@@ -55,7 +55,7 @@ cmake/setup_compiler_flags.cmake
 cmake/setup_compiler_flags_gnu.cmake
 cmake/setup_compiler_flags_icc.cmake
 </pre>
-          Patches are highly welcome! See <a href="../mail.html">here</a>
+          Patches are highly welcome! See <a href="http://www.dealii.org/participate.html">here</a>
           for information on how to get in contact with us.
         <li>
           You might want to have a look at


### PR DESCRIPTION
../mail.html is a 404 and I prefer linking to "participate" instead of
the mailing list...