### PR TITLE
Make conversion constructors of ::Vector explicit.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -39,6 +39,17 @@ inconvenience this causes.
 
 <ol>
 
+ <li> Changed: The conversion constructors of class Vector from the
+ PETScWrappers::Vector, PETScWrappers::MPI::Vector,
+ TrilinosWrappers::Vector, and TrilinosWrappers::MPI::Vector classes
+ are now marked as <code>explicit</code>, i.e., they will no longer
+ allow implicit, silent conversions. Such conversions lead to awkward
+ errors that are hard to debug, and in cases where they are necessary,
+ are best described in code through explicit casts.
+ <br>
+ (Wolfgang Bangerth, 2016/06/25)
+ </li>
+
  <li> Changed: The deal.II distributed vector classes do now derive from
  LinearAlgebra::VectorSpaceVector and have been moved to the
  LinearAlgebra::distributed namespace. In the definition of the new

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -205,7 +205,7 @@ public:
    * vector class. This copy constructor is only available if PETSc was
    * detected during configuration time.
    */
-  Vector (const PETScWrappers::Vector &v);
+  explicit Vector (const PETScWrappers::Vector &v);
 
   /**
    * Another copy constructor: copy the values from a parallel PETSc wrapper
@@ -217,7 +217,7 @@ public:
    * possible for only one process to obtain a copy of a parallel vector while
    * the other jobs do something else.
    */
-  Vector (const PETScWrappers::MPI::Vector &v);
+  explicit Vector (const PETScWrappers::MPI::Vector &v);
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -232,14 +232,14 @@ public:
    * vector while the other jobs do something else. This call will rather
    * result in a copy of the vector on all processors.
    */
-  Vector (const TrilinosWrappers::MPI::Vector &v);
+  explicit Vector (const TrilinosWrappers::MPI::Vector &v);
 
   /**
    * Another copy constructor: copy the values from a localized Trilinos
    * wrapper vector. This copy constructor is only available if Trilinos was
    * detected during configuration time.
    */
-  Vector (const TrilinosWrappers::Vector &v);
+  explicit Vector (const TrilinosWrappers::Vector &v);
 #endif
 
   /**


### PR DESCRIPTION
This is apparently a quite useful change since it would have prevented
two people within the span of just a few minutes from committing the
same mistake.