### PR TITLE
operator* for SynchronousIterators

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -305,6 +305,13 @@ inconvenience this causes.
 
 <ol>
 
+ <li> New: Added an operator* to SynchronousIterators which returns a
+ reference to the stored tuple of iterators iterators. The iterators member
+ may be made private in a future release.
+ <br>
+ (Daniel Shapero, 2016/06/24)
+ </li>
+
  <li> New: IndexSet::at(idx) returns an iterator pointing to the given index
  or the next larger element in the set if idx is not contained.
  <br>

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -2443,7 +2443,7 @@ namespace Step14
       // First task on each cell is to compute the cell residual
       // contributions of this cell, and put them into the
       // <code>error_indicators</code> variable:
-      active_cell_iterator cell = std_cxx11::get<0>(cell_and_error.iterators);
+      active_cell_iterator cell = std_cxx11::get<0>(*cell_and_error);
 
       integrate_over_cell (cell_and_error,
                            scratch_data.primal_solution,
@@ -2532,7 +2532,7 @@ namespace Step14
       // error estimation formula: first get the right hand side and Laplacian
       // of the numerical solution at the quadrature points for the cell
       // residual,
-      cell_data.fe_values.reinit (std_cxx11::get<0>(cell_and_error.iterators));
+      cell_data.fe_values.reinit (std_cxx11::get<0>(*cell_and_error));
       cell_data.right_hand_side
       ->value_list (cell_data.fe_values.get_quadrature_points(),
                     cell_data.rhs_values);
@@ -2550,7 +2550,7 @@ namespace Step14
         sum += ((cell_data.rhs_values[p]+cell_data.cell_laplacians[p]) *
                 cell_data.dual_weights[p] *
                 cell_data.fe_values.JxW (p));
-      *(std_cxx11::get<1>(cell_and_error.iterators)) += sum;
+      *(std_cxx11::get<1>(*cell_and_error)) += sum;
     }
 
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -888,11 +888,11 @@ namespace Step35
                                  InitGradScratchData &scratch,
                                  InitGradPerTaskData &data)
   {
-    scratch.fe_val_vel.reinit (std_cxx11::get<0> (SI.iterators));
-    scratch.fe_val_pres.reinit (std_cxx11::get<1> (SI.iterators));
+    scratch.fe_val_vel.reinit (std_cxx11::get<0> (*SI));
+    scratch.fe_val_pres.reinit (std_cxx11::get<1> (*SI));
 
-    std_cxx11::get<0> (SI.iterators)->get_dof_indices (data.vel_local_dof_indices);
-    std_cxx11::get<1> (SI.iterators)->get_dof_indices (data.pres_local_dof_indices);
+    std_cxx11::get<0> (*SI)->get_dof_indices (data.vel_local_dof_indices);
+    std_cxx11::get<1> (*SI)->get_dof_indices (data.pres_local_dof_indices);
 
     data.local_grad = 0.;
     for (unsigned int q=0; q<scratch.nqp; ++q)

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1107,7 +1107,7 @@ namespace Step9
     active_neighbors.reserve (GeometryInfo<dim>::faces_per_cell *
                               GeometryInfo<dim>::max_children_per_face);
 
-    typename DoFHandler<dim>::active_cell_iterator cell_it(std_cxx11::get<0>(cell.iterators));
+    typename DoFHandler<dim>::active_cell_iterator cell_it(std_cxx11::get<0>(*cell));
 
     // First initialize the <code>FEValues</code> object, as well as the
     // <code>Y</code> tensor:
@@ -1142,14 +1142,14 @@ namespace Step9
     // neighbors, of course.
     active_neighbors.clear ();
     for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
-      if (! std_cxx11::get<0>(cell.iterators)->at_boundary(face_no))
+      if (! std_cxx11::get<0>(*cell)->at_boundary(face_no))
         {
           // First define an abbreviation for the iterator to the face and
           // the neighbor
           const typename DoFHandler<dim>::face_iterator
-          face = std_cxx11::get<0>(cell.iterators)->face(face_no);
+          face = std_cxx11::get<0>(*cell)->face(face_no);
           const typename DoFHandler<dim>::cell_iterator
-          neighbor = std_cxx11::get<0>(cell.iterators)->neighbor(face_no);
+          neighbor = std_cxx11::get<0>(*cell)->neighbor(face_no);
 
           // Then check whether the neighbor is active. If it is, then it
           // is on the same level or one level coarser (if we are not in
@@ -1192,7 +1192,7 @@ namespace Step9
                   // as an internal error. We therefore use a predefined
                   // exception class to throw here.
                   Assert (neighbor_child->neighbor(face_no==0 ? 1 : 0)
-                          ==std_cxx11::get<0>(cell.iterators),ExcInternalError());
+                          ==std_cxx11::get<0>(*cell),ExcInternalError());
 
                   // If the check succeeded, we push the active neighbor
                   // we just found to the stack we keep:
@@ -1203,7 +1203,7 @@ namespace Step9
                 // `behind' the subfaces of the current face
                 for (unsigned int subface_no=0; subface_no<face->n_children(); ++subface_no)
                   active_neighbors.push_back (
-                    std_cxx11::get<0>(cell.iterators)->neighbor_child_on_subface(face_no,subface_no));
+                    std_cxx11::get<0>(*cell)->neighbor_child_on_subface(face_no,subface_no));
             }
         }
 
@@ -1305,9 +1305,9 @@ namespace Step9
     // at the second element of the pair of iterators, which requires
     // slightly awkward syntax but is not otherwise particularly
     // difficult:
-    *(std_cxx11::get<1>(cell.iterators)) = (std::pow(std_cxx11::get<0>(cell.iterators)->diameter(),
-                                                     1+1.0*dim/2) *
-                                            std::sqrt(gradient.norm_square()));
+    *(std_cxx11::get<1>(*cell)) = (std::pow(std_cxx11::get<0>(*cell)->diameter(),
+                                            1+1.0*dim/2) *
+                                   std::sqrt(gradient.norm_square()));
 
   }
 }

--- a/include/deal.II/base/synchronous_iterator.h
+++ b/include/deal.II/base/synchronous_iterator.h
@@ -61,6 +61,18 @@ struct SynchronousIterators
   SynchronousIterators (const SynchronousIterators &i);
 
   /**
+   * Dereference const operator. Returns a const reference to the iterators
+   * represented by the current class.
+   */
+  const Iterators &operator* () const;
+
+  /**
+   * Dereference operator. Returns a reference to the iterators
+   * represented by the current class.
+   */
+  Iterators &operator* ();
+
+  /**
    * Storage for the iterators represented by the current class.
    */
   Iterators iterators;
@@ -87,6 +99,26 @@ SynchronousIterators (const SynchronousIterators &i)
 
 
 
+template <typename Iterators>
+inline
+const Iterators &
+SynchronousIterators<Iterators>::operator* () const
+{
+  return iterators;
+}
+
+
+
+template <typename Iterators>
+inline
+Iterators &
+SynchronousIterators<Iterators>::operator* ()
+{
+  return iterators;
+}
+
+
+
 /**
  * Return whether the first element of the first argument is less than the
  * first element of the second argument. Since the objects compared march
@@ -101,7 +133,7 @@ bool
 operator< (const SynchronousIterators<Iterators> &a,
            const SynchronousIterators<Iterators> &b)
 {
-  return std_cxx11::get<0>(a.iterators) < std_cxx11::get<0>(b.iterators);
+  return std_cxx11::get<0>(*a) < std_cxx11::get<0>(*b);
 }
 
 
@@ -119,11 +151,11 @@ std::size_t
 operator- (const SynchronousIterators<Iterators> &a,
            const SynchronousIterators<Iterators> &b)
 {
-  Assert (std::distance (std_cxx11::get<0>(b.iterators),
-                         std_cxx11::get<0>(a.iterators)) >= 0,
+  Assert (std::distance (std_cxx11::get<0>(*b),
+                         std_cxx11::get<0>(*a)) >= 0,
           ExcInternalError());
-  return std::distance (std_cxx11::get<0>(b.iterators),
-                        std_cxx11::get<0>(a.iterators));
+  return std::distance (std_cxx11::get<0>(*b),
+                        std_cxx11::get<0>(*a));
 }
 
 
@@ -232,7 +264,7 @@ operator + (const SynchronousIterators<Iterators> &a,
             const std::size_t                      n)
 {
   SynchronousIterators<Iterators> x (a);
-  dealii::advance (x.iterators, n);
+  dealii::advance (*x, n);
   return x;
 }
 
@@ -246,7 +278,7 @@ inline
 SynchronousIterators<Iterators>
 operator ++ (SynchronousIterators<Iterators> &a)
 {
-  dealii::advance_by_one (a.iterators);
+  dealii::advance_by_one (*a);
   return a;
 }
 
@@ -263,8 +295,8 @@ bool
 operator != (const SynchronousIterators<Iterators> &a,
              const SynchronousIterators<Iterators> &b)
 {
-  return (std_cxx11::get<0>(a.iterators) !=
-          std_cxx11::get<0>(b.iterators));
+  return (std_cxx11::get<0>(*a) !=
+          std_cxx11::get<0>(*b));
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -937,19 +937,19 @@ namespace DerivativeApproximation
      const unsigned int                  component)
     {
       // if the cell is not locally owned, then there is nothing to do
-      if (std_cxx11::get<0>(cell.iterators)->is_locally_owned() == false)
-        *std_cxx11::get<1>(cell.iterators) = 0;
+      if (std_cxx11::get<0>(*cell)->is_locally_owned() == false)
+        *std_cxx11::get<1>(*cell) = 0;
       else
         {
           typename DerivativeDescription::Derivative derivative;
           // call the function doing the actual
           // work on this cell
           approximate_cell<DerivativeDescription,dim,DoFHandlerType,InputVector, spacedim>
-          (mapping,dof_handler,solution,component,std_cxx11::get<0>(cell.iterators),derivative);
+          (mapping,dof_handler,solution,component,std_cxx11::get<0>(*cell),derivative);
 
           // evaluate the norm and fill the vector
           //*derivative_norm_on_this_cell
-          *std_cxx11::get<1>(cell.iterators) = DerivativeDescription::derivative_norm (derivative);
+          *std_cxx11::get<1>(*cell) = DerivativeDescription::derivative_norm (derivative);
         }
     }
 


### PR DESCRIPTION
This PR adds a dereference operator for `SynchronousIterators`. This operator is necessary to use synchronous iterators in a C++11 range-based for loop. I've also replaced any accesses to the `iterators` struct member to invoking the dereference operator in the examples (9, 14, 35) that use synchronous iterators.

(Earlier PR got goofed up because I don't know how to git.)