### PR TITLE
Add missing instantiations

### DIFF
--- a/source/dofs/dof_handler.inst.in
+++ b/source/dofs/dof_handler.inst.in
@@ -21,6 +21,10 @@ for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 #if deal_II_dimension < 3
     template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+1>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids) const;
 #endif
+
+#if deal_II_dimension == 1
+    template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+2>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids) const;
+#endif
     
   }
   
@@ -30,6 +34,10 @@ for (scalar: COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS)
     
 #if deal_II_dimension < 3
     template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+1>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids) const;
+#endif
+
+#if deal_II_dimension == 1
+    template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+2>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids) const;
 #endif
     
   }

--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -52,6 +52,22 @@ for (scalar: REAL_SCALARS; SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSION
     // SP    &sparsity);
   
 #endif     
+
+#if deal_II_dimension == 1
+    template void
+    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+2>,SP,scalar>
+    (const hp::DoFHandler<deal_II_dimension,deal_II_dimension+2>& dof,
+     const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*>  &boundary_ids,
+     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
+     SP    &sparsity);
+     
+    template void
+    DoFTools::make_boundary_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+2>,SP,scalar>
+    (const DoFHandler<deal_II_dimension,deal_II_dimension+2>& dof,
+     const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids,
+     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
+     SP    &sparsity);
+#endif
      
   }
 
@@ -320,20 +336,6 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
     (const hp::DoFHandler<1,3>& dof,
      const std::vector<types::global_dof_index>  &,
      SP    &);
-
-    template void
-    DoFTools::make_boundary_sparsity_pattern<DoFHandler<1,3>,SP,double>
-    (const DoFHandler<1,3>& dof,
-     const std::map<types::boundary_id, const Function<3,double>*>  &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
-
-    template void
-    DoFTools::make_boundary_sparsity_pattern<hp::DoFHandler<1,3>,SP,double>
-    (const hp::DoFHandler<1,3>& dof,
-     const std::map<types::boundary_id, const Function<3,double>*> &boundary_ids,
-     const std::vector<types::global_dof_index>  &dof_to_boundary_mapping,
-     SP    &sparsity);
 
 #endif
 

--- a/source/hp/dof_handler.inst.in
+++ b/source/hp/dof_handler.inst.in
@@ -22,6 +22,10 @@ for (scalar: REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 #if deal_II_dimension < 3
       template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+1>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids) const;
 #endif
+
+#if deal_II_dimension == 1
+      template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+2>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids) const;
+#endif
     \}
   }
   
@@ -33,6 +37,10 @@ for (scalar: COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS)
     
 #if deal_II_dimension < 3
       template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+1>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+1,scalar>*> &boundary_ids) const;
+#endif
+    
+#if deal_II_dimension == 1
+      template types::global_dof_index DoFHandler<deal_II_dimension,deal_II_dimension+2>::n_boundary_dofs<scalar> (const std::map<types::boundary_id, const Function<deal_II_dimension+2,scalar>*> &boundary_ids) const;
 #endif
     \}
   }


### PR DESCRIPTION
When compiling with Intel 16.0.1, there were a few dim=1, spacedim=3 instantiations missing in debug mode.