### PR TITLE
make expand_instantiations more robust

### DIFF
--- a/cmake/macros/macro_expand_instantiations.cmake
+++ b/cmake/macros/macro_expand_instantiations.cmake
@@ -45,6 +45,9 @@ MACRO(EXPAND_INSTANTIATIONS _target _inst_in_files)
       SET(_dependency)
     ENDIF()
 
+    # create a .inst.tmp file first and only move to the correct name if the
+    # first call succeeds. Otherwise we might be generating an incomplete
+    # .inst file
     ADD_CUSTOM_COMMAND(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
       DEPENDS ${_dependency}
@@ -53,7 +56,11 @@ MACRO(EXPAND_INSTANTIATIONS _target _inst_in_files)
       COMMAND ${_command}
       ARGS ${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/template-arguments
            < ${CMAKE_CURRENT_SOURCE_DIR}/${_inst_in_file}
-           > ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
+           > ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}.tmp
+      COMMAND ${CMAKE_COMMAND}
+      ARGS -E rename 
+           ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}.tmp
+           ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
       )
 
     LIST(APPEND _inst_targets ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file})

--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -456,7 +456,7 @@ void process_instantiations ()
           names_and_type = split_string_list (*s, ':');
           if (names_and_type.size() != 2)
             {
-              std::cerr << "Invalid instantiation header" << std::endl;
+              std::cerr << "Invalid instantiation header: '"<< *s << "'" << std::endl;
               std::exit (1);
             }
 


### PR DESCRIPTION
If the .inst.in files contains a mistake so that expand_instantiations
fails, the output will still be created and is then considered updated.
As a result, a second run of "make" happily continues without failing.
Fix this by creating a temporary file and only moving if the first call
succeededs.
Also make one error message more verbose.