### PR TITLE
Eliminate random_shuffle

### DIFF
--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1871,9 +1871,8 @@ namespace DoFRenumbering
     for (unsigned int i=0; i<n_dofs; ++i)
       new_indices[i] = i;
 
-    // shuffle the elements; the following is essentially the
-    // std::random_shuffle algorithm but uses a predictable
-    // random number generator
+    // shuffle the elements; the following is essentially std::shuffle (which
+    // is new in C++11) but with a boost URNG
     ::boost::mt19937 random_number_generator;
     for (unsigned int i=1; i<n_dofs; ++i)
       {


### PR DESCRIPTION
Work on #2882.

All instances of random_shuffle removed from source, include, tests, and examples. The only reference found was in a comment about an algorithm being similar in intent/practice. This reference has been modified to compare std::shuffle instead.