### PR TITLE
More cleanups.

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -112,7 +112,7 @@ public:
   /**
    * Computes the volume element associated with the jacobian of the
    * transformation F. That is to say if $DF$ is square, it computes
-   * $\det(DF)$, in case DF is not square returns $\sqrt(\det(DF^{t} * DF))$.
+   * $\det(DF)$, in case DF is not square returns $\sqrt{\det(DF^T * DF)}$.
    */
   double determinant () const;
 
@@ -141,9 +141,9 @@ public:
 
 private:
   /**
-   * Auxiliary function that computes (*this) * T^{t}
+   * Auxiliary function that computes (*this) * $T^{T}$
    */
-  DerivativeForm<1, dim, spacedim, Number> times_T_t (Tensor<2,dim,Number> T) const;
+  DerivativeForm<1, dim, spacedim, Number> times_T_t (const Tensor<2,dim,Number> &T) const;
 
 
   /**
@@ -307,7 +307,7 @@ transpose () const
 template <int order, int dim, int spacedim, typename Number>
 inline
 DerivativeForm<1, dim, spacedim,Number>
-DerivativeForm<order,dim,spacedim,Number>::times_T_t (Tensor<2,dim,Number> T) const
+DerivativeForm<order,dim,spacedim,Number>::times_T_t (const Tensor<2,dim,Number> &T) const
 {
   Assert( order==1, ExcMessage("Only for order == 1."));
   DerivativeForm<1,dim, spacedim,Number> dest;
@@ -327,13 +327,13 @@ DerivativeForm<order,dim,spacedim,Number>::determinant () const
   Assert( order==1, ExcMessage("Only for order == 1."));
   if (dim == spacedim)
     {
-      Tensor<2,dim,Number> T = (Tensor<2,dim,Number>)( (*this) );
+      const Tensor<2,dim,Number> T = static_cast<Tensor<2,dim,Number> >(*this);
       return dealii::determinant(T);
     }
   else
     {
       Assert( spacedim>dim, ExcMessage("Only for spacedim>dim."));
-      DerivativeForm<1,spacedim,dim> DF_t = this->transpose();
+      const DerivativeForm<1,spacedim,dim> DF_t = this->transpose();
       Tensor<2,dim,Number> G; //First fundamental form
       for (unsigned int i=0; i<dim; ++i)
         for (unsigned int j=0; j<dim; ++j)
@@ -388,7 +388,7 @@ DerivativeForm<order, dim, spacedim, Number>::memory_consumption ()
 /**
  * One of the uses of DerivativeForm is to apply it as a transformation. This
  * is what this function does.  If @p T is DerivativeForm<1,dim,1> it computes
- * $DF * T$, if @p T is DerivativeForm<1,dim,rank> it computes $T*DF^{t}$.
+ * $DF * T$, if @p T is DerivativeForm<1,dim,rank> it computes $T*DF^{T}$.
  *
  * @relates DerivativeForm
  * @author Sebastian Pauletti, 2011
@@ -408,7 +408,7 @@ apply_transformation (const DerivativeForm<1,dim,spacedim,Number> &DF,
 
 
 /**
- * Similar to previous apply_transformation. It computes $T*DF^{t}$.
+ * Similar to previous apply_transformation. It computes $T*DF^{T}$.
  *
  * @relates DerivativeForm
  * @author Sebastian Pauletti, 2011
@@ -429,7 +429,7 @@ apply_transformation (const DerivativeForm<1,dim,spacedim,Number> &DF,
 }
 
 /**
- * Similar to previous apply_transformation. It computes $DF2*DF1^{t}$
+ * Similar to previous apply_transformation. It computes $DF2*DF1^{T}$
  *
  * @relates DerivativeForm
  * @author Sebastian Pauletti, 2011


### PR DESCRIPTION
In particular, make a function argument a const reference. Also
standardize on '^T' to denote the transpose of a matrix.