### PR TITLE
Add forward declaration in VectorSpaceVector.

### DIFF
--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -25,6 +25,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+class CommunicationPatternBase;
 class IndexSet;
 template <typename Number> class ReadWriteVector;
 


### PR DESCRIPTION
Two tests in all-headers fail because a forward declaration is missing.