### PR TITLE
CMake: Use -fPIC instead of -fpic

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -46,7 +46,7 @@ ENDIF()
 #
 # Set the pic flag.
 #
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fPIC")
 
 #
 # Check whether the -as-needed flag is available. If so set it to link

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -204,6 +204,11 @@ inconvenience this causes.
 
 <ol>
 
+ <li> Fixed: The build system now uses -fPIC instead of -fpic
+ <br>
+ (Matthias Maier, 2016/08/31)
+ </li>
+
  <li> New: There are 6 new video lectures that explain the
  basics of Linux and the command line, how mesh refinement works, and some
  more complicated time stepping schemes.


### PR DESCRIPTION
This resolves a build failure on architectures that differentiate between
-fpic and -fPIC.

Special thanks to Matthias Klose and Graham Inggs.