### PR TITLE
Fix compile for gcc 4.4.7

### DIFF
--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -33,7 +33,7 @@ namespace
     else
       {
         typedef FE_Q_Base<TensorProductPolynomials<1>, 1, 1> FEQ;
-        AssertThrow(false, typename FEQ::ExcFEQCannotHaveDegree0());
+        AssertThrow(false, FEQ::ExcFEQCannotHaveDegree0());
       }
     return std::vector<Point<1> >();
   }


### PR DESCRIPTION
I am not familiar enough with compiler specifics to say if the attached patch breaks some other compiler version, but to compile the current master on gcc 4.4.7, I had to make the attached change (I know, ancient compilers on home-build clusters are a pain). 
Maybe someone can comment if the patch is correct?