### PR TITLE
Tests/petsc complex l1 again

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -465,6 +465,10 @@ namespace PETScWrappers
 
     /**
      * $l_1$-norm of the vector. The sum of the absolute values.
+     *
+     * @note In complex-valued PETSc priori to 3.7.0 this norm is implemented
+     * as the sum of absolute values of real and imaginary parts of elements
+     * of a complex vector.
      */
     real_type l1_norm () const;
 

--- a/tests/petsc_complex/17.cc
+++ b/tests/petsc_complex/17.cc
@@ -32,7 +32,11 @@ void test (PETScWrappers::Vector &v)
     {
       const PetscScalar  s(1.*k,2.*k);
       v(k) = s;
+#if DEAL_II_PETSC_VERSION_LT(3,7,0)
+      norm += std::fabs (1.*k)+std::fabs(2.*k);
+#else
       norm += std::abs (s);
+#endif
     }
   v.compress (VectorOperation::insert);
 


### PR DESCRIPTION
> For complex numbers NORM_1 will return the traditional 1 norm of the 2 norm of the complex numbers; that is the 1 norm of the absolutely values of the complex entries. In PETSc 3.6 and earlier releases it returned the 1 norm of the 1 norm of the complex entries (what is returned by the BLAS routine asum()).

from http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecNorm.html

in reference to https://github.com/dealii/dealii/issues/2033