### PR TITLE
Do not use mpi_initlog where initlog will do.

### DIFF
--- a/tests/base/cell_data_storage_01.cc
+++ b/tests/base/cell_data_storage_01.cc
@@ -156,7 +156,7 @@ void test()
 int main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-  mpi_initlog();
+  initlog();
 
   test<2>();
 }
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
 int main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-  mpi_initlog();
+  initlog();
   deallog << "Ok" << std::endl;
 }
 #endif

--- a/tests/base/cell_data_storage_02.cc
+++ b/tests/base/cell_data_storage_02.cc
@@ -137,7 +137,7 @@ void test()
 int main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-  mpi_initlog();
+  initlog();
 
   test<2>();
 }
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
 int main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-  mpi_initlog();
+  initlog();
   deallog << "Ok" << std::endl;
 }
 #endif


### PR DESCRIPTION
Since these tests are run without mpi (i.e., without mpirun) `mpi_initlog` is not necessary. This also fixes the tests in the case where deal.II is configured without support for MPI.

These were caught by one of the clang testers that compiles things without MPI.