### PR TITLE
Mark a function that already has a doxygen @deprecated string as deprecated.

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -1145,7 +1145,7 @@ namespace FETools
    */
   template <int dim>
   FiniteElement<dim,dim> *
-  get_fe_from_name (const std::string &name);
+  get_fe_from_name (const std::string &name) DEAL_II_DEPRECATED;
 
 
   /**


### PR DESCRIPTION
Specifically, use the DEAL_II_DEPRECATED mark.