### PR TITLE
CMake: Bugfix: Clean up Boost-Python setup

### DIFF
--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -43,12 +43,8 @@ ENDIF()
 
 # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
 LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-SET(_boost_python "")
-IF(DEAL_II_COMPONENT_PYTHON_BINDINGS)
-  SET(_boost_python "python")
-ENDIF()
 FIND_PACKAGE(Boost 1.54 COMPONENTS
-  iostreams serialization system thread ${_boost_python}
+  iostreams serialization system thread
   )
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 

--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -406,7 +406,7 @@ FOREACH(_var ${_res})
   #
   # Same for components:
   #
-  IF(_var MATCHES "^(DOCUMENTATION|EXAMPLES|PACKAGE)")
+  IF(_var MATCHES "^(DOCUMENTATION|EXAMPLES|PACKAGE|PYTHON_BINDINGS)")
     SET(DEAL_II_COMPONENT_${_var} ${${_var}} CACHE BOOL "" FORCE)
     UNSET(${_var} CACHE)
   ENDIF()

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -21,6 +21,16 @@ INCLUDE(FindPythonLibs)
 INCLUDE(FindPythonInterp)
 
 #
+# Unset Boost_Found and run the low level FindBOOST.cmake module again to
+# pick up libboost_python.so
+#
+LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+SET(Boost_FOUND)
+# Use the low level _FIND_PACKAGE function instead of our wrapper
+_FIND_PACKAGE(Boost 1.54 COMPONENTS python)
+LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+
+#
 # FIXME: Once finalized, reconsider moving this definitions into
 # cmake/setup_dealii.cmake
 #

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -105,8 +105,8 @@ FOREACH(_build ${DEAL_II_BUILD_TYPES})
 
   TARGET_LINK_LIBRARIES(PyDealII_${_build_lowercase}
     ${DEAL_II_BASE_NAME}${DEAL_II_${_build}_SUFFIX}
-    ${PYTHON_LIBRARIES}
     ${Boost_LIBRARIES}
+    ${PYTHON_LIBRARIES}
     )
 
   EXPORT(TARGETS PyDealII_${_build_lowercase}

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -20,6 +20,14 @@
 INCLUDE(FindPythonLibs)
 INCLUDE(FindPythonInterp)
 
+IF(FEATURE_BOOST_BUNDLED_CONFIGURED)
+  MESSAGE(FATAL_ERROR
+    "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
+    "Python bindings require an external boost library, but deal.II was "
+    "configured with bundled boost."
+    )
+ENDIF()
+
 #
 # Unset Boost_Found and run the low level FindBOOST.cmake module again to
 # pick up libboost_python.so
@@ -29,6 +37,13 @@ SET(Boost_FOUND)
 # Use the low level _FIND_PACKAGE function instead of our wrapper
 _FIND_PACKAGE(Boost 1.54 COMPONENTS python)
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+
+IF(NOT Boost_FOUND)
+  MESSAGE(FATAL_ERROR
+    "DEAL_II_COMPONENT_PYTHON_BINDINGS has unmet configuration requirements: "
+    "The external boost library does not provide Boost.Python"
+    )
+ENDIF()
 
 #
 # FIXME: Once finalized, reconsider moving this definitions into


### PR DESCRIPTION
CMake: Use FindBOOST.cmake to find python libraries in
   contrib/python_bindings

   CMake: Bugfix: Do not set up python component for boost

   CMake: Bugfix: Also expand PYTHON_BINDINGS to DEAL_II_COMPONENT_*

Closes #2920