### PR TITLE
Add an assertion for clearer errors.

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4432,6 +4432,11 @@ namespace GridGenerator
                              MeshType<dim-1,spacedim>           &surface_mesh,
                              const std::set<types::boundary_id> &boundary_ids)
   {
+    Assert ((dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>
+             (&volume_mesh.get_triangulation())
+             == 0),
+            ExcNotImplemented());
+
 // This function works using the following assumption:
 //    Triangulation::create_triangulation(...) will create cells that preserve
 //    the order of cells passed in using the CellData argument; also,


### PR DESCRIPTION
Specifically, say that we can use GridGenerator::extract_boundary_mesh() for p::d::Triangulation.
This adds the assertion mentioned in #1189.