### PR TITLE
closest_point_and_differential_forms changed to return min and max curvatures

### DIFF
--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -276,7 +276,7 @@ namespace OpenCASCADE
    * face, returns the corresponding point in real space, the normal to the
    * surface at that point and the min and max curvatures as a tuple.
    */
-  std_cxx11::tuple<Point<3>, Point<3>, double, double>
+  std_cxx11::tuple<Point<3>,  Tensor<1,3>, double, double>
   push_forward_and_differential_forms(const TopoDS_Face &face,
                                       const double u,
                                       const double v,
@@ -290,7 +290,7 @@ namespace OpenCASCADE
    * and only the closest point is returned. This function will throw an
    * exception if the @p in_shape does not contain at least one face.
    */
-  std_cxx11::tuple<Point<3>, Point<3>, double, double>
+  std_cxx11::tuple<Point<3>,  Tensor<1,3>, double, double>
   closest_point_and_differential_forms(const TopoDS_Shape &in_shape,
                                        const Point<3> &origin,
                                        const double tolerance=1e-7);

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -274,9 +274,9 @@ namespace OpenCASCADE
   /**
    * Given a TopoDS_Face @p face and the reference coordinates within this
    * face, returns the corresponding point in real space, the normal to the
-   * surface at that point and the mean curvature as a tuple.
+   * surface at that point and the min and max curvatures as a tuple.
    */
-  std_cxx11::tuple<Point<3>, Point<3>, double >
+  std_cxx11::tuple<Point<3>, Point<3>, double, double>
   push_forward_and_differential_forms(const TopoDS_Face &face,
                                       const double u,
                                       const double v,
@@ -285,12 +285,12 @@ namespace OpenCASCADE
 
   /**
    * Get the closest point to the given topological shape, together with the
-   * normal and the mean curvature at that point. If the shape is not
+   * normal and the min and max curvatures at that point. If the shape is not
    * elementary, all its sub-faces (only the faces) are iterated, faces first,
    * and only the closest point is returned. This function will throw an
    * exception if the @p in_shape does not contain at least one face.
    */
-  std_cxx11::tuple<Point<3>, Point<3>, double>
+  std_cxx11::tuple<Point<3>, Point<3>, double, double>
   closest_point_and_differential_forms(const TopoDS_Shape &in_shape,
                                        const Point<3> &origin,
                                        const double tolerance=1e-7);

--- a/source/opencascade/boundary_lib.cc
+++ b/source/opencascade/boundary_lib.cc
@@ -169,7 +169,7 @@ namespace OpenCASCADE
       {
         for (unsigned int i=0; i<surrounding_points.size(); ++i)
           {
-            std_cxx11::tuple<Point<3>, Point<3>, double, double>
+            std_cxx11::tuple<Point<3>,  Tensor<1,3>, double, double>
             p_and_diff_forms =
               closest_point_and_differential_forms(sh,
                                                    surrounding_points[i],

--- a/source/opencascade/boundary_lib.cc
+++ b/source/opencascade/boundary_lib.cc
@@ -169,7 +169,7 @@ namespace OpenCASCADE
       {
         for (unsigned int i=0; i<surrounding_points.size(); ++i)
           {
-            std_cxx11::tuple<Point<3>, Point<3>, double>
+            std_cxx11::tuple<Point<3>, Point<3>, double, double>
             p_and_diff_forms =
               closest_point_and_differential_forms(sh,
                                                    surrounding_points[i],

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -546,7 +546,7 @@ namespace OpenCASCADE
     return std_cxx11::get<0>(ref);
   }
 
-  std_cxx11::tuple<Point<3>, Point<3>, double, double>
+  std_cxx11::tuple<Point<3>,  Tensor<1,3>, double, double>
   closest_point_and_differential_forms(const TopoDS_Shape &in_shape,
                                        const Point<3> &origin,
                                        const double tolerance)
@@ -601,7 +601,7 @@ namespace OpenCASCADE
     return Point<3>();
   }
 
-  std_cxx11::tuple<Point<3>, Point<3>, double, double>
+  std_cxx11::tuple<Point<3>,  Tensor<1,3>, double, double>
   push_forward_and_differential_forms(const TopoDS_Face &face,
                                       const double u,
                                       const double v,
@@ -615,7 +615,7 @@ namespace OpenCASCADE
     Assert(props.IsCurvatureDefined(), ExcMessage("Curvature is not well defined!"));
     Standard_Real Min_Curvature = props.MinCurvature();
     Standard_Real Max_Curvature = props.MaxCurvature();
-    Point<3> normal = Point<3>(Normal.X(),Normal.Y(),Normal.Z());
+    Tensor<1,3> normal = Point<3>(Normal.X(),Normal.Y(),Normal.Z());
 
     // In the case your manifold changes from convex to concave or viceversa
     // the normal could jump from "inner" to "outer" normal.
@@ -628,7 +628,7 @@ namespace OpenCASCADE
         Max_Curvature *= -1;
       }
 
-    return std_cxx11::tuple<Point<3>, Point<3>, double, double>(point(Value), normal, Min_Curvature, Max_Curvature);
+    return std_cxx11::tuple<Point<3>, Tensor<1,3>, double, double>(point(Value), normal, Min_Curvature, Max_Curvature);
   }
 
 

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -546,7 +546,7 @@ namespace OpenCASCADE
     return std_cxx11::get<0>(ref);
   }
 
-  std_cxx11::tuple<Point<3>, Point<3>, double>
+  std_cxx11::tuple<Point<3>, Point<3>, double, double>
   closest_point_and_differential_forms(const TopoDS_Shape &in_shape,
                                        const Point<3> &origin,
                                        const double tolerance)
@@ -601,7 +601,7 @@ namespace OpenCASCADE
     return Point<3>();
   }
 
-  std_cxx11::tuple<Point<3>, Point<3>, double >
+  std_cxx11::tuple<Point<3>, Point<3>, double, double>
   push_forward_and_differential_forms(const TopoDS_Face &face,
                                       const double u,
                                       const double v,
@@ -613,7 +613,8 @@ namespace OpenCASCADE
     Assert(props.IsNormalDefined(), ExcMessage("Normal is not well defined!"));
     gp_Dir Normal = props.Normal();
     Assert(props.IsCurvatureDefined(), ExcMessage("Curvature is not well defined!"));
-    Standard_Real Mean_Curvature = props.MeanCurvature();
+    Standard_Real Min_Curvature = props.MinCurvature();
+    Standard_Real Max_Curvature = props.MaxCurvature();
     Point<3> normal = Point<3>(Normal.X(),Normal.Y(),Normal.Z());
 
     // In the case your manifold changes from convex to concave or viceversa
@@ -623,10 +624,11 @@ namespace OpenCASCADE
     if (face.Orientation()==TopAbs_REVERSED)
       {
         normal *= -1;
-        Mean_Curvature *= -1;
+        Min_Curvature *= -1;
+        Max_Curvature *= -1;
       }
 
-    return std_cxx11::tuple<Point<3>, Point<3>, double>(point(Value), normal, Mean_Curvature);
+    return std_cxx11::tuple<Point<3>, Point<3>, double, double>(point(Value), normal, Min_Curvature, Max_Curvature);
   }
 
 


### PR DESCRIPTION
A (very) small modification to the opencascade surface projection in opencascade/utilities.cc .
The closest_point_and_differential_forms function is now returning (in a tuple, along with other things) both the min and max curvature of the surface at the projected point. It was previously returning only the mean curvature.
This is useful because one can use the maximum curvature to decide whether to refine a cell or not. Let's say, for instance, that one wants a cell dimension which corresponds to approximating a circle with 20 elements. The inverse of the local max curvature will give the radius of the local circle, so that the local dimension of the cells can be established.
Employing such strategy with the mean curvature led to poor results for surfaces such as cylinders, in which minimum and maximum curvatures are very different.