### PR TITLE
Instantiate the SymmetricTensor class and all of its members.

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -78,6 +78,7 @@ SET(_inst
   function_time.inst.in
   mpi.inst.in
   polynomials_rannacher_turek.inst.in
+  symmetric_tensor.inst.in
   tensor.inst.in
   tensor_function.inst.in
   time_stepping.inst.in

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -125,5 +125,18 @@ invert<3,double> (const SymmetricTensor<4,3,double> &t)
 
   return tmp;
 }
+
+
+
+// provide definitions for static members
+template <int rank, int dim, typename Number>
+const unsigned int SymmetricTensor<rank,dim,Number>::dimension;
+
+template <int rank, int dim, typename Number>
+const unsigned int SymmetricTensor<rank,dim,Number>::n_independent_components;
+
+
+#include "symmetric_tensor.inst"
+
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
In particular, also instantiate the static member variables. This is in analogy to #2667.

This needs #2699 first before it can work.