### PR TITLE
Equip one exception with an error text.

### DIFF
--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -98,13 +98,11 @@ public:
    */
 
   /**
-   * No more available vectors.
-   */
-  DeclException0(ExcNoMoreVectors);
-  /**
    * Vector was not allocated from this memory pool.
    */
-  DeclException0(ExcNotAllocatedHere);
+  DeclExceptionMsg(ExcNotAllocatedHere,
+                   "You are trying to deallocate a vector from a memory pool, but this "
+                   "vector has not actually been allocated by the same pool before.");
 
   //@}
   /**


### PR DESCRIPTION
Remove a second exception class that was unused.

In reference to #610.