### PR TITLE
confusing set_all_manifold* errors if empty

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9023,6 +9023,9 @@ template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::set_all_manifold_ids (const types::manifold_id m_number)
 {
+  Assert(n_cells()>0,
+         ExcMessage("Error: set_all_manifold_ids() can not be called on an empty Triangulation."));
+
   typename Triangulation<dim,spacedim>::active_cell_iterator
   cell=this->begin_active(), endc=this->end();
 
@@ -9035,6 +9038,9 @@ template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary (const types::manifold_id m_number)
 {
+  Assert(n_cells()>0,
+         ExcMessage("Error: set_all_manifold_ids_on_boundary() can not be called on an empty Triangulation."));
+
   typename Triangulation<dim,spacedim>::active_cell_iterator
   cell=this->begin_active(), endc=this->end();
 
@@ -9050,6 +9056,9 @@ void
 Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary (const types::boundary_id b_id,
     const types::manifold_id m_number)
 {
+  Assert(n_cells()>0,
+         ExcMessage("Error: set_all_manifold_ids_on_boundary() can not be called on an empty Triangulation."));
+
   bool boundary_found = false;
   typename Triangulation<dim,spacedim>::active_cell_iterator
   cell=this->begin_active(), endc=this->end();


### PR DESCRIPTION
The error messages for set_all_manifold_ids* are confusing if the mesh
is empty:

```
An error occurred in line <10760> of file </ssd/deal-
git/source/grid/tria.cc> in function
    dealii::Triangulation<dim, spacedim>::raw_quad_iterator
dealii::Triangulation<dim, spacedim>::begin_raw_quad(unsigned int) const
[with int dim = 2, int spacedim = 2, dealii::Triangulation<dim,
spacedim>::raw_quad_iterator =
dealii::TriaRawIterator<dealii::CellAccessor<2, 2> >]
The violated condition was:
    level<n_global_levels() || level<levels.size()
The name and call sequence of the exception was:
    ExcInvalidLevel(level)
Additional Information:
The given level 0 is not in the valid range!
```

Fix that.