### PR TITLE
fix eager Assertion in DoFAccessor

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -60,7 +60,7 @@ DoFAccessor (const Triangulation<DoFHandlerType::dimension,DoFHandlerType::space
                                                index),
   dof_handler(const_cast<DoFHandlerType *>(dof_handler))
 {
-  Assert (&dof_handler->get_triangulation() == tria,
+  Assert (tria == NULL || &dof_handler->get_triangulation() == tria,
           ExcMessage ("You can't create a DoF accessor in which the DoFHandler object "
                       "uses a different triangulation than the one you pass as argument."));
 }


### PR DESCRIPTION
TriaRawIterator constructs a DoFAccessor with NULL as the Triangulation, see
include/deal.II/grid/tria_iterator.templates.h:71
so the new Assert introduced in #2179 triggers.