### PR TITLE
Fix compilation with PETSc.

### DIFF
--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -19,6 +19,7 @@
 
 #  include <deal.II/base/utilities.h>
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/petsc_solver.h>


### PR DESCRIPTION
@davydden I misread your remark: one of the headers I removed was necessary. I was foolish enough to be editing that source file while compiling so I did not catch this at first.