### PR TITLE
added make (or ninja) indent

### DIFF
--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -91,6 +91,15 @@ IF(NOT DEAL_II_COMPONENT_PACKAGE)
 ENDIF()
 
 #
+# Provide "indent" target for indenting all headers and source files
+#
+ADD_CUSTOM_TARGET(indent
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ./contrib/utilities/indent
+  )
+
+
+#
 # Provide an "info" target to print a help message:
 #
 IF(CMAKE_GENERATOR MATCHES "Ninja")
@@ -127,6 +136,8 @@ FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_info.cmake
 #
 #    setup_tests    - set up testsuite subprojects
 #    prune_tests    - remove all testsuite subprojects
+#
+#    indent         - indent all headers and source file
 #
 ###\")"
   )

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -68,6 +68,12 @@ inconvenience this causes.
 <h3>General</h3>
 
 <ol>
+ <li> New: added indent target to indent all headers and source
+ files. Now you can do make (or ninja) indent inside the build
+ directory.
+ <br>
+ (Alberto Sartori, 2016/03/02)
+ </li>
 </ol>
 
 


### PR DESCRIPTION
this PR adds the target *indent* so that within the build I can do `make indent` instead of `cd` to the source dir and do `./contrib/utilities/indent`. 