### PR TITLE
Fix nvcc warnings

### DIFF
--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -351,7 +351,7 @@ namespace GraphColoring
                   // iterators.
                   std::vector<unsigned int>::iterator it;
                   it = std::max_element(colors_counter[i].begin(),colors_counter[i].end());
-                  unsigned int min_iterators(-1);
+                  unsigned int min_iterators (static_cast<unsigned int>(-1));
                   unsigned int pos(0);
                   // Find the color of coloring with the least number of colors among
                   // the colors that have not been used yet.
@@ -402,7 +402,7 @@ namespace GraphColoring
                       // iterators.
                       std::vector<unsigned int>::iterator it;
                       it = std::max_element(colors_counter[i].begin(),colors_counter[i].end());
-                      unsigned int min_iterators(-1);
+                      unsigned int min_iterators(static_cast<unsigned int>(-1));
                       unsigned int pos(0);
                       // Find the color of coloring with the least number of colors among
                       // the colors that have not been used yet.

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -66,7 +66,7 @@ public:
    * construct an empty CellId.
    */
   CellId()
-    : coarse_cell_id(-1)
+    : coarse_cell_id(static_cast<unsigned int>(-1))
   {}
 
   /**

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3098,7 +3098,7 @@ CellAccessor<dim,spacedim>::id() const
   while (ptr.level()>0)
     {
       // determine which child we are
-      unsigned char v=-1;
+      unsigned char v = static_cast<unsigned char>(-1);
       for (unsigned int c=0; c<ptr.parent()->n_children(); ++c)
         {
           if (ptr.parent()->child_index(c)==ptr.index())

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3205,7 +3205,6 @@ CellAccessor<3>::subface_case(const unsigned int face_no) const
     {
     case RefinementCase<3>::no_refinement:
       return dealii::internal::SubfaceCase<3>::case_none;
-      break;
     case RefinementCase<3>::cut_x:
       if (face(face_no)->child(0)->has_children())
         {
@@ -3231,7 +3230,6 @@ CellAccessor<3>::subface_case(const unsigned int face_no) const
           else
             return dealii::internal::SubfaceCase<3>::case_x;
         }
-      break;
     case RefinementCase<3>::cut_y:
       if (face(face_no)->child(0)->has_children())
         {
@@ -3257,10 +3255,8 @@ CellAccessor<3>::subface_case(const unsigned int face_no) const
           else
             return dealii::internal::SubfaceCase<3>::case_y;
         }
-      break;
     case RefinementCase<3>::cut_xy:
       return dealii::internal::SubfaceCase<3>::case_xy;
-      break;
     default:
       Assert(false, ExcInternalError());
     }

--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -74,7 +74,6 @@ namespace LAPACKSupport
       default:
         return "unknown";
       }
-    return "internal error";
   }
 
   /**


### PR DESCRIPTION
The Nvidia compiler nvcc is picky with some implicit casts and unreachable code. This fixes some warnings of those two types.