### PR TITLE
Use the same affinity for inner products as for vector updates

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -995,7 +995,7 @@ protected:
    * For parallel loops with TBB, this member variable stores the affinity
    * information of loops.
    */
-  std_cxx11::shared_ptr<parallel::internal::TBBPartitioner> thread_loop_partitioner;
+  mutable std_cxx11::shared_ptr<parallel::internal::TBBPartitioner> thread_loop_partitioner;
 
   /**
    * Make all other vector types friends.


### PR DESCRIPTION
This commit unifies the loops for the vector updates addressed by #2507 as discussed in #2496. Since we want to have repeatable computations with the same order of additions in every run but still want to have `tbb::affinity_partitioner` that only is supported by for loops, we express the inner product as parallel for loop (see TBBReduceFunctor) and put the partial results into a small array. We limit the number of tasks to four times the number of threads which should be more than enough for good work balancing. To use, we of course have to use the same layout for the vector updates which I converted to the same mechanism (TBBForFunctor).

This commit moves a lot of code around. The new parts are the aforementioned TBBReduceFunctor and TBBForFunctor and somewhat improved vectorization of the inner product (part of accumulate_regular for the case where we can vectorize).

As far as performance is concerned, the vector updates perform similarly to before (except at small lengths which are served from L1/L2 cache where some operations sometimes are not vectorized when changing something seemingly unrelated). The dot product is signifcantly improved. This picture compares the old implementation before #2506, the result after #2507 and finally this patch in the setting described on #2496. We can nicely see the much better performance due to NUMA awareness for large vector sizes (the small drop between 16k and 100k dofs is benchmark-specific with respect to the amount of available parallelism and probably not be seen in real cases; the behavior is the same for the vector updates).
![performance_ddot_b](https://cloud.githubusercontent.com/assets/8276200/14600804/e3d0b68a-055e-11e6-82cc-d06dd195e6bd.png)
