### PR TITLE
No longer use 'throw()', use 'noexcept' instead.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -182,6 +182,13 @@ SparsityPattern.
 
 <ol>
 
+ <li> New: deal.II no longer uses features of the C++ language that
+ were deprecated with C++11, C++14, or that are scheduled to be
+ deprecated for C++17.
+ <br>
+ (David Wells, Jonathan Robey, Wolfgang Bangerth, 2016/08/11)
+ </li>
+
  <li> New: Introduce operators for residuals and interior penalty terms for
  the Grad-Div operator in LocalIntegrators::GradDiv.
  <br>

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -267,6 +267,23 @@
 
 
 /***********************************************************************
+ * A macro that is used to mark function as not throwing any exceptions.
+ * The appropriate way to do this in C++98 was to say
+ *     void foo () throw ();
+ * but in C++11, this is now
+ *     void foo () noexcept;
+ * Furthermore, the first of these two methods is being deprecated, so
+ * we want to use the latter when possible.
+ */
+
+#ifdef DEAL_II_WITH_CXX11
+#  define DEAL_II_NOEXCEPT noexcept
+#else
+#  define DEAL_II_NOEXCEPT throw()
+#endif
+
+
+/***********************************************************************
  * Two macros to guard external header includes.
  *
  * Selectively disable diagnostics set by "-Wextra" (and similar flags) for

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -55,7 +55,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~ExceptionBase () throw();
+  virtual ~ExceptionBase () DEAL_II_NOEXCEPT;
 
   /**
    * Set the file name and line of where the exception appeared as well as the
@@ -72,7 +72,7 @@ public:
   /**
    * Override the standard function that returns the description of the error.
    */
-  virtual const char *what() const throw();
+  virtual const char *what() const DEAL_II_NOEXCEPT;
 
   /**
    * Get exception name.
@@ -391,7 +391,7 @@ namespace deal_II_exceptions
   {                                                                       \
   public:                                                                 \
     Exception (const std::string &msg = defaulttext) : arg (msg) {}       \
-    virtual ~Exception () throw () {}                                     \
+    virtual ~Exception () DEAL_II_NOEXCEPT {}                             \
     virtual void print_info (std::ostream &out) const {                   \
       out << arg << std::endl;                                            \
     }                                                                     \
@@ -409,7 +409,7 @@ namespace deal_II_exceptions
   class Exception1 : public dealii::ExceptionBase {                       \
   public:                                                                 \
     Exception1 (const type1 a1) : arg1 (a1) {}                            \
-    virtual ~Exception1 () throw () {}                                    \
+    virtual ~Exception1 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
       out outsequence << std::endl;                                       \
     }                                                                     \
@@ -429,7 +429,7 @@ namespace deal_II_exceptions
   public:                                                                 \
     Exception2 (const type1 a1, const type2 a2) :                         \
       arg1 (a1), arg2(a2) {}                                              \
-    virtual ~Exception2 () throw () {}                                    \
+    virtual ~Exception2 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
       out outsequence << std::endl;                                       \
     }                                                                     \
@@ -450,7 +450,7 @@ namespace deal_II_exceptions
   public:                                                                 \
     Exception3 (const type1 a1, const type2 a2, const type3 a3) :         \
       arg1 (a1), arg2(a2), arg3(a3) {}                                    \
-    virtual ~Exception3 () throw () {}                                    \
+    virtual ~Exception3 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
       out outsequence << std::endl;                                       \
     }                                                                     \
@@ -473,7 +473,7 @@ namespace deal_II_exceptions
     Exception4 (const type1 a1, const type2 a2,                           \
                 const type3 a3, const type4 a4) :                         \
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4) {}                          \
-    virtual ~Exception4 () throw () {}                                    \
+    virtual ~Exception4 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
       out outsequence << std::endl;                                       \
     }                                                                     \
@@ -497,7 +497,7 @@ namespace deal_II_exceptions
     Exception5 (const type1 a1, const type2 a2, const type3 a3,           \
                 const type4 a4, const type5 a5) :                         \
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4), arg5(a5) {}                \
-    virtual ~Exception5 () throw () {}                                    \
+    virtual ~Exception5 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
       out outsequence << std::endl;                                       \
     }                                                                     \

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1462,7 +1462,7 @@ public:
      * automatically generated destructor would have a different one due to
      * member objects.
      */
-    virtual ~DistortedCellList () throw();
+    virtual ~DistortedCellList () DEAL_II_NOEXCEPT;
 
     /**
      * A list of those cells among the coarse mesh cells that are deformed or

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2015 by the deal.II authors
+// Copyright (C) 1998 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -99,7 +99,7 @@ public:
       : last_step (last_step), last_residual(last_residual)
     {}
 
-    virtual ~NoConvergence () throw () {}
+    virtual ~NoConvergence () DEAL_II_NOEXCEPT {}
 
     virtual void print_info (std::ostream &out) const
     {

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -87,7 +87,7 @@ ExceptionBase::ExceptionBase (const ExceptionBase &exc)
 
 
 
-ExceptionBase::~ExceptionBase () throw ()
+ExceptionBase::~ExceptionBase () DEAL_II_NOEXCEPT
 {
   free (stacktrace); // free(NULL) is allowed
   stacktrace = NULL;
@@ -117,7 +117,7 @@ void ExceptionBase::set_fields (const char *f,
 #endif
 }
 
-const char *ExceptionBase::what() const throw()
+const char *ExceptionBase::what() const DEAL_II_NOEXCEPT
 {
   // If no error c_string was generated so far, do it now:
   if (what_str == "")

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13584,11 +13584,12 @@ Triangulation<dim, spacedim>::memory_consumption () const
 
 
 template<int dim, int spacedim>
-Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList () throw ()
+Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList () DEAL_II_NOEXCEPT
 {
   // don't do anything here. the compiler will automatically convert
   // any exceptions created by the destructors of the member variables
-  // into abort() in order to satisfy the throw() specification
+  // into abort() in order to satisfy the throw()/noexcept
+  // specification
 }
 
 


### PR DESCRIPTION
This addresses the fact that 'throw' specifications are/will be deprecated.
In reference to #2882.

I verified that it compiles in both C++11 and C++03 mode.