### PR TITLE
Factored out repeated code in InterpolatedTensorProductGridData

### DIFF
--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -1170,7 +1170,12 @@ namespace Functions
     gradient (const Point<dim>    &p,
               const unsigned int component = 0) const;
 
-  private:
+  protected:
+    /**
+     * Find the index in the table of the rectangle containing an input point
+     */
+    TableIndices<dim> table_index_of_point (const Point<dim> &p) const;
+
     /**
      * The set of coordinate values in each of the coordinate directions.
      */


### PR DESCRIPTION
`InterpolatedTensorProductGridData` has some repeated code for finding the right `TableIndex` for an input point. I have factored out this functionality into a protected member function `table_index_of_point` and changed the `coordinate_values` and `data_values` members from private to protected.

I changed these members to `protected` so that I could write an extension of this class for the case where some of the data are missing. This is similar in spirit to numpy's [masked arrays](http://docs.scipy.org/doc/numpy/reference/maskedarray.html); having a class that explicitly handles missing data is very useful when working with remote sensing observations, which are often missing patches of pixels due to e.g. cloud cover. I can't extend the class in my own code if these members are private; however, they're still `const`.