### PR TITLE
Fix a clang warning.

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -37,7 +37,7 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
-    template <typename Number> class ConstraintValues;
+    template <typename Number> struct ConstraintValues;
 
     /**
      * The class that stores the indices of the degrees of freedom for all the


### PR DESCRIPTION
The declaration of ConstraintValues uses 'struct', so the forward declaration should also use 'struct'.