### PR TITLE
Unify handling of ExcPetscError.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -18,6 +18,7 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/vector_operations_internal.h>
 #include <deal.II/lac/read_write_vector.h>

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -887,13 +887,6 @@ namespace PETScWrappers
     /**
      * Exception
      */
-    DeclException1 (ExcPETScError,
-                    int,
-                    << "An error with error number " << arg1
-                    << " occurred while calling a PETSc function");
-    /**
-     * Exception
-     */
     DeclException0 (ExcSourceEqualsDestination);
 
     /**

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -154,14 +154,6 @@ namespace PETScWrappers
        * the referenced element of the vector.
        */
       operator PetscScalar () const;
-
-      /**
-       * Exception
-       */
-      DeclException1 (ExcPETScError,
-                      int,
-                      << "An error with error number " << arg1
-                      << " occurred while calling a PETSc function");
       /**
        * Exception
        */

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -18,9 +18,11 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/partitioner.h>
+
+#include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/read_write_vector.h>
 #include <deal.II/lac/vector_operations_internal.h>
-#include <deal.II/base/partitioner.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
 #ifdef DEAL_II_WITH_PETSC

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/numbers.h>
+#include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/vector_operations_internal.h>

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -17,7 +17,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/exceptions.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -17,6 +17,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_full_matrix.h>
 #  include <deal.II/lac/petsc_sparse_matrix.h>
 #  include <deal.II/lac/petsc_parallel_sparse_matrix.h>
@@ -52,7 +53,7 @@ namespace PETScWrappers
       int ierr;
       (void)ierr;
       ierr = MatGetRow(*matrix, this->a_row, &ncols, &colnums, &values);
-      AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+      AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       // copy it into our caches if the line
       // isn't empty. if it is, then we've
@@ -66,7 +67,7 @@ namespace PETScWrappers
 
       // and finally restore the matrix
       ierr = MatRestoreRow(*matrix, this->a_row, &ncols, &colnums, &values);
-      AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+      AssertThrow (ierr == 0, ExcPETScError(ierr));
     }
   }
 
@@ -355,7 +356,7 @@ namespace PETScWrappers
 //query this information from PETSc
     int ierr;
     ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
-    AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then restore the matrix and return the number of columns in this row as
     // queried previously. Starting with PETSc 3.4, MatRestoreRow actually
@@ -364,7 +365,7 @@ namespace PETScWrappers
     // and return the saved value.
     const PetscInt ncols_saved = ncols;
     ierr = MatRestoreRow(*this, row, &ncols, &colnums, &values);
-    AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return ncols_saved;
   }
@@ -644,7 +645,7 @@ namespace PETScWrappers
       {
         int ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
         (void)ierr;
-        AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+        AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         for (PetscInt col = 0; col < ncols; ++col)
           {
@@ -652,7 +653,7 @@ namespace PETScWrappers
           }
 
         ierr = MatRestoreRow(*this, row, &ncols, &colnums, &values);
-        AssertThrow (ierr == 0, MatrixBase::ExcPETScError(ierr));
+        AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
 
     AssertThrow (out, ExcIO());

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -18,6 +18,8 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#include <deal.II/lac/exceptions.h>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace PETScWrappers

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -18,7 +18,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/base/utilities.h>
-#  include <deal.II/lac/petsc_compatibility.h>
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/petsc_solver.h>

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -19,6 +19,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/petsc_precondition.h>

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -17,6 +17,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/source/lac/petsc_vector.cc
+++ b/source/lac/petsc_vector.cc
@@ -17,6 +17,8 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#include <deal.II/lac/exceptions.h>
+
 #  include <cmath>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/base/memory_consumption.h>
+#  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/petsc_parallel_vector.h>
 #  include <cmath>


### PR DESCRIPTION
This is the first of a few commits that will hopefully lower the amount of code we need to handle various versions of PETSc. In this case multiple classes reimplemented the same `ExcPetscError` exception; I defaulted to the one in `lac/exceptions.h`.