### PR TITLE
Performance improvements: Triangulation::end(level) can be expensive

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4681,7 +4681,9 @@ namespace parallel
     {
       const std::vector<bool> locally_active_vertices =
         mark_locally_active_vertices_on_level(level);
-      for (cell_iterator cell = this->begin(level); cell != this->end(level); ++cell)
+      cell_iterator cell = this->begin(level),
+                    endc = this->end(level);
+      for ( ; cell != endc; ++cell)
         if (cell->level_subdomain_id() != dealii::numbers::artificial_subdomain_id
             && cell->level_subdomain_id() != this->locally_owned_subdomain())
           for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
@@ -4704,7 +4706,9 @@ namespace parallel
       Assert (dim>1, ExcNotImplemented());
 
       std::vector<bool> marked_vertices(this->n_vertices(), false);
-      for (cell_iterator cell = this->begin(level); cell != this->end(level); ++cell)
+      cell_iterator cell = this->begin(level),
+                    endc = this->end(level);
+      for ( ; cell != endc; ++cell)
         if (cell->level_subdomain_id() == this->locally_owned_subdomain())
           for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
             marked_vertices[cell->vertex_index(v)] = true;

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1437,7 +1437,8 @@ void DoFHandler<2>::renumber_dofs (const unsigned int  level,
       // level, as those lines logically belong to the same
       // level as the cell, at least for for isotropic
       // refinement
-      for (level_cell_iterator cell = begin(level); cell != end(level); ++cell)
+      level_cell_iterator cell, endc = end(level);
+      for (cell = begin(level); cell != endc; ++cell)
         for (unsigned int line=0; line < GeometryInfo<2>::faces_per_cell; ++line)
           cell->face(line)->set_user_flag();
 
@@ -1497,12 +1498,13 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
       // level, as those lines logically belong to the same
       // level as the cell, at least for for isotropic
       // refinement
-      for (level_cell_iterator cell = begin(level) ; cell != end(level) ; ++cell)
+      level_cell_iterator cell, endc = end(level);
+      for (cell = begin(level) ; cell != endc ; ++cell)
         for (unsigned int line=0; line < GeometryInfo<3>::lines_per_cell; ++line)
           cell->line(line)->set_user_flag();
 
 
-      for (cell_iterator cell = begin(level); cell != end(level); ++cell)
+      for (cell = begin(level); cell != endc; ++cell)
         for (unsigned int l=0; l<GeometryInfo<3>::lines_per_cell; ++l)
           if (cell->line(l)->user_flag_set())
             {
@@ -1527,11 +1529,12 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
       // level, as those lines logically belong to the same
       // level as the cell, at least for for isotropic
       // refinement
-      for (level_cell_iterator cell = begin(level) ; cell != end(level); ++cell)
+      level_cell_iterator cell, endc = end(level);
+      for (cell = begin(level) ; cell != endc; ++cell)
         for (unsigned int quad=0; quad < GeometryInfo<3>::faces_per_cell; ++quad)
           cell->face(quad)->set_user_flag();
 
-      for (cell_iterator cell = begin(level); cell != end(level); ++cell)
+      for (cell = begin(level); cell != endc; ++cell)
         for (unsigned int q=0; q<GeometryInfo<3>::quads_per_cell; ++q)
           if (cell->quad(q)->user_flag_set())
             {

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -731,8 +731,9 @@ namespace internal
               // level, as those lines logically belong to the same
               // level as the cell, at least for for isotropic
               // refinement
-              for (typename DoFHandler<2,spacedim>::level_cell_iterator cell = dof_handler.begin(level);
-                   cell != dof_handler.end(level); ++cell)
+              typename DoFHandler<2,spacedim>::level_cell_iterator cell,
+                       endc = dof_handler.end(level);
+              for (cell = dof_handler.begin(level); cell != endc; ++cell)
                 for (unsigned int line=0; line < GeometryInfo<2>::faces_per_cell; ++line)
                   cell->face(line)->set_user_flag();
 
@@ -883,8 +884,9 @@ namespace internal
               // flag all lines adjacent to cells of the current level, as
               // those lines logically belong to the same level as the cell,
               // at least for isotropic refinement
-              for (typename DoFHandler<3,spacedim>::level_cell_iterator cell = dof_handler.begin(level);
-                   cell != dof_handler.end(level); ++cell)
+              typename DoFHandler<3,spacedim>::level_cell_iterator cell,
+                       endc = dof_handler.end(level);
+              for (cell = dof_handler.begin(level); cell != endc; ++cell)
                 for (unsigned int line=0; line < GeometryInfo<3>::lines_per_cell; ++line)
                   cell->line(line)->set_user_flag();
 
@@ -909,8 +911,7 @@ namespace internal
               // flag all quads adjacent to cells of the current level, as
               // those quads logically belong to the same level as the cell,
               // at least for isotropic refinement
-              for (typename DoFHandler<3,spacedim>::level_cell_iterator cell = dof_handler.begin(level);
-                   cell != dof_handler.end(level); ++cell)
+              for (cell = dof_handler.begin(level); cell != endc; ++cell)
                 for (unsigned int quad=0; quad < GeometryInfo<3>::quads_per_cell; ++quad)
                   cell->quad(quad)->set_user_flag();
 

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -321,8 +321,8 @@ void MGTransferMatrixFree<dim,Number>::build
       std::vector<types::global_dof_index> ghosted_level_dofs_l0;
 
       // step 2.1: loop over the cells on the coarse side
-      for (typename DoFHandler<dim>::cell_iterator cell = mg_dof.begin(level-1);
-           cell != mg_dof.end(level-1); ++cell)
+      typename DoFHandler<dim>::cell_iterator cell, endc = mg_dof.end(level-1);
+      for (cell = mg_dof.begin(level-1); cell != endc; ++cell)
         {
           // need to look into a cell if it has children and it is locally owned
           if (!cell->has_children())

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -172,8 +172,8 @@ void MGTransferPrebuilt<VectorType>::build_matrices
       DynamicSparsityPattern dsp (this->sizes[level+1],
                                   this->sizes[level],
                                   level_p1_relevant_dofs);
-      for (typename DoFHandler<dim,spacedim>::cell_iterator cell=mg_dof.begin(level);
-           cell != mg_dof.end(level); ++cell)
+      typename DoFHandler<dim>::cell_iterator cell, endc = mg_dof.end(level);
+      for (cell=mg_dof.begin(level); cell != endc; ++cell)
         if (cell->has_children() &&
             ( mg_dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
               || cell->level_subdomain_id()==mg_dof.get_triangulation().locally_owned_subdomain()
@@ -219,8 +219,7 @@ void MGTransferPrebuilt<VectorType>::build_matrices
       FullMatrix<double> prolongation;
 
       // now actually build the matrices
-      for (typename DoFHandler<dim,spacedim>::cell_iterator cell=mg_dof.begin(level);
-           cell != mg_dof.end(level); ++cell)
+      for (cell=mg_dof.begin(level); cell != endc; ++cell)
         if (cell->has_children() &&
             (mg_dof.get_triangulation().locally_owned_subdomain()==numbers::invalid_subdomain_id
              || cell->level_subdomain_id()==mg_dof.get_triangulation().locally_owned_subdomain())


### PR DESCRIPTION
My large multigrid computations could spend a long time in `DoFHandler::distribute_mg_dofs` (e.g. 900s on 224 procs with 90m cells - it gets worse with more procs and larger local sizes) because there are a few uses of dof_handler.end(level) used for loop checks. Since the compiler cannot see the definition, it needs to evaluate end(level) for every iteration, leading to a classical `O(n^2)` behavior. This only happens for certain meshes (or processor configurations in my case) where there are many invalid cells at front of begin(level+1).

This patch avoids the most prominent uses of this code. In the above example, the timing is now 9.22s on the same processor configuration.