### PR TITLE
Fix error generated in removing mem_fun

### DIFF
--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -1482,12 +1482,10 @@ void TimeDependent::do_loop (InitFunctionObject      init_function,
     switch (direction)
       {
       case forward:
-        init_function (static_cast<typename InitFunctionObject::argument_type>
-                       (&*timesteps[step]));
+        init_function ((&*timesteps[step]));
         break;
       case backward:
-        init_function (static_cast<typename InitFunctionObject::argument_type>
-                       (&*timesteps[n_timesteps-step-1]));
+        init_function ((&*timesteps[n_timesteps-step-1]));
         break;
       };
 
@@ -1532,12 +1530,10 @@ void TimeDependent::do_loop (InitFunctionObject      init_function,
       switch (direction)
         {
         case forward:
-          loop_function (static_cast<typename LoopFunctionObject::argument_type>
-                         (&*timesteps[step]));
+          loop_function ((&*timesteps[step]));
           break;
         case backward:
-          loop_function (static_cast<typename LoopFunctionObject::argument_type>
-                         (&*timesteps[n_timesteps-step-1]));
+          loop_function ((&*timesteps[n_timesteps-step-1]));
           break;
         };
 

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -175,8 +175,8 @@ TimeDependent::solve_dual_problem ()
 void
 TimeDependent::postprocess ()
 {
-  do_loop (std_cxx11::bind(&TimeStepBase::init_for_postprocessing, std_cxx11),
-           std_cxx11::bind(&TimeStepBase::postprocess_timestep, std_cxx11),
+  do_loop (std_cxx11::bind(&TimeStepBase::init_for_postprocessing, std_cxx11::_1),
+           std_cxx11::bind(&TimeStepBase::postprocess_timestep, std_cxx11::_1),
            timestepping_data_postprocess,
            forward);
 }


### PR DESCRIPTION
Doing some local testing, I found that I may have broken the build when eliminating mem_fun. This corrects the issue at least on my machine with C++11, and also compiles successfully when C++11 is disabled in CMAKE.

My apologies for not being as careful as usual about ensuring that the pull request is correct before submitting it.