### PR TITLE
Explicitly instantiate Tensor<...> and its members.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -269,6 +269,15 @@ inconvenience this causes.
 
 <ol>
 
+ <li> Fixed: The Tensor class was not explicitly instantiated. This did
+ not matter in almost all contexts because its members are all defined
+ as @p inline in the header file. The only cases where it matters if one
+ (or the compiler) were to take the address of one of the static member
+ variables.
+ <br>
+ (Wolfgang Bangerth, 2016/06/03)
+ </li>
+
  <li> New: Return value std::vector<unsigned int> vertex_mapping for the
  DoFTools::make_vertex_patches() function, including the optional inversion
  of the vertex mapping.

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -66,6 +66,7 @@ SET(_src
   tensor_product_polynomials_bubbles.cc
   tensor_product_polynomials_const.cc
   thread_management.cc
+  tensor.cc
   timer.cc
   time_stepping.cc
   utilities.cc
@@ -77,6 +78,7 @@ SET(_inst
   function_time.inst.in
   mpi.inst.in
   polynomials_rannacher_turek.inst.in
+  tensor.inst.in
   tensor_function.inst.in
   time_stepping.inst.in
   )

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -18,6 +18,13 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+template <int dim, typename Number>
+const unsigned int Tensor<0,dim,Number>::n_independent_components;
+
+template <int rank, int dim, typename Number>
+const unsigned int Tensor<rank,dim,Number>::n_independent_components;
+
+
 #include "tensor.inst"
 
 

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/tensor.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+#include "tensor.inst"
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/base/tensor.inst.in
+++ b/source/base/tensor.inst.in
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
+{
+  template
+  class Tensor<rank,deal_II_dimension,number>;
+}
+
+
+for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
+{
+  template
+  class Tensor<0,deal_II_dimension,number>;
+}
+
+
+for (rank : RANKS; deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
+{
+  template
+  class Tensor<rank,deal_II_dimension,number>;
+}
+
+
+for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)
+{
+  template
+  class Tensor<0,deal_II_dimension,number>;
+}


### PR DESCRIPTION
From the changelog:
```
 Fixed: The Tensor class was not explicitly instantiated. This did
 not matter in almost all contexts because its members are all defined
 as @p inline in the header file. The only cases where it matters if one
 (or the compiler) were to take the address of one of the static member
 variables.
```