### PR TITLE
Fix TrilinosWrappers::locally_owned_elements

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -530,6 +530,13 @@ inconvenience this causes.
 
 <ol>
 
+ <li> Fixed: TrilinosWrappers::MPI::Vector::locally_owned_elements()
+ now returns the correct IndexSet also if initialized with two
+ IndexSets. 
+ <br>
+ (Daniel Arndt, 2016/09/16)
+ </li>
+
  <li> New: LinearAlgebra::Vector is now instantiated for float and double.
  <br>
  (Bruno Turcksin, 2016/09/15)

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -511,6 +511,10 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * In case the provided IndexSet forms an overlapping partitioning,
+       * it it not clear which elements are owned by which process and
+       * locally_owned_elements will return an IndexSet of size zero.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -661,6 +661,7 @@ namespace TrilinosWrappers
     {
       *this = Vector(parallel_partitioner.make_trilinos_map (communicator, true),
                      v);
+      owned_elements = parallel_partitioner;
     }
 
 
@@ -671,9 +672,7 @@ namespace TrilinosWrappers
                          const dealii::Vector<number> &v)
     {
       if (vector.get() == 0 || vector->Map().SameAs(parallel_partitioner) == false)
-        vector.reset (new Epetra_FEVector(parallel_partitioner));
-
-      has_ghosts = vector->Map().UniqueGIDs()==false;
+        reinit(parallel_partitioner);
 
       const int size = parallel_partitioner.NumMyElements();
 
@@ -681,6 +680,7 @@ namespace TrilinosWrappers
       // that a direct access is not possible.
       for (int i=0; i<size; ++i)
         (*vector)[0][i] = v(gid(parallel_partitioner,i));
+
     }
 
 
@@ -966,6 +966,7 @@ namespace TrilinosWrappers
         Epetra_LocalMap map ((TrilinosWrappers::types::int_type)v.size(), 0,
                              Utilities::Trilinos::comm_self());
         vector.reset (new Epetra_FEVector(map));
+        owned_elements = v.locally_owned_elements();
       }
 
     const Epetra_Map &map = vector_partitioner();

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -513,7 +513,7 @@ namespace TrilinosWrappers
        *
        * In case the provided IndexSet forms an overlapping partitioning,
        * it it not clear which elements are owned by which process and
-       * locally_owned_elements will return an IndexSet of size zero.
+       * locally_owned_elements() will return an IndexSet of size zero.
        *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -583,6 +583,10 @@ namespace TrilinosWrappers
        * or may not have ghost elements. See the general documentation of this
        * class for more information.
        *
+       * In case @p parallel_partitioning is overlapping, it is not clear which
+       * process should own which elements. Hence, locally_owned_elements()
+       * returns an empty IndexSet in this case.
+       *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
        */

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -1087,6 +1087,10 @@ namespace TrilinosWrappers
   IndexSet
   VectorBase::locally_owned_elements() const
   {
+    Assert(owned_elements.size()==size(),
+           ExcMessage("The locally owned elements have not been properly initialized!"
+                      " This happens for example if this object has been initialized"
+                      " with exactly one overlapping IndexSet."));
     return owned_elements;
   }
 
@@ -1204,7 +1208,7 @@ namespace TrilinosWrappers
     if (v.nonlocal_vector.get() != 0)
       nonlocal_vector.reset(new Epetra_MultiVector(v.nonlocal_vector->Map(), 1));
 
-    owned_elements = v.locally_owned_elements();
+    owned_elements = v.owned_elements;
   }
 
 

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -938,6 +938,11 @@ namespace TrilinosWrappers
     std_cxx11::shared_ptr<Epetra_MultiVector> nonlocal_vector;
 
     /**
+     * An IndexSet storing the indices this vector owns exclusively.
+     */
+    IndexSet owned_elements;
+
+    /**
      * Make the reference class a friend.
      */
     friend class internal::VectorReference;
@@ -1082,27 +1087,7 @@ namespace TrilinosWrappers
   IndexSet
   VectorBase::locally_owned_elements() const
   {
-    IndexSet is (size());
-
-    // easy case: local range is contiguous
-    if (vector->Map().LinearMap())
-      {
-        const std::pair<size_type, size_type> x = local_range();
-        is.add_range (x.first, x.second);
-      }
-    else if (vector->Map().NumMyElements() > 0)
-      {
-        const size_type n_indices = vector->Map().NumMyElements();
-#ifndef DEAL_II_WITH_64BIT_INDICES
-        unsigned int *vector_indices = (unsigned int *)vector->Map().MyGlobalElements();
-#else
-        size_type *vector_indices = (size_type *)vector->Map().MyGlobalElements64();
-#endif
-        is.add_indices(vector_indices, vector_indices+n_indices);
-        is.compress();
-      }
-
-    return is;
+    return owned_elements;
   }
 
 
@@ -1218,6 +1203,8 @@ namespace TrilinosWrappers
 
     if (v.nonlocal_vector.get() != 0)
       nonlocal_vector.reset(new Epetra_MultiVector(v.nonlocal_vector->Map(), 1));
+
+    owned_elements = v.locally_owned_elements();
   }
 
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -122,7 +122,7 @@ namespace TrilinosWrappers
       last_action = Zero;
       vector.reset (new Epetra_FEVector(*v.vector));
       has_ghosts = v.has_ghosts;
-      owned_elements = v.locally_owned_elements();
+      owned_elements = v.owned_elements;
     }
 
 
@@ -318,7 +318,7 @@ namespace TrilinosWrappers
               vector.reset (new Epetra_FEVector(v.vector->Map()));
               has_ghosts = v.has_ghosts;
               last_action = Zero;
-              owned_elements = v.locally_owned_elements();
+              owned_elements = v.owned_elements;
             }
           else if (omit_zeroing_entries == false)
             {
@@ -395,7 +395,7 @@ namespace TrilinosWrappers
             my_global_elements(v.block(block).vector_partitioner());
           for (size_type i=0; i<v.block(block).local_size(); ++i)
             global_ids[added_elements++] = glob_elements[i] + block_offset;
-          owned_elements.add_indices(v.block(block).locally_owned_elements(),
+          owned_elements.add_indices(v.block(block).owned_elements,
                                      block_offset);
           block_offset += v.block(block).size();
         }
@@ -532,7 +532,7 @@ namespace TrilinosWrappers
           vector.reset (new Epetra_FEVector(*v.vector));
           last_action = Zero;
           has_ghosts = v.has_ghosts;
-          owned_elements = v.locally_owned_elements();
+          owned_elements = v.owned_elements;
         }
 
       if (v.nonlocal_vector.get() != 0)
@@ -732,7 +732,7 @@ namespace TrilinosWrappers
                                  v.vector->Map().IndexBase(),
                                  v.vector->Comm());
             vector.reset (new Epetra_FEVector(map));
-            owned_elements = v.locally_owned_elements();
+            owned_elements = v.owned_elements;
           }
         else if (omit_zeroing_entries)
           {
@@ -806,7 +806,7 @@ namespace TrilinosWrappers
                              v.vector->Map().IndexBase(),
                              v.vector->Comm());
         vector.reset (new Epetra_FEVector(map));
-        owned_elements = v.locally_owned_elements();
+        owned_elements = v.owned_elements;
       }
 
     const int ierr = vector->Update(1.0, *v.vector, 0.0);

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -262,10 +262,10 @@ namespace TrilinosWrappers
       // which process owns what. So we decide that no process
       // owns anything in that case.
       if (has_ghosts)
-      {
-        owned_elements.clear();
-        owned_elements.set_size(parallel_partitioner.size());
-      }
+        {
+          owned_elements.clear();
+          owned_elements.set_size(parallel_partitioner.size());
+        }
       else
         owned_elements = parallel_partitioner;
 

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -101,7 +101,10 @@ namespace TrilinosWrappers
     compressed (true),
     has_ghosts  (v.has_ghosts),
     vector(new Epetra_FEVector(*v.vector))
-  {}
+  {
+    owned_elements.set_size(v.size());
+    owned_elements.add_range(0,v.size());
+  }
 
 
 
@@ -139,6 +142,7 @@ namespace TrilinosWrappers
         last_action = Zero;
         vector.reset (new Epetra_FEVector(*v.vector));
         has_ghosts = v.has_ghosts;
+        owned_elements = v.locally_owned_elements();
       }
     else
       {

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -141,7 +141,7 @@ namespace TrilinosWrappers
         last_action = Zero;
         vector.reset (new Epetra_FEVector(*v.vector));
         has_ghosts = v.has_ghosts;
-        owned_elements = v.locally_owned_elements();
+        owned_elements = v.owned_elements;
       }
     else
       {

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -102,8 +102,7 @@ namespace TrilinosWrappers
     has_ghosts  (v.has_ghosts),
     vector(new Epetra_FEVector(*v.vector))
   {
-    owned_elements.set_size(v.size());
-    owned_elements.add_range(0,v.size());
+    owned_elements = complete_index_set(v.size());
   }
 
 

--- a/tests/mpi/blockvec_02.cc
+++ b/tests/mpi/blockvec_02.cc
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test constructor/reinit of BlockVector with IndexSets and the conversion
+// to a Vector
+
+#include "../tests.h"
+#include "coarse_grid_common.h"
+#include <deal.II/lac/petsc_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/base/index_set.h>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+void test ()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  std::vector<IndexSet> local_active(2);
+
+  // block 0:
+  local_active[0].set_size(numproc);
+  local_active[0].add_range(myid,myid+1);
+
+  local_active[1].set_size(2*numproc);
+  local_active[1].add_range(myid*2,myid*2+2);
+
+  TrilinosWrappers::MPI::BlockVector v_block(local_active, MPI_COMM_WORLD);
+
+  v_block(myid) = 100.0 + myid;
+
+  v_block.block(1)(myid*2)=myid*2.0;
+  v_block.block(1)(myid*2+1)=myid*2.0+1.0;
+
+  v_block.compress(VectorOperation::insert);
+
+  deallog << "block size: " << v_block.size() << std::endl;
+  deallog << "block size[0]: " << v_block.block(0).size() << std::endl;
+  deallog << "block size[1]: " << v_block.block(1).size() << std::endl;
+  v_block.locally_owned_elements().print(deallog.get_file_stream());
+
+  TrilinosWrappers::MPI::Vector v;
+  v.reinit (v_block);
+
+  deallog << "size: " << v.size() << std::endl;
+  v.locally_owned_elements().print(deallog.get_file_stream());
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+  test();
+}

--- a/tests/mpi/blockvec_02.with_trilinos=true.mpirun=2.output
+++ b/tests/mpi/blockvec_02.with_trilinos=true.mpirun=2.output
@@ -1,0 +1,15 @@
+
+DEAL:0::block size: 6
+DEAL:0::block size[0]: 2
+DEAL:0::block size[1]: 4
+{0, [2,3]}
+DEAL:0::size: 6
+{0, [2,3]}
+
+DEAL:1::block size: 6
+DEAL:1::block size[0]: 2
+DEAL:1::block size[1]: 4
+{1, [4,5]}
+DEAL:1::size: 6
+{1, [4,5]}
+

--- a/tests/mpi/constraint_matrix_trilinos_bug.with_trilinos=true.mpirun=10.debug.output
+++ b/tests/mpi/constraint_matrix_trilinos_bug.with_trilinos=true.mpirun=10.debug.output
@@ -1,2 +1,2 @@
 
-DEAL:0:2d::Exception: ExcGhostsPresent()
+DEAL:0:2d::Exception: ExcMessage("The locally owned elements have not been properly initialized!" " This happens for example if this object has been initialized" " with exactly one overlapping IndexSet.")

--- a/tests/mpi/constraint_matrix_trilinos_bug.with_trilinos=true.mpirun=4.debug.output
+++ b/tests/mpi/constraint_matrix_trilinos_bug.with_trilinos=true.mpirun=4.debug.output
@@ -1,2 +1,2 @@
 
-DEAL:0:2d::Exception: ExcGhostsPresent()
+DEAL:0:2d::Exception: ExcMessage("The locally owned elements have not been properly initialized!" " This happens for example if this object has been initialized" " with exactly one overlapping IndexSet.")

--- a/tests/mpi/trilinos_locally_owned_elements_02.cc
+++ b/tests/mpi/trilinos_locally_owned_elements_02.cc
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test TrilinosVector::locally_owned_elements
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <fstream>
+#include <sstream>
+
+
+void test ()
+{
+  const int n_proc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int my_id = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  //All processes should own 10 entries
+  const int entries_per_process = 10;
+
+  IndexSet locally_owned(entries_per_process*n_proc);
+  const int begin_index = my_id*entries_per_process;
+  const int end_index = (my_id+1)*entries_per_process;
+  locally_owned.add_range(begin_index, end_index);
+
+  IndexSet locally_relevant(entries_per_process*n_proc);
+  const int local_begin = std::max(0, begin_index-entries_per_process/2);
+  const int local_end = entries_per_process*n_proc;
+  locally_relevant.add_range (local_begin, local_end);
+
+  TrilinosWrappers::MPI::Vector ghosted, distributed;
+  distributed.reinit(locally_owned, MPI_COMM_WORLD);
+  ghosted.reinit (locally_owned, locally_relevant, MPI_COMM_WORLD);
+
+  IndexSet locally_owned_elements_distributed = distributed.locally_owned_elements();
+  IndexSet locally_owned_elements_ghosted = ghosted.locally_owned_elements();
+
+  const types::global_dof_index local_range_begin_ghosted = ghosted.local_range().first;
+  const types::global_dof_index local_range_end_ghosted = ghosted.local_range().second;
+
+  const types::global_dof_index local_range_begin_distributed = distributed.local_range().first;
+  const types::global_dof_index local_range_end_distributed = distributed.local_range().second;
+
+  deallog << "locally_owned_elements_distributed: ";
+  locally_owned_elements_distributed.print(deallog);
+  deallog << "locally_owned_elements_ghosted: ";
+  locally_owned_elements_ghosted.print(deallog);
+  deallog << "local_range_begin_ghosted: "
+          << local_range_begin_ghosted << std::endl;
+  deallog << "local_range_end_ghosted: "
+          << local_range_end_ghosted << std::endl;
+  deallog << "local_range_begin_distributed: "
+          << local_range_begin_distributed << std::endl;
+  deallog << "local_range_end_distributed: "
+          << local_range_end_distributed << std::endl;
+
+  AssertThrow (locally_owned_elements_distributed == locally_owned_elements_ghosted,
+               ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+
+  MPILogInitAll log;
+
+  test();
+}

--- a/tests/mpi/trilinos_locally_owned_elements_02.with_trilinos=true.mpirun=2.output
+++ b/tests/mpi/trilinos_locally_owned_elements_02.with_trilinos=true.mpirun=2.output
@@ -1,0 +1,17 @@
+
+DEAL:0::locally_owned_elements_distributed: {[0,9]}
+DEAL:0::locally_owned_elements_ghosted: {[0,9]}
+DEAL:0::local_range_begin_ghosted: 0
+DEAL:0::local_range_end_ghosted: 20
+DEAL:0::local_range_begin_distributed: 0
+DEAL:0::local_range_end_distributed: 10
+DEAL:0::OK
+
+DEAL:1::locally_owned_elements_distributed: {[10,19]}
+DEAL:1::locally_owned_elements_ghosted: {[10,19]}
+DEAL:1::local_range_begin_ghosted: 5
+DEAL:1::local_range_end_ghosted: 20
+DEAL:1::local_range_begin_distributed: 10
+DEAL:1::local_range_end_distributed: 20
+DEAL:1::OK
+


### PR DESCRIPTION
Fixes PR #2955. 
In the cases where we have just an EpetraMap object to construct the or reinitialize the vector we use all the elements we store as locally owned elements. Note that all these functions are deprecated.