### PR TITLE
Do not use 'xargs' with locally defined functions.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -62,5 +62,6 @@ format_inst()
     rm $f.tmp $f.tmp.orig
 }
 
-export -f format_inst
-find source -name '*.inst.in' | xargs -n 1 -P 10 -I % bash -c 'format_inst "$@"' _ %
+for i in `find source -name '*.inst.in'` ; do
+  format_inst $i
+done


### PR DESCRIPTION
This breaks some versions of 'bash'. Rather, just run the function on each
individual file -- they are not too many anyway, and should indent rather
quickly.