### PR TITLE
Inhomogeneous constraints in Meshworker

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -739,6 +739,14 @@ public:
                               const std::vector<size_type> &local_dof_indices,
                               VectorType                   &global_vector,
                               const FullMatrix<LocalType>  &local_matrix) const;
+    
+  template <typename VectorType, typename LocalType>
+  void
+  distribute_local_to_global (const Vector<LocalType>      &local_vector,
+                              const std::vector<size_type> &local_dof_indices_row,
+                              const std::vector<size_type> &local_dof_indices_col,
+                              VectorType                   &global_vector,
+                              const FullMatrix<LocalType>  &local_matrix) const;
 
   /**
    * Enter a single value into a result vector, obeying constraints.

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -739,7 +739,7 @@ public:
                               const std::vector<size_type> &local_dof_indices,
                               VectorType                   &global_vector,
                               const FullMatrix<LocalType>  &local_matrix) const;
-    
+
   template <typename VectorType, typename LocalType>
   void
   distribute_local_to_global (const Vector<LocalType>      &local_vector,

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -107,11 +107,12 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
-    private:
+    protected:
       /**
        * The global residal vectors filled by assemble().
        */
       AnyData residuals;
+    private:
       /**
        * A pointer to the object containing constraints.
        */
@@ -203,6 +204,19 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
+    protected:
+      /**
+       * The vector of global matrices being assembled.
+       */
+      std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
+        
+      /**
+        * The smallest positive number that will be entered into the global
+        * matrix. All smaller absolute values will be treated as zero and will
+        * not be assembled.
+        */
+      const double threshold;
+        
     private:
       /**
        * Assemble a single matrix <code>M</code> into the element at
@@ -214,20 +228,9 @@ namespace MeshWorker
                     const std::vector<types::global_dof_index> &i2);
 
       /**
-       * The vector of global matrices being assembled.
-       */
-      std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
-      /**
        * A pointer to the object containing constraints.
        */
       SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
-
-      /**
-       * The smallest positive number that will be entered into the global
-       * matrix. All smaller absolute values will be treated as zero and will
-       * not be assembled.
-       */
-      const double threshold;
 
     };
 
@@ -457,6 +460,26 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
+    
+    private:
+      /**
+       * A pointer to the object containing constraints.
+       */
+      SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
+      /**
+        * Assemble a single matrix <code>M</code> into the element at
+        * <code>index</code> in the vector #matrix.
+        */
+      void assemble(const FullMatrix<double> &M,
+                    const Vector<double> &vector,
+                    const unsigned int index,
+                    const std::vector<types::global_dof_index> &indices);
+        
+      void assemble(const FullMatrix<double> &M,
+                    const Vector<double> &vector,
+                    const unsigned int index,
+                    const std::vector<types::global_dof_index> &i1,
+                    const std::vector<types::global_dof_index> &i2);
     };
 
 
@@ -1120,8 +1143,7 @@ namespace MeshWorker
     inline void
     SystemSimple<MatrixType,VectorType>::initialize(const ConstraintMatrix &c)
     {
-      MatrixSimple<MatrixType>::initialize(c);
-      ResidualSimple<VectorType>::initialize(c);
+      constraints = &c;
     }
 
 
@@ -1135,25 +1157,159 @@ namespace MeshWorker
       ResidualSimple<VectorType>::initialize_info(info, face);
     }
 
-
+    template <typename MatrixType,typename VectorType>
+    inline void
+    SystemSimple<MatrixType,VectorType>::assemble(const FullMatrix<double> &M,
+                                                  const Vector<double> &vector,
+                                                  const unsigned int index,
+                                                  const std::vector<types::global_dof_index> &indices)
+    {
+      AssertDimension(M.m(), indices.size());
+      AssertDimension(M.n(), indices.size());
+      
+      AnyData residuals = ResidualSimple<VectorType>::residuals;
+      VectorType *v = residuals.entry<VectorType*>(index);
+      
+      if (constraints == 0)
+      {
+        for (unsigned int i=0; i<indices.size(); ++i)
+          (*v)(indices[i]) += vector(i);
+        
+        for (unsigned int j=0; j<indices.size(); ++j)
+          for (unsigned int k=0; k<indices.size(); ++k)
+            if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+              MatrixSimple<MatrixType>::matrix[index]->add(indices[j], indices[k], M(j,k));
+      }
+      else
+      {
+        constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
+      }
+    }
+    
+    template <typename MatrixType,typename VectorType>
+    inline void
+    SystemSimple<MatrixType,VectorType>::assemble(const FullMatrix<double> &M,
+                                                  const Vector<double> &vector,
+                                                  const unsigned int index,
+                                                  const std::vector<types::global_dof_index> &i1,
+                                                  const std::vector<types::global_dof_index> &i2)
+    {
+      AssertDimension(M.m(), i1.size());
+      AssertDimension(M.n(), i2.size());
+      
+      AnyData residuals = ResidualSimple<VectorType>::residuals;
+      VectorType *v = residuals.entry<VectorType *>(index);
+      
+      if (constraints == 0)
+      {
+        for (unsigned int i=0; i<i1.size(); ++i)
+          (*v)(i1[i]) += vector(i);
+        
+        for (unsigned int j=0; j<i1.size(); ++j)
+          for (unsigned int k=0; k<i2.size(); ++k)
+            if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+              MatrixSimple<MatrixType>::matrix[index]->add(i1[j], i2[k], M(j,k));
+      }
+      else
+      {
+        constraints->distribute_local_to_global(vector, i1, i2, *v, M);
+        constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
+      }
+    }
+    
+    
     template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
     SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info)
     {
-      MatrixSimple<MatrixType>::assemble(info);
-      ResidualSimple<VectorType>::assemble(info);
+      AssertDimension(MatrixSimple<MatrixType>::matrix.size(),ResidualSimple<VectorType>::residuals.size());
+      Assert(!info.level_cell, ExcMessage("Cell may not access level dofs"));
+      const unsigned int n = info.indices_by_block.size();
+      
+      if(n == 0)
+      {
+        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+          assemble(info.matrix(m,false).matrix,info.vector(m).block(0), m, info.indices);
+        
+      }
+      else
+      {
+        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+          for (unsigned int k=0; k<n*n; ++k)
+          {
+            const unsigned int row = info.matrix(k+m*n*n,false).row;
+            const unsigned int column = info.matrix(k+m*n*n,false).column;
+            
+            if (row == column)
+              assemble(info.matrix(k+m*n*n,false).matrix,
+                       info.vector(m).block(column), m,
+                       info.indices_by_block[column]);
+            else
+              assemble(info.matrix(k+m*n*n,false).matrix,
+                       info.vector(m).block(column), m,
+                       info.indices_by_block[row],
+                       info.indices_by_block[column]);
+          }
+      }
+      
     }
-
-
+    
+    
     template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
     SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info1,
                                                   const DOFINFO &info2)
     {
-      MatrixSimple<MatrixType>::assemble(info1, info2);
-      ResidualSimple<VectorType>::assemble(info1, info2);
+      Assert(!info1.level_cell, ExcMessage("Cell may not access level dofs"));
+      Assert(!info2.level_cell, ExcMessage("Cell may not access level dofs"));
+      AssertDimension(info1.indices_by_block.size(),info2.indices_by_block.size());
+      
+      const unsigned int n = info1.indices_by_block.size();
+      
+      if (n == 0)
+      {
+        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+        {
+          assemble(info1.matrix(m,false).matrix, info1.vector(m).block(0), m, info1.indices);
+          assemble(info1.matrix(m,true).matrix, info1.vector(m).block(0), m, info1.indices, info2.indices);
+          assemble(info2.matrix(m,false).matrix, info2.vector(m).block(0), m, info2.indices);
+          assemble(info2.matrix(m,true).matrix, info2.vector(m).block(0), m, info2.indices, info1.indices);
+        }
+      }
+      else
+      {
+        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+          for (unsigned int k=0; k<n*n; ++k)
+          {
+            const unsigned int row = info1.matrix(k+m*n*n,false).row;
+            const unsigned int column = info1.matrix(k+m*n*n,false).column;
+            
+            if (row == column)
+            {
+              assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                       info1.indices_by_block[column]);
+              assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                       info1.indices_by_block[row], info2.indices_by_block[column]);
+              assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                       info2.indices_by_block[column]);
+              assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                       info2.indices_by_block[row], info1.indices_by_block[column]);
+            }
+            else
+            {
+              assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                       info1.indices_by_block[row], info1.indices_by_block[column]);
+              assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                       info1.indices_by_block[row], info2.indices_by_block[column]);
+              assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                       info2.indices_by_block[row], info2.indices_by_block[column]);
+              assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                       info2.indices_by_block[row], info1.indices_by_block[column]);
+            }
+          }
+      }
     }
   }
 }

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -1289,24 +1289,20 @@ namespace MeshWorker
                   {
                     assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
                              info1.indices_by_block[column]);
-                    assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
-                             info1.indices_by_block[row], info2.indices_by_block[column]);
                     assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
                              info2.indices_by_block[column]);
-                    assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
-                             info2.indices_by_block[row], info1.indices_by_block[column]);
                   }
                 else
                   {
                     assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
                              info1.indices_by_block[row], info1.indices_by_block[column]);
-                    assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
-                             info1.indices_by_block[row], info2.indices_by_block[column]);
                     assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
                              info2.indices_by_block[row], info2.indices_by_block[column]);
-                    assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
-                             info2.indices_by_block[row], info1.indices_by_block[column]);
                   }
+                assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                         info1.indices_by_block[row], info2.indices_by_block[column]);
+                assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                         info2.indices_by_block[row], info1.indices_by_block[column]);
               }
         }
     }

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -209,14 +209,14 @@ namespace MeshWorker
        * The vector of global matrices being assembled.
        */
       std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
-        
+
       /**
         * The smallest positive number that will be entered into the global
         * matrix. All smaller absolute values will be treated as zero and will
         * not be assembled.
         */
       const double threshold;
-        
+
     private:
       /**
        * Assemble a single matrix <code>M</code> into the element at
@@ -460,7 +460,7 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
-    
+
     private:
       /**
        * A pointer to the object containing constraints.
@@ -474,7 +474,7 @@ namespace MeshWorker
                     const Vector<double> &vector,
                     const unsigned int index,
                     const std::vector<types::global_dof_index> &indices);
-        
+
       void assemble(const FullMatrix<double> &M,
                     const Vector<double> &vector,
                     const unsigned int index,
@@ -1166,26 +1166,26 @@ namespace MeshWorker
     {
       AssertDimension(M.m(), indices.size());
       AssertDimension(M.n(), indices.size());
-      
+
       AnyData residuals = ResidualSimple<VectorType>::residuals;
-      VectorType *v = residuals.entry<VectorType*>(index);
-      
+      VectorType *v = residuals.entry<VectorType *>(index);
+
       if (constraints == 0)
-      {
-        for (unsigned int i=0; i<indices.size(); ++i)
-          (*v)(indices[i]) += vector(i);
-        
-        for (unsigned int j=0; j<indices.size(); ++j)
-          for (unsigned int k=0; k<indices.size(); ++k)
-            if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
-              MatrixSimple<MatrixType>::matrix[index]->add(indices[j], indices[k], M(j,k));
-      }
+        {
+          for (unsigned int i=0; i<indices.size(); ++i)
+            (*v)(indices[i]) += vector(i);
+
+          for (unsigned int j=0; j<indices.size(); ++j)
+            for (unsigned int k=0; k<indices.size(); ++k)
+              if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+                MatrixSimple<MatrixType>::matrix[index]->add(indices[j], indices[k], M(j,k));
+        }
       else
-      {
-        constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
-      }
+        {
+          constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
+        }
     }
-    
+
     template <typename MatrixType,typename VectorType>
     inline void
     SystemSimple<MatrixType,VectorType>::assemble(const FullMatrix<double> &M,
@@ -1196,28 +1196,28 @@ namespace MeshWorker
     {
       AssertDimension(M.m(), i1.size());
       AssertDimension(M.n(), i2.size());
-      
+
       AnyData residuals = ResidualSimple<VectorType>::residuals;
       VectorType *v = residuals.entry<VectorType *>(index);
-      
+
       if (constraints == 0)
-      {
-        for (unsigned int i=0; i<i1.size(); ++i)
-          (*v)(i1[i]) += vector(i);
-        
-        for (unsigned int j=0; j<i1.size(); ++j)
-          for (unsigned int k=0; k<i2.size(); ++k)
-            if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
-              MatrixSimple<MatrixType>::matrix[index]->add(i1[j], i2[k], M(j,k));
-      }
+        {
+          for (unsigned int i=0; i<i1.size(); ++i)
+            (*v)(i1[i]) += vector(i);
+
+          for (unsigned int j=0; j<i1.size(); ++j)
+            for (unsigned int k=0; k<i2.size(); ++k)
+              if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+                MatrixSimple<MatrixType>::matrix[index]->add(i1[j], i2[k], M(j,k));
+        }
       else
-      {
-        constraints->distribute_local_to_global(vector, i1, i2, *v, M);
-        constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
-      }
+        {
+          constraints->distribute_local_to_global(vector, i1, i2, *v, M);
+          constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
+        }
     }
-    
-    
+
+
     template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
@@ -1226,36 +1226,35 @@ namespace MeshWorker
       AssertDimension(MatrixSimple<MatrixType>::matrix.size(),ResidualSimple<VectorType>::residuals.size());
       Assert(!info.level_cell, ExcMessage("Cell may not access level dofs"));
       const unsigned int n = info.indices_by_block.size();
-      
-      if(n == 0)
-      {
-        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
-          assemble(info.matrix(m,false).matrix,info.vector(m).block(0), m, info.indices);
-        
-      }
+
+      if (n == 0)
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            assemble(info.matrix(m,false).matrix,info.vector(m).block(0), m, info.indices);
+        }
       else
-      {
-        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
-          for (unsigned int k=0; k<n*n; ++k)
-          {
-            const unsigned int row = info.matrix(k+m*n*n,false).row;
-            const unsigned int column = info.matrix(k+m*n*n,false).column;
-            
-            if (row == column)
-              assemble(info.matrix(k+m*n*n,false).matrix,
-                       info.vector(m).block(column), m,
-                       info.indices_by_block[column]);
-            else
-              assemble(info.matrix(k+m*n*n,false).matrix,
-                       info.vector(m).block(column), m,
-                       info.indices_by_block[row],
-                       info.indices_by_block[column]);
-          }
-      }
-      
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            for (unsigned int k=0; k<n*n; ++k)
+              {
+                const unsigned int row = info.matrix(k+m*n*n,false).row;
+                const unsigned int column = info.matrix(k+m*n*n,false).column;
+
+                if (row == column)
+                  assemble(info.matrix(k+m*n*n,false).matrix,
+                           info.vector(m).block(column), m,
+                           info.indices_by_block[column]);
+                else
+                  assemble(info.matrix(k+m*n*n,false).matrix,
+                           info.vector(m).block(column), m,
+                           info.indices_by_block[row],
+                           info.indices_by_block[column]);
+              }
+        }
+
     }
-    
-    
+
+
     template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
@@ -1265,51 +1264,51 @@ namespace MeshWorker
       Assert(!info1.level_cell, ExcMessage("Cell may not access level dofs"));
       Assert(!info2.level_cell, ExcMessage("Cell may not access level dofs"));
       AssertDimension(info1.indices_by_block.size(),info2.indices_by_block.size());
-      
+
       const unsigned int n = info1.indices_by_block.size();
-      
+
       if (n == 0)
-      {
-        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
         {
-          assemble(info1.matrix(m,false).matrix, info1.vector(m).block(0), m, info1.indices);
-          assemble(info1.matrix(m,true).matrix, info1.vector(m).block(0), m, info1.indices, info2.indices);
-          assemble(info2.matrix(m,false).matrix, info2.vector(m).block(0), m, info2.indices);
-          assemble(info2.matrix(m,true).matrix, info2.vector(m).block(0), m, info2.indices, info1.indices);
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            {
+              assemble(info1.matrix(m,false).matrix, info1.vector(m).block(0), m, info1.indices);
+              assemble(info1.matrix(m,true).matrix, info1.vector(m).block(0), m, info1.indices, info2.indices);
+              assemble(info2.matrix(m,false).matrix, info2.vector(m).block(0), m, info2.indices);
+              assemble(info2.matrix(m,true).matrix, info2.vector(m).block(0), m, info2.indices, info1.indices);
+            }
         }
-      }
       else
-      {
-        for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
-          for (unsigned int k=0; k<n*n; ++k)
-          {
-            const unsigned int row = info1.matrix(k+m*n*n,false).row;
-            const unsigned int column = info1.matrix(k+m*n*n,false).column;
-            
-            if (row == column)
-            {
-              assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
-                       info1.indices_by_block[column]);
-              assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
-                       info1.indices_by_block[row], info2.indices_by_block[column]);
-              assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
-                       info2.indices_by_block[column]);
-              assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
-                       info2.indices_by_block[row], info1.indices_by_block[column]);
-            }
-            else
-            {
-              assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
-                       info1.indices_by_block[row], info1.indices_by_block[column]);
-              assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
-                       info1.indices_by_block[row], info2.indices_by_block[column]);
-              assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
-                       info2.indices_by_block[row], info2.indices_by_block[column]);
-              assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
-                       info2.indices_by_block[row], info1.indices_by_block[column]);
-            }
-          }
-      }
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            for (unsigned int k=0; k<n*n; ++k)
+              {
+                const unsigned int row = info1.matrix(k+m*n*n,false).row;
+                const unsigned int column = info1.matrix(k+m*n*n,false).column;
+
+                if (row == column)
+                  {
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[column]);
+                    assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[row], info2.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[row], info1.indices_by_block[column]);
+                  }
+                else
+                  {
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[row], info1.indices_by_block[column]);
+                    assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[row], info2.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[row], info2.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[row], info1.indices_by_block[column]);
+                  }
+              }
+        }
     }
   }
 }

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1225,12 +1225,23 @@ ConstraintMatrix::resolve_indices (std::vector<types::global_dof_index> &indices
   distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
+                                           const FullMatrix<VectorType::value_type>        &) const;\
+  template void ConstraintMatrix:: \
+  distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           VectorType                      &, \
                                            const FullMatrix<VectorType::value_type>        &) const
-
 
 #define PARALLEL_VECTOR_FUNCTIONS(VectorType) \
   template void ConstraintMatrix:: \
   distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           VectorType                      &, \
+                                           const FullMatrix<VectorType::value_type>        &) const;\
+  template void ConstraintMatrix:: \
+  distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
                                            const FullMatrix<VectorType::value_type>        &) const

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -28,7 +28,7 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(const parallel::distributed::T<S> &, parallel::distributed::T<S> &) const;
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(parallel::distributed::T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
-      const Vector<double>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<double>&) const;
+      const Vector<S>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<parallel::distributed::T<S> >(parallel::distributed::T<S> &) const;
   }
 

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -19,6 +19,8 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<T<S> >(T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;  
+    template void ConstraintMatrix::distribute_local_to_global<T<S> > (
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<T<S> >(T<S> &) const;
   }
 
@@ -29,6 +31,8 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(parallel::distributed::T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
+    template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<parallel::distributed::T<S> >(parallel::distributed::T<S> &) const;
   }
 
@@ -39,6 +43,8 @@ for (V: EXTERNAL_SEQUENTIAL_VECTORS)
     template void ConstraintMatrix::condense<V >(V&vec) const;
     template void ConstraintMatrix::distribute_local_to_global<V > (
       const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
+    template void ConstraintMatrix::distribute_local_to_global<V > (
+      const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
     template void ConstraintMatrix::set_zero<V >(V&) const;
   }
 


### PR DESCRIPTION
As follow up to the thread
https://groups.google.com/forum/#!topic/dealii/UoTWTXpl_lk
with title "using Meshworker with a ConstraintMatrix",
I modified Meshworker::Assembler::SystemSimple such that inhomogeneous constraints are treated correctly. In order to do so I had to modify the distribute_local_to_global that assembles an inhomogeneous vector such that it accepts two different index sets, one for the rows and one for the columns. This is necessary in Meshworker when an edge local matrix is assembled, since then the rows correspond to an element T_1 while the columns correspond to the neighboring element T_2. As it turns out this is only a minor modification of that function plus the respective changes in the header and the template instantiates.
The main changes are then done in simple.h for the SystemSimple class.
This has been tested for step-12 and step-16 and the test from Korosh Taebi from the google thread (as well as with my fourth order obstacle implementation).
Here is an updated version of Korosh Taebi's test that works with this branch 
[MeshWorkerConstraintMatrixTest.cc.zip](https://github.com/dealii/dealii/files/159973/MeshWorkerConstraintMatrixTest.cc.zip)
(Note that the SystemSimpleInhom.h that Korosh Taebi provides in the google thread does only work for uniform meshes and inhomogeneous constraints only, while this branch is a complete modification of SystemSimple to support the general case of mixed homogeneous and inhomogeneous constraints on uniform and adaptively refined meshes)

