### PR TITLE
CMake: Bugfix: Strip input variables for CHECK_COMPILER_SETUP

### DIFF
--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -25,7 +25,13 @@
 # ${_var} is set to true, otherwise it is set to false.
 #
 
-MACRO(CHECK_COMPILER_SETUP _compiler_flags _linker_flags _var)
+MACRO(CHECK_COMPILER_SETUP _compiler_flags_unstr _linker_flags_unstr _var)
+  #
+  # Strip leading and trailing whitespace to make CMake 2.8.8 happy
+  #
+  STRING(STRIP "${_compiler_flags_unstr}" _compiler_flags)
+  STRING(STRIP "${_linker_flags_unstr}" _linker_flags)
+
   #
   # Rerun this test if flags have changed:
   #


### PR DESCRIPTION
CMake 2.8.8 (and possibly till 2.8.11) do not normalize
CMAKE_REQUIRED_FLAGS and CMAKE_REQUIRED_LIBRARIES correctly leading to
stray "-l " in the linker command line.

Fix this by normalizing the input of CHECK_COMPILER_SETUP by stripping
leading and trailing whitespace

Closes #2902