### PR TITLE
GCC 6 fixes 2

### DIFF
--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -2505,6 +2505,9 @@ namespace VectorTools
    * equal to one, and the vector that is associated with the constant mode is
    * not equal to $(1,1,\ldots,1)^T$. For such elements, a different procedure
    * has to be used when subtracting the mean value.
+   *
+   * @warning This function is only implemented for Vector and BlockVector. It
+   * is not implemented for any of the distributed vector classes.
    */
   template <typename VectorType>
   void subtract_mean_value(VectorType              &v,

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7086,15 +7086,8 @@ namespace VectorTools
       }
     else
       {
-        // This function is not implemented for distributed vectors, so
-        // if v is not a boring Vector or BlockVector:
-        Assert(   dynamic_cast<Vector<double> *>(& v)
-                  || dynamic_cast<Vector<float> *>(& v)
-                  || dynamic_cast<Vector<long double> *>(& v)
-                  || dynamic_cast<BlockVector<double> *>(& v)
-                  || dynamic_cast<BlockVector<float> *>(& v)
-                  || dynamic_cast<BlockVector<long double> *>(& v),
-                  ExcNotImplemented());
+        // This function is not implemented for distributed vectors.
+        Assert(!v.supports_distributed_data, ExcNotImplemented());
 
         const unsigned int n = v.size();
 


### PR DESCRIPTION
This is the other fix due to warnings GCC6 now raises.

For the curious: since `*this` is never allowed to be `NULL`, GCC added some optimization (and warning) improvements based on this fact in the most recent release.