### PR TITLE
Move check for C++11 inside if case to not affect non-cuda configuration

### DIFF
--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -19,15 +19,17 @@
 
 MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
 
-  IF(NOT DEAL_II_WITH_CXX11)
-    MESSAGE(FATAL_ERROR "\n"
-      "CUDA only supported with C++11. Reconfigure with DEAL_II_WITH_CXX11=ON.\n"
-      )
-  ENDIF()
 
   FIND_PACKAGE(CUDA)
 
   IF(CUDA_FOUND)
+
+    IF(NOT DEAL_II_WITH_CXX11)
+      MESSAGE(FATAL_ERROR "\n"
+        "CUDA only supported with C++11. Reconfigure with DEAL_II_WITH_CXX11=ON.\n"
+        )
+    ENDIF()
+
     SET(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE FALSE)
 
     # Activate C++11 since we require it above.


### PR DESCRIPTION
CUDA makes no sense without C++11, but check must be made after having loaded CUDA, so as to not pollute the build system. See comment by @Rombur in #2605 .