### PR TITLE
Try to fix a failing test.

### DIFF
--- a/tests/manifold/composition_manifold_04.cc
+++ b/tests/manifold/composition_manifold_04.cc
@@ -43,9 +43,12 @@ int main ()
   cp[0][0] = 1.0;
   cp[1][0] = 1.0;
 
+  // Force roundoff errors on one side only
+  double eps=1e-10;
+
   // Last point
   cp[0][1] = -numbers::PI/4;
-  cp[1][1] =  numbers::PI/4;
+  cp[1][1] =  numbers::PI/4-eps;
 
   // Spacedim points
   std::vector<Point<spacedim> > sp(2);


### PR DESCRIPTION
See #2530.

This PR tries to force roundoff errors on one direction. The original version of the test was working for me, so @tjhei or @kronbichler should check if this fixes `composition_manifold_04.cc`