### PR TITLE
Assert input stream validity when reading XML.

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1862,6 +1862,7 @@ namespace
 
 bool ParameterHandler::read_input_from_xml (std::istream &in)
 {
+  AssertThrow(in, ExcIO());
   // read the XML tree assuming that (as we
   // do in print_parameters(XML) it has only
   // a single top-level node called


### PR DESCRIPTION
As was discovered in 2bc6f8c810, every other ParameterHandler method that takes an input stream argument and reads from it throws an exception if the input stream is not in a valid state. This PR adds such a check to the XML reader.