### PR TITLE
Move testmatrix.h in the remaining tests.

### DIFF
--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iomanip>

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iomanip>

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <iostream>
 #include <iomanip>
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix.templates.h>

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -19,7 +19,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -19,7 +19,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -16,7 +16,7 @@
 // test the PETSc Richardson solver
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -16,7 +16,7 @@
 // test the PETSc Chebychev solver
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -19,7 +19,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -20,7 +20,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -19,7 +19,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -22,7 +22,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -16,7 +16,7 @@
 // test the PETSc LSQR solver
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc/sparse_direct_mumps.cc
+++ b/tests/petsc/sparse_direct_mumps.cc
@@ -18,7 +18,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc_complex/solver_real_01.cc
+++ b/tests/petsc_complex/solver_real_01.cc
@@ -19,7 +19,7 @@
 // Note: This is (almost) a clone of the tests/petsc/solver_01.cc
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 
 #include <deal.II/lac/petsc_precondition.h>
 #include <deal.II/lac/petsc_solver.h>

--- a/tests/petsc_complex/solver_real_02.cc
+++ b/tests/petsc_complex/solver_real_02.cc
@@ -19,7 +19,7 @@
 // Note: This is (almost) a clone of the tests/petsc/solver_02.cc
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 
 #include <deal.II/lac/petsc_precondition.h>
 #include <deal.II/lac/petsc_solver.h>

--- a/tests/petsc_complex/solver_real_03.cc
+++ b/tests/petsc_complex/solver_real_03.cc
@@ -19,7 +19,7 @@
 // Note: This is (almost) a clone of the tests/petsc/solver_03.cc
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/petsc_complex/solver_real_04.cc
+++ b/tests/petsc_complex/solver_real_04.cc
@@ -19,7 +19,7 @@
 // Note: This is (almost) a clone of the tests/petsc/solver_03.cc
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include <cmath>
 #include <fstream>
 #include <iostream>

--- a/tests/slepc/solve_01.cc
+++ b/tests/slepc/solve_01.cc
@@ -20,7 +20,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include "testmatrix.h"
 #include <cmath>
 #include <fstream>

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -20,7 +20,7 @@
 
 
 #include "../tests.h"
-#include "../lac/testmatrix.h"
+#include "../testmatrix.h"
 #include "testmatrix.h"
 #include <cmath>
 #include <fstream>


### PR DESCRIPTION
This commit finishes the work started in bea2270a943, where `tests/lac/testmatrix.h` was renamed to `tests/testmatrix.h`. I should have looked more carefully before merging.