### PR TITLE
Remove a declaration that is no longer needed.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1247,30 +1247,7 @@ namespace GridTools
 
 
   /*@}*/
-  /**
-   * @name Lower-dimensional meshes for parts of higher-dimensional meshes
-   */
-  /*@{*/
 
-
-#ifdef _MSC_VER
-  // Microsoft's VC++ has a bug where it doesn't want to recognize that
-  // an implementation (definition) of the extract_boundary_mesh function
-  // matches a declaration. This can apparently only be avoided by
-  // doing some contortion with the return type using the following
-  // intermediate type. This is only used when using MS VC++ and uses
-  // the direct way of doing it otherwise
-  template <template <int,int> class MeshType, int dim, int spacedim>
-  struct ExtractBoundaryMesh
-  {
-    typedef
-    std::map<typename MeshType<dim-1,spacedim>::cell_iterator,
-        typename MeshType<dim,spacedim>::face_iterator>
-        return_type;
-  };
-#endif
-
-  /*@}*/
   /**
    * @name Dealing with periodic domains
    */


### PR DESCRIPTION
It was used in a function that has been used from namespace GridTools to
namespace GridGenerator, where the structure is now duplicated. It was
only used for MS Visual Studio in any case.