### PR TITLE
Remove unimplemented assignment operators.

### DIFF
--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -364,24 +364,6 @@ public:
   TriaRawIterator &operator = (const TriaRawIterator &);
 
   /**
-   * Assignment operator.
-   */
-//    template <class OtherAccessor>
-//    TriaRawIterator & operator = (const TriaRawIterator<OtherAccessor>&);
-
-  /**
-   * Assignment operator.
-   */
-//    template <class OtherAccessor>
-//    TriaRawIterator & operator = (const TriaIterator<OtherAccessor>&);
-
-  /**
-   * Assignment operator.
-   */
-//    template <class OtherAccessor>
-//    TriaRawIterator & operator = (const TriaActiveIterator<OtherAccessor>&);
-
-  /**
    * Compare for equality.
    */
   bool operator == (const TriaRawIterator &) const;


### PR DESCRIPTION
These have been commented out since they were added in ce50155aea (March 2010). Since the comment blocks begin with `/**` this caused this amusing doxygen description for `operator==`:

> Assignment operator. Assignment operator. Assignment operator. Compare for equality.