### PR TITLE
Avoid semicolons.

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -480,10 +480,10 @@ namespace parallel
 //                         TransferableQuadraturePointData
 //--------------------------------------------------------------------
 inline TransferableQuadraturePointData::TransferableQuadraturePointData()
-{};
+{}
 
 inline TransferableQuadraturePointData::~TransferableQuadraturePointData()
-{};
+{}
 
 //--------------------------------------------------------------------
 //                         CellDataStorage
@@ -492,14 +492,14 @@ inline TransferableQuadraturePointData::~TransferableQuadraturePointData()
 template <typename CellIteratorType, typename DataType>
 CellDataStorage<CellIteratorType,DataType>::
 CellDataStorage()
-{};
+{}
 
 
 
 template <typename CellIteratorType, typename DataType>
 CellDataStorage<CellIteratorType,DataType>::
 ~CellDataStorage()
-{};
+{}
 
 
 


### PR DESCRIPTION
While *declarations* require semicolons, definitions do not. In fact, at namespace
scope (like here), they are strictly speaking wrong.