### PR TITLE
Return a nonzero value if the quick tests fail.

### DIFF
--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -21,12 +21,11 @@ SEPARATE_ARGUMENTS(ALL_TESTS)
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -O quicktests.log RESULT_VARIABLE res_var)
 
-if(NOT "${res_var}" STREQUAL "0")
-  MESSAGE( "
-
-*******************************     WARNING     *******************************
-
-Some of the tests failed!
+IF(NOT "${res_var}" STREQUAL "0")
+  MESSAGE("
+***************************************************************************
+**                 Error: Some of the quick tests failed.
+***************************************************************************
 
 Please scroll up or check the file tests/quick_tests/quicktests.log for the
 error messages. If you are unable to fix the problems, see the FAQ or write

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013 by the deal.II authors
+## Copyright (C) 2013 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -60,5 +60,12 @@ recent version or use a different MPI library like MPICH.\n"
     ENDIF()
 
   ENDFOREACH()
+
+  # The CMake command MESSAGE(SEND_ERROR ...) is, to the best of the authors'
+  # knowledge, the only way to set the exit status of CMake to a nonzero value.
+  # If we used MESSAGE(SEND_ERROR ...) at the top (with the actual error
+  # message) then subsequent messages (i.e., the test specific help) would not
+  # be printed. Hence, do it down here.
+  MESSAGE(SEND_ERROR "")
 
 ENDIF()


### PR DESCRIPTION
Previously 'make test' would return 0 regardless of whether or not any quick tests failed. Now (at least on my machine) it returns 2.

Closes #2447.