### PR TITLE
Fixed: SymmetricTensor::third_invariant returns Tensor number type

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2198,7 +2198,7 @@ Number determinant (const SymmetricTensor<2,dim,Number> &t)
  */
 template <int dim, typename Number>
 inline
-double third_invariant (const SymmetricTensor<2,dim,Number> &t)
+Number third_invariant (const SymmetricTensor<2,dim,Number> &t)
 {
   return determinant (t);
 }


### PR DESCRIPTION
Fixed: SymmetricTensor::third_invariant returns Tensor number type