### PR TITLE
Eliminate mem_fun, mem_fun_1

### DIFF
--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -251,8 +251,8 @@ template <int dim, int spacedim> class Triangulation;
  *   void
  *   TimeDependent::solve_primal_problem ()
  *   {
- *     do_loop (mem_fun(&TimeStepBase::init_for_primal_problem),
- *              mem_fun(&TimeStepBase::solve_primal_problem),
+ *     do_loop (std_cxx11::bind(&TimeStepBase::init_for_primal_problem, std_cxx11::_1),
+ *              std_cxx11::bind(&TimeStepBase::solve_primal_problem, std_cxx11::_1),
  *              timestepping_data_primal,
  *              forward);
  *   };
@@ -273,7 +273,7 @@ template <int dim, int spacedim> class Triangulation;
  * look-back and the last one denotes in which direction the loop is to be
  * run.
  *
- * Using function pointers through the @p mem_fun functions provided by the
+ * Using function pointers through the @p std_cxx11::bind functions provided by the
  * <tt>C++</tt> standard library, it is possible to do neat tricks, like the
  * following, also taken from the wave program, in this case from the function
  * @p refine_grids:
@@ -282,11 +282,11 @@ template <int dim, int spacedim> class Triangulation;
  *   compute the thresholds for refinement
  *   ...
  *
- *   do_loop (mem_fun (&TimeStepBase_Tria<dim>::init_for_refinement),
- *            std_cxx11::bind (&TimeStepBase_Wave<dim>::refine_grid,
- *                             std_cxx11::_1,
- *                             TimeStepBase_Tria<dim>::RefinementData (top_threshold,
- *                                                                     bottom_threshold)),
+ *   do_loop (std_cxx11::bind(&TimeStepBase_Tria<dim>::init_for_refinement, std_cxx11::_1),
+ *            std_cxx11::bind(&TimeStepBase_Wave<dim>::refine_grid,
+ *                            std_cxx11::_1,
+ *                            TimeStepBase_Tria<dim>::RefinementData (top_threshold,
+ *                                                                    bottom_threshold)),
  *            TimeDependent::TimeSteppingData (0,1),
  *            TimeDependent::forward);
  * @endcode
@@ -512,8 +512,8 @@ public:
    *
    * To see how this function work, note that the function @p
    * solve_primal_problem only consists of a call to <tt>do_loop
-   * (mem_fun(&TimeStepBase::init_for_primal_problem),
-   * mem_fun(&TimeStepBase::solve_primal_problem), timestepping_data_primal,
+   * (std_cxx11::bind(&TimeStepBase::init_for_primal_problem, std_cxx11::_1),
+   * std_cxx11::bind(&TimeStepBase::solve_primal_problem, std_cxx11::_1), timestepping_data_primal,
    * forward);</tt>.
    *
    * Note also, that the given class from which the two functions are taken

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/parallel.h>
+#include <deal.II/base/std_cxx11/bind.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
@@ -154,8 +155,8 @@ void TimeDependent::delete_timestep (const unsigned int position)
 void
 TimeDependent::solve_primal_problem ()
 {
-  do_loop (std::mem_fun(&TimeStepBase::init_for_primal_problem),
-           std::mem_fun(&TimeStepBase::solve_primal_problem),
+  do_loop (std_cxx11::bind(&TimeStepBase::init_for_primal_problem, std_cxx11::_1),
+           std_cxx11::bind(&TimeStepBase::solve_primal_problem, std_cxx11::_1),
            timestepping_data_primal,
            forward);
 }
@@ -164,8 +165,8 @@ TimeDependent::solve_primal_problem ()
 void
 TimeDependent::solve_dual_problem ()
 {
-  do_loop (std::mem_fun(&TimeStepBase::init_for_dual_problem),
-           std::mem_fun(&TimeStepBase::solve_dual_problem),
+  do_loop (std_cxx11::bind(&TimeStepBase::init_for_dual_problem, std_cxx11::_1),
+           std_cxx11::bind(&TimeStepBase::solve_dual_problem, std_cxx11::_1),
            timestepping_data_dual,
            backward);
 }
@@ -174,8 +175,8 @@ TimeDependent::solve_dual_problem ()
 void
 TimeDependent::postprocess ()
 {
-  do_loop (std::mem_fun(&TimeStepBase::init_for_postprocessing),
-           std::mem_fun(&TimeStepBase::postprocess_timestep),
+  do_loop (std_cxx11::bind(&TimeStepBase::init_for_postprocessing, std_cxx11),
+           std_cxx11::bind(&TimeStepBase::postprocess_timestep, std_cxx11),
            timestepping_data_postprocess,
            forward);
 }


### PR DESCRIPTION
Work on #2882.

Replaces calls to std::mem_fun with calls to std_cxx11::bind. Avoids use of C++11 mem_fn due to requirement of continued functionality when C++11 not available.

No calls to mem_fun_1 found for modification.