### PR TITLE
Precompute line support points

### DIFF
--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -390,6 +390,16 @@ public:
      */
     const unsigned int n_shape_functions;
 
+    /*
+     * The default line support points. Is used in when the shape function
+     * values are computed.
+     *
+     * The number of quadrature points depends on the degree of this
+     * class, and it matches the number of degrees of freedom of an
+     * FE_Q<1>(this->degree).
+     */
+    QGaussLobatto<1> line_support_points;
+
     /**
      * Tensors of covariant transformation at each of the quadrature points.
      * The matrix stored is the Jacobian * G^{-1}, where G = Jacobian^{t} *

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -665,7 +665,8 @@ template<int dim, int spacedim>
 MappingQGeneric<dim,spacedim>::InternalData::InternalData (const unsigned int polynomial_degree)
   :
   polynomial_degree (polynomial_degree),
-  n_shape_functions (Utilities::fixed_power<dim>(polynomial_degree+1))
+  n_shape_functions (Utilities::fixed_power<dim>(polynomial_degree+1)),
+  line_support_points (polynomial_degree + 1)
 {}
 
 
@@ -862,7 +863,6 @@ compute_shape_function_values (const std::vector<Point<dim> > &unit_points)
 
       // Construct the tensor product polynomials used as shape functions for the
       // Qp mapping of cells at the boundary.
-      const QGaussLobatto<1> line_support_points (polynomial_degree + 1);
       const TensorProductPolynomials<dim>
       tensor_pols (Polynomials::generate_complete_Lagrange_basis(line_support_points.get_points()));
       Assert (n_shape_functions==tensor_pols.n(),


### PR DESCRIPTION
Further fallout from #2992.
Every time the `MappingQGeneric<dim,spacedim>::InternalData::
compute_shape_function_values` is called it created a `QGaussLobatto` quadrature formula that was the same every time, but takes 30% of the cpu cycles of this function. This is usually not an issue because the function is not called often, except if you have many calls to `Mapping::transform_real_to_unit_cell` like I do.

I have one question about this though: The `MappingQGeneric` has a fixed polynomial degree, but its `InternalData` class has a public member variabe `polynomial_degree` that is not const, although it seems it is only supposed to be set in the constructor. Is there any case somebody would create such an object and later on change its polynomial degree? I have checked the `MappingQ` class, but even that has two different `InternalData` objects for its `MappingQ1` and `MappingQGeneric` parts. In case somebody would change the polynomial degree the `QGaussLobatto` support points would have to be recomputed.