### PR TITLE
Fix compilation on clang.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -157,30 +157,18 @@ namespace GridTools
    * get the same result using <code>cell-@>measure()</code>, but this
    * function also works for cells that do not exist except that you make it
    * up by naming its vertices from the list.
-   *
-   * @note Since <code>dim</code> does not explicitly appear in the function
-   * signature, you must explicitly specify both dimensions when using this
-   * function.
-   */
-  template <int dim, int spacedim>
-  double cell_measure (const std::vector<Point<spacedim> > &all_vertices,
-                       const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell]);
-
-
-  /**
-   * Same as the last function, but for the codimension zero case. This extra
-   * function allows one to write
-   *
-   * @code
-   * cell_measure(vertices, indices);
-   * @endcode
-   *
-   * and have the template function argument (i.e. <code>dim</code>) inferred
-   * automatically.
    */
   template <int dim>
   double cell_measure (const std::vector<Point<dim> > &all_vertices,
                        const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell]);
+
+  /**
+   * A version of the last function that can accept input for nonzero
+   * codimension cases. This function only exists to aid generic programming
+   * and calling it will just raise an exception.
+   */
+  template <int dim, typename T>
+  double cell_measure (const T &, ...);
 
   /*@}*/
   /**
@@ -1655,16 +1643,12 @@ namespace GridTools
 
 namespace GridTools
 {
-  // This function just wraps the general case: see the note in its
-  // documentation above.
-  template <int dim>
-  double cell_measure (const std::vector<Point<dim> > &all_vertices,
-                       const unsigned int (&vertex_indices)[GeometryInfo<dim>::vertices_per_cell])
+  template <int dim, typename T>
+  double cell_measure (const T &, ...)
   {
-    return cell_measure<dim, dim>(all_vertices, vertex_indices);
+    Assert(false, ExcNotImplemented());
+    return std::numeric_limits<double>::quiet_NaN();
   }
-
-
 
   template <int dim, typename Predicate, int spacedim>
   void transform (const Predicate    &predicate,

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -170,7 +170,7 @@ namespace GridTools
 
   template <>
   double
-  cell_measure<1, 1>
+  cell_measure<1>
   (const std::vector<Point<1> > &all_vertices,
    const unsigned int (&vertex_indices)[GeometryInfo<1>::vertices_per_cell])
   {
@@ -182,43 +182,7 @@ namespace GridTools
 
   template <>
   double
-  cell_measure<1, 2>
-  (const std::vector<Point<2> > &,
-   const unsigned int (&)[GeometryInfo<1>::vertices_per_cell])
-  {
-    Assert(false, ExcNotImplemented());
-    return std::numeric_limits<double>::quiet_NaN();
-  }
-
-
-
-  template <>
-  double
-  cell_measure<1, 3>
-  (const std::vector<Point<3> > &,
-   const unsigned int (&)[GeometryInfo<1>::vertices_per_cell])
-  {
-    Assert(false, ExcNotImplemented());
-    return std::numeric_limits<double>::quiet_NaN();
-  }
-
-
-
-  template <>
-  double
-  cell_measure<2, 3>
-  (const std::vector<Point<3> > &,
-   const unsigned int (&)[GeometryInfo<2>::vertices_per_cell])
-  {
-    Assert(false, ExcNotImplemented());
-    return std::numeric_limits<double>::quiet_NaN();
-  }
-
-
-
-  template <>
-  double
-  cell_measure<3, 3>
+  cell_measure<3>
   (const std::vector<Point<3> > &all_vertices,
    const unsigned int (&vertex_indices)[GeometryInfo<3>::vertices_per_cell])
   {
@@ -342,7 +306,7 @@ namespace GridTools
 
   template <>
   double
-  cell_measure<2, 2>
+  cell_measure<2>
   (const std::vector<Point<2> > &all_vertices,
    const unsigned int (&vertex_indices) [GeometryInfo<2>::vertices_per_cell])
   {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1652,7 +1652,7 @@ namespace internal
                 // throw an exception if no such cells should exist.
                 if (!triangulation.check_for_distorted_cells)
                   {
-                    const double cell_measure = GridTools::cell_measure<1, spacedim>
+                    const double cell_measure = GridTools::cell_measure<1>
                                                 (triangulation.vertices, cells[cell_no].vertices);
                     AssertThrow(cell_measure > 0, ExcGridHasInvalidCell(cell_no));
                   }
@@ -1851,7 +1851,7 @@ namespace internal
                 // See the note in the 1D function on this if statement.
                 if (!triangulation.check_for_distorted_cells)
                   {
-                    const double cell_measure = GridTools::cell_measure<2, spacedim>
+                    const double cell_measure = GridTools::cell_measure<2>
                                                 (triangulation.vertices, cells[cell_no].vertices);
                     AssertThrow(cell_measure > 0, ExcGridHasInvalidCell(cell_no));
                   }
@@ -2234,7 +2234,7 @@ namespace internal
             // See the note in the 1D function on this if statement.
             if (!triangulation.check_for_distorted_cells)
               {
-                const double cell_measure = GridTools::cell_measure<3, spacedim>
+                const double cell_measure = GridTools::cell_measure<3>
                                             (triangulation.vertices, cells[cell_no].vertices);
                 AssertThrow(cell_measure > 0, ExcGridHasInvalidCell(cell_no));
               }


### PR DESCRIPTION
The previous commit 18ddfc4cf1 compiled under GCC but not clang.

This may be a compiler bug; what I did to make things backwards compatible (and work with a space dimension) was pretty questionable, so I suppose I deserve what I got. Here is a minimum working example of something that compiles correctly under GCC but not under clang:

```cpp
#include <iostream>

#include <vector>

template <int dim>
struct
Point
{
  const double& operator[](const std::size_t index) const
  {
    return data[index];
  }
private:
  double data[dim];
};

template <int dim, int spacedim>
double
cell_measure(const std::vector<Point<spacedim> > points,
             const unsigned int (&vertices)[1 << dim])
{
  std::cout << "in original\n";
  (void)points;
  (void)vertices;
  return 0.0*vertices[0] + 1; // does not matter for current purposes
}

template <int dim>
double
cell_measure(const std::vector<Point<dim> > points,
             const unsigned int (&vertices)[1 << dim])
{
  std::cout << "in helper\n";
  return cell_measure<dim, dim>(points, vertices);
}

int main()
{
  static const int dim = 3;
  static const int spacedim = dim;

  std::vector<Point<spacedim> > points;
  unsigned int vertices[1 << dim];
  std::cout << cell_measure<dim>(points, vertices) << '\n';
}
```

I would argue that what GCC does is right when this code is run (it picks the most specialized variant, with two template arguments) but what clang does is wrong (it does not compile at all).

Should fix #2599.