### PR TITLE
Enable some tests to run in C++03 mode.

### DIFF
--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -322,7 +322,7 @@ void test ()
           stiffness_matrix.vmult(Ax,eigenfunctions[i]);
           Ax.add(-1.0*std::real(lambda[i]),Bx);
           Assert (Ax.l2_norm() < precision,
-                  ExcMessage(std::to_string(Ax.l2_norm())));
+                  ExcMessage(Utilities::to_string(Ax.l2_norm())));
         }
     }
   }

--- a/tests/fe/fe_series_05.cc
+++ b/tests/fe/fe_series_05.cc
@@ -70,7 +70,7 @@ double Lh(const Point<dim>  &x_q,
       const double x = 2.0*(x_q[d]-0.5);
       Assert ( (x_q[d] <= 1.0) && (x_q[d] >= 0.),
                ExcMessage("x_q is not in [0,1]" +
-                          std::to_string(x_q[d])));
+                          Utilities::to_string(x_q[d])));
       const int ind = indices[d];
       res *= sqrt(2.0) * gsl_sf_legendre_Pl (ind, x);
     }

--- a/tests/slepc/step-36_parallel.cc
+++ b/tests/slepc/step-36_parallel.cc
@@ -314,7 +314,7 @@ void test (std::string solver_name,
           stiffness_matrix.vmult(Ax,eigenfunctions[i]);
           Ax.add(-1.0*eigenvalues[i],Bx);
           Assert (Ax.l2_norm() < precision,
-                  ExcMessage(std::to_string(Ax.l2_norm())));
+                  ExcMessage(Utilities::to_string(Ax.l2_norm())));
         }
     }
   }


### PR DESCRIPTION
`std::to_string` is not in C++03.