### PR TITLE
doxygen: format exception messages

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -214,6 +214,7 @@ INSTALL(FILES
 
 INSTALL(FILES
   ${CMAKE_SOURCE_DIR}/doc/deal.ico
+  ${CMAKE_SOURCE_DIR}/doc/doxygen/custom.js
   DESTINATION ${DEAL_II_DOCHTML_RELDIR}/doxygen/deal.II
   COMPONENT documentation
   )

--- a/doc/doxygen/custom.js
+++ b/doc/doxygen/custom.js
@@ -1,0 +1,14 @@
+$( document ).ready( function() {
+    // replace the text inside every div with class 'doxygen-generated-exception-message' to be more readable:
+    $('.doxygen-generated-exception-message').each(function(i, obj) {
+	var s = $(this).html();
+	s=s.replace(/\\n|std::endl/g,"<br/>");
+	s=s.replace(/"|&lt;&lt;/g,"");
+	s=s.replace(/arg1/g,"<i>arg1</i>");
+	s=s.replace(/arg2/g,"<i>arg2</i>");
+	s=s.replace(/arg3/g,"<i>arg3</i>");
+	s=s.replace(/arg4/g,"<i>arg4</i>");
+	s=s.replace(/arg5/g,"<i>arg5</i>");
+	$(this).html(s);
+    });
+});

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -83,7 +83,7 @@ ALIASES += dealiiRequiresUpdateFlags{1}="@note For this function to work properl
 
 ALIASES += dealiiOperationIsMultithreaded="@note If deal.II is configured with threads, this operation will run multi-threaded by splitting the work into smaller chunks (assuming there is enough work to make this worthwhile)."
 
-ALIASES += dealiiExceptionMessage{1}="@note The message that will be printed by this exception reads: @code \1 @endcode"
+ALIASES += dealiiExceptionMessage{1}="@note The message that will be printed by this exception reads: <div class='doxygen-generated-exception-message'> \1 </div> "
 
 #---------------------------------------------------------------------------
 # configuration options related to source browsing

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -7,6 +7,7 @@ $year += 1900;
 if (m'</head>')
 {
     print '<link rel="SHORTCUT ICON" href="deal.ico"></link>', "\n";
+    print '<script type="text/javascript" src="$relpath^custom.js"></script>', "\n";
     print '<meta name="author" content="The deal.II Authors <authors@dealii.org>"></meta>', "\n";
     print '<meta name="copyright" content="Copyright (C) 1998 - ', $year, ' by the deal.II authors"></meta>', "\n";
     print '<meta name="deal.II-version" content="@DEAL_II_PACKAGE_VERSION@"></meta>', "\n";

--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -19,3 +19,10 @@ div.tutorial {
     padding: 50px;
     font-size: 95%;
 }
+div.doxygen-generated-exception-message {
+    color: black;
+    border: 1px solid #aaa;
+    background-color: #f9f9f9;
+    padding: 5px;
+    font-size: 95%;
+}


### PR DESCRIPTION
This creates pretty formatting in the doxygen documentation for the
exception texts. We do this by including a javascript function that does
a couple of string replacements. It is difficult to do this
transformation before generating the documentation as detailed in #2571.

Fixes #2571 

preview:
![image](https://cloud.githubusercontent.com/assets/1531285/18256129/4df2463a-737f-11e6-9091-e86a980c9854.png)

There is a few cases where this is not perfect (ternary operator for example):
![image](https://cloud.githubusercontent.com/assets/1531285/18256137/6877fb26-737f-11e6-897b-3af5c6f7c939.png)
