### PR TITLE
Increase minimal BOOST version to 1.56.

### DIFF
--- a/cmake/modules/FindBOOST.cmake
+++ b/cmake/modules/FindBOOST.cmake
@@ -43,7 +43,7 @@ ENDIF()
 
 # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
 LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-FIND_PACKAGE(Boost 1.54 COMPONENTS
+FIND_PACKAGE(Boost 1.56 COMPONENTS
   iostreams serialization system thread
   )
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
@@ -56,7 +56,7 @@ IF(NOT Boost_FOUND AND Boost_USE_STATIC_LIBS)
 
   # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
   LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-  FIND_PACKAGE(Boost 1.54 COMPONENTS iostreams serialization system thread)
+  FIND_PACKAGE(Boost 1.56 COMPONENTS iostreams serialization system thread)
   LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 ENDIF()
 

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,17 @@ inconvenience this causes.
 </p>
 
 <ol>
+ <li> New: deal.II now requires at least BOOST version 1.56, rather than the
+ previous minimal version of 1.54. This is because 1.54 does not support
+ serializing objects of type std::unique_ptr if C++11 is used, but we now
+ use such objects in a variety of places in classes that can be serialized.
+ BOOST 1.56, on the other hand, supports this. deal.II bundles BOOST 1.56
+ for cases where no or no sufficiently new version of BOOST is found on
+ a system.
+ <br>
+ (Wolfgang Bangerth, 2016/08/22)
+ </li>
+
  <li> Removed: Deprecated classes CompressedSparsityPattern,
  CompressedSimpleSparsityPattern, CompressedSetSparsityPattern, and their
  block variants got removed.

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,17 +38,7 @@ inconvenience this causes.
 </p>
 
 <ol>
-
- <li> New: It is now possible to generate a cell_iterator to a cell
- that is identified by a CellId. CellIds are unique even across
- processes in distributed computations, therefore this change allows
- to identify a particular cell (e.g. a ghost cell of the local process) in
- another domain.
- <br>
- (Rene Gassmoeller, 2016/08/17)
- </li>
-
- <li> Removed: deprecated classes CompressedSparsityPattern,
+ <li> Removed: Deprecated classes CompressedSparsityPattern,
  CompressedSimpleSparsityPattern, CompressedSetSparsityPattern, and their
  block variants got removed.
  <br>
@@ -202,6 +192,15 @@ inconvenience this causes.
  (@dealiiVideoLectureSeeAlso{2.9,2.91,17.25,17.5,17.75,30.25})
  <br>
  (Wolfgang Bangerth, 2016/08/19)
+ </li>
+
+ <li> New: It is now possible to generate a cell_iterator to a cell
+ that is identified by a CellId. CellIds are unique even across
+ processes in distributed computations, therefore this change allows
+ to identify a particular cell (e.g. a ghost cell of the local process) in
+ another domain.
+ <br>
+ (Rene Gassmoeller, 2016/08/17)
  </li>
 
  <li> New: deal.II no longer uses features of the C++ language that


### PR DESCRIPTION
This is necessary because the previous minimum, 1.54, did not support
serializing std::unique_ptr for those users who have this old a BOOST
version but want to use C++11 anyway. (It does support serializing
the boost::scoped_ptr class that we use as a fall-back in non-C++11 mode
when using std_cxx11::unique_ptr.)

Fixes #2973.