### PR TITLE
Fix a test by not using a C++11 statement GCC 4.6 balks at.

### DIFF
--- a/tests/grid/move_constructor.cc
+++ b/tests/grid/move_constructor.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2015 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -87,8 +87,7 @@ void test_periodic_cube()
   Triangulation<dim> tria;
   GridGenerator::hyper_cube(tria, -1.0, 1.0, true);
 
-  using periodic_face_pair =
-    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>;
+  typedef GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator> periodic_face_pair;
   std::vector<periodic_face_pair> periodicity_vector;
   GridTools::collect_periodic_faces(tria, 0, 1, 0, periodicity_vector);
   tria.add_periodicity(periodicity_vector);


### PR DESCRIPTION
Apparently, GCC 4.6.3 hadn't yet learned to deal with 'using'-style typedefs.
Fixes #2958.