### PR TITLE
Use portable version of erfc().

### DIFF
--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -23,6 +23,7 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
+#include <boost/math/special_functions/erf.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #ifdef DEAL_II_WITH_MUPARSER
@@ -182,7 +183,7 @@ namespace internal
 
   double mu_erfc(double value)
   {
-    return erfc(value);
+    return boost::math::erfc(value);
   }
 
   // returns a random value in the range [0,1] initializing the generator


### PR DESCRIPTION
erfc is only part of C99, and thus not in C++98. It did make it into C++ via the TR1
addition, which I think is in C++03 and consequently in C++11, but be that as it may,
let's just use the BOOST version of it to be on the safe side.