### PR TITLE
Add DoFAccessor<0,...>::get_mg_dof_indices.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -906,6 +906,17 @@ public:
   void get_dof_indices (std::vector<types::global_dof_index> &dof_indices,
                         const unsigned int fe_index = AccessorData::default_fe_index) const;
 
+
+  /**
+   * Return the global multilevel indices of the degrees of freedom that live
+   * on the current object with respect to the given level within the
+   * multigrid hierarchy. The indices refer to the local numbering for the
+   * level this line lives on.
+   */
+  void get_mg_dof_indices (const int level,
+                           std::vector<types::global_dof_index> &dof_indices,
+                           const unsigned int fe_index = AccessorData::default_fe_index) const;
+
   /**
    * Global DoF index of the <i>i</i> degree associated with the @p vertexth
    * vertex of the present cell.

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2302,6 +2302,24 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::get_dof_indices
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 inline
+void
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+get_mg_dof_indices (const int,
+                    std::vector<types::global_dof_index> &dof_indices,
+                    const unsigned int fe_index) const
+{
+  Assert (this->dof_handler != 0, ExcInvalidObject ());
+  Assert (dof_indices.size () ==
+          this->dof_handler->get_fe ()[fe_index].dofs_per_vertex,
+          ExcVectorDoesNotMatch ());
+
+  Assert (false, ExcNotImplemented());
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
 types::global_dof_index
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
 vertex_dof_index (const unsigned int vertex,

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1167,17 +1167,6 @@ namespace MGTools
   }
 
 
-  template <>
-  void
-  make_boundary_list(
-    const DoFHandler<1,1> &,
-    const FunctionMap<1>::type &,
-    std::vector<std::set<types::global_dof_index> > &,
-    const ComponentMask &)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
 
   template <int dim, int spacedim>
   void
@@ -1224,17 +1213,6 @@ namespace MGTools
     make_boundary_list (dof, boundary_ids, boundary_indices, component_mask);
   }
 
-
-  template <>
-  void
-  make_boundary_list(
-    const DoFHandler<1,1> &,
-    const std::set<types::boundary_id> &,
-    std::vector<IndexSet> &,
-    const ComponentMask &)
-  {
-    Assert(false, ExcNotImplemented());
-  }
 
 
   template <int dim, int spacedim>


### PR DESCRIPTION
This function was previously missing. The patch really only adds the declaration
and a dummy definition throwing ExcNotImplemented(), but it at least enables some
generic programming that would otherwise lead to compiler errors.

This is in response to a comment in #2847.