### PR TITLE
Reorder operations.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9024,10 +9024,13 @@ Triangulation<dim, spacedim>::~Triangulation ()
 template <int dim, int spacedim>
 void Triangulation<dim, spacedim>::clear ()
 {
+  // clear all content of the triangulation...
   clear_despite_subscriptions();
-  signals.clear();
   periodic_face_pairs_level_0.clear();
   periodic_face_map.clear();
+
+  // ...and then notify listeners to it
+  signals.clear();
 }
 
 


### PR DESCRIPTION
First clear all data before triggering the 'clear' signal in the triangulation,
rather than putting the signal code somewhere in the middle.