### PR TITLE
CMake: Bugfix: Do not error out if a variable for a feature constraint is undefined

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -187,26 +187,24 @@ LIST(SORT _deal_ii_features_sorted)
 FOREACH(_name ${_deal_ii_features_sorted})
   SET(_var DEAL_II_WITH_${_name})
 
-  #
-  # Do not pollute deal.IIConfig.cmake with package details of unconfigured
-  # features.
-  #
-  IF(NOT ${_var})
-    CONTINUE()
-  ENDIF()
-
   FOREACH(_file ${_files})
     FILE(APPEND ${_file} "SET(${_var} ${${_var}})\n")
-    IF(NOT "${${_name}_VERSION}" STREQUAL "")
-      FILE(APPEND ${_file}
-        "SET(DEAL_II_${_name}_VERSION \"${${_name}_VERSION}\")\n"
-        )
-    ENDIF()
-    FOREACH(_additional ${_additional_config_variables})
-      IF(_additional MATCHES "DEAL_II_${_name}_WITH")
-        FILE(APPEND ${_file} "SET(${_additional} ${${_additional}})\n")
+    #
+    # Do not pollute deal.IIConfig.cmake with package details of
+    # unconfigured features.
+    #
+    IF(${_var})
+      IF(NOT "${${_name}_VERSION}" STREQUAL "")
+        FILE(APPEND ${_file}
+          "SET(DEAL_II_${_name}_VERSION \"${${_name}_VERSION}\")\n"
+          )
       ENDIF()
-    ENDFOREACH()
+      FOREACH(_additional ${_additional_config_variables})
+        IF(_additional MATCHES "DEAL_II_${_name}_WITH")
+          FILE(APPEND ${_file} "SET(${_additional} ${${_additional}})\n")
+        ENDIF()
+      ENDFOREACH()
+    ENDIF()
   ENDFOREACH()
 ENDFOREACH()
 

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -187,9 +187,17 @@ LIST(SORT _deal_ii_features_sorted)
 FOREACH(_name ${_deal_ii_features_sorted})
   SET(_var DEAL_II_WITH_${_name})
 
+  #
+  # Do not pollute deal.IIConfig.cmake with package details of unconfigured
+  # features.
+  #
+  IF(NOT ${_var})
+    CONTINUE()
+  ENDIF()
+
   FOREACH(_file ${_files})
     FILE(APPEND ${_file} "SET(${_var} ${${_var}})\n")
-    IF(${_var} AND NOT "${${_name}_VERSION}" STREQUAL "")
+    IF(NOT "${${_name}_VERSION}" STREQUAL "")
       FILE(APPEND ${_file}
         "SET(DEAL_II_${_name}_VERSION \"${${_name}_VERSION}\")\n"
         )

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -178,19 +178,17 @@ MACRO(DEAL_II_PICKUP_TESTS)
       STRING(REGEX MATCH "([0-9]+(\\.[0-9]+)*)$" _version ${_match})
 
       #
-      # Valid feature?
-      #
       # We support two variables: DEAL_II_WITH_<FEATURE> and DEAL_II_<FEATURE>
       #
       SET(_variable "DEAL_II_WITH_${_feature}")
       IF(NOT DEFINED ${_variable})
         SET(_variable "DEAL_II_${_feature}")
         IF(NOT DEFINED ${_variable})
-          MESSAGE(FATAL_ERROR "
-Invalid feature constraint \"${_match}\" in file
-\"${_comparison}\":
-The feature \"DEAL_II_WITH_${_feature}\" (or \"DEAL_II_${_feature}\") does not exist.\n"
-            )
+          #
+          # If a variable is undefined, assume that we cannot configure a
+          # given test
+          #
+          SET(_define_test FALSE)
         ENDIF()
       ENDIF()
 


### PR DESCRIPTION
As it is always the case with the build system - every change is rocky. :-/