### PR TITLE
Consistently format decorate block error messages.

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -128,8 +128,8 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
         COMMAND
            ${CMAKE_COMMAND} -E echo ''
         && ${CMAKE_COMMAND} -E echo '***************************************************************************'
-        && ${CMAKE_COMMAND} -E echo '**  Error: No Mac OSX developer certificate specified'
-        && ${CMAKE_COMMAND} -E echo '**  Please reconfigure with -DOSX_CERTIFICATE_NAME="<...>"'
+        && ${CMAKE_COMMAND} -E echo '**           Error: No Mac OSX developer certificate specified           **'
+        && ${CMAKE_COMMAND} -E echo '**         Please reconfigure with -DOSX_CERTIFICATE_NAME="<...>"        **'
         && ${CMAKE_COMMAND} -E echo '***************************************************************************'
         && ${CMAKE_COMMAND} -E echo ''
         COMMENT "Digitally signing ${TARGET}"

--- a/cmake/macros/macro_decorate_with_stars.cmake
+++ b/cmake/macros/macro_decorate_with_stars.cmake
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2016 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# Formats a string to be of length 75 and surrounded with '**'s, and, if
+# necessary, centered with extra spaces. This allows for nicer looking output
+# messages: for example, the middle two lines of
+#
+# ***************************************************************************
+# **    Error: Could not build and install disabled component examples.    **
+# **        Please reconfigure with -DDEAL_II_COMPONENT_EXAMPLES=ON        **
+# ***************************************************************************
+#
+# could be built automatically with this macro. If the line is too long to fit
+# in such a box then decorate it with just two stars at the beginning.
+#
+# Usage:
+#     DECORATE_WITH_STARS(message decorated_message)
+#
+#
+MACRO(DECORATE_WITH_STARS _message _decorated_message)
+  STRING(LENGTH ${_message} _message_length)
+  SET(_line_length 75)
+  MATH(EXPR _unpadded_line_length "${_line_length} - 6")
+
+  IF(${_message_length} LESS ${_unpadded_line_length})
+    MATH(EXPR _left_pad_size "(${_unpadded_line_length} - ${_message_length} + 1)/2")
+    MATH(EXPR _right_pad_size "(${_unpadded_line_length} - ${_message_length})/2")
+    # Unfortunately, it looks like taking substrings is the only way to pad
+    # strings with run time dependent length.
+    SET(_pad_strings_values "                                              ")
+    STRING(SUBSTRING "${_pad_strings_values}" 0 "${_left_pad_size}" _left_pad)
+    STRING(SUBSTRING "${_pad_strings_values}" 0 "${_right_pad_size}" _right_pad)
+    SET(${_decorated_message} "** ${_left_pad}${_message}${_right_pad} **")
+  ELSE()
+    SET(${_decorated_message} "** ${_message}")
+  ENDIF()
+ENDMACRO()

--- a/cmake/setup_custom_targets.cmake
+++ b/cmake/setup_custom_targets.cmake
@@ -60,13 +60,24 @@ FOREACH(_component compat_files documentation examples parameter_gui)
     _add_custom_target(${_component})
   ELSE()
     STRING(TOUPPER ${_component} _componentuppercase)
+
+    SET(_error_description_message
+      "Error: Could not ${_description_string} disabled component ${_component}.")
+    DECORATE_WITH_STARS(${_error_description_message}
+      _decorated_error_description_message)
+
+    SET(_reconfiguration_help_message
+      "Please reconfigure with -DDEAL_II_COMPONENT_${_componentuppercase}=ON")
+    DECORATE_WITH_STARS(${_reconfiguration_help_message}
+      _decorated_reconfiguration_help_message)
+
     ADD_CUSTOM_TARGET(${_component}
       COMMAND
            ${CMAKE_COMMAND} -E echo ''
         && ${CMAKE_COMMAND} -E echo ''
         && ${CMAKE_COMMAND} -E echo '***************************************************************************'
-        && ${CMAKE_COMMAND} -E echo "**  Error: Could not ${_description_string} disabled component \"${_component}\"."
-        && ${CMAKE_COMMAND} -E echo "**  Please reconfigure with -DDEAL_II_COMPONENT_${_componentuppercase}=ON"
+        && ${CMAKE_COMMAND} -E echo "${_decorated_error_description_message}"
+        && ${CMAKE_COMMAND} -E echo "${_decorated_reconfiguration_help_message}"
         && ${CMAKE_COMMAND} -E echo '***************************************************************************'
         && ${CMAKE_COMMAND} -E echo ''
         && ${CMAKE_COMMAND} -E echo ''
@@ -81,8 +92,8 @@ IF(NOT DEAL_II_COMPONENT_PACKAGE)
          ${CMAKE_COMMAND} -E echo ''
       && ${CMAKE_COMMAND} -E echo ''
       && ${CMAKE_COMMAND} -E echo '***************************************************************************'
-      && ${CMAKE_COMMAND} -E echo "**  Error: Could not generate binary package. The component is disabled."
-      && ${CMAKE_COMMAND} -E echo "**  Please reconfigure with -DDEAL_II_COMPONENT_PACKAGE=ON"
+      && ${CMAKE_COMMAND} -E echo '**  Error: Could not generate binary package. The component is disabled. **'
+      && ${CMAKE_COMMAND} -E echo '**        Please reconfigure with -DDEAL_II_COMPONENT_PACKAGE=ON         **'
       && ${CMAKE_COMMAND} -E echo '***************************************************************************'
       && ${CMAKE_COMMAND} -E echo ''
       && ${CMAKE_COMMAND} -E echo ''

--- a/tests/quick_tests/run.cmake
+++ b/tests/quick_tests/run.cmake
@@ -24,7 +24,7 @@ EXECUTE_PROCESS(COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --outpu
 IF(NOT "${res_var}" STREQUAL "0")
   MESSAGE("
 ***************************************************************************
-**                 Error: Some of the quick tests failed.
+**                 Error: Some of the quick tests failed.                **
 ***************************************************************************
 
 Please scroll up or check the file tests/quick_tests/quicktests.log for the


### PR DESCRIPTION
This is the followup to the discussion in #2566.