### PR TITLE
fix doxygen errors of undefined version macros

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -185,8 +185,9 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_NAMESPACE_OPEN= \
                          DEAL_II_NAMESPACE_CLOSE= \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
-                         DEAL_II_DISABLE_EXTRA_DIAGNOSTICS=
-
+                         DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
+                         DEAL_II_P4EST_VERSION_GTE=1 \
+                         DEAL_II_TRILINOS_VERSION_GTE=1
 
 # do not expand exception declarations
 EXPAND_AS_DEFINED      = DeclExceptionMsg \


### PR DESCRIPTION
This adds the version macros for p4est and Trilinos (always returning 1)
to doxygen. Otherwise doxygen freaks out when parsing header files that
contain them.