### PR TITLE
First call the signal, then destroy the object.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2023,6 +2023,12 @@ public:
      * is called. This signal is also triggered when loading a triangulation
      * from an archive via Triangulation::load() as the previous content of
      * the triangulation is first destroyed.
+     *
+     * The signal is triggered before the data structures of the
+     * triangulation are destroyed. In other words, the functions
+     * attached to this signal get a last look at the triangulation,
+     * for example to save information stored as part of the
+     * triangulation.
      */
     boost::signals2::signal<void ()> clear;
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9024,13 +9024,13 @@ Triangulation<dim, spacedim>::~Triangulation ()
 template <int dim, int spacedim>
 void Triangulation<dim, spacedim>::clear ()
 {
-  // clear all content of the triangulation...
+  // notify listeners that the triangulation is going down...
+  signals.clear();
+
+  // ...and then actually clear all content of it
   clear_despite_subscriptions();
   periodic_face_pairs_level_0.clear();
   periodic_face_map.clear();
-
-  // ...and then notify listeners to it
-  signals.clear();
 }
 
 


### PR DESCRIPTION
I'm reconsidering #2671. I think the better approach is to *first* call the signal,
and only then take down the triangulation data structures. This allows the functions
attached to the signal to actually still *do* something with the triangulation,
rather than simply being informed that it has disappeared.