### PR TITLE
Prefer PreconditionerType to Preconditioner.

### DIFF
--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -264,26 +264,26 @@ namespace Step22
   // <code>InverseMatrix</code> object is created. The member function
   // <code>vmult</code> is, as in step-20, a multiplication with a vector,
   // obtained by solving a linear system:
-  template <class MatrixType, class Preconditioner>
+  template <class MatrixType, class PreconditionerType>
   class InverseMatrix : public Subscriptor
   {
   public:
-    InverseMatrix (const MatrixType     &m,
-                   const Preconditioner &preconditioner);
+    InverseMatrix (const MatrixType         &m,
+                   const PreconditionerType &preconditioner);
 
     void vmult (Vector<double>       &dst,
                 const Vector<double> &src) const;
 
   private:
     const SmartPointer<const MatrixType> matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const SmartPointer<const PreconditionerType> preconditioner;
   };
 
 
-  template <class MatrixType, class Preconditioner>
-  InverseMatrix<MatrixType,Preconditioner>::InverseMatrix
-  (const MatrixType     &m,
-   const Preconditioner &preconditioner)
+  template <class MatrixType, class PreconditionerType>
+  InverseMatrix<MatrixType,PreconditionerType>::InverseMatrix
+  (const MatrixType         &m,
+   const PreconditionerType &preconditioner)
     :
     matrix (&m),
     preconditioner (&preconditioner)
@@ -300,9 +300,10 @@ namespace Step22
   // inverse of the Laplace matrix &ndash; which is hence directly responsible
   // for the accuracy of the solution itself, so we can't choose a too large
   // tolerance, either.
-  template <class MatrixType, class Preconditioner>
-  void InverseMatrix<MatrixType,Preconditioner>::vmult (Vector<double>       &dst,
-                                                        const Vector<double> &src) const
+  template <class MatrixType, class PreconditionerType>
+  void InverseMatrix<MatrixType,PreconditionerType>::vmult
+  (Vector<double>       &dst,
+   const Vector<double> &src) const
   {
     SolverControl solver_control (src.size(), 1e-6*src.l2_norm());
     SolverCG<>    cg (solver_control);
@@ -317,35 +318,35 @@ namespace Step22
 
   // This class implements the Schur complement discussed in the introduction.
   // It is in analogy to step-20.  Though, we now call it with a template
-  // parameter <code>Preconditioner</code> in order to access that when
+  // parameter <code>PreconditionerType</code> in order to access that when
   // specifying the respective type of the inverse matrix class. As a
   // consequence of the definition above, the declaration
   // <code>InverseMatrix</code> now contains the second template parameter for
   // a preconditioner class as above, which affects the
   // <code>SmartPointer</code> object <code>m_inverse</code> as well.
-  template <class Preconditioner>
+  template <class PreconditionerType>
   class SchurComplement : public Subscriptor
   {
   public:
     SchurComplement (const BlockSparseMatrix<double> &system_matrix,
-                     const InverseMatrix<SparseMatrix<double>, Preconditioner> &A_inverse);
+                     const InverseMatrix<SparseMatrix<double>, PreconditionerType> &A_inverse);
 
     void vmult (Vector<double>       &dst,
                 const Vector<double> &src) const;
 
   private:
     const SmartPointer<const BlockSparseMatrix<double> > system_matrix;
-    const SmartPointer<const InverseMatrix<SparseMatrix<double>, Preconditioner> > A_inverse;
+    const SmartPointer<const InverseMatrix<SparseMatrix<double>, PreconditionerType> > A_inverse;
 
     mutable Vector<double> tmp1, tmp2;
   };
 
 
 
-  template <class Preconditioner>
-  SchurComplement<Preconditioner>::
-  SchurComplement (const BlockSparseMatrix<double> &system_matrix,
-                   const InverseMatrix<SparseMatrix<double>,Preconditioner> &A_inverse)
+  template <class PreconditionerType>
+  SchurComplement<PreconditionerType>::SchurComplement
+  (const BlockSparseMatrix<double>                              &system_matrix,
+   const InverseMatrix<SparseMatrix<double>,PreconditionerType> &A_inverse)
     :
     system_matrix (&system_matrix),
     A_inverse (&A_inverse),
@@ -354,9 +355,9 @@ namespace Step22
   {}
 
 
-  template <class Preconditioner>
-  void SchurComplement<Preconditioner>::vmult (Vector<double>       &dst,
-                                               const Vector<double> &src) const
+  template <class PreconditionerType>
+  void SchurComplement<PreconditionerType>::vmult (Vector<double>       &dst,
+                                                   const Vector<double> &src) const
   {
     system_matrix->block(0,1).vmult (tmp1, src);
     A_inverse->vmult (tmp2, tmp1);

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -232,15 +232,15 @@ namespace Step32
   // discussion of composing solvers in step-20.
   namespace LinearSolvers
   {
-    template <class PreconditionerA, class PreconditionerMp>
+    template <class PreconditionerTypeA, class PreconditionerTypeMp>
     class BlockSchurPreconditioner : public Subscriptor
     {
     public:
-      BlockSchurPreconditioner (const TrilinosWrappers::BlockSparseMatrix  &S,
-                                const TrilinosWrappers::BlockSparseMatrix  &Spre,
-                                const PreconditionerMp                     &Mppreconditioner,
-                                const PreconditionerA                      &Apreconditioner,
-                                const bool                                  do_solve_A)
+      BlockSchurPreconditioner (const TrilinosWrappers::BlockSparseMatrix &S,
+                                const TrilinosWrappers::BlockSparseMatrix &Spre,
+                                const PreconditionerTypeMp                &Mppreconditioner,
+                                const PreconditionerTypeA                 &Apreconditioner,
+                                const bool                                 do_solve_A)
         :
         stokes_matrix     (&S),
         stokes_preconditioner_matrix     (&Spre),
@@ -286,8 +286,8 @@ namespace Step32
     private:
       const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> stokes_matrix;
       const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> stokes_preconditioner_matrix;
-      const PreconditionerMp &mp_preconditioner;
-      const PreconditionerA  &a_preconditioner;
+      const PreconditionerTypeMp &mp_preconditioner;
+      const PreconditionerTypeA  &a_preconditioner;
       const bool do_solve_A;
     };
   }

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -361,12 +361,12 @@ namespace Step43
   // darcy_matrix to match our problem.
   namespace LinearSolvers
   {
-    template <class MatrixType, class Preconditioner>
+    template <class MatrixType, class PreconditionerType>
     class InverseMatrix : public Subscriptor
     {
     public:
-      InverseMatrix (const MatrixType     &m,
-                     const Preconditioner &preconditioner);
+      InverseMatrix (const MatrixType         &m,
+                     const PreconditionerType &preconditioner);
 
 
       template <typename VectorType>
@@ -375,14 +375,14 @@ namespace Step43
 
     private:
       const SmartPointer<const MatrixType> matrix;
-      const Preconditioner &preconditioner;
+      const PreconditionerType &preconditioner;
     };
 
 
-    template <class MatrixType, class Preconditioner>
-    InverseMatrix<MatrixType,Preconditioner>::
-    InverseMatrix (const MatrixType     &m,
-                   const Preconditioner &preconditioner)
+    template <class MatrixType, class PreconditionerType>
+    InverseMatrix<MatrixType,PreconditionerType>::InverseMatrix
+    (const MatrixType         &m,
+     const PreconditionerType &preconditioner)
       :
       matrix (&m),
       preconditioner (preconditioner)
@@ -390,12 +390,12 @@ namespace Step43
 
 
 
-    template <class MatrixType, class Preconditioner>
+    template <class MatrixType, class PreconditionerType>
     template <typename VectorType>
     void
-    InverseMatrix<MatrixType,Preconditioner>::
-    vmult (VectorType       &dst,
-           const VectorType &src) const
+    InverseMatrix<MatrixType,PreconditionerType>::vmult
+    (VectorType       &dst,
+     const VectorType &src) const
     {
       SolverControl solver_control (src.size(), 1e-7*src.l2_norm());
       SolverCG<VectorType> cg (solver_control);
@@ -412,15 +412,15 @@ namespace Step43
         }
     }
 
-    template <class PreconditionerA, class PreconditionerMp>
+    template <class PreconditionerTypeA, class PreconditionerTypeMp>
     class BlockSchurPreconditioner : public Subscriptor
     {
     public:
       BlockSchurPreconditioner (
-        const TrilinosWrappers::BlockSparseMatrix     &S,
+        const TrilinosWrappers::BlockSparseMatrix &S,
         const InverseMatrix<TrilinosWrappers::SparseMatrix,
-        PreconditionerMp>         &Mpinv,
-        const PreconditionerA                         &Apreconditioner);
+        PreconditionerTypeMp>                     &Mpinv,
+        const PreconditionerTypeA                 &Apreconditioner);
 
       void vmult (TrilinosWrappers::MPI::BlockVector       &dst,
                   const TrilinosWrappers::MPI::BlockVector &src) const;
@@ -428,20 +428,20 @@ namespace Step43
     private:
       const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> darcy_matrix;
       const SmartPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
-            PreconditionerMp > > m_inverse;
-      const PreconditionerA &a_preconditioner;
+            PreconditionerTypeMp > > m_inverse;
+      const PreconditionerTypeA &a_preconditioner;
 
       mutable TrilinosWrappers::MPI::Vector tmp;
     };
 
 
 
-    template <class PreconditionerA, class PreconditionerMp>
-    BlockSchurPreconditioner<PreconditionerA, PreconditionerMp>::
-    BlockSchurPreconditioner(const TrilinosWrappers::BlockSparseMatrix  &S,
+    template <class PreconditionerTypeA, class PreconditionerTypeMp>
+    BlockSchurPreconditioner<PreconditionerTypeA, PreconditionerTypeMp>::
+    BlockSchurPreconditioner(const TrilinosWrappers::BlockSparseMatrix &S,
                              const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                             PreconditionerMp>      &Mpinv,
-                             const PreconditionerA                      &Apreconditioner)
+                             PreconditionerTypeMp>                     &Mpinv,
+                             const PreconditionerTypeA                 &Apreconditioner)
       :
       darcy_matrix            (&S),
       m_inverse               (&Mpinv),
@@ -450,8 +450,8 @@ namespace Step43
     {}
 
 
-    template <class PreconditionerA, class PreconditionerMp>
-    void BlockSchurPreconditioner<PreconditionerA, PreconditionerMp>::vmult (
+    template <class PreconditionerTypeA, class PreconditionerTypeMp>
+    void BlockSchurPreconditioner<PreconditionerTypeA, PreconditionerTypeMp>::vmult (
       TrilinosWrappers::MPI::BlockVector       &dst,
       const TrilinosWrappers::MPI::BlockVector &src) const
     {

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -182,21 +182,21 @@ namespace Step45
 
 
 
-  template <class MatrixType, class Preconditioner>
+  template <class MatrixType, class PreconditionerType>
   class InverseMatrix : public Subscriptor
   {
   public:
-    InverseMatrix (const MatrixType     &m,
-                   const Preconditioner &preconditioner,
-                   const IndexSet       &locally_owned,
-                   const MPI_Comm       &mpi_communicator);
+    InverseMatrix (const MatrixType         &m,
+                   const PreconditionerType &preconditioner,
+                   const IndexSet           &locally_owned,
+                   const MPI_Comm           &mpi_communicator);
 
     void vmult (TrilinosWrappers::MPI::Vector       &dst,
                 const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
     const SmartPointer<const MatrixType> matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const SmartPointer<const PreconditionerType> preconditioner;
 
     const MPI_Comm *mpi_communicator;
     mutable TrilinosWrappers::MPI::Vector tmp;
@@ -204,12 +204,12 @@ namespace Step45
 
 
 
-  template <class MatrixType, class Preconditioner>
-  InverseMatrix<MatrixType,Preconditioner>::InverseMatrix
-  (const MatrixType     &m,
-   const Preconditioner &preconditioner,
-   const IndexSet       &locally_owned,
-   const MPI_Comm       &mpi_communicator)
+  template <class MatrixType, class PreconditionerType>
+  InverseMatrix<MatrixType,PreconditionerType>::InverseMatrix
+  (const MatrixType         &m,
+   const PreconditionerType &preconditioner,
+   const IndexSet           &locally_owned,
+   const MPI_Comm           &mpi_communicator)
     :
     matrix (&m),
     preconditioner (&preconditioner),
@@ -219,8 +219,8 @@ namespace Step45
 
 
 
-  template <class MatrixType, class Preconditioner>
-  void InverseMatrix<MatrixType,Preconditioner>::vmult
+  template <class MatrixType, class PreconditionerType>
+  void InverseMatrix<MatrixType,PreconditionerType>::vmult
   (TrilinosWrappers::MPI::Vector       &dst,
    const TrilinosWrappers::MPI::Vector &src) const
   {
@@ -235,15 +235,15 @@ namespace Step45
 
 
 
-  template <class Preconditioner>
+  template <class PreconditionerType>
   class SchurComplement : public TrilinosWrappers::SparseMatrix
   {
   public:
-    SchurComplement ( const TrilinosWrappers::BlockSparseMatrix &system_matrix,
-                      const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                      Preconditioner> &A_inverse,
-                      const IndexSet &owned_pres,
-                      const MPI_Comm &mpi_communicator);
+    SchurComplement (const TrilinosWrappers::BlockSparseMatrix &system_matrix,
+                     const InverseMatrix<TrilinosWrappers::SparseMatrix,
+                     PreconditionerType>                       &A_inverse,
+                     const IndexSet                            &owned_pres,
+                     const MPI_Comm                            &mpi_communicator);
 
     void vmult (TrilinosWrappers::MPI::Vector       &dst,
                 const TrilinosWrappers::MPI::Vector &src) const;
@@ -251,19 +251,19 @@ namespace Step45
   private:
     const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> system_matrix;
     const SmartPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
-          Preconditioner> > A_inverse;
+          PreconditionerType> > A_inverse;
     mutable TrilinosWrappers::MPI::Vector tmp1, tmp2;
   };
 
 
 
-  template <class Preconditioner>
-  SchurComplement<Preconditioner>::
+  template <class PreconditionerType>
+  SchurComplement<PreconditionerType>::
   SchurComplement (const TrilinosWrappers::BlockSparseMatrix &system_matrix,
                    const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                   Preconditioner> &A_inverse,
-                   const IndexSet &owned_vel,
-                   const MPI_Comm &mpi_communicator)
+                   PreconditionerType>                       &A_inverse,
+                   const IndexSet                            &owned_vel,
+                   const MPI_Comm                            &mpi_communicator)
     :
     system_matrix (&system_matrix),
     A_inverse (&A_inverse),
@@ -273,8 +273,8 @@ namespace Step45
 
 
 
-  template <class Preconditioner>
-  void SchurComplement<Preconditioner>::vmult
+  template <class PreconditionerType>
+  void SchurComplement<PreconditionerType>::vmult
   (TrilinosWrappers::MPI::Vector       &dst,
    const TrilinosWrappers::MPI::Vector &src) const
   {


### PR DESCRIPTION
This commit updates the tutorials to use the same naming convention here as the rest of the library.