### PR TITLE
Hide unused parameters to suppress warnings

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -280,6 +280,20 @@ namespace deal_II_exceptions
 
 
 /**
+ * Sometimes, some parameters of a function are only used for Asserts or other
+ * code which is DEBUG-mode specific. To prevent warnings about unused
+ * parameters when compiling in RELEASE mode, the NDEBUG_UNUSED_PARAMETER macro
+ * allows hiding such parameters.
+ *
+ */
+#ifdef DEBUG
+#define NDEBUG_UNUSED_PARAMETER(var) var
+#else
+#define NDEBUG_UNUSED_PARAMETER(var)
+#endif
+
+
+/**
  * This is the main routine in the exception mechanism for debug mode error
  * checking. It asserts that a certain condition is fulfilled, otherwise
  * issues an error and aborts the program.

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2143,8 +2143,8 @@ namespace internal
   // parallel::distributed::Vector is really the same as stored in MatrixFree
   template <typename VectorType>
   inline
-  void check_vector_compatibility (const VectorType                             &vec,
-                                   const internal::MatrixFreeFunctions::DoFInfo &dof_info)
+  void check_vector_compatibility (const VectorType                             &NDEBUG_UNUSED_PARAMETER(vec),
+                                   const internal::MatrixFreeFunctions::DoFInfo &NDEBUG_UNUSED_PARAMETER(dof_info))
   {
     AssertDimension (vec.size(),
                      dof_info.vector_partitioner->size());
@@ -6523,7 +6523,7 @@ template <int dim, int fe_degree,  int n_q_points_1d, int n_components_,
 inline
 void
 FEEvaluation<dim,fe_degree,n_q_points_1d,n_components_,Number>
-::check_template_arguments(const unsigned int fe_no)
+::check_template_arguments(const unsigned int NDEBUG_UNUSED_PARAMETER(fe_no))
 {
 #ifdef DEBUG
   // print error message when the dimensions do not match. Propose a possible


### PR DESCRIPTION
nvcc complains that function parameters are unused in RELEASE mode. This is a suggestion of how to hide them to remove the warning.