### PR TITLE
Not longer use QSorted in Manifold::get_new_point()

### DIFF
--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -68,20 +68,19 @@ get_new_point (const Quadrature<spacedim> &quad) const
   Assert(std::abs(std::accumulate(quad.get_weights().begin(), quad.get_weights().end(), 0.0)-1.0) < tol,
          ExcMessage("The weights for the individual points should sum to 1!"));
 
-  QSorted<spacedim> sorted_quad(quad);
-  Point<spacedim> p = sorted_quad.point(0);
-  double w = sorted_quad.weight(0);
+  Point<spacedim> p = quad.point(0);
+  double w = quad.weight(0);
 
-  for (unsigned int i=1; i<sorted_quad.size(); ++i)
+  for (unsigned int i=1; i<quad.size(); ++i)
     {
       double weight = 0.0;
-      if ( (sorted_quad.weight(i) + w) < tol )
+      if ( (quad.weight(i) + w) < tol )
         weight = 0.0;
       else
-        weight =  w/(sorted_quad.weight(i) + w);
+        weight =  w/(quad.weight(i) + w);
 
-      p = get_intermediate_point(p, sorted_quad.point(i),1.0 - weight );
-      w += sorted_quad.weight(i);
+      p = get_intermediate_point(p, quad.point(i),1.0 - weight );
+      w += quad.weight(i);
     }
 
   return p;


### PR DESCRIPTION
As mentioned in #2989 I got some interesting results when profiling one of my ASPECT models.
Up to 15 % of the total runtime (in debug mode) was spent in the constructor of QSorted, and all of those calls came from the `Manifold::get_new_point` function. First I tried to optimize the constructor (see #2989), but realistically we should ask why we sort the quadrature points and weights here?
I suppose it is done to make sure that quadrature points with very small weights do not suffer from a floating-point truncation of their weights. On the other hand one of the few manifolds that actually uses this function (the SphericalManifold that I used in this testcase) internally uses another cutoff to simply ignore weights smaller than 1e-10, so we do not gain much by carefully sorting the weights previously. 
On the other hand this sort turns out to be expensive, because it is done so often. The attached change led to a speedup of about 40 % in a 2D release mode testcase of both my matrix assembly and my particle advection (which is effectively finding the reference coordinates of a lot of points in real space).

So I guess I would be interested to hear if there is a case where we need this sort. If not I suggest to merge this PR for a significant speedup of the SphericalManifold. If there is an important use case for other manifolds, maybe I should instead implement the change inside of a `SphericalManifold::get_new_point())` function?