### PR TITLE
[WIP] Use an explicit suffix on unindented backup files.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -50,16 +50,16 @@ format_inst()
 {
     f=$1
     cp $f $f.tmp
-    sed -i 's#\\{#{ //#g' $f.tmp
-    sed -i 's#\\}#} //#g' $f.tmp
+    sed -i.orig 's#\\{#{ //#g' $f.tmp
+    sed -i.orig 's#\\}#} //#g' $f.tmp
     astyle --quiet $f.tmp
-    sed -i 's#{ //#\\{#g' $f.tmp
-    sed -i 's#} //#\\}#g' $f.tmp
+    sed -i.orig 's#{ //#\\{#g' $f.tmp
+    sed -i.orig 's#} //#\\}#g' $f.tmp
     if ! diff -q $f $f.tmp >/dev/null
     then
 	cp $f.tmp $f
     fi
-    rm $f.tmp
+    rm $f.tmp $f.tmp.orig
 }
 
 export -f format_inst


### PR DESCRIPTION
I do not have a mac handy to test this right now, but I have solved this same problem in the past. IIRC BSD sed does not have a `-i` flag at all so I think the best choice is to use perl to emulate sed.

Closes #2937.