### PR TITLE
Load the correct parameter file in some tests.

### DIFF
--- a/tests/parameter_handler/parameter_handler_6_bool.cc
+++ b/tests/parameter_handler/parameter_handler_6_bool.cc
@@ -41,7 +41,7 @@ int main ()
                          "docs 1");
       prm.leave_subsection ();
 
-      prm.read_input("prm");
+      prm.read_input(SOURCE_DIR "/prm/parameter_handler_6_bool.prm");
 
       // now set the parameter to a different
       // value

--- a/tests/parameter_handler/parameter_handler_read_xml_error_01.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_01.cc
@@ -75,7 +75,7 @@ int main ()
   prm.leave_subsection ();
 
   // read from XML
-  std::ifstream in ("prm");
+  std::ifstream in (SOURCE_DIR "/prm/parameter_handler_read_xml_error_01.prm");
   bool result = prm.read_input_from_xml (in);
   Assert (result == false, ExcInternalError());
 

--- a/tests/parameter_handler/parameter_handler_read_xml_error_02.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_02.cc
@@ -75,7 +75,7 @@ int main ()
   prm.leave_subsection ();
 
   // read from XML
-  std::ifstream in ("prm");
+  std::ifstream in (SOURCE_DIR "/prm/parameter_handler_read_xml_error_02.prm");
   bool result = prm.read_input_from_xml (in);
   AssertThrow (result == false, ExcInternalError());
 

--- a/tests/parameter_handler/parameter_handler_read_xml_error_03.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_03.cc
@@ -75,7 +75,7 @@ int main ()
   prm.leave_subsection ();
 
   // read from XML
-  std::ifstream in ("prm");
+  std::ifstream in (SOURCE_DIR "/prm/parameter_handler_read_xml_error_03.prm");
   bool result = prm.read_input_from_xml (in);
   AssertThrow (result == false, ExcInternalError());
 

--- a/tests/parameter_handler/parameter_handler_read_xml_error_04.cc
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_04.cc
@@ -75,7 +75,7 @@ int main ()
   prm.leave_subsection ();
 
   // read from XML
-  std::ifstream in ("prm");
+  std::ifstream in (SOURCE_DIR "/prm/parameter_handler_read_xml_error_04.prm");
   bool result = prm.read_input_from_xml (in);
   AssertThrow (result == false, ExcInternalError());
 


### PR DESCRIPTION
Commit bd1b0e5606a performed a mass rename where some of the test files lost track of their input files. Somehow `read_input` does not raise an exception if one asks it to read from a file that does not exist; that is a bug.