### PR TITLE
Use the same type for a non-type template argument in declaration/definition.

### DIFF
--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -195,7 +195,7 @@ namespace MemoryConsumption
    * arrays of strings, etc, where the individual elements may have vastly
    * different sizes.
    */
-  template <typename T, int N>
+  template <typename T, std::size_t N>
   inline
   std::size_t memory_consumption (const std_cxx11::array<T,N> &v);
 


### PR DESCRIPTION
We previously had used 'int' in the declaration but 'std::size_t' in the definition of the
MemoryConsumption::memory_consumption(std_cxx::array) function. The latter is the type
the C++ standard says 'std::array' should take for its size, so be consistent about this.