### PR TITLE
Fix mg dof indices on objects not in standard orientation.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -171,7 +171,7 @@ inconvenience this causes.
  (Jonathan Robey, 2016/07/21)
  </li>
 
- <li> New: Added GridGenerator::quarter_hyper_ball() to generate the 
+ <li> New: Added GridGenerator::quarter_hyper_ball() to generate the
  intersection of a hyper ball with the positive orthant relative
  to its center.
  <br>
@@ -388,7 +388,14 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
- <li> Improved: Allow for including dofs for individual components on 
+ <li> Fixed: Level indices for geometric multigrid queried through
+ DoFAccessor::get_mg_dof_indices() would return wrong indices on lines
+ and faces in non-standard orientation in 3D. This is now fixed.
+ <br>
+ (Martin Kronbichler, 2016/07/27)
+ </li>
+
+ <li> Improved: Allow for including dofs for individual components on
    boundary in DoFTools::make_vertex_patches().
  <br>
  (Ryan Grove, Daniel Arndt, 2016/07/21)

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1460,11 +1460,18 @@ namespace internal
 
         for (unsigned int line = 0; line < GeometryInfo<3>::lines_per_cell; ++line)
           for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
-            accessor.line(line)->set_mg_dof_index(level, dof, *next++);
+            accessor.line (line)->set_mg_dof_index
+            (level, fe.adjust_line_dof_index_for_line_orientation(dof,accessor.line_orientation(line)), *next++);
 
         for (unsigned int quad = 0; quad < GeometryInfo<3>::quads_per_cell; ++quad)
           for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
-            accessor.quad(quad)->set_mg_dof_index(level, dof, *next++);
+            accessor.quad (quad)->set_mg_dof_index
+            (level, fe.adjust_quad_dof_index_for_face_orientation
+             (dof,
+              accessor.face_orientation(quad),
+              accessor.face_flip(quad),
+              accessor.face_rotation(quad)),
+             *next++);
 
         for (unsigned int dof = 0; dof < fe.dofs_per_hex; ++dof)
           accessor.set_mg_dof_index(level, dof, *next++);
@@ -1883,11 +1890,17 @@ namespace internal
 
       for (unsigned int line = 0; line < GeometryInfo<3>::lines_per_cell; ++line)
         for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
-          *next++ = accessor.line (line)->mg_dof_index (level, dof);
+          *next++ = accessor.line (line)->mg_dof_index
+                    (level, accessor.get_fe(fe_index).adjust_line_dof_index_for_line_orientation(dof,accessor.line_orientation(line)));
 
       for (unsigned int quad = 0; quad < GeometryInfo<3>::quads_per_cell; ++quad)
         for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
-          *next++ = accessor.quad (quad)->mg_dof_index (level, dof);
+          *next++ = accessor.quad (quad)->mg_dof_index
+                    (level, accessor.get_fe(fe_index).adjust_quad_dof_index_for_face_orientation
+                     (dof,
+                      accessor.face_orientation(quad),
+                      accessor.face_flip(quad),
+                      accessor.face_rotation(quad)));
 
       for (unsigned int dof = 0; dof < fe.dofs_per_hex; ++dof)
         *next++ = accessor.mg_dof_index (level, dof);

--- a/tests/multigrid/dof_04.cc
+++ b/tests/multigrid/dof_04.cc
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check DoFAccessor::get_mg_dof_indices on meshes that are not in standard
+// orientation by comparing to DoFAccessor::get_dof_indices
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/fe/fe_q.h>
+
+
+template <int dim>
+void check()
+{
+  // need cubic polynomials that have two dofs on lines
+  FE_Q<dim> fe(3);
+
+  Triangulation<dim> tr;
+  if (dim > 1)
+    GridGenerator::hyper_shell(tr, Point<dim>(), 0.5, 1, 12);
+  else
+    GridGenerator::hyper_cube(tr);
+
+  DoFHandler<dim> dof(tr);
+  dof.distribute_dofs(fe);
+  dof.distribute_mg_dofs(fe);
+
+  std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> mg_dof_indices(fe.dofs_per_cell);
+  for (typename DoFHandler<dim>::active_cell_iterator cell=dof.begin_active();
+       cell != dof.end(); ++cell)
+    {
+      cell->get_dof_indices(dof_indices);
+      cell->get_mg_dof_indices(mg_dof_indices);
+      bool has_error = false;
+      // dof indices should have the same order on both the mg dofs and the
+      // usual dofs becuse there is only one level
+      for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
+        if (dof_indices[i] != mg_dof_indices[i])
+          has_error = true;
+      if (has_error)
+        {
+          deallog << "Offending cell with center " << cell->center() << ": ";
+          for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
+            deallog << dof_indices[i] << " vs " << mg_dof_indices[i] << ", ";
+          deallog << std::endl;
+          return;
+        }
+    }
+  deallog << dim << "D OK" << std::endl;
+}
+
+int main()
+{
+  initlog(__FILE__);
+  check<1> ();
+  check<2> ();
+  check<3> ();
+}

--- a/tests/multigrid/dof_04.output
+++ b/tests/multigrid/dof_04.output
@@ -1,0 +1,4 @@
+
+DEAL::1D OK
+DEAL::2D OK
+DEAL::3D OK

--- a/tests/multigrid/dof_05.cc
+++ b/tests/multigrid/dof_05.cc
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check that distributed_mg_dofs works correctly on non-standard oriented
+// meshes when used in parallel
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_q.h>
+
+
+template <int dim>
+void check()
+{
+  // need cubic polynomials that have two dofs on lines
+  FE_Q<dim> fe(3);
+
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD, Triangulation<dim>::none,
+                                               parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::hyper_shell(tr, Point<dim>(), 0.5, 1, 12);
+  tr.refine_global(1);
+
+  DoFHandler<dim> dof(tr);
+  dof.distribute_dofs(fe);
+  dof.distribute_mg_dofs(fe);
+  deallog << dim << "D OK" << std::endl;
+}
+
+int main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  mpi_initlog();
+  check<2> ();
+  check<3> ();
+}

--- a/tests/multigrid/dof_05.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/multigrid/dof_05.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,3 @@
+
+DEAL::2D OK
+DEAL::3D OK


### PR DESCRIPTION
Well, this bug took me a while to find. All algorithms would run through but only the multigrid iterations went through the roof for polynomial degree three and higher. Since I observed this on a mesh with curved boundaries, I first thought that this was due to some bad mapping somewhere. Only after carefully checking the generated mesh I turned to the indices that were indeed not oriented correctly.