### PR TITLE
[8.4] take over #2183: suppress more warnings in external libs

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -284,6 +284,8 @@ _Pragma("GCC diagnostic ignored \"-Wunused-function\"")          \
 _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")          \
 _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")              \
+_Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") \
+_Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")       \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"") \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")     \


### PR DESCRIPTION
this suppresses:
/ssd/libs-candi/trilinos-12.4.2-Source/include/Amesos2_Superludist_FunctionMap.hpp:285:17: warning: comparison of constant 67 with expression of type 'SLUD::DiagScale_t' is always false [-Wtautological-constant-out-of-range-compare]
      char eq = AMESOS2_SLUD_GET_EQUED(*equed);

and

/ssd/libs-candi/trilinos-12.4.2-Source/include/Tpetra_Experimental_BlockCrsMatrix_def.hpp:2826:3: warning: all paths through this function will call itself [-Winfinite-recursion]