### PR TITLE
Fix compilation with PETSc and not hypre.

### DIFF
--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -480,7 +480,7 @@ namespace PETScWrappers
   void
   PreconditionBoomerAMG::initialize ()
   {
-#ifndef PETSC_USE_COMPLEX
+#ifdef PETSC_HAVE_HYPRE
     int ierr;
     ierr = PCSetType (pc, const_cast<char *>(PCHYPRE));
     AssertThrow (ierr == 0, ExcPETScError(ierr));


### PR DESCRIPTION
@davydden This seems to fix things (you were right). This should be fine since one cannot build hypre with complex PetscScalar, right?