### PR TITLE
Reduce code duplication in all_reduce.

### DIFF
--- a/tests/mpi/collective_02_dealii_vector.cc
+++ b/tests/mpi/collective_02_dealii_vector.cc
@@ -47,7 +47,7 @@ void test()
     Vector<double> values(2);
     values[0] = 1.5;
     values[1] = 2.5;
-    Vector<double> sums;
+    Vector<double> sums(2);
     Utilities::MPI::sum (values,
                          MPI_COMM_WORLD,
                          sums);


### PR DESCRIPTION
There were previously four versions of this function that all did approximately the same thing.

I fixed a test that failed as a result of this change.