### PR TITLE
add examples and tests to project for IDEs

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,3 +48,15 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
 
   MESSAGE(STATUS "Setting up examples - Done")
 ENDIF()
+
+#
+# Add a dummy target to make files known to IDEs like qtcreator
+#
+
+FILE(GLOB _misc
+  ${CMAKE_CURRENT_SOURCE_DIR}/step-*/*.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/step-*/*.h
+)
+ADD_CUSTOM_TARGET(dummy_examples_files
+  SOURCES ${_misc}
+  )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,5 +141,20 @@ ENDFOREACH()
 
 
 IF(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
+  #
+  # Add a dummy target to make files known to IDEs like qtcreator
+  #
+
+  FILE(GLOB _misc
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/*/*.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/*/*.h
+  )
+
+  ADD_CUSTOM_TARGET(dummy_tests_files
+    SOURCES ${_misc}
+  )
+
   MESSAGE(STATUS "Setting up testsuite - Done")
 ENDIF()


### PR DESCRIPTION
This adds the example and test source and header files to the cmake
project with a dummy target that is not built. IDEs like qtcreator will
then include the files inside the project.