### PR TITLE
Use a fixed size data structure for MappingManifold::InternalData::unit_tangentials.

### DIFF
--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -269,7 +269,7 @@ public:
      * Unit tangential vectors. Used for the computation of boundary forms and
      * normal vectors.
      *
-     * This vector has (dim-1)GeometryInfo::faces_per_cell entries. The first
+     * This array has (dim-1)*GeometryInfo::faces_per_cell entries. The first
      * GeometryInfo::faces_per_cell contain the vectors in the first
      * tangential direction for each face; the second set of
      * GeometryInfo::faces_per_cell entries contain the vectors in the second
@@ -278,7 +278,7 @@ public:
      *
      * Filled once.
      */
-    std::vector<std::vector<Tensor<1,dim> > > unit_tangentials;
+    std_cxx11::array<std::vector<Tensor<1,dim> >, GeometryInfo<dim>::faces_per_cell *(dim-1)> unit_tangentials;
 
     /**
      * Tensors of covariant transformation at each of the quadrature points.

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -114,11 +114,9 @@ initialize_face (const UpdateFlags      update_flags,
         {
           aux.resize (dim-1, std::vector<Tensor<1,spacedim> > (n_original_q_points));
 
-          // Compute tangentials to the
-          // unit cell.
-          const unsigned int nfaces = GeometryInfo<dim>::faces_per_cell;
-          unit_tangentials.resize (nfaces*(dim-1),
-                                   std::vector<Tensor<1,dim> > (n_original_q_points));
+          // Compute tangentials to the unit cell.
+          for (unsigned int i=0; i<unit_tangentials.size(); ++i)
+            unit_tangentials[i].resize (n_original_q_points);
           switch (dim)
             {
             case 2:
@@ -126,18 +124,19 @@ initialize_face (const UpdateFlags      update_flags,
               // ensure a counterclockwise
               // orientation of tangentials
               static const int tangential_orientation[4]= {-1,1,1,-1};
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang;
                   tang[1-i/2]=tangential_orientation[i];
                   std::fill (unit_tangentials[i].begin(),
-                             unit_tangentials[i].end(), tang);
+                             unit_tangentials[i].end(),
+                             tang);
                 }
               break;
             }
             case 3:
             {
-              for (unsigned int i=0; i<nfaces; ++i)
+              for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
                 {
                   Tensor<1,dim> tang1, tang2;
 
@@ -160,8 +159,9 @@ initialize_face (const UpdateFlags      update_flags,
                   // points on this face
                   std::fill (unit_tangentials[i].begin(),
                              unit_tangentials[i].end(), tang1);
-                  std::fill (unit_tangentials[nfaces+i].begin(),
-                             unit_tangentials[nfaces+i].end(), tang2);
+                  std::fill (unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].begin(),
+                             unit_tangentials[GeometryInfo<dim>::faces_per_cell+i].end(),
+                             tang2);
                 }
               break;
             }


### PR DESCRIPTION
This fixes #2424 in the same way as was previously already done in #2471, but for the `MappingManifold` class introduced in #2272.

In reference to #1198.