### PR TITLE
Remove only one block warning.

### DIFF
--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -128,7 +128,7 @@ void PreconditionBlock<MatrixType,inverse_type>::invert_permuted_diagblocks
 
   if (this->same_diagonal())
     {
-      deallog << "PreconditionBlock uses only one diagonal block" << std::endl;
+      /* deallog << "PreconditionBlock uses only one diagonal block" << std::endl; */
 
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
@@ -438,7 +438,7 @@ void PreconditionBlock<MatrixType,inverse_type>::invert_diagblocks()
 
   if (this->same_diagonal())
     {
-      deallog << "PreconditionBlock uses only one diagonal block" << std::endl;
+      /* deallog << "PreconditionBlock uses only one diagonal block" << std::endl; */
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
           typename MatrixType::const_iterator entry = M.begin(row_cell);

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -128,8 +128,6 @@ void PreconditionBlock<MatrixType,inverse_type>::invert_permuted_diagblocks
 
   if (this->same_diagonal())
     {
-      /* deallog << "PreconditionBlock uses only one diagonal block" << std::endl; */
-
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
           typename MatrixType::const_iterator entry = M.begin(row_cell);
@@ -438,7 +436,6 @@ void PreconditionBlock<MatrixType,inverse_type>::invert_diagblocks()
 
   if (this->same_diagonal())
     {
-      /* deallog << "PreconditionBlock uses only one diagonal block" << std::endl; */
       for (size_type row_cell=0; row_cell<blocksize; ++row_cell)
         {
           typename MatrixType::const_iterator entry = M.begin(row_cell);


### PR DESCRIPTION
I find it not that useful and very annoying in a matrix free setup when this class is called frequently.
Using one block is not the default mode, if only one block has been chosen, it is very clear from the call to the PreconditionBlock< MatrixType, inverse_type >::AdditionalData Class constructor.