### PR TITLE
A workaround for MPI_Comm_free() before MPI_FINALIZE() error

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2155,8 +2155,8 @@ namespace internal
 
           if (initialized == false)
             {
-              sc_init (MPI_COMM_WORLD,
-                       0, 0, 0, SC_LP_SILENT);
+              sc_init (MPI_COMM_NULL,
+                       0, 0, NULL, SC_LP_SILENT);
               p4est_init (0, SC_LP_SILENT);
 
               initialized = true;


### PR DESCRIPTION
A possible workaround for #2951