### PR TITLE
fix clang error

### DIFF
--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -295,7 +295,7 @@ namespace
           unsigned int
           my_count = std::count_if (criteria.begin(),
                                     criteria.end(),
-                                    std_cxx11::bind (&std::greater<double>,
+                                    std_cxx11::bind (std::greater<double>(),
                                                      std_cxx11::_1,
                                                      test_threshold));
 


### PR DESCRIPTION
on OSX the line 298 in grid_refinement.cc did not compile with clang.
`error: expected '(' for function-style cast` ...
The reference to the std function did not work as well as the brackets were missing.