### PR TITLE
Prefer std::abs over std::fabs.

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1756,7 +1756,7 @@ namespace internal
     switch (dim)
       {
       case 1:
-        return_value = std::fabs(data[0]);
+        return_value = std::abs(data[0]);
         break;
       case 2:
         return_value = std::sqrt(data[0]*data[0] + data[1]*data[1] +
@@ -1793,7 +1793,7 @@ namespace internal
     switch (dim)
       {
       case 1:
-        return_value = std::fabs (data[0][0]);
+        return_value = std::abs (data[0][0]);
         break;
       default:
         return_value = Number();


### PR DESCRIPTION
Some compilers/C++ standard libraries do not seem to import fabs from the C header `math.h` into the `std` namespace, see e.g. here:
http://cdash.kyomu.43-1.org/viewBuildError.php?buildid=1068