### PR TITLE
implement VectorTools::compute_global_error

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -120,6 +120,13 @@ inconvenience this causes.
 <h3>General</h3>
 
 <ol>
+ <li> New: Add VectorTools::compute_global_error that computes global
+ errors from cellwise errors obtained by VectorTools::integrate_difference()
+ and do MPI collectives if necessary.
+ <br>
+ (Timo Heister, 2016/05/15)
+ </li>
+
  <li> New: Add functions to transform Cartesian coordinates to spherical and back:
  GeometricUtilities::Coordinates::to_spherical and
  GeometricUtilities::Coordinates::from_spherical.

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -367,9 +367,10 @@ namespace Step11
                                        VectorTools::H1_seminorm);
     // Then, the function just called returns its results as a vector of
     // values each of which denotes the norm on one cell. To get the global
-    // norm, a simple computation shows that we have to take the l2 norm of
-    // the vector:
-    const double norm = norm_per_cell.l2_norm();
+    // norm, we do the following:
+    const double norm = VectorTools::compute_global_error(triangulation,
+                                                          norm_per_cell,
+                                                          VectorTools::H1_seminorm);
 
     // Last task -- generate output:
     output_table.add_value ("cells", triangulation.n_active_cells());

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -777,9 +777,9 @@ namespace Step20
   // frequently the case in mixed finite element applications). What we
   // therefore have to do is to `mask' the components that we are interested
   // in. This is easily done: the
-  // <code>VectorTools::integrate_difference</code> function takes as its last
-  // argument a pointer to a weight function (the parameter defaults to the
-  // null pointer, meaning unit weights). What we simply have to do is to pass
+  // <code>VectorTools::integrate_difference</code> function takes as one of its
+  // arguments a pointer to a weight function (the parameter defaults to the
+  // null pointer, meaning unit weights). What we have to do is to pass
   // a function object that equals one in the components we are interested in,
   // and zero in the other ones. For example, to compute the pressure error,
   // we should pass a function that represents the constant vector with a unit
@@ -829,13 +829,17 @@ namespace Step20
                                        cellwise_errors, quadrature,
                                        VectorTools::L2_norm,
                                        &pressure_mask);
-    const double p_l2_error = cellwise_errors.l2_norm();
+    const double p_l2_error = VectorTools::compute_global_error(triangulation,
+                                                                cellwise_errors,
+                                                                VectorTools::L2_norm);
 
     VectorTools::integrate_difference (dof_handler, solution, exact_solution,
                                        cellwise_errors, quadrature,
                                        VectorTools::L2_norm,
                                        &velocity_mask);
-    const double u_l2_error = cellwise_errors.l2_norm();
+    const double u_l2_error = VectorTools::compute_global_error(triangulation,
+                                                                cellwise_errors,
+                                                                VectorTools::L2_norm);
 
     std::cout << "Errors: ||e_p||_L2 = " << p_l2_error
               << ",   ||e_u||_L2 = " << u_l2_error

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -768,8 +768,9 @@ namespace Step34
                                        difference_per_cell,
                                        QGauss<(dim-1)>(2*fe.degree+1),
                                        VectorTools::L2_norm);
-    const double L2_error = difference_per_cell.l2_norm();
-
+    const double L2_error = VectorTools::compute_global_error(triangulation,
+                                                              difference_per_cell,
+                                                              VectorTools::L2_norm);
 
     // The error in the alpha vector can be computed directly using the
     // Vector::linfty_norm() function, since on each node, the value should be

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -525,8 +525,11 @@ namespace Step38
                                        QGauss<dim>(2*fe.degree+1),
                                        VectorTools::H1_norm);
 
+    double h1_error = VectorTools::compute_global_error(triangulation,
+                                                        difference_per_cell,
+                                                        VectorTools::H1_norm);
     std::cout << "H1 error = "
-              << difference_per_cell.l2_norm()
+              << h1_error
               << std::endl;
   }
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -467,7 +467,9 @@ namespace Step48
                                        QGauss<dim>(fe_degree+1),
                                        VectorTools::L2_norm);
     const double solution_norm =
-      std::sqrt(Utilities::MPI::sum (norm_per_cell.norm_sqr(), MPI_COMM_WORLD));
+      VectorTools::compute_global_error(triangulation,
+                                        norm_per_cell,
+                                        VectorTools::L2_norm);
 
     pcout << "   Time:"
           << std::setw(8) << std::setprecision(3) << time

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -1052,7 +1052,9 @@ namespace Step51
                                        QGauss<dim>(fe.degree+2),
                                        VectorTools::L2_norm,
                                        &value_select);
-    const double L2_error = difference_per_cell.l2_norm();
+    const double L2_error = VectorTools::compute_global_error(triangulation,
+                                                              difference_per_cell,
+                                                              VectorTools::L2_norm);
 
     ComponentSelectFunction<dim> gradient_select (std::pair<unsigned int,unsigned int>(0, dim),
                                                   dim+1);
@@ -1063,7 +1065,9 @@ namespace Step51
                                        QGauss<dim>(fe.degree+2),
                                        VectorTools::L2_norm,
                                        &gradient_select);
-    const double grad_error = difference_per_cell.l2_norm();
+    const double grad_error = VectorTools::compute_global_error(triangulation,
+                                                                difference_per_cell,
+                                                                VectorTools::L2_norm);
 
     VectorTools::integrate_difference (dof_handler_u_post,
                                        solution_u_post,
@@ -1071,7 +1075,9 @@ namespace Step51
                                        difference_per_cell,
                                        QGauss<dim>(fe.degree+3),
                                        VectorTools::L2_norm);
-    const double post_error = difference_per_cell.l2_norm();
+    const double post_error = VectorTools::compute_global_error(triangulation,
+                                                                difference_per_cell,
+                                                                VectorTools::L2_norm);
 
     convergence_table.add_value("cells",     triangulation.n_active_cells());
     convergence_table.add_value("dofs",      dof_handler.n_dofs());

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -867,22 +867,26 @@ namespace Step7
                                        difference_per_cell,
                                        QGauss<dim>(3),
                                        VectorTools::L2_norm);
-    const double L2_error = difference_per_cell.l2_norm();
+    const double L2_error = VectorTools::compute_global_error(triangulation,
+                                                              difference_per_cell,
+                                                              VectorTools::L2_norm);
 
     // By same procedure we get the H1 semi-norm. We re-use the
     // <code>difference_per_cell</code> vector since it is no longer used
     // after computing the <code>L2_error</code> variable above. The global
     // $H^1$ semi-norm error is then computed by taking the sum of squares
     // of the errors on each individual cell, and then the square root of
-    // it -- an operation that conveniently again coincides with taking
-    // the $l_2$ norm of the vector of error indicators.
+    // it -- an operation that is conveniently performed by
+    // VectorTools::compute_global_error.
     VectorTools::integrate_difference (dof_handler,
                                        solution,
                                        Solution<dim>(),
                                        difference_per_cell,
                                        QGauss<dim>(3),
                                        VectorTools::H1_seminorm);
-    const double H1_error = difference_per_cell.l2_norm();
+    const double H1_error = VectorTools::compute_global_error(triangulation,
+                                                              difference_per_cell,
+                                                              VectorTools::H1_seminorm);
 
     // Finally, we compute the maximum norm. Of course, we can't actually
     // compute the true maximum, but only the maximum at the quadrature
@@ -896,10 +900,8 @@ namespace Step7
     //
     // Using this special quadrature rule, we can then try to find the maximal
     // error on each cell. Finally, we compute the global L infinity error
-    // from the L infinite errors on each cell. Instead of summing squares, we
-    // now have to take the maximum value over all cell-wise entries, an
-    // operation that is conveniently done using the Vector::linfty()
-    // function:
+    // from the L infinity errors on each cell with a call to
+    // VectorTools::compute_global_error.
     const QTrapez<1>     q_trapez;
     const QIterated<dim> q_iterated (q_trapez, 5);
     VectorTools::integrate_difference (dof_handler,
@@ -908,7 +910,9 @@ namespace Step7
                                        difference_per_cell,
                                        q_iterated,
                                        VectorTools::Linfty_norm);
-    const double Linfty_error = difference_per_cell.linfty_norm();
+    const double Linfty_error = VectorTools::compute_global_error(triangulation,
+                                difference_per_cell,
+                                VectorTools::Linfty_norm);
 
     // After all these errors have been computed, we finally write some
     // output. In addition, we add the important data to the TableHandler by

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -114,3 +114,24 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
       \}
 #endif
   }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+  namespace VectorTools \{
+  template
+    double compute_global_error<deal_II_dimension,deal_II_space_dimension,Vector<float> >(
+    const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
+        const Vector<float> &,
+        const NormType &,
+        const double);
+
+  template
+    double compute_global_error<deal_II_dimension,deal_II_space_dimension,Vector<double> >(
+    const Triangulation<deal_II_dimension,deal_II_space_dimension> &,
+        const Vector<double> &,
+        const NormType &,
+        const double);
+  \}
+#endif
+  }

--- a/tests/mpi/integrate_difference.cc
+++ b/tests/mpi/integrate_difference.cc
@@ -87,15 +87,10 @@ void test()
                                      results,
                                      QGauss<dim>(3),
                                      VectorTools::L2_norm);
-  double local = results.l2_norm() * results.l2_norm();
-  double global;
-
-  MPI_Allreduce (&local, &global, 1, MPI_DOUBLE,
-                 MPI_SUM,
-                 tr.get_communicator());
+  double global = VectorTools::compute_global_error(tr, results, VectorTools::L2_norm);
 
   if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
-    deallog << "difference = " << std::sqrt(global)
+    deallog << "difference = " << global
             << std::endl;
 
   // we have f(\vec x)=x, so the difference
@@ -105,7 +100,7 @@ void test()
   // note that we have used a quadrature
   // formula of sufficient order to get exact
   // results
-  Assert (std::fabs(std::sqrt(global) - 1./std::sqrt(3.)) < 1e-6,
+  Assert (std::fabs(global - 1./std::sqrt(3.)) < 1e-6,
           ExcInternalError());
 }
 

--- a/tests/vector_tools/integrate_difference_02.cc
+++ b/tests/vector_tools/integrate_difference_02.cc
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test integrate_difference and compute_global_error
+
+// see http://www.wolframalpha.com/input/?i=integrate+(x%2By%2Bz)%5E3%2B(x%5E2%2By%5E2)%5E3%2B(z%2Bxy)%5E3+from+x%3D0..1,y%3D0..1,z%3D0..1
+
+#include "../tests.h"
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+using namespace dealii;
+
+
+// x+y+z, x^2+y^2, z+xy
+// div = 1+2y+1
+template <int dim>
+class Ref : public Function<dim>
+{
+public:
+  Ref()
+    :Function<dim>(dim)
+  {}
+
+  double value (const Point<dim> &p, const unsigned int c) const
+  {
+    if (c==0)
+      return p[0]+p[1]+((dim==3)?p[2]:0.0);
+    if (c==1)
+      return p[0]*p[0]+p[1]*p[1];
+    if (c==2)
+      return p[2]+p[0]*p[1];
+    return 0.0;
+  }
+};
+
+
+
+template <int dim>
+void test(VectorTools::NormType norm, double value, double exp = 2.0)
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FESystem<dim> fe(FE_Q<dim>(4),dim);
+  DoFHandler<dim> dofh(tria);
+  dofh.distribute_dofs(fe);
+
+  Vector<double> solution (dofh.n_dofs ());
+  VectorTools::interpolate(dofh, Ref<dim>(), solution);
+
+  Vector<double> cellwise_errors (tria.n_active_cells());
+  QIterated<dim> quadrature (QTrapez<1>(), 5);
+
+  const dealii::Function<dim,double> *w = 0;
+  VectorTools::integrate_difference (dofh,
+                                     solution,
+                                     ZeroFunction<dim>(dim),
+                                     cellwise_errors,
+                                     quadrature,
+                                     norm,
+                                     w,
+                                     exp);
+
+  const double error
+    = VectorTools::compute_global_error(tria, cellwise_errors, norm, exp);
+
+  const double difference = std::abs(error-value);
+  deallog << "computed: " << error
+          << " expected: " << value
+          << " difference: " << difference
+          << std::endl;
+  Assert(difference<2e-3, ExcMessage("Error in integrate_difference"));
+}
+
+template <int dim>
+void test()
+{
+  deallog << "Hdiv_seminorm:" << std::endl;
+  // sqrt(\int (div f)^2 = sqrt(\int (1+2y+1)^2)
+  test<dim>(VectorTools::Hdiv_seminorm, 2.0*std::sqrt(7.0/3.0));
+
+  deallog << "L2_norm:" << std::endl;
+  // sqrt(\int_\Omega f^2) = sqrt(\int (x+y+z)^2+(x^2+y^2)^2+(z+xy)^2)
+  test<dim>(VectorTools::L2_norm, std::sqrt(229.0/60.0));
+
+  deallog << "H1_seminorm:" << std::endl;
+  // sqrt( \int sum_k | d/dxi f_k |_0^2 )
+  // = sqrt( \int 3+ (2x)^2+(2y)^2 + y^2+x^2+1
+  // = sqrt( 22/3  )
+  test<dim>(VectorTools::H1_seminorm, std::sqrt(22.0/3.0));
+
+  deallog << "H1_norm:" << std::endl;
+  test<dim>(VectorTools::H1_norm, std::sqrt(229.0/60.0+22.0/3.0));
+
+  deallog << "L1_norm:" << std::endl;
+  test<dim>(VectorTools::L1_norm, 35.0/12.0);
+
+  deallog << "Linfty_norm:" << std::endl;
+  test<dim>(VectorTools::Linfty_norm, 3.0);
+
+  deallog << "mean:" << std::endl;
+  // int -(x+y+z + x^2+y^2 + z+xy)
+  test<dim>(VectorTools::mean, -35.0/12.0);
+
+  deallog << "Lp_norm:" << std::endl;
+  // (int (x+y+z)^p+(x^2+y^2)^p+(z+xy)^p) ) ^ 1./p
+  // = std::pow(9937.0/1680.0, 1.0/3.0)
+  test<dim>(VectorTools::Lp_norm, std::pow(9937.0/1680.0, 1.0/3.0), 3.0);
+
+  deallog << "W1p_seminorm:" << std::endl;
+  // ( \int_K sum_k | d/dxi f_k |_0^2^(p/2) )^1/p
+  // ( integrate 3^(3/2) + ((2x)^2+(2y)^2)^(3/2) + (y^2+x^2+1)^(3/2) ) ^1/p
+  // = (12.4164) ^1/3 = 2.31560
+  test<dim>(VectorTools::W1p_seminorm, 2.31560, 3.0);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  initlog();
+  test<3>();
+}

--- a/tests/vector_tools/integrate_difference_02.output
+++ b/tests/vector_tools/integrate_difference_02.output
@@ -1,0 +1,20 @@
+
+DEAL::Hdiv_seminorm:
+DEAL::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL::L2_norm:
+DEAL::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL::H1_seminorm:
+DEAL::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL::H1_norm:
+DEAL::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL::L1_norm:
+DEAL::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL::Linfty_norm:
+DEAL::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL::mean:
+DEAL::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL::Lp_norm:
+DEAL::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL::W1p_seminorm:
+DEAL::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL::OK

--- a/tests/vector_tools/integrate_difference_03.cc
+++ b/tests/vector_tools/integrate_difference_03.cc
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test integrate_difference and compute_global_error in parallel
+// see integrate_difference_02.cc for the serial version
+
+#include "../tests.h"
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+using namespace dealii;
+
+
+// x+y+z, x^2+y^2, z+xy
+// div = 1+2y+1
+template <int dim>
+class Ref : public Function<dim>
+{
+public:
+  Ref()
+    :Function<dim>(dim)
+  {}
+
+  double value (const Point<dim> &p, const unsigned int c) const
+  {
+    if (c==0)
+      return p[0]+p[1]+((dim==3)?p[2]:0.0);
+    if (c==1)
+      return p[0]*p[0]+p[1]*p[1];
+    if (c==2)
+      return p[2]+p[0]*p[1];
+    return 0.0;
+  }
+};
+
+
+
+template <int dim>
+void test(VectorTools::NormType norm, double value, double exp = 2.0)
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FESystem<dim> fe(FE_Q<dim>(4),dim);
+  DoFHandler<dim> dofh(tria);
+  dofh.distribute_dofs(fe);
+
+  TrilinosWrappers::MPI::Vector interpolated(dofh.locally_owned_dofs(),
+                                             MPI_COMM_WORLD);
+
+  VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
+
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dofh, relevant_set);
+  TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
+  solution = interpolated;
+
+  Vector<double> cellwise_errors (tria.n_active_cells());
+  QIterated<dim> quadrature (QTrapez<1>(), 5);
+
+  const dealii::Function<dim,double> *w = 0;
+  VectorTools::integrate_difference (dofh,
+                                     solution,
+                                     ZeroFunction<dim>(dim),
+                                     cellwise_errors,
+                                     quadrature,
+                                     norm,
+                                     w,
+                                     exp);
+
+  const double error
+    = VectorTools::compute_global_error(tria, cellwise_errors, norm, exp);
+
+  const double difference = std::abs(error-value);
+  deallog << "computed: " << error
+          << " expected: " << value
+          << " difference: " << difference
+          << std::endl;
+  Assert(difference<2e-3, ExcMessage("Error in integrate_difference"));
+}
+
+template <int dim>
+void test()
+{
+  deallog << "Hdiv_seminorm:" << std::endl;
+  // sqrt(\int (div f)^2 = sqrt(\int (1+2y+1)^2)
+  test<dim>(VectorTools::Hdiv_seminorm, 2.0*std::sqrt(7.0/3.0));
+
+  deallog << "L2_norm:" << std::endl;
+  // sqrt(\int_\Omega f^2) = sqrt(\int (x+y+z)^2+(x^2+y^2)^2+(z+xy)^2)
+  test<dim>(VectorTools::L2_norm, std::sqrt(229.0/60.0));
+
+  deallog << "H1_seminorm:" << std::endl;
+  // sqrt( \int sum_k | d/dxi f_k |_0^2 )
+  // = sqrt( \int 3+ (2x)^2+(2y)^2 + y^2+x^2+1
+  // = sqrt( 22/3  )
+  test<dim>(VectorTools::H1_seminorm, std::sqrt(22.0/3.0));
+
+  deallog << "H1_norm:" << std::endl;
+  test<dim>(VectorTools::H1_norm, std::sqrt(229.0/60.0+22.0/3.0));
+
+  deallog << "L1_norm:" << std::endl;
+  test<dim>(VectorTools::L1_norm, 35.0/12.0);
+
+  deallog << "Linfty_norm:" << std::endl;
+  test<dim>(VectorTools::Linfty_norm, 3.0);
+
+  deallog << "mean:" << std::endl;
+  // int -(x+y+z + x^2+y^2 + z+xy)
+  test<dim>(VectorTools::mean, -35.0/12.0);
+
+  deallog << "Lp_norm:" << std::endl;
+  // (int (x+y+z)^p+(x^2+y^2)^p+(z+xy)^p) ) ^ 1./p
+  // = std::pow(9937.0/1680.0, 1.0/3.0)
+  test<dim>(VectorTools::Lp_norm, std::pow(9937.0/1680.0, 1.0/3.0), 3.0);
+
+  deallog << "W1p_seminorm:" << std::endl;
+  // ( \int_K sum_k | d/dxi f_k |_0^2^(p/2) )^1/p
+  // ( integrate 3^(3/2) + ((2x)^2+(2y)^2)^(3/2) + (y^2+x^2+1)^(3/2) ) ^1/p
+  // = (12.4164) ^1/3 = 2.31560
+  test<dim>(VectorTools::W1p_seminorm, 2.31560, 3.0);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+  test<3>();
+}

--- a/tests/vector_tools/integrate_difference_03.with_trilinos=true.with_p4est=true.mpirun=1.output
+++ b/tests/vector_tools/integrate_difference_03.with_trilinos=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,20 @@
+
+DEAL:0::Hdiv_seminorm:
+DEAL:0::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:0::L2_norm:
+DEAL:0::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:0::H1_seminorm:
+DEAL:0::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:0::H1_norm:
+DEAL:0::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:0::L1_norm:
+DEAL:0::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:0::Linfty_norm:
+DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::mean:
+DEAL:0::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:0::Lp_norm:
+DEAL:0::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:0::W1p_seminorm:
+DEAL:0::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:0::OK

--- a/tests/vector_tools/integrate_difference_03.with_trilinos=true.with_p4est=truempirun=3.output
+++ b/tests/vector_tools/integrate_difference_03.with_trilinos=true.with_p4est=truempirun=3.output
@@ -1,0 +1,62 @@
+
+DEAL:0::Hdiv_seminorm:
+DEAL:0::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:0::L2_norm:
+DEAL:0::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:0::H1_seminorm:
+DEAL:0::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:0::H1_norm:
+DEAL:0::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:0::L1_norm:
+DEAL:0::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:0::Linfty_norm:
+DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::mean:
+DEAL:0::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:0::Lp_norm:
+DEAL:0::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:0::W1p_seminorm:
+DEAL:0::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:0::OK
+
+DEAL:1::Hdiv_seminorm:
+DEAL:1::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:1::L2_norm:
+DEAL:1::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:1::H1_seminorm:
+DEAL:1::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:1::H1_norm:
+DEAL:1::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:1::L1_norm:
+DEAL:1::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:1::Linfty_norm:
+DEAL:1::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:1::mean:
+DEAL:1::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:1::Lp_norm:
+DEAL:1::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:1::W1p_seminorm:
+DEAL:1::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:1::OK
+
+
+DEAL:2::Hdiv_seminorm:
+DEAL:2::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:2::L2_norm:
+DEAL:2::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:2::H1_seminorm:
+DEAL:2::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:2::H1_norm:
+DEAL:2::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:2::L1_norm:
+DEAL:2::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:2::Linfty_norm:
+DEAL:2::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:2::mean:
+DEAL:2::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:2::Lp_norm:
+DEAL:2::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:2::W1p_seminorm:
+DEAL:2::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:2::OK
+

--- a/tests/vector_tools/integrate_difference_04.cc
+++ b/tests/vector_tools/integrate_difference_04.cc
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Test integrate_difference and compute_global_error in parallel
+// see integrate_difference_02.cc for the serial version
+
+#include "../tests.h"
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+using namespace dealii;
+
+
+// x+y+z, x^2+y^2, z+xy
+// div = 1+2y+1
+template <int dim>
+class Ref : public Function<dim>
+{
+public:
+  Ref()
+    :Function<dim>(dim)
+  {}
+
+  double value (const Point<dim> &p, const unsigned int c) const
+  {
+    if (c==0)
+      return p[0]+p[1]+((dim==3)?p[2]:0.0);
+    if (c==1)
+      return p[0]*p[0]+p[1]*p[1];
+    if (c==2)
+      return p[2]+p[0]*p[1];
+    return 0.0;
+  }
+};
+
+
+
+template <int dim>
+void test(VectorTools::NormType norm, double value, double exp = 2.0)
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FESystem<dim> fe(FE_Q<dim>(4),dim);
+  DoFHandler<dim> dofh(tria);
+  dofh.distribute_dofs(fe);
+
+  TrilinosWrappers::MPI::Vector interpolated(dofh.locally_owned_dofs(),
+                                             MPI_COMM_WORLD);
+
+  VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
+
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dofh, relevant_set);
+  TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
+  solution = interpolated;
+
+  Vector<double> cellwise_errors (tria.n_active_cells());
+  QIterated<dim> quadrature (QTrapez<1>(), 5);
+
+  const dealii::Function<dim,double> *w = 0;
+  VectorTools::integrate_difference (dofh,
+                                     solution,
+                                     ZeroFunction<dim>(dim),
+                                     cellwise_errors,
+                                     quadrature,
+                                     norm,
+                                     w,
+                                     exp);
+
+  const double error
+    = VectorTools::compute_global_error(tria, cellwise_errors, norm, exp);
+
+  const double difference = std::abs(error-value);
+  deallog << "computed: " << error
+          << " expected: " << value
+          << " difference: " << difference
+          << std::endl;
+  Assert(difference<2e-3, ExcMessage("Error in integrate_difference"));
+}
+
+template <int dim>
+void test()
+{
+  deallog << "Hdiv_seminorm:" << std::endl;
+  // sqrt(\int (div f)^2 = sqrt(\int (1+2y+1)^2)
+  test<dim>(VectorTools::Hdiv_seminorm, 2.0*std::sqrt(7.0/3.0));
+
+  deallog << "L2_norm:" << std::endl;
+  // sqrt(\int_\Omega f^2) = sqrt(\int (x+y+z)^2+(x^2+y^2)^2+(z+xy)^2)
+  test<dim>(VectorTools::L2_norm, std::sqrt(229.0/60.0));
+
+  deallog << "H1_seminorm:" << std::endl;
+  // sqrt( \int sum_k | d/dxi f_k |_0^2 )
+  // = sqrt( \int 3+ (2x)^2+(2y)^2 + y^2+x^2+1
+  // = sqrt( 22/3  )
+  test<dim>(VectorTools::H1_seminorm, std::sqrt(22.0/3.0));
+
+  deallog << "H1_norm:" << std::endl;
+  test<dim>(VectorTools::H1_norm, std::sqrt(229.0/60.0+22.0/3.0));
+
+  deallog << "L1_norm:" << std::endl;
+  test<dim>(VectorTools::L1_norm, 35.0/12.0);
+
+  deallog << "Linfty_norm:" << std::endl;
+  test<dim>(VectorTools::Linfty_norm, 3.0);
+
+  deallog << "mean:" << std::endl;
+  // int -(x+y+z + x^2+y^2 + z+xy)
+  test<dim>(VectorTools::mean, -35.0/12.0);
+
+  deallog << "Lp_norm:" << std::endl;
+  // (int (x+y+z)^p+(x^2+y^2)^p+(z+xy)^p) ) ^ 1./p
+  // = std::pow(9937.0/1680.0, 1.0/3.0)
+  test<dim>(VectorTools::Lp_norm, std::pow(9937.0/1680.0, 1.0/3.0), 3.0);
+
+  deallog << "W1p_seminorm:" << std::endl;
+  // ( \int_K sum_k | d/dxi f_k |_0^2^(p/2) )^1/p
+  // ( integrate 3^(3/2) + ((2x)^2+(2y)^2)^(3/2) + (y^2+x^2+1)^(3/2) ) ^1/p
+  // = (12.4164) ^1/3 = 2.31560
+  test<dim>(VectorTools::W1p_seminorm, 2.31560, 3.0);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+  test<3>();
+}

--- a/tests/vector_tools/integrate_difference_04.with_trilinos=true.with_metis=true.mpirun=1.output
+++ b/tests/vector_tools/integrate_difference_04.with_trilinos=true.with_metis=true.mpirun=1.output
@@ -1,0 +1,20 @@
+
+DEAL:0::Hdiv_seminorm:
+DEAL:0::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:0::L2_norm:
+DEAL:0::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:0::H1_seminorm:
+DEAL:0::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:0::H1_norm:
+DEAL:0::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:0::L1_norm:
+DEAL:0::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:0::Linfty_norm:
+DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::mean:
+DEAL:0::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:0::Lp_norm:
+DEAL:0::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:0::W1p_seminorm:
+DEAL:0::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:0::OK

--- a/tests/vector_tools/integrate_difference_04.with_trilinos=true.with_metis=true.mpirun=3.output
+++ b/tests/vector_tools/integrate_difference_04.with_trilinos=true.with_metis=true.mpirun=3.output
@@ -1,0 +1,62 @@
+
+DEAL:0::Hdiv_seminorm:
+DEAL:0::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:0::L2_norm:
+DEAL:0::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:0::H1_seminorm:
+DEAL:0::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:0::H1_norm:
+DEAL:0::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:0::L1_norm:
+DEAL:0::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:0::Linfty_norm:
+DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::mean:
+DEAL:0::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:0::Lp_norm:
+DEAL:0::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:0::W1p_seminorm:
+DEAL:0::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:0::OK
+
+DEAL:1::Hdiv_seminorm:
+DEAL:1::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:1::L2_norm:
+DEAL:1::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:1::H1_seminorm:
+DEAL:1::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:1::H1_norm:
+DEAL:1::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:1::L1_norm:
+DEAL:1::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:1::Linfty_norm:
+DEAL:1::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:1::mean:
+DEAL:1::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:1::Lp_norm:
+DEAL:1::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:1::W1p_seminorm:
+DEAL:1::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:1::OK
+
+
+DEAL:2::Hdiv_seminorm:
+DEAL:2::computed: 3.05532 expected: 3.05505 difference: 0.000272760
+DEAL:2::L2_norm:
+DEAL:2::computed: 1.95470 expected: 1.95363 difference: 0.00106613
+DEAL:2::H1_seminorm:
+DEAL:2::computed: 2.70878 expected: 2.70801 difference: 0.000769213
+DEAL:2::H1_norm:
+DEAL:2::computed: 3.34041 expected: 3.33916 difference: 0.00124760
+DEAL:2::L1_norm:
+DEAL:2::computed: 2.91750 expected: 2.91667 difference: 0.000833333
+DEAL:2::Linfty_norm:
+DEAL:2::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:2::mean:
+DEAL:2::computed: -2.91750 expected: -2.91667 difference: 0.000833333
+DEAL:2::Lp_norm:
+DEAL:2::computed: 1.80970 expected: 1.80849 difference: 0.00121796
+DEAL:2::W1p_seminorm:
+DEAL:2::computed: 2.31644 expected: 2.31560 difference: 0.000840093
+DEAL:2::OK
+


### PR DESCRIPTION
add a function that computes global errors from cellwise errors obtained
by VectorTools::integrate_difference(). Do MPI collective if necessary.