### PR TITLE
Fix get_intermediate_point in 1D.

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -185,6 +185,11 @@ get_intermediate_point (const Point<spacedim> &p1,
   else if (w > 1.0 - tol)
     return p2;
 
+  // If the points are one dimensional then there is no need for anything but
+  // a linear combination.
+  if (spacedim == 1)
+    return Point<spacedim>(w*p2 + (1-w)*p1);
+
   const Tensor<1,spacedim> v1 = p1 - center;
   const Tensor<1,spacedim> v2 = p2 - center;
   const double r1 = v1.norm();


### PR DESCRIPTION
I tried running some 1D code with a manifold (it is nice for genericity, even though it doesn't make a lot of sense) and ran into this. I am certainly not an expert in the manifold code, but I do not see any other reasonable way to do this.