### PR TITLE
added move constructor to Subscriptor

### DIFF
--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -206,6 +206,13 @@ private:
    * in between and store it here.
    */
   mutable const std::type_info *object_info;
+
+  /**
+   * Check that there are no objects subscribing to this object and throw an
+   * error if there are, in order to guarantee that it is safe to either move
+   * or destroy this object.
+   */
+  void check_no_subscribers () const;
 };
 
 //---------------------------------------------------------------------------

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -69,6 +69,16 @@ public:
    */
   Subscriptor(const Subscriptor &);
 
+#ifdef DEAL_II_WITH_CXX11
+  /**
+   * Move constructor.
+   *
+   * An object inheriting from Subscriptor can only be moved if no other
+   * objects are subscribing to it.
+   */
+  Subscriptor(Subscriptor&&);
+#endif
+
   /**
    * Destructor, asserting that the counter is zero.
    */

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -76,7 +76,7 @@ public:
    * An object inheriting from Subscriptor can only be moved if no other
    * objects are subscribing to it.
    */
-  Subscriptor(Subscriptor&&);
+  Subscriptor(Subscriptor &&);
 #endif
 
   /**

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -73,7 +73,7 @@ SparseMatrix<number>::SparseMatrix (const SparseMatrix &m)
 template <typename number>
 SparseMatrix<number>::SparseMatrix (SparseMatrix<number> &&m)
   :
-  Subscriptor(),
+  Subscriptor(std::move(m)),
   cols(m.cols),
   val(m.val),
   max_len(m.max_len)

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -62,6 +62,22 @@ Subscriptor::Subscriptor (const Subscriptor &)
 {}
 
 
+
+#ifdef DEAL_II_WITH_CXX11
+Subscriptor::Subscriptor (Subscriptor &&subscriptor)
+  :
+  counter(0),
+  object_info (subscriptor.object_info)
+{
+  // Explicitly invoke the destructor of `Subscriptor` for the object
+  // to be moved from in order to guarantee that we're not moving an
+  // object that has subscriptions.
+  subscriptor.~Subscriptor();
+}
+#endif
+
+
+
 Subscriptor::~Subscriptor ()
 {
   // check whether there are still
@@ -136,6 +152,13 @@ Subscriptor::~Subscriptor ()
   // do_unsubscribe below that the
   // object is unused now.
   counter = 0;
+
+#ifdef DEAL_II_WITH_CXX11
+  object_info = nullptr;
+#else
+  object_info = 0;
+#endif
+
 #endif
 }
 

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -70,8 +70,6 @@ Subscriptor::Subscriptor (Subscriptor &&subscriptor)
   object_info (subscriptor.object_info)
 {
   subscriptor.check_no_subscribers();
-  subscriptor.counter = 0;
-  subscriptor.counter_map.clear();
 }
 #endif
 
@@ -80,8 +78,6 @@ Subscriptor::Subscriptor (Subscriptor &&subscriptor)
 Subscriptor::~Subscriptor ()
 {
   check_no_subscribers();
-  counter = 0;
-  counter_map.clear();
 
 #ifdef DEAL_II_WITH_CXX11
   object_info = nullptr;

--- a/tests/lac/sparse_matrix_move.cc
+++ b/tests/lac/sparse_matrix_move.cc
@@ -101,31 +101,5 @@ int main()
     deallog << A.empty() << std::endl;
   }
 
-  {
-    // Try to move a sparse matrix that has a subscription
-    SparseMatrix<double> A = graph_laplacian(sparsity);
-    SmartPointer<SparseMatrix<double> > smart_pointer_to_A(&A);
-
-    bool need_to_catch_exc_in_use = false;
-#ifdef DEBUG
-    need_to_catch_exc_in_use = true;
-#endif
-
-    try
-      {
-        SparseMatrix<double> B = std::move(A);
-      }
-    catch (const Subscriptor::ExcInUse &)
-      {
-        need_to_catch_exc_in_use = false;
-      }
-    catch (...)
-      {
-        return 1;
-      }
-
-    deallog << "Exception caught if in debug mode." << std::endl;
-  }
-
   return 0;
 }

--- a/tests/lac/sparse_matrix_move.cc
+++ b/tests/lac/sparse_matrix_move.cc
@@ -115,11 +115,11 @@ int main()
       {
         SparseMatrix<double> B = std::move(A);
       }
-    catch (const Subscriptor::ExcInUse&)
+    catch (const Subscriptor::ExcInUse &)
       {
         need_to_catch_exc_in_use = false;
       }
-    catch(...)
+    catch (...)
       {
         return 1;
       }

--- a/tests/lac/sparse_matrix_move.cc
+++ b/tests/lac/sparse_matrix_move.cc
@@ -71,30 +71,61 @@ int main()
   testproblem.five_point_structure(sparsity);
   sparsity.compress();
 
-  // Return a sparse matrix, possibly using RVO or move constructor
-  SparseMatrix<double> A = graph_laplacian(sparsity);
-  deallog << A.n_nonzero_elements() << std::endl;
-
   Vector<double> x(dim), y(dim);
-  x = 1.0;
-  y = 1.0;
-  A.vmult(y, x);
 
-  deallog << y.l2_norm() << std::endl;
+  {
+    // Return a sparse matrix, possibly using RVO or move constructor
+    SparseMatrix<double> A = graph_laplacian(sparsity);
+    deallog << A.n_nonzero_elements() << std::endl;
 
-  // Return a sparse matrix using the move constructor
-  SparseMatrix<double> B = graph_laplacian_move_return(sparsity);
-  deallog << B.n_nonzero_elements() << std::endl;
-  y = 1.0;
-  B.vmult(y, x);
+    x = 1.0;
+    y = 1.0;
+    A.vmult(y, x);
 
-  deallog << y.l2_norm() << std::endl;
+    deallog << y.l2_norm() << std::endl;
+  }
 
-  // Explicitly move a sparse matrix
-  SparseMatrix<double> C;
-  C = std::move(B);
-  deallog << C.m() << std::endl;
-  deallog << B.empty() << std::endl;
+  {
+    // Return a sparse matrix using the move constructor
+    SparseMatrix<double> A = graph_laplacian_move_return(sparsity);
+    deallog << A.n_nonzero_elements() << std::endl;
+    y = 1.0;
+    A.vmult(y, x);
+
+    deallog << y.l2_norm() << std::endl;
+
+    // Explicitly move a sparse matrix
+    SparseMatrix<double> B;
+    B = std::move(A);
+    deallog << B.m() << std::endl;
+    deallog << A.empty() << std::endl;
+  }
+
+  {
+    // Try to move a sparse matrix that has a subscription
+    SparseMatrix<double> A = graph_laplacian(sparsity);
+    SmartPointer<SparseMatrix<double> > smart_pointer_to_A(&A);
+
+    bool need_to_catch_exc_in_use = false;
+#ifdef DEBUG
+    need_to_catch_exc_in_use = true;
+#endif
+
+    try
+      {
+        SparseMatrix<double> B = std::move(A);
+      }
+    catch (const Subscriptor::ExcInUse&)
+      {
+        need_to_catch_exc_in_use = false;
+      }
+    catch(...)
+      {
+        return 1;
+      }
+
+    deallog << "Exception caught if in debug mode." << std::endl;
+  }
 
   return 0;
 }

--- a/tests/lac/sparse_matrix_move.with_cxx11=on.output
+++ b/tests/lac/sparse_matrix_move.with_cxx11=on.output
@@ -5,3 +5,4 @@ DEAL::64
 DEAL::0.00
 DEAL::16
 DEAL::1
+DEAL::Exception caught if in debug mode.

--- a/tests/lac/sparse_matrix_move.with_cxx11=on.output
+++ b/tests/lac/sparse_matrix_move.with_cxx11=on.output
@@ -5,4 +5,3 @@ DEAL::64
 DEAL::0.00
 DEAL::16
 DEAL::1
-DEAL::Exception caught if in debug mode.


### PR DESCRIPTION
As per #2425 I've added move semantics to subscriptor. The error checking that one has to do when moving a subscriptor is practically identical to the existing code in the destructor, so I've implemented this by just calling the destructor on the moved object.

I've also changed the test I wrote for sparse matrix move to check that `Subscriptor::ExcInUse` is thrown if you do something bad. Since the error checking in subscriptor only occurs in debug mode, I had to add preprocessor defines in order to make the test give the same output in both debug and release mode. I couldn't figure out a better way to accomplish the same thing but I'm happy to change it if someone has a suggestion.

If this all looks good I'll go ahead and change the move constructors for `Vector` and `BlockVector`, and start adding move constructors to other classes.