### PR TITLE
Set --options=none when indenting .inst.in files.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -52,7 +52,7 @@ format_inst()
     cp $f $f.tmp
     sed -i.orig 's#\\{#{ //#g' $f.tmp
     sed -i.orig 's#\\}#} //#g' $f.tmp
-    astyle --quiet $f.tmp
+    astyle --options=none --quiet $f.tmp
     sed -i.orig 's#{ //#\\{#g' $f.tmp
     sed -i.orig 's#} //#\\}#g' $f.tmp
     if ! diff -q $f $f.tmp >/dev/null


### PR DESCRIPTION
This works around a problem where, if one has global astyle options turned on, they will be used to indent all of the .inst.in files when one calls 'make indent'.