### PR TITLE
Update newton_01 test output.

### DIFF
--- a/tests/algorithms/newton_01.output
+++ b/tests/algorithms/newton_01.output
@@ -1,7 +1,7 @@
 
 DEAL:Newton::Step 0
 DEAL:Newton::solution 10.0000
-DEAL:Newton::update
+DEAL:Newton::update 0
 DEAL:Newton::residual 98.0000
 DEAL:Newton::
 DEAL:Newton::Check 0	98.0000


### PR DESCRIPTION
Commit 11c94ad5e fixed a bug where the update vector was initially empty. This commit fixes the corresponding test output file to show that the update vector, at the first Newton step, contains one entry and that entry is equal to zero.

This fixes two failing tests.