### PR TITLE
added new option to read boundary indicators in a ucd file as manifold ids

### DIFF
--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -366,8 +366,14 @@ public:
 
   /**
    * Read grid data from an ucd file. Numerical data is ignored.
+   * It is not possible to use a ucd file to set both boundary_id and
+   * manifold_id for the same cell. Yet it is possible to use
+   * the flag apply_all_indicators_to_manifolds to decide if
+   * the indicators in the file refer to manifolds (flag set to true)
+   * or boundaries (flag set to false).
    */
-  void read_ucd (std::istream &in);
+  void read_ucd (std::istream                                  &in,
+                 const bool apply_all_indicators_to_manifolds=false);
 
   /**
    * Read grid data from an Abaqus file. Numerical and constitutive data is

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -377,7 +377,10 @@ public:
 
   /**
    * Read grid data from an Abaqus file. Numerical and constitutive data is
-   * ignored.
+   * ignored. As in the case of the ucd file format, it is possible to use
+   * the flag apply_all_indicators_to_manifolds to decide if
+   * the indicators in the file refer to manifolds (flag set to true)
+   * or boundaries (flag set to false).
    *
    * @note The current implementation of this mesh reader is suboptimal, and
    * may therefore be slow for large meshes.
@@ -411,7 +414,8 @@ public:
    * ID's". An invalid file will encounter errors if this box is left checked.
    *     - Click apply.
    */
-  void read_abaqus (std::istream &in);
+  void read_abaqus (std::istream                                  &in,
+                    const bool apply_all_indicators_to_manifolds=false);
 
   /**
    * Read grid data from a file containing data in the DB mesh format.

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -610,7 +610,8 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
 
 
 template <int dim, int spacedim>
-void GridIn<dim, spacedim>::read_ucd (std::istream &in)
+void GridIn<dim, spacedim>::read_ucd (std::istream                            &in,
+                                      const bool apply_all_indicators_to_manifolds)
 {
   Assert (tria != 0, ExcNoTriangulationSelected());
   AssertThrow (in, ExcIO());
@@ -727,8 +728,12 @@ void GridIn<dim, spacedim>::read_ucd (std::istream &in)
           Assert(material_id < numbers::internal_face_boundary_id,
                  ExcIndexRange(material_id,0,numbers::internal_face_boundary_id));
 
-          subcelldata.boundary_lines.back().boundary_id
-            = static_cast<types::boundary_id>(material_id);
+          if (apply_all_indicators_to_manifolds)
+            subcelldata.boundary_lines.back().manifold_id
+              = static_cast<types::manifold_id>(material_id);
+          else
+            subcelldata.boundary_lines.back().boundary_id
+              = static_cast<types::boundary_id>(material_id);
 
           // transform from ucd to
           // consecutive numbering
@@ -764,8 +769,12 @@ void GridIn<dim, spacedim>::read_ucd (std::istream &in)
           Assert(material_id < numbers::internal_face_boundary_id,
                  ExcIndexRange(material_id,0,numbers::internal_face_boundary_id));
 
-          subcelldata.boundary_quads.back().boundary_id
-            = static_cast<types::boundary_id>(material_id);
+          if (apply_all_indicators_to_manifolds)
+            subcelldata.boundary_quads.back().manifold_id
+              = static_cast<types::manifold_id>(material_id);
+          else
+            subcelldata.boundary_quads.back().boundary_id
+              = static_cast<types::boundary_id>(material_id);
 
           // transform from ucd to
           // consecutive numbering

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -844,7 +844,8 @@ namespace
 }
 
 template <int dim, int spacedim>
-void GridIn<dim, spacedim>::read_abaqus (std::istream &in)
+void GridIn<dim, spacedim>::read_abaqus (std::istream                            &in,
+                                         const bool apply_all_indicators_to_manifolds)
 {
   Assert (tria != 0, ExcNoTriangulationSelected());
   Assert (dim==2 || dim==3, ExcNotImplemented());
@@ -864,7 +865,7 @@ void GridIn<dim, spacedim>::read_abaqus (std::istream &in)
   // and doesn't think that they've somehow called the wrong function.
   try
     {
-      read_ucd(in_ucd);
+      read_ucd(in_ucd, apply_all_indicators_to_manifolds);
     }
   catch (...)
     {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2068,13 +2068,32 @@ namespace internal
             // need to allow that
             if (boundary_line->boundary_id != numbers::internal_face_boundary_id)
               {
-                AssertThrow (! (line->boundary_id() == numbers::internal_face_boundary_id),
-                             ExcInteriorLineCantBeBoundary(line->vertex_index(0),
-                                                           line->vertex_index(1),
-                                                           boundary_line->boundary_id));
-                line->set_boundary_id (boundary_line->boundary_id);
+                if (line->boundary_id() == numbers::internal_face_boundary_id)
+                  {
+                    // if we are here, it means that we want to assign a boundary indicator
+                    // different from numbers::internal_face_boundary_id to an internal line.
+                    // As said, this would be not allowed, and an exception should be immediately
+                    // thrown. Still, there is the possibility that one only wants to specifiy a
+                    // manifold_id here. If that is the case (manifold_id !=  numbers::flat_manifold_id)
+                    // the operation is allowed. Otherwise, we really tried to specify a boundary_id
+                    // (and not a manifold_id) to an internal face. The exception must be thrown.
+                    if (boundary_line->manifold_id == numbers::flat_manifold_id)
+                      {
+                        // If we are here, this assertion will surely fail, for the aforementioned
+                        // reasons
+                        AssertThrow (! (line->boundary_id() == numbers::internal_face_boundary_id),
+                                     ExcInteriorLineCantBeBoundary(line->vertex_index(0),
+                                                                   line->vertex_index(1),
+                                                                   boundary_line->boundary_id));
+                      }
+                    else
+                      {
+                        line->set_manifold_id (boundary_line->manifold_id);
+                      }
+                  }
+                else
+                  line->set_boundary_id (boundary_line->boundary_id);
               }
-
             line->set_manifold_id (boundary_line->manifold_id);
           }
 


### PR DESCRIPTION
In a ucd file one can specify only one indicator per cell. In a grid of dimension dim, all the dim-1 entities are normally interpreted as boundary ids. This gives problems whenever one wants to specify a flag to internal faces in the grid. With this option one can tell to the read_ucd function to read all the flags for the dim-1 cells as manifold indicators. Flags on internal faces can now be specified.  