### PR TITLE
add in support for changing vertices for 

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -57,6 +57,13 @@ inconvenience this causes.
 
 
 <ol> 
+ <li> Fixed: The GridTools::build_triangulation_from_patches() function now 
+ also copies the locations of vertices from the cells of the source 
+ triangulation to the triangulation that is built from the list of patch cells.
+ <br>
+ (Spencer Patty, 2016/02/11)
+ </li>
+
 </ol>
 
 */

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1019,6 +1019,13 @@ namespace GridTools
    * identify the cells in the output Triangulation and corresponding cells in
    * the input list.
    *
+   * The function copies the location of vertices of cells from the cells of the
+   * source triangulation to the triangulation that is built from the list of
+   * patch cells.  This adds support for triangulations which have been
+   * perturbed or smoothed in some manner which makes the triangulation
+   * deviate from the standard deal.ii refinement strategy of placing new
+   * vertices at midpoints of faces or edges.
+   *
    * The operation implemented by this function is frequently used in the
    * definition of error estimators that need to solve "local" problems on
    * each cell and its neighbors. A similar construction is necessary in the

--- a/tests/grid/build_triangulation_from_patch_03.cc
+++ b/tests/grid/build_triangulation_from_patch_03.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C)  2015 - 2016  by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+
+// Test GridTools::build_triangulation_from_patch () with a distorted triangulation
+// to make sure the vertices are captured properly when the patch triangulation
+// does not come from the standard deal.II refinement strategy.
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <fstream>
+
+
+template<int dim>
+void test()
+{
+  Triangulation<dim> triangulation (Triangulation<dim>::limit_level_difference_at_vertices);
+
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global (1);
+
+  // Apply distortion here, note that distort_random
+  // is designed to be reproducable, each time you apply
+  // it to the same triangulation, you get the same
+  // random distortion.  Thus the output is consistent
+  // for the test to be run multiple times.
+  GridTools::distort_random(0.2,triangulation,false);
+
+  unsigned int index = 0;
+  for (typename Triangulation<dim>::active_cell_iterator
+       cell = triangulation.begin_active();
+       cell != triangulation.end(); ++cell, ++index)
+    {
+      std::vector<typename Triangulation<dim>::active_cell_iterator> patch_cells
+        = GridTools::get_patch_around_cell<Triangulation<dim> > (cell);
+
+      Triangulation<dim> local_triangulation(Triangulation<dim>::limit_level_difference_at_vertices);
+      std::map<typename Triangulation<dim>::active_cell_iterator ,
+          typename Triangulation<dim>::active_cell_iterator> patch_to_global_tria_map;
+
+      GridTools::build_triangulation_from_patch <Triangulation<dim> >
+      (patch_cells,local_triangulation,patch_to_global_tria_map);
+
+      deallog << "patch_cells " << cell << ": ";
+      for (unsigned int i=0; i<patch_cells.size(); ++i)
+        deallog << patch_cells[i] << ' ';
+      deallog << std::endl;
+
+      deallog << "local_triangulation " << cell << ":\n";
+      for (typename Triangulation<dim>::active_cell_iterator
+           tria_cell = local_triangulation.begin_active();
+           tria_cell != local_triangulation.end(); ++tria_cell)
+        {
+          deallog << "   "
+                  << tria_cell
+                  << " user flag check:  "
+                  << (tria_cell->user_flag_set() ? " (+) " : " (-) ")
+                  << std::endl;
+          for (unsigned int v=0;  v< GeometryInfo<dim>::vertices_per_cell; ++v)
+            {
+              deallog << "  vertices for cell  "
+                      << tria_cell << " : "
+                      << tria_cell->vertex(v) << std::endl;
+            }
+        }
+
+    }
+
+}
+
+
+int main()
+{
+  initlog();
+  deallog.threshold_double(1.e-10);
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/grid/build_triangulation_from_patch_03.output
+++ b/tests/grid/build_triangulation_from_patch_03.output
@@ -1,0 +1,389 @@
+
+DEAL:1d::patch_cells 1.0: 1.0 1.1 
+DEAL:1d::local_triangulation 1.0:
+   0.0 user flag check:   (+) 
+DEAL:1d::  vertices for cell  0.0 : 0.100000
+DEAL:1d::  vertices for cell  0.0 : 0.600000
+DEAL:1d::   0.1 user flag check:   (+) 
+DEAL:1d::  vertices for cell  0.1 : 0.600000
+DEAL:1d::  vertices for cell  0.1 : 0.900000
+DEAL:1d::patch_cells 1.1: 1.1 1.0 
+DEAL:1d::local_triangulation 1.1:
+   0.0 user flag check:   (+) 
+DEAL:1d::  vertices for cell  0.0 : 0.100000
+DEAL:1d::  vertices for cell  0.0 : 0.600000
+DEAL:1d::   0.1 user flag check:   (+) 
+DEAL:1d::  vertices for cell  0.1 : 0.600000
+DEAL:1d::  vertices for cell  0.1 : 0.900000
+DEAL:2d::patch_cells 1.0: 1.0 1.1 1.2 
+DEAL:2d::local_triangulation 1.0:
+   0.0 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.0 : 0.0653511 -0.0756917
+DEAL:2d::  vertices for cell  0.0 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.0 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.0 : 0.567767 0.573537
+DEAL:2d::   0.1 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.1 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.1 : 1.07712 0.0636643
+DEAL:2d::  vertices for cell  0.1 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.1 : 0.942064 0.418493
+DEAL:2d::   0.2 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.2 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.2 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.2 : -0.0622575 1.07826
+DEAL:2d::  vertices for cell  0.2 : 0.509469 1.09955
+DEAL:2d::patch_cells 1.1: 1.1 1.0 1.3 
+DEAL:2d::local_triangulation 1.1:
+   0.0 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.0 : 0.0653511 -0.0756917
+DEAL:2d::  vertices for cell  0.0 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.0 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.0 : 0.567767 0.573537
+DEAL:2d::   0.1 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.1 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.1 : 1.07712 0.0636643
+DEAL:2d::  vertices for cell  0.1 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.1 : 0.942064 0.418493
+DEAL:2d::   0.2 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.2 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.2 : 0.942064 0.418493
+DEAL:2d::  vertices for cell  0.2 : 0.509469 1.09955
+DEAL:2d::  vertices for cell  0.2 : 1.08289 0.944061
+DEAL:2d::patch_cells 1.2: 1.2 1.3 1.0 
+DEAL:2d::local_triangulation 1.2:
+   0.0 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.0 : 0.0653511 -0.0756917
+DEAL:2d::  vertices for cell  0.0 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.0 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.0 : 0.567767 0.573537
+DEAL:2d::   0.1 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.1 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.1 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.1 : -0.0622575 1.07826
+DEAL:2d::  vertices for cell  0.1 : 0.509469 1.09955
+DEAL:2d::   0.2 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.2 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.2 : 0.942064 0.418493
+DEAL:2d::  vertices for cell  0.2 : 0.509469 1.09955
+DEAL:2d::  vertices for cell  0.2 : 1.08289 0.944061
+DEAL:2d::patch_cells 1.3: 1.3 1.2 1.1 
+DEAL:2d::local_triangulation 1.3:
+   0.0 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.0 : 0.556791 -0.0823091
+DEAL:2d::  vertices for cell  0.0 : 1.07712 0.0636643
+DEAL:2d::  vertices for cell  0.0 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.0 : 0.942064 0.418493
+DEAL:2d::   0.1 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.1 : -0.0993187 0.511653
+DEAL:2d::  vertices for cell  0.1 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.1 : -0.0622575 1.07826
+DEAL:2d::  vertices for cell  0.1 : 0.509469 1.09955
+DEAL:2d::   0.2 user flag check:   (+) 
+DEAL:2d::  vertices for cell  0.2 : 0.567767 0.573537
+DEAL:2d::  vertices for cell  0.2 : 0.942064 0.418493
+DEAL:2d::  vertices for cell  0.2 : 0.509469 1.09955
+DEAL:2d::  vertices for cell  0.2 : 1.08289 0.944061
+DEAL:3d::patch_cells 1.0: 1.0 1.1 1.2 1.4 
+DEAL:3d::local_triangulation 1.0:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.0499753 -0.0578830 0.0644362
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.1 : 1.04880 -0.0543399 0.0683038
+DEAL:3d::  vertices for cell  0.1 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.1 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : 1.07346 0.548093 0.547862
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.2 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.2 : 0.0801169 0.945933 0.0256527
+DEAL:3d::  vertices for cell  0.2 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.2 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.3 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.3 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : -0.0575054 -0.0809011 1.01217
+DEAL:3d::  vertices for cell  0.3 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.3 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::patch_cells 1.1: 1.1 1.0 1.3 1.5 
+DEAL:3d::local_triangulation 1.1:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.0499753 -0.0578830 0.0644362
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.1 : 1.04880 -0.0543399 0.0683038
+DEAL:3d::  vertices for cell  0.1 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.1 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : 1.07346 0.548093 0.547862
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.2 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.2 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.2 : 0.957212 0.910232 0.0105325
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.2 : 0.947772 1.07868 0.532881
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.3 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.3 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.3 : 1.05896 0.0547327 1.05939
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.947323 0.461919 1.07599
+DEAL:3d::patch_cells 1.2: 1.2 1.3 1.0 1.6 
+DEAL:3d::local_triangulation 1.2:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.0499753 -0.0578830 0.0644362
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.1 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.1 : 0.0801169 0.945933 0.0256527
+DEAL:3d::  vertices for cell  0.1 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.1 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.1 : 0.542324 0.918575 0.460267
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.2 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.2 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.2 : 0.957212 0.910232 0.0105325
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.2 : 0.947772 1.07868 0.532881
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.0625669 1.06294 0.953920
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::patch_cells 1.3: 1.3 1.2 1.1 1.7 
+DEAL:3d::local_triangulation 1.3:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 1.04880 -0.0543399 0.0683038
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.0 : 1.07346 0.548093 0.547862
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.1 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.1 : 0.0801169 0.945933 0.0256527
+DEAL:3d::  vertices for cell  0.1 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.1 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.1 : 0.542324 0.918575 0.460267
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.2 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.2 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.2 : 0.957212 0.910232 0.0105325
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.2 : 0.947772 1.07868 0.532881
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.947772 1.07868 0.532881
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.947323 0.461919 1.07599
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::  vertices for cell  0.3 : 1.03181 1.06629 1.06777
+DEAL:3d::patch_cells 1.4: 1.4 1.5 1.6 1.0 
+DEAL:3d::local_triangulation 1.4:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.0499753 -0.0578830 0.0644362
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : -0.0575054 -0.0809011 1.01217
+DEAL:3d::  vertices for cell  0.1 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.1 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.1 : 0.550539 0.586270 0.998197
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.2 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.2 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.2 : 1.05896 0.0547327 1.05939
+DEAL:3d::  vertices for cell  0.2 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.2 : 0.947323 0.461919 1.07599
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.0625669 1.06294 0.953920
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::patch_cells 1.5: 1.5 1.4 1.7 1.1 
+DEAL:3d::local_triangulation 1.5:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.576044 -0.0648949 -0.00243259
+DEAL:3d::  vertices for cell  0.0 : 1.04880 -0.0543399 0.0683038
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.0 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.0 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.0 : 1.07346 0.548093 0.547862
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : -0.0575054 -0.0809011 1.01217
+DEAL:3d::  vertices for cell  0.1 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.1 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.1 : 0.550539 0.586270 0.998197
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.2 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.2 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.2 : 1.05896 0.0547327 1.05939
+DEAL:3d::  vertices for cell  0.2 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.2 : 0.947323 0.461919 1.07599
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.947772 1.07868 0.532881
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.947323 0.461919 1.07599
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::  vertices for cell  0.3 : 1.03181 1.06629 1.06777
+DEAL:3d::patch_cells 1.6: 1.6 1.7 1.4 1.2 
+DEAL:3d::local_triangulation 1.6:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.0635228 0.563986 -0.0432506
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : 0.0801169 0.945933 0.0256527
+DEAL:3d::  vertices for cell  0.0 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.0 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.0 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.0 : 0.542324 0.918575 0.460267
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : -0.0581238 -0.0803764 0.487301
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : -0.0575054 -0.0809011 1.01217
+DEAL:3d::  vertices for cell  0.1 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.1 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.1 : 0.550539 0.586270 0.998197
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.2 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.2 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.2 : 0.0625669 1.06294 0.953920
+DEAL:3d::  vertices for cell  0.2 : 0.435253 0.934721 0.960674
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.947772 1.07868 0.532881
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.947323 0.461919 1.07599
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::  vertices for cell  0.3 : 1.03181 1.06629 1.06777
+DEAL:3d::patch_cells 1.7: 1.7 1.6 1.5 1.3 
+DEAL:3d::local_triangulation 1.7:
+   0.0 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.0 : 0.461076 0.452667 0.0790222
+DEAL:3d::  vertices for cell  0.0 : 0.933786 0.571032 0.0238797
+DEAL:3d::  vertices for cell  0.0 : 0.501089 1.04632 0.0886166
+DEAL:3d::  vertices for cell  0.0 : 0.957212 0.910232 0.0105325
+DEAL:3d::  vertices for cell  0.0 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.0 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.0 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.0 : 0.947772 1.07868 0.532881
+DEAL:3d::   0.1 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.1 : 0.534828 0.0502487 0.420867
+DEAL:3d::  vertices for cell  0.1 : 1.04407 0.0570682 0.569292
+DEAL:3d::  vertices for cell  0.1 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.1 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.1 : 0.554229 -0.0307234 1.07820
+DEAL:3d::  vertices for cell  0.1 : 1.05896 0.0547327 1.05939
+DEAL:3d::  vertices for cell  0.1 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.1 : 0.947323 0.461919 1.07599
+DEAL:3d::   0.2 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.2 : -0.0647413 0.449944 0.442529
+DEAL:3d::  vertices for cell  0.2 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.2 : -0.0777391 0.976775 0.558457
+DEAL:3d::  vertices for cell  0.2 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.2 : 0.0701558 0.570880 0.992641
+DEAL:3d::  vertices for cell  0.2 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.2 : 0.0625669 1.06294 0.953920
+DEAL:3d::  vertices for cell  0.2 : 0.435253 0.934721 0.960674
+DEAL:3d::   0.3 user flag check:   (+) 
+DEAL:3d::  vertices for cell  0.3 : 0.406375 0.532902 0.487681
+DEAL:3d::  vertices for cell  0.3 : 1.07346 0.548093 0.547862
+DEAL:3d::  vertices for cell  0.3 : 0.542324 0.918575 0.460267
+DEAL:3d::  vertices for cell  0.3 : 0.947772 1.07868 0.532881
+DEAL:3d::  vertices for cell  0.3 : 0.550539 0.586270 0.998197
+DEAL:3d::  vertices for cell  0.3 : 0.947323 0.461919 1.07599
+DEAL:3d::  vertices for cell  0.3 : 0.435253 0.934721 0.960674
+DEAL:3d::  vertices for cell  0.3 : 1.03181 1.06629 1.06777


### PR DESCRIPTION
build_triangulation_from_patch and an associated test routine based on distorting the vertices with GridTools::distort_random().  This pull request resolves issue #2081.  @bangerth I removed an Assertion that would always fail in the case of vertices being perturbed and I add some other assertions at the end to make sure each cell matches something and that the centers are the same.

The test is the same as tests/grid/build_triangulation_from_patch_01.cc except that we apply the "reproducible" GridTools::distort_random() function and then run the test.