### PR TITLE
Bugfixes without MPI

### DIFF
--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -476,7 +476,7 @@ namespace LinearAlgebra
      */
     void resize_val (const size_type new_allocated_size);
 
-#ifdef DEAL_II_WITH_TRILINOS
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
     /**
      * Return a EpetraWrappers::Communication pattern and store it for future
      * use.

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -173,7 +173,7 @@ namespace LinearAlgebra
 
 
 
-#ifdef DEAL_II_WITH_TRILINOS
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
   template <typename Number>
   void
   ReadWriteVector<Number>::import(const Epetra_MultiVector        &multivector,
@@ -315,7 +315,7 @@ namespace LinearAlgebra
 
 
 
-#ifdef DEAL_II_WITH_TRILINOS
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
   template <typename Number>
   EpetraWrappers::CommunicationPattern
   ReadWriteVector<Number>::create_epetra_comm_pattern(const IndexSet &source_index_set,

--- a/tests/lac/vector_reinit_01.cc
+++ b/tests/lac/vector_reinit_01.cc
@@ -101,7 +101,7 @@ int main (int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
-  mpi_initlog();
+  initlog();
 
   do_test<parallel::distributed::Vector<double> >();
 }

--- a/tests/lac/vector_reinit_02.cc
+++ b/tests/lac/vector_reinit_02.cc
@@ -101,7 +101,7 @@ int main (int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
 
-  mpi_initlog();
+  initlog();
 
   do_test<TrilinosWrappers::Vector>();
   do_test<TrilinosWrappers::MPI::Vector>();

--- a/tests/lac/vector_reinit_03.cc
+++ b/tests/lac/vector_reinit_03.cc
@@ -102,7 +102,7 @@ int main (int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
 
-  mpi_initlog();
+  initlog();
 
   do_test<PETScWrappers::MPI::Vector>();
 }


### PR DESCRIPTION
This collects two independent bug fixes when deal.II is compiled without MPI, see also http://cdash.kyomu.43-1.org/buildSummary.php?buildid=300 for the compile failures (first commit).