### PR TITLE
Fix Doxygen exceptions

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -150,7 +150,7 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = @CMAKE_SOURCE_DIR@/include/deal.II
+INCLUDE_PATH           = @CMAKE_SOURCE_DIR@/include @CMAKE_BINARY_DIR@/include
 INCLUDE_FILE_PATTERNS  =
 
 # set a few variables that help us generate documentation for
@@ -189,7 +189,8 @@ PREDEFINED             = DOXYGEN=1 \
 
 
 # do not expand exception declarations
-EXPAND_AS_DEFINED      = DeclException0 \
+EXPAND_AS_DEFINED      = DeclExceptionMsg \
+                         DeclException0 \
                          DeclException1 \
                          DeclException2 \
                          DeclException3 \

--- a/doc/doxygen/scripts/filter
+++ b/doc/doxygen/scripts/filter
@@ -54,9 +54,6 @@ s/(?<![\"\\\/])step-(\d+)(?!\")/\@ref step_\1 \"step-\1\"/gi
 # latter
 s/\\(step-\d+)/\1/g;
 
-
-s#(static dealii::ExceptionBase\&)#\n//\! \@ingroup Exceptions\n \1#g;
-
 # doxygen version 1.7.1 and later have the habit of thinking that
 # everything that starts with "file:" is the beginning of a link,
 # but we occasionally use this in our tutorials in the form

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -533,7 +533,7 @@ namespace deal_II_exceptions
  */
 #define DeclExceptionMsg(Exception, defaulttext)                          \
   /** @ingroup Exceptions */ \
-  /** @note The error text is: @code defaulttext @endcode */	\
+  /** @note The error text is: @code defaulttext @endcode */  \
   static dealii::ExceptionBase& Exception ()
 
 /**

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -520,6 +520,7 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException0(Exception0)                                        \
+  /** @ingroup Exceptions */ \
   static dealii::ExceptionBase& Exception0 ()
 
 /**
@@ -531,6 +532,8 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclExceptionMsg(Exception, defaulttext)                          \
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code defaulttext @endcode */	\
   static dealii::ExceptionBase& Exception ()
 
 /**
@@ -540,7 +543,9 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException1(Exception1, type1, outsequence)                    \
-  static dealii::ExceptionBase& Exception1 (type1 arg1) throw (errortext outsequence)
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code outsequence @endcode */              \
+  static dealii::ExceptionBase& Exception1 (type1 arg1)
 
 
 /**
@@ -550,7 +555,9 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException2(Exception2, type1, type2, outsequence)             \
-  static dealii::ExceptionBase& Exception2 (type1 arg1, type2 arg2) throw (errortext outsequence)
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code outsequence @endcode */              \
+  static dealii::ExceptionBase& Exception2 (type1 arg1, type2 arg2)
 
 
 /**
@@ -560,7 +567,9 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException3(Exception3, type1, type2, type3, outsequence)      \
-  static dealii::ExceptionBase& Exception3 (type1 arg1, type2 arg2, type3 arg3) throw (errortext outsequence)
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code outsequence @endcode */              \
+  static dealii::ExceptionBase& Exception3 (type1 arg1, type2 arg2, type3 arg3)
 
 
 /**
@@ -570,7 +579,9 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException4(Exception4, type1, type2, type3, type4, outsequence) \
-  static dealii::ExceptionBase& Exception4 (type1 arg1, type2 arg2, type3 arg3, type4 arg4) throw (errortext outsequence)
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code outsequence @endcode */                \
+  static dealii::ExceptionBase& Exception4 (type1 arg1, type2 arg2, type3 arg3, type4 arg4)
 
 
 /**
@@ -580,7 +591,9 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #define DeclException5(Exception5, type1, type2, type3, type4, type5, outsequence) \
-  static dealii::ExceptionBase& Exception5 (type1 arg1, type2 arg2, type3 arg3, type4 arg4, type5 arg5) throw (errortext outsequence)
+  /** @ingroup Exceptions */ \
+  /** @note The error text is: @code outsequence @endcode */                       \
+  static dealii::ExceptionBase& Exception5 (type1 arg1, type2 arg2, type3 arg3, type4 arg4, type5 arg5)
 
 #endif /*ifndef DOXYGEN*/
 


### PR DESCRIPTION
Exceptions in the documentation are currently completely broken, see https://www.dealii.org/developer/doxygen/deal.II/group__Exceptions.html
Note that 1. the ``outsequence`` is part of the signature which totally breaks the layout (just scroll to the bottom) and 2. the macros only seem to work in exceptions.h not in other files (see ``ExcWrongValueType`` for example).

This PR changes the following:
1. Fix the include paths so that doxygen actually finds ``exceptions.h`` when processing other files.
2. Also replace the macro ``DeclExceptionMsg``
3. Fix automatically putting all exceptions into the group ``Exceptions`` (turns out the perl regex never applied because we kill ``dealii`` in a regex before)
4. Move the ``outsequence`` into a note. Note that the formatting is not great because newlines are lost (see screenshot), but this is much better than before.

Preview:
![screenshot - 05012016 - 11 19 06 am](https://cloud.githubusercontent.com/assets/1531285/14941325/b471e3a2-0f8e-11e6-8fb6-db409407bb87.png)
