### PR TITLE
Fix symmetric tensor operator

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -690,13 +690,17 @@ public:
   operator [] (const unsigned int row);
 
   /**
-   * Access to an element where you specify the entire set of indices.
+   * Return an element by value.
+   *
+   * Exactly the same as operator().
    */
   Number
   operator [] (const TableIndices<rank> &indices) const;
 
   /**
-   * Access to an element where you specify the entire set of indices.
+   * Return a read-write reference to the indicated element.
+   *
+   * Exactly the same as operator().
    */
   Number &
   operator [] (const TableIndices<rank> &indices);
@@ -1651,7 +1655,7 @@ inline
 Number
 SymmetricTensor<rank,dim,Number>::operator [] (const TableIndices<rank> &indices) const
 {
-  return data[component_to_unrolled_index(indices)];
+  return operator()(indices);
 }
 
 
@@ -1661,7 +1665,7 @@ inline
 Number &
 SymmetricTensor<rank,dim,Number>::operator [] (const TableIndices<rank> &indices)
 {
-  return data[component_to_unrolled_index(indices)];
+  return operator()(indices);
 }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -667,11 +667,7 @@ public:
   Number &operator() (const TableIndices<rank> &indices);
 
   /**
-   * Return the value of the indicated element as a read-only reference.
-   *
-   * We return the requested value as a constant reference rather than by
-   * value since this object may hold data types that may be large, and we
-   * don't know here whether copying is expensive or not.
+   * Return an element by value.
    */
   Number operator() (const TableIndices<rank> &indices) const;
 

--- a/tests/base/symmetric_tensor_30.cc
+++ b/tests/base/symmetric_tensor_30.cc
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Verify that SymmetricTensor::operator() and SymmetricTensor::operator[] do
+// what we think they should do.
+
+#include "../tests.h"
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/table_indices.h>
+#include <deal.II/base/logstream.h>
+
+
+template <int dim>
+void check_2 ()
+{
+  using namespace dealii;
+  Testing::rand(true, 42);
+
+  SymmetricTensor<2, dim> change_with_brackets;
+  SymmetricTensor<2, dim> change_with_parentheses;
+  for (unsigned int k = 0; k < dim; ++k)
+    {
+      for (unsigned int l = 0; l < dim; ++l)
+        {
+          const double entry = double(Testing::rand());
+          TableIndices<2> indices(k, l);
+
+          // check assignment
+          change_with_brackets[indices] = entry;
+          change_with_parentheses(indices) = entry;
+          AssertThrow(change_with_brackets[k][l] == entry,
+                      ExcMessage("Entries should match"));
+          AssertThrow(change_with_parentheses[k][l] == entry,
+                      ExcMessage("Entries should match"));
+
+          // and access
+          const double brackets_entry = change_with_brackets[indices];
+          const double parentheses_entry = change_with_parentheses(indices);
+          AssertThrow(brackets_entry == entry,
+                      ExcMessage("Entries should match"));
+          AssertThrow(parentheses_entry == entry,
+                      ExcMessage("Entries should match"));
+        }
+    }
+}
+
+template <int dim>
+void check_4 ()
+{
+  using namespace dealii;
+  Testing::rand(true, 42);
+
+  SymmetricTensor<4, dim> change_with_brackets;
+  SymmetricTensor<4, dim> change_with_parentheses;
+  for (unsigned int i = 0; i < dim; ++i)
+    {
+      for (unsigned int j = 0; j < dim; ++j)
+        {
+          for (unsigned int k = 0; k < dim; ++k)
+            {
+              for (unsigned int l = 0; l < dim; ++l)
+                {
+                  const double entry = double(Testing::rand());
+                  TableIndices<4> indices(i, j, k, l);
+
+                  // check assignment
+                  change_with_brackets[indices] = entry;
+                  change_with_parentheses(indices) = entry;
+                  AssertThrow(change_with_brackets[i][j][k][l] == entry,
+                              ExcMessage("Entries should match"));
+                  AssertThrow(change_with_parentheses[i][j][k][l] == entry,
+                              ExcMessage("Entries should match"));
+
+                  // and access
+                  const double brackets_entry = change_with_brackets[indices];
+                  const double parentheses_entry = change_with_parentheses(indices);
+                  AssertThrow(brackets_entry == entry,
+                              ExcMessage("Entries should match"));
+                  AssertThrow(parentheses_entry == entry,
+                              ExcMessage("Entries should match"));
+                }
+            }
+        }
+    }
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  deallog << "check rank 2 tensors" << std::endl;
+  check_2<1>();
+  check_2<2>();
+  check_2<3>();
+
+  deallog << "check rank 4 tensors" << std::endl;
+  check_4<1>();
+  check_4<2>();
+  check_4<3>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/base/symmetric_tensor_30.output
+++ b/tests/base/symmetric_tensor_30.output
@@ -1,0 +1,4 @@
+
+DEAL::check rank 2 tensors
+DEAL::check rank 4 tensors
+DEAL::OK


### PR DESCRIPTION
As was discussed in #2649, `SymmetricTensor::operator[]` should be rank dependent. Fortunately the work for this has already been done: we can just alias that operator to `operator()`.

I fixed what looks like an old copy paste error while I was in the neighborhood.

Closes #2649.