### PR TITLE
Bugfix: Update MultipleParameterLoop::read_input to cb72c13

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2285,13 +2285,18 @@ public:
    *
    * Return whether the read was successful.
    *
+   * If non-empty @p last_line is provided, the ParameterHandler object
+   * will stop parsing lines after encountering @p last_line .
+   * This is handy when adding extra data that shall be parsed manually.
+   *
    * @note Of the three <tt>read_input</tt> functions implemented by
    * ParameterHandler, this is the only one overridden with new behavior by
    * this class. This is because the other two <tt>read_input</tt> functions
    * just reformat their inputs and then call this version.
    */
   virtual bool read_input (std::istream &input,
-                           const std::string &filename = "input file");
+                           const std::string &filename = "input file",
+                           const std::string &last_line = "");
 
   /**
    * Overriding virtual functions which are overloaded (like

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2829,11 +2829,12 @@ MultipleParameterLoop::~MultipleParameterLoop ()
 
 
 bool MultipleParameterLoop::read_input (std::istream &input,
-                                        const std::string &filename)
+                                        const std::string &filename,
+                                        const std::string &last_line)
 {
   AssertThrow (input, ExcIO());
 
-  bool x = ParameterHandler::read_input (input, filename);
+  bool x = ParameterHandler::read_input (input, filename, last_line);
   if (x)
     init_branches ();
   return x;


### PR DESCRIPTION
Fix a regression introduced by cb72c13 that changed the signature of
ParameterHandler::read_input.

In reference to #2526
Fixes #2545