### PR TITLE
Inhomogeneous constraints in Meshworker

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -742,19 +742,19 @@ public:
 
   /**
    * Same as the previous function, except that it uses two (possibly) different
-   * index sets to correctly handle inhomogeneties when the local matrix is
+   * index sets to correctly handle inhomogeneities when the local matrix is
    * computed from a combination of two neighboring elements, for example for an
    * edge integral term in DG. Note that in the case that these two elements have
    * different polynomial degree, the local matrix is rectangular.
    *
-   * <tt>local_dof_indices_row<tt> is the set of row indices and
-   * <tt>local_dof_indices_col<tt> is the set of column indices of the local matrix.
-   * <tt>diagonal=false<tt> says whether the two index sets are equal or not.
+   * <tt>local_dof_indices_row</tt> is the set of row indices and
+   * <tt>local_dof_indices_col</tt> is the set of column indices of the local matrix.
+   * <tt>diagonal=false</tt> says whether the two index sets are equal or not.
    *
-   * If both index sets are equal, <tt>diagonal<tt> must be set to true or we
+   * If both index sets are equal, <tt>diagonal</tt> must be set to true or we
    * simply use the previous function. If both index sets are different (diagonal=false)
-   * the <tt>global_vector<tt> is modified to handle inhomogeneties but no
-   * entries from <tt>local_vector<tt> are added. Note that the edge integrals for inner
+   * the <tt>global_vector</tt> is modified to handle inhomogeneities but no
+   * entries from <tt>local_vector</tt> are added. Note that the edge integrals for inner
    * edged for DG do not contribute any values to the right hand side.
    */
   template <typename VectorType, typename LocalType>

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -740,6 +740,14 @@ public:
                               VectorType                   &global_vector,
                               const FullMatrix<LocalType>  &local_matrix) const;
 
+  template <typename VectorType, typename LocalType>
+  void
+  distribute_local_to_global (const Vector<LocalType>      &local_vector,
+                              const std::vector<size_type> &local_dof_indices_row,
+                              const std::vector<size_type> &local_dof_indices_col,
+                              VectorType                   &global_vector,
+                              const FullMatrix<LocalType>  &local_matrix) const;
+
   /**
    * Enter a single value into a result vector, obeying constraints.
    */

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -740,6 +740,16 @@ public:
                               VectorType                   &global_vector,
                               const FullMatrix<LocalType>  &local_matrix) const;
 
+  /**
+   * Same as the previous function, except that it uses two (possibly) different
+   * index sets to correctly handle inhomogeneties when the local matrix is
+   * computed from a combination of two neighboring elements, for example for an
+   * edge integral term in dG. Note that in the case that these two elements have
+   * different polynomial degree, the local matrix is rectangular.
+   *
+   * <tt>local_dof_indices_row<tt> is the set of row indices and
+   * <tt>local_dof_indices_col<tt> is the set of column indices of the local matrix.
+   */
   template <typename VectorType, typename LocalType>
   void
   distribute_local_to_global (const Vector<LocalType>      &local_vector,

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -744,11 +744,18 @@ public:
    * Same as the previous function, except that it uses two (possibly) different
    * index sets to correctly handle inhomogeneties when the local matrix is
    * computed from a combination of two neighboring elements, for example for an
-   * edge integral term in dG. Note that in the case that these two elements have
+   * edge integral term in DG. Note that in the case that these two elements have
    * different polynomial degree, the local matrix is rectangular.
    *
    * <tt>local_dof_indices_row<tt> is the set of row indices and
    * <tt>local_dof_indices_col<tt> is the set of column indices of the local matrix.
+   * <tt>diagonal=false<tt> says whether the two index sets are equal or not.
+   *
+   * If both index sets are equal, <tt>diagonal<tt> must be set to true or we
+   * simply use the previous function. If both index sets are different (diagonal=false)
+   * the <tt>global_vector<tt> is modified to handle inhomogeneties but no
+   * entries from <tt>local_vector<tt> are added. Note that the edge integrals for inner
+   * edged for DG do not contribute any values to the right hand side.
    */
   template <typename VectorType, typename LocalType>
   void
@@ -756,7 +763,8 @@ public:
                               const std::vector<size_type> &local_dof_indices_row,
                               const std::vector<size_type> &local_dof_indices_col,
                               VectorType                   &global_vector,
-                              const FullMatrix<LocalType>  &local_matrix) const;
+                              const FullMatrix<LocalType>  &local_matrix,
+                              bool diagonal = false) const;
 
   /**
    * Enter a single value into a result vector, obeying constraints.

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -645,11 +645,11 @@ distribute_local_to_global (const Vector<LocalType>      &local_vector,
 
   // diagonal checks if we have only one index set (if both are equal
   // diagonal should be set to true).
-  // If true we do both, assemply of the right hand side (next lines)
+  // If true we do both, assembly of the right hand side (next lines)
   // and (see further below) modifications of the right hand side
   // according to the inhomogeneous constraints.
   // Otherwise we only modify the right hand side according to
-  // local_matrix and the inhomogeneos constraints, and omit the vector add.
+  // local_matrix and the inhomogeneous constraints, and omit the vector add.
 
   const size_type m_local_dofs = local_dof_indices_row.size();
   const size_type n_local_dofs = local_dof_indices_col.size();

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -642,7 +642,7 @@ distribute_local_to_global (const Vector<LocalType>      &local_vector,
   AssertDimension (local_vector.size(), local_dof_indices_row.size());
   AssertDimension (local_matrix.m(), local_dof_indices_row.size());
   AssertDimension (local_matrix.n(), local_dof_indices_col.size());
-  
+
   // diagonal checks if we have only one index set (if both are equal
   // diagonal should be set to true).
   // If true we do both, assemply of the right hand side (next lines)
@@ -718,9 +718,9 @@ distribute_local_to_global (const Vector<LocalType>      &local_vector,
             for (size_type j=0; j<position->entries.size(); ++j)
               {
                 Assert (!(!local_lines.size()
-                      || local_lines.is_element(position->entries[j].first))
-                      || is_constrained(position->entries[j].first) == false,
-                      ExcMessage ("Tried to distribute to a fixed dof."));
+                          || local_lines.is_element(position->entries[j].first))
+                        || is_constrained(position->entries[j].first) == false,
+                        ExcMessage ("Tried to distribute to a fixed dof."));
                 global_vector(position->entries[j].first)
                 += local_vector(i) * position->entries[j].second;
               }

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -615,7 +615,6 @@ ConstraintMatrix::set_zero (VectorType &vec) const
 
 
 
-
 template <typename VectorType, typename LocalType>
 void
 ConstraintMatrix::
@@ -626,6 +625,8 @@ distribute_local_to_global (const Vector<LocalType>      &local_vector,
 {
   distribute_local_to_global(local_vector,local_dof_indices,local_dof_indices, global_vector, local_matrix);
 }
+
+
 
 template <typename VectorType, typename LocalType>
 void

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -112,7 +112,7 @@ namespace MeshWorker
        * The global residal vectors filled by assemble().
        */
       AnyData residuals;
-    private:
+
       /**
        * A pointer to the object containing constraints.
        */
@@ -462,10 +462,6 @@ namespace MeshWorker
                     const DOFINFO &info2);
 
     private:
-      /**
-       * A pointer to the object containing constraints.
-       */
-      SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
       /**
         * Assemble a single matrix <code>M</code> into the element at
         * <code>index</code> in the vector #matrix.
@@ -1143,7 +1139,7 @@ namespace MeshWorker
     inline void
     SystemSimple<MatrixType,VectorType>::initialize(const ConstraintMatrix &c)
     {
-      constraints = &c;
+      ResidualSimple<VectorType>::initialize(c);
     }
 
 
@@ -1170,7 +1166,7 @@ namespace MeshWorker
       AnyData residuals = ResidualSimple<VectorType>::residuals;
       VectorType *v = residuals.entry<VectorType *>(index);
 
-      if (constraints == 0)
+      if (ResidualSimple<VectorType>::constraints == 0)
         {
           for (unsigned int i=0; i<indices.size(); ++i)
             (*v)(indices[i]) += vector(i);
@@ -1182,7 +1178,7 @@ namespace MeshWorker
         }
       else
         {
-          constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
+          ResidualSimple<VectorType>::constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
         }
     }
 
@@ -1200,7 +1196,7 @@ namespace MeshWorker
       AnyData residuals = ResidualSimple<VectorType>::residuals;
       VectorType *v = residuals.entry<VectorType *>(index);
 
-      if (constraints == 0)
+      if (ResidualSimple<VectorType>::constraints == 0)
         {
           for (unsigned int i=0; i<i1.size(); ++i)
             (*v)(i1[i]) += vector(i);
@@ -1212,8 +1208,8 @@ namespace MeshWorker
         }
       else
         {
-          constraints->distribute_local_to_global(vector, i1, i2, *v, M);
-          constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
+          ResidualSimple<VectorType>::constraints->distribute_local_to_global(vector, i1, i2, *v, M);
+          ResidualSimple<VectorType>::constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
         }
     }
 

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -107,11 +107,12 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
-    private:
+    protected:
       /**
        * The global residal vectors filled by assemble().
        */
       AnyData residuals;
+    private:
       /**
        * A pointer to the object containing constraints.
        */
@@ -203,6 +204,19 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
+    protected:
+      /**
+       * The vector of global matrices being assembled.
+       */
+      std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
+
+      /**
+        * The smallest positive number that will be entered into the global
+        * matrix. All smaller absolute values will be treated as zero and will
+        * not be assembled.
+        */
+      const double threshold;
+
     private:
       /**
        * Assemble a single matrix <code>M</code> into the element at
@@ -214,20 +228,9 @@ namespace MeshWorker
                     const std::vector<types::global_dof_index> &i2);
 
       /**
-       * The vector of global matrices being assembled.
-       */
-      std::vector<SmartPointer<MatrixType,MatrixSimple<MatrixType> > > matrix;
-      /**
        * A pointer to the object containing constraints.
        */
       SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
-
-      /**
-       * The smallest positive number that will be entered into the global
-       * matrix. All smaller absolute values will be treated as zero and will
-       * not be assembled.
-       */
-      const double threshold;
 
     };
 
@@ -457,6 +460,26 @@ namespace MeshWorker
       template<class DOFINFO>
       void assemble(const DOFINFO &info1,
                     const DOFINFO &info2);
+
+    private:
+      /**
+       * A pointer to the object containing constraints.
+       */
+      SmartPointer<const ConstraintMatrix,MatrixSimple<MatrixType> > constraints;
+      /**
+        * Assemble a single matrix <code>M</code> into the element at
+        * <code>index</code> in the vector #matrix.
+        */
+      void assemble(const FullMatrix<double> &M,
+                    const Vector<double> &vector,
+                    const unsigned int index,
+                    const std::vector<types::global_dof_index> &indices);
+
+      void assemble(const FullMatrix<double> &M,
+                    const Vector<double> &vector,
+                    const unsigned int index,
+                    const std::vector<types::global_dof_index> &i1,
+                    const std::vector<types::global_dof_index> &i2);
     };
 
 
@@ -1120,8 +1143,7 @@ namespace MeshWorker
     inline void
     SystemSimple<MatrixType,VectorType>::initialize(const ConstraintMatrix &c)
     {
-      MatrixSimple<MatrixType>::initialize(c);
-      ResidualSimple<VectorType>::initialize(c);
+      constraints = &c;
     }
 
 
@@ -1135,14 +1157,101 @@ namespace MeshWorker
       ResidualSimple<VectorType>::initialize_info(info, face);
     }
 
+    template <typename MatrixType,typename VectorType>
+    inline void
+    SystemSimple<MatrixType,VectorType>::assemble(const FullMatrix<double> &M,
+                                                  const Vector<double> &vector,
+                                                  const unsigned int index,
+                                                  const std::vector<types::global_dof_index> &indices)
+    {
+      AssertDimension(M.m(), indices.size());
+      AssertDimension(M.n(), indices.size());
+
+      AnyData residuals = ResidualSimple<VectorType>::residuals;
+      VectorType *v = residuals.entry<VectorType *>(index);
+
+      if (constraints == 0)
+        {
+          for (unsigned int i=0; i<indices.size(); ++i)
+            (*v)(indices[i]) += vector(i);
+
+          for (unsigned int j=0; j<indices.size(); ++j)
+            for (unsigned int k=0; k<indices.size(); ++k)
+              if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+                MatrixSimple<MatrixType>::matrix[index]->add(indices[j], indices[k], M(j,k));
+        }
+      else
+        {
+          constraints->distribute_local_to_global(M,vector,indices,*MatrixSimple<MatrixType>::matrix[index],*v, true);
+        }
+    }
+
+    template <typename MatrixType,typename VectorType>
+    inline void
+    SystemSimple<MatrixType,VectorType>::assemble(const FullMatrix<double> &M,
+                                                  const Vector<double> &vector,
+                                                  const unsigned int index,
+                                                  const std::vector<types::global_dof_index> &i1,
+                                                  const std::vector<types::global_dof_index> &i2)
+    {
+      AssertDimension(M.m(), i1.size());
+      AssertDimension(M.n(), i2.size());
+
+      AnyData residuals = ResidualSimple<VectorType>::residuals;
+      VectorType *v = residuals.entry<VectorType *>(index);
+
+      if (constraints == 0)
+        {
+          for (unsigned int i=0; i<i1.size(); ++i)
+            (*v)(i1[i]) += vector(i);
+
+          for (unsigned int j=0; j<i1.size(); ++j)
+            for (unsigned int k=0; k<i2.size(); ++k)
+              if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
+                MatrixSimple<MatrixType>::matrix[index]->add(i1[j], i2[k], M(j,k));
+        }
+      else
+        {
+          constraints->distribute_local_to_global(vector, i1, i2, *v, M);
+          constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
+        }
+    }
+
 
     template <typename MatrixType, typename VectorType>
     template <class DOFINFO>
     inline void
     SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info)
     {
-      MatrixSimple<MatrixType>::assemble(info);
-      ResidualSimple<VectorType>::assemble(info);
+      AssertDimension(MatrixSimple<MatrixType>::matrix.size(),ResidualSimple<VectorType>::residuals.size());
+      Assert(!info.level_cell, ExcMessage("Cell may not access level dofs"));
+      const unsigned int n = info.indices_by_block.size();
+
+      if (n == 0)
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            assemble(info.matrix(m,false).matrix,info.vector(m).block(0), m, info.indices);
+        }
+      else
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            for (unsigned int k=0; k<n*n; ++k)
+              {
+                const unsigned int row = info.matrix(k+m*n*n,false).row;
+                const unsigned int column = info.matrix(k+m*n*n,false).column;
+
+                if (row == column)
+                  assemble(info.matrix(k+m*n*n,false).matrix,
+                           info.vector(m).block(column), m,
+                           info.indices_by_block[column]);
+                else
+                  assemble(info.matrix(k+m*n*n,false).matrix,
+                           info.vector(m).block(column), m,
+                           info.indices_by_block[row],
+                           info.indices_by_block[column]);
+              }
+        }
+
     }
 
 
@@ -1152,8 +1261,50 @@ namespace MeshWorker
     SystemSimple<MatrixType,VectorType>::assemble(const DOFINFO &info1,
                                                   const DOFINFO &info2)
     {
-      MatrixSimple<MatrixType>::assemble(info1, info2);
-      ResidualSimple<VectorType>::assemble(info1, info2);
+      Assert(!info1.level_cell, ExcMessage("Cell may not access level dofs"));
+      Assert(!info2.level_cell, ExcMessage("Cell may not access level dofs"));
+      AssertDimension(info1.indices_by_block.size(),info2.indices_by_block.size());
+
+      const unsigned int n = info1.indices_by_block.size();
+
+      if (n == 0)
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            {
+              assemble(info1.matrix(m,false).matrix, info1.vector(m).block(0), m, info1.indices);
+              assemble(info1.matrix(m,true).matrix, info1.vector(m).block(0), m, info1.indices, info2.indices);
+              assemble(info2.matrix(m,false).matrix, info2.vector(m).block(0), m, info2.indices);
+              assemble(info2.matrix(m,true).matrix, info2.vector(m).block(0), m, info2.indices, info1.indices);
+            }
+        }
+      else
+        {
+          for (unsigned int m=0; m<MatrixSimple<MatrixType>::matrix.size(); ++m)
+            for (unsigned int k=0; k<n*n; ++k)
+              {
+                const unsigned int row = info1.matrix(k+m*n*n,false).row;
+                const unsigned int column = info1.matrix(k+m*n*n,false).column;
+
+                if (row == column)
+                  {
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[column]);
+                  }
+                else
+                  {
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                             info1.indices_by_block[row], info1.indices_by_block[column]);
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                             info2.indices_by_block[row], info2.indices_by_block[column]);
+                  }
+                assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                         info1.indices_by_block[row], info2.indices_by_block[column]);
+                assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                         info2.indices_by_block[row], info1.indices_by_block[column]);
+              }
+        }
     }
   }
 }

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -72,11 +72,11 @@ namespace MeshWorker
        * structure in DoFInfo is being used.
        *
        * Store information on the local block structure. If the assembler is
-       * inititialized with this function, initialize_info() will generate one
+       * initialized with this function, initialize_info() will generate one
        * local matrix for each block row and column, which will be numbered
        * lexicographically, row by row.
        *
-       * In spite of using local block structure, all blocks will be enteres
+       * In spite of using local block structure, all blocks will be entered
        * into the same global matrix, disregarding any global block structure.
        */
 
@@ -109,7 +109,7 @@ namespace MeshWorker
                     const DOFINFO &info2);
     protected:
       /**
-       * The global residal vectors filled by assemble().
+       * The global residual vectors filled by assemble().
        */
       AnyData residuals;
 
@@ -957,7 +957,7 @@ namespace MeshWorker
         for (unsigned int k=0; k<i2.size(); ++k)
           if (std::fabs(M(j,k)) >= threshold)
             // Enter values into matrix only if j corresponds to a
-            // degree of freedom on the refinemenent edge, k does
+            // degree of freedom on the refinement edge, k does
             // not, and both are not on the boundary. This is part
             // the difference between the complete matrix with no
             // boundary condition at the refinement edge and and

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -1198,9 +1198,6 @@ namespace MeshWorker
 
       if (ResidualSimple<VectorType>::constraints == 0)
         {
-          for (unsigned int i=0; i<i1.size(); ++i)
-            (*v)(i1[i]) += vector(i);
-
           for (unsigned int j=0; j<i1.size(); ++j)
             for (unsigned int k=0; k<i2.size(); ++k)
               if (std::fabs(M(j,k)) >= MatrixSimple<MatrixType>::threshold)
@@ -1208,7 +1205,7 @@ namespace MeshWorker
         }
       else
         {
-          ResidualSimple<VectorType>::constraints->distribute_local_to_global(vector, i1, i2, *v, M);
+          ResidualSimple<VectorType>::constraints->distribute_local_to_global(vector, i1, i2, *v, M, false);
           ResidualSimple<VectorType>::constraints->distribute_local_to_global(M, i1, i2, *MatrixSimple<MatrixType>::matrix[index]);
         }
     }
@@ -1238,11 +1235,11 @@ namespace MeshWorker
 
                 if (row == column)
                   assemble(info.matrix(k+m*n*n,false).matrix,
-                           info.vector(m).block(column), m,
-                           info.indices_by_block[column]);
+                           info.vector(m).block(row), m,
+                           info.indices_by_block[row]);
                 else
                   assemble(info.matrix(k+m*n*n,false).matrix,
-                           info.vector(m).block(column), m,
+                           info.vector(m).block(row), m,
                            info.indices_by_block[row],
                            info.indices_by_block[column]);
               }
@@ -1283,21 +1280,21 @@ namespace MeshWorker
 
                 if (row == column)
                   {
-                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
-                             info1.indices_by_block[column]);
-                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
-                             info2.indices_by_block[column]);
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(row), m,
+                             info1.indices_by_block[row]);
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(row), m,
+                             info2.indices_by_block[row]);
                   }
                 else
                   {
-                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(column), m,
+                    assemble(info1.matrix(k+m*n*n,false).matrix, info1.vector(m).block(row), m,
                              info1.indices_by_block[row], info1.indices_by_block[column]);
-                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(column), m,
+                    assemble(info2.matrix(k+m*n*n,false).matrix, info2.vector(m).block(row), m,
                              info2.indices_by_block[row], info2.indices_by_block[column]);
                   }
-                assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(column), m,
+                assemble(info1.matrix(k+m*n*n,true).matrix, info1.vector(m).block(row), m,
                          info1.indices_by_block[row], info2.indices_by_block[column]);
-                assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(column), m,
+                assemble(info2.matrix(k+m*n*n,true).matrix, info2.vector(m).block(row), m,
                          info2.indices_by_block[row], info1.indices_by_block[column]);
               }
         }

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1225,12 +1225,23 @@ ConstraintMatrix::resolve_indices (std::vector<types::global_dof_index> &indices
   distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
+                                           const FullMatrix<VectorType::value_type>        &) const;\
+  template void ConstraintMatrix:: \
+  distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           VectorType                      &, \
                                            const FullMatrix<VectorType::value_type>        &) const
-
 
 #define PARALLEL_VECTOR_FUNCTIONS(VectorType) \
   template void ConstraintMatrix:: \
   distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
+                                           VectorType                      &, \
+                                           const FullMatrix<VectorType::value_type>        &) const;\
+  template void ConstraintMatrix:: \
+  distribute_local_to_global<VectorType > (const Vector<VectorType::value_type>            &, \
+                                           const std::vector<ConstraintMatrix::size_type>  &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
                                            const FullMatrix<VectorType::value_type>        &) const

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1231,7 +1231,8 @@ ConstraintMatrix::resolve_indices (std::vector<types::global_dof_index> &indices
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
-                                           const FullMatrix<VectorType::value_type>        &) const
+                                           const FullMatrix<VectorType::value_type> &, \
+                                           bool) const
 
 #define PARALLEL_VECTOR_FUNCTIONS(VectorType) \
   template void ConstraintMatrix:: \
@@ -1244,8 +1245,8 @@ ConstraintMatrix::resolve_indices (std::vector<types::global_dof_index> &indices
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            const std::vector<ConstraintMatrix::size_type>  &, \
                                            VectorType                      &, \
-                                           const FullMatrix<VectorType::value_type>        &) const
-
+                                           const FullMatrix<VectorType::value_type> &, \
+                                           bool) const
 
 #ifdef DEAL_II_WITH_PETSC
 VECTOR_FUNCTIONS(PETScWrappers::MPI::Vector);

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -28,7 +28,7 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(const parallel::distributed::T<S> &, parallel::distributed::T<S> &) const;
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(parallel::distributed::T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
-      const Vector<double>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<double>&) const;
+      const Vector<S>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<parallel::distributed::T<S> >(parallel::distributed::T<S> &) const;
   }
 

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -20,7 +20,7 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::distribute_local_to_global<T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;  
     template void ConstraintMatrix::distribute_local_to_global<T<S> > (
-      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&, bool) const;
     template void ConstraintMatrix::set_zero<T<S> >(T<S> &) const;
   }
 
@@ -32,7 +32,7 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
-      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&, bool) const;
     template void ConstraintMatrix::set_zero<parallel::distributed::T<S> >(parallel::distributed::T<S> &) const;
   }
 
@@ -44,7 +44,7 @@ for (V: EXTERNAL_SEQUENTIAL_VECTORS)
     template void ConstraintMatrix::distribute_local_to_global<V > (
       const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
     template void ConstraintMatrix::distribute_local_to_global<V > (
-      const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
+      const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&, bool) const;
     template void ConstraintMatrix::set_zero<V >(V&) const;
   }
 

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -19,6 +19,8 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<T<S> >(T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;  
+    template void ConstraintMatrix::distribute_local_to_global<T<S> > (
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<T<S> >(T<S> &) const;
   }
 
@@ -29,6 +31,8 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::condense<parallel::distributed::T<S> >(parallel::distributed::T<S> &vec) const;
     template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
       const Vector<S>&, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
+    template void ConstraintMatrix::distribute_local_to_global<parallel::distributed::T<S> > (
+      const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, parallel::distributed::T<S> &, const FullMatrix<S>&) const;
     template void ConstraintMatrix::set_zero<parallel::distributed::T<S> >(parallel::distributed::T<S> &) const;
   }
 
@@ -39,6 +43,8 @@ for (V: EXTERNAL_SEQUENTIAL_VECTORS)
     template void ConstraintMatrix::condense<V >(V&vec) const;
     template void ConstraintMatrix::distribute_local_to_global<V > (
       const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
+    template void ConstraintMatrix::distribute_local_to_global<V > (
+      const Vector<V::value_type>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, V&, const FullMatrix<V::value_type>&) const;
     template void ConstraintMatrix::set_zero<V >(V&) const;
   }
 

--- a/tests/integrators/assembler_simple_system_inhom_01.cc
+++ b/tests/integrators/assembler_simple_system_inhom_01.cc
@@ -1,0 +1,691 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2012 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+/*
+ * Test SystemSimple with mixed homogeneous and inhomogeneous constraints.
+ * Compare SystemSimple with matrix and rhs computed from
+ * MatrixSimple, ResidualSimple with homogeneous constraints
+ * and global constraints.condense(matrix,rhs) operation to
+ * incorporate the inhomogeneous constraints.
+ * Tests are run for
+ * -> FE_Q<2>(1), FE_DGQ<2>(1)
+ * -> mesh: adaptive with hanging nodes
+ * -> homogeneous hanging nodes constraints
+ * -> inhomogeneous boundary constraints plus constraint of all degrees
+ *    at the origin
+ * -> matrix is the (nonsymmetric) advection matrix plus the jump of the
+ *    normal flux times the average of the values along inner edges.
+ * -> vector is standard rhs plus neumann boundary integral.
+ *
+ * Output: norm of the difference of the matrices and vectors
+ */
+
+#include "../tests.h"
+
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/compressed_sparsity_pattern.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/dofs/dof_accessor.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/meshworker/dof_info.h>
+#include <deal.II/meshworker/integration_info.h>
+#include <deal.II/meshworker/simple.h>
+#include <deal.II/meshworker/loop.h>
+
+#include <iostream>
+#include <fstream>
+
+#include <deal.II/lac/constraint_matrix.h>
+
+#include <deal.II/base/tensor_function.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <deal.II/numerics/data_out.h>
+
+
+using namespace dealii;
+
+
+/*
+ * Right hand side
+ */
+template <int dim>
+class RightHandSide : public Function<dim>
+{
+public:
+  RightHandSide () : Function<dim>() {}
+
+  virtual double value (const Point<dim>   &p,
+                        const unsigned int  component = 0) const;
+};
+
+template <int dim>
+double RightHandSide<dim>::value (const Point<dim> &p,
+                                  const unsigned int component) const
+{
+  Assert (component == 0, ExcNotImplemented());
+
+  double val = 1; // f = 1
+  return val;
+}
+
+
+/*
+ * Boundary values
+ */
+template <int dim>
+class BoundaryValues : public Function<dim>
+{
+public:
+  BoundaryValues () : Function<dim>() {}
+
+  virtual double value (const Point<dim>   &p,
+                        const unsigned int  component = 0) const;
+};
+
+template <int dim>
+double BoundaryValues<dim>::value (const Point<dim> &p,
+                                   const unsigned int component) const
+{
+  Assert (component == 0, ExcNotImplemented());
+
+  double val = 1; // u_D = 1
+  return val;
+}
+
+
+/*
+ * Flux boundary values
+ */
+template <int dim>
+class FluxBoundaryValues : public Function<dim>
+{
+public:
+  FluxBoundaryValues () : Function<dim>() {}
+
+  virtual double value (const Point<dim>   &p,
+                        const unsigned int  component = 0) const;
+};
+
+template <int dim>
+double FluxBoundaryValues<dim>::value (const Point<dim> &p,
+                                       const unsigned int component) const
+{
+  double val = 1; // g = 1
+  return val;
+}
+
+
+/*
+ * Advection coefficient
+ */
+template <int dim>
+class Advection : public TensorFunction<1,dim>
+{
+public:
+  Advection () : TensorFunction<1,dim> () {}
+
+  virtual Tensor<1,dim> value (const Point<dim> &p) const;
+};
+
+template <int dim>
+Tensor<1,dim>
+Advection<dim>::value (const Point<dim> &p) const
+{
+  Point<dim> value; // beta = (1,0)^t
+  value[0] = 1;
+  value[1] = 0;
+
+  return value;
+}
+
+
+/*
+ * System integrator
+ */
+template <int dim>
+class SystemIntegrator : public MeshWorker::LocalIntegrator<dim>
+{
+public:
+  void cell(MeshWorker::DoFInfo<dim> &dinfo,
+            typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void boundary(MeshWorker::DoFInfo<dim> &dinfo,
+                typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void face(MeshWorker::DoFInfo<dim> &dinfo1,
+            MeshWorker::DoFInfo<dim> &dinfo2,
+            typename MeshWorker::IntegrationInfo<dim> &info1,
+            typename MeshWorker::IntegrationInfo<dim> &info2) const;
+};
+
+template <int dim>
+void SystemIntegrator<dim>::cell(
+  MeshWorker::DoFInfo<dim> &dinfo,
+  typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+  // Matrix
+  const FEValuesBase<dim> &fe = info.fe_values();
+
+  FullMatrix<double> &local_matrix = dinfo.matrix(0).matrix;
+  const unsigned int n_points = fe.n_quadrature_points;
+  const unsigned int n_dofs = fe.dofs_per_cell;
+  const Advection<dim> advection;
+
+  for (unsigned int k = 0; k < n_points; ++k)
+    {
+      const Tensor<1,dim> advection_directions = advection.value(fe.quadrature_point(k));
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        for (unsigned int j = 0; j < n_dofs; ++j)
+          local_matrix(i, j) += ( fe.shape_grad(i,k)* fe.shape_grad(j,k)
+                                  + fe.shape_value(i,k)*(advection_directions*fe.shape_grad(j,k))
+                                ) * fe.JxW(k);
+    }
+
+  // RHS
+  Vector<double> &b = dinfo.vector(0).block(0);
+  const RightHandSide<dim>  right_hand_side;
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double fval = right_hand_side.value(fe.quadrature_point(k));
+      for (unsigned int i=0; i<n_dofs; ++i)
+        b(i) += fe.JxW(k)*(fe.shape_value(i,k) * fval);
+    }
+}
+
+
+template <int dim>
+void SystemIntegrator<dim>::boundary(
+  MeshWorker::DoFInfo<dim> &dinfo,
+  typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+  const FEValuesBase<dim> &fe = info.fe_values();
+  const unsigned int n_points = fe.n_quadrature_points;
+  const unsigned int n_dofs = fe.dofs_per_cell;
+  Vector<double> &b = dinfo.vector(0).block(0);
+  const FluxBoundaryValues<dim>  flux_bd;
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double flux_bd_value = flux_bd.value(fe.quadrature_point(k));
+      for (unsigned int i=0; i<n_dofs; ++i)
+        b(i) += fe.JxW(k)*(fe.shape_value(i,k) * flux_bd_value);
+    }
+}
+
+
+template <int dim>
+void SystemIntegrator<dim>::face(
+  MeshWorker::DoFInfo<dim> &dinfo1,
+  MeshWorker::DoFInfo<dim> &dinfo2,
+  typename MeshWorker::IntegrationInfo<dim> &info1,
+  typename MeshWorker::IntegrationInfo<dim> &info2) const
+{
+  FullMatrix<double> &A11 = dinfo1.matrix(0,false).matrix;
+  FullMatrix<double> &A12 = dinfo1.matrix(0,true).matrix;
+  FullMatrix<double> &A21 = dinfo2.matrix(0,true).matrix;
+  FullMatrix<double> &A22 = dinfo2.matrix(0,false).matrix;
+  const FEValuesBase<dim> &fe1 = info1.fe_values(0);
+  const FEValuesBase<dim> &fe2 = info2.fe_values(0);
+  const unsigned int n_points = fe1.n_quadrature_points;
+  const unsigned int n_dofs = fe1.dofs_per_cell;
+  double h_e;
+  if (dim==3) h_e = std::sqrt(dinfo1.face->measure());
+  else h_e = dinfo1.face->measure();
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double dx = fe1.JxW(k);
+      const Point<dim> &n = (Point<dim>)fe1.normal_vector(k);
+      for (unsigned int i=0; i<n_dofs; ++i)
+        {
+          // average
+          const double value1i = 0.5*fe1.shape_value(i,k);
+          const double value2i = 0.5*fe2.shape_value(i,k);
+
+          for (unsigned int j=0; j<n_dofs; ++j)
+            {
+              // normal jump
+              const double grad1j = -n * fe1.shape_grad(j,k);
+              const double grad2j = n * fe2.shape_grad(j,k);
+
+              A11(i,j) += fe1.JxW(k)*( value1i*grad1j );
+              A12(i,j) += fe1.JxW(k)*( value1i*grad2j );
+              A21(i,j) += fe1.JxW(k)*( value2i*grad1j );
+              A22(i,j) += fe1.JxW(k)*( value2i*grad2j );
+            }
+        }
+    }
+}
+
+
+/*
+ * Matrix integrator
+ */
+template <int dim>
+class MatrixIntegrator : public MeshWorker::LocalIntegrator<dim>
+{
+public:
+  void cell(MeshWorker::DoFInfo<dim> &dinfo,
+            typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void boundary(MeshWorker::DoFInfo<dim> &dinfo,
+                typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void face(MeshWorker::DoFInfo<dim> &dinfo1,
+            MeshWorker::DoFInfo<dim> &dinfo2,
+            typename MeshWorker::IntegrationInfo<dim> &info1,
+            typename MeshWorker::IntegrationInfo<dim> &info2) const;
+};
+
+template <int dim>
+void MatrixIntegrator<dim>::cell(
+  MeshWorker::DoFInfo<dim> &dinfo,
+  typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+  const FEValuesBase<dim> &fe = info.fe_values();
+  FullMatrix<double> &local_matrix = dinfo.matrix(0).matrix;
+
+  const unsigned int n_points = fe.n_quadrature_points;
+  const unsigned int n_dofs = fe.dofs_per_cell;
+  const Advection<dim> advection;
+
+  for (unsigned int k = 0; k < n_points; ++k)
+    {
+      const Tensor<1,dim> advection_directions = advection.value(fe.quadrature_point(k));
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        for (unsigned int j = 0; j < n_dofs; ++j)
+          local_matrix(i, j) += ( fe.shape_grad(i,k)* fe.shape_grad(j,k)
+                                  + fe.shape_value(i,k)*(advection_directions*fe.shape_grad(j,k))
+                                ) * fe.JxW(k);
+    }
+}
+
+
+template <int dim>
+void MatrixIntegrator<dim>::boundary(
+  MeshWorker::DoFInfo<dim> &dinfo,
+  typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+}
+
+
+template <int dim>
+void MatrixIntegrator<dim>::face(
+  MeshWorker::DoFInfo<dim> &dinfo1,
+  MeshWorker::DoFInfo<dim> &dinfo2,
+  typename MeshWorker::IntegrationInfo<dim> &info1,
+  typename MeshWorker::IntegrationInfo<dim> &info2) const
+{
+  FullMatrix<double> &A11 = dinfo1.matrix(0,false).matrix;
+  FullMatrix<double> &A12 = dinfo1.matrix(0,true).matrix;
+  FullMatrix<double> &A21 = dinfo2.matrix(0,true).matrix;
+  FullMatrix<double> &A22 = dinfo2.matrix(0,false).matrix;
+  const FEValuesBase<dim> &fe1 = info1.fe_values(0);
+  const FEValuesBase<dim> &fe2 = info2.fe_values(0);
+  const unsigned int n_points = fe1.n_quadrature_points;
+  const unsigned int n_dofs = fe1.dofs_per_cell;
+  double h_e;
+  if (dim==3) h_e = std::sqrt(dinfo1.face->measure());
+  else h_e = dinfo1.face->measure();
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double dx = fe1.JxW(k);
+      const Point<dim> &n = (Point<dim>)fe1.normal_vector(k);
+      for (unsigned int i=0; i<n_dofs; ++i)
+        {
+          // average
+          const double value1i = 0.5*fe1.shape_value(i,k);
+          const double value2i = 0.5*fe2.shape_value(i,k);
+
+          for (unsigned int j=0; j<n_dofs; ++j)
+            {
+              // normal jump
+              const double grad1j = -n * fe1.shape_grad(j,k);
+              const double grad2j = n * fe2.shape_grad(j,k);
+
+              A11(i,j) += fe1.JxW(k)*( value1i*grad1j );
+              A12(i,j) += fe1.JxW(k)*( value1i*grad2j );
+              A21(i,j) += fe1.JxW(k)*( value2i*grad1j );
+              A22(i,j) += fe1.JxW(k)*( value2i*grad2j );
+            }
+        }
+    }
+}
+
+
+/*
+ * Vector integrator
+ */
+template <int dim>
+class RHSIntegrator : public MeshWorker::LocalIntegrator<dim>
+{
+public:
+  void cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const;
+  void face(MeshWorker::DoFInfo<dim> &dinfo1,
+            MeshWorker::DoFInfo<dim> &dinfo2,
+            typename MeshWorker::IntegrationInfo<dim> &info1,
+            typename MeshWorker::IntegrationInfo<dim> &info2) const;
+};
+
+
+template <int dim>
+void RHSIntegrator<dim>::cell(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+  const FEValuesBase<dim> &fe = info.fe_values();
+  const unsigned int n_points = fe.n_quadrature_points;
+  const unsigned int n_dofs = fe.dofs_per_cell;
+  Vector<double> &b = dinfo.vector(0).block(0);
+  const RightHandSide<dim>  right_hand_side;
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double fval = right_hand_side.value(fe.quadrature_point(k));
+      for (unsigned int i=0; i<n_dofs; ++i)
+        b(i) += fe.JxW(k)*(fe.shape_value(i,k) * fval);
+    }
+}
+
+
+template <int dim>
+void RHSIntegrator<dim>::boundary(MeshWorker::DoFInfo<dim> &dinfo, typename MeshWorker::IntegrationInfo<dim> &info) const
+{
+  const FEValuesBase<dim> &fe = info.fe_values();
+  const unsigned int n_points = fe.n_quadrature_points;
+  const unsigned int n_dofs = fe.dofs_per_cell;
+  Vector<double> &b = dinfo.vector(0).block(0);
+  const FluxBoundaryValues<dim>  flux_bd;
+
+  for (unsigned int k=0; k<n_points; ++k)
+    {
+      const double flux_bd_value = flux_bd.value(fe.quadrature_point(k));
+      for (unsigned int i=0; i<n_dofs; ++i)
+        b(i) += fe.JxW(k)*(fe.shape_value(i,k) * flux_bd_value);
+    }
+}
+
+
+template <int dim>
+void RHSIntegrator<dim>::face(MeshWorker::DoFInfo<dim> &,
+                              MeshWorker::DoFInfo<dim> &,
+                              typename MeshWorker::IntegrationInfo<dim> &,
+                              typename MeshWorker::IntegrationInfo<dim> &) const
+{}
+
+
+/*
+ * Main class
+ */
+template<int dim>
+class MeshWorkerConstraintMatrixTest
+{
+public:
+  MeshWorkerConstraintMatrixTest(const FiniteElement<dim> &fe);
+  ~MeshWorkerConstraintMatrixTest();
+
+  void run();
+
+private:
+  void setup_system();
+  void createInhomConstraints();
+  void assemble_system_MeshWorker();
+  void assemble_MeshWorker();
+
+  Triangulation<dim> triangulation;
+  const MappingQ1<dim> mapping;
+  DoFHandler<dim> dof_handler;
+  const FiniteElement<dim> &fe;
+
+  SparsityPattern sparsity_pattern;
+  SparseMatrix<double> system_matrix;
+  SparseMatrix<double> matrix;
+  SparseMatrix<double> error_matrix;
+
+  Vector<double> system_rhs;
+  Vector<double> rhs;
+  Vector<double> error_rhs;
+
+  ConstraintMatrix constraintsInhom;
+  ConstraintMatrix constraints;
+  ConstraintMatrix constraintsAll;
+};
+
+
+template<int dim>
+MeshWorkerConstraintMatrixTest<dim>::MeshWorkerConstraintMatrixTest(const FiniteElement<dim> &fe) :
+  mapping(),
+  dof_handler(triangulation),
+  fe(fe)
+{
+  GridGenerator::hyper_cube(this->triangulation, -1, 1);
+
+  //refine with hanging node
+  this->triangulation.refine_global (1);
+  this->triangulation.begin_active()->set_refine_flag ();
+  this->triangulation.execute_coarsening_and_refinement ();
+  this->triangulation.refine_global (1);
+}
+
+
+template <int dim>
+MeshWorkerConstraintMatrixTest<dim>::~MeshWorkerConstraintMatrixTest ()
+{
+  dof_handler.clear ();
+}
+
+
+template<int dim>
+void MeshWorkerConstraintMatrixTest<dim>::setup_system()
+{
+  dof_handler.distribute_dofs(fe);
+
+  system_rhs.reinit(dof_handler.n_dofs());
+  rhs.reinit(dof_handler.n_dofs());
+  error_rhs.reinit(dof_handler.n_dofs());
+
+  constraints.clear();
+  DoFTools::make_hanging_node_constraints (dof_handler, constraints);
+  constraints.close();
+
+  DynamicSparsityPattern c_sparsity(dof_handler.n_dofs());
+
+  std::string str("FE_DGQ");
+  std::string fe_name = fe.get_name();
+  std::size_t found = fe_name.find(str);
+  if ( found!=std::string::npos)
+    DoFTools::make_flux_sparsity_pattern(dof_handler, c_sparsity, constraints,
+                                         false);
+  else
+    DoFTools::make_sparsity_pattern(dof_handler, c_sparsity, constraints,
+                                    false);
+
+  sparsity_pattern.copy_from(c_sparsity);
+
+  system_matrix.reinit(sparsity_pattern);
+  matrix.reinit(sparsity_pattern);
+  error_matrix.reinit(sparsity_pattern);
+}
+
+/*
+ * Assemble with SystemSimple
+ */
+template<int dim>
+void MeshWorkerConstraintMatrixTest<dim>::assemble_system_MeshWorker()
+{
+
+  MeshWorker::IntegrationInfoBox<dim> info_box;
+
+  const unsigned int n_gauss_points = dof_handler.get_fe().degree + 1;
+  info_box.initialize_gauss_quadrature(n_gauss_points, n_gauss_points,
+                                       n_gauss_points);
+
+  UpdateFlags update_flags = update_quadrature_points |
+                             update_values |
+                             update_gradients;
+
+  info_box.add_update_flags_all(update_flags);
+  info_box.initialize(fe, mapping);
+
+  MeshWorker::DoFInfo<dim> dof_info(dof_handler);
+  MeshWorker::Assembler::SystemSimple<SparseMatrix<double>, Vector<double> > assembler;
+
+  assembler.initialize(system_matrix, system_rhs);
+  assembler.initialize(constraintsAll);
+
+  SystemIntegrator<dim> matrix_integrator;
+  MeshWorker::integration_loop<dim, dim> (
+    dof_handler.begin_active(), dof_handler.end(),
+    dof_info, info_box, matrix_integrator, assembler);
+
+}
+
+/*
+ * Assemble matrix and vector seperately
+ */
+template<int dim>
+void MeshWorkerConstraintMatrixTest<dim>::assemble_MeshWorker()
+{
+
+  MeshWorker::IntegrationInfoBox<dim> info_box;
+
+  const unsigned int n_gauss_points = dof_handler.get_fe().degree + 1;
+  info_box.initialize_gauss_quadrature(n_gauss_points, n_gauss_points,
+                                       n_gauss_points);
+
+  UpdateFlags update_flags = update_quadrature_points |
+                             update_values |
+                             update_gradients;
+
+  info_box.add_update_flags_all(update_flags);
+  info_box.initialize(fe, mapping);
+
+  MeshWorker::DoFInfo<dim> dof_info(dof_handler);
+  MeshWorker::Assembler::MatrixSimple<SparseMatrix<double> > assemblerMatrix;
+  assemblerMatrix.initialize(constraints);
+  assemblerMatrix.initialize(matrix);
+  MeshWorker::Assembler::ResidualSimple<Vector<double> > assemblerVector;
+  assemblerVector.initialize(constraints);
+  AnyData data;
+  data.add<Vector<double>*>(&rhs, "RHS");
+  assemblerVector.initialize(data);
+
+  MatrixIntegrator<dim> matrix_integrator;
+  MeshWorker::integration_loop<dim, dim> (
+    dof_handler.begin_active(), dof_handler.end(),
+    dof_info, info_box, matrix_integrator, assemblerMatrix);
+  RHSIntegrator<dim> vector_integrator;
+  MeshWorker::integration_loop<dim, dim> (
+    dof_handler.begin_active(), dof_handler.end(),
+    dof_info, info_box, vector_integrator, assemblerVector);
+}
+
+
+template <int dim>
+void MeshWorkerConstraintMatrixTest<dim>::createInhomConstraints()
+{
+  this->constraintsInhom.clear();
+  // boundary constraints
+  VectorTools::interpolate_boundary_values (this->dof_handler,
+                                            0,
+                                            BoundaryValues<dim>(),
+                                            this->constraintsInhom);
+  // constraint of the origin
+  std::map<types::global_dof_index, Point<dim> > support_points;
+  DoFTools::map_dofs_to_support_points(this->mapping,this->dof_handler,support_points);
+  for (unsigned int dof_index=0; dof_index < this->dof_handler.n_dofs(); ++dof_index)
+    {
+      if (!this->constraints.is_constrained(dof_index) && !this->constraintsInhom.is_constrained(dof_index))
+        {
+          const Point<dim> p = support_points[dof_index];
+
+          if  (std::sqrt(p.square()) < 1e-6)
+            {
+              this->constraintsInhom.add_line (dof_index);
+              this->constraintsInhom.set_inhomogeneity (dof_index, 2);
+            }
+        }
+    }
+  this->constraintsInhom.close();
+}
+
+
+template<int dim>
+void MeshWorkerConstraintMatrixTest<dim>::run()
+{
+  setup_system();
+  createInhomConstraints();
+  constraintsAll.clear();
+  constraintsAll.merge(constraints);
+  constraintsAll.merge(constraintsInhom);
+  constraintsAll.close();
+
+  assemble_system_MeshWorker();
+
+  assemble_MeshWorker();
+  constraintsInhom.condense(matrix,rhs);
+
+  // make diagonal entries and constraints component equal
+  constraintsAll.distribute(system_rhs);
+  constraintsAll.distribute(rhs);
+  for (unsigned int i=0; i<error_matrix.m(); ++i)
+    if (constraintsAll.is_constrained(i))
+      {
+        system_matrix.diag_element(i) = 1;
+        matrix.diag_element(i) = 1;
+      }
+
+  // evaluate difference
+  error_matrix.copy_from(system_matrix);
+  error_matrix.add(-1.0,matrix);
+  error_rhs = system_rhs;
+  error_rhs -= rhs;
+  deallog << "difference rhs "<< error_rhs.l2_norm() << std::endl;
+  deallog << "difference matrix "<< error_matrix.frobenius_norm() << std::endl;
+
+}
+
+
+int main()
+{
+  initlog();
+  deallog.threshold_double(1.e-10);
+
+  FE_Q<2> fe(1);
+  deallog.push(fe.get_name());
+  MeshWorkerConstraintMatrixTest<2> test(fe);
+  test.run();
+  deallog.pop ();
+
+  FE_DGQ<2> fe2(1);
+  deallog.push(fe2.get_name());
+  MeshWorkerConstraintMatrixTest<2> test2(fe2);
+  test2.run();
+  deallog.pop ();
+
+}
+

--- a/tests/integrators/assembler_simple_system_inhom_01.output
+++ b/tests/integrators/assembler_simple_system_inhom_01.output
@@ -1,0 +1,5 @@
+
+DEAL:FE_Q<2>(1)::difference rhs 0
+DEAL:FE_Q<2>(1)::difference matrix 0
+DEAL:FE_DGQ<2>(1)::difference rhs 0
+DEAL:FE_DGQ<2>(1)::difference matrix 0


### PR DESCRIPTION
As follow up to the thread
https://groups.google.com/forum/#!topic/dealii/UoTWTXpl_lk
with title "using Meshworker with a ConstraintMatrix",
I modified Meshworker::Assembler::SystemSimple such that inhomogeneous constraints are treated correctly. In order to do so I had to modify the distribute_local_to_global that assembles an inhomogeneous vector such that it accepts two different index sets, one for the rows and one for the columns. This is necessary in Meshworker when an edge local matrix is assembled, since then the rows correspond to an element T_1 while the columns correspond to the neighboring element T_2. As it turns out this is only a minor modification of that function plus the respective changes in the header and the template instantiates.
The main changes are then done in simple.h for the SystemSimple class.
This has been tested for step-12 and step-16 and the test from Korosh Taebi from the google thread (as well as with my fourth order obstacle implementation).
Here is an updated version of Korosh Taebi's test that works with this branch
https://github.com/dealii/dealii/files/159973/MeshWorkerConstraintMatrixTest.cc.zip
(Note that the SystemSimpleInhom.h that Korosh Taebi provides in the google thread does only work for uniform meshes and inhomogeneous constraints only, while this branch is a complete modification of SystemSimple to support the general case of mixed homogeneous and inhomogeneous constraints on uniform and adaptively refined meshes)