### PR TITLE
Add missing instantiation of one function.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -322,6 +322,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Fixed: The function DoFTools::dof_couplings_from_component_couplings
+ for hp::FECollection arguments was compiled but not exported from the
+ object file. This is now fixed.
+ <br>
+ (Wolfgang Bangerth, 2016/07/01)
+ </li>
+
  <li> New: The MappingFEField class was previously only instantiated
  if the vector type was dealii::Vector. It is now also instantiated
  for PETSc and Trilinos wrapper vector types.

--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -348,5 +348,11 @@ for (deal_II_dimension : DIMENSIONS)
   Table<2,DoFTools::Coupling>
   DoFTools::dof_couplings_from_component_couplings
   (const FiniteElement<deal_II_dimension> &fe,
+   const Table<2,DoFTools::Coupling> &component_couplings);
+
+  template
+  std::vector<Table<2,DoFTools::Coupling> >
+  DoFTools::dof_couplings_from_component_couplings
+  (const hp::FECollection<deal_II_dimension> &fe,
    const Table<2,DoFTools::Coupling> &component_couplings);
 }


### PR DESCRIPTION
Found because we tried to call this function in a user program. This led to
linker errors because the function was only implicitly instantiated, but
consequently not exported from the object file.