### PR TITLE
Fixed linker error under VS2013, moved definition of format_version v…

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1035,7 +1035,7 @@ namespace DataOutBase
      * this number is used only to verify that the format we are writing is
      * what the current readers and writers understand.
      */
-    static unsigned int format_version;
+    static const unsigned int format_version;
   };
 
   /**

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1035,7 +1035,7 @@ namespace DataOutBase
      * this number is used only to verify that the format we are writing is
      * what the current readers and writers understand.
      */
-    static const unsigned int format_version = 3;
+    static unsigned int format_version;
   };
 
   /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1501,7 +1501,7 @@ namespace DataOutBase
   template <int dim, int spacedim>
   const unsigned int Patch<dim,spacedim>::space_dim;
 
-  const unsigned int Deal_II_IntermediateFlags::format_version;
+  unsigned int Deal_II_IntermediateFlags::format_version = 3;
 
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1501,7 +1501,7 @@ namespace DataOutBase
   template <int dim, int spacedim>
   const unsigned int Patch<dim,spacedim>::space_dim;
 
-  unsigned int Deal_II_IntermediateFlags::format_version = 3;
+  const unsigned int Deal_II_IntermediateFlags::format_version = 3;
 
 
 


### PR DESCRIPTION
Fixed linker error under VS2013: deal_II.g.lib(data_out_base.obj) : error LNK2005: "public: static unsigned int const dealii::DataOutBase::Deal_II_IntermediateFlags::format_version"
(?format_version@Deal_II_IntermediateFlags@DataOutBase@dealii@@2IB) is already defined in step-1.ob