### PR TITLE
Improve QSorted constructor

### DIFF
--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -436,15 +436,19 @@ class QSorted : public Quadrature<dim>
 {
 public:
   /**
-   * The constructor takes an arbitrary quadrature formula.
+   * The constructor takes an arbitrary quadrature formula @p quad and sorts
+   * its points and weights according to ascending weights.
    */
   QSorted (const Quadrature<dim> &quad);
 
+private:
   /**
-   * A rule to reorder pairs of points and weights.
+   * A rule for std::sort to reorder pairs of points and weights.
+   * @p a and @p b are indices into the weights array and the result will
+   * be determined by comparing the weights.
    */
-  bool operator()(const std::size_t &a,
-                  const std::size_t &b) const;
+  bool compare_weights(const unsigned int a,
+                       const unsigned int b) const;
 };
 
 /**

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -438,13 +438,13 @@ public:
   /**
    * The constructor takes an arbitrary quadrature formula.
    */
-  QSorted (const Quadrature<dim>);
+  QSorted (const Quadrature<dim> &quad);
 
   /**
    * A rule to reorder pairs of points and weights.
    */
-  bool operator()(const std::pair<double, Point<dim> > &a,
-                  const std::pair<double, Point<dim> > &b);
+  bool operator()(const std::size_t &a,
+                  const std::size_t &b) const;
 };
 
 /**

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/geometry_info.h>
 
+#include <deal.II/base/std_cxx11/bind.h>
 
 #include <cmath>
 #include <limits>
@@ -935,9 +936,16 @@ template <int dim>
 QSorted<dim>::QSorted(const Quadrature<dim> &quad) :
   Quadrature<dim>(quad)
 {
-  std::vector<std::size_t> permutation(quad.size());
-  std::iota(permutation.begin(), permutation.end(), 0);
-  std::sort(permutation.begin(), permutation.end(), *this);
+  std::vector<unsigned int> permutation(quad.size());
+  for (unsigned int i=0; i<quad.size(); ++i)
+    permutation[i] = i;
+
+  std::sort(permutation.begin(),
+            permutation.end(),
+            std_cxx11::bind(&QSorted<dim>::compare_weights,
+                            std_cxx11::ref(*this),
+                            std_cxx11::_1,
+                            std_cxx11::_2));
 
   for (unsigned int i=0; i<quad.size(); ++i)
     {
@@ -948,8 +956,8 @@ QSorted<dim>::QSorted(const Quadrature<dim> &quad) :
 
 
 template <int dim>
-bool QSorted<dim>::operator()(const std::size_t &a,
-                              const std::size_t &b) const
+bool QSorted<dim>::compare_weights(const unsigned int a,
+                                   const unsigned int b) const
 {
   return (this->weights[a] < this->weights[b]);
 }

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -932,27 +932,26 @@ QGaussOneOverR<2>::QGaussOneOverR(const unsigned int n,
 
 
 template <int dim>
-QSorted<dim>::QSorted(Quadrature<dim> quad) :
-  Quadrature<dim>(quad.size())
+QSorted<dim>::QSorted(const Quadrature<dim> &quad) :
+  Quadrature<dim>(quad)
 {
-  std::vector< std::pair<double, Point<dim> > > wp;
-  for (unsigned int i=0; i<quad.size(); ++i)
-    wp.push_back(std::pair<double, Point<dim> >(quad.weight(i),
-                                                quad.point(i)));
-  sort(wp.begin(), wp.end(), *this);
+  std::vector<std::size_t> permutation(quad.size());
+  std::iota(permutation.begin(), permutation.end(), 0);
+  std::sort(permutation.begin(), permutation.end(), *this);
+
   for (unsigned int i=0; i<quad.size(); ++i)
     {
-      this->weights[i] = wp[i].first;
-      this->quadrature_points[i] = wp[i].second;
+      this->weights[i]           = quad.weight(permutation[i]);
+      this->quadrature_points[i] = quad.point(permutation[i]);
     }
 }
 
 
 template <int dim>
-bool QSorted<dim>::operator()(const std::pair<double, Point<dim> > &a,
-                              const std::pair<double, Point<dim> > &b)
+bool QSorted<dim>::operator()(const std::size_t &a,
+                              const std::size_t &b) const
 {
-  return (a.first < b.first);
+  return (this->weights[a] < this->weights[b]);
 }
 
 


### PR DESCRIPTION
When profiling an ASPECT model I noticed that we spend significant time (~15 % of total runtime in my biased test case) in the constructor of QSorted. This puzzled me, and I will open another PR that suggests to reduce the number of times QSorted is constructed. As a first step this PR optimizes the constructor itself. According to callgrind this change should reduce the number of CPU cycles by around 15%, which I could confirm for my 2D test case (a total model runtime reduction of 2-4% or so in debug and even more in release mode). Since this change should be not critical, I open this as a separate PR.
Let me know if you see other possible improvements, or problems.