### PR TITLE
[8.4] take over #2336: CMake: Fix rpath handling on Mac OSX

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -76,11 +76,19 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
     LINKER_LANGUAGE "CXX"
     COMPILE_DEFINITIONS "${DEAL_II_DEFINITIONS};${DEAL_II_DEFINITIONS_${build}}"
     COMPILE_FLAGS "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}"
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${DEAL_II_LIBRARY_RELDIR}"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_EXECUTABLE_RELDIR}"
     )
+
+  IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    SET_TARGET_PROPERTIES(${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX}
+      PROPERTIES
+      MACOSX_RPATH OFF
+      BUILD_WITH_INSTALL_RPATH OFF
+      INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${DEAL_II_LIBRARY_RELDIR}"
+      )
+  ENDIF()
 
   # Under Windows (MSVC) cmake will always generate multi-configuration
   # projects. When building on the command line with 'cmake --build .',


### PR DESCRIPTION
This forces global paths upon installation to avoid error messages like

dyld: Library not loaded: /lib/libdeal_II.g.8.4.0-rc3.dylib
  Referenced from: /[...]/step-18
  Reason: image not found

In Reference to #1938