### PR TITLE
Remove a reference to optimize_diagonal.

### DIFF
--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1007,8 +1007,7 @@ public:
 
   /**
    * Return the main diagonal element in the <i>i</i>th row. This function
-   * throws an error if the matrix is not quadratic (see
-   * SparsityPattern::optimize_diagonal()).
+   * throws an error if the matrix is not quadratic.
    *
    * This function is considerably faster than the operator()(), since for
    * quadratic matrices, the diagonal entry may be the first to be stored in


### PR DESCRIPTION
Commit 2dfcd899ad4 (February 2013) deprecated `SparsityPattern::optimize_diagonal()` and it has since been removed from the library.