### PR TITLE
Re-enable and fix matrix free test

### DIFF
--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2015 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -22,7 +22,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/full_matrix.h>
@@ -122,10 +122,18 @@ void do_test (const DoFHandler<dim> &dof)
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   if (dim < 3 || fe_degree < 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2015 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -21,7 +21,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/full_matrix.h>
@@ -174,10 +174,18 @@ void do_test (const DoFHandler<dim> &dof)
 template <int dim>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   if (dim == 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -32,6 +32,7 @@ std::ofstream logfile("output");
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria_boundary_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -124,12 +125,16 @@ private:
 template <int dim, int fe_degree>
 void test ()
 {
+  SphericalManifold<dim> manifold;
+  HyperShellBoundary<dim> boundary;
   Triangulation<dim>   triangulation;
   GridGenerator::hyper_shell (triangulation, Point<dim>(),
                               0.5, 1., 96, true);
-  static HyperShellBoundary<dim> boundary;
-  triangulation.set_boundary (0, boundary);
-  triangulation.set_boundary (1, boundary);
+  triangulation.set_all_manifold_ids(0);
+  triangulation.set_all_manifold_ids_on_boundary(1);
+  triangulation.set_manifold (0, manifold);
+  triangulation.set_manifold (1, boundary);
+
   triangulation.begin_active()->set_refine_flag();
   triangulation.last()->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
@@ -164,8 +169,7 @@ void test ()
   stokes_sub_blocks[dim] = 1;
   DoFRenumbering::component_wise (dof_handler, stokes_sub_blocks);
 
-  std::set<unsigned char> no_normal_flux_boundaries;
-  no_normal_flux_boundaries.insert (0);
+  std::set<types::boundary_id> no_normal_flux_boundaries;
   no_normal_flux_boundaries.insert (1);
   DoFTools::make_hanging_node_constraints (dof_handler,
                                            constraints);
@@ -345,4 +349,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/get_functions_circle.cc
+++ b/tests/matrix_free/get_functions_circle.cc
@@ -31,10 +31,18 @@ std::ofstream logfile("output");
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
@@ -51,4 +59,3 @@ void test ()
 
   do_test <dim, fe_degree, double> (dof, constraints);
 }
-

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -1,7 +1,17 @@
-//------------------  get_functions_common.h  ------------------------
-//    Version: $Name$
+// ---------------------------------------------------------------------
 //
-//------------------  get_functions_common.h  ------------------------
+// Copyright (C) 2011 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
 
 
 // this is a template for getting the function values and comparing them with
@@ -19,7 +29,7 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>

--- a/tests/matrix_free/get_functions_gl.cc
+++ b/tests/matrix_free/get_functions_gl.cc
@@ -34,10 +34,18 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
@@ -82,4 +90,3 @@ void test ()
   MatrixFreeTest<dim,fe_degree,fe_degree+1,number> mf (mf_data, mapping);
   mf.test_functions (solution);
 }
-

--- a/tests/matrix_free/get_functions_mappingq.cc
+++ b/tests/matrix_free/get_functions_mappingq.cc
@@ -32,10 +32,18 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
@@ -85,4 +93,3 @@ void test ()
   mf.test_functions(solution);
   deallog << std::endl;
 }
-

--- a/tests/matrix_free/get_functions_q_hierarchical.cc
+++ b/tests/matrix_free/get_functions_q_hierarchical.cc
@@ -37,10 +37,18 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
@@ -85,4 +93,3 @@ void test ()
   MatrixFreeTest<dim,fe_degree,fe_degree+1,number> mf (mf_data, mapping);
   mf.test_functions (solution);
 }
-

--- a/tests/matrix_free/get_functions_rect.cc
+++ b/tests/matrix_free/get_functions_rect.cc
@@ -53,10 +53,18 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
@@ -105,4 +113,3 @@ void test ()
     sub_test <dim,fe_degree,fe_degree+3,number> (dof, constraints, mf_data,
                                                  solution);
 }
-

--- a/tests/matrix_free/get_values_plain.cc
+++ b/tests/matrix_free/get_values_plain.cc
@@ -30,7 +30,7 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -140,11 +140,11 @@ void do_test (const DoFHandler<dim> &dof,
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_shell (tria, Point<dim>(), 1., 2., 96, true);
-  static const HyperShellBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
-  tria.set_boundary (1, boundary);
+  tria.set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
 
   // refine a few cells
   for (unsigned int i=0; i<11-3*dim; ++i)
@@ -191,4 +191,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -29,7 +29,7 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -145,13 +145,19 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
   typename Triangulation<dim>::active_cell_iterator
   cell = tria.begin_active (),
   endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();
@@ -231,4 +237,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -30,7 +30,7 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -226,13 +226,19 @@ void test ()
 {
   // create hyper ball geometry and refine some
   // cells
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
   typename Triangulation<dim>::active_cell_iterator
   cell = tria.begin_active (),
   endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();
@@ -354,4 +360,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/inverse_mass_01.cc
+++ b/tests/matrix_free/inverse_mass_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2015 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,7 +24,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe_dgq.h>
@@ -163,18 +163,24 @@ void do_test (const DoFHandler<dim> &dof)
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   if (dim < 3 || fe_degree < 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator
-  cell = tria.begin_active (),
-  endc = tria.end();
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();

--- a/tests/matrix_free/inverse_mass_03.cc
+++ b/tests/matrix_free/inverse_mass_03.cc
@@ -24,7 +24,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe_dgq.h>
@@ -174,18 +174,24 @@ void do_test (const DoFHandler<dim> &dof)
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   if (dim < 3 || fe_degree < 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator
-  cell = tria.begin_active (),
-  endc = tria.end();
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();

--- a/tests/matrix_free/matrix_vector_01.cc
+++ b/tests/matrix_free/matrix_vector_01.cc
@@ -40,6 +40,6 @@ void test ()
   ConstraintMatrix constraints;
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }
 

--- a/tests/matrix_free/matrix_vector_02.cc
+++ b/tests/matrix_free/matrix_vector_02.cc
@@ -43,5 +43,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_03.cc
+++ b/tests/matrix_free/matrix_vector_03.cc
@@ -71,5 +71,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_04.cc
+++ b/tests/matrix_free/matrix_vector_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,12 +30,12 @@ std::ofstream logfile("output");
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_shell (tria, Point<dim>(),
                               0.5, 1., 96, true);
-  static const HyperShellBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
-  tria.set_boundary (1, boundary);
+  tria.set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
   if (dim == 2)
     tria.refine_global (2);
 
@@ -46,5 +46,5 @@ void test ()
   DoFTools::make_hanging_node_constraints(dof, constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_04b.cc
+++ b/tests/matrix_free/matrix_vector_04b.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Same as matrix_vector_04, but using more quadrature points than the FE
+// degree would suggest
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_common.h"
+
+
+template <int dim, int fe_degree>
+void test ()
+{
+  const SphericalManifold<dim> manifold;
+  Triangulation<dim> tria;
+  GridGenerator::hyper_shell (tria, Point<dim>(),
+                              0.5, 1., 96, true);
+  tria.set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+  if (dim == 2)
+    tria.refine_global (2);
+
+  FE_Q<dim> fe (fe_degree);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+  ConstraintMatrix constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  do_test<dim, fe_degree, double, fe_degree+3> (dof, constraints);
+}

--- a/tests/matrix_free/matrix_vector_04b.output
+++ b/tests/matrix_free/matrix_vector_04b.output
@@ -1,0 +1,13 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(1)
+DEAL:3d::Norm of difference: 0
+DEAL:3d::
+DEAL:3d::Testing FE_Q<3>(2)
+DEAL:3d::Norm of difference: 0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_05.cc
+++ b/tests/matrix_free/matrix_vector_05.cc
@@ -76,5 +76,5 @@ void test ()
   DoFTools::make_hanging_node_constraints(dof, constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_06.cc
+++ b/tests/matrix_free/matrix_vector_06.cc
@@ -70,5 +70,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_07.cc
+++ b/tests/matrix_free/matrix_vector_07.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2014-2014 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -35,13 +35,18 @@ std::ofstream logfile("output");
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
   typename Triangulation<dim>::active_cell_iterator
   cell = tria.begin_active (),
   endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+  cell = tria.begin_active();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();
@@ -83,8 +88,8 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 
   // test with coloring only as well
-  do_test<dim, fe_degree, double> (dof, constraints, 2);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints, 2);
 }

--- a/tests/matrix_free/matrix_vector_08.cc
+++ b/tests/matrix_free/matrix_vector_08.cc
@@ -69,5 +69,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_09.cc
+++ b/tests/matrix_free/matrix_vector_09.cc
@@ -68,5 +68,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_14b.cc
+++ b/tests/matrix_free/matrix_vector_14b.cc
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2014 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Same as matrix_vector_14, but using more quadrature points than the FE
+// degree would suggest
+
+#include "../tests.h"
+#include <deal.II/fe/fe_dgp.h>
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_common.h"
+
+
+
+template <int dim, int fe_degree>
+void test ()
+{
+  const SphericalManifold<dim> manifold;
+  Triangulation<dim> tria;
+  GridGenerator::hyper_ball (tria);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+  if (dim < 3 || fe_degree < 2)
+    tria.refine_global(1);
+  tria.begin(tria.n_levels()-1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active ();
+  for (; cell!=endc; ++cell)
+    if (cell->center().norm()<1e-8)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  FE_DGP<dim> fe (fe_degree);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+  ConstraintMatrix constraints;
+
+  do_test<dim, fe_degree, double, fe_degree+3> (dof, constraints);
+}

--- a/tests/matrix_free/matrix_vector_14b.output
+++ b/tests/matrix_free/matrix_vector_14b.output
@@ -1,0 +1,13 @@
+
+DEAL:2d::Testing FE_DGP<2>(1)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
+DEAL:2d::Testing FE_DGP<2>(2)
+DEAL:2d::Norm of difference: 0
+DEAL:2d::
+DEAL:3d::Testing FE_DGP<3>(1)
+DEAL:3d::Norm of difference: 0
+DEAL:3d::
+DEAL:3d::Testing FE_DGP<3>(2)
+DEAL:3d::Norm of difference: 0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -23,7 +23,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -181,18 +181,24 @@ void do_test (const DoFHandler<dim>  &dof,
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   if (dim < 3 || fe_degree < 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator
-  cell = tria.begin_active (),
-  endc = tria.end();
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();

--- a/tests/matrix_free/matrix_vector_17.cc
+++ b/tests/matrix_free/matrix_vector_17.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,18 +33,23 @@ std::ofstream logfile("output");
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
   if (dim < 3 || fe_degree < 2)
     tria.refine_global(1);
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator
-  cell = tria.begin_active (),
-  endc = tria.end();
+  cell = tria.begin_active ();
   for (; cell!=endc; ++cell)
     if (cell->center().norm()<1e-8)
       cell->set_refine_flag();
@@ -59,8 +64,5 @@ void test ()
                                             constraints);
   constraints.close();
 
-  do_test<dim, fe_degree, double> (dof, constraints);
+  do_test<dim, fe_degree, double, fe_degree+1> (dof, constraints);
 }
-
-
-

--- a/tests/matrix_free/matrix_vector_curl.cc
+++ b/tests/matrix_free/matrix_vector_curl.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,7 +33,7 @@ std::ofstream logfile("output");
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
@@ -104,10 +104,17 @@ private:
 template <int dim, int fe_degree>
 void test ()
 {
-  Triangulation<dim>   tria;
+  const SphericalManifold<dim> manifold;
+  Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
   tria.refine_global(4-dim);
 
   // refine a few cells
@@ -286,4 +293,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_float.cc
+++ b/tests/matrix_free/matrix_vector_float.cc
@@ -69,5 +69,5 @@ void test ()
   constraints.close();
 
   deallog.threshold_double (5e-6);
-  do_test<dim, fe_degree, float> (dof, constraints);
+  do_test<dim, fe_degree, float, fe_degree+1> (dof, constraints);
 }

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -48,32 +48,32 @@ public:
     std::pair<unsigned int,unsigned int> subrange_deg =
       data.create_cell_subrange_hp (cell_range, 1);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,1,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,1,Vector<Number>,2> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 2);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,2,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,2,Vector<Number>,3> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 3);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,3,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,3,Vector<Number>,4> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 4);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,4,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,4,Vector<Number>,5> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 5);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,5,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,5,Vector<Number>,6> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 6);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,6,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,6,Vector<Number>,7> (data, dst, src,
+                                                  subrange_deg);
     subrange_deg = data.create_cell_subrange_hp (cell_range, 7);
     if (subrange_deg.second > subrange_deg.first)
-      helmholtz_operator<dim,7,Vector<Number> > (data, dst, src,
-                                                 subrange_deg);
+      helmholtz_operator<dim,7,Vector<Number>,8> (data, dst, src,
+                                                  subrange_deg);
   }
 
   void vmult (Vector<Number>       &dst,
@@ -96,10 +96,17 @@ void test ()
     return;
 
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
   tria.refine_global(1);
 
   // refine a few cells
@@ -233,4 +240,3 @@ void test ()
   const double diff_norm = result_mf.linfty_norm();
   deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
 }
-

--- a/tests/matrix_free/matrix_vector_mf.h
+++ b/tests/matrix_free/matrix_vector_mf.h
@@ -1,7 +1,17 @@
-//------------------  matrix_vector_common.h  ------------------------
-//    Version: $Name$
+// ---------------------------------------------------------------------
 //
-//------------------  matrix_vector_common.h  ------------------------
+// Copyright (C) 2013 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
 
 
 // this is a template for matrix-vector products with the Helmholtz equation
@@ -18,7 +28,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 
-template <int dim, int fe_degree, typename VectorType>
+template <int dim, int fe_degree, typename VectorType, int n_q_points_1d>
 void
 helmholtz_operator (const MatrixFree<dim,typename VectorType::value_type> &data,
                     VectorType                                            &dst,
@@ -26,7 +36,7 @@ helmholtz_operator (const MatrixFree<dim,typename VectorType::value_type> &data,
                     const std::pair<unsigned int,unsigned int>            &cell_range)
 {
   typedef typename VectorType::value_type Number;
-  FEEvaluation<dim,fe_degree,fe_degree+1,1,Number> fe_eval (data);
+  FEEvaluation<dim,fe_degree,n_q_points_1d,1,Number> fe_eval (data);
   const unsigned int n_q_points = fe_eval.n_q_points;
 
   for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
@@ -46,7 +56,7 @@ helmholtz_operator (const MatrixFree<dim,typename VectorType::value_type> &data,
 
 
 
-template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number> >
+template <int dim, int fe_degree, typename Number, typename VectorType=Vector<Number>, int n_q_points_1d=fe_degree+1>
 class MatrixFreeTest
 {
 public:
@@ -64,7 +74,7 @@ public:
                                    VectorType &,
                                    const VectorType &,
                                    const std::pair<unsigned int,unsigned int> &)>
-    wrap = helmholtz_operator<dim,fe_degree,VectorType>;
+    wrap = helmholtz_operator<dim,fe_degree,VectorType,n_q_points_1d>;
     data.cell_loop (wrap, dst, src);
   };
 

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,6 +33,7 @@ std::ofstream logfile("output");
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria_boundary_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -122,12 +123,16 @@ private:
 template <int dim, int fe_degree>
 void test ()
 {
+  SphericalManifold<dim> manifold;
+  HyperShellBoundary<dim> boundary;
   Triangulation<dim>   triangulation;
   GridGenerator::hyper_shell (triangulation, Point<dim>(),
                               0.5, 1., 96, true);
-  static HyperShellBoundary<dim> boundary;
-  triangulation.set_boundary (0, boundary);
-  triangulation.set_boundary (1, boundary);
+  triangulation.set_all_manifold_ids(0);
+  triangulation.set_all_manifold_ids_on_boundary(1);
+  triangulation.set_manifold (0, manifold);
+  triangulation.set_manifold (1, boundary);
+
   triangulation.begin_active()->set_refine_flag();
   triangulation.last()->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
@@ -162,7 +167,7 @@ void test ()
   stokes_sub_blocks[dim] = 1;
   DoFRenumbering::component_wise (dof_handler, stokes_sub_blocks);
 
-  std::set<unsigned char> no_normal_flux_boundaries;
+  std::set<types::boundary_id> no_normal_flux_boundaries;
   no_normal_flux_boundaries.insert (0);
   no_normal_flux_boundaries.insert (1);
   DoFTools::make_hanging_node_constraints (dof_handler,
@@ -343,4 +348,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -31,7 +31,7 @@ std::ofstream logfile("output");
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -170,10 +170,18 @@ int main ()
 template <int dim, int fe_degree>
 void test ()
 {
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
+
   // refine first and last cell
   tria.begin(tria.n_levels()-1)->set_refine_flag();
   tria.last()->set_refine_flag();

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -27,7 +27,7 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -46,10 +46,17 @@ template <int dim, int fe_degree>
 void test ()
 {
   typedef double number;
+  const SphericalManifold<dim> manifold;
   Triangulation<dim> tria;
   GridGenerator::hyper_ball (tria);
-  static const HyperBallBoundary<dim> boundary;
-  tria.set_boundary (0, boundary);
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active (),
+  endc = tria.end();
+  for (; cell!=endc; ++cell)
+    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_manifold_ids(0);
+  tria.set_manifold (0, manifold);
   tria.refine_global(5-dim);
 
   MappingQ<dim> mapping (4);
@@ -119,4 +126,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -52,7 +52,7 @@ public:
 #define CALL_METHOD(degree)                                             \
   subrange_deg = data.create_cell_subrange_hp(cell_range, degree);    \
   if (subrange_deg.second > subrange_deg.first)                       \
-    helmholtz_operator<dim,degree,Vector<Number> > (data, dst, src, subrange_deg)
+    helmholtz_operator<dim,degree,Vector<Number>,degree+1> (data, dst, src, subrange_deg)
 
     CALL_METHOD(1);
     CALL_METHOD(2);
@@ -226,4 +226,3 @@ void test ()
   do_test<dim,float>(parallel_option);
   deallog.pop();
 }
-


### PR DESCRIPTION
This restores and fixes the `matrix_free/matrix_vector_14b` test that got deleted by #2994. Now it properly uses the expanded quadrature formulas as promised.
I also used the opportunity to use a more modern code for the manifold parts (last commit).