### PR TITLE
Comment out argument names for move constructors/operators.

### DIFF
--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2015 by the deal.II authors
+// Copyright (C) 1999 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -107,12 +107,12 @@ public:
 #ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. Creates a new vector by stealing the internal data of
-   * the vector @p v.
+   * the given argument vector.
    *
    * @note This constructor is only available if deal.II is configured with
    * C++11 support.
    */
-  BlockVector (BlockVector<Number> &&v) = default;
+  BlockVector (BlockVector<Number> &&/*v*/) = default;
 #endif
 
 
@@ -202,13 +202,13 @@ public:
 
 #ifdef DEAL_II_WITH_CXX11
   /**
-   * Move the given vector. This operator replaces the present vector with @p
-   * v by efficiently swapping the internal data structures.
+   * Move the given vector. This operator replaces the present vector with
+   * the contents of the given argument vector.
    *
    * @note This operator is only available if deal.II is configured with C++11
    * support.
    */
-  BlockVector<Number> &operator= (BlockVector<Number> &&v) = default;
+  BlockVector<Number> &operator= (BlockVector<Number> &&/*v*/) = default;
 #endif
 
   /**

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2015 by the deal.II authors
+// Copyright (C) 2004 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -584,14 +584,14 @@ public:
   BlockVectorBase (const BlockVectorBase &V) = default;
 
   /**
-   * Move constructor. Each block of the vector @p V is moved into the current
+   * Move constructor. Each block of the argument vector is moved into the current
    * object if the underlying <code>VectorType</code> is move-constructible,
    * otherwise they are copied.
    *
    * @note This constructor is only available if deal.II is configured with
    * C++11 support.
    */
-  BlockVectorBase (BlockVectorBase &&V) = default;
+  BlockVectorBase (BlockVectorBase &&/*V*/) = default;
 #endif
 
   /**
@@ -742,10 +742,11 @@ public:
 
 #ifdef DEAL_II_WITH_CXX11
   /**
-   * Move assignment operator. Move each block of the vector @p V into the
-   * current object if `VectorType` is move-constructible, otherwise copy them.
+   * Move assignment operator. Move each block of the given argument
+   * vector into the current object if `VectorType` is
+   * move-constructible, otherwise copy them.
    */
-  BlockVectorBase &operator= (BlockVectorBase &&V) = default;
+  BlockVectorBase &operator= (BlockVectorBase &&/*V*/) = default;
 #endif
 
   /**


### PR DESCRIPTION
This avoids warnings by gcc 4.6 which takes a '=default' declaration to be a
function definition in which it doesn't use the name of the argument. It then
proceeds to issue a warning about an unused argument :-(

This patch avoids this. Fixes #2527.