### PR TITLE
don't use ninja for testsuite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,7 +115,10 @@ FOREACH(_category ${_categories})
   IF(DEAL_II_MSVC)
     SET(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir})
   ELSE()
-    SET(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir} > /dev/null)
+    # Do not pass the generator with -G so that we use make instead of ninja
+    # for the test projects. This is because calling ninja several times in
+    # parallel for the same project will break the configuration.
+    SET(_command ${CMAKE_COMMAND} ${_options} ${_category_dir} > /dev/null)
   ENDIF()
 
   ADD_CUSTOM_TARGET(setup_tests_${_category}


### PR DESCRIPTION
Do not pass the generator to the testsuite so that we use make instead
of ninja for the test projects. This is because calling ninja several
times in parallel for the same project will break the configuration.

This shouldn't have a performance penalty because the individual targets
are relatively simple and don't depend on more than one file.