### PR TITLE
MSVC fixes

### DIFF
--- a/bundled/boost-1.56.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.56.0/include/boost/config/compiler/visualc.hpp
@@ -264,7 +264,8 @@
 //
 // last known and checked version is 18.00.20827.3 (VC12 RC, aka 2013 RC):
 // tjhei: change 180020827 to 190023506 (vs 2015 update 1)
-#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190023506)
+// tjhei: change to 190024213 (vs 2015 update 3)
+#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190024213)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -596,4 +596,8 @@ void swap (LinearAlgebra::distributed::BlockVector<Number> &u,
 
 DEAL_II_NAMESPACE_CLOSE
 
+#ifdef DEAL_II_MSVC
+#include <deal.II/lac/la_parallel_block_vector.templates.h>
+#endif
+
 #endif

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -383,4 +383,8 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#ifdef DEAL_II_MSVC
+#include <deal.II/lac/la_vector.templates.h>
+#endif
+
 #endif

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -20,7 +20,7 @@
 # include <unistd.h>
 #endif
 
-#ifdef DEAM_II_MSVC
+#ifdef DEAL_II_MSVC
 #  include <WinSock2.h>
 #endif
 

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -20,10 +20,6 @@
 # include <unistd.h>
 #endif
 
-#ifdef DEAL_II_MSVC
-#  include <WinSock2.h>
-#endif
-
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/lac/la_parallel_block_vector.cc
+++ b/source/lac/la_parallel_block_vector.cc
@@ -18,6 +18,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+// disable instantiation for MSVC for now because of a compiler bug,
+// see https://github.com/dealii/dealii/issues/2875
+#ifndef DEAL_II_MSVC
+
 #include "la_parallel_block_vector.inst"
 
 // do a few functions that currently don't fit the scheme because they have
@@ -42,5 +47,6 @@ namespace LinearAlgebra
   }
 }
 
+#endif // ! DEAL_II_MSVC
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/la_vector.cc
+++ b/source/lac/la_vector.cc
@@ -17,6 +17,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// disable instantiation for MSVC for now because of a compiler bug,
+// see https://github.com/dealii/dealii/issues/2875
+#ifndef DEAL_II_MSVC
+
 namespace LinearAlgebra
 {
 #include "la_vector.inst"
@@ -41,5 +45,7 @@ namespace LinearAlgebra
 
 #undef TEMPL_COPY_CONSTRUCTOR
 }
+
+#endif // ! DEAL_II_MSVC
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
- support newer VS15 update 3 compiler in bundled boost
- disable instantiations of LA::[Block]Vector (fixes #2875 )