### PR TITLE
CTest: Do not try to manipulate xml submission files with sed

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -523,27 +523,6 @@ Unable to determine test submission files from TAG. Bailing out.
     )
 ENDIF()
 
-IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  #
-  # Only use the following sed command on GNU userlands:
-  #
-  # TODO: Come up with a more robust way to inject this that also works on
-  # BSD and Mac
-  #
-  FILE(GLOB _xml_files ${_path}/*.xml)
-  EXECUTE_PROCESS(COMMAND sed -i -e
-    s/CompilerName=\\"\\"/CompilerName=\\"${_compiler_name}\\"\\n\\tCompilerVersion=\\"${_compiler_version}\\"/g
-    ${_xml_files}
-    OUTPUT_QUIET RESULT_VARIABLE  _res
-    )
-  IF(NOT "${_res}" STREQUAL "0")
-    MESSAGE(FATAL_ERROR "
-  \"sed\" failed. Bailing out.
-  "
-      )
-  ENDIF()
-ENDIF()
-
 FILE(WRITE ${_path}/Update.xml
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <Update mode=\"Client\" Generator=\"ctest-${CTEST_VERSION}\">


### PR DESCRIPTION
Due to this sed magic we might end up with two identical keys in
Configure.xml. Unfortunately, this terribly confuses CDash.

Further, we don't really use this information any more. (Compiler name and
version is used in the build string and can be looked up in the configure
output and detailed.log.)