### PR TITLE
Use proper code gallery name

### DIFF
--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -49,7 +49,13 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     LIST(APPEND _code_gallery_names_sans_dir "${_step}")
   ENDFOREACH()
 
-  # Describe how to build code-gallery.h:
+  # Describe how to build code-gallery.h. Make sure we properly
+  # track dependencies on the input files, by assuming that the PERL
+  # script is going to read all of the files in the doc/ subdirectories
+  FILE(GLOB _code_gallery_h_deps
+       "${DEAL_II_CODE_GALLERY_DIRECTORY}/*/doc/*")
+  STRING(REPLACE "//" "/" _code_gallery_h_deps "${_code_gallery_h_deps}")
+
   ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
     COMMAND ${PERL_EXECUTABLE}
@@ -62,10 +68,12 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     DEPENDS
       ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/code-gallery.pl
       ${CMAKE_CURRENT_SOURCE_DIR}/code-gallery.h.in
-      ${_code_gallery_names}
+      ${_code_gallery_h_deps}
     )
   ADD_CUSTOM_TARGET(build_code-gallery_h
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
+    DEPENDS 
+      ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+      ${_code_gallery_h_deps})
   ADD_DEPENDENCIES(code-gallery build_code-gallery_h)
 
 

--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -73,7 +73,9 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
   ADD_CUSTOM_TARGET(build_code-gallery_h
     DEPENDS 
       ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
-      ${_code_gallery_h_deps})
+      ${_code_gallery_h_deps}
+    COMMENT
+      "Building code-gallery.h")
   ADD_DEPENDENCIES(code-gallery build_code-gallery_h)
 
 
@@ -127,6 +129,8 @@ IF (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     ADD_CUSTOM_TARGET(code-gallery_${_step}
       DEPENDS
         ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
+      COMMENT
+        "Building doxygen input file for code gallery program <${_step}>"
       )
     ADD_DEPENDENCIES(code-gallery code-gallery_${_step})
 
@@ -150,7 +154,9 @@ ELSE()
   # Make the custom command for code-gallery.h visible to the parent CMakeLists.txt by attaching to the code-gallery
   # custom target:
   ADD_CUSTOM_TARGET(build_code-gallery_h
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h)
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/code-gallery.h
+    COMMENT
+      "Building code-gallery.h")
   ADD_DEPENDENCIES(code-gallery build_code-gallery_h)
 
 ENDIF()

--- a/doc/doxygen/scripts/code-gallery.pl
+++ b/doc/doxygen/scripts/code-gallery.pl
@@ -36,19 +36,28 @@ foreach my $gallery (sort @ARGV)
 {
     my $gallery_underscore = $gallery;
 
+    # Read the proper name of the program
+    open ENTRYNAME, "<$gallery_dir/$gallery/doc/entry-name";
+    my $entryname;
+    while (my $line = <ENTRYNAME>) {
+        chop $line;
+        $entryname .= $line . " ";
+    }
+    chop $entryname;
+
+    # Read the names of the authors, collate with commas, and at the
+    # end chop the last comma off
     open AUTHOR, "<$gallery_dir/$gallery/doc/author";
     my $authors;
     while (my $line = <AUTHOR>) {
         chop $line;
         $authors .= $line . ", ";
     }
-
-    # remove trailing whitespaces, as well as the trailing comma
     chop $authors;
     $authors =~ s/,$//;
 
     $gallery_underscore    =~ s/-/_/;
-    print "  <dt><b>\@ref code_gallery_${gallery_underscore} \"$gallery\"</b> (by $authors)</dt>\n";
+    print "  <dt><b>\@ref code_gallery_${gallery_underscore} \"$entryname\"</b> (by $authors)</dt>\n";
     print "    <dd>\n";
     open TOOLTIP, "<$gallery_dir/$gallery/doc/tooltip";
     while (my $line = <TOOLTIP>) {

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -25,7 +25,6 @@ my $gallery_underscore = $gallery;
 $gallery_underscore    =~ s/-/_/;
 
 my $gallery_dir = shift(@ARGV);
-my $author_file = "$gallery_dir/doc/author";
 
 # next get the source files. sort all markdown files
 # first so that we get to show them first. this makes
@@ -38,15 +37,26 @@ push @src_files, sort(grep { !($_ =~ m/.*\.(md|markdown)/) }@ARGV);
 # read the names of authors; escape '<' and '>' as they
 # appear in the email address. also trim trailing space and
 # newlines
-open AUTHORS, "<$author_file";
+open AUTHORS, "<$gallery_dir/doc/author";
 my $authors = <AUTHORS>;
 $authors    =~ s/</&lt;/g; 
 $authors    =~ s/>/&gt;/g; 
 $authors    =~ s/\s*$//g;
 
+
+# Read the proper name of the program
+open ENTRYNAME, "<$gallery_dir/doc/entry-name";
+my $entryname;
+while (my $line = <ENTRYNAME>) {
+    chop $line;
+    $entryname .= $line . " ";
+}
+chop $entryname;
+
+
 print
 "/**
-  * \@page code_gallery_$gallery_underscore The $gallery code gallery program
+  * \@page code_gallery_$gallery_underscore The '$entryname' code gallery program
 \@htmlonly
 <p align=\"center\"> 
   This program was contributed by $authors.

--- a/doc/doxygen/tutorial/CMakeLists.txt
+++ b/doc/doxygen/tutorial/CMakeLists.txt
@@ -78,7 +78,9 @@ ADD_CUSTOM_COMMAND(
     ${_code_gallery_names}
   )
 ADD_CUSTOM_TARGET(build_tutorial_h
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h)
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tutorial.h
+    COMMENT
+      "Building tutorial.h")
 ADD_DEPENDENCIES(tutorial build_tutorial_h)
 
 
@@ -126,6 +128,8 @@ FOREACH(_step ${_deal_ii_steps})
     DEPENDS
       ${CMAKE_CURRENT_BINARY_DIR}/${_step}.h
       ${CMAKE_CURRENT_BINARY_DIR}/${_step}.cc
+      COMMENT
+        "Building doxygen input file for tutorial program <${_step}>"
     )
   ADD_DEPENDENCIES(tutorial tutorial_${_step})
 ENDFOREACH()


### PR DESCRIPTION
This addresses part of #2200: It displays the (now available) full name of the code gallery programs. It is not necessary to use this in the steps graph because we there use the content of the `tooltip` files, rather than the proper name of the tutorial program.

The patch adds some extra dependency tracking. It also outputs some more output during the build phase.