### PR TITLE
Assert nonsingular chart

### DIFF
--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -563,6 +563,16 @@ get_tangent_vector (const Point<spacedim> &x1,
                     const Point<spacedim> &x2) const
 {
   const DerivativeForm<1,chartdim,spacedim> F_prime = push_forward_gradient(pull_back(x1));
+
+  // ensure that the chart is not singular by asserting that its
+  // derivative has a positive determinant. we need to make this
+  // comparison relative to the size of the derivative. since the
+  // determinant is the product of chartdim factors, take the
+  // chartdim-th root of it in comparing against the size of the
+  // derivative
+  Assert (std::pow(F_prime.determinant(), 1./chartdim) >= 1e-12 * F_prime.norm(),
+          ExcMessage("The derivative of a chart function must not be singular."));
+
   const Tensor<1,chartdim>                  delta   = sub_manifold.get_tangent_vector(pull_back(x1),
                                                       pull_back(x2));
 

--- a/tests/manifold/chart_manifold_05_embedded.cc
+++ b/tests/manifold/chart_manifold_05_embedded.cc
@@ -22,14 +22,14 @@
 
 
 template <int dim, int spacedim>
-class MyFlatManifold : public ChartManifold<dim,spacedim,spacedim+1>
+class MyFlatManifold : public ChartManifold<dim,spacedim,spacedim>
 {
 public:
   virtual
-  Point<spacedim+1>
+  Point<spacedim>
   pull_back(const Point<spacedim> &space_point) const
   {
-    Point<spacedim+1> p;
+    Point<spacedim> p;
     for (unsigned int d=0; d<spacedim; ++d)
       p[d] = space_point[d];
     return p;
@@ -38,7 +38,7 @@ public:
 
   virtual
   Point<spacedim>
-  push_forward(const Point<spacedim+1> &chart_point) const
+  push_forward(const Point<spacedim> &chart_point) const
   {
     Point<spacedim> p;
     for (unsigned int d=0; d<spacedim; ++d)
@@ -47,10 +47,10 @@ public:
   }
 
   virtual
-  DerivativeForm<1,spacedim+1,spacedim>
-  push_forward_gradient(const Point<spacedim+1> &chart_point) const
+  DerivativeForm<1,spacedim,spacedim>
+  push_forward_gradient(const Point<spacedim> &chart_point) const
   {
-    DerivativeForm<1,spacedim+1,spacedim> x;
+    DerivativeForm<1,spacedim,spacedim> x;
     for (unsigned int d=0; d<spacedim; ++d)
       x[d][d] = 1;
     return x;

--- a/tests/manifold/chart_manifold_06_embedded.cc
+++ b/tests/manifold/chart_manifold_06_embedded.cc
@@ -12,8 +12,6 @@
 // Test direction vector of flat manifold with periodicity, where the
 // flat manifold is implemented as a ChartManifold with identity
 // pull-back and push-forward
-//
-// make the chart higher dimensional
 
 #include "../tests.h"
 #include <fstream>
@@ -23,19 +21,19 @@
 
 
 template <int dim, int spacedim>
-class MyFlatManifold : public ChartManifold<dim,spacedim,spacedim+1>
+class MyFlatManifold : public ChartManifold<dim,spacedim,spacedim>
 {
 public:
-  MyFlatManifold (const Tensor<1,spacedim+1> &periodicity)
+  MyFlatManifold (const Tensor<1,spacedim> &periodicity)
     :
-    ChartManifold<dim,spacedim,spacedim+1>(periodicity)
+    ChartManifold<dim,spacedim,spacedim>(periodicity)
   {}
 
   virtual
-  Point<spacedim+1>
+  Point<spacedim>
   pull_back(const Point<spacedim> &space_point) const
   {
-    Point<spacedim+1> p;
+    Point<spacedim> p;
     for (unsigned int d=0; d<spacedim; ++d)
       p[d] = space_point[d];
     return p;
@@ -44,7 +42,7 @@ public:
 
   virtual
   Point<spacedim>
-  push_forward(const Point<spacedim+1> &chart_point) const
+  push_forward(const Point<spacedim> &chart_point) const
   {
     Point<spacedim> p;
     for (unsigned int d=0; d<spacedim; ++d)
@@ -53,10 +51,10 @@ public:
   }
 
   virtual
-  DerivativeForm<1,spacedim+1,spacedim>
-  push_forward_gradient(const Point<spacedim+1> &chart_point) const
+  DerivativeForm<1,spacedim,spacedim>
+  push_forward_gradient(const Point<spacedim> &chart_point) const
   {
-    DerivativeForm<1,spacedim+1,spacedim> x;
+    DerivativeForm<1,spacedim,spacedim> x;
     for (unsigned int d=0; d<spacedim; ++d)
       x[d][d] = 1;
     return x;
@@ -74,7 +72,7 @@ void test()
           << ", spacedim="<< spacedim << std::endl;
 
   // make the domain periodic in the first direction with periodicity 1.1
-  Tensor<1,spacedim+1> periodicity;
+  Tensor<1,spacedim> periodicity;
   periodicity[0] = 1.1;
   MyFlatManifold<dim,spacedim> manifold(periodicity);
 


### PR DESCRIPTION
This fixes #2775 by adding the assertion for non-singular charts. It required me to add a function to compute the norm of a `DerivativeForm` object, which is probably useful in itself.

I had to adjust two tests that were previously not making much sense by themselves. It also leads to the failure of the following two tests that trigger the new assertion:
* mappings/mapping_manifold_07.debug
* grid/torus_01.debug
We will have to fix these separately, or maybe #2676 actually fixes this eventually. I find it annoying that this PR makes tests fail, but think it is still the right way to go. The existing tests were likely not doing the correct thing anyway.