### PR TITLE
Remove further instances of the ExcInvalidConstructorCall exception.

### DIFF
--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -308,10 +308,6 @@ public:
                   int, int, int, int,
                   << "The blocks [" << arg1 << ',' << arg2 << "] and ["
                   << arg3 << ',' << arg4 << "] have differing column numbers.");
-  /**
-   * Exception
-   */
-  DeclException0 (ExcInvalidConstructorCall);
   //@}
 
 protected:

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -754,10 +754,6 @@ public:
   /**
    * Exception
    */
-  DeclException0 (ExcInvalidConstructorCall);
-  /**
-   * Exception
-   */
   DeclException2 (ExcIteratorRange,
                   int, int,
                   << "The iterators denote a range of " << arg1

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -992,10 +992,6 @@ public:
   /**
    * Exception
    */
-  DeclException0 (ExcInvalidConstructorCall);
-  /**
-   * Exception
-   */
   DeclException2 (ExcIteratorRange,
                   int, int,
                   << "The iterators denote a range of " << arg1

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -47,14 +47,15 @@ template <class SparsityPatternBase>
 BlockSparsityPatternBase<SparsityPatternBase>::
 BlockSparsityPatternBase (const BlockSparsityPatternBase &s)
   :
-  Subscriptor ()
+  Subscriptor (),
+  rows (0),
+  columns (0)
 {
   (void)s;
-  Assert(s.rows==0, ExcInvalidConstructorCall());
-  Assert(s.columns==0, ExcInvalidConstructorCall());
-
-  rows = 0;
-  columns=0;
+  Assert (s.rows==0 && s.columns==0,
+          ExcMessage("This constructor can only be called if the provided argument "
+                     "is the sparsity pattern for an empty matrix. This constructor can "
+                     "not be used to copy-construct a non-empty sparsity pattern."));
 }
 
 

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2015 by the deal.II authors
+// Copyright (C) 2008 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -35,8 +35,10 @@ ChunkSparsityPattern::ChunkSparsityPattern (const ChunkSparsityPattern &s)
   chunk_size (s.chunk_size),
   sparsity_pattern(s.sparsity_pattern)
 {
-  Assert (s.rows == 0, ExcInvalidConstructorCall());
-  Assert (s.cols == 0, ExcInvalidConstructorCall());
+  Assert (s.rows==0 && s.cols==0,
+          ExcMessage("This constructor can only be called if the provided argument "
+                     "is the sparsity pattern for an empty matrix. This constructor can "
+                     "not be used to copy-construct a non-empty sparsity pattern."));
 
   reinit (0,0,0,0);
 }
@@ -97,8 +99,14 @@ ChunkSparsityPattern::~ChunkSparsityPattern ()
 ChunkSparsityPattern &
 ChunkSparsityPattern::operator = (const ChunkSparsityPattern &s)
 {
-  Assert (s.rows == 0, ExcInvalidConstructorCall());
-  Assert (s.cols == 0, ExcInvalidConstructorCall());
+  Assert (s.rows==0 && s.cols==0,
+          ExcMessage("This operator can only be called if the provided argument "
+                     "is the sparsity pattern for an empty matrix. This operator can "
+                     "not be used to copy a non-empty sparsity pattern."));
+
+  Assert (rows==0 && cols==0,
+          ExcMessage("This operator can only be called if the current object is "
+                     "empty."));
 
   // perform the checks in the underlying object as well
   sparsity_pattern = s.sparsity_pattern;

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -62,10 +62,10 @@ SparsityPattern::SparsityPattern (const SparsityPattern &s)
   store_diagonal_first_in_row(false)
 {
   (void)s;
-  Assert (s.rowstart == 0, ExcInvalidConstructorCall());
-  Assert (s.colnums == 0, ExcInvalidConstructorCall());
-  Assert (s.rows == 0, ExcInvalidConstructorCall());
-  Assert (s.cols == 0, ExcInvalidConstructorCall());
+  Assert (s.rows==0 && s.cols==0 && s.rowstart==0 && s.colnums==0,
+          ExcMessage("This constructor can only be called if the provided argument "
+                     "is the sparsity pattern for an empty matrix. This constructor can "
+                     "not be used to copy-construct a non-empty sparsity pattern."));
 
   reinit (0,0,0);
 }
@@ -226,15 +226,14 @@ SparsityPattern &
 SparsityPattern::operator = (const SparsityPattern &s)
 {
   (void)s;
-  Assert (s.rowstart == 0, ExcInvalidConstructorCall());
-  Assert (s.colnums == 0, ExcInvalidConstructorCall());
-  Assert (s.rows == 0, ExcInvalidConstructorCall());
-  Assert (s.cols == 0, ExcInvalidConstructorCall());
+  Assert (s.rows==0 && s.cols==0 && s.rowstart==0 && s.colnums==0,
+          ExcMessage("This operator can only be called if the provided argument "
+                     "is the sparsity pattern for an empty matrix. This operator can "
+                     "not be used to copy a non-empty sparsity pattern."));
 
-  Assert (rowstart == 0, ExcInvalidConstructorCall());
-  Assert (colnums == 0, ExcInvalidConstructorCall());
-  Assert (rows == 0, ExcInvalidConstructorCall());
-  Assert (cols == 0, ExcInvalidConstructorCall());
+  Assert (rows==0 && cols==0 && rowstart==0 && cols==0,
+          ExcMessage("This operator can only be called if the current object is "
+                     "empty."));
 
   return *this;
 }


### PR DESCRIPTION
In the same spirit as #3011 and #3015. Part of #610.