### PR TITLE
Update GnuplotFlags::memory_consumption().

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -546,6 +546,12 @@ namespace DataOutBase
     std::vector<std::string> space_dimension_labels;
 
     /**
+     * Return an estimate for the memory consumption, in bytes, of this
+     * object.
+     */
+    std::size_t memory_consumption () const;
+
+    /**
      * Exception to raise when there are not enough specified dimension
      * labels.
      */

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1620,6 +1620,14 @@ namespace DataOutBase
 
 
 
+  std::size_t
+  GnuplotFlags::memory_consumption () const
+  {
+    return MemoryConsumption::memory_consumption(space_dimension_labels);
+  }
+
+
+
   PovrayFlags::PovrayFlags (const bool smooth,
                             const bool bicubic_patch,
                             const bool external_data)

--- a/tests/base/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=off.output
@@ -44,7 +44,7 @@ DEAL::Memory consumption -- Sparsity:      936
 DEAL::Memory consumption -- Matrix:        1400
 DEAL::Memory consumption -- Solution:      432
 DEAL::Memory consumption -- Rhs:           432
-DEAL::Memory consumption -- DataOut:       3359
+DEAL::Memory consumption -- DataOut:       3394
 DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
@@ -90,7 +90,7 @@ DEAL::Memory consumption -- Sparsity:      64168
 DEAL::Memory consumption -- Matrix:        120824
 DEAL::Memory consumption -- Solution:      7472
 DEAL::Memory consumption -- Rhs:           7472
-DEAL::Memory consumption -- DataOut:       42819
+DEAL::Memory consumption -- DataOut:       42854
 DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
@@ -136,4 +136,4 @@ DEAL::Memory consumption -- Sparsity:      8321768
 DEAL::Memory consumption -- Matrix:        16383928
 DEAL::Memory consumption -- Solution:      259568
 DEAL::Memory consumption -- Rhs:           259568
-DEAL::Memory consumption -- DataOut:       1159755
+DEAL::Memory consumption -- DataOut:       1159790

--- a/tests/base/memory_consumption_01.with_64bit_indices=on.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=on.output
@@ -44,7 +44,7 @@ DEAL::Memory consumption -- Sparsity:      1752
 DEAL::Memory consumption -- Matrix:        1400
 DEAL::Memory consumption -- Solution:      440
 DEAL::Memory consumption -- Rhs:           440
-DEAL::Memory consumption -- DataOut:       3336
+DEAL::Memory consumption -- DataOut:       3394
 DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
@@ -90,7 +90,7 @@ DEAL::Memory consumption -- Sparsity:      128216
 DEAL::Memory consumption -- Matrix:        120824
 DEAL::Memory consumption -- Solution:      7480
 DEAL::Memory consumption -- Rhs:           7480
-DEAL::Memory consumption -- DataOut:       42796
+DEAL::Memory consumption -- DataOut:       42854
 DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
@@ -136,4 +136,4 @@ DEAL::Memory consumption -- Sparsity:      16643416
 DEAL::Memory consumption -- Matrix:        16383928
 DEAL::Memory consumption -- Solution:      259576
 DEAL::Memory consumption -- Rhs:           259576
-DEAL::Memory consumption -- DataOut:       1159732
+DEAL::Memory consumption -- DataOut:       1159790


### PR DESCRIPTION
Commit 32d9748d4e added new fields to `GnuplotFlags` but did not change the way it reported its own memory consumption.

I do not have a good answer for why the memory usage in 64 bit mode increased by 58 bytes. Storing a vector and three strings should be more than that.