### PR TITLE
Remove some extra '*'s in comments.

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -1808,11 +1808,11 @@ struct GeometryInfo
 
   /**
    * Return true if the given point is inside the unit cell of the present
-   * space dimension. This * function accepts an additional * parameter which
-   * specifies how * much the point position may * actually be outside the
-   * true * unit cell. This is useful because in practice we may often not be
-   * able to compute the coordinates of a point in reference coordinates
-   * exactly, but only up to numerical roundoff.
+   * space dimension. This function accepts an additional parameter which
+   * specifies how much the point position may actually be outside the true
+   * unit cell. This is useful because in practice we may often not be able to
+   * compute the coordinates of a point in reference coordinates exactly, but
+   * only up to numerical roundoff.
    *
    * The tolerance parameter may be less than zero, indicating that the point
    * should be safely inside the cell.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2331,7 +2331,7 @@ private:
   {
   public:
     /**
-     * Declare what a multiple entry is: a variant * entry (in curly braces
+     * Declare what a multiple entry is: a variant entry (in curly braces
      * <tt>{</tt>, <tt>}</tt>) or an array (in double curly braces
      * <tt>{{</tt>, <tt>}}</tt>).
      */


### PR DESCRIPTION
I noticed the one in `GeometryInfo` and then found the other one with a regular expression.