### PR TITLE
Remove some statements that don't do anything.

### DIFF
--- a/include/deal.II/lac/matrix_lib.templates.h
+++ b/include/deal.II/lac/matrix_lib.templates.h
@@ -76,8 +76,6 @@ MeanValueFilter::filter(BlockVector<number> &v) const
   for (unsigned int i=0; i<v.n_blocks(); ++i)
     if (i == component)
       vmult(v.block(i), v.block(i));
-    else
-      v.block(i) = v.block(i);
 }
 
 

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -475,6 +475,7 @@ SolverBicgstab<VectorType>::solve(const MatrixType         &A,
           break;
         }
       state = iterate(A, precondition);
+      ++step;
     }
   while (state.breakdown == true);
 

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -203,8 +203,6 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
                                  const VectorType         &b,
                                  const PreconditionerType &precondition)
 {
-  SolverControl::State conv=SolverControl::iterate;
-
   deallog.push("minres");
 
   // Memory allocation
@@ -274,8 +272,7 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
   m[1]->reinit(b);
   m[2]->reinit(b);
 
-  conv = this->iteration_status(0, r_l2, x);
-
+  SolverControl::State conv = this->iteration_status(0, r_l2, x);
   while (conv==SolverControl::iterate)
     {
       if (delta[1]!=0)

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -53,8 +53,7 @@ namespace internal
                                const FiniteElement<dim> &fe_in,
                                const unsigned int base_element_number)
     {
-      const FiniteElement<dim> *fe = &fe_in;
-      fe = &fe_in.base_element(base_element_number);
+      const FiniteElement<dim> *fe = &fe_in.base_element(base_element_number);
 
       Assert (fe->n_components() == 1,
               ExcMessage("FEEvaluation only works for scalar finite elements."));

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3688,8 +3688,8 @@ namespace parallel
                           {
                             //at least one of the children belongs to us, so
                             //make sure we set the level subdomain id
-                            types::subdomain_id mark = numbers::artificial_subdomain_id;
-                            mark = cell->child(0)->level_subdomain_id();
+                            const types::subdomain_id mark =
+                              cell->child(0)->level_subdomain_id();
                             Assert(mark != numbers::artificial_subdomain_id, ExcInternalError()); //we should know the child(0)
                             cell->set_level_subdomain_id(mark);
                             break;


### PR DESCRIPTION
These were caught by cppcheck: PR 6/7.

The change in `solver_bicgstab.h` is different: in this case the author most likely meant to increment the step, which is now done.