### PR TITLE
Introduce affinity partitioner to Vector

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -120,7 +120,7 @@ inconvenience this causes.
       indicators specified in a UCD file should be interpreted as
       boundary_ids or as manifold_ids. This is particularly useful
       when the indicators refer to internal faces, for which
-      boundary_ids cannot be used. 
+      boundary_ids cannot be used.
  <br>
  (Andrea Mola, 2016/04/11)
  </li>
@@ -196,6 +196,15 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+
+ <li> Improved: The parallel loops in the deal.II Vector class for
+ vector-vector operations have been revised for performance. This includes
+ adjusting the minimum parallel grain size to 4096 vector entries and using an
+ affinity partitioner provided by Threading Building Blocks for better data
+ locality, especially on multi-socket systems.
+ <br>
+ (Martin Kronbichler, 2016/04/14)
+ </li>
 
  <li> New: added ReinitHelper for PETSc. This is required by LinearOperator
  class to reinit vectors.

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1040,7 +1040,9 @@ Vector<Number>::Vector ()
   vec_size(0),
   max_vec_size(0),
   val(0)
-{}
+{
+  reinit(0);
+}
 
 
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -129,8 +129,9 @@ namespace internal
     if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size &&
         MultithreadInfo::n_threads() > 1)
       {
-        if (partitioner.get() == NULL)
-          partitioner.reset(new parallel::internal::TBBPartitioner());
+        Assert(partitioner.get() != NULL,
+               ExcInternalError("Unexpected initialization of Vector that does "
+                                "not set the TBB partitioner to a usable state."));
         std_cxx11::shared_ptr<tbb::affinity_partitioner> tbb_partitioner =
           partitioner->acquire_one_partitioner();
 
@@ -878,7 +879,7 @@ void Vector<Number>::reinit (const size_type n,
 
       // only reset the partitioner if we actually expect a significant vector
       // size
-      if (vec_size > 4*internal::Vector::minimum_parallel_grain_size)
+      if (vec_size >= 4*internal::Vector::minimum_parallel_grain_size)
         thread_loop_partitioner.reset(new parallel::internal::TBBPartitioner());
     }
 

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -21,17 +21,7 @@ DEAL_II_NAMESPACE_OPEN
 
 // instantiate for integers:
 template class Vector<int>;
-namespace internal
-{
-  namespace Vector
-  {
-    template void copy_vector<int,double> (const dealii::Vector<int> &,
-                                           dealii::Vector<double> &);
-
-    template void copy_vector<int,int> (const dealii::Vector<int> &,
-                                        dealii::Vector<int> &);
-  }
-}
+template Vector<double> &Vector<double>::operator=<int> (const dealii::Vector<int> &);
 
 template
 void Vector<int>::reinit<double>(const Vector<double> &, const bool);
@@ -42,8 +32,9 @@ void Vector<int>::reinit<double>(const Vector<double> &, const bool);
 // arguments is covered by the default copy constructor and copy operator that
 // is declared separately)
 
-#define TEMPL_COPY_CONSTRUCTOR(S1,S2)                   \
-  template Vector<S1>::Vector (const Vector<S2> &)
+#define TEMPL_COPY_CONSTRUCTOR(S1,S2)                           \
+  template Vector<S1>::Vector (const Vector<S2> &);             \
+  template Vector<S1>& Vector<S1>::operator=<S2> (const Vector<S2> &)
 
 #ifndef DEAL_II_EXPLICIT_CONSTRUCTOR_BUG
 TEMPL_COPY_CONSTRUCTOR(double,float);

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -22,14 +22,6 @@ for (SCALAR : REAL_SCALARS)
 
 for (S1, S2 : REAL_SCALARS)
   {
-    namespace internal
-    \{
-      namespace Vector
-      \{
-      template void copy_vector<S1,S2> (const dealii::Vector<S1>&,
-                                        dealii::Vector<S2>&);
-      \}
-    \}
     template
       bool
       Vector<S1>::operator==<S2>(const Vector<S2>&) const;
@@ -49,14 +41,6 @@ for (SCALAR : COMPLEX_SCALARS)
 
 for (S1, S2 : COMPLEX_SCALARS)
   {
-    namespace internal
-    \{
-      namespace Vector
-      \{
-      template void copy_vector<S1,S2> (const dealii::Vector<S1>&,
-                                        dealii::Vector<S2>&);
-      \}
-    \}
     template
       bool
       Vector<S1>::operator==<S2>(const Vector<S2>&) const;
@@ -69,11 +53,6 @@ for (S1, S2 : COMPLEX_SCALARS)
 
 for (S1: REAL_SCALARS; S2: COMPLEX_SCALARS)
   {
-    namespace internal
-    \{
-      namespace Vector
-      \{
-      template void copy_vector<S1,S2> (const dealii::Vector<S1>&,
-                                        dealii::Vector<S2>&);
-      \}
-    \}
+    template
+      Vector<S2>& Vector<S2>::operator=<S1> (const Vector<S1> &);
+  }

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -56,3 +56,4 @@ for (S1: REAL_SCALARS; S2: COMPLEX_SCALARS)
     template
       Vector<S2>& Vector<S2>::operator=<S1> (const Vector<S1> &);
   }
+

--- a/tests/base/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=off.output
@@ -9,8 +9,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      448
 DEAL::Memory consumption -- Matrix:        632
-DEAL::Memory consumption -- Solution:      224
-DEAL::Memory consumption -- Rhs:           224
+DEAL::Memory consumption -- Solution:      240
+DEAL::Memory consumption -- Rhs:           240
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       11
 DEAL::   Number of degrees of freedom: 23
@@ -20,8 +20,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      568
 DEAL::Memory consumption -- Matrix:        824
-DEAL::Memory consumption -- Solution:      272
-DEAL::Memory consumption -- Rhs:           272
+DEAL::Memory consumption -- Solution:      288
+DEAL::Memory consumption -- Rhs:           288
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       15
 DEAL::   Number of degrees of freedom: 31
@@ -31,8 +31,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      728
 DEAL::Memory consumption -- Matrix:        1080
-DEAL::Memory consumption -- Solution:      336
-DEAL::Memory consumption -- Rhs:           336
+DEAL::Memory consumption -- Solution:      352
+DEAL::Memory consumption -- Rhs:           352
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 41
@@ -42,8 +42,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      928
 DEAL::Memory consumption -- Matrix:        1400
-DEAL::Memory consumption -- Solution:      416
-DEAL::Memory consumption -- Rhs:           416
+DEAL::Memory consumption -- Solution:      432
+DEAL::Memory consumption -- Rhs:           432
 DEAL::Memory consumption -- DataOut:       3336
 DEAL::2d
 DEAL::Cycle 0:
@@ -55,8 +55,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      5728
 DEAL::Memory consumption -- Matrix:        10616
-DEAL::Memory consumption -- Solution:      800
-DEAL::Memory consumption -- Rhs:           800
+DEAL::Memory consumption -- Solution:      816
+DEAL::Memory consumption -- Rhs:           816
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
@@ -66,8 +66,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   3102
 DEAL::Memory consumption -- Sparsity:      13984
 DEAL::Memory consumption -- Matrix:        26168
-DEAL::Memory consumption -- Solution:      1760
-DEAL::Memory consumption -- Rhs:           1760
+DEAL::Memory consumption -- Solution:      1776
+DEAL::Memory consumption -- Rhs:           1776
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
@@ -77,8 +77,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   10734
 DEAL::Memory consumption -- Sparsity:      31232
 DEAL::Memory consumption -- Matrix:        58744
-DEAL::Memory consumption -- Solution:      3680
-DEAL::Memory consumption -- Rhs:           3680
+DEAL::Memory consumption -- Solution:      3696
+DEAL::Memory consumption -- Rhs:           3696
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
@@ -88,8 +88,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   19966
 DEAL::Memory consumption -- Sparsity:      64160
 DEAL::Memory consumption -- Matrix:        120824
-DEAL::Memory consumption -- Solution:      7456
-DEAL::Memory consumption -- Rhs:           7456
+DEAL::Memory consumption -- Solution:      7472
+DEAL::Memory consumption -- Rhs:           7472
 DEAL::Memory consumption -- DataOut:       42796
 DEAL::3d
 DEAL::Cycle 0:
@@ -101,8 +101,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      120272
 DEAL::Memory consumption -- Matrix:        236280
-DEAL::Memory consumption -- Solution:      4224
-DEAL::Memory consumption -- Rhs:           4224
+DEAL::Memory consumption -- Solution:      4240
+DEAL::Memory consumption -- Rhs:           4240
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
@@ -112,8 +112,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   55262
 DEAL::Memory consumption -- Sparsity:      567144
 DEAL::Memory consumption -- Matrix:        1116424
-DEAL::Memory consumption -- Solution:      17824
-DEAL::Memory consumption -- Rhs:           17824
+DEAL::Memory consumption -- Solution:      17840
+DEAL::Memory consumption -- Rhs:           17840
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
@@ -123,8 +123,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   367086
 DEAL::Memory consumption -- Sparsity:      2517200
 DEAL::Memory consumption -- Matrix:        4959288
-DEAL::Memory consumption -- Solution:      75072
-DEAL::Memory consumption -- Rhs:           75072
+DEAL::Memory consumption -- Solution:      75088
+DEAL::Memory consumption -- Rhs:           75088
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
@@ -134,6 +134,6 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   1307806
 DEAL::Memory consumption -- Sparsity:      8321760
 DEAL::Memory consumption -- Matrix:        16383928
-DEAL::Memory consumption -- Solution:      259552
-DEAL::Memory consumption -- Rhs:           259552
+DEAL::Memory consumption -- Solution:      259568
+DEAL::Memory consumption -- Rhs:           259568
 DEAL::Memory consumption -- DataOut:       1159732

--- a/tests/base/memory_consumption_01.with_64bit_indices=on.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=on.output
@@ -9,8 +9,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      792
 DEAL::Memory consumption -- Matrix:        632
-DEAL::Memory consumption -- Solution:      232
-DEAL::Memory consumption -- Rhs:           232
+DEAL::Memory consumption -- Solution:      248
+DEAL::Memory consumption -- Rhs:           248
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       11
 DEAL::   Number of degrees of freedom: 23
@@ -20,8 +20,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      1032
 DEAL::Memory consumption -- Matrix:        824
-DEAL::Memory consumption -- Solution:      280
-DEAL::Memory consumption -- Rhs:           280
+DEAL::Memory consumption -- Solution:      296
+DEAL::Memory consumption -- Rhs:           296
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       15
 DEAL::   Number of degrees of freedom: 31
@@ -31,8 +31,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      1352
 DEAL::Memory consumption -- Matrix:        1080
-DEAL::Memory consumption -- Solution:      344
-DEAL::Memory consumption -- Rhs:           344
+DEAL::Memory consumption -- Solution:      360
+DEAL::Memory consumption -- Rhs:           360
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 41
@@ -42,8 +42,8 @@ DEAL::Memory consumption -- FE:            1488
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      1752
 DEAL::Memory consumption -- Matrix:        1400
-DEAL::Memory consumption -- Solution:      424
-DEAL::Memory consumption -- Rhs:           424
+DEAL::Memory consumption -- Solution:      440
+DEAL::Memory consumption -- Rhs:           440
 DEAL::Memory consumption -- DataOut:       3336
 DEAL::2d
 DEAL::Cycle 0:
@@ -55,8 +55,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      11352
 DEAL::Memory consumption -- Matrix:        10616
-DEAL::Memory consumption -- Solution:      808
-DEAL::Memory consumption -- Rhs:           808
+DEAL::Memory consumption -- Solution:      824
+DEAL::Memory consumption -- Rhs:           824
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
@@ -66,8 +66,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   4594
 DEAL::Memory consumption -- Sparsity:      27864
 DEAL::Memory consumption -- Matrix:        26168
-DEAL::Memory consumption -- Solution:      1768
-DEAL::Memory consumption -- Rhs:           1768
+DEAL::Memory consumption -- Solution:      1784
+DEAL::Memory consumption -- Rhs:           1784
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
@@ -77,8 +77,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   15250
 DEAL::Memory consumption -- Sparsity:      62360
 DEAL::Memory consumption -- Matrix:        58744
-DEAL::Memory consumption -- Solution:      3688
-DEAL::Memory consumption -- Rhs:           3688
+DEAL::Memory consumption -- Solution:      3704
+DEAL::Memory consumption -- Rhs:           3704
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
@@ -88,8 +88,8 @@ DEAL::Memory consumption -- FE:            3904
 DEAL::Memory consumption -- Constraints:   28082
 DEAL::Memory consumption -- Sparsity:      128216
 DEAL::Memory consumption -- Matrix:        120824
-DEAL::Memory consumption -- Solution:      7464
-DEAL::Memory consumption -- Rhs:           7464
+DEAL::Memory consumption -- Solution:      7480
+DEAL::Memory consumption -- Rhs:           7480
 DEAL::Memory consumption -- DataOut:       42796
 DEAL::3d
 DEAL::Cycle 0:
@@ -101,8 +101,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      240440
 DEAL::Memory consumption -- Matrix:        236280
-DEAL::Memory consumption -- Solution:      4232
-DEAL::Memory consumption -- Rhs:           4232
+DEAL::Memory consumption -- Solution:      4248
+DEAL::Memory consumption -- Rhs:           4248
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
@@ -112,8 +112,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   78450
 DEAL::Memory consumption -- Sparsity:      1134184
 DEAL::Memory consumption -- Matrix:        1116424
-DEAL::Memory consumption -- Solution:      17832
-DEAL::Memory consumption -- Rhs:           17832
+DEAL::Memory consumption -- Solution:      17848
+DEAL::Memory consumption -- Rhs:           17848
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
@@ -123,8 +123,8 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   487314
 DEAL::Memory consumption -- Sparsity:      5034296
 DEAL::Memory consumption -- Matrix:        4959288
-DEAL::Memory consumption -- Solution:      75080
-DEAL::Memory consumption -- Rhs:           75080
+DEAL::Memory consumption -- Solution:      75096
+DEAL::Memory consumption -- Rhs:           75096
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
@@ -134,6 +134,6 @@ DEAL::Memory consumption -- FE:            12280
 DEAL::Memory consumption -- Constraints:   1729778
 DEAL::Memory consumption -- Sparsity:      16643416
 DEAL::Memory consumption -- Matrix:        16383928
-DEAL::Memory consumption -- Solution:      259560
-DEAL::Memory consumption -- Rhs:           259560
+DEAL::Memory consumption -- Solution:      259576
+DEAL::Memory consumption -- Rhs:           259576
 DEAL::Memory consumption -- DataOut:       1159732


### PR DESCRIPTION
This commit is the second part to fix #2496, namely by introducing the affinity partitioner to the vector class that gets re-used between different vectors of the same size by a shared pointer (if the initialization is through copy assignment or reinit from another vector of the same size).