### PR TITLE
remove assert in distributed Tria for dim==1

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -217,7 +217,6 @@ namespace parallel
   types::subdomain_id
   Triangulation<dim,spacedim>::locally_owned_subdomain () const
   {
-    Assert (dim > 1, ExcNotImplemented());
     return my_subdomain;
   }
 


### PR DESCRIPTION
the assert was copy-pasted from p::d::Tria::locally_owned_subdomain()
to the based class p::Tria. Not sure why it was there for distributed
case, but for shared tria + metis, everything should work ok.


in reference to https://github.com/dealii/dealii/pull/212