### PR TITLE
Avoid a warning.

### DIFF
--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -352,7 +352,7 @@ namespace MemoryConsumption
     else
       {
         std::size_t mem = 0;
-        for (std::size_t i=0; i<N; ++i)
+        for (std::size_t i=0; i!=N; ++i)
           mem += memory_consumption(v[i]);
         return mem;
       }


### PR DESCRIPTION
This fixes a warning introduced in #2449. There, @drwells had asked me why I wrote
```
          for (std::size_t i=0; i!=N; ++i)
```
when I could have written
```
        for (std::size_t i=0; i<N; ++i)
```
I didn't remember and changed it to the latter, which did not warn on my laptop but does now on the compute server. The reason is that `N` is of type `std::size_t`, which turns out to be unsigned, and so warns if we happen to have `N==0`. This patch fixes the issue.