### PR TITLE
Prettier output for LaTeX and Description ParameterHandler output

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -150,6 +150,12 @@ inconvenience this causes.
 <h3>General</h3>
 
 <ol>
+ <li> Improved: Split out pattern descriptions for LaTeX and Description
+ ParameterHandler OutputStyles, and add better description text.
+ <br>
+ (Jonathan Robey, 2016/07/21)
+ </li>
+
  <li> New: Added GridGenerator::quarter_hyper_ball() to generate the 
  intersection of a hyper ball with the positive orthant relative
  to its center.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -68,9 +68,34 @@ namespace Patterns
     virtual bool match (const std::string &test_string) const = 0;
 
     /**
+     * List of possible description output formats.
+     *
+     * Capitalization chosen for similarity to ParameterHandler::OutputStyle.
+     */
+    enum OutputStyle
+    {
+      /**
+       * Simple text suitable for machine parsing in the static public member
+       * functions for all of the built in inheriting classes.
+       *
+       * Preferably human readable, but machine parsing is more critical.
+       */
+      Machine,
+      /**
+       * Easily human readable plain text format suitable for plain text
+       * documentation.
+       */
+      Text,
+      /**
+       * Easily human readable LaTeX format suitable for printing in manuals.
+       */
+      LaTeX
+    };
+
+    /**
      * Return a string describing the pattern.
      */
-    virtual std::string description () const = 0;
+    virtual std::string description (const OutputStyle style=Machine) const = 0;
 
     /**
      * Return a pointer to an exact copy of the object. This is necessary
@@ -160,7 +185,7 @@ namespace Patterns
      * match. If bounds were specified to the constructor, then include them
      * into this description.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -252,7 +277,7 @@ namespace Patterns
      * match. If bounds were specified to the constructor, then include them
      * into this description.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -322,7 +347,7 @@ namespace Patterns
      * match. Here, this is the list of valid strings passed to the
      * constructor.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -403,7 +428,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -518,7 +543,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -612,7 +637,7 @@ namespace Patterns
      * match. Here, this is the list of valid strings passed to the
      * constructor.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -676,7 +701,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -721,7 +746,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Anything]"</tt>.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -784,7 +809,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the
@@ -843,7 +868,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
      */
-    virtual std::string description () const;
+    virtual std::string description (const OutputStyle style=Machine) const;
 
     /**
      * Return a copy of the present object, which is newly allocated on the

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -179,25 +179,65 @@ namespace Patterns
 
 
 
-  std::string Integer::description () const
+  std::string Integer::description (const OutputStyle style) const
   {
-    // check whether valid bounds
-    // were specified, and if so
-    // output their values
-    if (lower_bound <= upper_bound)
+    switch (style)
       {
-        std::ostringstream description;
+      case Machine:
+      {
+        // check whether valid bounds
+        // were specified, and if so
+        // output their values
+        if (lower_bound <= upper_bound)
+          {
+            std::ostringstream description;
 
-        description << description_init
-                    <<" range "
-                    << lower_bound << "..." << upper_bound
-                    << " (inclusive)]";
-        return description.str();
+            description << description_init
+                        <<" range "
+                        << lower_bound << "..." << upper_bound
+                        << " (inclusive)]";
+            return description.str();
+          }
+        else
+          // if no bounds were given, then
+          // return generic string
+          return "[Integer]";
       }
-    else
-      // if no bounds were given, then
-      // return generic string
-      return "[Integer]";
+      case Text:
+      {
+        if (lower_bound <= upper_bound)
+          {
+            std::ostringstream description;
+
+            description << "An integer n such that "
+                        << lower_bound << " <= n <= " << upper_bound;
+
+            return description.str();
+          }
+        else
+          return "An integer";
+      }
+      case LaTeX:
+      {
+        if (lower_bound <= upper_bound)
+          {
+            std::ostringstream description;
+
+            description << "An integer $n$ such that $"
+                        << lower_bound << "\\leq n \\leq " << upper_bound
+                        << "$";
+
+            return description.str();
+          }
+        else
+          return "An integer";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -278,34 +318,90 @@ namespace Patterns
 
 
 
-  std::string Double::description () const
+  std::string Double::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    if (lower_bound <= upper_bound)
-      {
-        // bounds are valid
-        description << description_init << " ";
-        // We really want to compare with ==, but -Wfloat-equal would create
-        // a warning here, so work around it.
-        if (0==std::memcmp(&lower_bound, &min_double_value, sizeof(lower_bound)))
-          description << "-MAX_DOUBLE";
+        if (lower_bound <= upper_bound)
+          {
+            // bounds are valid
+            description << description_init << " ";
+            // We really want to compare with ==, but -Wfloat-equal would create
+            // a warning here, so work around it.
+            if (0==std::memcmp(&lower_bound, &min_double_value, sizeof(lower_bound)))
+              description << "-MAX_DOUBLE";
+            else
+              description << lower_bound;
+            description << "...";
+            if (0==std::memcmp(&upper_bound, &max_double_value, sizeof(upper_bound)))
+              description << "MAX_DOUBLE";
+            else
+              description << upper_bound;
+            description << " (inclusive)]";
+            return description.str();
+          }
         else
-          description << lower_bound;
-        description << "...";
-        if (0==std::memcmp(&upper_bound, &max_double_value, sizeof(upper_bound)))
-          description << "MAX_DOUBLE";
-        else
-          description << upper_bound;
-        description << " (inclusive)]";
-        return description.str();
+          {
+            // invalid bounds, assume unbounded double:
+            description << description_init << "]";
+            return description.str();
+          }
       }
-    else
+      case Text:
       {
-        // invalid bounds, assume unbounded double:
-        description << description_init << "]";
-        return description.str();
+        if (lower_bound <= upper_bound)
+          {
+            std::ostringstream description;
+
+            description << "A floating point number v such that ";
+            if (0==std::memcmp(&lower_bound, &min_double_value, sizeof(lower_bound)))
+              description << "-MAX_DOUBLE";
+            else
+              description << lower_bound;
+            description << " <= v <= ";
+            if (0==std::memcmp(&upper_bound, &max_double_value, sizeof(upper_bound)))
+              description << "MAX_DOUBLE";
+            else
+              description << upper_bound;
+
+            return description.str();
+          }
+        else
+          return "A floating point number";
       }
+      case LaTeX:
+      {
+        if (lower_bound <= upper_bound)
+          {
+            std::ostringstream description;
+
+            description << "A floating point number $v$ such that $";
+            if (0==std::memcmp(&lower_bound, &min_double_value, sizeof(lower_bound)))
+              description << "-\\text{MAX\\_DOUBLE}";
+            else
+              description << lower_bound;
+            description << " \\leq v \\leq ";
+            if (0==std::memcmp(&upper_bound, &max_double_value, sizeof(upper_bound)))
+              description << "\\text{MAX\\_DOUBLE}";
+            else
+              description << upper_bound;
+            description << "$";
+
+            return description.str();
+          }
+        else
+          return "A floating point number";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -392,16 +488,37 @@ namespace Patterns
 
 
 
-  std::string Selection::description () const
+  std::string Selection::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << " "
-                << sequence
-                << " ]";
+        description << description_init
+                    << " "
+                    << sequence
+                    << " ]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        std::ostringstream description;
+
+        description << "Any one of "
+                    << Utilities::replace_in_string(sequence,"|",", ");
+
+        return description.str();
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -516,19 +633,46 @@ namespace Patterns
 
 
 
-  std::string List::description () const
+  std::string List::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << " list of <" << pattern->description() << ">"
-                << " of length " << min_elements << "..." << max_elements
-                << " (inclusive)";
-    if (separator != ",")
-      description << " separated by <" << separator << ">";
-    description << "]";
+        description << description_init
+                    << " list of <" << pattern->description(style) << ">"
+                    << " of length " << min_elements << "..." << max_elements
+                    << " (inclusive)";
+        if (separator != ",")
+          description << " separated by <" << separator << ">";
+        description << "]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        std::ostringstream description;
+
+        description << "A list of "
+                    << min_elements << " to " << max_elements
+                    << " elements ";
+        if (separator != ",")
+          description << "separated by <" << separator << "> ";
+        description  << "where each element is ["
+                     << pattern->description(style)
+                     << "]";
+
+        return description.str();
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -693,21 +837,51 @@ namespace Patterns
 
 
 
-  std::string Map::description () const
+  std::string Map::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << " map of <"
-                << key_pattern->description() << ":"
-                << value_pattern->description() << ">"
-                << " of length " << min_elements << "..." << max_elements
-                << " (inclusive)";
-    if (separator != ",")
-      description << " separated by <" << separator << ">";
-    description << "]";
+        description << description_init
+                    << " map of <"
+                    << key_pattern->description(style) << ":"
+                    << value_pattern->description(style) << ">"
+                    << " of length " << min_elements << "..." << max_elements
+                    << " (inclusive)";
+        if (separator != ",")
+          description << " separated by <" << separator << ">";
+        description << "]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        std::ostringstream description;
+
+        description << "A key-value map of "
+                    << min_elements << " to " << max_elements
+                    << " elements ";
+        if (separator != ",")
+          description << " separated by <" << separator << "> ";
+        description << " where each key is ["
+                    << key_pattern->description(style)
+                    << "]"
+                    << " and each value is ["
+                    << value_pattern->description(style)
+                    << "]";
+
+        return description.str();
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -859,16 +1033,37 @@ namespace Patterns
 
 
 
-  std::string MultipleSelection::description () const
+  std::string MultipleSelection::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << " "
-                << sequence
-                << " ]";
+        description << description_init
+                    << " "
+                    << sequence
+                    << " ]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        std::ostringstream description;
+
+        description << "A comma-separated list of any of "
+                    << Utilities::replace_in_string(sequence,"|",", ");
+
+        return description.str();
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -916,14 +1111,30 @@ namespace Patterns
 
 
 
-  std::string Bool::description () const
+  std::string Bool::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << "]";
+        description << description_init
+                    << "]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        return "A boolean value (true or false)";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -961,14 +1172,30 @@ namespace Patterns
 
 
 
-  std::string Anything::description () const
+  std::string Anything::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init
-                << "]";
+        description << description_init
+                    << "]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        return "Any string";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -1007,18 +1234,37 @@ namespace Patterns
 
 
 
-  std::string FileName::description () const
+  std::string FileName::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init;
+        description << description_init;
 
-    if (file_type == input)
-      description << " (Type: input)]";
-    else
-      description << " (Type: output)]";
+        if (file_type == input)
+          description << " (Type: input)]";
+        else
+          description << " (Type: output)]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        if (file_type == input)
+          return "an input filename";
+        else
+          return "an output filename";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -1071,13 +1317,29 @@ namespace Patterns
 
 
 
-  std::string DirectoryName::description () const
+  std::string DirectoryName::description (const OutputStyle style) const
   {
-    std::ostringstream description;
+    switch (style)
+      {
+      case Machine:
+      {
+        std::ostringstream description;
 
-    description << description_init << "]";
+        description << description_init << "]";
 
-    return description.str();
+        return description.str();
+      }
+      case Text:
+      case LaTeX:
+      {
+        return "A directory name";
+      }
+      default:
+        AssertThrow(false, ExcNotImplemented());
+      }
+    // Should never occur without an exception, but prevent compiler from
+    // complaining
+    return "";
   }
 
 
@@ -2274,8 +2536,10 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
                       << std::endl;
 
                 // also output possible values
+                const unsigned int pattern_index = p->second.get<unsigned int> ("pattern");
+                const std::string desc_str = patterns[pattern_index]->description (Patterns::PatternBase::LaTeX);
                 out << "{\\it Possible values:} "
-                    << p->second.get<std::string> ("pattern_description")
+                    << desc_str
                     << std::endl;
               }
             else if (is_alias_node (p->second) == true)
@@ -2358,9 +2622,10 @@ ParameterHandler::print_parameters_section (std::ostream      &out,
                 << " = ";
 
             // print possible values:
+            const unsigned int pattern_index = p->second.get<unsigned int> ("pattern");
+            const std::string full_desc_str = patterns[pattern_index]->description (Patterns::PatternBase::Text);
             const std::vector<std::string> description_str
-              = Utilities::break_text_into_lines (p->second.get<std::string>
-                                                  ("pattern_description"),
+              = Utilities::break_text_into_lines (full_desc_str,
                                                   78 - overall_indent_level*2 - 2, '|');
             if (description_str.size() > 1)
               {

--- a/tests/parameter_handler/parameter_handler_4.output
+++ b/tests/parameter_handler/parameter_handler_4.output
@@ -23,7 +23,7 @@
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int}
 \phantomsection\label{parameters:Testing/int}
 
@@ -36,7 +36,7 @@
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string list}
 
@@ -52,5 +52,5 @@
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}

--- a/tests/parameter_handler/parameter_handler_4a.output
+++ b/tests/parameter_handler/parameter_handler_4a.output
@@ -23,7 +23,7 @@
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int}
 \phantomsection\label{parameters:Testing/int}
 
@@ -36,7 +36,7 @@
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list}
 \phantomsection\label{parameters:Testing/string list}
 
@@ -52,7 +52,7 @@
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}
 
 
@@ -76,7 +76,7 @@
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing 2/int 2}
 
@@ -89,7 +89,7 @@
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing 2/string list 2}
 
@@ -105,5 +105,5 @@
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias.output
@@ -23,7 +23,7 @@
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt double_alias}
 \phantomsection\label{parameters:Testing/double_alias}
 
@@ -45,7 +45,7 @@ This parameter is an alias for the parameter ``\texttt{double}''.
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt int_alias}
 \phantomsection\label{parameters:Testing/int_alias}
 
@@ -70,7 +70,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}
 
 
@@ -94,7 +94,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing 2/int 2}
 
@@ -107,7 +107,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing 2/string list 2}
 
@@ -123,5 +123,5 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}

--- a/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
+++ b/tests/parameter_handler/parameter_handler_4a_with_alias_deprecated.output
@@ -23,7 +23,7 @@
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt double_alias}
 \phantomsection\label{parameters:Testing/double_alias}
 
@@ -45,7 +45,7 @@ This parameter is an alias for the parameter ``\texttt{double}''. Its use is dep
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt int_alias}
 \phantomsection\label{parameters:Testing/int_alias}
 
@@ -70,7 +70,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}
 
 
@@ -94,7 +94,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 3
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt int 2}
 \phantomsection\label{parameters:Testing/Testing 2/int 2}
 
@@ -107,7 +107,7 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Default:} 1
 
 
-{\it Possible values:} [Integer range -2147483648...2147483647 (inclusive)]
+{\it Possible values:} An integer $n$ such that $-2147483648\leq n \leq 2147483647$
 \item {\it Parameter name:} {\tt string list 2}
 \phantomsection\label{parameters:Testing/Testing 2/string list 2}
 
@@ -123,5 +123,5 @@ This parameter is an alias for the parameter ``\texttt{int}''.
 {\it Description:} docs 1
 
 
-{\it Possible values:} [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+{\it Possible values:} A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
 \end{itemize}

--- a/tests/parameter_handler/parameter_handler_7.output
+++ b/tests/parameter_handler/parameter_handler_7.output
@@ -2,10 +2,8 @@
 Listing of Parameters:
 
 subsection Testing
-  set double       =   [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+  set double       =   A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE
                        (docs 3)
-  set int          =   [Integer range -2147483648...2147483647 (inclusive)]
-  set string list  = 
-        [List list of <[Selection a|b|c|d|e|f|g
-        h ]> of length 0...4294967295 (inclusive)]
+  set int          =   An integer n such that -2147483648 <= n <= 2147483647
+  set string list  =   A list of 0 to 4294967295 elements where each element is [Any one of a, b, c, d, e, f, g, h]
                        (docs 1)

--- a/tests/parameter_handler/parameter_handler_double_01.output
+++ b/tests/parameter_handler/parameter_handler_double_01.output
@@ -19,7 +19,7 @@
 {\it Description:} no limit
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt b}
 \phantomsection\label{parameters:b}
 
@@ -35,7 +35,7 @@
 {\it Description:} lower limit
 
 
-{\it Possible values:} [Double -2.13...MAX_DOUBLE (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-2.13 \leq v \leq \text{MAX\_DOUBLE}$
 \item {\it Parameter name:} {\tt c}
 \phantomsection\label{parameters:c}
 
@@ -51,7 +51,7 @@
 {\it Description:} upper limit
 
 
-{\it Possible values:} [Double -MAX_DOUBLE...42 (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $-\text{MAX\_DOUBLE} \leq v \leq 42$
 \item {\it Parameter name:} {\tt d}
 \phantomsection\label{parameters:d}
 
@@ -67,7 +67,7 @@
 {\it Description:} both limits
 
 
-{\it Possible values:} [Double 0.2...42 (inclusive)]
+{\it Possible values:} A floating point number $v$ such that $0.2 \leq v \leq 42$
 \item {\it Parameter name:} {\tt e}
 \phantomsection\label{parameters:e}
 
@@ -83,5 +83,5 @@
 {\it Description:} no limits
 
 
-{\it Possible values:} [Double]
+{\it Possible values:} A floating point number
 \end{itemize}


### PR DESCRIPTION
An initial approach to solving #952.

This is expected to change the output for any LaTeX parameter file tests.

I would appreciate comments on the particular text chosen for the descriptions for each pattern. I attempted to format the text such that both the List and Map patterns would produce somewhat reasonable output, while the descriptions would still remain sensible.