### PR TITLE
Avoid a warning.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2309,6 +2309,7 @@ get_mg_dof_indices (const int,
                     const unsigned int fe_index) const
 {
   (void) dof_indices;
+  (void) fe_index;
   Assert (this->dof_handler != 0, ExcInvalidObject ());
   Assert (dof_indices.size () ==
           this->dof_handler->get_fe ()[fe_index].dofs_per_vertex,


### PR DESCRIPTION
A previous patch updated one variable, but forgot to void a second one in the same function.