### PR TITLE
Reset object to native state in IndexSet::clear().

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1222,9 +1222,11 @@ inline
 void
 IndexSet::clear ()
 {
+  // reset so that there are no indices in the set any more; however,
+  // as documented, the index set retains its size
   ranges.clear ();
-  largest_range = 0;
   is_compressed = true;
+  largest_range = numbers::invalid_unsigned_int;
 }
 
 


### PR DESCRIPTION
IndexSet stores an index into an array. Upon construction, this index is set
to an invalid value (because the array is empty), whereas after IndexSet::clear()
the index was set to zero -- a perfectly reasonable, and consequently objectionable
index. This patch sets the index to an invalid value instead, as is also
done in the constructor.