### PR TITLE
Added colorize option for hyper_L grid

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -575,9 +575,9 @@ namespace GridGenerator
    * the interval [<i>(left+right)/2,right</i>] for each coordinate. If the
    * @p colorize flag is set, the @p boundary_ids of the surfaces are
    * assigned, such that the left boundary is 0, and the others are set with
-   * growing number accordingly to the counterclockwise. This function will
-   * create the classical L-shape in 2d and it will look like the following
-   * in 3d:
+   * growing number accordingly to the counterclockwise. Colorize option works
+   * only with 2-dimensional problem. This function will create the classical 
+   * L-shape in 2d and it will look like the following in 3d:
    *
    * @image html hyper_l.png
    *

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -576,7 +576,7 @@ namespace GridGenerator
    * @p colorize flag is set, the @p boundary_ids of the surfaces are
    * assigned, such that the left boundary is 0, and the others are set with
    * growing number accordingly to the counterclockwise. Colorize option works
-   * only with 2-dimensional problem. This function will create the classical 
+   * only with 2-dimensional problem. This function will create the classical
    * L-shape in 2d and it will look like the following in 3d:
    *
    * @image html hyper_l.png

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -572,9 +572,12 @@ namespace GridGenerator
    * Initialize the given triangulation with a hyper-L (in 2d or 3d)
    * consisting of exactly <tt>2^dim-1</tt> cells. It produces the hypercube
    * with the interval [<i>left,right</i>] without the hypercube made out of
-   * the interval [<i>(left+right)/2,right</i>] for each coordinate.  All
-   * faces will have boundary indicator 0. This function will create the
-   * classical L-shape in 2d and it will look like the following in 3d:
+   * the interval [<i>(left+right)/2,right</i>] for each coordinate. If the 
+   * @p colorize flag is set, the @p boundary_ids of the surfaces are
+   * assigned, such that the left boundary is 0, and the others are set with
+   * growing number accordingly to the counterclockwise. This function will 
+   * create the classical L-shape in 2d and it will look like the following 
+   * in 3d:
    *
    * @image html hyper_l.png
    *
@@ -586,7 +589,8 @@ namespace GridGenerator
   template <int dim>
   void hyper_L (Triangulation<dim> &tria,
                 const double        left = -1.,
-                const double        right= 1.);
+                const double        right= 1.,
+                const bool          colorize = false);
 
   /**
    * Initialize the given Triangulation with a hypercube with a slit. In each

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -572,11 +572,11 @@ namespace GridGenerator
    * Initialize the given triangulation with a hyper-L (in 2d or 3d)
    * consisting of exactly <tt>2^dim-1</tt> cells. It produces the hypercube
    * with the interval [<i>left,right</i>] without the hypercube made out of
-   * the interval [<i>(left+right)/2,right</i>] for each coordinate. If the 
+   * the interval [<i>(left+right)/2,right</i>] for each coordinate. If the
    * @p colorize flag is set, the @p boundary_ids of the surfaces are
    * assigned, such that the left boundary is 0, and the others are set with
-   * growing number accordingly to the counterclockwise. This function will 
-   * create the classical L-shape in 2d and it will look like the following 
+   * growing number accordingly to the counterclockwise. This function will
+   * create the classical L-shape in 2d and it will look like the following
    * in 3d:
    *
    * @image html hyper_l.png

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -350,8 +350,7 @@ namespace GridGenerator
         p1(i) = std::min(p_1(i), p_2(i));
         p2(i) = std::max(p_1(i), p_2(i));
       }
-      //for (typename Triangulation<1,spacedim>::cell_iterator cell = tria.begin();
-      //     cell != tria.end(); ++cell)
+    //
 
     std::vector<Point<spacedim> > vertices (GeometryInfo<dim>::vertices_per_cell);
     switch (dim)
@@ -2116,7 +2115,7 @@ namespace GridGenerator
     if (colorize)
       {
         auto cell = tria.begin();
-        
+
         cell->face(0)->set_boundary_id(0);
         cell->face(2)->set_boundary_id(1);
         cell++;
@@ -2795,7 +2794,7 @@ namespace GridGenerator
     if (colorize)
       {
         Assert (false, ExcNotImplemented());
-      } 
+      }
   }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -350,6 +350,8 @@ namespace GridGenerator
         p1(i) = std::min(p_1(i), p_2(i));
         p2(i) = std::max(p_1(i), p_2(i));
       }
+      //for (typename Triangulation<1,spacedim>::cell_iterator cell = tria.begin();
+      //     cell != tria.end(); ++cell)
 
     std::vector<Point<spacedim> > vertices (GeometryInfo<dim>::vertices_per_cell);
     switch (dim)
@@ -1846,7 +1848,8 @@ namespace GridGenerator
   template <>
   void hyper_L (Triangulation<1> &,
                 const double,
-                const double)
+                const double,
+                const bool)
   {
     Assert (false, ExcNotImplemented());
   }
@@ -2080,7 +2083,8 @@ namespace GridGenerator
   void
   hyper_L (Triangulation<2> &tria,
            const double a,
-           const double b)
+           const double b,
+           const bool colorize)
   {
     const Point<2> vertices[8] = { Point<2> (a,a),
                                    Point<2> ((a+b)/2,a),
@@ -2109,6 +2113,26 @@ namespace GridGenerator
       std::vector<Point<2> >(&vertices[0], &vertices[8]),
       cells,
       SubCellData());       // no boundary information
+
+    if (colorize)
+      {
+        auto cell = tria.begin();
+        
+        cell->face(0)->set_boundary_id(0);
+        cell->face(2)->set_boundary_id(1);
+        cell++;
+
+        cell->face(1)->set_boundary_id(2);
+        cell->face(2)->set_boundary_id(1);
+        cell->face(3)->set_boundary_id(3);
+        cell++;
+
+        cell->face(0)->set_boundary_id(0);
+        cell->face(1)->set_boundary_id(4);
+        cell->face(3)->set_boundary_id(5);
+
+      }
+
   }
 
 
@@ -2707,7 +2731,8 @@ namespace GridGenerator
   void
   hyper_L (Triangulation<3> &tria,
            const double      a,
-           const double      b)
+           const double      b,
+           const bool)
   {
     // we slice out the top back right
     // part of the cube

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -350,7 +350,6 @@ namespace GridGenerator
         p1(i) = std::min(p_1(i), p_2(i));
         p2(i) = std::max(p_1(i), p_2(i));
       }
-    //
 
     std::vector<Point<spacedim> > vertices (GeometryInfo<dim>::vertices_per_cell);
     switch (dim)
@@ -2114,7 +2113,7 @@ namespace GridGenerator
 
     if (colorize)
       {
-        auto cell = tria.begin();
+        typename Triangulation<2>::cell_iterator cell = tria.begin();
 
         cell->face(0)->set_boundary_id(0);
         cell->face(2)->set_boundary_id(1);

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2077,7 +2077,6 @@ namespace GridGenerator
 
 
 
-//TODO: Colorize edges as circumference, left and right radius
 // Implementation for 2D only
   template <>
   void
@@ -2112,7 +2111,7 @@ namespace GridGenerator
     tria.create_triangulation (
       std::vector<Point<2> >(&vertices[0], &vertices[8]),
       cells,
-      SubCellData());       // no boundary information
+      SubCellData());
 
     if (colorize)
       {
@@ -2732,7 +2731,7 @@ namespace GridGenerator
   hyper_L (Triangulation<3> &tria,
            const double      a,
            const double      b,
-           const bool)
+           const bool        colorize)
   {
     // we slice out the top back right
     // part of the cube
@@ -2792,6 +2791,11 @@ namespace GridGenerator
       std::vector<Point<3> >(&vertices[0], &vertices[26]),
       cells,
       SubCellData());       // no boundary information
+
+    if (colorize)
+      {
+        Assert (false, ExcNotImplemented());
+      } 
   }
 
 


### PR DESCRIPTION
I implemented "colorize" option also for the hyper_L grid, in according to the others grids implementations. Now boundary tags is set from 0 to 5, starting from the left boundary and with counterclockwise sense. Just implemented for 2dim. Added small description for the colorize option in the header file.