### PR TITLE
Add tests

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -336,6 +336,18 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Fixed: SymmetricTensor::access_raw_entry() erroneously produced
+ an indexing error for rank-4 symmetric tensors. This is now fixed.
+ <br>
+ (Wolfgang Bangerth, 2016/07/08)
+ </li>
+
+ <li> Fixed: SymmetricTensor::norm() did not work correctly for complex
+ underlying scalar types. This is now fixed.
+ <br>
+ (Wolfgang Bangerth, 2016/07/08)
+ </li>
+
  <li> Fixed: The function DoFTools::dof_couplings_from_component_couplings
  for hp::FECollection arguments was compiled but not exported from the
  object file. This is now fixed.

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1728,7 +1728,7 @@ inline
 Number
 SymmetricTensor<rank,dim,Number>::access_raw_entry (const unsigned int index) const
 {
-  AssertIndexRange (index, data.dimension);
+  AssertIndexRange (index, n_independent_components);
   return data[internal::SymmetricTensor::entry_to_indices(*this, index)];
 }
 
@@ -1739,7 +1739,7 @@ inline
 Number &
 SymmetricTensor<rank,dim,Number>::access_raw_entry (const unsigned int index)
 {
-  AssertIndexRange (index, data.dimension);
+  AssertIndexRange (index, n_independent_components);
   return data[internal::SymmetricTensor::entry_to_indices(*this, index)];
 }
 

--- a/tests/base/symmetric_tensor_31.cc
+++ b/tests/base/symmetric_tensor_31.cc
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test SymmetricTensor::memory_consumption
+
+#include "../tests.h"
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/memory_consumption.h>
+
+
+template <int rank, int dim>
+void check ()
+{
+  deallog << "dim=" << dim << ", T=double "
+          << MemoryConsumption::memory_consumption (SymmetricTensor<rank,dim>())
+          << std::endl;
+  deallog << "dim=" << dim << ", T=complex<double> "
+          << MemoryConsumption::memory_consumption (SymmetricTensor<rank,dim,std::complex<double> >())
+          << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  deallog << "check rank 2 tensors" << std::endl;
+  check<2,1>();
+  check<2,2>();
+  check<2,3>();
+
+  deallog << "check rank 4 tensors" << std::endl;
+  check<4,1>();
+  check<4,2>();
+  check<4,3>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/base/symmetric_tensor_31.output
+++ b/tests/base/symmetric_tensor_31.output
@@ -1,0 +1,16 @@
+
+DEAL::check rank 2 tensors
+DEAL::dim=1, T=double 8
+DEAL::dim=1, T=complex<double> 16
+DEAL::dim=2, T=double 24
+DEAL::dim=2, T=complex<double> 48
+DEAL::dim=3, T=double 48
+DEAL::dim=3, T=complex<double> 96
+DEAL::check rank 4 tensors
+DEAL::dim=1, T=double 8
+DEAL::dim=1, T=complex<double> 16
+DEAL::dim=2, T=double 72
+DEAL::dim=2, T=complex<double> 144
+DEAL::dim=3, T=double 288
+DEAL::dim=3, T=complex<double> 576
+DEAL::OK

--- a/tests/base/symmetric_tensor_32.cc
+++ b/tests/base/symmetric_tensor_32.cc
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test SymmetricTensor::norm() for complex-valued tensors
+
+#include "../tests.h"
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/logstream.h>
+
+
+template <int rank, int dim>
+void check ()
+{
+  // build a regular tensor
+  SymmetricTensor<rank,dim> t;
+
+  // build one in which all numbers are the same but purely imaginary
+  SymmetricTensor<rank,dim,std::complex<double> > ti;
+
+  // build one in which all numbers have both real and imaginary components
+  SymmetricTensor<rank,dim,std::complex<double> > tc;
+
+  for (unsigned int i=0; i<t.n_independent_components; ++i)
+    {
+      t.access_raw_entry(i)  = 1.0 * (i+1);
+      ti.access_raw_entry(i) = std::complex<double>(0,1.0*(i+1));
+      tc.access_raw_entry(i) = std::complex<double>(1.0*(i+1),1.0*(i+1));
+    }
+
+  deallog << t.norm() << ' '
+          << ti.norm() << ' '
+          << tc.norm() << std::endl;
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog << std::setprecision(3);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  deallog << "check rank 2 tensors" << std::endl;
+  check<2,1>();
+  check<2,2>();
+  check<2,3>();
+
+  deallog << "check rank 4 tensors" << std::endl;
+  check<4,1>();
+  check<4,2>();
+  check<4,3>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/base/symmetric_tensor_32.output
+++ b/tests/base/symmetric_tensor_32.output
@@ -1,0 +1,10 @@
+
+DEAL::check rank 2 tensors
+DEAL::1.00 1.00 1.41
+DEAL::4.80 4.80 6.78
+DEAL::13.0 13.0 18.3
+DEAL::check rank 4 tensors
+DEAL::1.00 1.00 1.41
+DEAL::26.2 26.2 37.0
+DEAL::217. 217. 307.
+DEAL::OK


### PR DESCRIPTION
This was intended as a 10-minute project to address #2701, but as often: if there is no test, the functionality is broken :-( Indeed, computing the norm of a complex-valued tensor did not compile, among other reasons because it wanted to return a complex number. It was also broken in other ways. Secondly, the `SymmetricTensor::access_raw_entry()` function happened to have an invalid index check in it for rank-4 tensors.

All fixed now, tests added, changelog entry written. All in separate commits to make untangling easier later if necessary.