### PR TITLE
Prefer const reference to const value.

### DIFF
--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -105,7 +105,7 @@ namespace LocalIntegrators
     void weighted_mass_matrix (
       FullMatrix<double> &M,
       const FEValuesBase<dim> &fe,
-      const std::vector<double> weights)
+      const std::vector<double> &weights)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int n_components = fe.get_fe().n_components();

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -409,7 +409,7 @@ public:
    * locations output.
    */
   void write_gnuplot (const std::string &base_name,
-                      const std::vector <Point <dim> > postprocessor_locations = std::vector <Point <dim> > ());
+                      const std::vector <Point <dim> > &postprocessor_locations = std::vector <Point <dim> > ());
 
 
   /**

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -899,7 +899,8 @@ void PointValueHistory<dim>
 
 template <int dim>
 void PointValueHistory<dim>
-::write_gnuplot (const std::string &base_name, const std::vector <Point <dim> > postprocessor_locations)
+::write_gnuplot (const std::string &base_name,
+                 const std::vector <Point <dim> > &postprocessor_locations)
 {
   AssertThrow (closed, ExcInvalidState ());
   AssertThrow (!cleared, ExcInvalidState ());


### PR DESCRIPTION
These were caught by cppcheck.