### PR TITLE
Update information on dealing with ghost values

### DIFF
--- a/doc/doxygen/headers/distributed.h
+++ b/doc/doxygen/headers/distributed.h
@@ -160,7 +160,7 @@
  *   proven that each subdomain consists of at most two disconnected
  *   pieces; see C. Burstedde, T. Isaac: "Morton curve segments produce
  *   no more than two distinct face-connected subdomains",
- *   <a href="http://arxiv.org/abs/1505.05055>arXiv 1505.05055</a>,
+ *   <a href="http://arxiv.org/abs/1505.05055">arXiv 1505.05055</a>,
  *   2015.)
  *
  *
@@ -404,16 +404,14 @@
  * those degrees of freedom as well. In general, therefore, one needs access
  * to the solution values for all degrees of freedom that are <i>locally
  * relevant</i>. On the other hand, both of the packages we can use for
- * parallel linear algebra (PETSc and Trilinos) subdivide vectors into chunks
+ * parallel linear algebra (PETSc and Trilinos) as well as
+ * parallel::distributed::Vector subdivide vectors into chunks
  * each processor owns and chunks stored on other processors. To postprocess
  * stuff therefore means that we have to tell PETSc or Trilinos that it should
  * also import <i>ghost elements</i>, i.e. additional vector elements of the
- * solution vector other than the ones we store locally. Both the
- * PETScWrappers::MPI::Vector and TrilinosWrappers::MPI::Vector class support
- * specifying this information (see step-40 and step-32, respectively) through
- * the PETScWrappers::MPI::Vector::update_ghost_values() function or, in the
- * case of Trilinos, construction of a vector with an the locally relevant
- * degrees of freedom index set.
+ * solution vector other than the ones we own locally.
+ * For ghosted vectors, this can be achieved by using operator= with a
+ * distributed vector as argument.
  */
 
 


### PR DESCRIPTION
At least as a temporary solution for #2857, say that we want to use `operator=` for updating ghost values.
