### PR TITLE
assert unique names in DataOut

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2474,6 +2474,15 @@ protected:
   get_vector_data_ranges () const;
 
   /**
+   * Validate that the names of the datasets returned by get_dataset_names() and
+   * get_vector_data_ranges() are valid. This currently consists of checking
+   * that names are not used more than once. If an invalid state is encountered,
+   * an Assert() will be triggered in debug mode.
+   */
+  void validate_dataset_names () const;
+
+
+  /**
    * The default number of subdivisions for patches. This is filled by
    * parse_parameters() and should be obeyed by build_patches() in derived
    * classes.

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -338,6 +338,8 @@ void DataOut<dim,DoFHandlerType>::build_patches
   Assert (n_subdivisions >= 1,
           Exceptions::DataOut::ExcInvalidNumberOfSubdivisions(n_subdivisions));
 
+  this->validate_dataset_names();
+
   // First count the cells we want to create patches of. Also fill the object
   // that maps the cell indices to the patch numbers, as this will be needed
   // for generation of neighborship information.

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -294,6 +294,8 @@ void DataOutFaces<dim,DoFHandlerType>::build_patches (const Mapping<dimension> &
   Assert (this->triangulation != 0,
           Exceptions::DataOut::ExcNoTriangulationSelected());
 
+  this->validate_dataset_names();
+
   unsigned int n_datasets     = this->cell_data.size();
   for (unsigned int i=0; i<this->dof_data.size(); ++i)
     n_datasets += this->dof_data[i]->n_output_variables;

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -414,6 +414,8 @@ void DataOutRotation<dim,DoFHandlerType>::build_patches (const unsigned int n_pa
   Assert (n_subdivisions >= 1,
           Exceptions::DataOut::ExcInvalidNumberOfSubdivisions(n_subdivisions));
 
+  this->validate_dataset_names();
+
   unsigned int n_datasets=this->cell_data.size();
   for (unsigned int i=0; i<this->dof_data.size(); ++i)
     n_datasets+= this->dof_data[i]->n_output_variables;

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -246,6 +246,8 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::build_patches (const unsigned in
   Assert (dof_handler != 0,
           Exceptions::DataOut::ExcNoDoFHandlerSelected());
 
+  this->validate_dataset_names();
+
   const unsigned int n_components   = dof_handler->get_fe().n_components();
   const unsigned int n_datasets     = dof_data.size() * n_components +
                                       cell_data.size();

--- a/tests/mappings/mapping_q1_eulerian_01.cc
+++ b/tests/mappings/mapping_q1_eulerian_01.cc
@@ -105,8 +105,7 @@ void test ()
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
-  std::vector<std::string> names (dim, "displacement");
-  data_out.add_data_vector(displacements,names);
+  data_out.add_data_vector(displacements, "displacement");
 
   // output with all cells curved
   data_out.build_patches(euler,1,DataOut<dim>::curved_inner_cells);

--- a/tests/mappings/mapping_q1_eulerian_01.output
+++ b/tests/mappings/mapping_q1_eulerian_01.output
@@ -18,7 +18,7 @@ DEAL::dim=2
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <displacement> <displacement> 
+# <x> <y> <displacement_0> <displacement_1> 
 -2.000 -2.000 -1.000 -1.000 
 2.000 -2.000 1.000 -1.000 
 
@@ -33,7 +33,7 @@ DEAL::dim=3
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <z> <displacement> <displacement> <displacement> 
+# <x> <y> <z> <displacement_0> <displacement_1> <displacement_2> 
 -2.000 -2.000 -2.000 -1.000 -1.000 -1.000
 2.000 -2.000 -2.000 1.000 -1.000 -1.000
 

--- a/tests/mappings/mapping_q_eulerian_01.cc
+++ b/tests/mappings/mapping_q_eulerian_01.cc
@@ -103,8 +103,7 @@ void test ()
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
-  std::vector<std::string> names (dim, "displacement");
-  data_out.add_data_vector(displacements,names);
+  data_out.add_data_vector(displacements, "displacement");
 
   // output with all cells curved
   data_out.build_patches(euler,1,DataOut<dim>::curved_inner_cells);

--- a/tests/mappings/mapping_q_eulerian_01.output
+++ b/tests/mappings/mapping_q_eulerian_01.output
@@ -18,7 +18,7 @@ DEAL::dim=2
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <displacement> <displacement> 
+# <x> <y> <displacement_0> <displacement_1> 
 -2.000 -2.000 -1.000 -1.000 
 2.000 -2.000 1.000 -1.000 
 
@@ -33,7 +33,7 @@ DEAL::dim=3
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <z> <displacement> <displacement> <displacement> 
+# <x> <y> <z> <displacement_0> <displacement_1> <displacement_2> 
 -2.000 -2.000 -2.000 -1.000 -1.000 -1.000
 2.000 -2.000 -2.000 1.000 -1.000 -1.000
 

--- a/tests/mappings/mapping_q_eulerian_02.cc
+++ b/tests/mappings/mapping_q_eulerian_02.cc
@@ -105,8 +105,7 @@ void test ()
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
-  std::vector<std::string> names (dim, "displacement");
-  data_out.add_data_vector(displacements,names);
+  data_out.add_data_vector(displacements, "displacement");
 
   // output with all cells curved
   data_out.build_patches(euler,1,DataOut<dim>::curved_inner_cells);

--- a/tests/mappings/mapping_q_eulerian_02.output
+++ b/tests/mappings/mapping_q_eulerian_02.output
@@ -18,7 +18,7 @@ DEAL::dim=2
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <displacement> <displacement> 
+# <x> <y> <displacement_0> <displacement_1> 
 -0.5000 -0.5000 0.5000 0.5000 
 1.500 -1.500 0.5000 -0.5000 
 
@@ -33,7 +33,7 @@ DEAL::dim=3
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <z> <displacement> <displacement> <displacement> 
+# <x> <y> <z> <displacement_0> <displacement_1> <displacement_2> 
 -0.5000 -0.5000 -0.5000 0.5000 0.5000 0.5000
 1.500 -1.500 -1.500 0.5000 -0.5000 -0.5000
 

--- a/tests/mappings/mapping_q_eulerian_03.cc
+++ b/tests/mappings/mapping_q_eulerian_03.cc
@@ -106,8 +106,7 @@ void test ()
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
-  std::vector<std::string> names (dim, "displacement");
-  data_out.add_data_vector(displacements,names);
+  data_out.add_data_vector(displacements, "displacement");
 
   // output with all cells curved
   data_out.build_patches(euler,5,DataOut<dim>::curved_inner_cells);

--- a/tests/mappings/mapping_q_eulerian_03.output
+++ b/tests/mappings/mapping_q_eulerian_03.output
@@ -22,7 +22,7 @@ DEAL::dim=2
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <displacement> <displacement> 
+# <x> <y> <displacement_0> <displacement_1> 
 -3.000 -3.000 -2.000 -2.000 
 -1.800 -2.360 -1.200 -1.360 
 -0.6000 -2.040 -0.4000 -1.040 
@@ -73,7 +73,7 @@ DEAL::dim=3
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <z> <displacement> <displacement> <displacement> 
+# <x> <y> <z> <displacement_0> <displacement_1> <displacement_2> 
 -4.000 -4.000 -4.000 -3.000 -3.000 -3.000
 -2.400 -3.360 -3.360 -1.800 -2.360 -2.360
 


### PR DESCRIPTION
It turns out that you can specify the same name for a variable in DataOut. That doesn't make a lot of sense and makes paraview and visit crash when opening a .vtu written that way. Oops.

I think the right way to fix this is to add an assertion to check this condition and fix all tests that are now broken. (I haven't done the latter yet, so WIP)