### PR TITLE
temporary masking of few places for complex-valued PETSc

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -37,6 +37,33 @@ SERIAL_VECTORS := { Vector<double>;
                     @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR@;
                   }
 
+REAL_SERIAL_VECTORS := { Vector<double>;
+                    Vector<float> ;
+                    Vector<long double>;
+
+                    BlockVector<double>;
+                    BlockVector<float>;
+                    BlockVector<long double>;
+
+                    parallel::distributed::Vector<double>;
+                    parallel::distributed::Vector<float> ;
+                    parallel::distributed::Vector<long double>;
+
+                    parallel::distributed::BlockVector<double>;
+                    parallel::distributed::BlockVector<float> ;
+                    parallel::distributed::BlockVector<long double>;
+
+                    @DEAL_II_EXPAND_TRILINOS_VECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_MPI_VECTOR@;
+                    @DEAL_II_EXPAND_PETSC_VECTOR_REAL@;
+                    @DEAL_II_EXPAND_PETSC_MPI_VECTOR_REAL@;                    
+
+                    @DEAL_II_EXPAND_TRILINOS_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_TRILINOS_MPI_BLOCKVECTOR@;
+                    @DEAL_II_EXPAND_PETSC_BLOCKVECTOR_REAL@;
+                    @DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR_REAL@;
+                  }
+
 EXTERNAL_SEQUENTIAL_VECTORS := { @DEAL_II_EXPAND_TRILINOS_VECTOR@;
                                  @DEAL_II_EXPAND_TRILINOS_BLOCKVECTOR@;
                                  @DEAL_II_EXPAND_PETSC_VECTOR@;

--- a/cmake/configure/configure_3_petsc.cmake
+++ b/cmake/configure/configure_3_petsc.cmake
@@ -103,6 +103,17 @@ MACRO(FEATURE_PETSC_CONFIGURE_EXTERNAL)
   SET(DEAL_II_EXPAND_PETSC_BLOCKVECTOR "PETScWrappers::BlockVector")
   SET(DEAL_II_EXPAND_PETSC_MPI_VECTOR "PETScWrappers::MPI::Vector")
   SET(DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR "PETScWrappers::MPI::BlockVector")
+  #
+  # FIXME:
+  # temporary variable until deal.II fully support complex-valued PETSc
+  IF( NOT PETSC_WITH_COMPLEX )
+    SET(DEAL_II_EXPAND_PETSC_VECTOR_REAL "PETScWrappers::Vector")
+    SET(DEAL_II_EXPAND_PETSC_BLOCKVECTOR_REAL "PETScWrappers::BlockVector")
+    SET(DEAL_II_EXPAND_PETSC_MPI_VECTOR_REAL "PETScWrappers::MPI::Vector")
+    SET(DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR_REAL "PETScWrappers::MPI::BlockVector")
+  ELSE()
+    MESSAGE(STATUS "Compiling with complex-valued algebra")
+  ENDIF()
 ENDMACRO()
 
 

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -71,8 +71,12 @@ namespace
       // to get the array of values from PETSc
       // in every iteration), but works
       PetscScalar m = 0;
+#ifndef PETSC_USE_COMPLEX
       for (unsigned int i=0; i<criteria.size(); ++i)
         m = std::max (m, criteria(i));
+#else
+      Assert(false, ExcNotImplemented())
+#endif
       return m;
     }
 
@@ -85,8 +89,12 @@ namespace
       // to get the array of values from PETSc
       // in every iteration), but works
       PetscScalar m = criteria(0);
+#ifndef PETSC_USE_COMPLEX
       for (unsigned int i=1; i<criteria.size(); ++i)
         m = std::min (m, criteria(i));
+#else
+      Assert(false, ExcNotImplemented());
+#endif
       return m;
     }
 #endif

--- a/source/numerics/data_out_dof_data.inst.in
+++ b/source/numerics/data_out_dof_data.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS; DH : DOFHANDLER_TEMPLATES; deal_II_dimension : DIMENSIONS)
 {
 // codim=0
 

--- a/source/numerics/derivative_approximation.inst.in
+++ b/source/numerics/derivative_approximation.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS ; VEC : SERIAL_VECTORS ; DH : DOFHANDLER_TEMPLATES)
+for (deal_II_dimension : DIMENSIONS ; VEC : REAL_SERIAL_VECTORS ; DH : DOFHANDLER_TEMPLATES)
 {
   namespace DerivativeApproximation
   \{

--- a/source/numerics/dof_output_operator.inst.in
+++ b/source/numerics/dof_output_operator.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 {
   template class DoFOutputOperator<VEC, deal_II_dimension, deal_II_dimension>;
 }

--- a/source/numerics/point_value_history.inst.in
+++ b/source/numerics/point_value_history.inst.in
@@ -21,7 +21,7 @@ for (deal_II_dimension : DIMENSIONS)
 }
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 {  
   template
   void PointValueHistory<deal_II_dimension>::evaluate_field 
@@ -30,7 +30,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 }
 
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 {  
   template
   void PointValueHistory<deal_II_dimension>::evaluate_field_at_requested_location 
@@ -38,7 +38,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
    const VEC &);
 }
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 {  
   template
   void PointValueHistory<deal_II_dimension>::evaluate_field 
@@ -48,7 +48,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
    const Quadrature<deal_II_dimension> &);
 }
 
-for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
+for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS)
 {  
   template
   void PointValueHistory<deal_II_dimension>::evaluate_field 


### PR DESCRIPTION
This is a final part which temporary masks a few places, namely: (i) max_element() and min_element() in grid_refinement.cc; (ii) DataEntry<>::get_function_xyz() (related to DataOut); (iii) PointValueHistory; (iv) DerivativeApproximation.

- [x] fix cmake to read `PETSC_USE_COMPLEX`

On a bright side - deal.ii does compile with complex-valued PETSc/SLEPc ! :smile:
In order to keep it so, can we have a regular tester with complex PETSc? 

In reference to https://github.com/dealii/dealii/issues/2033