### PR TITLE
Remove a workaround for an old intel compiler.

### DIFF
--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -41,25 +41,6 @@ template <int dim> const unsigned int GeometryInfo<dim>::hexes_per_cell;
 
 using namespace numbers;
 
-// make sure that also the icc compiler defines (and not only declares)
-// these variables
-namespace internal
-{
-  void foo (const unsigned int *) {}
-
-  template <int dim>
-  void define_variables ()
-  {
-    foo(&::dealii::GeometryInfo<dim>::vertices_per_cell);
-  }
-
-  template void define_variables<2> ();
-  template void define_variables<3> ();
-  template void define_variables<4> ();
-}
-
-
-
 template <>
 const unsigned int
 GeometryInfo<1>::unit_normal_direction[faces_per_cell]


### PR DESCRIPTION
This was added in April 2005 in commit 0a58949ace and is no longer necessary: I was able to compile and run this branch with intel 13, gcc 5.3, and clang 3.7. I assume that this workaround is not necessary for more recent compilers as well.