### PR TITLE
Remove const cast 3

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -412,6 +412,14 @@ SparsityPattern.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Improved: The regular and hp versions of
+ DoFTools::make_flux_sparsity_pattern() no longer use the user flags of the
+ underlying triangulation to determine if entries along a certain face have been
+ added to the sparsity pattern.
+ <br>
+ (David Wells, 2016/03/02 - 2016/08/02)
+ </li>
+
  <li> Improved: DoFTools::make_cell_patches() can create block lists
  only extending over local cells of distributed triangulations.
  <br>

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -1252,23 +1252,10 @@ namespace DoFTools
                   "associated DoF handler objects, asking for any subdomain other "
                   "than the locally owned one does not make sense."));
 
-    // Clear user flags because we will need them. But first we save them
-    // and make sure that we restore them later such that at the end of
-    // this function the Triangulation will be in the same state as it was
-    // at the beginning of this function.
-    std::vector<bool> user_flags;
-    dof.get_triangulation().save_user_flags(user_flags);
-    const_cast<Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &>
-    (dof.get_triangulation()).clear_user_flags ();
-
     internal::make_flux_sparsity_pattern (dof, sparsity,
                                           constraints, keep_constrained_dofs,
                                           int_mask, flux_mask,
                                           subdomain_id);
-
-    // finally restore the user flags
-    const_cast<Triangulation<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &>
-    (dof.get_triangulation()).load_user_flags(user_flags);
   }
 
 


### PR DESCRIPTION
#2846 reminded me that I meant to fix this. All of the tests that I could find that use this function (`ctest -j4 -R 'constraints_block_01|crash_21|step-12'`) pass.

Partially addresses #2293.