### PR TITLE
Remove unused forward declarations

### DIFF
--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -134,6 +134,19 @@ style guidelines outlined in this page.</p>
   put before the data type specifier, i.e., we use Point<dim,number> and not
   Point<number,dim>.
 
+<li> There are several places in deal.II where we use forward declarations in
+  header files. The reason for this is that we can, hopefully, improve
+  compilation speeds by not using headers when we just need to mark a certain
+  type as an argument to a function. The convention used in deal.II is that, if
+  all we need is a type name, then the type may be forward declared in the
+  header where we need it; if a function (or member function) can return a value
+  then a declaration of that value's type should be available (by including the
+  necessary header). For example, <code>deal.II/dofs/dof_handler.h</code>
+  includes <code>deal.II/dofs/dof_accessor.h</code> so that one can write
+  something like <code>dof_handler.begin_active()->is_active()</code> without
+  explicitly including the header declaring the type of the object returned by
+  <code>begin_active()</code>.
+
 <li> Each class has to have at least 200 pages of documentation ;-)</li>
 
 </ol>

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -41,6 +41,7 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -56,6 +56,7 @@
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -30,10 +30,6 @@ namespace parallel
 {
   namespace distributed
   {
-    // forward declarations
-    template <int dim, int spacedim> class Triangulation;
-
-
     /**
      * Collection of functions controlling refinement and coarsening of
      * parallel::distributed::Triangulation objects. This namespace provides

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -41,9 +41,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int> class Triangulation;
-
-
 namespace parallel
 {
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -50,8 +50,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int> class Triangulation;
-
 #ifdef DEAL_II_WITH_P4EST
 
 namespace internal

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -35,9 +35,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int> class Triangulation;
-
-
 namespace parallel
 {
   /**

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -27,7 +27,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <typename number> class FullMatrix;
-template <typename number> class SparseMatrix;
 template <typename number> class Vector;
 class ConstraintMatrix;
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/dofs/block_info.h>
+#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/number_cache.h>
 #include <deal.II/dofs/dof_faces.h>

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -39,6 +39,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+template <int dim, int spacedim> class FiniteElement;
+template <int dim, int spacedim> class Triangulation;
+
 namespace internal
 {
   namespace DoFHandler

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -30,7 +30,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int> class FiniteElement;
 template <int, int> class DoFHandler;
 
 

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -31,7 +31,6 @@ template <typename Accessor> class TriaRawIterator;
 template <typename Accessor> class TriaIterator;
 template <typename Accessor> class TriaActiveIterator;
 template <int dim, int spacedim> class Triangulation;
-template <int dim, int spacedim> class DoFHandler;
 
 
 namespace internal

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -26,12 +26,9 @@ template <int, int, int> class InvalidAccessor;
 template <int structdim, typename DoFHandlerType, bool lda> class DoFAccessor;
 template <typename DoFHandlerType, bool lda> class DoFCellAccessor;
 
-template <int dim, int spacedim> class FiniteElement;
 template <typename Accessor> class TriaRawIterator;
 template <typename Accessor> class TriaIterator;
 template <typename Accessor> class TriaActiveIterator;
-template <int dim, int spacedim> class Triangulation;
-
 
 namespace internal
 {

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -19,16 +19,11 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/point.h>
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/lac/sparsity_pattern.h>
-#include <deal.II/dofs/function_map.h>
 #include <deal.II/dofs/dof_handler.h>
-#include <deal.II/fe/fe.h>
 #include <deal.II/fe/component_mask.h>
-#include <deal.II/hp/mapping_collection.h>
 #include <deal.II/hp/dof_handler.h>
 
 #include <vector>

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -29,6 +29,7 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/component_mask.h>
 #include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/dof_handler.h>
 
 #include <vector>
 #include <set>
@@ -36,20 +37,19 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<int dim, class T> class Table;
-class SparsityPattern;
-template <typename number> class Vector;
+class BlockMask;
 template <int dim, typename Number> class Function;
 template <int dim, int spacedim> class FiniteElement;
-template <int dim, int spacedim> class DoFHandler;
 namespace hp
 {
-  template <int dim, int spacedim> class DoFHandler;
   template <int dim, int spacedim> class MappingCollection;
+  template <int dim, int spacedim> class FECollection;
 }
-class ConstraintMatrix;
 template <class MeshType> class InterGridMap;
 template <int dim, int spacedim> class Mapping;
+class SparsityPattern;
+template <int dim, class T> class Table;
+template <typename Number> class Vector;
 
 namespace GridTools
 {

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -17,7 +17,6 @@
 #define dealii__fe_h
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/geometry_info.h>
 #include <deal.II/fe/fe_base.h>
 #include <deal.II/fe/fe_values_extractors.h>
 #include <deal.II/fe/fe_update_flags.h>

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -32,11 +32,6 @@ template <int dim, int spacedim> class FEValues;
 template <int dim, int spacedim> class FEFaceValues;
 template <int dim, int spacedim> class FESubfaceValues;
 template <int dim, int spacedim> class FESystem;
-namespace hp
-{
-  template <int dim, int spacedim> class FECollection;
-}
-
 
 /**
  * This is the base class for finite elements in arbitrary dimensions. It

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -29,8 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
 
 /*!@addtogroup fe */
 /*@{*/

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -33,9 +33,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<int dim, int spacedim> class FESystem;
-
-
 /**
  * A namespace solely for the purpose of defining the Domination enum as well
  * as associated operators.

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -31,9 +31,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
-
 /**
  * DG elements based on vector valued polynomials.
  *

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -22,8 +22,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -22,9 +22,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/fe/fe.h>
+#include <deal.II/fe/mapping.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -23,10 +23,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim> class PolynomialSpace;
-template <int dim, int spacedim> class MappingQ;
-
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -31,9 +31,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -22,9 +22,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -29,9 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class MappingQ;
-
-
 /*!@addtogroup fe */
 /*@{*/
 

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -32,14 +32,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <typename number> class FullMatrix;
-template <typename number> class Vector;
 template <int dim> class Quadrature;
 template <int dim, int spacedim> class FiniteElement;
 template <int dim, int spacedim> class DoFHandler;
-namespace hp
-{
-  template <int dim, int spacedim> class DoFHandler;
-}
 template <int dim> class FiniteElementData;
 class ConstraintMatrix;
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -48,12 +48,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim>   class Quadrature;
 template <int dim, int spacedim=dim> class FEValuesBase;
-
-template <typename Number> class Vector;
-template <typename Number> class BlockVector;
-
 
 namespace internal
 {

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -19,8 +19,10 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/table.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/thread_management.h>
 

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -22,9 +22,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, typename PolynomialType> class TensorProductPolynomials;
-
-
 /*!@addtogroup mapping */
 /*@{*/
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -28,11 +28,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class Triangulation;
-template <typename number> class Vector;
-template <typename number> class SparseMatrix;
-
-
 /**
  * This namespace provides a collection of functions for generating
  * triangulations for some basic geometries.

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -29,8 +29,6 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int space_dim> class Triangulation;
 template <int dim> struct CellData;
-struct SubCellData;
-
 
 /**
  * This class implements an input mechanism for grid data. It allows to read a

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -22,8 +22,6 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/data_out_base.h>
-#include <deal.II/grid/tria.h>
-#include <deal.II/fe/mapping.h>
 
 #include <string>
 

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -19,9 +19,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/grid/tria.h>
 
-#include <vector>
 #include <limits>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -28,7 +28,6 @@ DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
 template <int dim, int spacedim> class Triangulation;
-template <class T> class Vector;
 
 
 /**

--- a/include/deal.II/grid/grid_reordering_internal.h
+++ b/include/deal.II/grid/grid_reordering_internal.h
@@ -20,7 +20,6 @@
 #include <deal.II/base/config.h>
 #include <deal.II/grid/tria.h>
 
-#include <map>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -18,11 +18,13 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/mapping.h>
+#include <deal.II/fe/mapping_q1.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/fe/mapping_q1.h>
+#include <deal.II/hp/dof_handler.h>
 
 #include <bitset>
 #include <list>
@@ -31,11 +33,8 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int, int> class DoFHandler;
-template <int, int> class Mapping;
 namespace hp
 {
-  template <int, int> class DoFHandler;
   template <int, int> class MappingCollection;
 }
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -32,6 +32,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+namespace parallel
+{
+  namespace distributed
+  {
+    template <int, int> class Triangulation;
+  }
+}
 
 namespace hp
 {

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -29,9 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int space_dim> class Triangulation;
-
-
 /**
  * We collect here some helper functions used in the Manifold<dim,spacedim>
  * classes.

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -75,7 +75,6 @@ namespace internal
   }
 }
 
-template <int dim, int spacedim> class DoFHandler;
 namespace hp
 {
   template <int dim, int spacedim> class DoFHandler;

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -48,7 +48,7 @@ template <int dim, int spacedim> class Manifold;
 
 template <int, int, int> class TriaAccessor;
 template <int spacedim> class TriaAccessor<0,1,spacedim>;
-
+template <int, int, int> class TriaAccessorBase;
 
 namespace internal
 {

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -25,8 +25,6 @@
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/std_cxx11/function.h>
 #include <deal.II/grid/tria_iterator_selector.h>
-#include <deal.II/grid/tria_faces.h>
-#include <deal.II/grid/tria_levels.h>
 
 // Ignore deprecation warnings for auto_ptr.
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -35,16 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 namespace parallel
 {
   template <int, int> class Triangulation;
-
-  namespace distributed
-  {
-    template <int, int> class Triangulation;
-  }
-
-  namespace shared
-  {
-    template <int, int> class Triangulation;
-  }
 }
 
 

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -29,10 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int space_dim> class Triangulation;
-
-
-
 /**
  * This class is used to represent a boundary to a triangulation. When a
  * triangulation creates a new vertex on the boundary of the domain, it

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -35,7 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim> class Triangulation;
 template <int, int, int> class TriaAccessorBase;
 
-template <typename> class TriaRawIterator;
 template <typename> class TriaIterator;
 template <typename> class TriaActiveIterator;
 

--- a/include/deal.II/grid/tria_iterator_selector.h
+++ b/include/deal.II/grid/tria_iterator_selector.h
@@ -22,7 +22,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim> class CellAccessor;
-template <int, int, int> class TriaAccessorBase;
 template <int, int, int> class InvalidAccessor;
 template <int, int, int> class TriaAccessor;
 template <int dim, int spacedim>  class TriaAccessor<0, dim, spacedim>;

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/dofs/function_map.h>
+#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/number_cache.h>
 #include <deal.II/hp/fe_collection.h>

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -36,6 +36,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+template <int dim, int spacedim> class Triangulation;
+
 namespace internal
 {
   namespace hp

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -33,14 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <typename number> class BlockSparseMatrix;
-class BlockSparsityPattern;
 class BlockDynamicSparsityPattern;
-#ifdef DEAL_II_WITH_TRILINOS
-namespace TrilinosWrappers
-{
-  class BlockSparsityPattern;
-}
-#endif
 
 /*! @addtogroup Sparsity
  *@{

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -31,7 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 #ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
-  class Vector;
   class BlockVector;
 }
 #endif

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -43,8 +43,6 @@ class BlockSparsityPattern;
 class BlockDynamicSparsityPattern;
 template <typename number> class SparseMatrix;
 template <typename number> class BlockSparseMatrix;
-class BlockIndices;
-
 
 namespace internals
 {

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -29,7 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <typename number> class SparseMatrix;
 class DynamicSparsityPattern;
 
 

--- a/include/deal.II/lac/filtered_matrix.h
+++ b/include/deal.II/lac/filtered_matrix.h
@@ -29,9 +29,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <typename number> class Vector;
 template <class VectorType> class FilteredMatrixBlock;
-
 
 /*! @addtogroup Matrix2
  *@{

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -30,12 +30,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-
-// forward declaration
-template <typename> class Vector;
-class IndexSet;
-
-
 /*! @addtogroup PETScWrappers
  *@{
  */

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -27,9 +27,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template<typename MatrixType, typename inverse_type>
-class PreconditionBlockJacobi;
-
 /*! @addtogroup Preconditioners
  *@{
  */

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -27,10 +27,6 @@ class IndexSet;
 
 namespace LinearAlgebra
 {
-  template <typename Number>
-  class ReadWriteVector;
-
-
   /*! @addtogroup Vectors
    *@{
    */

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -37,6 +37,8 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
+    template <typename Number> class ConstraintValues;
+
     /**
      * The class that stores the indices of the degrees of freedom for all the
      * cells. Essentially, this is a smart number cache in the style of a

--- a/include/deal.II/matrix_free/helper_functions.h
+++ b/include/deal.II/matrix_free/helper_functions.h
@@ -33,9 +33,6 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
-    // forward declaration of internal data structure
-    template <typename Number> struct ConstraintValues;
-
     /**
      * A struct that collects all information related to parallelization with
      * threads: The work is subdivided into tasks that can be done

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -27,8 +27,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 class BlockIndices;
-template<int,int> class DoFHandler;
-
 
 /**
  * A collection of functions and classes for the mesh loops that are an

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -29,8 +29,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <typename> class MGLevelObject;
-
 /*!@addtogroup mg */
 /*@{*/
 

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -27,14 +27,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <class Object> class MGLevelObject;
 template <int dim, int spacedim> class DoFHandler;
-template <typename number> class Vector;
-template <typename number> class SparseMatrix;
-template <typename number> class BlockVector;
-template <typename number> class BlockSparseMatrix;
-template <typename number> class FullMatrix;
-template <typename number> class BlockSparseMatrix;
 
 /* !@addtogroup mg */
 /* @{ */

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -25,8 +25,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int, int> class FEValuesBase;
-
 namespace internal
 {
   namespace DataOut

--- a/include/deal.II/numerics/derivative_approximation.h
+++ b/include/deal.II/numerics/derivative_approximation.h
@@ -31,14 +31,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-template <int dim, int spacedim> class DoFHandler;
-namespace hp
-{
-  template <int dim, int spacedim> class DoFHandler;
-}
-
-
-
 /**
  * This namespace provides functions that compute a cell-wise approximation of
  * the norm of a derivative of a finite element field by taking difference

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -27,13 +27,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int, int> class DoFHandler;
 template <int, int> class Mapping;
 template <int> class Quadrature;
 
 namespace hp
 {
-  template <int, int> class DoFHandler;
   template <int> class QCollection;
 }
 

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -46,7 +46,6 @@ template <typename Number> class BlockVector;
 
 template <int dim, int spacedim> class Mapping;
 template <int dim, int spacedim> class DoFHandler;
-template <int dim, int spacedim> class FEValues;
 
 namespace hp
 {

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -46,16 +46,6 @@ namespace internal
 {
   namespace PointValueHistory
   {
-    template <int dim> class PointGeometryData;
-  }
-}
-
-
-
-namespace internal
-{
-  namespace PointValueHistory
-  {
     /**
      * A class that stores the data needed to reference the support points
      * closest to one requested point.

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/point.h>
 #include <deal.II/dofs/function_map.h>
-#include <deal.II/fe/mapping_q.h>
 #include <deal.II/hp/mapping_collection.h>
 
 #include <map>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -43,7 +43,6 @@ template <typename gridtype> class InterGridMap;
 namespace hp
 {
   template <int dim, int spacedim> class DoFHandler;
-  template <int dim, int spacedim> class MappingCollection;
   template <int dim> class QCollection;
 }
 class ConstraintMatrix;

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -50,6 +50,7 @@
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/mapping_q1.h>
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/fe_values.h>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -34,9 +34,11 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/fe_tools.h>
+#include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/fe_collection.h>
-#include <deal.II/hp/q_collection.h>
 #include <deal.II/hp/fe_values.h>
+#include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/q_collection.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/shared_tria.h>

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -41,6 +41,7 @@
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_cartesian.h>
+#include <deal.II/fe/mapping_q1.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/codim_one/gradients_1.cc
+++ b/tests/codim_one/gradients_1.cc
@@ -34,8 +34,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/lac/constraint_matrix.h>
-#include <deal.II/fe/mapping.h>
-#include <deal.II/fe/mapping_q1.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>

--- a/tests/dofs/block_list.h
+++ b/tests/dofs/block_list.h
@@ -17,7 +17,9 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_iterator.h>
+#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b1.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b1.cc
@@ -23,6 +23,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b2_mask.cc
@@ -23,6 +23,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b3_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b4_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_b5_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q1.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q1.cc
@@ -23,6 +23,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q2_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q2_mask.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q2_mask.cc
@@ -23,6 +23,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q3_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q4_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/fe/mapping_fe_field_real_to_unit_q5_curved.cc
+++ b/tests/fe/mapping_fe_field_real_to_unit_q5_curved.cc
@@ -27,6 +27,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/mapping_fe_field.h>

--- a/tests/hp/interpolate_nothing_02.cc
+++ b/tests/hp/interpolate_nothing_02.cc
@@ -21,6 +21,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/grid/tria.h>

--- a/tests/hp/project_01_curved_boundary.cc
+++ b/tests/hp/project_01_curved_boundary.cc
@@ -30,6 +30,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -30,6 +30,7 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q_generic.h>
 
 #include <deal.II/integrators/laplace.h>
 

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -21,6 +21,7 @@
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q_generic.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/lac/block_linear_operator.h>

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -21,6 +21,7 @@
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q_generic.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/lac/block_linear_operator.h>

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -42,6 +42,7 @@ std::ofstream logfile("output");
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -25,6 +25,7 @@
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>

--- a/tests/matrix_free/get_functions_q_hierarchical.cc
+++ b/tests/matrix_free/get_functions_q_hierarchical.cc
@@ -23,6 +23,7 @@
 
 #include "../tests.h"
 #include <deal.II/fe/fe_q_hierarchical.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/base/function.h>
 

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -43,6 +43,7 @@ std::ofstream logfile("output");
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -33,6 +33,7 @@
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>

--- a/tests/mpi/map_dofs_to_support_points.cc
+++ b/tests/mpi/map_dofs_to_support_points.cc
@@ -25,6 +25,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q_generic.h>
 
 #include <fstream>
 

--- a/tests/numerics/project_01_curved_boundary.cc
+++ b/tests/numerics/project_01_curved_boundary.cc
@@ -29,6 +29,8 @@
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/fe/mapping_q_generic.h>
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/dofs/dof_accessor.h>
 


### PR DESCRIPTION
This set of commits improves the handling of forward declarations versus headers. Unfortunately it conflicts with #2331 (both remove some extra headers): I don't mind merging that one first and then fixing this.

I propose that we add something like
```
There are several places in deal.II where we use forward declarations in header
files. The reason for this is that we can, hopefully, improve compilation speeds
by not using headers when we just need to mark a certain type as an argument to
a function. The convention used in deal.II is that, if all we need is a type
name, then the type may be forward declared in a header; if a function (or
member function) can return a value then the declaration of that value's type
should be available by including that header. For example, dofs/dof_handler.h
includes dofs/dof_accessor.h so that one can run

dof_handler.begin_active()->is_active()

without explicitly including the header for the type returned by begin_active().
```
to the style guide. Thoughts?