### PR TITLE
CMake: Restructure compiler sanity checks

### DIFF
--- a/cmake/configure/configure_1_mpi.cmake
+++ b/cmake/configure/configure_1_mpi.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -28,7 +28,25 @@ MACRO(FEATURE_MPI_FIND_EXTERNAL var)
         "Could not find a sufficient MPI version: "
         "Your MPI implementation must define MPI_SEEK_SET.")
       SET(MPI_ADDITIONAL_ERROR_STRING
-        "Your MPI implementation must define MPI_SEEK_SET.")
+        "Your MPI implementation must define MPI_SEEK_SET.\n")
+      SET(${var} FALSE)
+    ENDIF()
+
+    CHECK_COMPILER_SETUP(
+      "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_SAVED} ${MPI_CXX_FLAGS}"
+      "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_SAVED} ${MPI_LINKER_FLAGS}"
+      MPI_WORKING_COMPILER
+      ${DEAL_II_LIBRARIES} ${MPI_LIBRARIES}
+      )
+
+    IF(NOT MPI_WORKING_COMPILER)
+      MESSAGE(STATUS "Could not find a sufficient MPI installation: "
+        "Unable to compile a simple test program."
+        )
+      SET(MPI_ADDITIONAL_ERROR_STRING
+        ${MPI_ADDITIONAL_ERROR_STRING}
+        "Unable to compile and link a simple test program with your MPI installation. \n"
+        )
       SET(${var} FALSE)
     ENDIF()
   ENDIF()

--- a/cmake/macros/macro_check_compiler_flags.cmake
+++ b/cmake/macros/macro_check_compiler_flags.cmake
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2016 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# Usage:
+#   CHECK_COMPILER_FLAGS(_compiler_flags_variable _linker_flags_variable _var)
+#
+# This macro tries to compile and link a simple "int main(){ return 0; }
+# with the given set of compiler and flags provided in
+# _compiler_flags_variable and _linker_flags_variable. If the test is
+# succesful the variable ${_var} is set to true, otherwise to false.
+#
+
+MACRO(CHECK_COMPILER_FLAGS _compiler_flags_variable _linker_flags_variable _var)
+  #
+  # Rerun this test if flags have changed:
+  #
+  IF(NOT "${${_compiler_flags_variable}}" STREQUAL "${CACHED_${_var}_${_compiler_flags_variable}}"
+     OR NOT "${${_linker_flags_variable}}" STREQUAL "${CACHED_${_var}_${_linker_flags_variable}}")
+    UNSET(${_var} CACHE)
+  ENDIF()
+
+  SET(CACHED_${_var}_${_compiler_flags_variable} "${${_compiler_flags_variable}}"
+    CACHE INTERNAL "" FORCE
+    )
+  SET(CACHED_${_var}_${_linker_flags_variable} "${${_linker_flags_variable}}"
+    CACHE INTERNAL "" FORCE
+    )
+
+  SET(CMAKE_REQUIRED_FLAGS ${${_compiler_flags_variable}})
+  SET(CMAKE_REQUIRED_LIBRARIES ${${_linker_flags_variable}})
+  CHECK_CXX_SOURCE_COMPILES("int main(){ return 0; }" ${_var})
+  RESET_CMAKE_REQUIRED()
+
+  IF(${_var})
+    SET(${_var} TRUE CACHE INTERNAL "")
+  ENDIF()
+ENDMACRO()

--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -15,38 +15,37 @@
 
 #
 # Usage:
-#   CHECK_COMPILER_SETUP(
-#     _compiler_flags_variable _linker_flags_variable _var
+#   CHECK_COMPILER_SETUP("compiler flag string" "linker flag string" _var
 #     [libraries]
 #     )
 #
 # This macro tries to compile and link a simple "int main(){ return 0; }
-# with the given set of compiler and flags provided in
-# _compiler_flags_variable and _linker_flags_variable and an optional list
-# of libraries to link against. If the test is succesful the variable
-# ${_var} is set to true, otherwise to false.
+# with the given set of provided compiler and linker flags  and an optional
+# list of libraries to link against. If the test is succesful the variable
+# ${_var} is set to true, otherwise it is set to false.
 #
 
-MACRO(CHECK_COMPILER_SETUP _compiler_flags_variable _linker_flags_variable _var)
+MACRO(CHECK_COMPILER_SETUP _compiler_flags _linker_flags _var)
   #
   # Rerun this test if flags have changed:
   #
-  IF(NOT "${${_compiler_flags_variable}}" STREQUAL "${CACHED_${_var}_${_compiler_flags_variable}}"
-     OR NOT "${${_linker_flags_variable}}" STREQUAL "${CACHED_${_var}_${_linker_flags_variable}}"
+  IF(NOT "${_compiler_flags}" STREQUAL "${CACHED_${_var}_compiler_flags}"
+     OR NOT "${_linker_flags}" STREQUAL "${CACHED_${_var}_linker_flags}"
      OR NOT "${ARGN}" STREQUAL "${CACHED_${_var}_ARGN}")
     UNSET(${_var} CACHE)
   ENDIF()
 
-  SET(CACHED_${_var}_${_compiler_flags_variable} "${${_compiler_flags_variable}}"
+  SET(CACHED_${_var}_compiler_flags "${_compiler_flags}"
     CACHE INTERNAL "" FORCE
     )
-  SET(CACHED_${_var}_${_linker_flags_variable} "${${_linker_flags_variable}}"
+  SET(CACHED_${_var}_linker_flags "${_linker_flags}"
     CACHE INTERNAL "" FORCE
     )
   SET(CACHED_${_var}_ARGN "${ARGN}" CACHE INTERNAL "" FORCE)
 
-  SET(CMAKE_REQUIRED_FLAGS ${${_compiler_flags_variable}})
-  SET(CMAKE_REQUIRED_LIBRARIES ${${_linker_flags_variable}} ${ARGN})
+  SET(CMAKE_REQUIRED_FLAGS ${_compiler_flags})
+  SET(CMAKE_REQUIRED_LIBRARIES ${_linker_flags} ${ARGN})
+
   CHECK_CXX_SOURCE_COMPILES("int main(){ return 0; }" ${_var})
   RESET_CMAKE_REQUIRED()
 

--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -15,20 +15,25 @@
 
 #
 # Usage:
-#   CHECK_COMPILER_FLAGS(_compiler_flags_variable _linker_flags_variable _var)
+#   CHECK_COMPILER_SETUP(
+#     _compiler_flags_variable _linker_flags_variable _var
+#     [libraries]
+#     )
 #
 # This macro tries to compile and link a simple "int main(){ return 0; }
 # with the given set of compiler and flags provided in
-# _compiler_flags_variable and _linker_flags_variable. If the test is
-# succesful the variable ${_var} is set to true, otherwise to false.
+# _compiler_flags_variable and _linker_flags_variable and an optional list
+# of libraries to link against. If the test is succesful the variable
+# ${_var} is set to true, otherwise to false.
 #
 
-MACRO(CHECK_COMPILER_FLAGS _compiler_flags_variable _linker_flags_variable _var)
+MACRO(CHECK_COMPILER_SETUP _compiler_flags_variable _linker_flags_variable _var)
   #
   # Rerun this test if flags have changed:
   #
   IF(NOT "${${_compiler_flags_variable}}" STREQUAL "${CACHED_${_var}_${_compiler_flags_variable}}"
-     OR NOT "${${_linker_flags_variable}}" STREQUAL "${CACHED_${_var}_${_linker_flags_variable}}")
+     OR NOT "${${_linker_flags_variable}}" STREQUAL "${CACHED_${_var}_${_linker_flags_variable}}"
+     OR NOT "${ARGN}" STREQUAL "${CACHED_${_var}_ARGN}")
     UNSET(${_var} CACHE)
   ENDIF()
 
@@ -38,9 +43,10 @@ MACRO(CHECK_COMPILER_FLAGS _compiler_flags_variable _linker_flags_variable _var)
   SET(CACHED_${_var}_${_linker_flags_variable} "${${_linker_flags_variable}}"
     CACHE INTERNAL "" FORCE
     )
+  SET(CACHED_${_var}_ARGN "${ARGN}" CACHE INTERNAL "" FORCE)
 
   SET(CMAKE_REQUIRED_FLAGS ${${_compiler_flags_variable}})
-  SET(CMAKE_REQUIRED_LIBRARIES ${${_linker_flags_variable}})
+  SET(CMAKE_REQUIRED_LIBRARIES ${${_linker_flags_variable}} ${ARGN})
   CHECK_CXX_SOURCE_COMPILES("int main(){ return 0; }" ${_var})
   RESET_CMAKE_REQUIRED()
 

--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -21,7 +21,7 @@
 #
 # This macro tries to compile and link a simple "int main(){ return 0; }
 # with the given set of provided compiler and linker flags  and an optional
-# list of libraries to link against. If the test is succesful the variable
+# list of libraries to link against. If the test is successful the variable
 # ${_var} is set to true, otherwise it is set to false.
 #
 

--- a/cmake/setup_compiler_flags.cmake
+++ b/cmake/setup_compiler_flags.cmake
@@ -75,15 +75,17 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
   SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
 
-  CHECK_COMPILER_FLAGS(_cxx_flags_${build} _linker_flags_${build}
+  CHECK_COMPILER_SETUP(_cxx_flags_${build} _linker_flags_${build}
     DEAL_II_HAVE_USABLE_USER_FLAGS_${build}
+    ${DEAL_II_LIBRARIES} ${DEAL_II_LIBRARIES_${build}}
     )
 
   IF(NOT DEAL_II_HAVE_USABLE_USER_FLAGS_${build})
     MESSAGE(FATAL_ERROR "
   Configuration error: Cannot compile with the user supplied flags:
-  CXX flags (${build}): ${_cxx_flags_${build}}
-  LD flags  (${build}): ${_linker_flags_${build}}
+    CXX flags (${build}): ${_cxx_flags_${build}}
+    LD flags  (${build}): ${_linker_flags_${build}}
+    LIBRARIES (${build}): ${DEAL_II_LIBRARIES};${DEAL_II_LIBRARIES_${build}}
   Please check the CMake variables
     DEAL_II_CXX_FLAGS, DEAL_II_CXX_FLAGS_${build},
     DEAL_II_LINKER_FLAGS, DEAL_II_CXX_FLAGS_${build}

--- a/cmake/setup_compiler_flags.cmake
+++ b/cmake/setup_compiler_flags.cmake
@@ -72,10 +72,9 @@
 #
 
 FOREACH(build ${DEAL_II_BUILD_TYPES})
-  SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
-  SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
-
-  CHECK_COMPILER_SETUP(_cxx_flags_${build} _linker_flags_${build}
+  CHECK_COMPILER_SETUP(
+    "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}"
+    "${DEAL_II_LINKER_FLAGS_SAVED} ${DEAL_II_LINKER_FLAGS_${build}_SAVED}"
     DEAL_II_HAVE_USABLE_USER_FLAGS_${build}
     ${DEAL_II_LIBRARIES} ${DEAL_II_LIBRARIES_${build}}
     )
@@ -83,8 +82,8 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   IF(NOT DEAL_II_HAVE_USABLE_USER_FLAGS_${build})
     MESSAGE(FATAL_ERROR "
   Configuration error: Cannot compile with the user supplied flags:
-    CXX flags (${build}): ${_cxx_flags_${build}}
-    LD flags  (${build}): ${_linker_flags_${build}}
+    CXX flags (${build}): ${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}
+    LD flags  (${build}): ${DEAL_II_LINKER_FLAGS_SAVED} ${DEAL_II_LINKER_FLAGS_${build}_SAVED}
     LIBRARIES (${build}): ${DEAL_II_LIBRARIES};${DEAL_II_LIBRARIES_${build}}
   Please check the CMake variables
     DEAL_II_CXX_FLAGS, DEAL_II_CXX_FLAGS_${build},

--- a/cmake/setup_compiler_flags.cmake
+++ b/cmake/setup_compiler_flags.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2016 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -71,33 +71,26 @@
 # Check the user provided CXX flags:
 #
 
-IF(NOT "${DEAL_II_CXX_FLAGS_SAVED}" STREQUAL "${CACHED_DEAL_II_CXX_FLAGS_SAVED}"
-   OR NOT "${DEAL_II_LINKER_FLAGS_SAVED}" STREQUAL "${CACHED_DEAL_II_LINKER_FLAGS_SAVED}")
-  # Rerun this test if cxx flags changed:
-  UNSET(DEAL_II_HAVE_USABLE_CXX_FLAGS CACHE)
-ELSE()
-  SET(DEAL_II_HAVE_USABLE_CXX_FLAGS TRUE CACHE INTERNAL "")
-ENDIF()
-SET(CACHED_DEAL_II_CXX_FLAGS_SAVED "${DEAL_II_CXX_FLAGS_SAVED}" CACHE INTERNAL "" FORCE)
-SET(CACHED_DEAL_II_LINKER_FLAGS_SAVED "${DEAL_II_LINKER_FLAGS_SAVED}" CACHE INTERNAL "" FORCE)
+FOREACH(build ${DEAL_II_BUILD_TYPES})
+  SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
+  SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS_SAVED} ${DEAL_II_CXX_FLAGS_${build}_SAVED}")
 
-# Initialize all CMAKE_REQUIRED_* variables a this point:
-RESET_CMAKE_REQUIRED()
-
-CHECK_CXX_SOURCE_COMPILES(
-  "int main(){ return 0; }"
-  DEAL_II_HAVE_USABLE_CXX_FLAGS)
-
-IF(NOT DEAL_II_HAVE_USABLE_CXX_FLAGS)
-  UNSET(DEAL_II_HAVE_USABLE_CXX_FLAGS CACHE)
-  MESSAGE(FATAL_ERROR "
-Configuration error: Cannot compile with the user supplied flags:
-CXX flags: ${DEAL_II_CXX_FLAGS_SAVED}
-LD flags: ${DEAL_II_LINKER_FLAGS_SAVED}
-Please check the CMake variables DEAL_II_CXX_FLAGS, DEAL_II_LINKER_FLAGS
-and the environment variables CXXFLAGS, LDFLAGS.\n\n"
+  CHECK_COMPILER_FLAGS(_cxx_flags_${build} _linker_flags_${build}
+    DEAL_II_HAVE_USABLE_USER_FLAGS_${build}
     )
-ENDIF()
+
+  IF(NOT DEAL_II_HAVE_USABLE_USER_FLAGS_${build})
+    MESSAGE(FATAL_ERROR "
+  Configuration error: Cannot compile with the user supplied flags:
+  CXX flags (${build}): ${_cxx_flags_${build}}
+  LD flags  (${build}): ${_linker_flags_${build}}
+  Please check the CMake variables
+    DEAL_II_CXX_FLAGS, DEAL_II_CXX_FLAGS_${build},
+    DEAL_II_LINKER_FLAGS, DEAL_II_CXX_FLAGS_${build}
+  and the environment variables CXXFLAGS, LDFLAGS.\n\n"
+      )
+  ENDIF()
+ENDFOREACH()
 
 
 ########################################################################

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -84,10 +84,9 @@ ENDFOREACH()
 #
 
 FOREACH(build ${DEAL_II_BUILD_TYPES})
-  SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
-  SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
-
-  CHECK_COMPILER_SETUP(_cxx_flags_${build} _linker_flags_${build}
+  CHECK_COMPILER_SETUP(
+    "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}"
+    "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_${build}}"
     DEAL_II_HAVE_USABLE_FLAGS_${build}
     ${DEAL_II_LIBRARIES} ${DEAL_II_LIBRARIES_${build}}
     )
@@ -96,8 +95,8 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
     MESSAGE(FATAL_ERROR "
   Configuration error: Cannot compile a test program with the final set of
   compiler and linker flags:
-    CXX flags (${build}): ${_cxx_flags_${build}}
-    LD flags  (${build}): ${_linker_flags_${build}}
+    CXX flags (${build}): ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}
+    LD flags  (${build}): ${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_${build}}
     LIBRARIES (${build}): ${DEAL_II_LIBRARIES};${DEAL_II_LIBRARIES_${build}}
   \n\n"
       )

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -87,16 +87,18 @@ FOREACH(build ${DEAL_II_BUILD_TYPES})
   SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
   SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
 
-  CHECK_COMPILER_FLAGS(_cxx_flags_${build} _linker_flags_${build}
+  CHECK_COMPILER_SETUP(_cxx_flags_${build} _linker_flags_${build}
     DEAL_II_HAVE_USABLE_FLAGS_${build}
+    ${DEAL_II_LIBRARIES} ${DEAL_II_LIBRARIES_${build}}
     )
 
   IF(NOT DEAL_II_HAVE_USABLE_FLAGS_${build})
     MESSAGE(FATAL_ERROR "
   Configuration error: Cannot compile a test program with the final set of
   compiler and linker flags:
-    CXX flags (${build}): ${_final_cxx_flags_${build}}
-    LD flags  (${build}): ${_final_linker_flags_${build}}
+    CXX flags (${build}): ${_cxx_flags_${build}}
+    LD flags  (${build}): ${_linker_flags_${build}}
+    LIBRARIES (${build}): ${DEAL_II_LIBRARIES};${DEAL_II_LIBRARIES_${build}}
   \n\n"
       )
   ENDIF()

--- a/cmake/setup_finalize.cmake
+++ b/cmake/setup_finalize.cmake
@@ -80,6 +80,29 @@ FOREACH(_suffix ${DEAL_II_LIST_SUFFIXES})
 ENDFOREACH()
 
 #
+# Sanity check: Can we compile with the final setup?
+#
+
+FOREACH(build ${DEAL_II_BUILD_TYPES})
+  SET(_cxx_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
+  SET(_linker_flags_${build} "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${build}}")
+
+  CHECK_COMPILER_FLAGS(_cxx_flags_${build} _linker_flags_${build}
+    DEAL_II_HAVE_USABLE_FLAGS_${build}
+    )
+
+  IF(NOT DEAL_II_HAVE_USABLE_FLAGS_${build})
+    MESSAGE(FATAL_ERROR "
+  Configuration error: Cannot compile a test program with the final set of
+  compiler and linker flags:
+    CXX flags (${build}): ${_final_cxx_flags_${build}}
+    LD flags  (${build}): ${_final_linker_flags_${build}}
+  \n\n"
+      )
+  ENDIF()
+ENDFOREACH()
+
+#
 # Clean up deal.IITargets.cmake in the build directory:
 #
 FILE(REMOVE

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -360,6 +360,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Fixed: Work around an issue with the OpenMPI installation on certain
+   Ubuntu versions: The build system now automatically drops the
+   "-fuse-ld=gold" linker flag if openmpi is incompatible with it.
+ <br>
+ (Wolfgang Bangerth, Martin Kronbichler, Matthias Maier, 2016/07/13)
+
+ </li>
  <li> Fixed: FEValues::reinit() would sometimes try to be overly
  clever and not re-compute information when called with the same
  cell twice in a row, even if the underlying triangulation had

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -150,6 +150,14 @@ inconvenience this causes.
 <h3>General</h3>
 
 <ol>
+ <li> Improved: The build system now checks for usable compiler/linker
+ flags during various stages of the configure run. This should catch the
+ majority of issues by user supplied flags/libraries and unusable final
+ link interfaces before we actually proceed to compile the library.
+ <br>
+ (Matthias Maier, 2016/07/13)
+ </li>
+
  <li> Improved: The testsuite now supports fine grained feature constraints
  of the form <code>test.with_[feature]_with_[...]=true</code> corresponding
  to variables <code>DEAL_II_<FEATURE>_WITH_[...]</code> exported to


### PR DESCRIPTION
This pull requests restructures the compiler sanity checks and adds a couple of
additional checks:

 * Check that the user supplied set of compiler/linker flags and libraries is
   usable (for both, debug and release)

 * Check that the MPI interface is not b0rked - i.e. whether it is possible to
   compile and link a simple "int main(){}" against the mpi installation

 * Check the final configuration, i.e. the full link interface with all flags
   for debug and release.

Closes #2820