### PR TITLE
Remove deprecated functions with names like 'boundary_indicator'.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,15 @@ inconvenience this causes.
 </p>
 
 <ol>
+  <li> Removed: Functions with names containing <code>boundary_indicator</code>
+  have been removed. They had previously already been deprecated, and replaced
+  by functions containing the string <code>boundary_id</code> instead, to keep
+  with the style used for <code>material_id</code>, <code>subdomain_id</code>,
+  etc.
+  <br>
+  (Wolfgang Bangerth, 2016/02/28)
+  </li>
+
   <li> Changed: Many functions in VectorTools and MatrixTools now require
   matching data types between vectors, matrices, and Function arguments.
   <br>

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1697,13 +1697,6 @@ public:
   std::vector<types::boundary_id> get_boundary_ids() const;
 
   /**
-   * Deprecated spelling of get_boundary_ids().
-   *
-   * @deprecated Use get_boundary_ids() instead.
-   */
-  std::vector<types::boundary_id> get_boundary_indicators() const DEAL_II_DEPRECATED;
-
-  /**
    * Returns a vector containing all manifold indicators assigned to the
    * objects of this Triangulation. Note, that each manifold indicator is
    * reported only once. The size of the return vector will represent the

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -885,14 +885,6 @@ public:
   types::boundary_id boundary_id () const;
 
   /**
-   * Return the boundary indicator of this object.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * boundary_id() instead.
-   */
-  types::boundary_id boundary_indicator () const DEAL_II_DEPRECATED;
-
-  /**
    * Set the boundary indicator of the current object. The same applies as for
    * the boundary_id() function.
    *
@@ -922,14 +914,6 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void set_boundary_id (const types::boundary_id) const;
-
-  /**
-   * Set the boundary indicator of this object.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * set_boundary_id() instead.
-   */
-  void set_boundary_indicator (const types::boundary_id) const DEAL_II_DEPRECATED;
 
   /**
    * Do as set_boundary_id() but also set the boundary indicators of the
@@ -962,14 +946,6 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void set_all_boundary_ids (const types::boundary_id) const;
-
-  /**
-   * Set the boundary indicator of this object and all that bound it.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * set_all_boundary_ids() instead.
-   */
-  void set_all_boundary_indicators (const types::boundary_id) const DEAL_II_DEPRECATED;
 
   /**
    * Return whether this object is at the boundary. Obviously, the use of this
@@ -2065,14 +2041,6 @@ public:
   types::boundary_id boundary_id () const;
 
   /**
-   * Return the boundary indicator of this object.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * boundary_id() instead.
-   */
-  types::boundary_id boundary_indicator () const DEAL_II_DEPRECATED;
-
-  /**
    * Return the manifold indicator of this object.
    *
    * @see
@@ -2208,14 +2176,6 @@ public:
   set_boundary_id (const types::boundary_id);
 
   /**
-   * Set the boundary indicator of this object.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * set_boundary_id() instead.
-   */
-  void set_boundary_indicator (const types::boundary_id) DEAL_II_DEPRECATED;
-
-  /**
    * Set the manifold indicator of this vertex. This does nothing so far since
    * manifolds are only used to refine and map objects, but vertices are not
    * refined and the mapping is trivial. This function is here only to allow
@@ -2237,14 +2197,6 @@ public:
    */
   void
   set_all_boundary_ids (const types::boundary_id);
-
-  /**
-   * Set the boundary indicator of this object and all that bound it.
-   *
-   * @deprecated This spelling of the function name is deprecated. Use
-   * set_all_boundary_ids() instead.
-   */
-  void set_all_boundary_indicators (const types::boundary_id) DEAL_II_DEPRECATED;
 
   /**
    * Set the manifold indicator of this object and all of its lower-

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1855,16 +1855,6 @@ TriaAccessor<structdim, dim, spacedim>::boundary_id () const
 
 
 template <int structdim, int dim, int spacedim>
-types::boundary_id
-TriaAccessor<structdim, dim, spacedim>::boundary_indicator () const
-{
-  return boundary_id();
-}
-
-
-
-
-template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::
 set_boundary_id (const types::boundary_id boundary_ind) const
@@ -1873,16 +1863,6 @@ set_boundary_id (const types::boundary_id boundary_ind) const
   Assert (this->used(), TriaAccessorExceptions::ExcCellNotUsed());
 
   this->objects().boundary_or_material_id[this->present_index].boundary_id = boundary_ind;
-}
-
-
-
-template <int structdim, int dim, int spacedim>
-void
-TriaAccessor<structdim, dim, spacedim>::
-set_boundary_indicator (const types::boundary_id boundary_ind) const
-{
-  set_boundary_id (boundary_ind);
 }
 
 
@@ -1911,16 +1891,6 @@ set_all_boundary_ids (const types::boundary_id boundary_ind) const
     default:
       Assert (false, ExcNotImplemented());
     }
-}
-
-
-
-template <int structdim, int dim, int spacedim>
-void
-TriaAccessor<structdim, dim, spacedim>::
-set_all_boundary_indicators (const types::boundary_id boundary_ind) const
-{
-  set_all_boundary_ids (boundary_ind);
 }
 
 
@@ -2774,16 +2744,6 @@ TriaAccessor<0, 1, spacedim>::boundary_id () const
 
 template <int spacedim>
 inline
-types::boundary_id
-TriaAccessor<0, 1, spacedim>::boundary_indicator () const
-{
-  return boundary_id();
-}
-
-
-
-template <int spacedim>
-inline
 types::manifold_id
 TriaAccessor<0, 1, spacedim>::manifold_id () const
 {
@@ -2925,17 +2885,6 @@ TriaAccessor<0, 1, spacedim>::set_boundary_id (const types::boundary_id b)
 template <int spacedim>
 inline
 void
-TriaAccessor<0, 1, spacedim>::set_boundary_indicator (const types::boundary_id b)
-{
-  set_boundary_id (b);
-}
-
-
-
-
-template <int spacedim>
-inline
-void
 TriaAccessor<0, 1, spacedim>::set_manifold_id (const types::manifold_id b)
 {
   (*tria->vertex_to_manifold_id_map_1d)[this->vertex_index()] = b;
@@ -2948,15 +2897,6 @@ inline
 void TriaAccessor<0, 1, spacedim>::set_all_boundary_ids (const types::boundary_id b)
 {
   set_boundary_id (b);
-}
-
-
-
-template <int spacedim>
-inline
-void TriaAccessor<0, 1, spacedim>::set_all_boundary_indicators (const types::boundary_id b)
-{
-  set_all_boundary_ids (b);
 }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3781,7 +3781,7 @@ namespace GridGenerator
         for (unsigned int f=0; f<4; ++f)
           if (cell->at_boundary(f)
               &&
-              (cell->face(f)->boundary_indicator() != 0))
+              (cell->face(f)->boundary_id() != 0))
             {
               quad.boundary_id = cell->face(f)->boundary_id();
               max_boundary_id = std::max(max_boundary_id, quad.boundary_id);

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -50,8 +50,8 @@ namespace
    */
   template <int spacedim>
   void
-  assign_1d_boundary_indicators (const std::map<unsigned int, types::boundary_id> &boundary_ids,
-                                 Triangulation<1,spacedim>                        &triangulation)
+  assign_1d_boundary_ids (const std::map<unsigned int, types::boundary_id> &boundary_ids,
+                          Triangulation<1,spacedim>                        &triangulation)
   {
     if (boundary_ids.size() > 0)
       for (typename Triangulation<1,spacedim>::active_cell_iterator
@@ -71,8 +71,8 @@ namespace
 
   template <int dim, int spacedim>
   void
-  assign_1d_boundary_indicators (const std::map<unsigned int, types::boundary_id> &,
-                                 Triangulation<dim,spacedim> &)
+  assign_1d_boundary_ids (const std::map<unsigned int, types::boundary_id> &,
+                          Triangulation<dim,spacedim> &)
   {
     // we shouldn't get here since boundary ids are not assigned to
     // vertices except in 1d
@@ -1559,7 +1559,7 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
   // in 1d, we also have to attach boundary ids to vertices, which does not
   // currently work through the call above
   if (dim == 1)
-    assign_1d_boundary_indicators (boundary_ids_1d, *tria);
+    assign_1d_boundary_ids (boundary_ids_1d, *tria);
 }
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9008,15 +9008,6 @@ Triangulation<dim, spacedim>::get_boundary_ids () const
 
 
 template <int dim, int spacedim>
-std::vector<types::boundary_id>
-Triangulation<dim, spacedim>::get_boundary_indicators () const
-{
-  return get_boundary_ids();
-}
-
-
-
-template <int dim, int spacedim>
 std::vector<types::manifold_id>
 Triangulation<dim, spacedim>::get_manifold_ids () const
 {

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
@@ -59,7 +59,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
@@ -55,7 +55,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
@@ -59,7 +59,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
@@ -59,7 +59,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
@@ -59,7 +59,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
@@ -61,7 +61,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
@@ -61,7 +61,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
@@ -58,7 +58,7 @@ void test_real_to_unit_cell()
   // set the boundary indicator for
   // one face of the single cell
   triangulation.set_boundary (1, boundary);
-  triangulation.begin_active()->face(0)->set_boundary_indicator (1);
+  triangulation.begin_active()->face(0)->set_boundary_id (1);
 
 
   const unsigned int n_points = 5;

--- a/tests/grid/grid_in_msh_02.cc
+++ b/tests/grid/grid_in_msh_02.cc
@@ -53,7 +53,7 @@ void check_file ()
         {
           if (cell->at_boundary(face))
             deallog << "vertex " << cell->face_index(face)
-                    << " has boundary indicator " << (int)cell->face(face)->boundary_indicator()
+                    << " has boundary indicator " << (int)cell->face(face)->boundary_id()
                     << std::endl;
         }
     }

--- a/tests/grid/grid_in_msh_02_13.cc
+++ b/tests/grid/grid_in_msh_02_13.cc
@@ -57,7 +57,7 @@ void check_file ()
         {
           if (cell->at_boundary(face))
             deallog << "vertex " << cell->face_index(face)
-                    << " has boundary indicator " << (int)cell->face(face)->boundary_indicator()
+                    << " has boundary indicator " << (int)cell->face(face)->boundary_id()
                     << std::endl;
         }
     }


### PR DESCRIPTION
They had previously already been replaced by functions with name 'boundary_id', to
be consistent with the spelling for other attributes such as subdomain_id,
material_id, etc.