### PR TITLE
Better unit tangentials data structure

### DIFF
--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -25,6 +25,8 @@
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe.h>
 
+#include <deal.II/base/std_cxx11/array.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -361,7 +363,7 @@ public:
      * Unit tangential vectors. Used for the computation of boundary forms and
      * normal vectors.
      *
-     * This vector has (dim-1)GeometryInfo::faces_per_cell entries. The first
+     * This array has (dim-1)*GeometryInfo::faces_per_cell entries. The first
      * GeometryInfo::faces_per_cell contain the vectors in the first
      * tangential direction for each face; the second set of
      * GeometryInfo::faces_per_cell entries contain the vectors in the second
@@ -370,7 +372,7 @@ public:
      *
      * Filled once.
      */
-    std::vector<std::vector<Tensor<1,dim> > > unit_tangentials;
+    std_cxx11::array<std::vector<Tensor<1,dim> >, GeometryInfo<dim>::faces_per_cell *(dim-1)> unit_tangentials;
 
     /**
      * Number of shape functions. If this is a Q1 mapping, then it is simply

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -25,6 +25,8 @@
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe_q.h>
 
+#include <deal.II/base/std_cxx11/array.h>
+
 #include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
@@ -360,7 +362,7 @@ public:
      * Unit tangential vectors. Used for the computation of boundary forms and
      * normal vectors.
      *
-     * This vector has (dim-1)GeometryInfo::faces_per_cell entries. The first
+     * This array has (dim-1)*GeometryInfo::faces_per_cell entries. The first
      * GeometryInfo::faces_per_cell contain the vectors in the first
      * tangential direction for each face; the second set of
      * GeometryInfo::faces_per_cell entries contain the vectors in the second
@@ -369,7 +371,7 @@ public:
      *
      * Filled once.
      */
-    std::vector<std::vector<Tensor<1,dim> > > unit_tangentials;
+    std_cxx11::array<std::vector<Tensor<1,dim> >, GeometryInfo<dim>::faces_per_cell *(dim-1)> unit_tangentials;
 
     /**
      * The polynomial degree of the mapping. Since the objects here are also

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -409,27 +409,27 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::compute_face_data
         {
           data.aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 
-          // Compute tangentials to the
-          // unit cell.
-          const unsigned int nfaces = GeometryInfo<dim>::faces_per_cell;
-          data.unit_tangentials.resize (nfaces*(dim-1),
-                                        std::vector<Tensor<1,dim> > (n_original_q_points));
+          // Compute tangentials to the unit cell.
+          for (unsigned int i=0; i<data.unit_tangentials.size(); ++i)
+            data.unit_tangentials[i].resize (n_original_q_points);
+
           if (dim==2)
             {
               // ensure a counterclockwise
               // orientation of tangentials
               static const int tangential_orientation[4]= {-1,1,1,-1};
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang;
                   tang[1-i/2]=tangential_orientation[i];
                   std::fill (data.unit_tangentials[i].begin(),
-                             data.unit_tangentials[i].end(), tang);
+                             data.unit_tangentials[i].end(),
+                             tang);
                 }
             }
           else if (dim==3)
             {
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang1, tang2;
 
@@ -451,9 +451,11 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::compute_face_data
                   // for all quadrature
                   // points on this face
                   std::fill (data.unit_tangentials[i].begin(),
-                             data.unit_tangentials[i].end(), tang1);
-                  std::fill (data.unit_tangentials[nfaces+i].begin(),
-                             data.unit_tangentials[nfaces+i].end(), tang2);
+                             data.unit_tangentials[i].end(),
+                             tang1);
+                  std::fill (data.unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].begin(),
+                             data.unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].end(),
+                             tang2);
                 }
             }
         }

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -764,24 +764,22 @@ initialize_face (const UpdateFlags      update_flags,
         {
           aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 
-          // Compute tangentials to the
-          // unit cell.
-          const unsigned int nfaces = GeometryInfo<dim>::faces_per_cell;
-          unit_tangentials.resize (nfaces*(dim-1),
-                                   std::vector<Tensor<1,dim> > (n_original_q_points));
+          // Compute tangentials to the unit cell.
+          for (unsigned int i=0; i<unit_tangentials.size(); ++i)
+            unit_tangentials[i].resize (n_original_q_points);
           switch (dim)
             {
             case 2:
             {
-              // ensure a counterclockwise
-              // orientation of tangentials
+              // ensure a counterclockwise orientation of tangentials
               static const int tangential_orientation[4]= {-1,1,1,-1};
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang;
-                  tang[1-i/2]=tangential_orientation[i];
+                  tang[1-i/2] = tangential_orientation[i];
                   std::fill (unit_tangentials[i].begin(),
-                             unit_tangentials[i].end(), tang);
+                             unit_tangentials[i].end(),
+                             tang);
                 }
 
               break;
@@ -789,7 +787,7 @@ initialize_face (const UpdateFlags      update_flags,
 
             case 3:
             {
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang1, tang2;
 
@@ -811,9 +809,11 @@ initialize_face (const UpdateFlags      update_flags,
                   // for all quadrature
                   // points on this face
                   std::fill (unit_tangentials[i].begin(),
-                             unit_tangentials[i].end(), tang1);
-                  std::fill (unit_tangentials[nfaces+i].begin(),
-                             unit_tangentials[nfaces+i].end(), tang2);
+                             unit_tangentials[i].end(),
+                             tang1);
+                  std::fill (unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].begin(),
+                             unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].end(),
+                             tang2);
                 }
 
               break;


### PR DESCRIPTION
#2424 points out that we could use better data structures for the `Mapping*::InternalData::unit_tangentials` fields. This patch implements this for `MappingQGeneric` and `MappingFEField`. The current patch for `MappingManifold` in #2272 still uses the old scheme and would need to eventually be converted.

In reference to #1198.