### PR TITLE
Add support for compiling CUDA code

### DIFF
--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -1,0 +1,40 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2016 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# Configuration for cuda support:
+#
+
+MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
+  FIND_PACKAGE(CUDA)
+
+  IF(CUDA_FOUND)
+    SET(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE FALSE)
+
+    SET(${var} TRUE)
+  ENDIF()
+
+ENDMACRO()
+
+MACRO(FEATURE_CUDA_ERROR_MESSAGE)
+  MESSAGE(FATAL_ERROR "\n"
+    "Could not find any suitable cuda library!\n"
+    ${CUDA_ADDITIONAL_ERROR_STRING}
+    "\nPlease ensure that a cuda library is installed on your computer\n"
+    )
+ENDMACRO()
+
+
+CONFIGURE_FEATURE(CUDA)

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -47,6 +47,28 @@ MACRO(DEAL_II_ADD_LIBRARY _library)
     SET_PROPERTY(GLOBAL APPEND PROPERTY DEAL_II_OBJECTS_${_build}
       "$<TARGET_OBJECTS:${_library}.${_build_lowercase}>"
       )
+
+    #
+    # Cuda specific target setup:
+    #
+    IF(DEAL_II_WITH_CUDA)
+      CUDA_WRAP_SRCS(${_library}.${_build_lowercase}
+        OBJ _generated_cuda_files ${ARGN} SHARED
+        )
+
+      ADD_CUSTOM_TARGET(${_library}.${_build_lowercase}_cuda
+        DEPENDS
+        ${_generated_cuda_files}
+        )
+      ADD_DEPENDENCIES(${_library}.${_build_lowercase}
+        ${_library}.${_build_lowercase}_cuda
+        )
+
+      SET_PROPERTY(GLOBAL APPEND PROPERTY DEAL_II_OBJECTS_${_build}
+        "${_generated_cuda_files}"
+        )
+    ENDIF()
+
   ENDFOREACH()
 
 ENDMACRO()

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -37,6 +37,7 @@
 #cmakedefine DEAL_II_WITH_64BIT_INDICES
 #cmakedefine DEAL_II_WITH_ARPACK
 #cmakedefine DEAL_II_WITH_BZIP2
+#cmakedefine DEAL_II_WITH_CUDA
 #cmakedefine DEAL_II_WITH_CXX11
 #cmakedefine DEAL_II_WITH_CXX14
 #cmakedefine DEAL_II_WITH_GSL

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -57,6 +57,21 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   #
 
   GET_PROPERTY(_objects GLOBAL PROPERTY DEAL_II_OBJECTS_${build})
+
+  #
+  # FIXME: Somehow the cuda object files lose the "generated" property.
+  # This is an ugly hack
+  #
+  FOREACH(_object ${_objects})
+    IF("${_object}" MATCHES "cu.o$")
+      SET_SOURCE_FILES_PROPERTIES("${_object}"
+        PROPERTIES
+        EXTERNAL_OBJECT TRUE
+        GENERATED TRUE
+        )
+    ENDIF()
+  ENDFOREACH()
+
   ADD_LIBRARY(${DEAL_II_BASE_NAME}${DEAL_II_${build}_SUFFIX}
     dummy.cc # Workaround for a bug in the Xcode generator
     ${_objects}


### PR DESCRIPTION
This adds support to the internal build system for CUDA code in .cu files inside the library.

Now that @Rombur has verified that these changes in the build system works for him too, it is probably time to include them in the main library. Thanks to @tamiko for all the help! I have squashed all the changes into a single commit since they are quite few, and really belong together. 

No dummy files included in these one, instead, they can be found here: https://github.com/kalj/dealii/tree/cuda-dummy-files . That commit together with this minimal application lets you try if the whole thing works for you too: https://github.com/kalj/dealii-cuda-example Of course, you need an Nvidia GPU, and to compile Deal.II with -DDEAL_II_WITH_CUDA .