### PR TITLE
Check the number of nodes in FE_DGQArbitraryNodes.

### DIFF
--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_tools.h>
 
@@ -200,6 +201,8 @@ FE_DGQ<dim, spacedim>::FE_DGQ (const Quadrature<1> &points)
   // are the tensor product of the
   // Lagrange interpolation points in
   // the constructor.
+  Assert (points.size() > 0,
+          (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints ()));
   Quadrature<dim> support_quadrature(points);
   this->unit_support_points = support_quadrature.get_points();
 


### PR DESCRIPTION
Currently, one can create an `FE_DGQArbitraryNodes` instance from a quadrature rule with zero points, which causes segmentation faults (even in debug mode) when one tries to use the element. This assertion verifies that this cannot happen, at least in debug mode.