### PR TITLE
Fix doxygen markup.

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1164,8 +1164,7 @@ namespace DoFTools
    */
 
   /**
-   * @name Identifying subsets of degrees of freedom with particular
-   * properties
+   * @name Identifying subsets of degrees of freedom with particular properties
    * @{
    */
 


### PR DESCRIPTION
doxygen only wants to use what's on the same line as the `@name` tag.

@tjhei -- does this need to be fixed in the comment wrapping script?