### PR TITLE
Fix FETools::get_fe_by_name with one template argument

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -1135,7 +1135,11 @@ namespace FETools
    * function, use the add_fe_name() function.  This function does not work if
    * one wants to get a codimension 1 finite element.
    */
-  template <int dim, int spacedim>
+  template <int dim, int spacedim
+#ifdef DEAL_II_WITH_CXX11
+            =dim
+#endif
+            >
   FiniteElement<dim, spacedim> *
   get_fe_by_name (const std::string &name);
 

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -2645,18 +2645,8 @@ namespace FETools
 
 
 
-  template <int dim>
-  FiniteElement<dim> *
-  get_fe_by_name (const std::string &parameter_name)
-  {
-    return get_fe_by_name<dim,dim> (parameter_name);
-  }
-
-
-
   template <int dim, int spacedim>
   void
-
   compute_projection_from_quadrature_points_matrix (const FiniteElement<dim,spacedim> &fe,
                                                     const Quadrature<dim>    &lhs_quadrature,
                                                     const Quadrature<dim>    &rhs_quadrature,

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -142,9 +142,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
       template FiniteElement<deal_II_dimension> *
       get_fe_from_name<deal_II_dimension> (const std::string &);
 
-      template FiniteElement<deal_II_dimension> *
-      get_fe_by_name<deal_II_dimension> (const std::string &);
-
       template
       void compute_node_matrix(
         FullMatrix<double> &,


### PR DESCRIPTION
In response to #2873. Define `FETools::get_fe_by_name<dim>` by a default `spacedim` argument equal to `dim`.