### PR TITLE
Resize defect vector when changing multigrid levels

### DIFF
--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -79,6 +79,16 @@ public:
   virtual void Tvmult_add (const unsigned int level,
                            VectorType         &dst,
                            const VectorType   &src) const = 0;
+
+  /**
+   * Return the minimal level for which matrices are stored.
+   */
+  virtual unsigned int get_minlevel() const = 0;
+
+  /**
+   * Return the minimal level for which matrices are stored.
+   */
+  virtual unsigned int get_maxlevel() const = 0;
 };
 
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -72,6 +72,8 @@ namespace mg
     virtual void vmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
     virtual void Tvmult (const unsigned int level, VectorType &dst, const VectorType &src) const;
     virtual void Tvmult_add (const unsigned int level, VectorType &dst, const VectorType &src) const;
+    virtual unsigned int get_minlevel() const;
+    virtual unsigned int get_maxlevel() const;
 
     /**
      * Memory used by this object.
@@ -181,6 +183,7 @@ namespace mg
   }
 
 
+
   template <typename VectorType>
   template <typename MatrixType>
   inline
@@ -190,10 +193,12 @@ namespace mg
   }
 
 
+
   template <typename VectorType>
   inline
   Matrix<VectorType>::Matrix ()
   {}
+
 
 
   template <typename VectorType>
@@ -203,6 +208,7 @@ namespace mg
   {
     return *matrices[level];
   }
+
 
 
   template <typename VectorType>
@@ -215,6 +221,7 @@ namespace mg
   }
 
 
+
   template <typename VectorType>
   void
   Matrix<VectorType>::vmult_add (const unsigned int level,
@@ -223,6 +230,7 @@ namespace mg
   {
     matrices[level]->vmult_add(dst, src);
   }
+
 
 
   template <typename VectorType>
@@ -235,6 +243,7 @@ namespace mg
   }
 
 
+
   template <typename VectorType>
   void
   Matrix<VectorType>::Tvmult_add (const unsigned int level,
@@ -243,6 +252,25 @@ namespace mg
   {
     matrices[level]->Tvmult_add(dst, src);
   }
+
+
+
+  template <typename VectorType>
+  unsigned int
+  Matrix<VectorType>::get_minlevel() const
+  {
+    return matrices.min_level();
+  }
+
+
+
+  template <typename VectorType>
+  unsigned int
+  Matrix<VectorType>::get_maxlevel() const
+  {
+    return matrices.max_level();
+  }
+
 
 
   template <typename VectorType>
@@ -278,6 +306,7 @@ MGMatrixSelect<MatrixType, number>::set_matrix (MGLevelObject<MatrixType> *p)
 }
 
 
+
 template <typename MatrixType, typename number>
 void
 MGMatrixSelect<MatrixType, number>::
@@ -287,6 +316,7 @@ select_block (const unsigned int brow,
   row = brow;
   col = bcol;
 }
+
 
 
 template <typename MatrixType, typename number>
@@ -303,6 +333,7 @@ vmult  (const unsigned int    level,
 }
 
 
+
 template <typename MatrixType, typename number>
 void
 MGMatrixSelect<MatrixType, number>::
@@ -317,6 +348,7 @@ vmult_add  (const unsigned int    level,
 }
 
 
+
 template <typename MatrixType, typename number>
 void
 MGMatrixSelect<MatrixType, number>::
@@ -329,6 +361,7 @@ Tvmult  (const unsigned int    level,
   const MGLevelObject<MatrixType> &m = *matrix;
   m[level].block(row, col).Tvmult(dst, src);
 }
+
 
 
 template <typename MatrixType, typename number>

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -99,9 +99,8 @@ public:
             Cycle                              cycle = v_cycle);
 
   /**
-   * Experimental constructor for cases in which no DoFHandler is available.
-   *
-   * @warning Not intended for general use.
+   * Constructor. Same as above but you can determine the multigrid
+   * levels to use yourself.
    */
   Multigrid(const unsigned int                 minlevel,
             const unsigned int                 maxlevel,
@@ -178,9 +177,8 @@ public:
 
   /**
    * Set the highest level for which the multilevel method is performed. By
-   * default, this is the finest level of the Triangulation; therefore, this
-   * function will only accept arguments smaller than the current #maxlevel
-   * and not smaller than the current #minlevel.
+   * default, this is the finest level of the Triangulation. Accepted are
+   * values not smaller than the current #minlevel.
    */
   void set_maxlevel (const unsigned int);
 

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2015 by the deal.II authors
+// Copyright (C) 1999 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -59,8 +59,11 @@ void
 Multigrid<VectorType>::reinit (const unsigned int min_level,
                                const unsigned int max_level)
 {
+  Assert (min_level <= max_level,
+          ExcLowerRangeType<unsigned int>(max_level, min_level));
   minlevel=min_level;
   maxlevel=max_level;
+  // solution, t and defect2 are resized in cycle()
   defect.resize(minlevel, maxlevel);
 }
 
@@ -69,9 +72,7 @@ template <typename VectorType>
 void
 Multigrid<VectorType>::set_maxlevel (const unsigned int l)
 {
-  Assert (l <= maxlevel, ExcIndexRange(l,minlevel,maxlevel+1));
-  Assert (l >= minlevel, ExcIndexRange(l,minlevel,maxlevel+1));
-  maxlevel = l;
+  reinit(minlevel, l);
 }
 
 
@@ -80,10 +81,10 @@ void
 Multigrid<VectorType>::set_minlevel (const unsigned int l,
                                      const bool relative)
 {
-  Assert (l <= maxlevel, ExcIndexRange(l,minlevel,maxlevel+1));
-  minlevel = (relative)
-             ? (maxlevel-l)
-             : l;
+  const unsigned int new_minlevel = (relative)
+                                    ? (maxlevel-l)
+                                    : l;
+  reinit(new_minlevel, maxlevel);
 }
 
 

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -23,42 +23,15 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-template <typename VectorType>
-Multigrid<VectorType>::Multigrid (const unsigned int                    minlevel,
-                                  const unsigned int                    maxlevel,
-                                  const MGMatrixBase<VectorType>        &matrix,
-                                  const MGCoarseGridBase<VectorType>    &coarse,
-                                  const MGTransferBase<VectorType>      &transfer,
-                                  const MGSmootherBase<VectorType>      &pre_smooth,
-                                  const MGSmootherBase<VectorType>      &post_smooth,
-                                  typename Multigrid<VectorType>::Cycle cycle)
-  :
-  cycle_type(cycle),
-  minlevel(minlevel),
-  maxlevel(maxlevel),
-  defect(minlevel,maxlevel),
-  solution(minlevel,maxlevel),
-  t(minlevel,maxlevel),
-  matrix(&matrix, typeid(*this).name()),
-  coarse(&coarse, typeid(*this).name()),
-  transfer(&transfer, typeid(*this).name()),
-  pre_smooth(&pre_smooth, typeid(*this).name()),
-  post_smooth(&post_smooth, typeid(*this).name()),
-  edge_out(0, typeid(*this).name()),
-  edge_in(0, typeid(*this).name()),
-  edge_down(0, typeid(*this).name()),
-  edge_up(0, typeid(*this).name()),
-  debug(0)
-{}
-
-
-
 template <typename VectorType>
 void
 Multigrid<VectorType>::reinit (const unsigned int min_level,
                                const unsigned int max_level)
 {
+  Assert (min_level >= matrix->get_minlevel(),
+          ExcLowerRangeType<unsigned int>(min_level, matrix->get_minlevel()));
+  Assert (max_level <= matrix->get_maxlevel(),
+          ExcLowerRangeType<unsigned int>(matrix->get_maxlevel(), max_level));
   Assert (min_level <= max_level,
           ExcLowerRangeType<unsigned int>(max_level, min_level));
   minlevel=min_level;
@@ -68,12 +41,14 @@ Multigrid<VectorType>::reinit (const unsigned int min_level,
 }
 
 
+
 template <typename VectorType>
 void
 Multigrid<VectorType>::set_maxlevel (const unsigned int l)
 {
   reinit(minlevel, l);
 }
+
 
 
 template <typename VectorType>
@@ -88,6 +63,7 @@ Multigrid<VectorType>::set_minlevel (const unsigned int l,
 }
 
 
+
 template <typename VectorType>
 void
 Multigrid<VectorType>::set_cycle(typename Multigrid<VectorType>::Cycle c)
@@ -96,12 +72,14 @@ Multigrid<VectorType>::set_cycle(typename Multigrid<VectorType>::Cycle c)
 }
 
 
+
 template <typename VectorType>
 void
 Multigrid<VectorType>::set_debug (const unsigned int d)
 {
   debug = d;
 }
+
 
 
 template <typename VectorType>
@@ -114,6 +92,7 @@ Multigrid<VectorType>::set_edge_matrices (const MGMatrixBase<VectorType> &down,
 }
 
 
+
 template <typename VectorType>
 void
 Multigrid<VectorType>::set_edge_flux_matrices (const MGMatrixBase<VectorType> &down,
@@ -122,6 +101,7 @@ Multigrid<VectorType>::set_edge_flux_matrices (const MGMatrixBase<VectorType> &d
   edge_down = &down;
   edge_up = &up;
 }
+
 
 
 template <typename VectorType>
@@ -374,6 +354,7 @@ Multigrid<VectorType>::level_step(const unsigned int level,
 }
 
 
+
 template <typename VectorType>
 void
 Multigrid<VectorType>::cycle()
@@ -399,6 +380,7 @@ Multigrid<VectorType>::cycle()
   else
     level_step (maxlevel, cycle_type);
 }
+
 
 
 template <typename VectorType>

--- a/tests/multigrid/cycles.cc
+++ b/tests/multigrid/cycles.cc
@@ -72,8 +72,8 @@ void test_cycles(unsigned int minlevel, unsigned int maxlevel)
     level_matrices[i].reinit(N, N);
   mg::Matrix<VectorType> mgmatrix(level_matrices);
 
-  Multigrid<VectorType> mg1(minlevel, maxlevel, mgmatrix, all, all, all, all,
-                            Multigrid<VectorType>::v_cycle);
+  Multigrid<VectorType> mg1(mgmatrix, all, all, all, all,
+                            minlevel, maxlevel, Multigrid<VectorType>::v_cycle);
   mg1.set_debug(3);
   for (unsigned int i=minlevel; i<=maxlevel; ++i)
     mg1.defect[i].reinit(N);

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -384,13 +384,15 @@ void LaplaceProblem<dim>::solve ()
   mg::Matrix<> mg_interface_up(mg_interface_matrices);
   mg::Matrix<> mg_interface_down(mg_interface_matrices);
 
-  Multigrid<Vector<double> > mg(min_level,
-                                triangulation.n_global_levels()-1,
+  Multigrid<Vector<double> > mg(mg_dof_handler,
                                 mg_matrix,
                                 coarse_grid_solver,
                                 mg_transfer,
                                 mg_smoother,
-                                mg_smoother);
+                                mg_smoother,
+                                Multigrid<Vector<double> >::v_cycle,
+                                min_level,
+                                triangulation.n_global_levels()-1);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double> > >

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -390,9 +390,9 @@ void LaplaceProblem<dim>::solve ()
                                 mg_transfer,
                                 mg_smoother,
                                 mg_smoother,
-                                Multigrid<Vector<double> >::v_cycle,
                                 min_level,
-                                triangulation.n_global_levels()-1);
+                                triangulation.n_global_levels()-1,
+                                Multigrid<Vector<double> >::v_cycle);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double> > >

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -396,13 +396,15 @@ void LaplaceProblem<dim>::solve ()
   mg::Matrix<LinearAlgebra::distributed::Vector<double> > mg_interface_up(mg_interface_matrices);
   mg::Matrix<LinearAlgebra::distributed::Vector<double> > mg_interface_down(mg_interface_matrices);
 
-  Multigrid<LinearAlgebra::distributed::Vector<double> > mg(min_level,
-                                                            triangulation.n_global_levels()-1,
-                                                            mg_matrix,
+  Multigrid<LinearAlgebra::distributed::Vector<double> > mg(mg_matrix,
                                                             coarse_grid_solver,
                                                             mg_transfer,
                                                             mg_smoother,
-                                                            mg_smoother);
+                                                            mg_smoother,
+                                                            min_level,
+                                                            triangulation.n_global_levels()-1);
+  Assert(min_level == mg.get_minlevel(), ExcInternalError());
+  Assert(triangulation.n_global_levels()-1 == mg.get_maxlevel(), ExcInternalError());
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, LinearAlgebra::distributed::Vector<double>, MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double> > >


### PR DESCRIPTION
Furthermore, I don't see any particular reason why the `Multigrid` constructor that let the user specify minimal and maximal level is considered to be problematic.