### PR TITLE
Avoid use of std::is_default_constructible.

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -32,7 +32,7 @@
 
 #include <vector>
 #include <map>
-#include <typeinfo>
+#include <type_traits>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -89,7 +89,7 @@ public:
    * in different parts of the domain.
    *
    * @pre The type @p T needs to either equal @p DataType, or be a class derived
-   * from @p DataType.
+   * from @p DataType. @p T needs to be default constructible.
    */
   template<typename T=DataType>
   void initialize(const CellIteratorType &cell,
@@ -507,8 +507,6 @@ void CellDataStorage<CellIteratorType,DataType>::initialize(const CellIteratorTy
 {
   static_assert(std::is_base_of<DataType, T>::value,
                 "User's T class should be derived from user's DataType class");
-  static_assert(std::is_default_constructible<T>::value,
-                "Class T requires default-constructible elements");
 
   if (map.find(cell) == map.end())
     {


### PR DESCRIPTION
Some older compilers that have a -std=c++0x flag and that we deem 
C++11 compatible do apparently not support std::is_default_constructible,
despite the fact that they support std::is_base_of. Therefore, avoid
the use of it. This does not matter here because just a few lines further
down, we call 'make_shared<T>()' which already requires default
constructibility, and so the user will get an error one way or the other.

While there, also ensure that we use the correct include file.

This is a final follow-up to #2772. My compiler is happy with this
patch and the earlier #2783.