### PR TITLE
Improve grainsize of vectors, unify vector loops

### DIFF
--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -23,33 +23,28 @@ namespace internal
 {
   namespace Vector
   {
-    // set minimum grain size. this value is
-    // roughly in accordance with the curve
-    // in the TBB book (fig 3.2) that shows
-    // run time as a function of grain size
-    // -- there, values from 200 upward are
-    // so that the scheduling overhead
-    // amortizes well (for very large values
-    // in that example, the grain size is too
-    // large to split the work load into
-    // enough chunks and the problem becomes
-    // badly balanced)
-    unsigned int minimum_parallel_grain_size = 1024;
+    // set minimum grain size. this value has been determined by experiments
+    // with the actual dealii::Vector implementation and takes vectorization
+    // that is done inside most functions of dealii::Vector into account
+    // (without vectorization, we would land at around 1000). for smaller
+    // values than this, the scheduling overhead will be significant. if the
+    // value becomes too large, on the other hand, the work load cannot be
+    // split into enough chunks and the problem becomes badly balanced. the
+    // tests are documented at https://github.com/dealii/dealii/issues/2496
+    unsigned int minimum_parallel_grain_size = 4096;
   }
 
 
   namespace SparseMatrix
   {
-    // set this value to 1/4 of the value of
-    // the minimum grain size of
-    // vectors. this rests on the fact that
-    // we have to do a lot more work per row
-    // of a matrix than per element of a
-    // vector. it could possibly be reduced
-    // even further but that doesn't appear
-    // worth it any more for anything but
-    // very small matrices that we don't care
-    // that much about anyway.
+    // set this value to 1/16 of the value of the minimum grain size of
+    // vectors (a factor of 4 because we assume that sparse matrix-vector
+    // products do not vectorize and the other factor of 4 because we expect
+    // at least four entries per row). this rests on the fact that we have to
+    // do a lot more work per row of a matrix than per element of a vector. it
+    // could possibly be reduced even further but that doesn't appear worth it
+    // any more for anything but very small matrices that we don't care that
+    // much about anyway.
     unsigned int minimum_parallel_grain_size = 256;
   }
 }


### PR DESCRIPTION
This is the uncontroversial part 1 of the discussion in #2496:
- set grainsize to the value that was determined the best compromise between scheduling overhead and work balancing in my tests for modern systems (selected as power of 2 to get the range; the exact value is problem-dependent and architecture-dependent and nothing we should try to optimize for)
- route all vector loops except the reductions through the same loop (`vectorized_transform`)
- only go through TBB in case we have more than 1 thread

The affinity partitioner will be fixed in a follow-up PR to keep things separated in case there is more discussion needed for the shared ptr and locks.