### PR TITLE
Update step-44 to be dimension independent

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -57,6 +57,12 @@ inconvenience this causes.
 
 
 <ol> 
+ <li> Updated: step-44 has been been expressed in a more dimension independent 
+ manner, and can be now run in both 2-d and 3-d.
+ <br>
+ (Jean-Paul Pelteret, 2016/02/17)
+ </li>
+
  <li> Fixed: FE_Nedelec elements up to polynomial order 12 can now be
  constructed.
  <br>

--- a/examples/step-44/doc/results.dox
+++ b/examples/step-44/doc/results.dox
@@ -1,6 +1,6 @@
 <h1>Results</h1>
 
-Firstly, we present a comparison of a series of results with those
+Firstly, we present a comparison of a series of 3-d results with those
 in the literature (see Reese et al (2000)) to demonstrate that the program works as expected.
 
 We begin with a comparison of the convergence with mesh refinement for the $Q_1-DGPM_0-DGPM_0$ and
@@ -18,13 +18,13 @@ as it should.
      <td align="center">
         <img src="http://www.dealii.org/images/steps/developer/step-44.Q1-P0_convergence.png" alt="">
 	<p align="center">
-        Convergence of the $Q_1-DGPM_0-DGPM_0$ formulation.
+        Convergence of the $Q_1-DGPM_0-DGPM_0$ formulation in 3-d.
 	</p>
     </td>
     <td align="center">
         <img src="http://www.dealii.org/images/steps/developer/step-44.Q2-P1_convergence.png" alt="">
 	<p align="center">
-        Convergence of the $Q_2-DGPM_1-DGPM_1$ formulation.
+        Convergence of the $Q_2-DGPM_1-DGPM_1$ formulation in 3-d.
 	</p>
     </td>
   </tr>
@@ -140,7 +140,7 @@ and is opposite to the physically realistic interpretation of pressure.
     <td align="center">
         <img src="http://www.dealii.org/images/steps/developer/step-44.Q1-P0_gr_1_p_ratio_80-displacement.png" alt="">
 	<p align="center">
-        Z-displacement solution.
+        Z-displacement solution for the 3-d problem.
 	</p>
     </td>
     <td align="center">
@@ -172,7 +172,7 @@ There is a clear distinction and transition between regions of compression and e
 and the linear approximation of the pressure field allows a refined visualisation
 of the pressure at the sub-element scale.
 It should however be noted that the pressure field remains discontinuous
- and could be smoothed on a continuous grid for the post-processing purposes.
+and could be smoothed on a continuous grid for the post-processing purposes.
 
 
 
@@ -182,7 +182,7 @@ It should however be noted that the pressure field remains discontinuous
     <td align="center">
         <img src="http://www.dealii.org/images/steps/developer/step-44.Q2-P1_gr_3_p_ratio_80-displacement.png" alt="">
 	<p align="center">
-        Z-displacement solution.
+        Z-displacement solution for the 3-d problem.
 	</p>
     </td>
     <td align="center">
@@ -213,7 +213,7 @@ than the $Q_1-DGPM_0-DGPM_0$ for a similar number of degrees-of-freedom
 This is shown in the graph below for a batch of tests run consecutively on a single 4-core (8-thread) machine.
 The increase in computational time for the higher-order method is likely due to
 the increased band-width required for the higher-order elements.
-As previously mentioned, the use of a better solver and precondtioner may mitigate the
+As previously mentioned, the use of a better solver and preconditioner may mitigate the
 expense of using a higher-order formulation.
 It was observed that for the given problem using the multithreaded Jacobi preconditioner can reduce the
 computational runtime by up to 72% (for the worst case being a higher-order formulation with a large number
@@ -228,6 +228,31 @@ some finite-strain problems involving alternative constitutive models.
         <img src="http://www.dealii.org/images/steps/developer/step-44.Normalised_runtime.png" alt="">
 	<p align="center">
         Runtime on a 4-core machine, normalised against the lowest grid resolution $Q_1-DGPM_0-DGPM_0$ solution that utilised a SSOR preconditioner.
+	</p>
+    </td>
+  </tr>
+</table>
+
+
+Lastly, results for the displacement solution for the 2-d problem are showcased below for
+two different levels of grid refinement.
+It is clear that due to the extra constraints imposed by simulating in 2-d that the resulting
+displacement field, although qualitatively similar, is different to that of the 3-d case.
+
+
+<table align="center" class="tutorial" cellspacing="3" cellpadding="3">
+
+  <tr>
+    <td align="center">
+        <img src="http://www.dealii.org/images/steps/developer/step-44.2d-gr_2.png" alt="">
+	<p align="center">
+        Y-displacement solution in 2-d for 2 global grid refinement levels.
+	</p>
+    </td>
+    <td align="center">
+        <img src="http://www.dealii.org/images/steps/developer/step-44.2d-gr_5.png" alt="">
+	<p align="center">
+        Y-displacement solution in 2-d for 5 global grid refinement levels.
 	</p>
     </td>
   </tr>

--- a/examples/step-44/parameters.prm
+++ b/examples/step-44/parameters.prm
@@ -23,7 +23,8 @@ end
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
-  set Max iteration multiplier = 1
+  # In 2-d, this value is best set at 2. In 3-d, a value of 1 work fine.
+  set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
   set Residual                 = 1e-6

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -724,7 +724,7 @@ namespace Step44
     void setup_lqp (const Parameters::AllParameters &parameters)
     {
       material.reset(new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
-          parameters.nu));
+                     parameters.nu));
       update_values(Tensor<2, dim>(), 0.0, 1.0);
     }
 
@@ -1534,25 +1534,25 @@ namespace Step44
     for (; cell != endc; ++cell)
       for (unsigned int face = 0;
            face < GeometryInfo<dim>::faces_per_cell; ++face)
-      {
-        if (cell->face(face)->at_boundary() == true
-            &&
-            cell->face(face)->center()[1] == 1.0 * parameters.scale)
         {
-          if (dim==3)
-          {
-            if (cell->face(face)->center()[0] < 0.5 * parameters.scale
-                &&
-                cell->face(face)->center()[2] < 0.5 * parameters.scale)
-              cell->face(face)->set_boundary_id(6);
-          }
-          else
-          {
-            if (cell->face(face)->center()[0] < 0.5 * parameters.scale)
-              cell->face(face)->set_boundary_id(6);
-          }
+          if (cell->face(face)->at_boundary() == true
+              &&
+              cell->face(face)->center()[1] == 1.0 * parameters.scale)
+            {
+              if (dim==3)
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale
+                      &&
+                      cell->face(face)->center()[2] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+              else
+                {
+                  if (cell->face(face)->center()[0] < 0.5 * parameters.scale)
+                    cell->face(face)->set_boundary_id(6);
+                }
+            }
         }
-      }
   }
 
 
@@ -2508,102 +2508,102 @@ namespace Step44
     }
 
     if (dim==3)
-    {
-      const FEValuesExtractors::Scalar z_displacement(2);
-
       {
-        const int boundary_id = 3;
+        const FEValuesExtractors::Scalar z_displacement(2);
 
-        if (apply_dirichlet_bc == true)
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)
-                                                    |
-                                                    fe.component_mask(z_displacement)));
-        else
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)
-                                                    |
-                                                    fe.component_mask(z_displacement)));
+        {
+          const int boundary_id = 3;
+
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
+        {
+          const int boundary_id = 4;
+
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     fe.component_mask(z_displacement));
+        }
+
+        {
+          const int boundary_id = 6;
+
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)
+                                                      |
+                                                      fe.component_mask(z_displacement)));
+        }
       }
-      {
-        const int boundary_id = 4;
-
-        if (apply_dirichlet_bc == true)
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   fe.component_mask(z_displacement));
-        else
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   fe.component_mask(z_displacement));
-      }
-
-      {
-        const int boundary_id = 6;
-
-        if (apply_dirichlet_bc == true)
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)
-                                                    |
-                                                    fe.component_mask(z_displacement)));
-        else
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)
-                                                    |
-                                                    fe.component_mask(z_displacement)));
-      }
-    }
     else
-    {
       {
-        const int boundary_id = 3;
+        {
+          const int boundary_id = 3;
 
-        if (apply_dirichlet_bc == true)
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)));
-        else
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)));
-      }
-      {
-        const int boundary_id = 6;
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
+        {
+          const int boundary_id = 6;
 
-        if (apply_dirichlet_bc == true)
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)));
-        else
-          VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                   boundary_id,
-                                                   ZeroFunction<dim>(n_components),
-                                                   constraints,
-                                                   (fe.component_mask(x_displacement)));
+          if (apply_dirichlet_bc == true)
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+          else
+            VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                     boundary_id,
+                                                     ZeroFunction<dim>(n_components),
+                                                     constraints,
+                                                     (fe.component_mask(x_displacement)));
+        }
       }
-    }
 
     constraints.close();
   }

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -559,7 +559,7 @@ namespace Step44
                               const double J_tilde_in)
     {
       det_F = determinant(F);
-      b_bar = std::pow(det_F, -2.0 / 3.0) * symmetrize(F * transpose(F));
+      b_bar = std::pow(det_F, -2.0 / dim) * symmetrize(F * transpose(F));
       p_tilde = p_tilde_in;
       J_tilde = J_tilde_in;
 
@@ -677,9 +677,9 @@ namespace Step44
                         tau_iso);
       const SymmetricTensor<4, dim> c_bar = get_c_bar();
 
-      return (2.0 / 3.0) * trace(tau_bar)
+      return (2.0 / dim) * trace(tau_bar)
              * StandardTensors<dim>::dev_P
-             - (2.0 / 3.0) * (tau_iso_x_I + I_x_tau_iso)
+             - (2.0 / dim) * (tau_iso_x_I + I_x_tau_iso)
              + StandardTensors<dim>::dev_P * c_bar
              * StandardTensors<dim>::dev_P;
     }
@@ -1120,6 +1120,7 @@ namespace Step44
     n_q_points (qf_cell.size()),
     n_q_points_f (qf_face.size())
   {
+    Assert(dim==2 || dim==3, ExcMessage("This problem only works in 2 or 3 space dimensions."));
     determine_component_extractors();
   }
 
@@ -1517,8 +1518,8 @@ namespace Step44
   void Solid<dim>::make_grid()
   {
     GridGenerator::hyper_rectangle(triangulation,
-                                   Point<dim>(0.0, 0.0, 0.0),
-                                   Point<dim>(1.0, 1.0, 1.0),
+                                   (dim==3 ? Point<dim>(0.0, 0.0, 0.0) : Point<dim>(0.0, 0.0)),
+                                   (dim==3 ? Point<dim>(1.0, 1.0, 1.0) : Point<dim>(1.0, 1.0)),
                                    true);
     GridTools::scale(parameters.scale, triangulation);
     triangulation.refine_global(std::max (1U, parameters.global_refinement));
@@ -1537,13 +1538,25 @@ namespace Step44
     for (; cell != endc; ++cell)
       for (unsigned int face = 0;
            face < GeometryInfo<dim>::faces_per_cell; ++face)
+      {
         if (cell->face(face)->at_boundary() == true
             &&
-            cell->face(face)->center()[2] == 1.0 * parameters.scale)
-          if (cell->face(face)->center()[0] < 0.5 * parameters.scale
-              &&
-              cell->face(face)->center()[1] < 0.5 * parameters.scale)
-            cell->face(face)->set_boundary_id(6);
+            cell->face(face)->center()[1] == 1.0 * parameters.scale)
+        {
+          if (dim==3)
+          {
+            if (cell->face(face)->center()[0] < 0.5 * parameters.scale
+                &&
+                cell->face(face)->center()[2] < 0.5 * parameters.scale)
+              cell->face(face)->set_boundary_id(6);
+          }
+          else
+          {
+            if (cell->face(face)->center()[0] < 0.5 * parameters.scale)
+              cell->face(face)->set_boundary_id(6);
+          }
+        }
+      }
   }
 
 
@@ -2448,11 +2461,11 @@ namespace Step44
 
     // The boundary conditions for the indentation problem are as follows: On
     // the -x, -y and -z faces (ID's 0,2,4) we set up a symmetry condition to
-    // allow only planar movement while the +x and +y faces (ID's 1,3) are
-    // traction free. In this contrived problem, part of the +z face (ID 5) is
-    // set to have no motion in the x- and y-component. Finally, as described
-    // earlier, the other part of the +z face has an the applied pressure but
-    // is also constrained in the x- and y-directions.
+    // allow only planar movement while the +x and +z faces (ID's 1,5) are
+    // traction free. In this contrived problem, part of the +y face (ID 3) is
+    // set to have no motion in the x- and z-component. Finally, as described
+    // earlier, the other part of the +y face has an the applied pressure but
+    // is also constrained in the x- and z-directions.
     //
     // In the following, we will have to tell the function interpolation
     // boundary values which components of the solution vector should be
@@ -2464,7 +2477,6 @@ namespace Step44
     // use it when generating the relevant component masks:
     const FEValuesExtractors::Scalar x_displacement(0);
     const FEValuesExtractors::Scalar y_displacement(1);
-    const FEValuesExtractors::Scalar z_displacement(2);
 
     {
       const int boundary_id = 0;
@@ -2498,61 +2510,103 @@ namespace Step44
                                                  constraints,
                                                  fe.component_mask(y_displacement));
     }
-    {
-      const int boundary_id = 4;
 
-      if (apply_dirichlet_bc == true)
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 fe.component_mask(z_displacement));
-      else
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 fe.component_mask(z_displacement));
+    if (dim==3)
+    {
+      const FEValuesExtractors::Scalar z_displacement(2);
+
+      {
+        const int boundary_id = 3;
+
+        if (apply_dirichlet_bc == true)
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)
+                                                    |
+                                                    fe.component_mask(z_displacement)));
+        else
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)
+                                                    |
+                                                    fe.component_mask(z_displacement)));
+      }
+      {
+        const int boundary_id = 4;
+
+        if (apply_dirichlet_bc == true)
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   fe.component_mask(z_displacement));
+        else
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   fe.component_mask(z_displacement));
+      }
+
+      {
+        const int boundary_id = 6;
+
+        if (apply_dirichlet_bc == true)
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)
+                                                    |
+                                                    fe.component_mask(z_displacement)));
+        else
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)
+                                                    |
+                                                    fe.component_mask(z_displacement)));
+      }
     }
+    else
     {
-      const int boundary_id = 5;
+      {
+        const int boundary_id = 3;
 
-      if (apply_dirichlet_bc == true)
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 (fe.component_mask(x_displacement)
-                                                  |
-                                                  fe.component_mask(y_displacement)));
-      else
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 (fe.component_mask(x_displacement)
-                                                  |
-                                                  fe.component_mask(y_displacement)));
-    }
-    {
-      const int boundary_id = 6;
+        if (apply_dirichlet_bc == true)
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)));
+        else
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)));
+      }
+      {
+        const int boundary_id = 6;
 
-      if (apply_dirichlet_bc == true)
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 (fe.component_mask(x_displacement)
-                                                  |
-                                                  fe.component_mask(y_displacement)));
-      else
-        VectorTools::interpolate_boundary_values(dof_handler_ref,
-                                                 boundary_id,
-                                                 ZeroFunction<dim>(n_components),
-                                                 constraints,
-                                                 (fe.component_mask(x_displacement)
-                                                  |
-                                                  fe.component_mask(y_displacement)));
+        if (apply_dirichlet_bc == true)
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)));
+        else
+          VectorTools::interpolate_boundary_values(dof_handler_ref,
+                                                   boundary_id,
+                                                   ZeroFunction<dim>(n_components),
+                                                   constraints,
+                                                   (fe.component_mask(x_displacement)));
+      }
     }
 
     constraints.close();
@@ -3155,7 +3209,7 @@ namespace Step44
     data_out.build_patches(q_mapping, degree);
 
     std::ostringstream filename;
-    filename << "solution-" << time.get_timestep() << ".vtk";
+    filename << "solution-" << dim << "d-" << time.get_timestep() << ".vtk";
 
     std::ofstream output(filename.str().c_str());
     data_out.write_vtk(output);
@@ -3174,8 +3228,9 @@ int main ()
 
   try
     {
-      Solid<3> solid_3d("parameters.prm");
-      solid_3d.run();
+      const unsigned int dim = 3;
+      Solid<dim> solid("parameters.prm");
+      solid.run();
     }
   catch (std::exception &exc)
     {

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -706,7 +706,6 @@ namespace Step44
   public:
     PointHistory()
       :
-      material(NULL),
       F_inv(StandardTensors<dim>::I),
       tau(SymmetricTensor<2, dim>()),
       d2Psi_vol_dJ2(0.0),
@@ -714,11 +713,10 @@ namespace Step44
       Jc(SymmetricTensor<4, dim>())
     {}
 
+    // That the material is stored in a smart pointer, we don't need to worry
+    // about its memory management
     virtual ~PointHistory()
-    {
-      delete material;
-      material = NULL;
-    }
+    {}
 
     // The first function is used to create a material object and to
     // initialize all tensors correctly: The second one updates the stored
@@ -727,8 +725,8 @@ namespace Step44
     // dilation $\widetilde{J}$ field values.
     void setup_lqp (const Parameters::AllParameters &parameters)
     {
-      material = new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
-          parameters.nu);
+      material.reset(new Material_Compressible_Neo_Hook_Three_Field<dim>(parameters.mu,
+          parameters.nu));
       update_values(Tensor<2, dim>(), 0.0, 1.0);
     }
 
@@ -819,7 +817,7 @@ namespace Step44
     // materials are used in different regions of the domain, as well as the
     // inverse of the deformation gradient...
   private:
-    Material_Compressible_Neo_Hook_Three_Field<dim> *material;
+    std_cxx11::shared_ptr< Material_Compressible_Neo_Hook_Three_Field<dim> > material;
 
     Tensor<2, dim> F_inv;
 

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -713,8 +713,6 @@ namespace Step44
       Jc(SymmetricTensor<4, dim>())
     {}
 
-    // That the material is stored in a smart pointer, we don't need to worry
-    // about its memory management
     virtual ~PointHistory()
     {}
 
@@ -2458,8 +2456,8 @@ namespace Step44
     const bool apply_dirichlet_bc = (it_nr == 0);
 
     // The boundary conditions for the indentation problem are as follows: On
-    // the -x, -y and -z faces (ID's 0,2,4) we set up a symmetry condition to
-    // allow only planar movement while the +x and +z faces (ID's 1,5) are
+    // the -x, -y and -z faces (IDs 0,2,4) we set up a symmetry condition to
+    // allow only planar movement while the +x and +z faces (IDs 1,5) are
     // traction free. In this contrived problem, part of the +y face (ID 3) is
     // set to have no motion in the x- and z-component. Finally, as described
     // earlier, the other part of the +y face has an the applied pressure but


### PR DESCRIPTION
By making the appropriate changes to the material class, grid generation
and boundary conditions, the quasi-incompressible indentation problem
can be made dimension independent. The traction is now applied on the +Y
face instead of the +Z face so that the 2-d and 3-d problems can be
post-processed in a similar manner. The 2-d results are qualitatively
similar to that of the 3-d case, but due to the more constrained nature
of the problem (planar motion) the amount of compression achieved is
less than that of the 3-d case (while the laterial extension increases).

While we're making changes... We now use a shared pointer to store an
instance of the Material class inside PointHistory.