### PR TITLE
Tests: Fix lac/linear_operator_04a

### DIFF
--- a/tests/lac/linear_operator_04a.cc
+++ b/tests/lac/linear_operator_04a.cc
@@ -13,8 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
-// Test that it is possible to use a operator*() of LinearOperator object for
-// Trilinos matrices and vectors
+// Test that it is possible to use a PackagedOperation created by
+// operator*() of a LinearOperator object for Trilinos matrices and vectors
 
 #include "../tests.h"
 
@@ -35,13 +35,14 @@ int main(int argc, char *argv[])
   typedef TrilinosWrappers::MPI::Vector vector_t;
   typedef TrilinosWrappers::SparseMatrix matrix_t;
 
-  matrix_t a;
+  matrix_t a(5U, 5U, 3U);
+  a.compress (VectorOperation::add);
 
   auto op_a  = linear_operator<vector_t>(a);
   vector_t u,res;
+  op_a.reinit_domain_vector(u, false);
   res = op_a * u;
-  // ^^ this was not working, whereas
-  // op_a.vmult(res,u) did.
+  // ^^ this was not working, whereas op_a.vmult(res,u) did.
 
   deallog << "OK" << std::endl;
 


### PR DESCRIPTION
Always use an initialized and compressed matrix object in this test. This
avoids a regression when deal.II is compiled with 64bit mode: unitialized
trilinos objects are not guaranteed to work at all.

Closes #2808