### PR TITLE
Remove function use in early steps

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -151,6 +151,13 @@ inconvenience this causes.
 
 <ol>
  <li>
+ Improved: A few of the introductory examples (steps five through eight) no
+ longer use the Function class; they use plain functions instead.
+ <br>
+ (David Wells, 2016/07/25)
+ </li>
+
+ <li>
  Improved: VectorTools::interpolate() may now be used on FESystems with mixed
  interpolating and non-interpolating FEs, if all of the selected components for
  interpolation originate from interpolating FEs.

--- a/examples/step-4/doc/tooltip
+++ b/examples/step-4/doc/tooltip
@@ -1,1 +1,1 @@
-Dimension independent programming. Boundary conditions.
+Dimension independent programming. Boundary conditions. Functions.

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -117,11 +117,19 @@ private:
 // where we want to evaluate the function. A value for the component can then
 // simply be omitted for scalar functions.
 //
-// Note that the C++ language forces us to declare and define a constructor to
-// the following classes even though they are empty. This is due to the fact
-// that the base class has no default constructor (i.e. one without
-// arguments), even though it has a constructor which has default values for
-// all arguments.
+// Function objects are used in lots of places in the library (for example, in
+// step-2 we used a ZeroFunction instance as an argument to
+// VectorTools::interpolate_boundary_values) and this is the first step where
+// we define a new class that inherits from Function. Since we only ever call
+// Function::value, we could get away with just a plain function (and this is
+// what is done in step-5), but since this is a tutorial we inherit from
+// Function for the sake of example.
+//
+// Unfortunately, some compilers (notably clang 3.8) have a bug where they
+// cannot figure out the default constructor (that is, the constructor which
+// takes no arguments) of classes derived from Function. For portability we
+// provide such constructors in all the tutorial programs so that all
+// supported compilers are happy.
 template <int dim>
 class RightHandSide : public Function<dim>
 {

--- a/examples/step-5/doc/results.dox
+++ b/examples/step-5/doc/results.dox
@@ -1,8 +1,7 @@
 <h1>Results</h1>
 
 
-When the last block in <code>main()</code> is commented in, the output
-of the program looks as follows:
+Here is the console output:
 @code
 Cycle 0:
    Number of active cells: 20
@@ -34,28 +33,10 @@ Cycle 5:
    Total number of cells: 27300
    Number of degrees of freedom: 20609
    182 CG iterations needed to obtain convergence.
---------------------------------------------------------
-An error occurred in line <273> of file <\step-5.cc> in function
-    void Coefficient<dim>::value_list(const std::vector<Point<dim>, std::allocator<Point<dim> > >&, std::vector<double, std::allocator<double> >&, unsigned int)
- const [with int dim = 2]
-The violated condition was:
-    values.size() == points.size()
-The name and call sequence of the exception was:
-    ExcDimensionMismatch (values.size(), points.size())
-Additional Information:
-Dimension 1 not equal to 2
-
-Stacktrace:
------------
-#0  ./\step-5: Coefficient<2>::value_list(std::vector<Point<2>, std::allocator<Point<2> > > const&, std::vector<double, std::allocator<double> >&, unsigned) const
-#1  ./\step-5: main
---------------------------------------------------------
-make: *** [run] Aborted
 @endcode
 
 
 
-Let's first focus on the things before the error:
 In each cycle, the number of cells quadruples and the number of CG
 iterations roughly doubles.
 Also, in each cycle, the program writes one output graphic file in EPS
@@ -100,63 +81,3 @@ the solution is flattened. The gradient of the solution is
 discontinuous there, although this is not very clearly visible in the
 pictures above. We will look at this in more detail in the next
 example.
-
-
-
-
-As for the error &mdash; let's look at it again:
-@code
---------------------------------------------------------
-An error occurred in line <273> of file <\step-5.cc> in function
-    void Coefficient<dim>::value_list(const std::vector<Point<dim>, std::allocator<Point<dim> > >&, std::vector<double, std::allocator<double> >&, unsigned int)
- const [with int dim = 2]
-The violated condition was:
-    values.size() == points.size()
-The name and call sequence of the exception was:
-    ExcDimensionMismatch (values.size(), points.size())
-Additional Information:
-Dimension 1 not equal to 2
-
-Stacktrace:
------------
-#0  ./\step-5: Coefficient<2>::value_list(std::vector<Point<2>, std::allocator<Point<2> > > const&, std::vector<double, std::allocator<double> >&, unsigned) const
-#1  ./\step-5: main
---------------------------------------------------------
-make: *** [run] Aborted
-@endcode
-
-
-
-What we see is that the error was triggered in line 273 of the
-step-5.cc file (as we modify tutorial programs over time, these line
-numbers change, so you should check what line number you actually get
-in your output). That's already good information if you want to look up
-in the code what exactly happened. But the text tells you even
-more. First, it prints the function this happens in, and then the
-plain text version of the condition that was violated. This will
-almost always be enough already to let you know what exactly went wrong.
-
-
-
-But that's not all yet. You get to see the name of the exception
-(<code>ExcDimensionMismatch</code>) and this exception even prints the
-values of the two array sizes. If you go back to the code in
-<code>main()</code>, you will remember that we gave the two variables
-sizes 1 and 2, which of course are the ones that you find in the
-output again.
-
-
-
-So now we know pretty exactly where the error happened and what went
-wrong. What we don't know yet is how exactly we got there. The
-stacktrace at the bottom actually tells us what happened: the problem
-happened in
-<code>Coefficient::value_list</code> (stackframe 0) and that it was
-called from <code>main()</code> (stackframe 1). In realistic programs,
-there would be many more functions in between these two. For example,
-we might have made the mistake in the <code>assemble_system</code>
-function, in which case stack frame 1 would be
-<code>Step5::assemble_system</code>, stack frame 2
-would be <code>Step5::run</code>, and stack frame 3
-would be <code>main()</code> &mdash; you get the idea.
-

--- a/examples/step-5/doc/tooltip
+++ b/examples/step-5/doc/tooltip
@@ -1,1 +1,1 @@
-Reading a grid from disk. Computations on successively refined grids. Variable coefficients.
+Reading a grid from disk. Computations on successively refined grids. Variable coefficients. Assertions.

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -404,7 +404,43 @@ void Step5<dim>::run ()
   // two-dimensional triangulation, while this function is a template for
   // arbitrary dimension. Since this is only a demonstration program, we will
   // not use different input files for the different dimensions, but rather
-  // kill the whole program if we are not in 2D:
+  // quickly kill the whole program if we are not in 2D. Of course, since the
+  // main function below assumes that we are working in two dimensions we
+  // could skip this check, in this version of the program, without any ill
+  // effects.
+  //
+  // It turns out that more than 90 per cent of programming errors are invalid
+  // function parameters such as invalid array sizes, etc, so we use
+  // assertions heavily throughout deal.II to catch such mistakes. For this,
+  // the <code>Assert</code> macro is a good choice, since it makes sure that
+  // the condition which is given as first argument is valid, and if not
+  // throws an exception (its second argument) which will usually terminate
+  // the program giving information where the error occurred and what the
+  // reason was. This generally reduces the time to find programming errors
+  // dramatically and we have found assertions an invaluable means to program
+  // fast.
+  //
+  // On the other hand, all these checks (there are over 9000 of them in the
+  // library at present) should not slow down the program too much if you want
+  // to do large computations. To this end, the <code>Assert</code> macro is
+  // only used in debug mode and expands to nothing if in optimized
+  // mode. Therefore, while you test your program on small problems and debug
+  // it, the assertions will tell you where the problems are. Once your
+  // program is stable, you can switch off debugging and the program will run
+  // your real computations without the assertions and at maximum speed. More
+  // precisely: turning off all the checks in the library (which prevent you
+  // from calling functions with wrong arguments, walking off of arrays, etc.)
+  // by compiling your program in optimized mode usually makes things run
+  // about four times faster. Even though optimized programs are more
+  // performant, we still recommend developing in debug mode since it allows
+  // the library to find lots of common programming errors automatically. For
+  // those who want to try: The way to switch from debug mode to optimized
+  // mode is to recompile your program with the command <code>make
+  // release</code>. The output of the <code>make</code> program should now
+  // indicate to you that the program is now compiled in optimized mode, and
+  // it will later also be linked to libraries that have been compiled for
+  // optimized mode. In order to switch back to debug mode, simply recompile
+  // with the command <code>make debug</code>.
   Assert (dim==2, ExcInternalError());
   // ExcInternalError is a globally defined exception, which may be thrown
   // whenever something is terribly wrong. Usually, one would like to use more

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -157,7 +157,7 @@ void Step5<dim>::setup_system ()
 // As in the previous examples, this function is not changed much with regard
 // to its functionality, but there are still some optimizations which we will
 // show. For this, it is important to note that if efficient solvers are used
-// (such as the preconditions CG method), assembling the matrix and right hand
+// (such as the preconditioned CG method), assembling the matrix and right hand
 // side can take a comparable time, and you should think about using one or
 // two optimizations at some places.
 //

--- a/examples/step-6/doc/results.dox
+++ b/examples/step-6/doc/results.dox
@@ -14,19 +14,19 @@ Cycle 2:
    Number of degrees of freedom: 449
 Cycle 3:
    Number of active cells:       200
-   Number of degrees of freedom: 961
+   Number of degrees of freedom: 921
 Cycle 4:
    Number of active cells:       440
-   Number of degrees of freedom: 2033
+   Number of degrees of freedom: 2017
 Cycle 5:
-   Number of active cells:       932
-   Number of degrees of freedom: 4465
+   Number of active cells:       956
+   Number of degrees of freedom: 4425
 Cycle 6:
    Number of active cells:       1916
-   Number of degrees of freedom: 9113
+   Number of degrees of freedom: 8993
 Cycle 7:
-   Number of active cells:       3884
-   Number of degrees of freedom: 18401
+   Number of active cells:       3860
+   Number of degrees of freedom: 18353
 @endcode
 
 

--- a/examples/step-6/doc/results.dox
+++ b/examples/step-6/doc/results.dox
@@ -109,51 +109,48 @@ from the optimal square.
 
 
 
-
 For completeness, we show what happens if the code we commented about
 in the destructor of the <code>Step6</code> class is omitted
 from this example.
 
 @code
 --------------------------------------------------------
-An error occurred in line <79> of file <source/subscriptor.cc> in function
-    virtual Subscriptor::~Subscriptor()
+An error occurred in line <128> of file <source/base/subscriptor.cc> in function
+    void dealii::Subscriptor::check_no_subscribers() const
 The violated condition was:
     counter == 0
 The name and call sequence of the exception was:
-    ExcInUse(counter, object_info->name(), infostring)
+    ExcInUse (counter, object_info->name(), infostring)
 Additional Information:
-Object of class 4FE_QILi2EE is still used by 1 other objects.
-  from Subscriber 10DoFHandlerILi2EE
+Object of class N6dealii4FE_QILi2ELi2EEE is still used by 1 other objects.
+
+(Additional information: <none>)
+
+See the entry in the Frequently Asked Questions of deal.II (linked to from
+http://www.dealii.org/) for a lot more information on what this error means and
+how to fix programs in which it happens.
 
 Stacktrace:
 -----------
-#0  /u/bangerth/p/deal.II/1/deal.II/lib/libbase.g.so: Subscriptor::~Subscriptor()
-#1  /u/bangerth/p/deal.II/1/deal.II/lib/libdeal_II_2d.g.so: FiniteElement<2>::~FiniteElement()
-#2  ./\step-6: FE_Poly<TensorProductPolynomials<2>, 2>::~FE_Poly()
-#3  ./\step-6: FE_Q<2>::~FE_Q()
-#4  ./\step-6: Step6<2>::~Step6()
-#5  ./\step-6: main
+#0  /lib/libdeal_II.g.so: dealii::Subscriptor::check_no_subscribers() const
+#1  /lib/libdeal_II.g.so: dealii::Subscriptor::~Subscriptor()
+#2  /lib/libdeal_II.g.so: dealii::FiniteElement<2, 2>::~FiniteElement()
+#3  ./step-6: Step6<2>::~Step6()
+#4  ./step-6: main
 --------------------------------------------------------
-make: *** [run] Aborted
 @endcode
 
+From the above error message, we conclude that something is still using an
+object with type <code>N6dealii4FE_QILi2EE</code>. This is of course the <a
+href="http://en.wikipedia.org/wiki/Name_mangling">"mangled" name</a> for
+<code>FE_Q</code>. The mangling works as follows: the <code>N6</code> indicates
+a namespace with six characters (i.e., <code>dealii</code>) and the
+<code>4</code> indicates the number of characters of the template class (i.e.,
+<code>FE_Q</code>).
 
-
-From the above error message, we conclude that an object of type
-<code>10DoFHandlerILi2EE</code> is still using the object of type
-<code>4FE_QILi2EE</code>. These are of course <a
-href="http://en.wikipedia.org/wiki/Name_mangling">"mangled" names</a> for
-<code>DoFHandler</code> and <code>FE_Q</code>. The mangling works as
-follows: the first number indicates the number of characters of the
-template class, i.e. 10 for <code>DoFHandler</code> and 4
-for <code>FE_Q</code>; the rest of the text is then template
-arguments. From this we can already glean a little bit who's the
-culprit here, and who the victim:
-The one object that still uses the finite element is the
-<code>dof_handler</code> object.
-
-
+The rest of the text is then template arguments. From this we can already glean
+a little bit who's the culprit here, and who the victim: The one object that
+still uses the finite element is the <code>dof_handler</code> object.
 
 The stacktrace gives an indication of where the problem happened. We
 see that the exception was triggered in the

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -64,11 +64,6 @@
 // the same file as the FEValues class:
 #include <deal.II/fe/fe_values.h>
 
-// We need one more include from standard C++, which is necessary when we try
-// to find out the actual type behind a pointer to a base class. We will
-// explain this in slightly more detail below. The other two include files are
-// obvious then:
-#include <typeinfo>
 #include <fstream>
 #include <iostream>
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -166,7 +166,20 @@ namespace Step7
   // base class. Note that the gradient of a function in <code>dim</code>
   // space dimensions is a vector of size <code>dim</code>, i.e. a tensor of
   // rank 1 and dimension <code>dim</code>. As for so many other things, the
-  // library provides a suitable class for this.
+  // library provides a suitable class for this. One new thing about this
+  // class is that it explicitly uses the Tensor objects, which previously
+  // appeared as intermediate terms in step-3 and step-4. A tensor is a
+  // generalization of scalars (rank zero tensors), vectors (rank one
+  // tensors), and matrices (rank two tensors), as well as higher dimensional
+  // objects. The Tensor class requires two template arguments: the tensor
+  // rank and tensor dimension. For example, here we use tensors of rank one
+  // (vectors) with dimension <code>dim</code> (so they have <code>dim</code>
+  // entries.) While this is a bit less flexible than using Vector, the
+  // compiler can generate faster code when the length of the vector is known
+  // at compile time. Additionally, specifying a Tensor of rank one and
+  // dimension <code>dim</code> guarantees that the tensor will have the right
+  // shape (since it is built into the type of the object itself), so the
+  // compiler can catch most size-related mistakes for us.
   //
   // Just as in previous examples, we are forced by the C++ language
   // specification to declare a seemingly useless default constructor.

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -181,8 +181,8 @@ namespace Step7
   // shape (since it is built into the type of the object itself), so the
   // compiler can catch most size-related mistakes for us.
   //
-  // Just as in previous examples, we are forced by the C++ language
-  // specification to declare a seemingly useless default constructor.
+  // Like in step-4, for compatibility with some compilers we explicitly
+  // declare the default constructor:
   template <int dim>
   class Solution : public Function<dim>,
     protected SolutionBase<dim>

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -1388,16 +1388,3 @@ int main ()
 
   return 0;
 }
-
-
-// What comes here is basically just an annoyance that you can ignore if you
-// are not working on an AIX system: on this system, static member variables
-// are not instantiated automatically when their enclosing class is
-// instantiated. This leads to linker errors if these variables are not
-// explicitly instantiated. As said, this is, strictly C++ standards speaking,
-// not necessary, but it doesn't hurt either on other systems, and since it is
-// necessary to get things running on AIX, why not do it:
-namespace Step7
-{
-  template const double SolutionBase<2>::width;
-}

--- a/examples/step-8/doc/tooltip
+++ b/examples/step-8/doc/tooltip
@@ -1,1 +1,1 @@
-Systems of PDE. Elasticity.
+Systems of PDE. Elasticity. Tensors.


### PR DESCRIPTION
In the process of (hopefully) closing #650 I also cleaned up these tutorials a bit.

My primary concern is that we lose a nice description of what happens when an exception is thrown from `Function::value_list` because the two arguments have different lengths. I took it out because that function call no longer exists. Thoughts?