### PR TITLE
Fix hyphenated lists

### DIFF
--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -595,16 +595,15 @@ namespace Step22
     const FEValuesExtractors::Vector velocities (0);
     const FEValuesExtractors::Scalar pressure (dim);
 
-    // As an extension over step-20 and step-21, we include a few
-    // optimizations that make assembly much faster for this particular
-    // problem.  The improvements are based on the observation that we do a
-    // few calculations too many times when we do as in step-20: The symmetric
-    // gradient actually has <code>dofs_per_cell</code> different values per
-    // quadrature point, but we extract it
-    // <code>dofs_per_cell*dofs_per_cell</code> times from the FEValues object
-    // - for both the loop over <code>i</code> and the inner loop over
-    // <code>j</code>. In 3d, that means evaluating it $89^2=7921$ instead of
-    // $89$ times, a not insignificant difference.
+    // As an extension over step-20 and step-21, we include a few optimizations
+    // that make assembly much faster for this particular problem. The
+    // improvements are based on the observation that we do a few calculations
+    // too many times when we do as in step-20: The symmetric gradient actually
+    // has <code>dofs_per_cell</code> different values per quadrature point, but
+    // we extract it <code>dofs_per_cell*dofs_per_cell</code> times from the
+    // FEValues object - for both the loop over <code>i</code> and the inner
+    // loop over <code>j</code>. In 3d, that means evaluating it $89^2=7921$
+    // instead of $89$ times, a not insignificant difference.
     //
     // So what we're going to do here is to avoid such repeated calculations
     // by getting a vector of rank-2 tensors (and similarly for the divergence

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1417,15 +1417,19 @@ namespace Patterns
  * We can think of the parameters so arranged as a file system in which every
  * parameter is a directory. The name of this directory is the name of the
  * parameter, and in this directory lie files that describe the parameter.
- * These files are: - <code>value</code>: The content of this file is the
- * current value of this parameter; initially, the content of the file equals
- * the default value of the parameter. - <code>default_value</code>: The
- * content of this file is the default value value of the parameter. -
- * <code>pattern</code>: A textual representation of the pattern that
- * describes the parameter's possible values. - <code>pattern_index</code>: A
- * number that indexes the Patterns::PatternBase object that is used to
- * describe the parameter. - <code>documentation</code>: The content of this
- * file is the documentation given for a parameter as the last argument of the
+ * These files are:
+ *
+ * - <code>value</code>: The content of this file is the current value of this
+ * parameter; initially, the content of the file equals the default value of
+ * the parameter.
+ * - <code>default_value</code>: The content of this file is the default value
+ * value of the parameter.
+ * - <code>pattern</code>: A textual representation of the pattern that
+ * describes the parameter's possible values.
+ * - <code>pattern_index</code>: A number that indexes the Patterns::PatternBase
+ * object that is used to describe the parameter.
+ * - <code>documentation</code>: The content of this file is the documentation
+ * given for a parameter as the last argument of the
  * ParameterHandler::declare_entry call. With the exception of the
  * <code>value</code> file, the contents of files are never changed after
  * declaration of a parameter.

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -699,10 +699,11 @@ namespace parallel
        * is
        *
        * - CELL_PERIST: the cell won't be refined/coarsened, but might be
-       * moved to a different processor - CELL_REFINE: this cell will be
-       * refined into 4/8 cells, you can not access the children (because they
-       * don't exist yet) - CELL_COARSEN: the children of this cell will be
-       * coarsened into the given cell (you can access the active children!)
+       * moved to a different processor
+       * - CELL_REFINE: this cell will be refined into 4/8 cells, you can not
+       * access the children (because they don't exist yet)
+       * - CELL_COARSEN: the children of this cell will be coarsened into the
+       * given cell (you can access the active children!)
        *
        * When unpacking the data with notify_ready_to_unpack() you can access
        * the children of the cell if the status is CELL_REFINE but not for

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -698,7 +698,7 @@ namespace parallel
        * can be different than the coarsen and refine flags set by you). If it
        * is
        *
-       * - CELL_PERIST: the cell won't be refined/coarsened, but might be
+       * - CELL_PERSIST: the cell won't be refined/coarsened, but might be
        * moved to a different processor
        * - CELL_REFINE: this cell will be refined into 4/8 cells, you can not
        * access the children (because they don't exist yet)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -135,10 +135,11 @@ struct CellData
   types::manifold_id manifold_id;
 
   /**
-   * Default constructor. Sets the member variables to the following values: -
-   * vertex indices to invalid values - boundary or material id zero (the
-   * default for boundary or material ids) - manifold id to
-   * numbers::invalid_manifold_id
+   * Default constructor. Sets the member variables to the following values:
+   *
+   * - vertex indices to invalid values
+   * - boundary or material id zero (the default for boundary or material ids)
+   * - manifold id to numbers::invalid_manifold_id
    */
   CellData ();
 };

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -405,9 +405,11 @@ private:
   /**
    * A class whose operator() combines two states indicating whether we should
    * continue iterating or stop, and returns a state that dominates. The rules
-   * are: - If one of the two states indicates failure, return failure. -
-   * Otherwise, if one of the two states indicates to continue iterating, then
-   * continue iterating. - Otherwise, return success.
+   * are:
+   * - If one of the two states indicates failure, return failure.
+   * - Otherwise, if one of the two states indicates to continue iterating, then
+   * continue iterating.
+   * - Otherwise, return success.
    */
   struct StateCombiner
   {


### PR DESCRIPTION
It looks like older versions of `wrapcomments.py` (this has apparently since been fixed; I reran the script to be sure) would combine hyphenated lists. This PR splits them out again.

I also fixed a typo while I was in the neighborhood.