### PR TITLE
[dealii-8.4.2] CMake: Use -fPIC instead of -fpic

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -46,7 +46,7 @@ ENDIF()
 #
 # Set the pic flag.
 #
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fPIC")
 
 #
 # Check whether the -as-needed flag is available. If so set it to link


### PR DESCRIPTION
This resolves a build failure on architectures that differentiate between
-fpic and -fPIC.

Special thanks to Matthias Klose and Graham Inggs.