### PR TITLE
Update triangulation comment style

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -491,19 +491,21 @@ namespace internal
  * <li> <em>Counting the number of cells on a specific level</em>
  *    @code
  *     template <int dim, int spacedim>
- *     int Triangulation<dim, spacedim>::n_cells (const int level) const {
+ *     int Triangulation<dim, spacedim>::n_cells (const int level) const
+ *     {
  *        cell_iterator cell = begin (level),
- *                      endc = end(level);
+ *                      endc = end (level);
  *        int n=0;
  *        for (; cell!=endc; ++cell)
  *          ++n;
  *        return n;
- *      };
+ *      }
  *    @endcode
  * Another way, which uses <tt>std::distance</tt>, would be to write
  *    @code
  *      template <int dim>
- *      int Triangulation<dim>::n_cells (const int level) const {
+ *      int Triangulation<dim>::n_cells (const int level) const
+ *      {
  *        int n=0;
  *        distance (begin(level),
  *                  (level == levels.size()-1 ?
@@ -511,20 +513,21 @@ namespace internal
  *                   begin (level+1)),
  *                  n);
  *        return n;
- *      };
+ *      }
  *    @endcode
  *
  * <li> <em>Refining all cells of a triangulation</em>
  *    @code
  *      template <int dim>
- *      void Triangulation<dim>::refine_global () {
+ *      void Triangulation<dim>::refine_global ()
+ *      {
  *        active_cell_iterator cell = begin_active(),
  *                             endc = end();
  *
  *        for (; cell != endc; ++cell)
  *          cell->set_refine_flag ();
  *        execute_coarsening_and_refinement ();
- *      };
+ *      }
  *    @endcode
  * </ul>
  *
@@ -534,42 +537,39 @@ namespace internal
  * Usage of a Triangulation is mainly done through the use of iterators. An
  * example probably shows best how to use it:
  *  @code
- *  void main () {
- *    Triangulation<2> tria;
+ * int main ()
+ * {
+ *   Triangulation<2> tria;
  *
- *    // read in a coarse grid file
+ *   // read in a coarse grid file
  *
- *                                     // we want to log the
- *                                     // refinement history
- *    ofstream history ("mesh.history");
+ *   // we want to log the refinement history
+ *   ofstream history ("mesh.history");
  *
- *                                     // refine first cell
- *    tria.begin_active()->set_refine_flag();
- *    tria.save_refine_flags (history);
- *    tria.execute_coarsening_and_refinement ();
+ *   // refine first cell
+ *   tria.begin_active()->set_refine_flag();
+ *   tria.save_refine_flags (history);
+ *   tria.execute_coarsening_and_refinement ();
  *
- *                                     // refine first active cell
- *                                     // on coarsest level
- *    tria.begin_active()->set_refine_flag ();
- *    tria.save_refine_flags (history);
- *    tria.execute_coarsening_and_refinement ();
+ *   // refine first active cell on coarsest level
+ *   tria.begin_active()->set_refine_flag ();
+ *   tria.save_refine_flags (history);
+ *   tria.execute_coarsening_and_refinement ();
  *
- *    Triangulation<2>::active_cell_iterator cell;
- *    for (int i=0; i<17; ++i)
- *      {
- *                                         // refine the presently
- *                                         // second last cell 17
- *                                         // times
- *        cell = tria.last_active(tria.n_levels()-1);
- *        --cell;
- *        cell->set_refine_flag ();
- *        tria.save_refine_flags (history);
- *        tria.execute_coarsening_and_refinement ();
- *      };
- *                                       // output the grid
- *    ofstream out("grid.1");
- *    GridOut::write_gnuplot (tria, out);
- *  };
+ *   Triangulation<2>::active_cell_iterator cell;
+ *   for (int i=0; i<17; ++i)
+ *     {
+ *       // refine the presently second last cell 17 times
+ *       cell = tria.last_active(tria.n_levels()-1);
+ *       --cell;
+ *       cell->set_refine_flag ();
+ *       tria.save_refine_flags (history);
+ *       tria.execute_coarsening_and_refinement ();
+ *     };
+ *   // output the grid
+ *   ofstream out("grid.1");
+ *   GridOut::write_gnuplot (tria, out);
+ * }
  *  @endcode
  *
  *
@@ -800,27 +800,29 @@ namespace internal
  * be stored and loaded through the @p save_refine_flags and @p
  * load_refine_flags functions. Normally, the code will look like this:
  *   @code
- *                                 // open output file
+ *     // open output file
  *     ofstream history("mesh.history");
- *                                 // do 10 refinement steps
- *     for (int step=0; step<10; ++step) {
- *       ...;
- *       // flag cells according to some criterion
- *       ...;
- *       tria.save_refine_flags (history);
- *       tria.execute_coarsening_and_refinement ();
- *     };
+ *     // do 10 refinement steps
+ *     for (unsigned int step=0; step<10; ++step)
+ *       {
+ *         ...;
+ *         // flag cells according to some criterion
+ *         ...;
+ *         tria.save_refine_flags (history);
+ *         tria.execute_coarsening_and_refinement ();
+ *       }
  *   @endcode
  *
  * If you want to re-create the grid from the stored information, you write:
  *   @code
- *                                 // open input file
+ *     // open input file
  *     ifstream history("mesh.history");
- *                                 // do 10 refinement steps
- *     for (int step=0; step<10; ++step) {
- *       tria.load_refine_flags (history);
- *       tria.execute_coarsening_and_refinement ();
- *     };
+ *     // do 10 refinement steps
+ *     for (unsigned int step=0; step<10; ++step)
+ *       {
+ *         tria.load_refine_flags (history);
+ *         tria.execute_coarsening_and_refinement ();
+ *       }
  *   @endcode
  *
  * The same scheme is employed for coarsening and the coarsening flags.
@@ -881,7 +883,8 @@ namespace internal
  * class derived from Boundary<tt><2></tt>):
  *
  *   @code
- *     void main () {
+ *     int main ()
+ *     {
  *       Triangulation<2> tria;
  *                                        // set the boundary function
  *                                        // for all boundaries with
@@ -889,25 +892,24 @@ namespace internal
  *       Ball ball;
  *       tria.set_boundary (0, ball);
  *
- *       // read some coarse grid
+ *   // read some coarse grid
  *
  *
- *       Triangulation<2>::active_cell_iterator cell, endc;
- *       for (int i=0; i<8; ++i)
- *         {
- *           cell = tria.begin_active();
- *           endc = tria.end();
+ *   Triangulation<2>::active_cell_iterator cell, endc;
+ *   for (int i=0; i<8; ++i)
+ *     {
+ *       cell = tria.begin_active();
+ *       endc = tria.end();
  *
- *                                            // refine all
- *                                            // boundary cells
- *           for (; cell!=endc; ++cell)
- *             if (cell->at_boundary())
- *               cell->set_refine_flag();
+ *       // refine all boundary cells
+ *       for (; cell!=endc; ++cell)
+ *         if (cell->at_boundary())
+ *           cell->set_refine_flag();
  *
- *           tria.execute_coarsening_and_refinement();
- *         };
- *     };
- *   @endcode
+ *       tria.execute_coarsening_and_refinement();
+ *     }
+ * }
+ * @endcode
  *
  * You should take note of one caveat: if you have concave boundaries, you
  * must make sure that a new boundary vertex does not lie too much inside the
@@ -940,11 +942,13 @@ namespace internal
  * As a simple example, the following code will print something to the output
  * every time the triangulation has just been refined:
  *   @code
- *     void f() {
+ *     void f()
+ *     {
  *       std::cout << "Triangulation has been refined." << std::endl;
  *     }
  *
- *     void run () {
+ *     void run ()
+ *     {
  *       Triangulation<dim> triangulation;
  *       // fill it somehow
  *       triangulation.signals.post_refinement.connect (&f);
@@ -968,16 +972,18 @@ namespace internal
  * concern to us here):
  *   @code
  *     template <int dim>
- *     class FEValues {
- *         Triangulation<dim>::active_cell_iterator current_cell, previous_cell;
- *       public:
- *         void reinit (Triangulation<dim>::active_cell_iterator &cell);
- *         void invalidate_previous_cell ();
+ *     class FEValues
+ *     {
+ *       Triangulation<dim>::active_cell_iterator current_cell, previous_cell;
+ *     public:
+ *       void reinit (Triangulation<dim>::active_cell_iterator &cell);
+ *       void invalidate_previous_cell ();
  *     };
  *
  *     template <int dim>
  *     void
- *     FEValues<dim>::reinit (Triangulation<dim>::active_cell_iterator &cell) {
+ *     FEValues<dim>::reinit (Triangulation<dim>::active_cell_iterator &cell)
+ *     {
  *       if (previous_cell.status() != valid)
  *         {
  *           // previous_cell has not been set. set it now, and register
@@ -992,13 +998,14 @@ namespace internal
  *         previous_cell = current_cell;
  *
  *       current_cell = cell;
- *       ... do something with the cell...
+ *       // ... do something with the cell...
  *     }
  *
  *
  *     template <int dim>
  *     void
- *     FEValues<dim>::invalidate_previous_cell () {
+ *     FEValues<dim>::invalidate_previous_cell ()
+ *     {
  *       previous_cell = Triangulation<dim>::active_cell_iterator();
  *     }
  *   @endcode

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -873,7 +873,7 @@ namespace internal
  * been called.
  *
  *
- * <h3>Boundary approximation</h3>
+ * <h3>%Boundary approximation</h3>
  *
  * You can specify a boundary function for each boundary component. If a new
  * vertex is created on a side or face at the boundary, this function is used
@@ -1070,7 +1070,7 @@ namespace internal
  *
  * <h3>Technical details</h3>
  *
- * <h4>Algorithms for mesh regularization and smoothing upon refinement</h4>
+ * <h4>%Algorithms for mesh regularization and smoothing upon refinement</h4>
  *
  * We chose an inductive point of view: since upon creation of the
  * triangulation all cells are on the same level, all regularity assumptions


### PR DESCRIPTION
These commits cleans up some of the code samples in `tria.h` and avoids some things that would currently raise warnings (like ending blocks with `};` or `void main`). Additionally, they get rid of some false links in section headings (preface with `%`).