### PR TITLE
Convert '>>' to '> >' in templates in some tests.

### DIFF
--- a/tests/hp/hp_constraints_neither_dominate_01.cc
+++ b/tests/hp/hp_constraints_neither_dominate_01.cc
@@ -128,7 +128,7 @@ void test2cells(const unsigned int p1=2,
 #ifdef DEBUG_OUTPUT_VTK
   // output to check if all is good:
   counter++;
-  std::vector<Vector<double>> shape_functions;
+  std::vector<Vector<double> > shape_functions;
   std::vector<std::string> names;
   for (unsigned int s=0; s < dof_handler.n_dofs(); s++)
     {
@@ -152,7 +152,7 @@ void test2cells(const unsigned int p1=2,
       shape_functions.push_back(shape_function);
     }
 
-  DataOut<dim,hp::DoFHandler<dim>> data_out;
+  DataOut<dim,hp::DoFHandler<dim> > data_out;
   data_out.attach_dof_handler (dof_handler);
 
   // get material ids:

--- a/tests/hp/step-27.cc
+++ b/tests/hp/step-27.cc
@@ -85,7 +85,7 @@ namespace Step27
     hp::QCollection<dim-1>   face_quadrature_collection;
 
     hp::QCollection<dim> fourier_q_collection;
-    std_cxx11::shared_ptr<FESeries::Fourier<dim>> fourier;
+    std_cxx11::shared_ptr<FESeries::Fourier<dim> > fourier;
     std::vector<double> ln_k;
     Table<dim,std::complex<double> > fourier_coefficients;
 

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -365,9 +365,9 @@ namespace Step22
       GridTools::collect_periodic_faces(
         dof_handler, 2, 3, 1, periodicity_vector, Tensor<1, dim>(), matrix);
 
-      DoFTools::make_periodicity_constraints<DoFHandler<dim>>(
-                                                             periodicity_vector, constraints, fe.component_mask(velocities)),
-                                                                                 first_vector_components;
+      DoFTools::make_periodicity_constraints<DoFHandler<dim> >(
+        periodicity_vector, constraints, fe.component_mask(velocities)),
+                            first_vector_components;
 #endif
     }
 


### PR DESCRIPTION
`>>` can only end a pair of template arguments in C++11, not C++03.