### PR TITLE
Rename and deprecate MGLevelObject::clear()

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -319,11 +319,11 @@ namespace Step16
     const unsigned int n_levels = triangulation.n_levels();
 
     mg_interface_in.resize(0, n_levels-1);
-    mg_interface_in.clear ();
+    mg_interface_in.clear_elements ();
     mg_interface_out.resize(0, n_levels-1);
-    mg_interface_out.clear ();
+    mg_interface_out.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
     mg_sparsity_patterns.resize(0, n_levels-1);
 
     // Now, we have to provide a matrix on each level. To this end, we first

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -752,8 +752,8 @@ namespace Step37
     setup_time = 0;
 
     system_matrix.clear();
-    mg_matrices.clear();
-    mg_constraints.clear();
+    mg_matrices.clear_elements();
+    mg_constraints.clear_elements();
 
     dof_handler.distribute_dofs (fe);
     dof_handler.distribute_mg_dofs (fe);

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -511,11 +511,11 @@ namespace Step39
     // The global system is set up, now we attend to the level matrices. We
     // resize all matrix objects to hold one matrix per level.
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
     // It is important to update the sparsity patterns after <tt>clear()</tt>
     // was called for the level matrices, since the matrices lock the sparsity
     // pattern through the SmartPointer and Subscriptor mechanism.

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -328,9 +328,9 @@ namespace Step50
     const unsigned int n_levels = triangulation.n_global_levels();
 
     mg_interface_matrices.resize(0, n_levels-1);
-    mg_interface_matrices.clear ();
+    mg_interface_matrices.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
 
     // Now, we have to provide a matrix on each
     // level. To this end, we first use the

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -112,8 +112,20 @@ public:
    * function will fail with a compiler error if the @p Object
    * template type to this class does not provide a
    * <code>clear()</code> member function.
+   *
+   * @deprecated Use clear_elements () instead
    */
-  void clear();
+  void clear() DEAL_II_DEPRECATED;
+
+  /**
+   * Call @p clear on all objects stored by this object. This function
+   * is only implemented for some @p Object classes, e.g., matrix
+   * types or the PreconditionBlockSOR and similar classes. Using this
+   * function will fail with a compiler error if the @p Object
+   * template type to this class does not provide a
+   * <code>clear()</code> member function.
+   */
+  void clear_elements();
 
   /**
    * The coarsest level for which this class stores a level object.
@@ -207,7 +219,16 @@ MGLevelObject<Object>::operator = (const double d)
 
 template<class Object>
 void
-MGLevelObject<Object>::clear ()
+MGLevelObject<Object>::clear () // DEPRECATED
+{
+  // Avoid code duplication in deprecated call by calling replacing function
+  clear_elements();
+}
+
+
+template<class Object>
+void
+MGLevelObject<Object>::clear_elements ()
 {
   typename std::vector<std_cxx11::shared_ptr<Object> >::iterator v;
   for (v = objects.begin(); v != objects.end(); ++v)

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -586,7 +586,7 @@ namespace mg
   inline void
   SmootherRelaxation<RelaxationType, VectorType>::clear ()
   {
-    MGLevelObject<RelaxationType>::clear();
+    MGLevelObject<RelaxationType>::clear_elements();
   }
 
 
@@ -687,7 +687,7 @@ template <typename MatrixType, class RelaxationType, typename VectorType>
 inline void
 MGSmootherRelaxation<MatrixType, RelaxationType, VectorType>::clear ()
 {
-  smoothers.clear();
+  smoothers.clear_elements();
 
   unsigned int i=matrices.min_level(),
                max_level=matrices.max_level();
@@ -854,7 +854,7 @@ template <typename MatrixType, typename PreconditionerType, typename VectorType>
 inline void
 MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::clear ()
 {
-  smoothers.clear();
+  smoothers.clear_elements();
 
   unsigned int i=matrices.min_level(),
                max_level=matrices.max_level();

--- a/include/deal.II/multigrid/sparse_matrix_collection.h
+++ b/include/deal.II/multigrid/sparse_matrix_collection.h
@@ -63,15 +63,15 @@ namespace mg
   SparseMatrixCollection<number>::resize(const unsigned int minlevel, const unsigned  int maxlevel)
   {
     matrix.resize(minlevel, maxlevel);
-    matrix.clear();
+    matrix.clear_elements();
     matrix_up.resize(minlevel+1, maxlevel);
-    matrix_up.clear();
+    matrix_up.clear_elements();
     matrix_down.resize(minlevel+1, maxlevel);
-    matrix_down.clear();
+    matrix_down.clear_elements();
     matrix_in.resize(minlevel, maxlevel);
-    matrix_in.clear();
+    matrix_in.clear_elements();
     matrix_out.resize(minlevel, maxlevel);
-    matrix_out.clear();
+    matrix_out.clear_elements();
     sparsity.resize(minlevel, maxlevel);
     sparsity_edge.resize(minlevel, maxlevel);
   }

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -406,8 +406,8 @@ namespace Step37
   void LaplaceProblem<dim>::setup_system ()
   {
     system_matrix.clear();
-    mg_matrices.clear();
-    mg_constraints.clear();
+    mg_matrices.clear_elements();
+    mg_constraints.clear_elements();
 
     dof_handler.distribute_dofs (fe);
     dof_handler.distribute_mg_dofs (fe);

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -119,11 +119,11 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_global_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
 
     for (unsigned int level=mg_matrix.min_level();
          level<=mg_matrix.max_level(); ++level)

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -209,9 +209,9 @@ namespace Step50
     const unsigned int n_levels = triangulation.n_global_levels();
 
     mg_interface_matrices.resize(0, n_levels-1);
-    mg_interface_matrices.clear ();
+    mg_interface_matrices.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
 
     for (unsigned int level=0; level<n_levels; ++level)
       {

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -209,9 +209,9 @@ namespace Step50
     const unsigned int n_levels = triangulation.n_global_levels();
 
     mg_interface_matrices.resize(0, n_levels-1);
-    mg_interface_matrices.clear ();
+    mg_interface_matrices.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
 
     for (unsigned int level=0; level<n_levels; ++level)
       {

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -415,11 +415,11 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_global_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
 
     for (unsigned int level=mg_matrix.min_level();
          level<=mg_matrix.max_level(); ++level)

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -237,9 +237,9 @@ void LaplaceProblem<dim>::setup_system ()
     }
 
   mg_matrices.resize(0, nlevels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_matrices_renumbered.resize(0, nlevels-1);
-  mg_matrices_renumbered.clear ();
+  mg_matrices_renumbered.clear_elements ();
   mg_sparsity.resize(0, nlevels-1);
   mg_sparsity_renumbered.resize(0, nlevels-1);
 

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -261,11 +261,11 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_in.resize(0, n_levels-1);
-  mg_interface_in.clear ();
+  mg_interface_in.clear_elements ();
   mg_interface_out.resize(0, n_levels-1);
-  mg_interface_out.clear ();
+  mg_interface_out.clear_elements ();
   mg_matrices.resize(0, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(0, n_levels-1);
 
   for (unsigned int level=0; level<n_levels; ++level)

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -191,9 +191,9 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels-1);
-  mg_interface_matrices.clear ();
+  mg_interface_matrices.clear_elements ();
   mg_matrices.resize(min_level, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(min_level, n_levels-1);
 
   for (unsigned int level=min_level; level<n_levels; ++level)

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -195,9 +195,9 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels-1);
-  mg_interface_matrices.clear ();
+  mg_interface_matrices.clear_elements ();
   mg_matrices.resize(min_level, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(min_level, n_levels-1);
 
   for (unsigned int level=min_level; level<n_levels; ++level)

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -228,9 +228,9 @@ namespace Step50
     const unsigned int n_levels = triangulation.n_global_levels();
 
     mg_interface_matrices.resize(0, n_levels-1);
-    mg_interface_matrices.clear ();
+    mg_interface_matrices.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
 
     for (unsigned int level=0; level<n_levels; ++level)
       {

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -196,9 +196,9 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(0, n_levels-1);
-  mg_interface_matrices.clear ();
+  mg_interface_matrices.clear_elements ();
   mg_matrices.resize(0, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(0, n_levels-1);
 
   for (unsigned int level=0; level<n_levels; ++level)

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -262,11 +262,11 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_in.resize(0, n_levels-1);
-  mg_interface_in.clear ();
+  mg_interface_in.clear_elements ();
   mg_interface_out.resize(0, n_levels-1);
-  mg_interface_out.clear ();
+  mg_interface_out.clear_elements ();
   mg_matrices.resize(0, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(0, n_levels-1);
 
   for (unsigned int level=0; level<n_levels; ++level)

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -199,9 +199,9 @@ void LaplaceProblem<dim>::setup_system ()
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(0, n_levels-1);
-  mg_interface_matrices.clear ();
+  mg_interface_matrices.clear_elements ();
   mg_matrices.resize(0, n_levels-1);
-  mg_matrices.clear ();
+  mg_matrices.clear_elements ();
   mg_sparsity_patterns.resize(0, n_levels-1);
 
   for (unsigned int level=0; level<n_levels; ++level)

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -405,13 +405,13 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
     mg_matrix_in_out.resize(0, n_levels-1);
-    mg_matrix_in_out.clear();
+    mg_matrix_in_out.clear_elements();
     mg_sparsity.resize(0, n_levels-1);
     mg_sparsity_dg_interface.resize(0, n_levels-1);
 

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -410,13 +410,13 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
     mg_matrix_in_out.resize(0, n_levels-1);
-    mg_matrix_in_out.clear();
+    mg_matrix_in_out.clear_elements();
     mg_sparsity.resize(0, n_levels-1);
     mg_sparsity_dg_interface.resize(0, n_levels-1);
 

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -411,13 +411,13 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
     mg_matrix_in_out.resize(0, n_levels-1);
-    mg_matrix_in_out.clear();
+    mg_matrix_in_out.clear_elements();
     mg_sparsity.resize(0, n_levels-1);
     mg_sparsity_dg_interface.resize(0, n_levels-1);
 

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -405,11 +405,11 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_levels();
     mg_matrix.resize(0, n_levels-1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels-1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels-1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
     mg_sparsity.resize(0, n_levels-1);
     mg_sparsity_dg_interface.resize(0, n_levels-1);
 

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -229,9 +229,9 @@ namespace Step50
     const unsigned int n_levels = triangulation.n_global_levels();
 
     mg_interface_matrices.resize(0, n_levels-1);
-    mg_interface_matrices.clear ();
+    mg_interface_matrices.clear_elements ();
     mg_matrices.resize(0, n_levels-1);
-    mg_matrices.clear ();
+    mg_matrices.clear_elements ();
 
     for (unsigned int level=0; level<n_levels; ++level)
       {


### PR DESCRIPTION
Fixes #2560.

Using clear_elements() as replacing method name, because I could not think of an obviously better/clearer name for the new function. Any suggestions for a better name would be appreciated.