### PR TITLE
fix macros appearing in doxygen documentation

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -182,7 +182,10 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_UMFPACK=1 \
                          DEAL_II_WITH_ZLIB=1 \
                          DEAL_II_NAMESPACE_OPEN= \
-                         DEAL_II_NAMESPACE_CLOSE=
+                         DEAL_II_NAMESPACE_CLOSE= \
+                         DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
+                         DEAL_II_DISABLE_EXTRA_DIAGNOSTICS=
+
 
 # do not expand exception declarations
 EXPAND_AS_DEFINED      = DeclException0 \


### PR DESCRIPTION
See
https://www.dealii.org/developer/doxygen/deal.II/classFunctionParser.html#a39c99186f03fa9c4ab7288f166a6ac5a
for an example