### PR TITLE
Workaround for cases where MPI_Finalize is called before MPI_Comm_free

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -332,9 +332,13 @@ namespace Utilities
      * program and to shut it down again at the end. It also allows you to
      * control the number threads used in each MPI task.
      *
-     * If deal.II is configured with PETSc, the library will also be
+     * If deal.II is configured with PETSc, the library will be
      * initialized in the beginning and destroyed at the end automatically
      * (internally by calling PetscInitialize() and PetscFinalize()).
+     *
+     * If deal.II is configured with p4est, that library will also be
+     * initialized in the beginning, and destroyed at the end automatically
+     * (internally by calling sc_init(), p4est_init(), and sc_finalize()).
      *
      * If a program uses MPI one would typically just create an object of this
      * type at the beginning of <code>main()</code>. The constructor of this

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -50,6 +50,10 @@
 #  endif
 #endif
 
+#ifdef DEAL_II_WITH_P4EST
+#   include <p4est_bits.h>
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -356,6 +360,12 @@ namespace Utilities
 #  endif
 #endif
 
+#ifdef DEAL_II_WITH_P4EST
+      //Initialize p4est and libsc components
+      sc_init(MPI_COMM_WORLD, 0, 0, NULL, SC_LP_SILENT);
+      p4est_init (0, SC_LP_SILENT);
+#endif
+
       constructor_has_already_run = true;
 
 
@@ -483,6 +493,12 @@ namespace Utilities
           PetscFinalize();
 #  endif
         }
+#endif
+
+#ifdef DEAL_II_WITH_P4EST
+      // now end p4est and libsc
+      // Note: p4est has no finalize function
+      sc_finalize ();
 #endif
 
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2137,59 +2137,6 @@ namespace
 }
 
 
-// initialize p4est
-namespace internal
-{
-  namespace p4est
-  {
-    struct InitFinalize
-    {
-    private:
-      struct Singleton
-      {
-        Singleton ()
-        {
-          // ensure that the initialization code is run only once, even if we
-          // link with 1d, 2d, and 3d libraries
-          static bool initialized = false;
-
-          if (initialized == false)
-            {
-              sc_init (MPI_COMM_WORLD,
-                       0, 0, 0, SC_LP_SILENT);
-              p4est_init (0, SC_LP_SILENT);
-
-              initialized = true;
-            }
-        }
-
-        ~Singleton ()
-        {
-          // same here
-          static bool deinitialized = false;
-
-          if (deinitialized == false)
-            {
-              // p4est has no p4est_finalize function
-              sc_finalize ();
-
-              deinitialized = true;
-            }
-        }
-      };
-
-    public:
-      // do run the initialization code, at least the first time around we get
-      // to this function
-      static void do_initialize ()
-      {
-        static Singleton singleton;
-      }
-    };
-  }
-}
-
-
 namespace parallel
 {
   namespace distributed
@@ -2218,11 +2165,6 @@ namespace parallel
       n_attached_datas(0),
       n_attached_deserialize(0)
     {
-      // initialize p4est. do this in a separate function since it has to
-      // happen only once, even if we have triangulation objects for several
-      // different space dimensions
-      dealii::internal::p4est::InitFinalize::do_initialize ();
-
       parallel_ghost = 0;
     }
 


### PR DESCRIPTION
This fixes #2951 in a more elegant way than either #3018 or #3019