### PR TITLE
Sort and remove some includes.

### DIFF
--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -19,8 +19,10 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/table.h>
-#include <cmath>
 #include <deal.II/fe/mapping.h>
+
+#include <cmath>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -19,12 +19,11 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/thread_management.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe.h>
-#include <deal.II/lac/vector.h>
-#include <deal.II/base/qprojector.h>
-#include <deal.II/base/thread_management.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -17,12 +17,7 @@
 #define dealii__mapping_q1_h
 
 
-#include <deal.II/base/derivative_form.h>
 #include <deal.II/base/config.h>
-#include <deal.II/base/table.h>
-#include <deal.II/base/qprojector.h>
-#include <deal.II/grid/tria_iterator.h>
-#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/mapping_q_generic.h>
 
 #include <cmath>

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -24,6 +24,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+template <typename> class Vector;
+
+
 /*!@addtogroup mapping */
 /*@{*/
 

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -17,6 +17,7 @@
 #ifndef dealii__mapping_q_eulerian_h
 #define dealii__mapping_q_eulerian_h
 
+#include <deal.II/base/config.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/grid/tria_iterator.h>
@@ -27,6 +28,8 @@
 
 
 DEAL_II_NAMESPACE_OPEN
+
+template <typename> class Vector;
 
 
 /*!@addtogroup mapping */

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -17,13 +17,11 @@
 #define dealii__mapping_q_generic_h
 
 
-#include <deal.II/base/derivative_form.h>
 #include <deal.II/base/config.h>
+#include <deal.II/base/derivative_form.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/qprojector.h>
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe_q.h>
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/qprojector.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/parallel_vector.h>

--- a/tests/bits/mapping_q_eulerian_04.cc
+++ b/tests/bits/mapping_q_eulerian_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -23,6 +23,7 @@
 
 // all include files you need here
 
+#include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_in.h>

--- a/tests/codim_one/mapping_q1_eulerian.cc
+++ b/tests/codim_one/mapping_q1_eulerian.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -32,6 +32,7 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q1_eulerian.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
 
 #include <fstream>
 #include <string>

--- a/tests/codim_one/mapping_q_eulerian.cc
+++ b/tests/codim_one/mapping_q_eulerian.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -23,6 +23,7 @@
 
 // all include files you need here
 
+#include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_out.h>

--- a/tests/fe/rt_normal_02.cc
+++ b/tests/fe/rt_normal_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2015 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -40,6 +40,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/qprojector.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/dofs/dof_tools.h>
 


### PR DESCRIPTION
The mapping_*.h files did not all #include config.h as first
argument, as they should. They also include all sorts of files
they don't actually need. Remove these. Add them again in other
files that do need them but previously got them via mapping.h.