### PR TITLE
fix cmake 3.3 error about code-gallery.h

### DIFF
--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -133,9 +133,17 @@ ELSE()
   MESSAGE(STATUS "Setting up code gallery documentation.")
   MESSAGE(STATUS "  Skipping as no code gallery exists in ${DEAL_II_CODE_GALLERY_DIRECTORY}.")
 
-  FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/no-code-gallery.h
-       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-  FILE(RENAME ${CMAKE_CURRENT_BINARY_DIR}/no-code-gallery.h
-       ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/no-code-gallery.h ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/no-code-gallery.h
+	)
+
+  # Make the custom command for code-gallery.h visible to the parent CMakeLists.txt by attaching to the code-gallery
+  # custom target:
+  ADD_CUSTOM_TARGET(build_code-gallery_h
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
+  ADD_DEPENDENCIES(code-gallery build_code-gallery_h)
+
 ENDIF()
 


### PR DESCRIPTION
cmake 3.3 will warn about CMP0058 and is unable to compile the documentation
when using Ninja:
```
 This project specifies custom command DEPENDS on files in the build tree
  that are not specified as the OUTPUT or BYPRODUCTS of any
  add_custom_command or add_custom_target:

   doc/doxygen/code-gallery/code-gallery.h
```

We have to jump through a few hoops to make this work: Generating a
dependency to a source file generated in a subdirectory CMakeLists.txt
requires a custom command attached to a custom_target. Because ADD_DEPENDENCIES
only allows custom_targets not custom_commands, we have to add another dummy.