### PR TITLE
CMake: Bugfix: Force cache update for DEAL_II_(C|CXX)_FLAGS

### DIFF
--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -265,6 +265,7 @@ FOREACH(_flag ${DEAL_II_USED_FLAGS})
   #
   SET(${_flag} "${${_flag}}" CACHE STRING
     "The user supplied cache variable will be appended _at the end_ of the configuration step to the auto generated ${_flag} variable"
+    FORCE
     )
   MARK_AS_ADVANCED(${_flag})
 


### PR DESCRIPTION
This fixes a subtle bug:

 - We use DEAL_II_(C|CXX)_FLAGS, DEAL_II_LINKER_FLAGS internally and we
   allow users to set additional compiler/linker flags via cached variants
   of these variables (because users tend to assume every variable starts
   with DEAL_II_*).

 - But, we also allow to set CMAKE_(C|CXX)_FLAGS, etc. (not supporting this
   would be crazy).

 - Last, but not least, the environment variables CFLAGS, CXXFLAGS, LDFLAGS
   are also supported.

We support this by prepending all DEAL_II_* variables with their CMAKE_*
and environment counterparts. But for this to work we also have to force
update the cache. With this change

  CXXFLAGS="-foo" cmake -DCMAKE_CXX_FLAGS="-bar" -DDEAL_II_CXX_FLAGS="-baz" .

results in

  DEAL_II_FLAGS="[.. internal flag setup ..] -foo -bar -baz"

as intended. Reconfiguring with

  CXXFLAGS="-foo" cmake .

retains DEAL_II_CXX_FLAGS.

@kronbichler I guess you hit this bug.