### PR TITLE
Refactor petsc compatibility

### DIFF
--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -25,6 +25,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #include <petscconf.h>
+#include <petscmat.h>
 #include <petscpc.h>
 
 #include <string>
@@ -51,6 +52,28 @@ namespace PETScWrappers
     PetscOptionsSetValue (name.c_str (), value.c_str ());
 #else
     PetscOptionsSetValue (NULL, name.c_str (), value.c_str ());
+#endif
+  }
+
+
+
+  /**
+   * Destroy a PETSc matrix. This function wraps MatDestroy with a version
+   * check (the signature of this function changed in PETSc 3.2.0).
+   *
+   * @warning Since the primary intent of this function is to enable RAII
+   * semantics in the PETSc wrappers, this function will not throw an
+   * exception if an error occurs, but instead just returns the error code
+   * given by MatDestroy.
+   *
+   */
+  inline PetscErrorCode destroy_matrix (Mat &matrix)
+  {
+    // PETSc will check whether or not matrix is NULL.
+#if DEAL_II_PETSC_VERSION_LT(3, 2, 0)
+    return MatDestroy (matrix);
+#else
+    return MatDestroy (&matrix);
 #endif
   }
 }

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -51,10 +51,12 @@ namespace PETScWrappers
                                 const std::string &value)
   {
 #if DEAL_II_PETSC_VERSION_LT(3, 7, 0)
-    PetscOptionsSetValue (name.c_str (), value.c_str ());
+    const PetscErrorCode ierr = PetscOptionsSetValue (name.c_str (), value.c_str ());
 #else
-    PetscOptionsSetValue (NULL, name.c_str (), value.c_str ());
+    const PetscErrorCode ierr = PetscOptionsSetValue (NULL, name.c_str (), value.c_str ());
 #endif
+    (void)ierr;
+    Assert (ierr == 0, ExcPETScError(ierr));
   }
 
 

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -33,6 +33,12 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace PETScWrappers
 {
+#if DEAL_II_PETSC_VERSION_LT(3,2,0)
+  typedef PetscTruth PetscBooleanType;
+#else
+  typedef PetscBool PetscBooleanType;
+#endif
+
   /**
    * Set an option in the global PETSc database. This function just wraps
    * PetscOptionsSetValue with a version check (the signature of this function

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -25,6 +25,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #include <petscconf.h>
+#include <petscksp.h>
 #include <petscmat.h>
 #include <petscpc.h>
 
@@ -74,6 +75,28 @@ namespace PETScWrappers
     return MatDestroy (matrix);
 #else
     return MatDestroy (&matrix);
+#endif
+  }
+
+
+
+  /**
+   * Destroy a Krylov Subspace (KSP) PETSc solver. This function wraps
+   * KSPDestroy with a version check (the signature of this function changed
+   * in PETSc 3.2.0).
+   *
+   * @warning Since the primary intent of this function is to enable RAII
+   * semantics in the PETSc wrappers, this function will not throw an
+   * exception if an error occurs, but instead just returns the error code
+   * given by MatDestroy.
+   */
+  inline PetscErrorCode destroy_krylov_solver (KSP &krylov_solver)
+  {
+    // PETSc will check whether or not matrix is NULL.
+#if DEAL_II_PETSC_VERSION_LT(3, 2, 0)
+    return KSPDestroy (krylov_solver);
+#else
+    return KSPDestroy (&krylov_solver);
 #endif
   }
 }

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -22,8 +22,9 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/base/subscriptor.h>
-#  include <deal.II/lac/full_matrix.h>
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/full_matrix.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/vector.h>
 
 #  include <petscmat.h>
@@ -841,11 +842,7 @@ namespace PETScWrappers
      * Test whether a matrix is symmetric.  Default tolerance is
      * $1000\times32$-bit machine precision.
      */
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
+    PetscBooleanType
     is_symmetric (const double tolerance = 1.e-12);
 
     /**
@@ -853,11 +850,7 @@ namespace PETScWrappers
      * its transpose. Default tolerance is $1000\times32$-bit machine
      * precision.
      */
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
+    PetscBooleanType
     is_hermitian (const double tolerance = 1.e-12);
 
     /**

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -17,6 +17,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
+#include <deal.II/lac/petsc_compatibility.h>
 #include <deal.II/lac/exceptions.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -42,12 +43,8 @@ namespace PETScWrappers
   {
     // get rid of old matrix and generate a
     // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatDestroy (matrix);
-#else
-    const int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix(matrix);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     do_reinit (m, n);
   }

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_full_matrix.h>
 #  include <deal.II/lac/petsc_sparse_matrix.h>
 #  include <deal.II/lac/petsc_parallel_sparse_matrix.h>
@@ -574,19 +575,10 @@ namespace PETScWrappers
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-  PetscTruth
-#else
-  PetscBool
-#endif
+  PetscBooleanType
   MatrixBase::is_symmetric (const double tolerance)
   {
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
-    truth;
+    PetscBooleanType truth;
     assert_is_compressed ();
     int ierr = MatIsSymmetric (matrix, tolerance, &truth);
     (void)ierr;
@@ -594,19 +586,10 @@ namespace PETScWrappers
     return truth;
   }
 
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-  PetscTruth
-#else
-  PetscBool
-#endif
+  PetscBooleanType
   MatrixBase::is_hermitian (const double tolerance)
   {
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
-    truth;
+    PetscBooleanType truth;
 
     assert_is_compressed ();
     int ierr = MatIsHermitian (matrix, tolerance, &truth);

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -127,32 +127,8 @@ namespace PETScWrappers
   MatrixBase::clear_row (const size_type   row,
                          const PetscScalar new_diag_value)
   {
-    assert_is_compressed ();
-
-    // now set all the entries of this row to zero
-    const PetscInt petsc_row = row;
-
-    IS index_set;
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    ISCreateGeneral (get_mpi_communicator(), 1, &petsc_row, &index_set);
-#else
-    ISCreateGeneral (get_mpi_communicator(), 1, &petsc_row, PETSC_COPY_VALUES, &index_set);
-#endif
-
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr
-      = MatZeroRowsIS(matrix, index_set, new_diag_value);
-#else
-    const int ierr
-      = MatZeroRowsIS(matrix, index_set, new_diag_value, PETSC_NULL, PETSC_NULL);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
-
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    ISDestroy (index_set);
-#else
-    ISDestroy (&index_set);
-#endif
+    std::vector<size_type> rows (1, row);
+    clear_rows(rows, new_diag_value);
   }
 
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -83,12 +83,7 @@ namespace PETScWrappers
 
   MatrixBase::~MatrixBase ()
   {
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatDestroy (matrix);
-#else
-    const int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    destroy_matrix (matrix);
   }
 
 
@@ -97,17 +92,16 @@ namespace PETScWrappers
   MatrixBase::clear ()
   {
     // destroy the matrix...
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    int ierr = MatDestroy (matrix);
-#else
-    int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    {
+      const PetscErrorCode ierr = destroy_matrix (matrix);
+      AssertThrow(ierr == 0, ExcPETScError(ierr));
+    }
+
     // ...and replace it by an empty
     // sequential matrix
     const int m=0, n=0, n_nonzero_per_row=0;
-    ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
-                           0, &matrix);
+    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
+                                     0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -19,6 +19,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #include <deal.II/lac/exceptions.h>
+#include <deal.II/lac/petsc_compatibility.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -105,14 +106,9 @@ namespace PETScWrappers
   {
     this->communicator = communicator;
 
-    // destroy the matrix and
-    // generate a new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    int ierr = MatDestroy (matrix);
-#else
-    int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    // destroy the matrix and generate a new one
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr == 0, ExcPETScError (ierr));
 
     do_reinit (m, n, local_rows, local_columns);
   }
@@ -133,13 +129,8 @@ namespace PETScWrappers
             ExcInternalError());
 
     this->communicator = communicator;
-
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    int ierr = MatDestroy (matrix);
-#else
-    int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr != 0, ExcPETScError (ierr));
 
     do_reinit (m, n,
                local_rows_per_process[this_process],
@@ -171,12 +162,8 @@ namespace PETScWrappers
 
   void MatrixFree::clear ()
   {
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    int ierr = MatDestroy (matrix);
-#else
-    int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr == 0, ExcPETScError (ierr));
 
     const int m=0;
     do_reinit (m, m, m, m);

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -19,6 +19,7 @@
 
 #  include <deal.II/base/mpi.h>
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
@@ -45,14 +46,7 @@ namespace PETScWrappers
 
     SparseMatrix::~SparseMatrix ()
     {
-      int ierr;
-
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      ierr = MatDestroy (matrix);
-#else
-      ierr = MatDestroy (&matrix);
-#endif
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      destroy_matrix (matrix);
     }
 
     SparseMatrix::SparseMatrix (const MPI_Comm  &communicator,
@@ -116,15 +110,10 @@ namespace PETScWrappers
 
       this->communicator = other.communicator;
 
-      int ierr;
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      ierr = MatDestroy (matrix);
-#else
-      ierr = MatDestroy (&matrix);
-#endif
+      PetscErrorCode ierr = destroy_matrix (matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
-      ierr = MatDuplicate(other.matrix, MAT_DO_NOT_COPY_VALUES, &matrix);
+      ierr = MatDuplicate (other.matrix, MAT_DO_NOT_COPY_VALUES, &matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
     }
 
@@ -160,14 +149,9 @@ namespace PETScWrappers
     {
       this->communicator = communicator;
 
-      // get rid of old matrix and generate a
-      // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      const int ierr = MatDestroy (matrix);
-#else
-      const int ierr = MatDestroy (&matrix);
-#endif
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      // get rid of old matrix and generate a new one
+      const PetscErrorCode ierr = destroy_matrix (matrix);
+      AssertThrow (ierr == 0, ExcPETScError (ierr));
 
       do_reinit (m, n, local_rows, local_columns,
                  n_nonzero_per_row, is_symmetric,
@@ -190,12 +174,8 @@ namespace PETScWrappers
 
       // get rid of old matrix and generate a
       // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      const int ierr = MatDestroy (matrix);
-#else
-      const int ierr = MatDestroy (&matrix);
-#endif
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      const PetscErrorCode ierr = destroy_matrix (matrix);
+      AssertThrow (ierr == 0, ExcPETScError (ierr));
 
       do_reinit (m, n, local_rows, local_columns,
                  row_lengths, is_symmetric, offdiag_row_lengths);
@@ -215,14 +195,11 @@ namespace PETScWrappers
     {
       this->communicator = communicator;
 
-      // get rid of old matrix and generate a
-      // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      const int ierr = MatDestroy (matrix);
-#else
-      const int ierr = MatDestroy (&matrix);
-#endif
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      // get rid of old matrix and generate a new one
+      destroy_matrix (matrix);
+      const PetscErrorCode ierr = destroy_matrix (matrix);
+      AssertThrow (ierr == 0, ExcPETScError (ierr));
+
 
       do_reinit (sparsity_pattern, local_rows_per_process,
                  local_columns_per_process, this_process,
@@ -239,14 +216,9 @@ namespace PETScWrappers
     {
       this->communicator = communicator;
 
-      // get rid of old matrix and generate a
-      // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      const int ierr = MatDestroy (matrix);
-#else
-      const int ierr = MatDestroy (&matrix);
-#endif
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      // get rid of old matrix and generate a new one
+      const PetscErrorCode ierr = destroy_matrix (matrix);
+      AssertThrow(ierr == 0, ExcPETScError (ierr));
 
       do_reinit (local_rows, local_columns, sparsity_pattern);
     }

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -770,6 +770,7 @@ namespace PETScWrappers
     {
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
       Assert(false,ExcNotImplemented());
+      return IndexSet();
 #else
       PetscInt n_rows, n_cols, n_loc_rows, n_loc_cols, min, max;
       PetscErrorCode ierr;
@@ -798,6 +799,7 @@ namespace PETScWrappers
     {
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
       Assert(false,ExcNotImplemented());
+      return IndexSet();
 #else
       PetscInt n_rows, n_cols, n_loc_rows, n_loc_cols, min, max;
       PetscErrorCode ierr;

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -20,6 +20,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/petsc_precondition.h>
@@ -34,17 +35,7 @@ namespace PETScWrappers
 
   SolverBase::SolverData::~SolverData ()
   {
-    if (ksp != NULL)
-      {
-        // destroy the solver object
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        int ierr = KSPDestroy (ksp);
-#else
-        int ierr = KSPDestroy (&ksp);
-#endif
-
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-      }
+    destroy_krylov_solver (ksp);
   }
 
 
@@ -651,14 +642,7 @@ namespace PETScWrappers
 
   SparseDirectMUMPS::SolverDataMUMPS::~SolverDataMUMPS ()
   {
-    // destroy the solver object
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    int ierr = KSPDestroy (ksp);
-#else
-    int ierr = KSPDestroy (&ksp);
-#endif
-
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    destroy_krylov_solver (ksp);
   }
 
 

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_PETSC
 
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
@@ -85,12 +86,8 @@ namespace PETScWrappers
   {
     // get rid of old matrix and generate a
     // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatDestroy (matrix);
-#else
-    const int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr == 0, ExcPETScError (ierr));
 
     do_reinit (m, n, n_nonzero_per_row, is_symmetric);
   }
@@ -105,12 +102,8 @@ namespace PETScWrappers
   {
     // get rid of old matrix and generate a
     // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatDestroy (matrix);
-#else
-    const int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr == 0, ExcPETScError (ierr));
 
     do_reinit (m, n, row_lengths, is_symmetric);
   }
@@ -125,12 +118,8 @@ namespace PETScWrappers
   {
     // get rid of old matrix and generate a
     // new one
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatDestroy (matrix);
-#else
-    const int ierr = MatDestroy (&matrix);
-#endif
-    AssertThrow (ierr == 0, ExcPETScError(ierr));
+    const PetscErrorCode ierr = destroy_matrix (matrix);
+    AssertThrow (ierr == 0, ExcPETScError (ierr));
 
     do_reinit (sparsity_pattern, preset_nonzero_locations);
   }

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -153,15 +153,7 @@ namespace PETScWrappers
     // set symmetric flag, if so requested
     if (is_symmetric == true)
       {
-#if DEAL_II_PETSC_VERSION_LT(3,0,0)
-        const int ierr
-          = MatSetOption (matrix, MAT_SYMMETRIC);
-#else
-        const int ierr
-          = MatSetOption (matrix, MAT_SYMMETRIC, PETSC_TRUE);
-#endif
-
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
+        set_matrix_option (matrix, MAT_SYMMETRIC, PETSC_TRUE);
       }
   }
 
@@ -195,15 +187,7 @@ namespace PETScWrappers
     // set symmetric flag, if so requested
     if (is_symmetric == true)
       {
-#if DEAL_II_PETSC_VERSION_LT(3,0,0)
-        const int ierr
-          = MatSetOption (matrix, MAT_SYMMETRIC);
-#else
-        const int ierr
-          = MatSetOption (matrix, MAT_SYMMETRIC, PETSC_TRUE);
-#endif
-
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
+        set_matrix_option(matrix, MAT_SYMMETRIC, PETSC_TRUE);
       }
   }
 
@@ -253,48 +237,8 @@ namespace PETScWrappers
           }
         compress (VectorOperation::insert);
 
-
-        // Tell PETSc that we are not
-        // planning on adding new entries
-        // to the matrix. Generate errors
-        // in debug mode.
-        int ierr;
-#if DEAL_II_PETSC_VERSION_LT(3,0,0)
-#ifdef DEBUG
-        ierr = MatSetOption (matrix, MAT_NEW_NONZERO_LOCATION_ERR);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#else
-        ierr = MatSetOption (matrix, MAT_NO_NEW_NONZERO_LOCATIONS);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#endif
-#else
-#ifdef DEBUG
-        ierr = MatSetOption (matrix, MAT_NEW_NONZERO_LOCATION_ERR, PETSC_TRUE);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#else
-        ierr = MatSetOption (matrix, MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#endif
-#endif
-
-        // Tell PETSc to keep the
-        // SparsityPattern entries even if
-        // we delete a row with
-        // clear_rows() which calls
-        // MatZeroRows(). Otherwise one can
-        // not write into that row
-        // afterwards.
-#if DEAL_II_PETSC_VERSION_LT(3,0,0)
-        ierr = MatSetOption (matrix, MAT_KEEP_ZEROED_ROWS);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#elif DEAL_II_PETSC_VERSION_LT(3,1,0)
-        ierr = MatSetOption (matrix, MAT_KEEP_ZEROED_ROWS, PETSC_TRUE);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#else
-        ierr = MatSetOption (matrix, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
-#endif
-
+        close_matrix (matrix);
+        set_keep_zero_rows (matrix);
       }
   }
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -19,6 +19,7 @@
 
 #  include <deal.II/base/memory_consumption.h>
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/petsc_parallel_vector.h>
 #  include <cmath>
@@ -266,13 +267,7 @@ namespace PETScWrappers
     Assert (size() == v.size(),
             ExcDimensionMismatch(size(), v.size()));
 
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
-    flag;
-
+    PetscBooleanType flag;
     const int ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -287,13 +282,7 @@ namespace PETScWrappers
     Assert (size() == v.size(),
             ExcDimensionMismatch(size(), v.size()));
 
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    PetscTruth
-#else
-    PetscBool
-#endif
-    flag;
-
+    PetscBooleanType flag;
     const int ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 


### PR DESCRIPTION
This PR continues the work in #2754 by consolidating more version checks into one place. Additionally, several of the destructors used to contain `AssertThrow` checks; I removed them (destructors should not throw).