### PR TITLE
C++ 03 template fix

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -157,8 +157,12 @@ namespace GridTools
    * get the same result using <code>cell-@>measure()</code>, but this
    * function also works for cells that do not exist except that you make it
    * up by naming its vertices from the list.
+   *
+   * @note Since <code>dim</code> does not explicitly appear in the function
+   * signature, you must explicitly specify both dimensions when using this
+   * function.
    */
-  template <int dim, int spacedim=dim>
+  template <int dim, int spacedim>
   double cell_measure (const std::vector<Point<spacedim> > &all_vertices,
                        const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell]);
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -166,6 +166,22 @@ namespace GridTools
   double cell_measure (const std::vector<Point<spacedim> > &all_vertices,
                        const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell]);
 
+
+  /**
+   * Same as the last function, but for the codimension zero case. This extra
+   * function allows one to write
+   *
+   * @code
+   * cell_measure(vertices, indices);
+   * @endcode
+   *
+   * and have the template function argument (i.e. <code>dim</code>) inferred
+   * automatically.
+   */
+  template <int dim>
+  double cell_measure (const std::vector<Point<dim> > &all_vertices,
+                       const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell]);
+
   /*@}*/
   /**
    * @name Functions supporting the creation of meshes
@@ -1639,6 +1655,16 @@ namespace GridTools
 
 namespace GridTools
 {
+  // This function just wraps the general case: see the note in its
+  // documentation above.
+  template <int dim>
+  double cell_measure (const std::vector<Point<dim> > &all_vertices,
+                       const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell])
+  {
+    return cell_measure<dim, dim>(all_vertices, vertex_indices);
+  }
+
+
 
   template <int dim, typename Predicate, int spacedim>
   void transform (const Predicate    &predicate,


### PR DESCRIPTION
This is a fix for the problem I induced with C++03 compilation. I took the opportunity to deprecate the older version of this function.

It would be nice to support the syntax `cell_measure(a, b)` without the template argument, but this does not seem possible with backwards compatibility (and C++03 compatibility). Suggestions?