### PR TITLE
Fix compilation on clang.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -25,7 +25,6 @@
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/dofs/block_info.h>
-#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/number_cache.h>
 #include <deal.II/dofs/dof_faces.h>


### PR DESCRIPTION
I added this header previously in d34f4fc116 to be consistent with the inclusion of the accessors header in the hp DoFHandler file. However, this header is not necessary, and including it breaks compilation under clang for reasons I do not fully understand.