### PR TITLE
Improve error message for GridIn::read_abaqus

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -867,6 +867,18 @@ void GridIn<dim, spacedim>::read_abaqus (std::istream                           
     {
       read_ucd(in_ucd, apply_all_indicators_to_manifolds);
     }
+  catch (std::exception &exc)
+    {
+      std::cerr
+          << "Exception on processing internal UCD data: " << std::endl
+          << exc.what()
+          << std::endl;
+
+      AssertThrow(false, ExcMessage("Internal conversion from ABAQUS file to UCD format was unsuccessful. \
+                                   More information is provided in an error message printed above. \
+                                   Are you sure that your ABAQUS mesh file conforms with the requirements \
+                                   listed in the documentation?"));
+    }
   catch (...)
     {
       AssertThrow(false, ExcMessage("Internal conversion from ABAQUS file to UCD format was unsuccessful. \


### PR DESCRIPTION
To assist debugging, where possible the error thrown internally when the
UCD grid is created is now displayed before the terminal error message
is given.