### PR TITLE
Move constructor for Triangulation

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -558,6 +558,11 @@ SparsityPattern.
  (Wolfgang Bangerth, 2016/07/08)
  </li>
 
+ <li> New: A move constructor has been added to Triangulation.
+ <br>
+ (Daniel Shapero, 2016/07/07)
+ </li>
+
  <li> Fixed: The function DoFTools::dof_couplings_from_component_couplings
  for hp::FECollection arguments was compiled but not exported from the
  object file. This is now fixed.

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1516,6 +1516,16 @@ public:
    */
   Triangulation (const Triangulation<dim, spacedim> &t);
 
+#ifdef DEAL_II_WITH_CXX11
+  /**
+   * Move constructor.
+   *
+   * Create a new triangulation by stealing the internal data of another
+   * triangulation.
+   */
+  Triangulation (Triangulation<dim, spacedim> &&tria);
+#endif
+
   /**
    * Delete the object and all levels of the hierarchy.
    */

--- a/tests/grid/move_constructor.cc
+++ b/tests/grid/move_constructor.cc
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+
+#include <fstream>
+
+
+template <int dim>
+void print_tria_info(const Triangulation<dim> &tria)
+{
+  deallog << (tria.n_active_cells() != 0) << ", "
+          << (tria.n_active_hexs() != 0) << ", "
+          << (tria.n_active_quads() != 0) << ", "
+          << (tria.n_active_lines() != 0) << ", "
+          << (tria.n_levels() != 0) << ", "
+          << (tria.n_vertices() != 0) << ", "
+          << (tria.get_periodic_face_map().size() != 0) << ", "
+          << (&tria.get_manifold(0)
+              == (const Manifold<dim> *)&Triangulation<dim>::straight_boundary)
+          << std::endl;
+}
+
+
+template <int dim>
+void test_hyper_cube()
+{
+  deallog << "Dimension: " << dim << std::endl;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, -1.0, 1.0);
+  tria.refine_global(2);
+
+  print_tria_info(tria);
+
+  Triangulation<dim> new_tria = std::move(tria);
+  print_tria_info(new_tria);
+  print_tria_info(tria);
+}
+
+
+template <int dim>
+void test_hyper_shell()
+{
+  deallog << "Dimension: " << dim << std::endl;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_ball(tria);
+
+  const SphericalManifold<dim> boundary;
+  tria.set_all_manifold_ids_on_boundary(0);
+  tria.set_manifold(0, boundary);
+
+  tria.refine_global(3);
+  print_tria_info(tria);
+
+  Triangulation<dim> new_tria = std::move(tria);
+  print_tria_info(new_tria);
+  print_tria_info(tria);
+}
+
+
+template <int dim>
+void test_periodic_cube()
+{
+  deallog << "Dimension: " << dim << std::endl;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, -1.0, 1.0, true);
+
+  using periodic_face_pair =
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>;
+  std::vector<periodic_face_pair> periodicity_vector;
+  GridTools::collect_periodic_faces(tria, 0, 1, 0, periodicity_vector);
+  tria.add_periodicity(periodicity_vector);
+  tria.refine_global(3);
+
+  print_tria_info(tria);
+
+  Triangulation<dim> new_tria = std::move(tria);
+  print_tria_info(new_tria);
+  print_tria_info(tria);
+}
+
+
+int main()
+{
+  initlog();
+
+  deallog << "Hyper-cube:" << std::endl;
+  test_hyper_cube<2>();
+  test_hyper_cube<3>();
+
+  deallog << std::endl << "Hyper-shell:" << std::endl;
+  test_hyper_shell<2>();
+  test_hyper_shell<3>();
+
+  deallog << std::endl << "Periodic hyper-cube:" << std::endl;
+  test_periodic_cube<2>();
+  test_periodic_cube<3>();
+
+  return 0;
+}

--- a/tests/grid/move_constructor.with_cxx11=on.output
+++ b/tests/grid/move_constructor.with_cxx11=on.output
@@ -1,0 +1,30 @@
+
+DEAL::Hyper-cube:
+DEAL::Dimension: 2
+DEAL::1, 0, 1, 1, 1, 1, 0, 1
+DEAL::1, 0, 1, 1, 1, 1, 0, 1
+DEAL::0, 0, 0, 0, 0, 0, 0, 1
+DEAL::Dimension: 3
+DEAL::1, 1, 1, 1, 1, 1, 0, 1
+DEAL::1, 1, 1, 1, 1, 1, 0, 1
+DEAL::0, 0, 0, 0, 0, 0, 0, 1
+DEAL::
+DEAL::Hyper-shell:
+DEAL::Dimension: 2
+DEAL::1, 0, 1, 1, 1, 1, 0, 0
+DEAL::1, 0, 1, 1, 1, 1, 0, 0
+DEAL::0, 0, 0, 0, 0, 0, 0, 1
+DEAL::Dimension: 3
+DEAL::1, 1, 1, 1, 1, 1, 0, 0
+DEAL::1, 1, 1, 1, 1, 1, 0, 0
+DEAL::0, 0, 0, 0, 0, 0, 0, 1
+DEAL::
+DEAL::Periodic hyper-cube:
+DEAL::Dimension: 2
+DEAL::1, 0, 1, 1, 1, 1, 1, 1
+DEAL::1, 0, 1, 1, 1, 1, 1, 1
+DEAL::0, 0, 0, 0, 0, 0, 0, 1
+DEAL::Dimension: 3
+DEAL::1, 1, 1, 1, 1, 1, 1, 1
+DEAL::1, 1, 1, 1, 1, 1, 1, 1
+DEAL::0, 0, 0, 0, 0, 0, 0, 1


### PR DESCRIPTION
This PR also changes some of the behavior in the destructor of Triangulation. Any pointer members are checked before deleting, and set to 0 after. I've run all the triangulation tests; since this is change is pretty far-reaching, I can run more of the test suite if need be.