### PR TITLE
Clean up mpi header

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -2,6 +2,14 @@ BOOL            := { true; false }
 REAL_SCALARS    := { double; float }
 COMPLEX_SCALARS := { std::complex<double>;
                      std::complex<float> }
+MPI_SCALARS     := { int;
+                     long int;
+                     unsigned int;
+                     unsigned long int;
+                     unsigned long long int;
+                     float;
+                     double;
+                     long double }
 
 DERIVATIVE_TENSORS := { double;
                         Tensor<1,deal_II_dimension>;

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -471,20 +471,6 @@ namespace Utilities
       internal::all_reduce(MPI_MIN, values, mpi_communicator, minima, N);
     }
 #endif
-
-
-    inline
-    bool job_supports_mpi ()
-    {
-#ifdef DEAL_II_WITH_MPI
-      int MPI_has_been_started = 0;
-      MPI_Initialized(&MPI_has_been_started);
-
-      return (MPI_has_been_started > 0);
-#else
-      return false;
-#endif
-    }
   } // end of namespace MPI
 } // end of namespace Utilities
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -17,6 +17,7 @@
 #define dealii__mpi_h
 
 #include <deal.II/base/config.h>
+
 #include <vector>
 
 #if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_WITH_PETSC)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -434,282 +434,43 @@ namespace Utilities
      */
     bool job_supports_mpi ();
 
+#ifndef DOXYGEN
+    // declaration for an internal function that lives in mpi.templates.h
     namespace internal
     {
-#ifdef DEAL_II_WITH_MPI
-      /**
-       * Return the corresponding MPI data type id for the argument given.
-       */
-      inline MPI_Datatype mpi_type_id (const int *)
-      {
-        return MPI_INT;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const long int *)
-      {
-        return MPI_LONG;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const unsigned int *)
-      {
-        return MPI_UNSIGNED;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const unsigned long int *)
-      {
-        return MPI_UNSIGNED_LONG;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const unsigned long long int *)
-      {
-        return MPI_UNSIGNED_LONG_LONG;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const float *)
-      {
-        return MPI_FLOAT;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const double *)
-      {
-        return MPI_DOUBLE;
-      }
-
-
-      inline MPI_Datatype mpi_type_id (const long double *)
-      {
-        return MPI_LONG_DOUBLE;
-      }
-#endif
-
       template <typename T>
-      inline
       void all_reduce (const MPI_Op      &mpi_op,
                        const T *const    values,
                        const MPI_Comm    &mpi_communicator,
                        T                 *output,
-                       const std::size_t  size)
-      {
-#ifdef DEAL_II_WITH_MPI
-        if (job_supports_mpi())
-          {
-            MPI_Allreduce (values != output
-                           ?
-                           // TODO This const_cast is only needed for older
-                           // (e.g., openMPI 1.6, released in 2012)
-                           // implementations of MPI-2. It is not needed as of
-                           // MPI-3 and we should remove it at some point in
-                           // the future.
-                           const_cast<void *>(static_cast<const void *> (values))
-                           :
-                           MPI_IN_PLACE,
-                           static_cast<void *>(output),
-                           static_cast<int>(size),
-                           internal::mpi_type_id(values),
-                           mpi_op,
-                           mpi_communicator);
-          }
-        else
-#endif
-          {
-            (void)mpi_op;
-            (void)mpi_communicator;
-            for (std::size_t i=0; i<size; ++i)
-              output[i] = values[i];
-          }
-      }
-
-      template <typename T>
-      inline
-      T all_reduce (const MPI_Op &mpi_op,
-                    const T &t,
-                    const MPI_Comm &mpi_communicator)
-      {
-        T output;
-        all_reduce(mpi_op, &t, mpi_communicator, &output, 1);
-        return output;
-      }
-
-      template <typename T, unsigned int N>
-      inline
-      void all_reduce (const MPI_Op &mpi_op,
-                       const T (&values)[N],
-                       const MPI_Comm &mpi_communicator,
-                       T (&output)[N])
-      {
-        all_reduce(mpi_op, values, mpi_communicator, output, N);
-      }
-
-      template <typename T>
-      inline
-      void all_reduce (const MPI_Op &mpi_op,
-                       const std::vector<T> &values,
-                       const MPI_Comm       &mpi_communicator,
-                       std::vector<T>       &output)
-      {
-        Assert(values.size() == output.size(),
-               ExcDimensionMismatch(values.size(), output.size()));
-        all_reduce(mpi_op, &values[0], mpi_communicator, &output[0], values.size());
-      }
-
-      template <typename T>
-      inline
-      void all_reduce (const MPI_Op    &mpi_op,
-                       const Vector<T> &values,
-                       const MPI_Comm  &mpi_communicator,
-                       Vector<T>  &output)
-      {
-        Assert(values.size() == output.size(),
-               ExcDimensionMismatch(values.size(), output.size()));
-        all_reduce(mpi_op, values.begin(), mpi_communicator, output.begin(), values.size());
-      }
+                       const std::size_t  size);
     }
 
-
-    template <typename T>
-    inline
-    T sum (const T &t,
-           const MPI_Comm &mpi_communicator)
-    {
-      return internal::all_reduce(MPI_SUM, t, mpi_communicator);
-    }
-
-
+    // Since these depend on N they must live in the header file
     template <typename T, unsigned int N>
-    inline
     void sum (const T (&values)[N],
               const MPI_Comm &mpi_communicator,
               T (&sums)[N])
     {
-      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
+      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums, N);
     }
-
-
-    template <typename T>
-    inline
-    void sum (const std::vector<T> &values,
-              const MPI_Comm       &mpi_communicator,
-              std::vector<T>       &sums)
-    {
-      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
-    }
-
-    template <typename T>
-    inline
-    void sum (const Vector<T> &values,
-              const MPI_Comm &mpi_communicator,
-              Vector<T> &sums)
-    {
-      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
-    }
-
-
-    template <int rank, int dim, typename Number>
-    inline
-    Tensor<rank,dim,Number>
-    sum (const Tensor<rank,dim,Number> &local,
-         const MPI_Comm &mpi_communicator)
-    {
-      const unsigned int n_entries = Tensor<rank,dim,Number>::n_independent_components;
-      Number entries[ Tensor<rank,dim,Number>::n_independent_components ];
-
-      for (unsigned int i=0; i< n_entries; ++i)
-        entries[i] = local[ local.unrolled_to_component_indices(i) ];
-
-      Number global_entries[ Tensor<rank,dim,Number>::n_independent_components ];
-      dealii::Utilities::MPI::sum( entries, mpi_communicator, global_entries );
-
-      Tensor<rank,dim,Number> global;
-      for (unsigned int i=0; i< n_entries; ++i)
-        global[ global.unrolled_to_component_indices(i) ] = global_entries[i];
-
-      return global;
-    }
-
-    template <int rank, int dim, typename Number>
-    inline
-    SymmetricTensor<rank,dim,Number>
-    sum (const SymmetricTensor<rank,dim,Number> &local,
-         const MPI_Comm &mpi_communicator)
-    {
-      const unsigned int n_entries = SymmetricTensor<rank,dim,Number>::n_independent_components;
-      Number entries[ SymmetricTensor<rank,dim,Number>::n_independent_components ];
-
-      for (unsigned int i=0; i< n_entries; ++i)
-        entries[i] = local[ local.unrolled_to_component_indices(i) ];
-
-      Number global_entries[ SymmetricTensor<rank,dim,Number>::n_independent_components ];
-      dealii::Utilities::MPI::sum( entries, mpi_communicator, global_entries );
-
-      SymmetricTensor<rank,dim,Number> global;
-      for (unsigned int i=0; i< n_entries; ++i)
-        global[ global.unrolled_to_component_indices(i) ] = global_entries[i];
-
-      return global;
-    }
-
-    template <typename T>
-    inline
-    T max (const T &t,
-           const MPI_Comm &mpi_communicator)
-    {
-      return internal::all_reduce(MPI_MAX, t, mpi_communicator);
-    }
-
 
     template <typename T, unsigned int N>
-    inline
     void max (const T (&values)[N],
               const MPI_Comm &mpi_communicator,
               T (&maxima)[N])
     {
-      internal::all_reduce(MPI_MAX, values, mpi_communicator, maxima);
+      internal::all_reduce(MPI_MAX, values, mpi_communicator, maxima, N);
     }
-
-
-    template <typename T>
-    inline
-    void max (const std::vector<T> &values,
-              const MPI_Comm       &mpi_communicator,
-              std::vector<T>       &maxima)
-    {
-      internal::all_reduce(MPI_MAX, values, mpi_communicator, maxima);
-    }
-
-
-    template <typename T>
-    inline
-    T min (const T &t,
-           const MPI_Comm &mpi_communicator)
-    {
-      return internal::all_reduce(MPI_MIN, t, mpi_communicator);
-    }
-
 
     template <typename T, unsigned int N>
-    inline
     void min (const T (&values)[N],
               const MPI_Comm &mpi_communicator,
               T (&minima)[N])
     {
-      internal::all_reduce(MPI_MIN, values, mpi_communicator, minima);
+      internal::all_reduce(MPI_MIN, values, mpi_communicator, minima, N);
     }
-
-
-    template <typename T>
-    inline
-    void min (const std::vector<T> &values,
-              const MPI_Comm       &mpi_communicator,
-              std::vector<T>       &minima)
-    {
-      internal::all_reduce(MPI_MIN, values, mpi_communicator, minima);
-    }
+#endif
 
 
     inline

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -28,15 +28,7 @@ typedef int MPI_Comm;
 const int MPI_COMM_SELF = 0;
 typedef int MPI_Datatype;
 typedef int MPI_Op;
-namespace MPI
-{
-  static const unsigned int UNSIGNED = 0;
-  static const unsigned int LONG_DOUBLE = 0;
-  static const unsigned int LONG_DOUBLE_COMPLEX = 0;
-  static const unsigned int MAX = 0;
-  static const unsigned int MIN = 0;
-  static const unsigned int SUM = 0;
-}
+
 static const int MPI_MIN = 0;
 static const int MPI_MAX = 0;
 static const int MPI_SUM = 0;

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -1,0 +1,263 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2011 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__mpi_templates_h
+#define dealii__mpi_templates_h
+
+#include <deal.II/base/config.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/lac/vector.h>
+
+#include <vector>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace Utilities
+{
+  namespace MPI
+  {
+    namespace internal
+    {
+#ifdef DEAL_II_WITH_MPI
+      /**
+       * Return the corresponding MPI data type id for the argument given.
+       */
+      MPI_Datatype mpi_type_id (const int *)
+      {
+        return MPI_INT;
+      }
+
+
+      MPI_Datatype mpi_type_id (const long int *)
+      {
+        return MPI_LONG;
+      }
+
+
+      MPI_Datatype mpi_type_id (const unsigned int *)
+      {
+        return MPI_UNSIGNED;
+      }
+
+
+      MPI_Datatype mpi_type_id (const unsigned long int *)
+      {
+        return MPI_UNSIGNED_LONG;
+      }
+
+
+      MPI_Datatype mpi_type_id (const unsigned long long int *)
+      {
+        return MPI_UNSIGNED_LONG_LONG;
+      }
+
+
+      MPI_Datatype mpi_type_id (const float *)
+      {
+        return MPI_FLOAT;
+      }
+
+
+      MPI_Datatype mpi_type_id (const double *)
+      {
+        return MPI_DOUBLE;
+      }
+
+
+      MPI_Datatype mpi_type_id (const long double *)
+      {
+        return MPI_LONG_DOUBLE;
+      }
+#endif
+
+      template <typename T>
+      void all_reduce (const MPI_Op      &mpi_op,
+                       const T *const    values,
+                       const MPI_Comm    &mpi_communicator,
+                       T                 *output,
+                       const std::size_t  size)
+      {
+#ifdef DEAL_II_WITH_MPI
+        if (job_supports_mpi())
+          {
+            MPI_Allreduce (values != output
+                           ?
+                           // TODO This const_cast is only needed for older
+                           // (e.g., openMPI 1.6, released in 2012)
+                           // implementations of MPI-2. It is not needed as of
+                           // MPI-3 and we should remove it at some point in
+                           // the future.
+                           const_cast<void *>(static_cast<const void *>(values))
+                           :
+                           MPI_IN_PLACE,
+                           static_cast<void *>(output),
+                           static_cast<int>(size),
+                           internal::mpi_type_id(values),
+                           mpi_op,
+                           mpi_communicator);
+          }
+        else
+#endif
+          {
+            (void)mpi_op;
+            (void)mpi_communicator;
+            for (std::size_t i=0; i<size; ++i)
+              output[i] = values[i];
+          }
+      }
+
+      template <typename T>
+      T all_reduce (const MPI_Op &mpi_op,
+                    const T &t,
+                    const MPI_Comm &mpi_communicator)
+      {
+        T output;
+        all_reduce(mpi_op, &t, mpi_communicator, &output, 1);
+        return output;
+      }
+
+      template <typename T>
+      void all_reduce (const MPI_Op &mpi_op,
+                       const std::vector<T> &values,
+                       const MPI_Comm       &mpi_communicator,
+                       std::vector<T>       &output)
+      {
+        Assert(values.size() == output.size(),
+               ExcDimensionMismatch(values.size(), output.size()));
+        all_reduce(mpi_op, &values[0], mpi_communicator, &output[0], values.size());
+      }
+
+      template <typename T>
+      void all_reduce (const MPI_Op    &mpi_op,
+                       const Vector<T> &values,
+                       const MPI_Comm  &mpi_communicator,
+                       Vector<T>  &output)
+      {
+        Assert(values.size() == output.size(),
+               ExcDimensionMismatch(values.size(), output.size()));
+        all_reduce(mpi_op, values.begin(), mpi_communicator, output.begin(), values.size());
+      }
+    }
+
+
+    template <typename T>
+    T sum (const T &t,
+           const MPI_Comm &mpi_communicator)
+    {
+      return internal::all_reduce(MPI_SUM, t, mpi_communicator);
+    }
+
+
+    template <typename T>
+    void sum (const std::vector<T> &values,
+              const MPI_Comm       &mpi_communicator,
+              std::vector<T>       &sums)
+    {
+      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
+    }
+
+    template <typename T>
+    void sum (const Vector<T> &values,
+              const MPI_Comm &mpi_communicator,
+              Vector<T> &sums)
+    {
+      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
+    }
+
+
+    template <int rank, int dim, typename Number>
+    Tensor<rank,dim,Number>
+    sum (const Tensor<rank,dim,Number> &local,
+         const MPI_Comm &mpi_communicator)
+    {
+      const unsigned int n_entries = Tensor<rank,dim,Number>::n_independent_components;
+      Number entries[ Tensor<rank,dim,Number>::n_independent_components ];
+
+      for (unsigned int i=0; i< n_entries; ++i)
+        entries[i] = local[ local.unrolled_to_component_indices(i) ];
+
+      Number global_entries[ Tensor<rank,dim,Number>::n_independent_components ];
+      dealii::Utilities::MPI::sum( entries, mpi_communicator, global_entries );
+
+      Tensor<rank,dim,Number> global;
+      for (unsigned int i=0; i< n_entries; ++i)
+        global[ global.unrolled_to_component_indices(i) ] = global_entries[i];
+
+      return global;
+    }
+
+    template <int rank, int dim, typename Number>
+    SymmetricTensor<rank,dim,Number>
+    sum (const SymmetricTensor<rank,dim,Number> &local,
+         const MPI_Comm &mpi_communicator)
+    {
+      const unsigned int n_entries = SymmetricTensor<rank,dim,Number>::n_independent_components;
+      Number entries[ SymmetricTensor<rank,dim,Number>::n_independent_components ];
+
+      for (unsigned int i=0; i< n_entries; ++i)
+        entries[i] = local[ local.unrolled_to_component_indices(i) ];
+
+      Number global_entries[ SymmetricTensor<rank,dim,Number>::n_independent_components ];
+      dealii::Utilities::MPI::sum( entries, mpi_communicator, global_entries );
+
+      SymmetricTensor<rank,dim,Number> global;
+      for (unsigned int i=0; i< n_entries; ++i)
+        global[ global.unrolled_to_component_indices(i) ] = global_entries[i];
+
+      return global;
+    }
+
+    template <typename T>
+    T max (const T &t,
+           const MPI_Comm &mpi_communicator)
+    {
+      return internal::all_reduce(MPI_MAX, t, mpi_communicator);
+    }
+
+
+    template <typename T>
+    void max (const std::vector<T> &values,
+              const MPI_Comm       &mpi_communicator,
+              std::vector<T>       &maxima)
+    {
+      internal::all_reduce(MPI_MAX, values, mpi_communicator, maxima);
+    }
+
+
+    template <typename T>
+    T min (const T &t,
+           const MPI_Comm &mpi_communicator)
+    {
+      return internal::all_reduce(MPI_MIN, t, mpi_communicator);
+    }
+
+
+    template <typename T>
+    void min (const std::vector<T> &values,
+              const MPI_Comm       &mpi_communicator,
+              std::vector<T>       &minima)
+    {
+      internal::all_reduce(MPI_MIN, values, mpi_communicator, minima);
+    }
+  } // end of namespace MPI
+} // end of namespace Utilities
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -33,6 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, typename Number> class Point;
 template <int rank_, int dim, typename Number = double> class Tensor;
+template <typename Number> class Vector;
 
 #ifndef DOXYGEN
 // Overload invalid tensor types of negative rank that come up during

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/mpi.h>
 
 #include <vector>
 #include <utility>

--- a/include/deal.II/lac/parallel_vector.h
+++ b/include/deal.II/lac/parallel_vector.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/index_set.h>
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -17,7 +17,6 @@
 #define dealii__vector_space_vector_h
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/lac/vector.h>

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(_inst
   data_out_base.inst.in
   function.inst.in
   function_time.inst.in
+  mpi.inst.in
   polynomials_rannacher_turek.inst.in
   tensor_function.inst.in
   time_stepping.inst.in

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/index_set.h>
 #include <list>
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/lac/vector_memory.h>
@@ -506,10 +507,9 @@ namespace Utilities
         }
 #endif
     }
-
-
+#include "mpi.inst"
+    }
   } // end of namespace MPI
-
 } // end of namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -58,39 +58,21 @@ namespace Utilities
   namespace MPI
   {
 #ifdef DEAL_II_WITH_MPI
-    // Unfortunately, we have to work
-    // around an oddity in the way PETSc
-    // and some gcc versions interact. If
-    // we use PETSc's MPI dummy
-    // implementation, it expands the
-    // calls to the two MPI functions
-    // basically as ``(n_jobs=1, 0)'',
-    // i.e. it assigns the number one to
-    // the variable holding the number of
-    // jobs, and then uses the comma
-    // operator to let the entire
-    // expression have the value zero. The
-    // latter is important, since
-    // ``MPI_Comm_size'' returns an error
-    // code that we may want to check (we
-    // don't here, but one could in
-    // principle), and the trick with the
-    // comma operator makes sure that both
-    // the number of jobs is correctly
-    // assigned, and the return value is
-    // zero. Unfortunately, if some recent
-    // versions of gcc detect that the
-    // comma expression just stands by
-    // itself, i.e. the result is not
-    // assigned to another variable, then
-    // they warn ``right-hand operand of
-    // comma has no effect''. This
-    // unwanted side effect can be
-    // suppressed by casting the result of
-    // the entire expression to type
-    // ``void'' -- not beautiful, but
-    // helps calming down unwarranted
-    // compiler warnings...
+    // Unfortunately, we have to work around an oddity in the way PETSc and
+    // some gcc versions interact. If we use PETSc's MPI dummy implementation,
+    // it expands the calls to the two MPI functions basically as ``(n_jobs=1,
+    // 0)'', i.e. it assigns the number one to the variable holding the number
+    // of jobs, and then uses the comma operator to let the entire expression
+    // have the value zero. The latter is important, since ``MPI_Comm_size''
+    // returns an error code that we may want to check (we don't here, but one
+    // could in principle), and the trick with the comma operator makes sure
+    // that both the number of jobs is correctly assigned, and the return
+    // value is zero. Unfortunately, if some recent versions of gcc detect
+    // that the comma expression just stands by itself, i.e. the result is not
+    // assigned to another variable, then they warn ``right-hand operand of
+    // comma has no effect''. This unwanted side effect can be suppressed by
+    // casting the result of the entire expression to type ``void'' -- not
+    // beautiful, but helps calming down unwarranted compiler warnings...
     unsigned int n_mpi_processes (const MPI_Comm &mpi_communicator)
     {
       int n_jobs=1;
@@ -133,10 +115,8 @@ namespace Utilities
         }
 
 
-      // let all processors
-      // communicate the maximal
-      // number of destinations they
-      // have
+      // let all processors communicate the maximal number of destinations
+      // they have
       const unsigned int max_n_destinations
         = Utilities::MPI::max (destinations.size(), mpi_comm);
 
@@ -144,36 +124,25 @@ namespace Utilities
         // all processes have nothing to send/receive:
         return std::vector<unsigned int>();
 
-      // now that we know the number
-      // of data packets every
-      // processor wants to send, set
-      // up a buffer with the maximal
-      // size and copy our
-      // destinations in there,
-      // padded with -1's
+      // now that we know the number of data packets every processor wants to
+      // send, set up a buffer with the maximal size and copy our destinations
+      // in there, padded with -1's
       std::vector<unsigned int> my_destinations(max_n_destinations,
                                                 numbers::invalid_unsigned_int);
       std::copy (destinations.begin(), destinations.end(),
                  my_destinations.begin());
 
-      // now exchange these (we could
-      // communicate less data if we
-      // used MPI_Allgatherv, but
-      // we'd have to communicate
-      // my_n_destinations to all
-      // processors in this case,
-      // which is more expensive than
-      // the reduction operation
-      // above in MPI_Allreduce)
+      // now exchange these (we could communicate less data if we used
+      // MPI_Allgatherv, but we'd have to communicate my_n_destinations to all
+      // processors in this case, which is more expensive than the reduction
+      // operation above in MPI_Allreduce)
       std::vector<unsigned int> all_destinations (max_n_destinations * n_procs);
       MPI_Allgather (&my_destinations[0], max_n_destinations, MPI_UNSIGNED,
                      &all_destinations[0], max_n_destinations, MPI_UNSIGNED,
                      mpi_comm);
 
-      // now we know who is going to
-      // communicate with
-      // whom. collect who is going
-      // to communicate with us!
+      // now we know who is going to communicate with whom. collect who is
+      // going to communicate with us!
       std::vector<unsigned int> origins;
       for (unsigned int i=0; i<n_procs; ++i)
         for (unsigned int j=0; j<max_n_destinations; ++j)
@@ -363,12 +332,12 @@ namespace Utilities
       AssertThrow (mpi_err == 0,
                    ExcMessage ("MPI could not be initialized."));
 
-      // disable for now because at least some implementations always return MPI_THREAD_SINGLE.
+      // disable for now because at least some implementations always return
+      // MPI_THREAD_SINGLE.
       //Assert(max_num_threads==1 || provided != MPI_THREAD_SINGLE,
       //    ExcMessage("MPI reports that we are not allowed to use multiple threads."));
 #else
-      // make sure the compiler doesn't warn
-      // about these variables
+      // make sure the compiler doesn't warn about these variables
       (void)argc;
       (void)argv;
 #endif
@@ -392,19 +361,18 @@ namespace Utilities
       if (max_num_threads != numbers::invalid_unsigned_int)
         {
           // set maximum number of threads (also respecting the environment
-          // variable that the called function evaluates) based on what
-          // the user asked
+          // variable that the called function evaluates) based on what the
+          // user asked
           MultithreadInfo::set_thread_limit(max_num_threads);
         }
       else
         // user wants automatic choice
         {
 #ifdef DEAL_II_WITH_MPI
-          // we need to figure out how many MPI processes there
-          // are on the current node, as well as how many CPU cores
-          // we have. for the first task, check what get_hostname()
-          // returns and then to an allgather so each processor
-          // gets the answer
+          // we need to figure out how many MPI processes there are on the
+          // current node, as well as how many CPU cores we have. for the
+          // first task, check what get_hostname() returns and then to an
+          // allgather so each processor gets the answer
           //
           // in calculating the length of the string, don't forget the
           // terminating \0 on C-style strings
@@ -421,8 +389,8 @@ namespace Utilities
                          &all_hostnames[0], max_hostname_size, MPI_CHAR,
                          MPI_COMM_WORLD);
 
-          // search how often our own hostname appears and the
-          // how-manyth instance the current process represents
+          // search how often our own hostname appears and the how-manyth
+          // instance the current process represents
           unsigned int n_local_processes=0;
           unsigned int nth_process_on_host = 0;
           for (unsigned int i=0; i<MPI::n_mpi_processes(MPI_COMM_WORLD); ++i)
@@ -435,12 +403,12 @@ namespace Utilities
           Assert (nth_process_on_host > 0, ExcInternalError());
 
 
-          // compute how many cores each process gets. if the number does
-          // not divide evenly, then we get one more core if we are
-          // among the first few processes
+          // compute how many cores each process gets. if the number does not
+          // divide evenly, then we get one more core if we are among the
+          // first few processes
           //
-          // if the number would be zero, round up to one since every
-          // process needs to have at least one thread
+          // if the number would be zero, round up to one since every process
+          // needs to have at least one thread
           const unsigned int n_threads
             = std::max(MultithreadInfo::n_cores() / n_local_processes
                        +
@@ -462,11 +430,10 @@ namespace Utilities
 
     MPI_InitFinalize::~MPI_InitFinalize()
     {
-      // make memory pool release all PETSc/Trilinos/MPI-based vectors that are no
-      // longer used at this point. this is relevant because the
-      // static object destructors run for these vectors at the end of
-      // the program would run after MPI_Finalize is called, leading
-      // to errors
+      // make memory pool release all PETSc/Trilinos/MPI-based vectors that
+      // are no longer used at this point. this is relevant because the static
+      // object destructors run for these vectors at the end of the program
+      // would run after MPI_Finalize is called, leading to errors
 
 #ifdef DEAL_II_WITH_MPI
       // Start with the deal.II MPI vectors (need to do this before finalizing
@@ -490,8 +457,8 @@ namespace Utilities
 #endif
 
 
-      // Now deal with PETSc (with or without MPI). Only delete the vectors if finalize hasn't
-      // been called yet, otherwise this will lead to errors.
+      // Now deal with PETSc (with or without MPI). Only delete the vectors if
+      // finalize hasn't been called yet, otherwise this will lead to errors.
 #ifdef DEAL_II_WITH_PETSC
       if ((PetscInitializeCalled == PETSC_TRUE)
           &&
@@ -518,8 +485,8 @@ namespace Utilities
 
 
       // only MPI_Finalize if we are running with MPI. We also need to do this
-      // when running PETSc, because we initialize MPI ourselves before calling
-      // PetscInitialize
+      // when running PETSc, because we initialize MPI ourselves before
+      // calling PetscInitialize
 #ifdef DEAL_II_WITH_MPI
       if (job_supports_mpi() == true)
         {

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -22,7 +22,6 @@
 #include <deal.II/lac/parallel_block_vector.h>
 #include <deal.II/base/multithread_info.h>
 
-#include <cstddef>
 #include <iostream>
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -507,8 +507,24 @@ namespace Utilities
         }
 #endif
     }
-#include "mpi.inst"
+
+
+
+    bool job_supports_mpi ()
+    {
+#ifdef DEAL_II_WITH_MPI
+      int MPI_has_been_started = 0;
+      MPI_Initialized(&MPI_has_been_started);
+
+      return (MPI_has_been_started > 0);
+#else
+      return false;
+#endif
     }
+
+
+
+#include "mpi.inst"
   } // end of namespace MPI
 } // end of namespace Utilities
 

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+for (S : MPI_SCALARS)
+{
+  template
+  void sum<S> (const Vector<S> &, const MPI_Comm &, Vector<S> &);
+
+  template
+  S sum<S> (const S &, const MPI_Comm &);
+
+  template
+  void sum<S> (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+
+  template
+  S max<S> (const S &, const MPI_Comm &);
+
+  template
+  void max<S> (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+
+  template
+  S min<S> (const S &, const MPI_Comm &);
+
+  template
+  void min<S> (const std::vector<S> &, const MPI_Comm &, std::vector<S> &);
+}
+
+
+for (S : REAL_SCALARS; rank: RANKS; dim : SPACE_DIMENSIONS)
+{
+  template
+  Tensor<rank,dim,S>
+  sum<rank,dim,S> (const Tensor<rank,dim,S> &, const MPI_Comm &);
+}
+
+
+// Recall that SymmetricTensor only makes sense for rank 2 and 4
+for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
+{
+  template
+  SymmetricTensor<2,dim,S>
+  sum<2,dim,S> (const SymmetricTensor<2,dim,S> &, const MPI_Comm &);
+
+  template
+  SymmetricTensor<4,dim,S>
+  sum<4,dim,S> (const SymmetricTensor<4,dim,S> &, const MPI_Comm &);
+}

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/timer.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 #include <sstream>
 #include <iostream>

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/thread_local_storage.h>
 

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -17,6 +17,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#  include <deal.II/base/mpi.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/mpi.h>
 #include <deal.II/lac/petsc_parallel_vector.h>
 
 #ifdef DEAL_II_WITH_PETSC

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -25,6 +25,7 @@
 
 #ifdef DEAL_II_WITH_MPI
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #endif

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <deal.II/base/utilities.h>
+#  include <deal.II/base/mpi.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -17,6 +17,7 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
+#  include <deal.II/base/mpi.h>
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_block_vector.h>
 

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -18,6 +18,8 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
+#  include <deal.II/base/mpi.h>
+
 #  include <cmath>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -22,6 +22,7 @@
 #include "../tests.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -22,6 +22,7 @@
 #include "../tests.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/job_identifier.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/thread_management.h>


### PR DESCRIPTION
After #2648 I took some time to clean up the header. I moved a bunch of things to `mpi.cc` or the new `mpi.templates.h` file.

Part of this involved removing the `inline` attribute from most of the functions in this header. If the library is compiled with MPI then all of these functions communicate across the network, so I don't think this should cause any new performance problems (and I doubt the functions ended up getting inlined anyway). If the library is compiled without MPI then these functions are basically noops so they might be slightly slower now; I doubt anyone is calling MPI functions in inner loops so I doubt it will be an issue here either.

I looked in to #2651 because of this PR.