### PR TITLE
CMake: Bugfix: Properly fix (CMAKE|DEAL_II)_CXX_FLAGS* caching

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -365,8 +365,15 @@ inconvenience this causes.
    "-fuse-ld=gold" linker flag if openmpi is incompatible with it.
  <br>
  (Wolfgang Bangerth, Martin Kronbichler, Matthias Maier, 2016/07/13)
-
  </li>
+
+ <li> Fixed: CMake now handles mixed compiler and linker setup via
+ <code>DEAL_II_CXX_FLAGS*</code> / <code>DEAL_II_LINKER_FLAGS*</code> and
+ <code>CMAKE_CXX_FLAGS*</code> properly.
+ <br>
+ (Matthias Maier, 2016/07/13)
+ </li>
+
  <li> Fixed: FEValues::reinit() would sometimes try to be overly
  clever and not re-compute information when called with the same
  cell twice in a row, even if the underlying triangulation had


### PR DESCRIPTION
Well, #2793 did not really solve the problem.

This commit reorganizes the caching process entirely:

 * always store CMAKE_* variables in internal cache

 * do not force update cached DEAL_II_* variables

 * fix the issue of simultaneous usage of CMAKE_* and DEAL_II_* variables
   by prepending DEAL_II_* variables *after* the cache setup