### PR TITLE
supports_distributed_data

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -39,6 +39,13 @@ inconvenience this causes.
 
 <ol>
 
+ <li> Changed: The static variable supports_distributed_data, which is part
+ of the Vector interface, has been replaced by the member function 
+ supports_distributed_data() for all the vectors.
+ <br>
+ (Bruno Turcksin, 2016/07/15)
+ </li>
+
  <li> Changed: The conversion constructors of class Vector from the
  PETScWrappers::Vector, PETScWrappers::MPI::Vector,
  TrilinosWrappers::Vector, and TrilinosWrappers::MPI::Vector classes

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -562,17 +562,6 @@ public:
   typedef typename BlockType::real_type real_type;
 
   /**
-   * A variable that indicates whether this vector supports distributed data
-   * storage. If true, then this vector also needs an appropriate compress()
-   * function that allows communicating recent set or add operations to
-   * individual elements to be communicated to other processors.
-   *
-   * For the current class, the variable equals the value declared for the
-   * type of the individual blocks.
-   */
-  static const bool supports_distributed_data = BlockType::supports_distributed_data;
-
-  /**
    * Default constructor.
    */
   BlockVectorBase ();
@@ -973,6 +962,15 @@ public:
    * an empty function.
    */
   void update_ghost_values () const;
+
+  /**
+   * A variable that indicates whether this vector supports distributed data
+   * storage.
+   *
+   * For the current class, the variable equals the value declared for the
+   * type of the individual blocks.
+   */
+  bool supports_distributed_data() const;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -2262,6 +2260,17 @@ void BlockVectorBase<VectorType>::extract_subvector_to (ForwardIterator         
       indices_begin++;
       values_begin++;
     }
+}
+
+
+template <typename VectorType>
+inline
+bool BlockVectorBase<VectorType>::supports_distributed_data() const
+{
+  // Create a dummy vector of type VectorType to check
+  // supports_distributed_data even if BlockVectorBase contains no block
+  VectorType dummy;
+  return dummy.supports_distributed_data();
 }
 
 #endif // DOXYGEN

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -851,7 +851,7 @@ ConstraintMatrix::distribute (VectorType &vec) const
   // call compress() finally. the first case here is for the complicated case,
   // the last else is for the simple case (sequential vector)
   const IndexSet vec_owned_elements = vec.locally_owned_elements();
-  if (vec.supports_distributed_data == true)
+  if (vec.supports_distributed_data() == true)
     {
       // This processor owns only part of the vector. one may think that
       // every processor should be able to simply communicate those elements

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -521,6 +521,12 @@ namespace LinearAlgebra
                                  const VectorSpaceVector<Number> &W);
 
       /**
+       * A variable that indicates whether this vector supports distributed
+       * data storage.
+       */
+      virtual bool supports_distributed_data() const;
+
+      /**
        * Return the global size of the vector, equal to the sum of the number of
        * locally owned indices among all processors.
        */

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -703,6 +703,15 @@ namespace LinearAlgebra
 
 
     template <typename Number>
+    inline
+    bool BlockVector<Number>::supports_distributed_data() const
+    {
+      return true;
+    }
+
+
+
+    template <typename Number>
     typename BlockVector<Number>::size_type
     BlockVector<Number>::size () const
     {

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -187,18 +187,6 @@ namespace LinearAlgebra
       typedef typename numbers::NumberTraits<Number>::real_type real_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       */
-      static const bool supports_distributed_data = true;
-
-      /**
        * @name 1: Basic Object-handling
        */
       //@{
@@ -640,6 +628,15 @@ namespace LinearAlgebra
       virtual Number add_and_dot(const Number a,
                                  const VectorSpaceVector<Number> &V,
                                  const VectorSpaceVector<Number> &W);
+
+      /**
+       * A variable that indicates whether this vector supports distributed
+       * data storage.
+       *
+       * For the current class, the variable equals true, since it does
+       * support parallel data storage.
+       */
+      virtual bool supports_distributed_data() const;
 
       /**
        * Return the global size of the vector, equal to the sum of the number of
@@ -1125,6 +1122,14 @@ namespace LinearAlgebra
       return vector_is_ghosted;
     }
 
+
+    template <typename Number>
+    inline
+    bool
+    Vector<Number>::supports_distributed_data() const
+    {
+      return true;
+    }
 
 
     template <typename Number>

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -209,6 +209,12 @@ namespace LinearAlgebra
                                const VectorSpaceVector<Number> &W);
 
     /**
+     * A variable that indicates whether this vector supports distributed data
+     * storage.
+     */
+    virtual bool supports_distributed_data() const;
+
+    /**
      * Return the global size of the vector, equal to the sum of the number of
      * locally owned indices among all processors.
      */
@@ -324,6 +330,15 @@ namespace LinearAlgebra
   template <typename Number>
   inline
   Vector<Number>::~Vector() {}
+
+
+
+  template <typename Number>
+  inline
+  bool Vector<Number>::supports_distributed_data() const
+  {
+    return false;
+  }
 
 
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -163,18 +163,6 @@ namespace PETScWrappers
       typedef types::global_dof_index size_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       */
-      static const bool supports_distributed_data = true;
-
-      /**
        * Default constructor. Initialize the vector as empty.
        */
       Vector ();
@@ -358,6 +346,15 @@ namespace PETScWrappers
        */
       void reinit (const IndexSet &local,
                    const MPI_Comm &communicator);
+
+      /**
+       * A variable that indicates whether this vector supports distributed
+       * data storage.
+       *
+       * For the current class, the variable equals true, since it does
+       * support parallel data storage.
+       */
+      bool supports_distributed_data() const;
 
       /**
        * Return a reference to the MPI communicator object in use with this
@@ -567,6 +564,14 @@ namespace PETScWrappers
       compress (::dealii::VectorOperation::insert);
 
       return *this;
+    }
+
+
+
+    inline
+    bool Vector::supports_distributed_data() const
+    {
+      return true;
     }
 
 

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -59,18 +59,6 @@ namespace PETScWrappers
     typedef types::global_dof_index size_type;
 
     /**
-     * A variable that indicates whether this vector supports distributed data
-     * storage. If true, then this vector also needs an appropriate compress()
-     * function that allows communicating recent set or add operations to
-     * individual elements to be communicated to other processors.
-     *
-     * For the current class, the variable equals false, since it does not
-     * support parallel data storage. If you do need parallel data storage,
-     * use PETScWrappers::MPI::Vector.
-     */
-    static const bool supports_distributed_data = false;
-
-    /**
      * Default constructor. Initialize the vector as empty.
      */
     Vector ();
@@ -182,6 +170,16 @@ namespace PETScWrappers
      */
     void reinit (const Vector &v,
                  const bool    omit_zeroing_entries = false);
+
+    /**
+     * A variable that indicates whether this vector supports distributed data
+     * storage.
+     *
+     * For the current class, the variable equals false, since it does not
+     * support parallel data storage. If you do need parallel data storage,
+     * use PETScWrappers::MPI::Vector.
+     */
+    bool supports_distributed_data() const;
 
   protected:
     /**
@@ -386,6 +384,14 @@ namespace PETScWrappers
     compress (::dealii::VectorOperation::insert);
 
     return *this;
+  }
+
+
+
+  inline
+  bool Vector::supports_distributed_data() const
+  {
+    return false;
   }
 #endif // DOXYGEN
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -467,6 +467,11 @@ namespace LinearAlgebra
     void add (const size_type  n_elements,
               const size_type *indices,
               const Number2   *values);
+    /**
+     * A variable that indicates whether this vector supports distributed data
+     * storage.
+     */
+    virtual bool supports_distributed_data() const;
 
     /**
      * Prints the vector to the output stream @p out.
@@ -879,12 +884,22 @@ namespace LinearAlgebra
 
   template <typename Number>
   template <typename Functor>
+  inline
   void
   ReadWriteVector<Number>::FunctorTemplate<Functor>::operator() (const size_type begin,
       const size_type end)
   {
     for (size_type i=begin; i<end; ++i)
       functor(parent.val[i]);
+  }
+
+
+
+  template <typename Number>
+  inline
+  bool ReadWriteVector<Number>::supports_distributed_data() const
+  {
+    return false;
   }
 #endif
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -208,6 +208,11 @@ namespace LinearAlgebra
       virtual double add_and_dot(const double a,
                                  const VectorSpaceVector<double> &V,
                                  const VectorSpaceVector<double> &W);
+      /**
+       * A variable that indicates whether this vector supports distributed data
+       * storage.
+       */
+      virtual bool supports_distributed_data() const;
 
       /**
        * Returns the global size of the vector, equal to the sum of the number of

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -259,18 +259,6 @@ namespace TrilinosWrappers
       typedef dealii::types::global_dof_index size_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       */
-      static const bool supports_distributed_data = true;
-
-      /**
        * @name Basic constructors and initialization.
        */
       //@{
@@ -619,6 +607,15 @@ namespace TrilinosWrappers
                    const IndexSet &ghost_entries,
                    const MPI_Comm &communicator = MPI_COMM_WORLD,
                    const bool      vector_writable = false);
+
+      /**
+       * A variable that indicates whether this vector supports distributed
+       * data storage.
+       *
+       * For the current class, the variable equals true, since it does
+       * support parallel data storage.
+       */
+      bool supports_distributed_data() const;
 //@}
     };
 
@@ -715,6 +712,12 @@ namespace TrilinosWrappers
     }
 
 
+
+    inline
+    bool Vector::supports_distributed_data() const
+    {
+      return true;
+    }
 #endif /* DOXYGEN */
 
   } /* end of namespace MPI */
@@ -741,18 +744,6 @@ namespace TrilinosWrappers
      * Declare type for container size.
      */
     typedef dealii::types::global_dof_index size_type;
-
-    /**
-     * A variable that indicates whether this vector supports distributed data
-     * storage. If true, then this vector also needs an appropriate compress()
-     * function that allows communicating recent set or add operations to
-     * individual elements to be communicated to other processors.
-     *
-     * For the current class, the variable equals false, since it does not
-     * support parallel data storage.  If you do need parallel data storage,
-     * use TrilinosWrappers::MPI::Vector.
-     */
-    static const bool supports_distributed_data = false;
 
     /**
      * Default constructor that generates an empty (zero size) vector. The
@@ -910,6 +901,16 @@ namespace TrilinosWrappers
      * thus an empty function.
      */
     void update_ghost_values () const;
+
+    /**
+     * A variable that indicates whether this vector supports distributed data
+     * storage.
+     *
+     * For the current class, the variable equals false, since it does not
+     * support parallel data storage.  If you do need parallel data storage,
+     * use TrilinosWrappers::MPI::Vector.
+     */
+    bool supports_distributed_data() const;
   };
 
 
@@ -990,6 +991,13 @@ namespace TrilinosWrappers
   Vector::update_ghost_values () const
   {}
 
+
+
+  inline
+  bool Vector::supports_distributed_data() const
+  {
+    return false;
+  }
 
 #endif
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -138,17 +138,6 @@ public:
    */
   typedef typename numbers::NumberTraits<Number>::real_type real_type;
 
-  /**
-   * A variable that indicates whether this vector supports distributed data
-   * storage. If true, then this vector also needs an appropriate compress()
-   * function that allows communicating recent set or add operations to
-   * individual elements to be communicated to other processors.
-   *
-   * For the current class, the variable equals false, since it does not
-   * support parallel data storage.
-   */
-  static const bool supports_distributed_data = false;
-
 public:
 
   /**
@@ -915,6 +904,15 @@ public:
   //@{
 
   /**
+   * A variable that indicates whether this vector supports distributed data
+   * storage.
+   *
+   * For the current class, the variable equals false, since it does not
+   * support parallel data storage.
+   */
+  bool supports_distributed_data() const;
+
+  /**
    * Returns true if the given global index is in the local range of this
    * processor.  Since this is not a distributed vector the method always
    * returns true.
@@ -1345,6 +1343,15 @@ Vector<Number>::load (Archive &ar, const unsigned int)
 
   allocate();
   ar &boost::serialization::make_array(val, max_vec_size);
+}
+
+
+
+template <typename Number>
+inline
+bool Vector<Number>::supports_distributed_data() const
+{
+  return false;
 }
 
 #endif

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -167,6 +167,12 @@ namespace LinearAlgebra
                                const VectorSpaceVector<Number> &W) = 0;
 
     /**
+     * A variable that indicates whether this vector supports distributed
+     * data storage.
+     */
+    virtual bool supports_distributed_data() const = 0;
+
+    /**
      * Return the global size of the vector, equal to the sum of the number of
      * locally owned indices among all processors.
      */

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7177,7 +7177,7 @@ namespace VectorTools
     else
       {
         // This function is not implemented for distributed vectors.
-        Assert(!v.supports_distributed_data, ExcNotImplemented());
+        Assert(!v.supports_distributed_data(), ExcNotImplemented());
 
         const unsigned int n = v.size();
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -399,6 +399,13 @@ namespace LinearAlgebra
 
 
 
+    bool Vector::supports_distributed_data() const
+    {
+      return true;
+    }
+
+
+
     Vector::size_type Vector::size() const
     {
 #ifndef DEAL_II_WITH_64BIT_INDICES


### PR DESCRIPTION
Replace the static variable ```supports_distributed_data``` by the member function ```supports_distributed_data()```. This is an incompatible change but necessary because of the new vector interface where every vector derives from ```ReadWriteVector``` and/or ```VectorSpaceVector```. Given that until not long ago neither @drwells, @davydden, or me knew about this variable (#2580), I really doubt that we will break anyone's code. I also changed the documentation because the new vectors don't implement ```compress()```.