### PR TITLE
Grammar police: Let comments start with the verb infinitive.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -71,7 +71,7 @@ public:
   AlignedVector ();
 
   /**
-   * Sets the vector size to the given size and initializes all elements with
+   * Set the vector size to the given size and initializes all elements with
    * T().
    *
    * @dealiiOperationIsMultithreaded
@@ -164,12 +164,12 @@ public:
   void push_back (const T in_data);
 
   /**
-   * Returns the last element of the vector (read and write access).
+   * Return the last element of the vector (read and write access).
    */
   reference back ();
 
   /**
-   * Returns the last element of the vector (read-only access).
+   * Return the last element of the vector (read-only access).
    */
   const_reference back () const;
 
@@ -197,17 +197,17 @@ public:
   void swap (AlignedVector<T> &vec);
 
   /**
-   * Returns whether the vector is empty, i.e., its size is zero.
+   * Return whether the vector is empty, i.e., its size is zero.
    */
   bool empty () const;
 
   /**
-   * Returns the size of the vector.
+   * Return the size of the vector.
    */
   size_type size () const;
 
   /**
-   * Returns the capacity of the vector, i.e., the size this vector can hold
+   * Return the capacity of the vector, i.e., the size this vector can hold
    * without reallocation. Note that capacity() >= size().
    */
   size_type capacity () const;
@@ -224,27 +224,27 @@ public:
   const_reference operator [] (const size_type index) const;
 
   /**
-   * Returns a read and write pointer to the beginning of the data array.
+   * Return a read and write pointer to the beginning of the data array.
    */
   iterator begin ();
 
   /**
-   * Returns a read and write pointer to the end of the data array.
+   * Return a read and write pointer to the end of the data array.
    */
   iterator end ();
 
   /**
-   * Returns a read-only pointer to the beginning of the data array.
+   * Return a read-only pointer to the beginning of the data array.
    */
   const_iterator begin () const;
 
   /**
-   * Returns a read-only pointer to the end of the data array.
+   * Return a read-only pointer to the end of the data array.
    */
   const_iterator end () const;
 
   /**
-   * Returns the memory consumption of the allocated memory in this class. If
+   * Return the memory consumption of the allocated memory in this class. If
    * the underlying type @p T allocates memory by itself, this memory is not
    * counted.
    */

--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -154,7 +154,7 @@ public:
    * Return the gradient of the specified component of the function at the
    * given point.
    *
-   * Computes numerical difference quotients using the preset
+   * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
    */
   virtual Tensor<1,dim> gradient (const Point<dim>   &p,
@@ -163,7 +163,7 @@ public:
   /**
    * Return the gradient of all components of the function at the given point.
    *
-   * Computes numerical difference quotients using the preset
+   * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
    */
   virtual void vector_gradient (const Point<dim>            &p,
@@ -175,7 +175,7 @@ public:
    * already has the right size, i.e.  the same size as the <tt>points</tt>
    * array.
    *
-   * Computes numerical difference quotients using the preset
+   * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
    */
   virtual void gradient_list (const std::vector<Point<dim> > &points,
@@ -191,14 +191,14 @@ public:
    * The outer loop over <tt>gradients</tt> is over the points in the list,
    * the inner loop over the different components of the function.
    *
-   * Computes numerical difference quotients using the preset
+   * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
    */
   virtual void vector_gradient_list (const std::vector<Point<dim> > &points,
                                      std::vector<std::vector<Tensor<1,dim> > > &gradients) const;
 
   /**
-   * Returns a #DifferenceFormula of the order <tt>ord</tt> at minimum.
+   * Return a #DifferenceFormula of the order <tt>ord</tt> at minimum.
    */
   static
   DifferenceFormula

--- a/include/deal.II/base/geometric_utilities.h
+++ b/include/deal.II/base/geometric_utilities.h
@@ -42,7 +42,7 @@ namespace GeometricUtilities
   {
 
     /**
-     * Returns spherical coordinates of a Cartesian point @p point.
+     * Return spherical coordinates of a Cartesian point @p point.
      * The returned array is filled with radius, azimuth angle $\in [0,2 \pi)$
      * and polar/inclination angle $ \in [0,\pi]$ (ommited in 2D).
      */

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -1831,7 +1831,7 @@ struct GeometryInfo
   project_to_unit_cell (const Point<dim> &p);
 
   /**
-   * Returns the infinity norm of the vector between a given point @p p
+   * Return the infinity norm of the vector between a given point @p p
    * outside the unit cell to the closest unit cell boundary. For points
    * inside the cell, this is defined as zero.
    */

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -332,25 +332,25 @@ public:
   void print(StreamType &out) const;
 
   /**
-   * Writes the IndexSet into a text based file format, that can be read in
+   * Write the IndexSet into a text based file format, that can be read in
    * again using the read() function.
    */
   void write(std::ostream &out) const;
 
   /**
-   * Constructs the IndexSet from a text based representation given by the
+   * Construct the IndexSet from a text based representation given by the
    * stream @p in written by the write() function.
    */
   void read(std::istream &in);
 
   /**
-   * Writes the IndexSet into a binary, compact representation, that can be
+   * Write the IndexSet into a binary, compact representation, that can be
    * read in again using the block_read() function.
    */
   void block_write(std::ostream &out) const;
 
   /**
-   * Constructs the IndexSet from a binary representation given by the stream
+   * Construct the IndexSet from a binary representation given by the stream
    * @p in written by the write_block() function.
    */
   void block_read(std::istream &in);

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -63,7 +63,7 @@ DEAL_II_NAMESPACE_OPEN
  * can be set via <tt>LogStream::Prefix p("loopname");</tt>. The destructor of
  * the prefix will pop the prefix text from the stack.
  *
- * Writes via the <tt>&lt;&lt;</tt> operator, <tt> deallog << "This is a log
+ * Write via the <tt>&lt;&lt;</tt> operator, <tt> deallog << "This is a log
  * notice";</tt> will be buffered thread locally until a <tt>std::flush</tt>
  * or <tt>std::endl</tt> is encountered, which will trigger a writeout to the
  * console and, if set up, the log file.

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -308,7 +308,7 @@ namespace Utilities
     };
 
     /**
-     * Returns sum, average, minimum, maximum, processor id of minimum and
+     * Return sum, average, minimum, maximum, processor id of minimum and
      * maximum as a collective operation of on the given MPI
      * @ref GlossMPICommunicator "communicator"
      * @p mpi_communicator. Each processor's value is given in @p my_value and

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -59,7 +59,7 @@ public:
   static unsigned int n_cores ();
 
   /**
-   * Returns the number of threads to use. This is initially set to the number
+   * Return the number of threads to use. This is initially set to the number
    * of cores the system has (see n_cores()) but can be further restricted by
    * set_thread_limit() and the environment variable DEAL_II_NUM_THREADS.
    */
@@ -87,7 +87,7 @@ public:
   static void set_thread_limit (const unsigned int max_threads = numbers::invalid_unsigned_int);
 
   /**
-   * Returns if the TBB is running using a single thread either because of
+   * Return if the TBB is running using a single thread either because of
    * thread affinity or because it is set via a call to set_thread_limit. This
    * is used in the PETScWrappers to avoid using the interface that is not
    * thread-safe.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -127,7 +127,7 @@ namespace Patterns
   };
 
   /**
-   * Returns pointer to the correct derived class based on description.
+   * Return pointer to the correct derived class based on description.
    */
   PatternBase *pattern_factory (const std::string &description);
 

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -106,7 +106,7 @@ namespace Utilities
                           const MPI_Comm &communicator);
 
       /**
-       * Sets the locally owned indices. Used in the constructor.
+       * Set the locally owned indices. Used in the constructor.
        */
       void set_owned_indices (const IndexSet &locally_owned_indices);
 
@@ -117,18 +117,18 @@ namespace Utilities
       void set_ghost_indices (const IndexSet &ghost_indices);
 
       /**
-       * Returns the global size.
+       * Return the global size.
        */
       types::global_dof_index size() const;
 
       /**
-       * Returns the local size, i.e. local_range().second minus
+       * Return the local size, i.e. local_range().second minus
        * local_range().first.
        */
       unsigned int local_size() const;
 
       /**
-       * Returns an IndexSet representation of the local range. This class
+       * Return an IndexSet representation of the local range. This class
        * only supports contiguous local ranges, so the IndexSet actually only
        * consists of one single range of data, and is equivalent to the result
        * of local_range().
@@ -136,7 +136,7 @@ namespace Utilities
       const IndexSet &locally_owned_range() const;
 
       /**
-       * Returns the local range. The returned pair consists of the index of
+       * Return the local range. The returned pair consists of the index of
        * the first element and the index of the element one past the last
        * locally owned one.
        */
@@ -144,13 +144,13 @@ namespace Utilities
       local_range() const;
 
       /**
-       * Returns true if the given global index is in the local range of this
+       * Return true if the given global index is in the local range of this
        * processor.
        */
       bool in_local_range (const types::global_dof_index global_index) const;
 
       /**
-       * Returns the local index corresponding to the given global index. If
+       * Return the local index corresponding to the given global index. If
        * the given global index is neither locally owned nor a ghost, an
        * exception is thrown.
        *
@@ -162,7 +162,7 @@ namespace Utilities
       global_to_local (const types::global_dof_index global_index) const;
 
       /**
-       * Returns the global index corresponding to the given local index.
+       * Return the global index corresponding to the given local index.
        *
        * Note that the local index for locally owned indices is between 0 and
        * local_size()-1, and the local index for ghosts is between
@@ -172,25 +172,25 @@ namespace Utilities
       local_to_global (const unsigned int local_index) const;
 
       /**
-       * Returns whether the given global index is a ghost index on the
+       * Return whether the given global index is a ghost index on the
        * present processor. Returns false for indices that are owned locally
        * and for indices not present at all.
        */
       bool is_ghost_entry (const types::global_dof_index global_index) const;
 
       /**
-       * Returns an IndexSet representation of all ghost indices.
+       * Return an IndexSet representation of all ghost indices.
        */
       const IndexSet &ghost_indices() const;
 
       /**
-       * Returns the number of ghost indices. Same as
+       * Return the number of ghost indices. Same as
        * ghost_indices().n_elements(), but cached for simpler access.
        */
       unsigned int n_ghost_indices() const;
 
       /**
-       * Returns a list of processors (first entry) and the number of degrees
+       * Return a list of processors (first entry) and the number of degrees
        * of freedom for the individual processor on the ghost elements present
        * (second entry).
        */
@@ -213,7 +213,7 @@ namespace Utilities
       unsigned int n_import_indices() const;
 
       /**
-       * Returns a list of processors (first entry) and the number of degrees
+       * Return a list of processors (first entry) and the number of degrees
        * of freedom for all the processors that data is obtained from (second
        * entry), i.e., locally owned indices that are ghosts on other
        * processors.
@@ -222,7 +222,7 @@ namespace Utilities
       import_targets() const;
 
       /**
-       * Checks whether the given partitioner is compatible with the
+       * Check whether the given partitioner is compatible with the
        * partitioner used for this vector. Two partitioners are compatible if
        * they have the same local size and the same ghost indices. They do not
        * necessarily need to be the same data field. This is a local operation
@@ -233,7 +233,7 @@ namespace Utilities
       bool is_compatible (const Partitioner &part) const;
 
       /**
-       * Checks whether the given partitioner is compatible with the
+       * Check whether the given partitioner is compatible with the
        * partitioner used for this vector. Two partitioners are compatible if
        * they have the same local size and the same ghost indices. They do not
        * necessarily need to be the same data field. As opposed to
@@ -248,36 +248,36 @@ namespace Utilities
       bool is_globally_compatible (const Partitioner &part) const;
 
       /**
-       * Returns the MPI ID of the calling processor. Cached to have simple
+       * Return the MPI ID of the calling processor. Cached to have simple
        * access.
        */
       unsigned int this_mpi_process () const;
 
       /**
-       * Returns the total number of MPI processor participating in the given
+       * Return the total number of MPI processor participating in the given
        * partitioner. Cached to have simple access.
        */
       unsigned int n_mpi_processes () const;
 
       /**
-       * Returns the MPI communicator underlying the partitioner object.
+       * Return the MPI communicator underlying the partitioner object.
        */
       const MPI_Comm &get_communicator() const DEAL_II_DEPRECATED;
 
       /**
-       * Returns the MPI communicator underlying the partitioner object.
+       * Return the MPI communicator underlying the partitioner object.
        */
       virtual const MPI_Comm &get_mpi_communicator() const;
 
       /**
-       * Returns whether ghost indices have been explicitly added as a @p
+       * Return whether ghost indices have been explicitly added as a @p
        * ghost_indices argument. Only true if a reinit call or constructor
        * provided that argument.
        */
       bool ghost_indices_initialized() const;
 
       /**
-       * Computes the memory consumption of this structure.
+       * Compute the memory consumption of this structure.
        */
       std::size_t memory_consumption() const;
 

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -322,7 +322,7 @@ namespace Polynomials
   private:
 
     /**
-     * Computes the <tt>coefficients</tt> of the base class Polynomial. This
+     * Compute the <tt>coefficients</tt> of the base class Polynomial. This
      * function is <tt>static</tt> to allow to be called in the constructor.
      */
     static

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -120,13 +120,13 @@ public:
   void output_indices(StreamType &out) const;
 
   /**
-   * Sets the ordering of the polynomials. Requires
+   * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==n()</tt>. Stores a copy of <tt>renumber</tt>.
    */
   void set_numbering(const std::vector<unsigned int> &renumber);
 
   /**
-   * Computes the value and the first and second derivatives of each
+   * Compute the value and the first and second derivatives of each
    * polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal 0 or equal n(). In the first
@@ -146,7 +146,7 @@ public:
                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th polynomial at unit point
+   * Compute the value of the <tt>i</tt>th polynomial at unit point
    * <tt>p</tt>.
    *
    * Consider using compute() instead.
@@ -155,7 +155,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th polynomial
+   * Compute the <tt>order</tt>th derivative of the <tt>i</tt>th polynomial
    * at unit point <tt>p</tt>.
    *
    * Consider using compute() instead.
@@ -167,7 +167,7 @@ public:
                                         const Point<dim> &p) const;
 
   /**
-   * Computes the gradient of the <tt>i</tt>th polynomial at unit point
+   * Compute the gradient of the <tt>i</tt>th polynomial at unit point
    * <tt>p</tt>.
    *
    * Consider using compute() instead.
@@ -176,7 +176,7 @@ public:
                               const Point<dim> &p) const;
 
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th polynomial
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th polynomial
    * at unit point <tt>p</tt>.
    *
    * Consider using compute() instead.

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -69,7 +69,7 @@ public:
   ~PolynomialsABF ();
 
   /**
-   * Computes the value and the first and second derivatives of each Raviart-
+   * Compute the value and the first and second derivatives of each Raviart-
    * Thomas polynomial at @p unit_point.
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
@@ -88,12 +88,12 @@ public:
                 std::vector<Tensor<5,dim> > &fourth_derivatives) const;
 
   /**
-   * Returns the number of ABF polynomials.
+   * Return the number of ABF polynomials.
    */
   unsigned int n () const;
 
   /**
-   * Returns the degree of the ABF space, which is two less than the highest
+   * Return the degree of the ABF space, which is two less than the highest
    * polynomial degree.
    */
   unsigned int degree () const;

--- a/include/deal.II/base/polynomials_adini.h
+++ b/include/deal.II/base/polynomials_adini.h
@@ -45,7 +45,7 @@ public:
    */
   PolynomialsAdini ();
   /**
-   * Computes the value and the first and second derivatives of each
+   * Compute the value and the first and second derivatives of each
    * polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal 0 or equal n(). In the first
@@ -64,7 +64,7 @@ public:
                 std::vector< Tensor<2,2> > &grad_grads) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th polynomial at <tt>unit_point</tt>.
+   * Compute the value of the <tt>i</tt>th polynomial at <tt>unit_point</tt>.
    *
    * Consider using compute() instead.
    */
@@ -73,7 +73,7 @@ public:
                         const Point<2> &p) const;
 
   /**
-   * Computes the gradient of the <tt>i</tt>th polynomial at
+   * Compute the gradient of the <tt>i</tt>th polynomial at
    * <tt>unit_point</tt>.
    *
    * Consider using compute() instead.
@@ -82,7 +82,7 @@ public:
   Tensor<1,2> compute_grad (const unsigned int i,
                             const Point<2> &p) const;
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th polynomial
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th polynomial
    * at <tt>unit_point</tt>.
    *
    * Consider using compute() instead.

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -111,7 +111,7 @@ public:
   PolynomialsBDM (const unsigned int k);
 
   /**
-   * Computes the value and the first and second derivatives of each BDM
+   * Compute the value and the first and second derivatives of each BDM
    * polynomial at @p unit_point.
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
@@ -130,12 +130,12 @@ public:
                 std::vector<Tensor<5,dim> > &fourth_derivatives) const;
 
   /**
-   * Returns the number of BDM polynomials.
+   * Return the number of BDM polynomials.
    */
   unsigned int n () const;
 
   /**
-   * Returns the degree of the BDM space, which is one less than the highest
+   * Return the degree of the BDM space, which is one less than the highest
    * polynomial degree.
    */
   unsigned int degree () const;

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -62,7 +62,7 @@ public:
   PolynomialsNedelec (const unsigned int k);
 
   /**
-   * Computes the value and the first and second derivatives of each Nédélec
+   * Compute the value and the first and second derivatives of each Nédélec
    * polynomial at @p unit_point.
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
@@ -80,12 +80,12 @@ public:
                 std::vector<Tensor<5,dim> > &fourth_derivatives) const;
 
   /**
-   * Returns the number of Nédélec polynomials.
+   * Return the number of Nédélec polynomials.
    */
   unsigned int n () const;
 
   /**
-   * Returns the degree of the Nédélec space, which is one less than the
+   * Return the degree of the Nédélec space, which is one less than the
    * highest polynomial degree.
    */
   unsigned int degree () const;

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -61,7 +61,7 @@ public:
   PolynomialsP (const unsigned int p);
 
   /**
-   * Returns the degree <tt>p</tt> of the polynomial space <tt>P_p</tt>.
+   * Return the degree <tt>p</tt> of the polynomial space <tt>P_p</tt>.
    *
    * Note, that this number is <tt>PolynomialSpace::degree()-1</tt>, compare
    * definition in PolynomialSpace.

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -60,7 +60,7 @@ public:
   PolynomialsRaviartThomas (const unsigned int k);
 
   /**
-   * Computes the value and the first and second derivatives of each Raviart-
+   * Compute the value and the first and second derivatives of each Raviart-
    * Thomas polynomial at @p unit_point.
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
@@ -79,12 +79,12 @@ public:
                 std::vector<Tensor<5,dim> > &fourth_derivatives) const;
 
   /**
-   * Returns the number of Raviart-Thomas polynomials.
+   * Return the number of Raviart-Thomas polynomials.
    */
   unsigned int n () const;
 
   /**
-   * Returns the degree of the Raviart-Thomas space, which is one less than
+   * Return the degree of the Raviart-Thomas space, which is one less than
    * the highest polynomial degree.
    */
   unsigned int degree () const;

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -226,13 +226,13 @@ public:
 
 protected:
   /**
-   * Sets the points of the quadrature formula.
+   * Set the points of the quadrature formula.
    */
   std::vector<double>
   set_quadrature_points(const unsigned int n) const;
 
   /**
-   * Sets the weights of the quadrature formula.
+   * Set the weights of the quadrature formula.
    */
   std::vector<double>
   set_quadrature_weights(const unsigned int n) const;

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2453,7 +2453,7 @@ deviator_tensor ()
 
 
 /**
- * Returns the fourth-order symmetric identity tensor which maps symmetric
+ * Return the fourth-order symmetric identity tensor which maps symmetric
  * second-order tensors to themselves.
  *
  * Note that this tensor, even though it is the identity, has a somewhat funny

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -383,7 +383,7 @@ public:
   void set_column_order (const std::vector<std::string> &new_order);
 
   /**
-   * Sets the <tt>precision</tt> e.g. double or float variables are written
+   * Set the <tt>precision</tt> e.g. double or float variables are written
    * with. <tt>precision</tt> is the same as in calling
    * <tt>out<<setprecision(precision)</tt>.
    */
@@ -391,14 +391,14 @@ public:
                       const unsigned int precision);
 
   /**
-   * Sets the <tt>scientific_flag</tt>. True means scientific, false means
+   * Set the <tt>scientific_flag</tt>. True means scientific, false means
    * fixed point notation.
    */
   void set_scientific (const std::string &key,
                        const bool         scientific);
 
   /**
-   * Sets the caption of the column <tt>key</tt> for tex output. You may want
+   * Set the caption of the column <tt>key</tt> for tex output. You may want
    * to chose this different from <tt>key</tt>, if it contains formulas or
    * similar constructs.
    */
@@ -406,17 +406,17 @@ public:
                         const std::string &tex_caption);
 
   /**
-   * Sets the tex caption of the entire <tt>table</tt> for tex output.
+   * Set the tex caption of the entire <tt>table</tt> for tex output.
    */
   void set_tex_table_caption (const std::string &table_caption);
 
   /**
-   * Sets the label of this <tt>table</tt> for tex output.
+   * Set the label of this <tt>table</tt> for tex output.
    */
   void set_tex_table_label (const std::string &table_label);
 
   /**
-   * Sets the caption the the supercolumn <tt>superkey</tt> for tex output.
+   * Set the caption the the supercolumn <tt>superkey</tt> for tex output.
    * You may want to chose this different from <tt>superkey</tt>, if it
    * contains formulas or similar constructs.
    */
@@ -424,7 +424,7 @@ public:
                              const std::string &tex_supercaption);
 
   /**
-   * Sets the tex output format of a column, e.g. <tt>c</tt>, <tt>r</tt>,
+   * Set the tex output format of a column, e.g. <tt>c</tt>, <tt>r</tt>,
    * <tt>l</tt>, or <tt>p{3cm}</tt>. The default is <tt>c</tt>. Also if this
    * function is not called for a column, the default is preset to be
    * <tt>c</tt>.
@@ -455,7 +455,7 @@ public:
   void write_tex (std::ostream &file, const bool with_header=true) const;
 
   /**
-   * Clears the rows of the table, i.e. calls clear() on all the underlying
+   * Clear the rows of the table, i.e. calls clear() on all the underlying
    * storage data structures.
    */
   void clear ();

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -523,7 +523,7 @@ public:
   void unroll (Vector<OtherNumber> &result) const;
 
   /**
-   * Returns an unrolled index in the range [0,dim^rank-1] for the element of
+   * Return an unrolled index in the range [0,dim^rank-1] for the element of
    * the tensor indexed by the argument to the function.
    */
   static
@@ -1707,7 +1707,7 @@ outer_product(const Tensor<rank_1, dim, Number> &src1,
 
 
 /**
- * Returns the cross product in 2d. This is just a rotation by 90 degrees
+ * Return the cross product in 2d. This is just a rotation by 90 degrees
  * clockwise to compute the outer normal from a tangential vector. This
  * function is defined for all space dimensions to allow for dimension
  * independent programming (e.g. within switches over the space dimension),
@@ -1734,7 +1734,7 @@ cross_product_2d (const Tensor<1,dim,Number> &src)
 
 
 /**
- * Returns the cross product of 2 vectors in 3d. This function is defined for
+ * Return the cross product of 2 vectors in 3d. This function is defined for
  * all space dimensions to allow for dimension independent programming (e.g.
  * within switches over the space dimension), but may only be called if the
  * actual dimension of the arguments is three (e.g. from the <tt>dim==3</tt>

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -85,7 +85,7 @@ public:
   void output_indices(std::ostream &out) const;
 
   /**
-   * Sets the ordering of the polynomials. Requires
+   * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==n()</tt>.  Stores a copy of <tt>renumber</tt>.
    */
   void set_numbering(const std::vector<unsigned int> &renumber);
@@ -101,7 +101,7 @@ public:
   const std::vector<unsigned int> &get_numbering_inverse() const;
 
   /**
-   * Computes the value and the first and second derivatives of each tensor
+   * Compute the value and the first and second derivatives of each tensor
    * product polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal 0 or equal n(). In the first
@@ -120,7 +120,7 @@ public:
                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th tensor product polynomial at
+   * Compute the value of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -135,7 +135,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
+   * Compute the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -153,7 +153,7 @@ public:
                                         const Point<dim> &p) const;
 
   /**
-   * Computes the grad of the <tt>i</tt>th tensor product polynomial at
+   * Compute the grad of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -168,7 +168,7 @@ public:
                               const Point<dim> &p) const;
 
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th tensor
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -183,7 +183,7 @@ public:
                                    const Point<dim> &p) const;
 
   /**
-   * Returns the number of tensor product polynomials. For <i>n</i> 1d
+   * Return the number of tensor product polynomials. For <i>n</i> 1d
    * polynomials this is <i>n<sup>dim</sup></i>.
    */
   unsigned int n () const;
@@ -255,7 +255,7 @@ public:
   AnisotropicPolynomials (const std::vector<std::vector<Polynomials::Polynomial<double> > > &pols);
 
   /**
-   * Computes the value and the first and second derivatives of each tensor
+   * Compute the value and the first and second derivatives of each tensor
    * product polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal <tt>0</tt> or equal
@@ -275,7 +275,7 @@ public:
                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th tensor product polynomial at
+   * Compute the value of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -290,7 +290,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
+   * Compute the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -308,7 +308,7 @@ public:
                                         const Point<dim> &p) const;
 
   /**
-   * Computes the grad of the <tt>i</tt>th tensor product polynomial at
+   * Compute the grad of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -323,7 +323,7 @@ public:
                               const Point<dim> &p) const;
 
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th tensor
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -338,7 +338,7 @@ public:
                                    const Point<dim> &p) const;
 
   /**
-   * Returns the number of tensor product polynomials. It is the product of
+   * Return the number of tensor product polynomials. It is the product of
    * the number of polynomials in each coordinate direction.
    */
   unsigned int n () const;

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -63,7 +63,7 @@ public:
   TensorProductPolynomialsBubbles (const std::vector<Pol> &pols);
 
   /**
-   * Computes the value and the first and second derivatives of each tensor
+   * Compute the value and the first and second derivatives of each tensor
    * product polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal 0 or equal n(). In the first
@@ -82,7 +82,7 @@ public:
                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th tensor product polynomial at
+   * Compute the value of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -97,7 +97,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the order @p order derivative of the <tt>i</tt>th tensor product
+   * Compute the order @p order derivative of the <tt>i</tt>th tensor product
    * polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor
    * product numbering.
    *
@@ -113,7 +113,7 @@ public:
                                         const Point<dim> &p) const;
 
   /**
-   * Computes the grad of the <tt>i</tt>th tensor product polynomial at
+   * Compute the grad of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -128,7 +128,7 @@ public:
                               const Point<dim> &p) const;
 
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th tensor
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -143,7 +143,7 @@ public:
                                    const Point<dim> &p) const;
 
   /**
-   * Returns the number of tensor product polynomials plus the bubble
+   * Return the number of tensor product polynomials plus the bubble
    * enrichments. For <i>n</i> 1d polynomials this is <i>n<sup>dim</sup>+1</i>
    * if the maximum degree of the polynomials is one and
    * <i>n<sup>dim</sup>+dim</i> otherwise.

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -62,7 +62,7 @@ public:
   TensorProductPolynomialsConst (const std::vector<Pol> &pols);
 
   /**
-   * Computes the value and the first and second derivatives of each tensor
+   * Compute the value and the first and second derivatives of each tensor
    * product polynomial at <tt>unit_point</tt>.
    *
    * The size of the vectors must either be equal 0 or equal n(). In the first
@@ -81,7 +81,7 @@ public:
                 std::vector<Tensor<4,dim> > &fourth_derivatives) const;
 
   /**
-   * Computes the value of the <tt>i</tt>th tensor product polynomial at
+   * Compute the value of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -96,7 +96,7 @@ public:
                         const Point<dim> &p) const;
 
   /**
-   * Computes the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
+   * Compute the <tt>order</tt>th derivative of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -114,7 +114,7 @@ public:
                                         const Point<dim> &p) const;
 
   /**
-   * Computes the grad of the <tt>i</tt>th tensor product polynomial at
+   * Compute the grad of the <tt>i</tt>th tensor product polynomial at
    * <tt>unit_point</tt>. Here <tt>i</tt> is given in tensor product
    * numbering.
    *
@@ -129,7 +129,7 @@ public:
                               const Point<dim> &p) const;
 
   /**
-   * Computes the second derivative (grad_grad) of the <tt>i</tt>th tensor
+   * Compute the second derivative (grad_grad) of the <tt>i</tt>th tensor
    * product polynomial at <tt>unit_point</tt>. Here <tt>i</tt> is given in
    * tensor product numbering.
    *
@@ -144,7 +144,7 @@ public:
                                    const Point<dim> &p) const;
 
   /**
-   * Returns the number of tensor product polynomials plus the constant
+   * Return the number of tensor product polynomials plus the constant
    * function. For <i>n</i> 1d polynomials this is <i>n<sup>dim</sup>+1</i>.
    */
   unsigned int n () const;

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -153,7 +153,7 @@ namespace Threads
     void clear ();
 
     /**
-     * Returns a reference to the internal Threading Building Blocks
+     * Return a reference to the internal Threading Building Blocks
      * implementation. This function is really only useful if deal.II has been
      * configured with multithreading and has no useful purpose otherwise.
      */

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -102,7 +102,7 @@ public:
          const bool sync_wall_time = false);
 
   /**
-   * Returns a reference to the data structure with global timing information.
+   * Return a reference to the data structure with global timing information.
    * Filled after calling stop().
    */
   const Utilities::MPI::MinMaxAvg &get_data() const;
@@ -123,7 +123,7 @@ public:
   void start ();
 
   /**
-   * Sets the current time as next starting time and return the elapsed time
+   * Set the current time as next starting time and return the elapsed time
    * in seconds.
    */
   double stop ();
@@ -152,7 +152,7 @@ public:
   double wall_time () const;
 
   /**
-   * Returns the last lap time; the time taken between the last start()/stop()
+   * Return the last lap time; the time taken between the last start()/stop()
    * call.
    */
   double get_lap_time () const;

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -452,7 +452,7 @@ namespace Utilities
   namespace Trilinos
   {
     /**
-     * Returns a Trilinos Epetra_Comm object needed for creation of
+     * Return a Trilinos Epetra_Comm object needed for creation of
      * Epetra_Maps.
      *
      * If deal.II has been configured to use a compiler that does not support
@@ -463,7 +463,7 @@ namespace Utilities
     const Epetra_Comm &comm_world();
 
     /**
-     * Returns a Trilinos Epetra_Comm object needed for creation of
+     * Return a Trilinos Epetra_Comm object needed for creation of
      * Epetra_Maps.
      *
      * If deal.II has been configured to use a compiler that does not support

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -213,7 +213,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by the amount of bytes
    * in the vectorized array, as opposed to casting a double address to
    * VectorizedArray<double>*.
@@ -224,7 +224,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * the amount of bytes in the vectorized array, as opposed to casting a
    * double address to VectorizedArray<double>*.
@@ -242,7 +242,7 @@ public:
 
 private:
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -254,7 +254,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -266,7 +266,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -278,7 +278,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -529,7 +529,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 64 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
    */
@@ -539,7 +539,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 64 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
@@ -557,7 +557,7 @@ public:
 
 private:
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -569,7 +569,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -587,7 +587,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -599,7 +599,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -728,7 +728,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 64 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
    */
@@ -738,7 +738,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 64 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
@@ -757,7 +757,7 @@ public:
 private:
 
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -769,7 +769,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -787,7 +787,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -799,7 +799,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -930,7 +930,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 32 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
    */
@@ -940,7 +940,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 32 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
@@ -958,7 +958,7 @@ public:
 
 private:
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -970,7 +970,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -986,7 +986,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -998,7 +998,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -1243,7 +1243,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 32 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
    */
@@ -1253,7 +1253,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 32 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
@@ -1272,7 +1272,7 @@ public:
 private:
 
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -1284,7 +1284,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -1300,7 +1300,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -1312,7 +1312,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -1605,7 +1605,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
    */
@@ -1615,7 +1615,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
@@ -1633,7 +1633,7 @@ public:
 
 private:
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -1645,7 +1645,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -1662,7 +1662,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -1674,7 +1674,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -1875,7 +1875,7 @@ public:
   }
 
   /**
-   * Loads @p n_array_elements from memory into the calling class, starting at
+   * Load @p n_array_elements from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
    */
@@ -1885,7 +1885,7 @@ public:
   }
 
   /**
-   * Writes the content of the calling class into memory in form of @p
+   * Write the content of the calling class into memory in form of @p
    * n_array_elements to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
@@ -1903,7 +1903,7 @@ public:
 
 private:
   /**
-   * Returns the square root of this field. Not for use in user code. Use
+   * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
    */
   VectorizedArray
@@ -1915,7 +1915,7 @@ private:
   }
 
   /**
-   * Returns the absolute value of this field. Not for use in user code. Use
+   * Return the absolute value of this field. Not for use in user code. Use
    * abs(x) instead.
    */
   VectorizedArray
@@ -1931,7 +1931,7 @@ private:
   }
 
   /**
-   * Returns the component-wise maximum of this field and another one. Not for
+   * Return the component-wise maximum of this field and another one. Not for
    * use in user code. Use max(x,y) instead.
    */
   VectorizedArray
@@ -1943,7 +1943,7 @@ private:
   }
 
   /**
-   * Returns the component-wise minimum of this field and another one. Not for
+   * Return the component-wise minimum of this field and another one. Not for
    * use in user code. Use min(x,y) instead.
    */
   VectorizedArray
@@ -2460,7 +2460,7 @@ DEAL_II_NAMESPACE_CLOSE
 namespace std
 {
   /**
-   * Computes the sine of a vectorized data field. The result is returned as
+   * Compute the sine of a vectorized data field. The result is returned as
    * vectorized array in the form <tt>{sin(x[0]), sin(x[1]), ...,
    * sin(x[n_array_elements-1])}</tt>.
    *
@@ -2487,7 +2487,7 @@ namespace std
 
 
   /**
-   * Computes the cosine of a vectorized data field. The result is returned as
+   * Compute the cosine of a vectorized data field. The result is returned as
    * vectorized array in the form <tt>{cos(x[0]), cos(x[1]), ...,
    * cos(x[n_array_elements-1])}</tt>.
    *
@@ -2509,7 +2509,7 @@ namespace std
 
 
   /**
-   * Computes the tangent of a vectorized data field. The result is returned
+   * Compute the tangent of a vectorized data field. The result is returned
    * as vectorized array in the form <tt>{tan(x[0]), tan(x[1]), ...,
    * tan(x[n_array_elements-1])}</tt>.
    *
@@ -2531,7 +2531,7 @@ namespace std
 
 
   /**
-   * Computes the exponential of a vectorized data field. The result is
+   * Compute the exponential of a vectorized data field. The result is
    * returned as vectorized array in the form <tt>{exp(x[0]), exp(x[1]), ...,
    * exp(x[n_array_elements-1])}</tt>.
    *
@@ -2553,7 +2553,7 @@ namespace std
 
 
   /**
-   * Computes the natural logarithm of a vectorized data field. The result is
+   * Compute the natural logarithm of a vectorized data field. The result is
    * returned as vectorized array in the form <tt>{log(x[0]), log(x[1]), ...,
    * log(x[n_array_elements-1])}</tt>.
    *
@@ -2575,7 +2575,7 @@ namespace std
 
 
   /**
-   * Computes the square root of a vectorized data field. The result is
+   * Compute the square root of a vectorized data field. The result is
    * returned as vectorized array in the form <tt>{sqrt(x[0]), sqrt(x[1]),
    * ..., sqrt(x[n_array_elements-1])}</tt>.
    *
@@ -2615,7 +2615,7 @@ namespace std
 
 
   /**
-   * Computes the absolute value (modulus) of a vectorized data field. The
+   * Compute the absolute value (modulus) of a vectorized data field. The
    * result is returned as vectorized array in the form <tt>{abs(x[0]),
    * abs(x[1]), ..., abs(x[n_array_elements-1])}</tt>.
    *
@@ -2632,7 +2632,7 @@ namespace std
 
 
   /**
-   * Computes the componentwise maximum of two vectorized data fields. The
+   * Compute the componentwise maximum of two vectorized data fields. The
    * result is returned as vectorized array in the form <tt>{max(x[0],y[0]),
    * max(x[1],y[1]), ...}</tt>.
    *
@@ -2650,7 +2650,7 @@ namespace std
 
 
   /**
-   * Computes the componentwise minimum of two vectorized data fields. The
+   * Compute the componentwise minimum of two vectorized data fields. The
    * result is returned as vectorized array in the form <tt>{min(x[0],y[0]),
    * min(x[1],y[1]), ...}</tt>.
    *

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -133,7 +133,7 @@ namespace internal
 
 
     /**
-     * Returns whether q1 and q2 are equal
+     * Return whether q1 and q2 are equal
      */
     template <int dim>
     bool
@@ -605,7 +605,7 @@ namespace parallel
 
 
       /**
-       * Returns true if the triangulation has hanging nodes.
+       * Return true if the triangulation has hanging nodes.
        *
        * In the context of parallel distributed triangulations, every
        * processor stores only that part of the triangulation it locally owns.
@@ -988,7 +988,7 @@ namespace parallel
       virtual ~Triangulation ();
 
       /**
-       * Returns a permutation vector for the order the coarse cells are
+       * Return a permutation vector for the order the coarse cells are
        * handed of to p4est. For example the first element i in this vector
        * denotes that the first cell in hierarchical ordering is the ith deal
        * cell starting from begin(0).

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -113,7 +113,7 @@ namespace parallel
 
 
     /**
-     * Returns the global maximum level. This may be bigger than the number
+     * Return the global maximum level. This may be bigger than the number
      * dealii::Triangulation::n_levels() (a function in this class's base
      * class) returns if the current processor only stores cells in parts of
      * the domain that are not very refined, but if other processors store
@@ -130,7 +130,7 @@ namespace parallel
     types::subdomain_id locally_owned_subdomain () const;
 
     /**
-     * Returns a set of MPI ranks of the processors that have at least one
+     * Return a set of MPI ranks of the processors that have at least one
      * ghost cell adjacent to the cells of the local processor. In other
      * words, this is the set of subdomain_id() for all ghost cells.
      *
@@ -140,7 +140,7 @@ namespace parallel
     const std::set<unsigned int> &ghost_owners () const;
 
     /**
-     * Returns a set of MPI ranks of the processors that have at least one
+     * Return a set of MPI ranks of the processors that have at least one
      * level ghost cell adjacent to our cells used in geometric multigrid. In
      * other words, this is the set of level_subdomain_id() for all level
      * ghost cells.

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -402,7 +402,7 @@ public:
                            const unsigned int fe_index = DoFHandlerType::default_fe_index) const;
 
   /**
-   * Sets the level DoF indices that are returned by get_mg_dof_indices.
+   * Set the level DoF indices that are returned by get_mg_dof_indices.
    */
   void set_mg_dof_indices (const int level,
                            const std::vector<types::global_dof_index> &dof_indices,
@@ -431,7 +431,7 @@ public:
    const unsigned int fe_index = DoFHandlerType::default_fe_index) const;
 
   /**
-   * Returns the global DoF index of the <code>i</code>th degree of freedom
+   * Return the global DoF index of the <code>i</code>th degree of freedom
    * associated with the <code>vertex</code>th vertex on level @p level. Also
    * see vertex_dof_index().
    */
@@ -473,7 +473,7 @@ public:
    const unsigned int fe_index = DoFHandlerType::default_fe_index) const;
 
   /**
-   * Returns the dof_index on the given level. Also see dof_index.
+   * Return the dof_index on the given level. Also see dof_index.
    */
   types::global_dof_index mg_dof_index (const int level, const unsigned int i) const;
 
@@ -1684,7 +1684,7 @@ public:
   get_fe () const;
 
   /**
-   * Returns the index inside the hp::FECollection of the FiniteElement used
+   * Return the index inside the hp::FECollection of the FiniteElement used
    * for this cell. This function is only useful if the DoF handler object
    * associated with the current cell is an hp::DoFHandler.
    *
@@ -1698,7 +1698,7 @@ public:
   unsigned int active_fe_index () const;
 
   /**
-   * Sets the index of the FiniteElement used for this cell. This determines
+   * Set the index of the FiniteElement used for this cell. This determines
    * which element in an hp::FECollection to use. This function is only useful
    * if the DoF handler object associated with the current cell is an
    * hp::DoFHandler.

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -759,14 +759,14 @@ public:
   const IndexSet &locally_owned_dofs() const;
 
   /**
-   * Returns an IndexSet describing the set of locally owned DoFs used for the
+   * Return an IndexSet describing the set of locally owned DoFs used for the
    * given multigrid level as a subset of 0..n_dofs(level).
    */
   const IndexSet &locally_owned_mg_dofs(const unsigned int level) const;
 
 
   /**
-   * Returns a vector that stores the locally owned DoFs of each processor. If
+   * Return a vector that stores the locally owned DoFs of each processor. If
    * you are only interested in the number of elements each processor owns
    * then n_locally_owned_dofs_per_processor() is a better choice.
    *

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -438,7 +438,7 @@ namespace DoFRenumbering
                    const bool      use_constraints    = false);
 
     /**
-     * Computes the renumbering vector needed by the Cuthill_McKee() function.
+     * Compute the renumbering vector needed by the Cuthill_McKee() function.
      * Does not perform the renumbering on the DoFHandler dofs but returns the
      * renumbering vector.
      */
@@ -549,7 +549,7 @@ namespace DoFRenumbering
                  = std::vector<types::global_dof_index>());
 
   /**
-   * Computes the renumbering vector needed by the Cuthill_McKee() function.
+   * Compute the renumbering vector needed by the Cuthill_McKee() function.
    * Does not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -644,7 +644,7 @@ namespace DoFRenumbering
                   = std::vector<unsigned int>());
 
   /**
-   * Computes the renumbering vector needed by the component_wise() functions.
+   * Compute the renumbering vector needed by the component_wise() functions.
    * Does not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -707,7 +707,7 @@ namespace DoFRenumbering
   block_wise (hp::DoFHandler<dim,spacedim> &dof_handler);
 
   /**
-   * Computes the renumbering vector needed by the block_wise() functions.
+   * Compute the renumbering vector needed by the block_wise() functions.
    * Does not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -878,7 +878,7 @@ namespace DoFRenumbering
               const bool                                    dof_wise_renumbering = false);
 
   /**
-   * Computes the renumbering vector needed by the downstream() function. Does
+   * Compute the renumbering vector needed by the downstream() function. Does
    * not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -891,7 +891,7 @@ namespace DoFRenumbering
                       const bool                                    dof_wise_renumbering);
 
   /**
-   * Computes the renumbering vector needed by the downstream() function. Does
+   * Compute the renumbering vector needed by the downstream() function. Does
    * not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -930,7 +930,7 @@ namespace DoFRenumbering
                 const bool                                    counter = false);
 
   /**
-   * Computes the renumbering vector needed by the clockwise_dg() functions.
+   * Compute the renumbering vector needed by the clockwise_dg() functions.
    * Does not perform the renumbering on the DoFHandler dofs but returns the
    * renumbering vector.
    */
@@ -981,7 +981,7 @@ namespace DoFRenumbering
                            const unsigned int       level);
 
   /**
-   * Computes the renumbering vector needed by the sort_selected_dofs_back()
+   * Compute the renumbering vector needed by the sort_selected_dofs_back()
    * function. Does not perform the renumbering on the DoFHandler dofs but
    * returns the renumbering vector.
    *
@@ -1025,7 +1025,7 @@ namespace DoFRenumbering
   random (DoFHandlerType &dof_handler);
 
   /**
-   * Computes the renumbering vector needed by the random() function. See
+   * Compute the renumbering vector needed by the random() function. See
    * there for more information on the computed random renumbering.
    *
    * This function does not perform the renumbering on the DoFHandler dofs but
@@ -1068,7 +1068,7 @@ namespace DoFRenumbering
   subdomain_wise (DoFHandlerType &dof_handler);
 
   /**
-   * Computes the renumbering vector needed by the subdomain_wise() function.
+   * Compute the renumbering vector needed by the subdomain_wise() function.
    * Does not perform the renumbering on the @p DoFHandler dofs but returns
    * the renumbering vector.
    */

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1707,7 +1707,7 @@ public:
   block_mask (const ComponentMask &component_mask) const;
 
   /**
-   * Returns a list of constant modes of the element. The number of rows in
+   * Return a list of constant modes of the element. The number of rows in
    * the resulting table depends on the elements in use. For standard
    * elements, the table has as many rows as there are components in the
    * element and dofs_per_cell columns. To each component of the finite
@@ -1857,7 +1857,7 @@ public:
   get_generalized_support_points () const;
 
   /**
-   * Returns <tt>true</tt> if the class provides nonempty vectors either from
+   * Return <tt>true</tt> if the class provides nonempty vectors either from
    * get_unit_support_points() or get_generalized_support_points().
    *
    * See the

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -466,7 +466,7 @@ public:
   };
 
   /**
-   * Returns a list of constant modes of the element. For this element, the
+   * Return a list of constant modes of the element. For this element, the
    * first entry is true, all other are false.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -294,7 +294,7 @@ public:
                                     const unsigned int face_index) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, it
+   * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -120,7 +120,7 @@ public:
   compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, it
+   * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
@@ -225,7 +225,7 @@ public:
   compare_for_face_domination (const FiniteElement<1,spacedim> &fe_other) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, it
+   * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
@@ -422,7 +422,7 @@ public:
   compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, the
+   * Return a list of constant modes of the element. For this element, the
    * first entry on each face is true, all other are false (as the constant
    * function is represented by the first base function of Legendre
    * polynomials).
@@ -452,7 +452,7 @@ public:
   FE_FaceP (const unsigned int p);
 
   /**
-   * Returns the name of the element
+   * Return the name of the element
    */
   std::string get_name() const;
 };

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -263,7 +263,7 @@ public:
   const;
 
   /**
-   * Returns a list of constant modes of the element.
+   * Return a list of constant modes of the element.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
   get_constant_modes () const;

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -572,7 +572,7 @@ public:
   FE_Q (const Quadrature<1> &points);
 
   /**
-   * Constructs a FE_Q_isoQ1 element. That element shares large parts of code
+   * Construct a FE_Q_isoQ1 element. That element shares large parts of code
    * with FE_Q so most of the construction work is done in this routine,
    * whereas the public constructor is in the class FE_Q_isoQ1.
    */

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -197,7 +197,7 @@ public:
                                    const bool face_rotation    = false) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, the
+   * Return a list of constant modes of the element. For this element, the
    * list consists of true arguments for all components.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -176,7 +176,7 @@ protected:
 private:
 
   /**
-   * Returns the restriction_is_additive flags. Only the last components for
+   * Return the restriction_is_additive flags. Only the last components for
    * the bubble enrichments are true.
    */
   static std::vector<bool> get_riaf_vector(const unsigned int degree);

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -308,7 +308,7 @@ public:
                                     const unsigned int face_index) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, there
+   * Return a list of constant modes of the element. For this element, there
    * are two constant modes despite the element is scalar: The first constant
    * mode is all ones for the usual FE_Q basis and the second one only using
    * the discontinuous part.
@@ -327,7 +327,7 @@ protected:
 private:
 
   /**
-   * Returns the restriction_is_additive flags. Only the last component is
+   * Return the restriction_is_additive flags. Only the last component is
    * true.
    */
   static std::vector<bool> get_riaf_vector(const unsigned int degree);

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -681,7 +681,7 @@ public:
   std::vector<unsigned int> get_embedding_dofs (const unsigned int sub_degree) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, the
+   * Return a list of constant modes of the element. For this element, the
    * list consists of true arguments for the first vertex shape functions and
    * false for the remaining ones.
    */

--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -108,7 +108,7 @@ class FE_Q_iso_Q1 : public FE_Q_Base<TensorProductPolynomials<dim, Polynomials::
 {
 public:
   /**
-   * Constructs a FE_Q_iso_Q1 element with a given number of subdivisions. The
+   * Construct a FE_Q_iso_Q1 element with a given number of subdivisions. The
    * number of subdivision is similar to the degree in FE_Q in the sense that
    * both elements produce the same number of degrees of freedom.
    */

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -138,7 +138,7 @@ public:
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;
 
   /**
-   * Returns a list of constant modes of the element. This method is currently
+   * Return a list of constant modes of the element. This method is currently
    * not correctly implemented because it returns ones for all components.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -732,7 +732,7 @@ public:
   unit_face_support_point (const unsigned int index) const;
 
   /**
-   * Returns a list of constant modes of the element. The returns table has as
+   * Return a list of constant modes of the element. The returns table has as
    * many rows as there are components in the element and dofs_per_cell
    * columns. To each component of the finite element, the row in the returned
    * table contains a basis representation of the constant function 1 on the

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -470,7 +470,7 @@ namespace FETools
                                                      FullMatrix<double>       &I_q);
 
   /**
-   * Computes the projection of tensorial (first-order tensor) data stored at
+   * Compute the projection of tensorial (first-order tensor) data stored at
    * the quadrature points @p vector_of_tensors_at_qp to data @p
    * vector_of_tensors_at_nodes at the support points of the cell.  The data
    * in @p vector_of_tensors_at_qp is ordered sequentially following the

--- a/include/deal.II/fe/fe_trace.h
+++ b/include/deal.II/fe/fe_trace.h
@@ -75,7 +75,7 @@ public:
                                     const unsigned int face_index) const;
 
   /**
-   * Returns a list of constant modes of the element. For this element, it
+   * Return a list of constant modes of the element. For this element, it
    * simply returns one row with all entries set to true.
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
@@ -152,7 +152,7 @@ public:
   FE_TraceQ (const unsigned int p);
 
   /**
-   * Returns the name of the element
+   * Return the name of the element
    */
   std::string get_name() const;
 };

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1672,7 +1672,7 @@ public:
   //@{
 
   /**
-   * Returns the values of a finite element function restricted to the current
+   * Return the values of a finite element function restricted to the current
    * cell, face or subface selected the last time the <tt>reinit</tt> function
    * of the derived class was called, at the quadrature points.
    *

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -324,7 +324,7 @@ public:
   get_vertices (const typename Triangulation<dim,spacedim>::cell_iterator &cell) const;
 
   /**
-   * Returns whether the mapping preserves vertex locations. In other words,
+   * Return whether the mapping preserves vertex locations. In other words,
    * this function returns whether the mapped location of the reference cell
    * vertices (given by GeometryInfo::unit_cell_vertex()) equals the result of
    * <code>cell-@>vertex()</code> (i.e., information stored by the

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -453,7 +453,7 @@ public:
   void read_tecplot (std::istream &in);
 
   /**
-   * Returns the standard suffix for a file in this format.
+   * Return the standard suffix for a file in this format.
    */
   static std::string default_suffix (const Format format);
 

--- a/include/deal.II/grid/grid_reordering_internal.h
+++ b/include/deal.II/grid/grid_reordering_internal.h
@@ -242,18 +242,18 @@ namespace internal
                         const unsigned int localsidenum);
 
       /**
-       * Returns true if all sides of the quad quadnum are oriented.
+       * Return true if all sides of the quad quadnum are oriented.
        */
       bool is_fully_oriented_quad (const unsigned int quadnum) const;
 
       /**
-       * Returns true if the side lsn of the quad quadnum is oriented.
+       * Return true if the side lsn of the quad quadnum is oriented.
        */
       bool is_oriented_side (const unsigned int quadnum,
                              const unsigned int lsn) const;
 
       /**
-       * Returns true is the side is oriented in the "default" direction
+       * Return true is the side is oriented in the "default" direction
        */
       bool is_side_default_oriented (const unsigned int qnum,
                                      const unsigned int lsn) const;
@@ -490,7 +490,7 @@ namespace internal
       std::vector<Cell> cell_list;
 
       /**
-       * Checks whether every cell in the mesh is sensible.
+       * Check whether every cell in the mesh is sensible.
        */
       void sanity_check() const;
 
@@ -537,7 +537,7 @@ namespace internal
        * This function is the single entry point to the functionality of this
        * class.
        *
-       * Returns, whether a consistent orientation of lines was possible for
+       * Return, whether a consistent orientation of lines was possible for
        * the given mesh.
        */
       static
@@ -592,7 +592,7 @@ namespace internal
       /**
        * Orient all the edges of a mesh.
        *
-       * Returns, whether this action was carried out successfully.
+       * Return, whether this action was carried out successfully.
        */
       bool orient_edges ();
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -331,7 +331,7 @@ namespace GridTools
                           const Function<dim,double> *coefficient = 0);
 
   /**
-   * Returns a std::map with all vertices of faces located in the boundary
+   * Return a std::map with all vertices of faces located in the boundary
    *
    * @param[in] tria The Triangulation object.
    */

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -168,7 +168,7 @@ public:
   void restore (const unsigned int step_no);
 
   /**
-   * Returns the number of refinement and coarsening steps. This is given by
+   * Return the number of refinement and coarsening steps. This is given by
    * the size of the @p refine_flags vector.
    */
   unsigned int n_refinement_steps () const;
@@ -204,7 +204,7 @@ public:
     const SubCellData                 &subcelldata);
 
   /**
-   * Writes all refine and coarsen flags to the ostream @p out.
+   * Write all refine and coarsen flags to the ostream @p out.
    */
   virtual void write_flags(std::ostream &out) const;
 
@@ -216,7 +216,7 @@ public:
   virtual void read_flags(std::istream &in);
 
   /**
-   * Clears all flags. Retains the same coarse grid.
+   * Clear all flags. Retains the same coarse grid.
    */
   virtual void clear_flags();
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1546,7 +1546,7 @@ public:
   virtual void clear ();
 
   /**
-   * Sets the mesh smoothing to @p mesh_smoothing. This overrides the
+   * Set the mesh smoothing to @p mesh_smoothing. This overrides the
    * MeshSmoothing given to the constructor. It is allowed to call this
    * function only if the triangulation is empty.
    */
@@ -1703,7 +1703,7 @@ public:
   const Manifold<dim,spacedim> &get_manifold (const types::manifold_id number) const;
 
   /**
-   * Returns a vector containing all boundary indicators assigned to boundary
+   * Return a vector containing all boundary indicators assigned to boundary
    * faces of this Triangulation object. Note, that each boundary indicator is
    * reported only once. The size of the return vector will represent the
    * number of different indicators (which is greater or equal one).
@@ -1716,7 +1716,7 @@ public:
   std::vector<types::boundary_id> get_boundary_ids() const;
 
   /**
-   * Returns a vector containing all manifold indicators assigned to the
+   * Return a vector containing all manifold indicators assigned to the
    * objects of this Triangulation. Note, that each manifold indicator is
    * reported only once. The size of the return vector will represent the
    * number of different indicators (which is greater or equal one).

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1249,12 +1249,12 @@ public:
   double extent_in_direction (const unsigned int axis) const;
 
   /**
-   * Returns the minimal distance between any two vertices.
+   * Return the minimal distance between any two vertices.
    */
   double minimum_vertex_distance () const;
 
   /**
-   * Returns a point belonging to the Manifold<dim,spacedim> where this object
+   * Return a point belonging to the Manifold<dim,spacedim> where this object
    * lives, given its parametric coordinates on the reference @p structdim
    * cell. This function queries the underlying manifold object, and can be
    * used to obtain the exact geometrical location of arbitrary points on this
@@ -2537,7 +2537,7 @@ public:
   neighbor_or_periodic_neighbor (const unsigned int i) const;
 
   /**
-   * Returns an iterator to the periodic neighbor of the cell at a given
+   * Return an iterator to the periodic neighbor of the cell at a given
    * face and subface number. The general guidelines for using this function
    * is similar to the function neighbor_child_on_subface(). The
    * implementation of this function is consistent with

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -196,7 +196,7 @@ public:
 
 protected:
   /**
-   * Returns the support points of the Gauss-Lobatto quadrature formula used
+   * Return the support points of the Gauss-Lobatto quadrature formula used
    * for intermediate points.
    *
    * @note Since the boundary description is closely tied to the unit cell

--- a/include/deal.II/grid/tria_boundary_lib.h
+++ b/include/deal.II/grid/tria_boundary_lib.h
@@ -525,7 +525,7 @@ public:
   /**
    * Constructor. The center of the spheres defaults to the origin.
    *
-   * Calls the constructor of its base @p HyperBallBoundary class with a dummy
+   * Call the constructor of its base @p HyperBallBoundary class with a dummy
    * radius as argument. This radius will be ignored
    */
   HyperShellBoundary (const Point<dim> &center = Point<dim>());

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -562,7 +562,7 @@ namespace hp
 
 
     /**
-     * Returns a vector that stores the locally owned DoFs of each processor.
+     * Return a vector that stores the locally owned DoFs of each processor.
      * If you are only interested in the number of elements each processor
      * owns then n_dofs_per_processor() is a better choice.
      *

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -88,7 +88,7 @@ namespace hp
     void push_back (const Mapping<dim,spacedim> &new_mapping);
 
     /**
-     * Returns the mapping object which was specified by the user for the
+     * Return the mapping object which was specified by the user for the
      * active_fe_index which is provided as a parameter to this method.
      *
      * @pre @p index must be between zero and the number of elements of the
@@ -98,7 +98,7 @@ namespace hp
     operator[] (const unsigned int index) const;
 
     /**
-     * Returns the number of mapping objects stored in this container.
+     * Return the number of mapping objects stored in this container.
      */
     unsigned int size () const;
 

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -92,7 +92,7 @@ namespace hp
     void push_back (const Quadrature<dim> &new_quadrature);
 
     /**
-     * Returns a reference to the quadrature rule specified by the argument.
+     * Return a reference to the quadrature rule specified by the argument.
      *
      * @pre @p index must be between zero and the number of elements of the
      * collection.
@@ -101,7 +101,7 @@ namespace hp
     operator[] (const unsigned int index) const;
 
     /**
-     * Returns the number of quadrature pointers stored in this object.
+     * Return the number of quadrature pointers stored in this object.
      */
     unsigned int size () const;
 

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -454,7 +454,7 @@ void ArpackSolver::solve (const MatrixType1                  &/*system_matrix*/,
   iparam[2] = control().max_steps();
 
   /**
-   * Sets the mode of dsaupd. 1 is exact shifting, 2 is user-supplied shifts,
+   * Set the mode of dsaupd. 1 is exact shifting, 2 is user-supplied shifts,
    * 3 is shift-invert mode, 4 is buckling mode, 5 is Cayley mode.
    */
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -825,7 +825,7 @@ public:
                           const BlockVectorBase &W);
 
   /**
-   * Returns true if the given global index is in the local range of this
+   * Return true if the given global index is in the local range of this
    * processor. Asks the corresponding block.
    */
   bool in_local_range (const size_type global_index) const;

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -80,7 +80,7 @@ namespace ChunkSparsityPatternIterators
     unsigned int row () const;
 
     /**
-     * Returns the global index from the reduced sparsity pattern.
+     * Return the global index from the reduced sparsity pattern.
      */
     std::size_t reduced_index() const;
 

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -211,7 +211,7 @@ public:
   bool can_store_line (const size_type line_index) const;
 
   /**
-   * Returns the index set describing locally relevant lines if any are
+   * Return the index set describing locally relevant lines if any are
    * present. Note that if no local lines were given, this represents an empty
    * IndexSet, whereas otherwise it contains the global problem size and the
    * local range.
@@ -449,27 +449,27 @@ public:
   size_type max_constraint_indirections () const;
 
   /**
-   * Returns <tt>true</tt> in case the dof is constrained and there is a non-
+   * Return <tt>true</tt> in case the dof is constrained and there is a non-
    * trivial inhomogeneous values set to the dof.
    */
   bool is_inhomogeneously_constrained (const size_type index) const;
 
   /**
-   * Returns <tt>false</tt> if all constraints in the ConstraintMatrix are
+   * Return <tt>false</tt> if all constraints in the ConstraintMatrix are
    * homogeneous ones, and <tt>true</tt> if there is at least one
    * inhomogeneity.
    */
   bool has_inhomogeneities () const;
 
   /**
-   * Returns a pointer to the the vector of entries if a line is constrained,
+   * Return a pointer to the the vector of entries if a line is constrained,
    * and a zero pointer in case the dof is not constrained.
    */
   const std::vector<std::pair<size_type,double> > *
   get_constraint_entries (const size_type line) const;
 
   /**
-   * Returns the value of the inhomogeneity stored in the constrained dof @p
+   * Return the value of the inhomogeneity stored in the constrained dof @p
    * line. Unconstrained dofs also return a zero value.
    */
   double get_inhomogeneity (const size_type line) const;
@@ -623,7 +623,7 @@ public:
                  BlockVectorType           &vector) const;
 
   /**
-   * Sets the values of all constrained DoFs in a vector to zero.  The @p
+   * Set the values of all constrained DoFs in a vector to zero.  The @p
    * VectorType may be a Vector<float>, Vector<double>,
    * BlockVector<tt><...></tt>, a PETSc or Trilinos vector wrapper class, or
    * any other type having the same interface.

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -545,7 +545,7 @@ public:
   real_type relative_symmetry_norm2 () const;
 
   /**
-   * Computes the determinant of a matrix.  This is only implemented for one,
+   * Compute the determinant of a matrix.  This is only implemented for one,
    * two, and three dimensions, since for higher dimensions the numerical work
    * explodes.  Obviously, the matrix needs to be quadratic for this function.
    */

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -328,7 +328,7 @@ namespace LinearAlgebra
       void zero_out_ghosts ();
 
       /**
-       * Returns if this Vector contains ghost elements.
+       * Return if this Vector contains ghost elements.
        */
       bool has_ghost_elements() const;
 
@@ -374,7 +374,7 @@ namespace LinearAlgebra
       bool all_zero () const;
 
       /**
-       * Computes the mean value of all the entries in the vector.
+       * Compute the mean value of all the entries in the vector.
        */
       Number mean_value () const;
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -213,13 +213,13 @@ namespace LinearAlgebra
       Vector (const Vector<Number> &in_vector);
 
       /**
-       * Constructs a parallel vector of the given global size without any
+       * Construct a parallel vector of the given global size without any
        * actual parallel distribution.
        */
       Vector (const size_type size);
 
       /**
-       * Constructs a parallel vector. The local range is specified by @p
+       * Construct a parallel vector. The local range is specified by @p
        * locally_owned_set (note that this must be a contiguous interval,
        * multiple intervals are not possible). The IndexSet @p ghost_indices
        * specifies ghost indices, i.e., indices which one might need to read
@@ -258,7 +258,7 @@ namespace LinearAlgebra
       virtual ~Vector ();
 
       /**
-       * Sets the global size of the vector to @p size without any actual
+       * Set the global size of the vector to @p size without any actual
        * parallel distribution.
        */
       void reinit (const size_type size,
@@ -512,7 +512,7 @@ namespace LinearAlgebra
       void zero_out_ghosts ();
 
       /**
-       * Returns whether the vector currently is in a state where ghost values
+       * Return whether the vector currently is in a state where ghost values
        * can be read or not. This is the same functionality as other parallel
        * vectors have. If this method returns false, this only means that
        * read-access to ghost elements is prohibited whereas write access is
@@ -729,13 +729,13 @@ namespace LinearAlgebra
       //@{
 
       /**
-       * Returns the local size of the vector, i.e., the number of indices
+       * Return the local size of the vector, i.e., the number of indices
        * owned locally.
        */
       size_type local_size() const;
 
       /**
-       * Returns the half-open interval that specifies the locally owned range
+       * Return the half-open interval that specifies the locally owned range
        * of the vector. Note that <code>local_size() == local_range().second -
        * local_range().first</code>.
        *
@@ -744,7 +744,7 @@ namespace LinearAlgebra
       std::pair<size_type, size_type> local_range () const DEAL_II_DEPRECATED;
 
       /**
-       * Returns true if the given global index is in the local range of this
+       * Return true if the given global index is in the local range of this
        * processor.
        *
        * This function is deprecated.
@@ -752,7 +752,7 @@ namespace LinearAlgebra
       bool in_local_range (const size_type global_index) const DEAL_II_DEPRECATED;
 
       /**
-       * Returns the number of ghost elements present on the vector.
+       * Return the number of ghost elements present on the vector.
        *
        * This function is deprecated.
        */
@@ -768,7 +768,7 @@ namespace LinearAlgebra
       const IndexSet &ghost_elements() const DEAL_II_DEPRECATED;
 
       /**
-       * Returns whether the given global index is a ghost index on the
+       * Return whether the given global index is a ghost index on the
        * present processor. Returns false for indices that are owned locally
        * and for indices not present at all.
        *
@@ -888,7 +888,7 @@ namespace LinearAlgebra
       bool all_zero () const;
 
       /**
-       * Computes the mean value of all the entries in the vector.
+       * Compute the mean value of all the entries in the vector.
        */
       Number mean_value () const;
 
@@ -920,7 +920,7 @@ namespace LinearAlgebra
       get_partitioner () const;
 
       /**
-       * Checks whether the given partitioner is compatible with the
+       * Check whether the given partitioner is compatible with the
        * partitioner used for this vector. Two partitioners are compatible if
        * they have the same local size and the same ghost indices. They do not
        * necessarily need to be the same data field of the shared pointer.
@@ -932,7 +932,7 @@ namespace LinearAlgebra
       partitioners_are_compatible (const Utilities::MPI::Partitioner &part) const;
 
       /**
-       * Checks whether the given partitioner is compatible with the
+       * Check whether the given partitioner is compatible with the
        * partitioner used for this vector. Two partitioners are compatible if
        * they have the same local size and the same ghost indices. They do not
        * necessarily need to be the same data field. As opposed to

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -255,7 +255,7 @@ namespace LinearAlgebra
     void block_read (std::istream &in);
 
     /**
-     * Returns the memory consumption of this class in bytes.
+     * Return the memory consumption of this class in bytes.
      */
     virtual std::size_t memory_consumption() const;
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -585,7 +585,7 @@ operator*(const LinearOperator<Range, Intermediate> &first_op,
 /**
  * @relates LinearOperator
  *
- * Returns the transpose linear operations of @p op.
+ * Return the transpose linear operations of @p op.
  *
  * @ingroup LAOperators
  */
@@ -609,7 +609,7 @@ transpose_operator(const LinearOperator<Range, Domain> &op)
 /**
  * @relates LinearOperator
  *
- * Returns an object representing the inverse of the LinearOperator @p op.
+ * Return an object representing the inverse of the LinearOperator @p op.
  *
  * The function takes references @p solver and @p preconditioner to an
  * iterative solver and a preconditioner that are used in the
@@ -688,7 +688,7 @@ inverse_operator(const LinearOperator<typename Solver::vector_type, typename Sol
 /**
  * @relates LinearOperator
  *
- * Returns a LinearOperator that is the identity of the vector space @p Range.
+ * Return a LinearOperator that is the identity of the vector space @p Range.
  *
  * The function takes an <code>std::function</code> object @p reinit_vector as
  * an argument to initialize the <code>reinit_range_vector</code> and
@@ -732,7 +732,7 @@ identity_operator(const std::function<void(Range &, bool)> &reinit_vector)
 /**
  * @relates LinearOperator
  *
- * Returns a nulled variant of the LinearOperator @p op, i.e. with optimized
+ * Return a nulled variant of the LinearOperator @p op, i.e. with optimized
  * LinearOperator::vmult, LinearOperator::vmult_add, etc. functions and with
  * LinearOperator::is_null_operator set to true.
  *

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -359,7 +359,7 @@ public:
   void reinit(const BlockSparsityPattern &sparsity);
 
   /**
-   * Clears the object.
+   * Clear the object.
    *
    * Since often only clearing of the individual matrices is desired, but not
    * removing the blocks themselves, there is an optional argument. If the
@@ -471,7 +471,7 @@ public:
   void reinit_edge_flux(const MGLevelObject<BlockSparsityPattern> &sparsity);
 
   /**
-   * Clears the object.
+   * Clear the object.
    *
    * Since often only clearing of the individual matrices is desired, but not
    * removing the blocks themselves, there is an optional argument. If the

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -873,7 +873,7 @@ namespace PETScWrappers
                 const bool    alternative_output = false) const;
 
     /**
-     * Returns the number bytes consumed by this matrix on this CPU.
+     * Return the number bytes consumed by this matrix on this CPU.
      */
     std::size_t memory_consumption() const;
 

--- a/include/deal.II/lac/petsc_matrix_free.h
+++ b/include/deal.II/lac/petsc_matrix_free.h
@@ -153,7 +153,7 @@ namespace PETScWrappers
                  const unsigned int  this_process);
 
     /**
-     * Calls the @p reinit() function above with <tt>communicator =
+     * Call the @p reinit() function above with <tt>communicator =
      * MPI_COMM_WORLD</tt>.
      */
     void reinit (const unsigned int  m,
@@ -162,7 +162,7 @@ namespace PETScWrappers
                  const unsigned int  local_columns);
 
     /**
-     * Calls the @p reinit() function above with <tt>communicator =
+     * Call the @p reinit() function above with <tt>communicator =
      * MPI_COMM_WORLD</tt>.
      */
     void reinit (const unsigned int  m,

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -248,7 +248,7 @@ namespace PETScWrappers
       void reinit (const unsigned int num_blocks);
 
       /**
-       * Returns if this vector is a ghosted vector (and thus read-only).
+       * Return if this vector is a ghosted vector (and thus read-only).
        */
       bool has_ghost_elements() const;
 

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -230,7 +230,7 @@ namespace PETScWrappers
                        const size_type     local_size);
 
       /**
-       * Constructs a new parallel ghosted PETSc vector from an IndexSet. Note
+       * Construct a new parallel ghosted PETSc vector from an IndexSet. Note
        * that @p local must be contiguous and the global size of the vector is
        * determined by local.size(). The global indices in @p ghost are
        * supplied as ghost indices that can also be read locally.
@@ -250,7 +250,7 @@ namespace PETScWrappers
               const MPI_Comm &communicator);
 
       /**
-       * Constructs a new parallel PETSc vector from an IndexSet. This creates
+       * Construct a new parallel PETSc vector from an IndexSet. This creates
        * a non ghosted vector.
        */
       explicit Vector (const IndexSet &local,

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -908,14 +908,14 @@ public:
                    const AdditionalData &additional_data = AdditionalData());
 
   /**
-   * Computes the action of the preconditioner on <tt>src</tt>, storing the
+   * Compute the action of the preconditioner on <tt>src</tt>, storing the
    * result in <tt>dst</tt>.
    */
   void vmult (VectorType       &dst,
               const VectorType &src) const;
 
   /**
-   * Computes the action of the transposed preconditioner on <tt>src</tt>,
+   * Compute the action of the transposed preconditioner on <tt>src</tt>,
    * storing the result in <tt>dst</tt>.
    */
   void Tvmult (VectorType       &dst,

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -223,7 +223,7 @@ public:
   void clear();
 
   /**
-   * Checks whether the object is empty.
+   * Check whether the object is empty.
    */
   bool empty () const;
 

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -135,7 +135,7 @@ public:
   bool inverses_ready () const;
 
   /**
-   * Checks whether the object is empty.
+   * Check whether the object is empty.
    */
   bool empty () const;
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -148,13 +148,13 @@ namespace LinearAlgebra
     ReadWriteVector (const ReadWriteVector<Number> &in_vector);
 
     /**
-     * Constructs a vector given the size, the stored elements have their
+     * Construct a vector given the size, the stored elements have their
      * index in [0,size).
      */
     explicit ReadWriteVector (const size_type size);
 
     /**
-     * Constructs a vector whose stored elements indices are given by the
+     * Construct a vector whose stored elements indices are given by the
      * IndexSet @p locally_stored_indices.
      */
     explicit ReadWriteVector (const IndexSet &locally_stored_indices);
@@ -165,7 +165,7 @@ namespace LinearAlgebra
     ~ReadWriteVector ();
 
     /**
-     * Sets the global size of the vector to @p size. The stored elements have
+     * Set the global size of the vector to @p size. The stored elements have
      * their index in [0,size).
      *
      * If the flag @p omit_zeroing_entries is set to false, the memory will be
@@ -336,19 +336,19 @@ namespace LinearAlgebra
     iterator begin ();
 
     /**
-     * Returns constant iterator to the start of the locally stored elements
+     * Return constant iterator to the start of the locally stored elements
      * of the vector.
      */
     const_iterator begin () const;
 
     /**
-     * Returns an iterator pointing to the element past the end of the array
+     * Return an iterator pointing to the element past the end of the array
      * of locally stored entries.
      */
     iterator end ();
 
     /**
-     * Returns a constant iterator pointing to the element past the end of the
+     * Return a constant iterator pointing to the element past the end of the
      * array of the locally stored entries.
      */
     const_iterator end () const;
@@ -476,7 +476,7 @@ namespace LinearAlgebra
                 const bool          scientific = true) const;
 
     /**
-     * Returns the memory consumption of this class in bytes.
+     * Return the memory consumption of this class in bytes.
      */
     std::size_t memory_consumption () const;
     //@}

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -194,7 +194,7 @@ public:
   void clear();
 
   /**
-   * Checks whether the object is empty.
+   * Check whether the object is empty.
    */
   bool empty () const;
 

--- a/include/deal.II/lac/schur_complement.h
+++ b/include/deal.II/lac/schur_complement.h
@@ -34,7 +34,7 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * @relates LinearOperator
  *
- * Returns a LinearOperator that performs the operations associated with the
+ * Return a LinearOperator that performs the operations associated with the
  * Schur complement. There are two additional helper functions,
  * condense_schur_rhs() and postprocess_schur_solution(), that are likely
  * necessary to be used in order to perform any useful tasks in linear algebra

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -277,7 +277,7 @@ public:
   void log_history (const bool);
 
   /**
-   * Returns the @p log_history flag.
+   * Return the @p log_history flag.
    */
   bool log_history () const;
 
@@ -292,7 +292,7 @@ public:
   void log_result (const bool);
 
   /**
-   * Returns the @p log_result flag.
+   * Return the @p log_result flag.
    */
   bool log_result () const;
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -84,7 +84,7 @@ namespace internal
                               const VectorType   &temp);
 
       /**
-       * Returns size of data vector. It is used in the solver to store
+       * Return size of data vector. It is used in the solver to store
        * the Arnoldi vectors.
        */
       unsigned int size() const;

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -198,7 +198,7 @@ namespace TrilinosWrappers
                  const double                               drop_tolerance=1e-13);
 
     /**
-     * Returns the state of the matrix, i.e., whether compress() needs to be
+     * Return the state of the matrix, i.e., whether compress() needs to be
      * called after an operation requiring data exchange. Does only return
      * non-true values when used in <tt>debug</tt> mode, since it is quite
      * expensive to keep track of all operations that lead to the need for

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -170,19 +170,19 @@ namespace LinearAlgebra
 
 
       /**
-       * Returns the l<sub>1</sub> norm of the vector (i.e., the sum of the
+       * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the
        * absolute values of all entries among all processors).
        */
       virtual double l1_norm() const;
 
       /**
-       * Returns the l<sub>2</sub> norm of the vector (i.e., the square root of
+       * Return the l<sub>2</sub> norm of the vector (i.e., the square root of
        * the sum of the square of all entries among all processors).
        */
       virtual double l2_norm() const;
 
       /**
-       * Returns the maximum norm of the vector (i.e., the maximum absolute value
+       * Return the maximum norm of the vector (i.e., the maximum absolute value
        * among all entries and among all processors).
        */
       virtual double linfty_norm() const;
@@ -210,7 +210,7 @@ namespace LinearAlgebra
                                  const VectorSpaceVector<double> &W);
 
       /**
-       * Returns the global size of the vector, equal to the sum of the number of
+       * Return the global size of the vector, equal to the sum of the number of
        * locally owned indices among all processors.
        */
       virtual size_type size() const;
@@ -253,7 +253,7 @@ namespace LinearAlgebra
                          const bool across=true) const;
 
       /**
-       * Returns the memory consumption of this class in bytes.
+       * Return the memory consumption of this class in bytes.
        */
       virtual std::size_t memory_consumption() const;
 

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -290,7 +290,7 @@ namespace TrilinosWrappers
                                         const BlockVector                         &v);
 
       /**
-       * Returns the state of the vector, i.e., whether compress() needs to be
+       * Return the state of the vector, i.e., whether compress() needs to be
        * called after an operation requiring data exchange. Does only return
        * non-true values when used in <tt>debug</tt> mode, since it is quite
        * expensive to keep track of all operations that lead to the need for
@@ -301,7 +301,7 @@ namespace TrilinosWrappers
       bool is_compressed () const DEAL_II_DEPRECATED;
 
       /**
-       * Returns if this Vector contains ghost elements.
+       * Return if this Vector contains ghost elements.
        *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -83,7 +83,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format and puts
+       * Set the additional data field to the desired output format and puts
        * the restart parameter in case the derived class is GMRES.
        *
        * TODO: Find a better way for setting the GMRES restart parameter since
@@ -275,7 +275,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format.
+       * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
@@ -321,7 +321,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format.
+       * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
@@ -421,7 +421,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format.
+       * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
@@ -468,7 +468,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format.
+       * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
@@ -523,7 +523,7 @@ namespace TrilinosWrappers
     struct AdditionalData
     {
       /**
-       * Sets the additional data field to the desired output format.
+       * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false,

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -1031,7 +1031,7 @@ namespace TrilinosWrappers
     unsigned int row_length (const size_type row) const;
 
     /**
-     * Returns the state of the matrix, i.e., whether compress() needs to be
+     * Return the state of the matrix, i.e., whether compress() needs to be
      * called after an operation requiring data exchange. A call to compress()
      * is also needed when the method set() has been called (even when working
      * in serial).

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -829,7 +829,7 @@ namespace TrilinosWrappers
 //@{
 
     /**
-     * Returns the state of the sparsity pattern, i.e., whether compress()
+     * Return the state of the sparsity pattern, i.e., whether compress()
      * needs to be called after an operation requiring data exchange.
      */
     bool is_compressed () const;

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -881,13 +881,13 @@ namespace TrilinosWrappers
     Vector &operator= (const TrilinosScalar s);
 
     /**
-     * Sets the left hand argument to the (parallel) Trilinos Vector.
+     * Set the left hand argument to the (parallel) Trilinos Vector.
      * Equivalent to the @p reinit function.
      */
     Vector &operator= (const MPI::Vector &v);
 
     /**
-     * Sets the left hand argument to the deal.II vector.
+     * Set the left hand argument to the deal.II vector.
      */
     template <typename Number>
     Vector &operator= (const ::dealii::Vector<Number> &v);

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -285,7 +285,7 @@ namespace TrilinosWrappers
     void compress (::dealii::VectorOperation::values operation);
 
     /**
-     * Returns the state of the vector, i.e., whether compress() has already
+     * Return the state of the vector, i.e., whether compress() has already
      * been called after an operation requiring data exchange.
      *
      * This function is deprecated.

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -915,7 +915,7 @@ public:
   //@{
 
   /**
-   * Returns true if the given global index is in the local range of this
+   * Return true if the given global index is in the local range of this
    * processor.  Since this is not a distributed vector the method always
    * returns true.
    */

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -70,61 +70,61 @@ namespace internal
       DoFInfo (const DoFInfo &dof_info);
 
       /**
-       * Clears all data fields in this class.
+       * Clear all data fields in this class.
        */
       void clear ();
 
 
       /**
-       * Returns a pointer to the first index in the DoF row @p row.
+       * Return a pointer to the first index in the DoF row @p row.
        */
       const unsigned int *begin_indices (const unsigned int row) const;
 
       /**
-       * Returns a pointer to the one past the last DoF index in the row @p
+       * Return a pointer to the one past the last DoF index in the row @p
        * row.
        */
       const unsigned int *end_indices (const unsigned int row) const;
 
       /**
-       * Returns the number of entries in the indices field for the given row.
+       * Return the number of entries in the indices field for the given row.
        */
       unsigned int row_length_indices (const unsigned int row) const;
 
       /**
-       * Returns a pointer to the first constraint indicator in the row @p
+       * Return a pointer to the first constraint indicator in the row @p
        * row.
        */
       const std::pair<unsigned short,unsigned short> *
       begin_indicators (const unsigned int row) const;
 
       /**
-       * Returns a pointer to the one past the last constraint indicator in
+       * Return a pointer to the one past the last constraint indicator in
        * the row @p row.
        */
       const std::pair<unsigned short,unsigned short> *
       end_indicators (const unsigned int row) const;
 
       /**
-       * Returns the number of entries in the constraint indicator field for
+       * Return the number of entries in the constraint indicator field for
        * the given row.
        */
       unsigned int row_length_indicators (const unsigned int row) const;
 
       /**
-       * Returns a pointer to the first index in the DoF row @p row for plain
+       * Return a pointer to the first index in the DoF row @p row for plain
        * indices (i.e., the entries where constraints are not embedded).
        */
       const unsigned int *begin_indices_plain (const unsigned int row) const;
 
       /**
-       * Returns a pointer to the one past the last DoF index in the row @p
+       * Return a pointer to the one past the last DoF index in the row @p
        * row (i.e., the entries where constraints are not embedded).
        */
       const unsigned int *end_indices_plain (const unsigned int row) const;
 
       /**
-       * Returns the FE index for a given finite element degree. If not in hp
+       * Return the FE index for a given finite element degree. If not in hp
        * mode, this function always returns index 0. If an index is not found
        * in hp mode, it returns max_fe_degree, i.e., one index past the last
        * valid one.
@@ -133,7 +133,7 @@ namespace internal
 
 
       /**
-       * Returns the FE index for a given finite element degree. If not in hp
+       * Return the FE index for a given finite element degree. If not in hp
        * mode or if the index is not found, this function always returns index
        * 0. Hence, this function does not check whether the given degree is
        * actually present.
@@ -186,7 +186,7 @@ namespace internal
                                        std::vector<unsigned int> &irregular_cells);
 
       /**
-       * Computes the initial renumbering of cells such that all cells with
+       * Compute the initial renumbering of cells such that all cells with
        * ghosts are put first. This is the first step before building the
        * thread graph and used to overlap computations and communication.
        */
@@ -276,7 +276,7 @@ namespace internal
       void renumber_dofs (std::vector<types::global_dof_index> &renumbering);
 
       /**
-       * Returns the memory consumption in bytes of this class.
+       * Return the memory consumption in bytes of this class.
        */
       std::size_t memory_consumption() const;
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -135,7 +135,7 @@ public:
   unsigned int get_cell_data_number() const;
 
   /**
-   * Returns the type of the cell the @p reinit function has been called for.
+   * Return the type of the cell the @p reinit function has been called for.
    * Valid values are @p cartesian for Cartesian cells (which allows for
    * considerable data compression), @p affine for cells with affine mappings,
    * and @p general for general cells without any compressed storage applied.
@@ -143,7 +143,7 @@ public:
   internal::MatrixFreeFunctions::CellType get_cell_type() const;
 
   /**
-   * Returns a reference to the ShapeInfo object currently in use.
+   * Return a reference to the ShapeInfo object currently in use.
    */
   const internal::MatrixFreeFunctions::ShapeInfo<Number> &
   get_shape_info() const;
@@ -285,7 +285,7 @@ public:
                                    const unsigned int       first_index=0) const;
 
   /**
-   * Writes data to several vectors. Same as other function with std::vector,
+   * Write data to several vectors. Same as other function with std::vector,
    * but accepts a vector of pointers to vectors.
    */
   template<typename VectorType>
@@ -325,7 +325,7 @@ public:
                        const unsigned int       first_index=0) const;
 
   /**
-   * Writes data to several vectors. Same as other function with std::vector,
+   * Write data to several vectors. Same as other function with std::vector,
    * but accepts a vector of pointers to vectors.
    */
   template<typename VectorType>
@@ -339,7 +339,7 @@ public:
    */
   //@{
   /**
-   * Returns the value stored for the local degree of freedom with index @p
+   * Return the value stored for the local degree of freedom with index @p
    * dof. If the object is vector-valued, a vector-valued return argument is
    * given. Note that when vectorization is enabled, values from several cells
    * are grouped together. If @p set_dof_values was called last, the value
@@ -367,7 +367,7 @@ public:
                          const unsigned int dof);
 
   /**
-   * Returns the value of a finite element function at quadrature point number
+   * Return the value of a finite element function at quadrature point number
    * @p q_point after a call to @p evaluate(true,...), or the value that has
    * been stored there with a call to @p submit_value. If the object is
    * vector-valued, a vector-valued return argument is given. Note that when
@@ -394,7 +394,7 @@ public:
                      const unsigned int q_point);
 
   /**
-   * Returns the gradient of a finite element function at quadrature point
+   * Return the gradient of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true,...), or the value
    * that has been stored there with a call to @p submit_gradient.
    *
@@ -420,7 +420,7 @@ public:
                        const unsigned int  q_point);
 
   /**
-   * Returns the Hessian of a finite element function at quadrature point
+   * Return the Hessian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true). If only the
    * diagonal or even the trace of the Hessian, the Laplacian, is needed, use
    * the other functions below.
@@ -433,7 +433,7 @@ public:
   get_hessian (const unsigned int q_point) const;
 
   /**
-   * Returns the diagonal of the Hessian of a finite element function at
+   * Return the diagonal of the Hessian of a finite element function at
    * quadrature point number @p q_point after a call to @p evaluate(...,true).
    *
    * Note that the derived class FEEvaluationAccess overloads this operation
@@ -443,7 +443,7 @@ public:
   gradient_type get_hessian_diagonal (const unsigned int q_point) const;
 
   /**
-   * Returns the Laplacian (i.e., the trace of the Hessian) of a finite
+   * Return the Laplacian (i.e., the trace of the Hessian) of a finite
    * element function at quadrature point number @p q_point after a call to @p
    * evaluate(...,true). Compared to the case when computing the full Hessian,
    * some operations can be saved when only the Laplacian is requested.
@@ -471,7 +471,7 @@ public:
    */
   //@{
   /**
-   * Returns a read-only pointer to the first field of the dof values. This is
+   * Return a read-only pointer to the first field of the dof values. This is
    * the data field the read_dof_values() functions write into. First come the
    * the dof values for the first component, then all values for the second
    * component, and so on. This is related to the internal data structures
@@ -481,7 +481,7 @@ public:
   const VectorizedArray<Number> *begin_dof_values () const;
 
   /**
-   * Returns a read and write pointer to the first field of the dof values.
+   * Return a read and write pointer to the first field of the dof values.
    * This is the data field the read_dof_values() functions write into. First
    * come the the dof values for the first component, then all values for the
    * second component, and so on. This is related to the internal data
@@ -491,7 +491,7 @@ public:
   VectorizedArray<Number> *begin_dof_values ();
 
   /**
-   * Returns a read-only pointer to the first field of function values on
+   * Return a read-only pointer to the first field of function values on
    * quadrature points. First come the function values on all quadrature
    * points for the first component, then all values for the second component,
    * and so on. This is related to the internal data structures used in this
@@ -503,7 +503,7 @@ public:
   const VectorizedArray<Number> *begin_values () const;
 
   /**
-   * Returns a read and write pointer to the first field of function values on
+   * Return a read and write pointer to the first field of function values on
    * quadrature points. First come the function values on all quadrature
    * points for the first component, then all values for the second component,
    * and so on. This is related to the internal data structures used in this
@@ -515,7 +515,7 @@ public:
   VectorizedArray<Number> *begin_values ();
 
   /**
-   * Returns a read-only pointer to the first field of function gradients on
+   * Return a read-only pointer to the first field of function gradients on
    * quadrature points. First comes the x-component of the gradient for the
    * first component on all quadrature points, then the y-component, and so
    * on. Next comes the x-component of the second component, and so on. This
@@ -528,7 +528,7 @@ public:
   const VectorizedArray<Number> *begin_gradients () const;
 
   /**
-   * Returns a read and write pointer to the first field of function gradients
+   * Return a read and write pointer to the first field of function gradients
    * on quadrature points. First comes the x-component of the gradient for the
    * first component on all quadrature points, then the y-component, and so
    * on. Next comes the x-component of the second component, and so on. This
@@ -541,7 +541,7 @@ public:
   VectorizedArray<Number> *begin_gradients ();
 
   /**
-   * Returns a read-only pointer to the first field of function hessians on
+   * Return a read-only pointer to the first field of function hessians on
    * quadrature points. First comes the xx-component of the hessian for the
    * first component on all quadrature points, then the yy-component, zz-
    * component in (3D), then the xy-component, and so on. Next comes the xx-
@@ -555,7 +555,7 @@ public:
   const VectorizedArray<Number> *begin_hessians () const;
 
   /**
-   * Returns a read and write pointer to the first field of function hessians
+   * Return a read and write pointer to the first field of function hessians
    * on quadrature points. First comes the xx-component of the hessian for the
    * first component on all quadrature points, then the yy-component, zz-
    * component in (3D), then the xy-component, and so on. Next comes the xx-
@@ -569,7 +569,7 @@ public:
   VectorizedArray<Number> *begin_hessians ();
 
   /**
-   * Returns the numbering of local degrees of freedom within the evaluation
+   * Return the numbering of local degrees of freedom within the evaluation
    * routines of FEEvaluation in terms of the standard numbering on finite
    * elements.
    */
@@ -968,7 +968,7 @@ public:
   typedef FEEvaluationBase<dim,1,Number>         BaseClass;
 
   /**
-   * Returns the value stored for the local degree of freedom with index @p
+   * Return the value stored for the local degree of freedom with index @p
    * dof. If the object is vector-valued, a vector-valued return argument is
    * given. Note that when vectorization is enabled, values from several cells
    * are grouped together. If @p set_dof_values was called last, the value
@@ -986,7 +986,7 @@ public:
                          const unsigned int dof);
 
   /**
-   * Returns the value of a finite element function at quadrature point number
+   * Return the value of a finite element function at quadrature point number
    * @p q_point after a call to @p evaluate(true,...), or the value that has
    * been stored there with a call to @p submit_value. If the object is
    * vector-valued, a vector-valued return argument is given. Note that when
@@ -1005,7 +1005,7 @@ public:
                      const unsigned int q_point);
 
   /**
-   * Returns the gradient of a finite element function at quadrature point
+   * Return the gradient of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true,...), or the value
    * that has been stored there with a call to @p submit_gradient.
    */
@@ -1023,7 +1023,7 @@ public:
                        const unsigned int  q_point);
 
   /**
-   * Returns the Hessian of a finite element function at quadrature point
+   * Return the Hessian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true). If only the
    * diagonal part of the Hessian or its trace, the Laplacian, are needed, use
    * the respective functions below.
@@ -1032,13 +1032,13 @@ public:
   get_hessian (unsigned int q_point) const;
 
   /**
-   * Returns the diagonal of the Hessian of a finite element function at
+   * Return the diagonal of the Hessian of a finite element function at
    * quadrature point number @p q_point after a call to @p evaluate(...,true).
    */
   gradient_type get_hessian_diagonal (const unsigned int q_point) const;
 
   /**
-   * Returns the Laplacian of a finite element function at quadrature point
+   * Return the Laplacian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true).
    */
   value_type get_laplacian (const unsigned int q_point) const;
@@ -1108,19 +1108,19 @@ public:
   typedef FEEvaluationBase<dim,dim,Number> BaseClass;
 
   /**
-   * Returns the gradient of a finite element function at quadrature point
+   * Return the gradient of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true,...).
    */
   gradient_type get_gradient (const unsigned int q_point) const;
 
   /**
-   * Returns the divergence of a vector-valued finite element at quadrature
+   * Return the divergence of a vector-valued finite element at quadrature
    * point number @p q_point after a call to @p evaluate(...,true,...).
    */
   VectorizedArray<Number> get_divergence (const unsigned int q_point) const;
 
   /**
-   * Returns the symmetric gradient of a vector-valued finite element at
+   * Return the symmetric gradient of a vector-valued finite element at
    * quadrature point number @p q_point after a call to @p
    * evaluate(...,true,...). It corresponds to <tt>0.5
    * (grad+grad<sup>T</sup>)</tt>.
@@ -1129,14 +1129,14 @@ public:
   get_symmetric_gradient (const unsigned int q_point) const;
 
   /**
-   * Returns the curl of the vector field, $nabla \times v$ after a call to @p
+   * Return the curl of the vector field, $nabla \times v$ after a call to @p
    * evaluate(...,true,...).
    */
   Tensor<1,(dim==2?1:dim),VectorizedArray<Number> >
   get_curl (const unsigned int q_point) const;
 
   /**
-   * Returns the Hessian of a finite element function at quadrature point
+   * Return the Hessian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true). If only the
    * diagonal of the Hessian or its trace, the Laplacian, is needed, use the
    * respective functions.
@@ -1145,7 +1145,7 @@ public:
   get_hessian (const unsigned int q_point) const;
 
   /**
-   * Returns the diagonal of the Hessian of a finite element function at
+   * Return the diagonal of the Hessian of a finite element function at
    * quadrature point number @p q_point after a call to @p evaluate(...,true).
    */
   gradient_type get_hessian_diagonal (const unsigned int q_point) const;
@@ -1254,7 +1254,7 @@ public:
   typedef FEEvaluationBase<1,1,Number>           BaseClass;
 
   /**
-   * Returns the value stored for the local degree of freedom with index @p
+   * Return the value stored for the local degree of freedom with index @p
    * dof. If the object is vector-valued, a vector-valued return argument is
    * given. Note that when vectorization is enabled, values from several cells
    * are grouped together. If @p set_dof_values was called last, the value
@@ -1272,7 +1272,7 @@ public:
                          const unsigned int dof);
 
   /**
-   * Returns the value of a finite element function at quadrature point number
+   * Return the value of a finite element function at quadrature point number
    * @p q_point after a call to @p evaluate(true,...), or the value that has
    * been stored there with a call to @p submit_value. If the object is
    * vector-valued, a vector-valued return argument is given. Note that when
@@ -1291,7 +1291,7 @@ public:
                      const unsigned int q_point);
 
   /**
-   * Returns the gradient of a finite element function at quadrature point
+   * Return the gradient of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true,...), or the value
    * that has been stored there with a call to @p submit_gradient.
    */
@@ -1309,7 +1309,7 @@ public:
                        const unsigned int  q_point);
 
   /**
-   * Returns the Hessian of a finite element function at quadrature point
+   * Return the Hessian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true). If only the
    * diagonal part of the Hessian or its trace, the Laplacian, are needed, use
    * the respective functions below.
@@ -1318,13 +1318,13 @@ public:
   get_hessian (unsigned int q_point) const;
 
   /**
-   * Returns the diagonal of the Hessian of a finite element function at
+   * Return the diagonal of the Hessian of a finite element function at
    * quadrature point number @p q_point after a call to @p evaluate(...,true).
    */
   gradient_type get_hessian_diagonal (const unsigned int q_point) const;
 
   /**
-   * Returns the Laplacian of a finite element function at quadrature point
+   * Return the Laplacian of a finite element function at quadrature point
    * number @p q_point after a call to @p evaluate(...,true).
    */
   value_type get_laplacian (const unsigned int q_point) const;
@@ -1637,7 +1637,7 @@ public:
                   const bool integrate_grad);
 
   /**
-   * Returns the q-th quadrature point stored in MappingInfo.
+   * Return the q-th quadrature point stored in MappingInfo.
    */
   Point<dim,VectorizedArray<Number> >
   quadrature_point (const unsigned int q_point) const;
@@ -1662,7 +1662,7 @@ private:
   void check_template_arguments(const unsigned int fe_no);
 
   /**
-   * Sets the pointers of the base class to my_data_array.
+   * Set the pointers of the base class to my_data_array.
    */
   void set_data_pointers();
 

--- a/include/deal.II/matrix_free/helper_functions.h
+++ b/include/deal.II/matrix_free/helper_functions.h
@@ -46,12 +46,12 @@ namespace internal
       TaskInfo ();
 
       /**
-       * Clears all the data fields and resets them to zero.
+       * Clear all the data fields and resets them to zero.
        */
       void clear ();
 
       /**
-       * Returns the memory consumption of the class.
+       * Return the memory consumption of the class.
        */
       std::size_t memory_consumption () const;
 
@@ -90,7 +90,7 @@ namespace internal
       SizeInfo ();
 
       /**
-       * Clears all data fields and resets the sizes to zero.
+       * Clear all data fields and resets the sizes to zero.
        */
       void clear();
 

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -82,7 +82,7 @@ namespace internal
       void reinit(typename dealii::Triangulation<dim>::cell_iterator cell);
 
       /**
-       * Returns whether reinit() has been called at least once, i.e., a cell
+       * Return whether reinit() has been called at least once, i.e., a cell
        * has been set.
        */
       bool is_initialized() const;

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -69,7 +69,7 @@ namespace internal
       MappingInfo();
 
       /**
-       * Computes the information in the given cells. The cells are specified
+       * Compute the information in the given cells. The cells are specified
        * by the level and the index within the level (as given by
        * CellIterator::level() and CellIterator::index(), in order to allow
        * for different kinds of iterators, e.g. standard DoFHandler,
@@ -93,22 +93,22 @@ namespace internal
                               std::vector<dealii::hp::QCollection<1> >());
 
       /**
-       * Returns the type of a given cell as detected during initialization.
+       * Return the type of a given cell as detected during initialization.
        */
       CellType get_cell_type (const unsigned int cell_chunk_no) const;
 
       /**
-       * Returns the type of a given cell as detected during initialization.
+       * Return the type of a given cell as detected during initialization.
        */
       unsigned int get_cell_data_index (const unsigned int cell_chunk_no) const;
 
       /**
-       * Clears all data fields in this class.
+       * Clear all data fields in this class.
        */
       void clear ();
 
       /**
-       * Returns the memory consumption of this class in bytes.
+       * Return the memory consumption of this class in bytes.
        */
       std::size_t memory_consumption() const;
 
@@ -261,7 +261,7 @@ namespace internal
         std::vector<unsigned int> quad_index_conversion;
 
         /**
-         * Returns the quadrature index for a given number of quadrature
+         * Return the quadrature index for a given number of quadrature
          * points. If not in hp mode or if the index is not found, this
          * function always returns index 0. Hence, this function does not
          * check whether the given degree is actually present.
@@ -279,7 +279,7 @@ namespace internal
                                       const SizeInfo &size_info) const;
 
         /**
-         * Returns the memory consumption in bytes.
+         * Return the memory consumption in bytes.
          */
         std::size_t memory_consumption () const;
       };

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -163,7 +163,7 @@ public:
     {};
 
     /**
-     * Sets the MPI communicator that the parallel layout of the operator
+     * Set the MPI communicator that the parallel layout of the operator
      * should be based upon. Defaults to MPI_COMM_SELF, but should be set to a
      * communicator similar to the one used for a distributed triangulation in
      * order to inform this class over all cells that are present.
@@ -171,7 +171,7 @@ public:
     MPI_Comm            mpi_communicator;
 
     /**
-     * Sets the scheme for task parallelism. There are four options available.
+     * Set the scheme for task parallelism. There are four options available.
      * If set to @p none, the operator application is done in serial without
      * shared memory parallelism. If this class is used together with MPI and
      * MPI is also used for parallelism within the nodes, this flag should be
@@ -201,7 +201,7 @@ public:
     TasksParallelScheme tasks_parallel_scheme;
 
     /**
-     * Sets the number of so-called macro cells that should form one
+     * Set the number of so-called macro cells that should form one
      * partition. If zero size is given, the class tries to find a good size
      * for the blocks based on MultithreadInfo::n_threads() and the number of
      * cells present. Otherwise, the given number is used. If the given number
@@ -409,7 +409,7 @@ public:
   void copy_from (const MatrixFree<dim,Number> &matrix_free_base);
 
   /**
-   * Clears all data fields and brings the class into a condition similar to
+   * Clear all data fields and brings the class into a condition similar to
    * after having called the default constructor.
    */
   void clear();
@@ -528,7 +528,7 @@ public:
                              const unsigned int vector_component=0) const;
 
   /**
-   * Returns the partitioner that represents the locally owned data and the
+   * Return the partitioner that represents the locally owned data and the
    * ghost indices where access is needed to for the cell loop. The
    * partitioner is constructed from the locally owned dofs and ghost dofs
    * given by the respective fields. If you want to have specific information
@@ -541,19 +541,19 @@ public:
   get_vector_partitioner (const unsigned int vector_component=0) const;
 
   /**
-   * Returns the set of cells that are oned by the processor.
+   * Return the set of cells that are oned by the processor.
    */
   const IndexSet &
   get_locally_owned_set (const unsigned int fe_component = 0) const;
 
   /**
-   * Returns the set of ghost cells needed but not owned by the processor.
+   * Return the set of ghost cells needed but not owned by the processor.
    */
   const IndexSet &
   get_ghost_set (const unsigned int fe_component = 0) const;
 
   /**
-   * Returns a list of all degrees of freedom that are constrained. The list
+   * Return a list of all degrees of freedom that are constrained. The list
    * is returned in MPI-local index space for the locally owned range of the
    * vector, not in global MPI index space that spans all MPI processors. To
    * get numbers in global index space, call
@@ -578,12 +578,12 @@ public:
    */
   //@{
   /**
-   * Returns the number of different DoFHandlers specified at initialization.
+   * Return the number of different DoFHandlers specified at initialization.
    */
   unsigned int n_components () const;
 
   /**
-   * Returns the number of cells this structure is based on. If you are using
+   * Return the number of cells this structure is based on. If you are using
    * a usual DoFHandler, it corresponds to the number of (locally owned)
    * active cells. Note that most data structures in this class do not
    * directly act on this number but rather on n_macro_cells() which gives the
@@ -593,7 +593,7 @@ public:
   unsigned int n_physical_cells () const;
 
   /**
-   * Returns the number of macro cells that this structure works on, i.e., the
+   * Return the number of macro cells that this structure works on, i.e., the
    * number of cell chunks that are worked on after the application of
    * vectorization which in general works on several cells at once. The cell
    * range in @p cell_loop runs from zero to n_macro_cells() (exclusive), so
@@ -668,21 +668,21 @@ public:
   n_components_filled (const unsigned int macro_cell_number) const;
 
   /**
-   * Returns the number of degrees of freedom per cell for a given hp index.
+   * Return the number of degrees of freedom per cell for a given hp index.
    */
   unsigned int
   get_dofs_per_cell (const unsigned int fe_component = 0,
                      const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Returns the number of quadrature points per cell for a given hp index.
+   * Return the number of quadrature points per cell for a given hp index.
    */
   unsigned int
   get_n_q_points (const unsigned int quad_index = 0,
                   const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Returns the number of degrees of freedom on each face of the cell for
+   * Return the number of degrees of freedom on each face of the cell for
    * given hp index.
    */
   unsigned int
@@ -690,7 +690,7 @@ public:
                      const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Returns the number of quadrature points on each face of the cell for
+   * Return the number of quadrature points on each face of the cell for
    * given hp index.
    */
   unsigned int
@@ -698,14 +698,14 @@ public:
                        const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Returns the quadrature rule for given hp index.
+   * Return the quadrature rule for given hp index.
    */
   const Quadrature<dim> &
   get_quadrature (const unsigned int quad_index = 0,
                   const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Returns the quadrature rule for given hp index.
+   * Return the quadrature rule for given hp index.
    */
   const Quadrature<dim-1> &
   get_face_quadrature (const unsigned int quad_index = 0,
@@ -724,7 +724,7 @@ public:
   bool mapping_initialized () const;
 
   /**
-   * Returns an approximation of the memory consumption of this class in
+   * Return an approximation of the memory consumption of this class in
    * bytes.
    */
   std::size_t memory_consumption() const;
@@ -749,43 +749,43 @@ public:
    */
   //@{
   /**
-   * Returns information on task graph.
+   * Return information on task graph.
    */
   const internal::MatrixFreeFunctions::TaskInfo &
   get_task_info () const;
 
   /**
-   * Returns information on system size.
+   * Return information on system size.
    */
   const internal::MatrixFreeFunctions::SizeInfo &
   get_size_info () const;
 
   /*
-   * Returns geometry-dependent information on the cells.
+   * Return geometry-dependent information on the cells.
    */
   const internal::MatrixFreeFunctions::MappingInfo<dim,Number> &
   get_mapping_info () const;
 
   /**
-   * Returns information on indexation degrees of freedom.
+   * Return information on indexation degrees of freedom.
    */
   const internal::MatrixFreeFunctions::DoFInfo &
   get_dof_info (const unsigned int fe_component = 0) const;
 
   /**
-   * Returns the number of weights in the constraint pool.
+   * Return the number of weights in the constraint pool.
    */
   unsigned int n_constraint_pool_entries() const;
 
   /**
-   * Returns a pointer to the first number in the constraint pool data with
+   * Return a pointer to the first number in the constraint pool data with
    * index @p pool_index (to be used together with @p constraint_pool_end()).
    */
   const Number *
   constraint_pool_begin (const unsigned int pool_index) const;
 
   /**
-   * Returns a pointer to one past the last number in the constraint pool data
+   * Return a pointer to one past the last number in the constraint pool data
    * with index @p pool_index (to be used together with @p
    * constraint_pool_begin()).
    */
@@ -793,7 +793,7 @@ public:
   constraint_pool_end (const unsigned int pool_index) const;
 
   /**
-   * Returns the unit cell information for given hp index.
+   * Return the unit cell information for given hp index.
    */
   const internal::MatrixFreeFunctions::ShapeInfo<Number> &
   get_shape_info (const unsigned int fe_component = 0,

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -85,7 +85,7 @@ namespace internal
                    const unsigned int base_element = 0);
 
       /**
-       * Returns the memory consumption of this class in bytes.
+       * Return the memory consumption of this class in bytes.
        */
       std::size_t memory_consumption () const;
 
@@ -216,13 +216,13 @@ namespace internal
       unsigned int dofs_per_face;
 
       /**
-       * Checks whether we have symmetries in the shape values. In that case,
+       * Check whether we have symmetries in the shape values. In that case,
        * also fill the shape_???_evenodd fields.
        */
       bool check_1d_shapes_symmetric(const unsigned int n_q_points_1d);
 
       /**
-       * Checks whether symmetric 1D basis functions are such that the shape
+       * Check whether symmetric 1D basis functions are such that the shape
        * values form a diagonal matrix, which allows to use specialized
        * algorithms that save some operations.
        */

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -87,17 +87,17 @@ namespace MeshWorker
     bool empty () const;
 
     /**
-     * Returns true if values are selected for any vector.
+     * Return true if values are selected for any vector.
      */
     bool has_values () const;
 
     /**
-     * Returns true if gradients are selected for any vector.
+     * Return true if gradients are selected for any vector.
      */
     bool has_gradients () const;
 
     /**
-     * Returns true if hessians are selected for any vector.
+     * Return true if hessians are selected for any vector.
      */
     bool has_hessians () const;
 

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -123,7 +123,7 @@ public:
                    const VectorType   &src) const;
 
   /**
-   * Sets the matrix. This gives the possibility to replace the matrix that
+   * Set the matrix. This gives the possibility to replace the matrix that
    * was given to the constructor by a new matrix.
    */
   template <typename MatrixType>

--- a/include/deal.II/numerics/derivative_approximation.h
+++ b/include/deal.II/numerics/derivative_approximation.h
@@ -179,7 +179,7 @@ namespace DerivativeApproximation
                         const unsigned int                  component = 0);
 
   /**
-   * Calls the @p interpolate function, see above, with
+   * Call the @p interpolate function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, template <int, int> class DoFHandlerType, class InputVector, int spacedim>
@@ -215,7 +215,7 @@ namespace DerivativeApproximation
                                  const unsigned int                  component = 0);
 
   /**
-   * Calls the @p interpolate function, see above, with
+   * Call the @p interpolate function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, template <int, int> class DoFHandlerType, class InputVector, int spacedim>

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -341,7 +341,7 @@ public:
    const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
-   * Calls the @p estimate function, see above, with
+   * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <typename InputVector, typename DoFHandlerType>
@@ -387,7 +387,7 @@ public:
    const Strategy                              strategy       = cell_diameter_over_24);
 
   /**
-   * Calls the @p estimate function, see above, with
+   * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <typename InputVector, typename DoFHandlerType>
@@ -586,7 +586,7 @@ public:
    const types::material_id                    material_id    = numbers::invalid_material_id);
 
   /**
-   * Calls the @p estimate function, see above, with
+   * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQGeneric1<1>()</tt>.
    */
   template <typename InputVector, typename DoFHandlerType>
@@ -630,7 +630,7 @@ public:
    const types::material_id                    material_id    = numbers::invalid_material_id);
 
   /**
-   * Calls the @p estimate function, see above, with
+   * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQGeneric1<1>()</tt>.
    */
   template <typename InputVector, typename DoFHandlerType>

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -244,7 +244,7 @@ namespace MatrixCreator
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
-   * Calls the create_mass_matrix() function, see above, with
+   * Call the create_mass_matrix() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename number>
@@ -281,7 +281,7 @@ namespace MatrixCreator
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
-   * Calls the create_mass_matrix() function, see above, with
+   * Call the create_mass_matrix() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename number>
@@ -375,7 +375,7 @@ namespace MatrixCreator
 
 
   /**
-   * Calls the create_boundary_mass_matrix() function, see above, with
+   * Call the create_boundary_mass_matrix() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename number>
@@ -440,7 +440,7 @@ namespace MatrixCreator
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
-   * Calls the create_laplace_matrix() function, see above, with
+   * Call the create_laplace_matrix() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
@@ -476,7 +476,7 @@ namespace MatrixCreator
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
-   * Calls the create_laplace_matrix() function, see above, with
+   * Call the create_laplace_matrix() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -591,7 +591,7 @@ namespace VectorTools
                     const ComponentMask                &component_mask = ComponentMask());
 
   /**
-   * Calls the @p interpolate() function above with
+   * Call the @p interpolate() function above with
    * <tt>mapping=MappingQGeneric1@<dim>@()</tt>.
    */
   template <typename VectorType, typename DoFHandlerType>
@@ -806,7 +806,7 @@ namespace VectorTools
                 const bool                      project_to_boundary_first = false);
 
   /**
-   * Calls the project() function above, with
+   * Call the project() function above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, typename VectorType, int spacedim>
@@ -839,7 +839,7 @@ namespace VectorTools
                 const bool                                 project_to_boundary_first = false);
 
   /**
-   * Calls the project() function above, with a collection of $Q_1$ mapping
+   * Call the project() function above, with a collection of $Q_1$ mapping
    * objects, i.e., with hp::StaticMappingQ1::mapping_collection.
    */
   template <int dim, typename VectorType, int spacedim>
@@ -945,7 +945,7 @@ namespace VectorTools
    const ComponentMask                                                      &component_mask = ComponentMask());
 
   /**
-   * Calls the other interpolate_boundary_values() function, see above, with
+   * Call the other interpolate_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>. The same comments
    * apply as for the previous function, in particular about the use of the
    * component mask and the requires size of the function object.
@@ -964,7 +964,7 @@ namespace VectorTools
 
 
   /**
-   * Calls the other interpolate_boundary_values() function, see above, with
+   * Call the other interpolate_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>. The same comments
    * apply as for the previous function, in particular about the use of the
    * component mask and the requires size of the function object.
@@ -1070,7 +1070,7 @@ namespace VectorTools
    const ComponentMask                                                      &component_mask = ComponentMask());
 
   /**
-   * Calls the other interpolate_boundary_values() function, see above, with
+   * Call the other interpolate_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>. The same comments
    * apply as for the previous function, in particular about the use of the
    * component mask and the requires size of the function object.
@@ -1091,7 +1091,7 @@ namespace VectorTools
 
 
   /**
-   * Calls the other interpolate_boundary_values() function, see above, with
+   * Call the other interpolate_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>. The same comments
    * apply as for the previous function, in particular about the use of the
    * component mask and the requires size of the function object.
@@ -1166,7 +1166,7 @@ namespace VectorTools
                                 std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
-   * Calls the project_boundary_values() function, see above, with
+   * Call the project_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename number>
@@ -1188,7 +1188,7 @@ namespace VectorTools
                                 std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
-   * Calls the project_boundary_values() function, see above, with
+   * Call the project_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename number>
@@ -1245,7 +1245,7 @@ namespace VectorTools
                                 std::vector<unsigned int>       component_mapping = std::vector<unsigned int>());
 
   /**
-   * Calls the project_boundary_values() function, see above, with
+   * Call the project_boundary_values() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim,spacedim@>(1)</tt>.
    *
    * @ingroup constraints
@@ -1843,7 +1843,7 @@ namespace VectorTools
                                Vector<double>        &rhs_vector);
 
   /**
-   * Calls the create_right_hand_side() function, see above, with
+   * Call the create_right_hand_side() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
@@ -1886,7 +1886,7 @@ namespace VectorTools
                                   Vector<double>        &rhs_vector);
 
   /**
-   * Calls the create_point_source_vector() function, see above, with
+   * Call the create_point_source_vector() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
@@ -1939,7 +1939,7 @@ namespace VectorTools
                                   Vector<double>                 &rhs_vector);
 
   /**
-   * Calls the create_point_source_vector() function for vector-valued finite
+   * Call the create_point_source_vector() function for vector-valued finite
    * elements, see above, with <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim>
@@ -1988,7 +1988,7 @@ namespace VectorTools
                                         const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
-   * Calls the create_boundary_right_hand_side() function, see above, with
+   * Call the create_boundary_right_hand_side() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    *
    * @see
@@ -2016,7 +2016,7 @@ namespace VectorTools
                                         const std::set<types::boundary_id> &boundary_ids = std::set<types::boundary_id>());
 
   /**
-   * Calls the create_boundary_right_hand_side() function, see above, with a
+   * Call the create_boundary_right_hand_side() function, see above, with a
    * single Q1 mapping as collection. This function therefore will only work
    * if the only active fe index in use is zero.
    *
@@ -2135,7 +2135,7 @@ namespace VectorTools
                              const double exponent = 2.);
 
   /**
-   * Calls the integrate_difference() function, see above, with
+   * Call the integrate_difference() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
@@ -2163,7 +2163,7 @@ namespace VectorTools
                              const double exponent = 2.);
 
   /**
-   * Calls the integrate_difference() function, see above, with
+   * Call the integrate_difference() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
@@ -2758,7 +2758,7 @@ namespace VectorTools
                       const unsigned int             component);
 
   /**
-   * Calls the other compute_mean_value() function, see above, with
+   * Call the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    */
   template <int dim, typename VectorType, int spacedim>

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -605,7 +605,7 @@ namespace VectorTools
   namespace internal
   {
     /**
-     * Returns whether the cell and all of its descendants are locally owned.
+     * Return whether the cell and all of its descendants are locally owned.
      */
     template <typename cell_iterator>
     bool is_locally_owned(const cell_iterator &cell)


### PR DESCRIPTION
This is sort of a pet peeve of mine: The vast majority of our documentation strings start with a sentence that is written in command form, followed by complete sentences:
```
  /**
   * Set the size of the vector to @p n. The new size has to be a positive number.
   */
  void set_size (const unsigned int n);
```
However, a minority of doc strings are as follows
```
  /**
   * Sets the size of the vector to @p n. The new size has to be a positive number.
   */
  void set_size (const unsigned int n);
```
Note the first word. What this is really supposed to read is "[This function] sets...", but the first two words are typically omitted, leaving the sentence typically still understandable, but ever so slightly ambiguous.

This patch fixes this for a good number of places. Y'all can tell me that I'm being silly in bothering about this and ignore the patch, or you can all join me in THIS VERY IMPORTANT CRUSADE!