### PR TITLE
Remove unnecessary 'typename'.

### DIFF
--- a/source/grid/cell_id.inst.in
+++ b/source/grid/cell_id.inst.in
@@ -18,6 +18,6 @@
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
-    template typename Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator CellId::to_cell(const Triangulation<deal_II_dimension,deal_II_space_dimension> &tria) const;
+    template Triangulation<deal_II_dimension,deal_II_space_dimension>::cell_iterator CellId::to_cell(const Triangulation<deal_II_dimension,deal_II_space_dimension> &tria) const;
 #endif
 }


### PR DESCRIPTION
This also avoids a resulting error with older versions of GCC.
Follow-up to #2981.