### PR TITLE
Fix problem detected by address sanitizer

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -348,6 +348,9 @@ namespace internal
     virtual void apply_to_subrange (const std::size_t begin,
                                     const std::size_t end) const
     {
+      if (end == begin)
+        return;
+
       // for classes trivial assignment can use memcpy. cast element to
       // (void*) to silence compiler warning for virtual classes (they will
       // never arrive here because they are non-trivial).


### PR DESCRIPTION
While all implementations of memcpy I know of do sane things when we pass in null pointers and length of size 0, the standard specifies that the pointer must not be the null pointer. Exit early in that case.