### PR TITLE
Fix a bug when using boost::shared_ptr

### DIFF
--- a/include/deal.II/lac/communication_pattern_base.h
+++ b/include/deal.II/lac/communication_pattern_base.h
@@ -42,6 +42,11 @@ namespace LinearAlgebra
   {
   public:
     /**
+     * Destructor.
+     */
+    virtual ~CommunicationPatternBase() {};
+
+    /**
      * Reinitialize the communication pattern. The first argument @p
      * vector_space_vector_index_set is the index set associated to a
      * VectorSpaceVector object. The second argument @p

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -517,7 +517,6 @@ namespace LinearAlgebra
   inline
   ReadWriteVector<Number>::ReadWriteVector ()
     :
-    comm_pattern(NULL),
     val(NULL)
   {}
 
@@ -528,7 +527,6 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::ReadWriteVector (const ReadWriteVector<Number> &v)
     :
     Subscriptor(),
-    comm_pattern(NULL),
     val(NULL)
   {
     this->operator=(v);
@@ -540,7 +538,6 @@ namespace LinearAlgebra
   inline
   ReadWriteVector<Number>::ReadWriteVector (const size_type size)
     :
-    comm_pattern(NULL),
     val(NULL)
   {
     reinit (size, false);
@@ -552,7 +549,6 @@ namespace LinearAlgebra
   inline
   ReadWriteVector<Number>::ReadWriteVector (const IndexSet &locally_stored_indices)
     :
-    comm_pattern(NULL),
     val(NULL)
   {
     reinit (locally_stored_indices);

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -151,7 +151,7 @@ namespace LinearAlgebra
   void
   ReadWriteVector<Number>::import(const PETScWrappers::MPI::Vector &petsc_vec,
                                   VectorOperation::values operation,
-                                  const CommunicationPatternBase *communication_pattern)
+                                  std_cxx11::shared_ptr<const CommunicationPatternBase> communication_pattern)
   {
     //TODO: this works only if no communication is needed.
     Assert(petsc_vec.locally_owned_elements() == stored_elements,

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -25,6 +25,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 class IndexSet;
+template <typename Number> class ReadWriteVector;
 
 namespace LinearAlgebra
 {

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -66,8 +66,8 @@ namespace LinearAlgebra
       else if (omit_zeroing_entries==false)
         {
           const int ierr = vector->PutScalar(0.);
-          (void) ierr;
           Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
         }
     }
 
@@ -89,6 +89,7 @@ namespace LinearAlgebra
 
               const int ierr = vector->Import(V.trilinos_vector(), data_exchange, Insert);
               Assert(ierr==0, ExcTrilinosError(ierr));
+              (void) ierr;
             }
           else
             vector.reset(new Epetra_FEVector(V.trilinos_vector()));
@@ -181,8 +182,8 @@ namespace LinearAlgebra
 #if DEAL_II_TRILINOS_VERSION_GTE(11,11,0)
           Epetra_Import data_exchange (vector->Map(), down_V.trilinos_vector().Map());
           int ierr = vector->Import(down_V.trilinos_vector(), data_exchange, Epetra_AddLocalAlso);
-          (void) ierr;
           Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
 #else
           // In versions older than 11.11 the Import function is broken for adding
           // Hence, we provide a workaround in this case
@@ -191,12 +192,12 @@ namespace LinearAlgebra
           Epetra_Import data_exchange(dummy.Map(), down_V.trilinos_vector().Map());
 
           int ierr = dummy.Import(down_V.trilinos_vector(), data_exchange, Insert);
-          (void) ierr;
           Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
 
           ierr = vector->Update(1.0, dummy, 1.0);
-          (void) ierr;
           Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
 #endif
         }
 
@@ -229,8 +230,8 @@ namespace LinearAlgebra
 
       double result(0.);
       const int ierr = vector->Dot(down_V.trilinos_vector(), &result);
-      (void) ierr;
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
 
       return result;
     }
@@ -261,6 +262,7 @@ namespace LinearAlgebra
 
       const int ierr = vector->Update(a, down_V.trilinos_vector(), 1.);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
     }
 
 
@@ -289,6 +291,7 @@ namespace LinearAlgebra
       const int ierr = vector->Update(a, down_V.trilinos_vector(), b,
                                       down_W.trilinos_vector(), 1.);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
     }
 
 
@@ -325,6 +328,7 @@ namespace LinearAlgebra
       const int ierr = vector->Multiply(1.0, down_scaling_factors.trilinos_vector(),
                                         *vector, 0.0);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
     }
 
 
@@ -345,6 +349,7 @@ namespace LinearAlgebra
           // Otherwise, just update
           int ierr = vector->Update(a, down_V.trilinos_vector(), 0.);
           Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
         }
     }
 
@@ -355,6 +360,7 @@ namespace LinearAlgebra
       double norm(0.);
       int ierr = vector->Norm1(&norm);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
 
       return norm;
     }
@@ -366,6 +372,7 @@ namespace LinearAlgebra
       double norm(0.);
       int ierr = vector->Norm2(&norm);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
 
       return norm;
     }
@@ -377,6 +384,7 @@ namespace LinearAlgebra
       double norm(0.);
       int ierr = vector->NormInf(&norm);
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
 
       return norm;
     }
@@ -472,6 +480,7 @@ namespace LinearAlgebra
       int ierr = vector->ExtractView(&val, &leading_dimension);
 
       Assert(ierr==0, ExcTrilinosError(ierr));
+      (void) ierr;
       out.precision (precision);
       if (scientific)
         out.setf(std::ios::scientific, std::ios::floatfield);

--- a/tests/lac/la_vector_norms.cc
+++ b/tests/lac/la_vector_norms.cc
@@ -51,7 +51,6 @@ void check_norms ()
       for (unsigned int i=0; i<size; ++i)
         vec[i] = (number)value;
       const number l1_norma = vec.l1_norm();
-      std::cout<<l1_norma<<std::endl;
       AssertThrow (std::abs(l1_norma-value*size) < acc*size*value,
                    ExcInternalError());
       const number l2_norma = vec.l2_norm();


### PR DESCRIPTION
boost::shared_ptr and std::shared_ptr behaves slightly different :-( 
fix #2401 