### PR TITLE
Replace deprecated MGConstrainedDoFs::initialize in examples

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -288,8 +288,10 @@ namespace Step16
     DoFTools::make_hanging_node_constraints (dof_handler, hanging_node_constraints);
     DoFTools::make_hanging_node_constraints (dof_handler, constraints);
 
+    std::set<types::boundary_id>         dirichlet_boundary_ids;
     typename FunctionMap<dim>::type      dirichlet_boundary_functions;
     ZeroFunction<dim>                    homogeneous_dirichlet_bc (1);
+    dirichlet_boundary_ids.insert(0);
     dirichlet_boundary_functions[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values (static_cast<const DoFHandler<dim>&>(dof_handler),
                                               dirichlet_boundary_functions,
@@ -304,7 +306,8 @@ namespace Step16
     // about the boundary values as well, so we pass the
     // <code>dirichlet_boundary</code> here as well.
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(dof_handler, dirichlet_boundary_functions);
+    mg_constrained_dofs.initialize(dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(dof_handler, dirichlet_boundary_ids);
 
 
     // Now for the things that concern the multigrid data structures. First,

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -287,8 +287,10 @@ namespace Step50
     DoFTools::make_hanging_node_constraints (mg_dof_handler, hanging_node_constraints);
     DoFTools::make_hanging_node_constraints (mg_dof_handler, constraints);
 
+    std::set<types::boundary_id>         dirichlet_boundary_ids;
     typename FunctionMap<dim>::type      dirichlet_boundary;
     ConstantFunction<dim>                    homogeneous_dirichlet_bc (1.0);
+    dirichlet_boundary_ids.insert(0);
     dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
     VectorTools::interpolate_boundary_values (mg_dof_handler,
                                               dirichlet_boundary,
@@ -307,7 +309,8 @@ namespace Step50
     // pass the <code>dirichlet_boundary</code>
     // here as well.
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, dirichlet_boundary_ids);
 
 
     // Now for the things that concern the

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -554,12 +554,12 @@ namespace Step56
         // sparsity patterns and matrices for each level. The resize()
         // function of MGLevelObject<T> will destroy all existing contained
         // objects.
-        typename FunctionMap<dim>::type boundary_condition_function_map;
-        BoundaryValuesForVelocity<dim> velocity_boundary_condition;
-        boundary_condition_function_map[0] = &velocity_boundary_condition;
+        std::set<types::boundary_id> zero_boundary_ids;
+        zero_boundary_ids.insert(0);
 
         mg_constrained_dofs.clear();
-        mg_constrained_dofs.initialize(velocity_dof_handler, boundary_condition_function_map);
+        mg_constrained_dofs.initialize(velocity_dof_handler);
+        mg_constrained_dofs.make_zero_boundary_constraints(velocity_dof_handler, zero_boundary_ids);
         const unsigned int n_levels = triangulation.n_levels();
 
         mg_interface_matrices.resize(0, n_levels-1);

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -62,7 +62,7 @@ public:
    * constrains degrees on the external boundary of the domain by calling
    * MGTools::make_boundary_list() with the given second and third argument.
    *
-   * @deprecated Use initialize() followed by set_zero_boundary_dofs() instead
+   * @deprecated Use initialize() followed by make_zero_boundary_constraints() instead
    */
   template <int dim, int spacedim>
   void initialize(const DoFHandler<dim,spacedim> &dof,


### PR DESCRIPTION
Fixes #2923.

Begin working on fixing calls to deprecated MGConstrainedDoFs::initialize(dof, fn_map) in examples. The main necessary replacement has been made, but documentation may need to be updated and some of the logic needs to be checked to see if some lines can be removed due to no longer being required.