### PR TITLE
Assert limit_level_difference_at_vertices for multigrid

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -414,6 +414,9 @@ namespace parallel
        * the kinds of smoothing operations that can be applied.
        *
        * @param settings See the description of the Settings enumerator.
+       * Providing <code>construct_multigrid_hierarchy</code> enforces
+       * <code>Triangulation::limit_level_difference_at_vertices</code>
+       * for smooth_grid.
        *
        * @note This class does not currently support the
        * <code>check_for_distorted_cells</code> argument provided by the base

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1553,6 +1553,11 @@ public:
   virtual void set_mesh_smoothing (const MeshSmoothing mesh_smoothing);
 
   /**
+   * Return the mesh smoothing requirements that are obeyed.
+   */
+  virtual const Triangulation<dim, spacedim>::MeshSmoothing &get_mesh_smoothing() const;
+
+  /**
    * If @p dim==spacedim, assign a boundary object to a certain part of the
    * boundary of a the triangulation. If a face with boundary number @p number
    * is refined, this object is used to find the location of new vertices on

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1555,7 +1555,7 @@ public:
   /**
    * Return the mesh smoothing requirements that are obeyed.
    */
-  virtual const Triangulation<dim, spacedim>::MeshSmoothing &get_mesh_smoothing() const;
+  virtual const MeshSmoothing &get_mesh_smoothing() const;
 
   /**
    * If @p dim==spacedim, assign a boundary object to a certain part of the

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1156,7 +1156,8 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs (const FiniteElement<dim, spa
   (void)old_fe;
   Assert(old_fe == &fe, ExcMessage("You are required to use the same FE for level and active DoFs!") );
 
-  Assert((tria->get_mesh_smoothing() & Triangulation<dim, spacedim>::limit_level_difference_at_vertices)==true,
+  Assert(((tria->get_mesh_smoothing() & Triangulation<dim, spacedim>::limit_level_difference_at_vertices)
+          != Triangulation<dim, spacedim>::none),
          ExcMessage("The mesh smoothing requirement 'limit_level_difference_at_vertices' has to be set for using multigrid!"));
 
   clear_mg_space();

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1156,6 +1156,9 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs (const FiniteElement<dim, spa
   (void)old_fe;
   Assert(old_fe == &fe, ExcMessage("You are required to use the same FE for level and active DoFs!") );
 
+  Assert((tria->get_mesh_smoothing() & Triangulation<dim, spacedim>::limit_level_difference_at_vertices)==true,
+         ExcMessage("The mesh smoothing requirement 'limit_level_difference_at_vertices' has to be set for using multigrid!"));
+
   clear_mg_space();
 
   internal::DoFHandler::Implementation::reserve_space_mg (*this);

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9075,6 +9075,15 @@ Triangulation<dim, spacedim>::set_mesh_smoothing(const MeshSmoothing mesh_smooth
 
 
 template <int dim, int spacedim>
+const typename Triangulation<dim, spacedim>::MeshSmoothing &
+Triangulation<dim,spacedim>::get_mesh_smoothing() const
+{
+  return smooth_grid;
+}
+
+
+
+template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::set_boundary (const types::manifold_id m_number,
                                             const Boundary<dim, spacedim> &boundary_object)
@@ -11831,6 +11840,7 @@ Triangulation<dim,spacedim>::get_triangulation () const
 }
 
 
+
 template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::add_periodicity
@@ -11846,6 +11856,8 @@ Triangulation<dim, spacedim>::add_periodicity
   update_periodic_face_map();
 }
 
+
+
 template <int dim, int spacedim>
 const typename std::map<std::pair<typename Triangulation<dim, spacedim>::cell_iterator, unsigned int>,
       std::pair<std::pair<typename Triangulation<dim, spacedim>::cell_iterator, unsigned int>, std::bitset<3> > > &
@@ -11853,6 +11865,7 @@ const typename std::map<std::pair<typename Triangulation<dim, spacedim>::cell_it
 {
   return periodic_face_map;
 }
+
 
 
 template <int dim, int spacedim>

--- a/tests/bits/step-16.cc
+++ b/tests/bits/step-16.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -88,6 +88,7 @@ private:
 
 template <int dim>
 LaplaceProblem<dim>::LaplaceProblem () :
+  triangulation(limit_level_difference_at_vertices),
   fe (1),
   mg_dof_handler (triangulation)
 {}

--- a/tests/dofs/block_info.cc
+++ b/tests/dofs/block_info.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -75,7 +75,7 @@ void test_grid(const Triangulation<dim> &tr,
 template<int dim>
 void test_fe (const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(5-dim);
   test_grid(tr, fe);

--- a/tests/dofs/block_info_02.cc
+++ b/tests/dofs/block_info_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -78,7 +78,7 @@ void test_grid(const Triangulation<dim> &tr,
 template<int dim>
 void test_fe (const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(5-dim);
   test_grid(tr, fe);

--- a/tests/dofs/block_list.h
+++ b/tests/dofs/block_list.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2011 - 2015 by the deal.II authors
+// Copyright (C) 2011 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -57,7 +57,8 @@ void test_global_refinement(
   void (*test_block_list)(const TR &tr, const FiniteElement<TR::dimension> &fe))
 {
   const unsigned int dim=TR::dimension;
-  TR trc, trl;
+  TR trc(Triangulation<dim>::limit_level_difference_at_vertices);
+  TR trl(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(trc);
   trc.refine_global(2);
   GridGenerator::hyper_L(trl);

--- a/tests/dofs/block_list_05.cc
+++ b/tests/dofs/block_list_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -136,7 +136,8 @@ template <int dim>
 void test_global_refinement(
   void (*test_block_list)(const Triangulation<dim> &tr, const FiniteElement<dim> &fe))
 {
-  Triangulation<dim> trc, trl;
+  Triangulation<dim> trc(Triangulation<dim>::limit_level_difference_at_vertices);
+  Triangulation<dim> trl(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(trc);
   trc.refine_global(2);
   GridGenerator::hyper_L(trl);

--- a/tests/dofs/dof_renumbering.cc
+++ b/tests/dofs/dof_renumbering.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -150,7 +150,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   if (dim==2)
     GridGenerator::hyper_ball(tr, Point<dim>(), 1);
   else

--- a/tests/dofs/dof_renumbering_02.cc
+++ b/tests/dofs/dof_renumbering_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -148,7 +148,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1., 1.);
   tr.refine_global (1);
   tr.begin_active()->set_refine_flag ();

--- a/tests/dofs/dof_renumbering_07.cc
+++ b/tests/dofs/dof_renumbering_07.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -88,7 +88,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1., 1.);
   tr.refine_global (1);
   tr.begin_active()->set_refine_flag ();

--- a/tests/dofs/dof_renumbering_08.cc
+++ b/tests/dofs/dof_renumbering_08.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -86,7 +86,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1., 1.);
   tr.refine_global (1);
   tr.begin_active()->set_refine_flag ();

--- a/tests/dofs/extract_dofs_by_component_01_mg.cc
+++ b/tests/dofs/extract_dofs_by_component_01_mg.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -44,7 +44,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>:: limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1,1);
   tr.refine_global (1);
   tr.begin_active()->set_refine_flag();

--- a/tests/dofs/extract_dofs_by_component_02_mg.cc
+++ b/tests/dofs/extract_dofs_by_component_02_mg.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -45,7 +45,7 @@ template <int dim>
 void
 check ()
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>:: limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1,1);
   tr.refine_global (1);
   tr.begin_active()->set_refine_flag();

--- a/tests/fe/transfer.cc
+++ b/tests/fe/transfer.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2015 by the deal.II authors
+// Copyright (C) 1998 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -79,12 +79,12 @@ main()
   deallog << std::setprecision(7);
   deallog.threshold_double(1.e-10);
 
-  Triangulation<2> tr2;
+  Triangulation<2> tr2(Triangulation<2>::limit_level_difference_at_vertices);
 
   GridGenerator::hyper_cube(tr2, -1., 1.);
   tr2.refine_global(2);
 
-  Triangulation<3> tr3;
+  Triangulation<3> tr3(Triangulation<3>::limit_level_difference_at_vertices);
 
   GridGenerator::hyper_cube(tr3, -1., 1.);
   tr3.refine_global(3);

--- a/tests/integrators/assembler_simple_mgmatrix_03.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -62,7 +62,7 @@ void test(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>:: limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
 

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -148,7 +148,7 @@ void test(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>:: limit_level_difference_at_vertices);
   std::vector<unsigned int> repititions (dim, 1);
   repititions[0] = 2;
   const Point<dim> p1 = (dim == 1 ? Point<dim> (-1.) : (dim == 2 ? Point<dim>(-1.,-1.) : Point<dim> (-1.,-1.,-1.)));

--- a/tests/integrators/cells_and_faces_01.cc
+++ b/tests/integrators/cells_and_faces_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -160,7 +160,7 @@ template<int dim>
 void
 test(const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   DoFHandler<dim> dofs(tr);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);

--- a/tests/integrators/functional_01.cc
+++ b/tests/integrators/functional_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -133,7 +133,7 @@ template<int dim>
 void
 test(const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   DoFHandler<dim> dofs(tr);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);

--- a/tests/integrators/mesh_worker_01.cc
+++ b/tests/integrators/mesh_worker_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -169,7 +169,7 @@ template<int dim>
 void
 test(const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin(1)->set_refine_flag();

--- a/tests/integrators/mesh_worker_02.cc
+++ b/tests/integrators/mesh_worker_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -261,7 +261,7 @@ template<int dim>
 void
 test(const FiniteElement<dim> &fe)
 {
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_L(tr);
   tr.begin()->set_refine_flag();
   tr.execute_coarsening_and_refinement();

--- a/tests/integrators/mesh_worker_03.cc
+++ b/tests/integrators/mesh_worker_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -275,7 +275,7 @@ void
 test(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_L(tr);
   tr.begin()->set_refine_flag();
   tr.execute_coarsening_and_refinement();

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -35,7 +35,7 @@ template <int dim, int fe_degree>
 void test ()
 {
   const SphericalManifold<dim> manifold;
-  Triangulation<dim> tria;
+  Triangulation<dim> tria(Triangulation<dim>:: limit_level_difference_at_vertices);
   GridGenerator::hyper_ball (tria);
   typename Triangulation<dim>::active_cell_iterator
   cell = tria.begin_active (),

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016-2015 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -397,7 +397,8 @@ void test ()
   for (unsigned int i=5; i<8; ++i)
     {
       parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                     dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+                                                     Triangulation<dim>::limit_level_difference_at_vertices,
+                                                     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
       GridGenerator::hyper_cube (tria);
       tria.refine_global(i-dim);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016-2015 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -548,7 +548,8 @@ template <int dim, int fe_degree>
 void test ()
 {
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+                                                 Triangulation<dim>::limit_level_difference_at_vertices,
+                                                 parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube (tria);
   tria.refine_global(6-dim);
   const unsigned int n_runs = fe_degree == 1 ? 6-dim : 5-dim;

--- a/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_mf.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016-2016 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -537,7 +537,8 @@ template <int dim, int fe_degree, typename Number>
 void test ()
 {
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+                                                 Triangulation<dim>::limit_level_difference_at_vertices,
+                                                 parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube (tria);
   tria.refine_global(8-2*dim);
   const unsigned int n_runs = fe_degree == 1 ? 6-dim : 5-dim;

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016-2016 by the deal.II authors
+// Copyright (C) 2014 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -397,7 +397,8 @@ void test ()
   for (unsigned int i=5; i<8; ++i)
     {
       parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                     dealii::Triangulation<dim>::none,parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+                                                     Triangulation<dim>::limit_level_difference_at_vertices,
+                                                     parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
       GridGenerator::hyper_cube (tria);
       tria.refine_global(i-dim);
 

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -395,6 +395,7 @@ namespace Step37
   template <int dim>
   LaplaceProblem<dim>::LaplaceProblem ()
     :
+    triangulation (Triangulation<dim>::limit_level_difference_at_vertices),
     fe (degree_finite_element),
     dof_handler (triangulation)
   {}

--- a/tests/mpi/mg_02.cc
+++ b/tests/mpi/mg_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -47,7 +47,7 @@ void test()
     deallog << "hyper_cube" << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>:: limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
 
   GridGenerator::hyper_cube(tr);

--- a/tests/mpi/mg_03.cc
+++ b/tests/mpi/mg_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -71,7 +71,7 @@ void test()
     deallog << "hyper_cube" << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>:: limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
 
   GridGenerator::hyper_cube(tr);

--- a/tests/mpi/mg_04.cc
+++ b/tests/mpi/mg_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -68,7 +68,7 @@ void test()
     deallog << "hyper_cube" << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>:: limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);

--- a/tests/mpi/mg_05.cc
+++ b/tests/mpi/mg_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -87,7 +87,7 @@ void test()
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>:: limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(3);

--- a/tests/mpi/mg_06.cc
+++ b/tests/mpi/mg_06.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -87,7 +87,7 @@ void test()
   unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>:: limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube_slit(tr,-1,1);
   tr.refine_global(2);

--- a/tests/mpi/mg_ghost_dofs_periodic_01.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2015 by the deal.II authors
+// Copyright (C) 2015 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -29,7 +29,7 @@ template <int dim>
 void test()
 {
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>:: limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   std::vector<unsigned int> subdivisions(dim);
   Point<dim> p1, p2;

--- a/tests/mpi/mg_ghost_dofs_periodic_02.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2015 by the deal.II authors
+// Copyright (C) 2015 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -32,7 +32,7 @@ void test()
 {
   Assert(dim == 3, ExcNotImplemented());
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>:: limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube(tria, 0, 1);
   for (unsigned int face=2; face<GeometryInfo<dim>::faces_per_cell; ++face)

--- a/tests/mpi/mg_ghost_dofs_periodic_03.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2015 by the deal.II authors
+// Copyright (C) 2015 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -32,7 +32,7 @@ void test()
 {
   Assert(dim == 2, ExcNotImplemented());
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>:: limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   for (unsigned int run=0; run<2; ++run)
     {

--- a/tests/mpi/mg_ghost_dofs_periodic_04.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2015 by the deal.II authors
+// Copyright (C) 2015 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,7 +30,7 @@ template <int dim>
 void test()
 {
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>:: limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   std::vector<unsigned int> subdivisions(dim);
   Point<dim> p1, p2;

--- a/tests/multigrid/boundary_01.cc
+++ b/tests/multigrid/boundary_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -58,7 +58,7 @@ void check_fe(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
   ZeroFunction<dim> zero;

--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -63,7 +63,7 @@ void check_fe(FiniteElement<dim> &fe)
   deallog << fe.get_name() << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>::limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 
@@ -79,7 +79,7 @@ void check_fe(FiniteElement<dim> &fe)
   {
     // reorder
     parallel::distributed::Triangulation<dim> tr(MPI_COMM_SELF,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>::limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
     setup_tria(tr);
 

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -119,7 +119,7 @@ void check_fe(FiniteElement<dim> &fe)
   deallog << fe.get_name() << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>::limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 
@@ -135,7 +135,7 @@ void check_fe(FiniteElement<dim> &fe)
   {
     // reorder
     parallel::distributed::Triangulation<dim> tr(MPI_COMM_SELF,
-                                                 Triangulation<dim>::none,
+                                                 Triangulation<dim>::limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
     setup_tria(tr);
 

--- a/tests/multigrid/constrained_dofs_03.cc
+++ b/tests/multigrid/constrained_dofs_03.cc
@@ -47,7 +47,7 @@ void check_fe(FiniteElement<dim> &fe, ComponentMask &component_mask)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
 

--- a/tests/multigrid/count_01.cc
+++ b/tests/multigrid/count_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -53,7 +53,7 @@ void check_fe(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin_active()->set_refine_flag();

--- a/tests/multigrid/distribute_bug_01.cc
+++ b/tests/multigrid/distribute_bug_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -54,7 +54,7 @@ void do_test ()
   deallog << "Testing " << fe.get_name() << std::endl << std::endl;
   parallel::distributed::Triangulation<dim> triangulation
   (MPI_COMM_WORLD,
-   Triangulation<dim>::none,
+   Triangulation<dim>::limit_level_difference_at_vertices,
    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
 
   GridGenerator::subdivided_hyper_cube (triangulation, 1, -1, 1);

--- a/tests/multigrid/dof_01.cc
+++ b/tests/multigrid/dof_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -70,7 +70,7 @@ void check_fe(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
   ZeroFunction<dim> zero;

--- a/tests/multigrid/dof_02.cc
+++ b/tests/multigrid/dof_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -75,7 +75,7 @@ void check_fe(FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
   ZeroFunction<dim> zero;

--- a/tests/multigrid/dof_03.cc
+++ b/tests/multigrid/dof_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -37,7 +37,7 @@ void check()
 {
   FE_Q<dim> fe(1);
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
 

--- a/tests/multigrid/dof_04.cc
+++ b/tests/multigrid/dof_04.cc
@@ -32,7 +32,7 @@ void check()
   // need cubic polynomials that have two dofs on lines
   FE_Q<dim> fe(3);
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   if (dim > 1)
     GridGenerator::hyper_shell(tr, Point<dim>(), 0.5, 1, 12);
   else

--- a/tests/multigrid/dof_05.cc
+++ b/tests/multigrid/dof_05.cc
@@ -32,7 +32,7 @@ void check()
   // need cubic polynomials that have two dofs on lines
   FE_Q<dim> fe(3);
 
-  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD, Triangulation<dim>::none,
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD, Triangulation<dim>::limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_shell(tr, Point<dim>(), 0.5, 1, 12);
   tr.refine_global(1);

--- a/tests/multigrid/renumbering_01.cc
+++ b/tests/multigrid/renumbering_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -43,7 +43,7 @@ void check()
   FESystem<dim> fe(FE_DGP<dim>(1), 1, FE_DGQ<dim>(2), 2, FE_Q<dim>(3), 1);
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin_active()->set_refine_flag();

--- a/tests/multigrid/renumbering_02.cc
+++ b/tests/multigrid/renumbering_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -44,7 +44,7 @@ void check()
   FE_DGQ<dim> fe(1);
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tria;
+  Triangulation<dim> tria(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
   typename Triangulation<dim>::active_cell_iterator cell=tria.begin_active();

--- a/tests/multigrid/renumbering_03.cc
+++ b/tests/multigrid/renumbering_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -46,7 +46,7 @@ void check()
   FE_Q<dim> fe(3);
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tria;
+  Triangulation<dim> tria(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
   typename Triangulation<dim>::active_cell_iterator cell=tria.begin_active();

--- a/tests/multigrid/renumbering_04.cc
+++ b/tests/multigrid/renumbering_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -42,7 +42,7 @@ void check(FiniteElement<dim> &fe)
 {
   deallog << std::endl << "**** " << fe.get_name() << std::endl;
 
-  Triangulation<dim> tria;
+  Triangulation<dim> tria(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tria);
   tria.refine_global(1);
   tria.begin_active()->set_refine_flag();

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -379,6 +379,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
+    triangulation(Triangulation<dim>::limit_level_difference_at_vertices),
     mapping(1),
     fe(fe),
     dof_handler(triangulation),

--- a/tests/multigrid/step-39-02.output
+++ b/tests/multigrid/step-39-02.output
@@ -20,7 +20,7 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 11 value 9.37499e-13
+DEAL:cg::Convergence step 11 value 9.09099e-13
 DEAL::energy-error: 0.332582
 DEAL::L2-error:     0.00548996
 DEAL::Estimate 0.838060
@@ -32,43 +32,43 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 12 value 3.41649e-13
+DEAL:cg::Convergence step 12 value 1.66147e-13
 DEAL::energy-error: 0.237705
 DEAL::L2-error:     0.00250869
 DEAL::Estimate 0.611449
 DEAL::Step 3
-DEAL::Triangulation 58 cells, 5 levels
-DEAL::DoFHandler 522 dofs, level dofs 36 144 180 180 144
+DEAL::Triangulation 64 cells, 5 levels
+DEAL::DoFHandler 576 dofs, level dofs 36 144 216 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 23.4898
-DEAL:cg::Convergence step 12 value 5.58516e-13
-DEAL::energy-error: 0.170860
-DEAL::L2-error:     0.00120805
-DEAL::Estimate 0.452418
+DEAL:cg::Starting value 24.1546
+DEAL:cg::Convergence step 13 value 2.19190e-13
+DEAL::energy-error: 0.170175
+DEAL::L2-error:     0.00120328
+DEAL::Estimate 0.448676
 DEAL::Step 4
-DEAL::Triangulation 85 cells, 6 levels
-DEAL::DoFHandler 765 dofs, level dofs 36 144 360 180 180 108
+DEAL::Triangulation 91 cells, 6 levels
+DEAL::DoFHandler 819 dofs, level dofs 36 144 396 216 180 108
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 25.9490
-DEAL:cg::Convergence step 13 value 2.71720e-13
-DEAL::energy-error: 0.122755
-DEAL::L2-error:     0.000602816
-DEAL::Estimate 0.332525
+DEAL:cg::Starting value 26.5522
+DEAL:cg::Convergence step 13 value 2.44978e-13
+DEAL::energy-error: 0.121878
+DEAL::L2-error:     0.000591777
+DEAL::Estimate 0.327296
 DEAL::Step 5
-DEAL::Triangulation 130 cells, 7 levels
-DEAL::DoFHandler 1170 dofs, level dofs 36 144 432 432 180 180 144
+DEAL::Triangulation 142 cells, 7 levels
+DEAL::DoFHandler 1278 dofs, level dofs 36 144 432 432 288 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 27.1421
-DEAL:cg::Convergence step 13 value 2.50045e-13
-DEAL::energy-error: 0.0869445
-DEAL::L2-error:     0.000292783
-DEAL::Estimate 0.236647
+DEAL:cg::Convergence step 13 value 3.08737e-13
+DEAL::energy-error: 0.0863235
+DEAL::L2-error:     0.000292807
+DEAL::Estimate 0.232279

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -381,6 +381,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
+    triangulation(Triangulation<dim>::limit_level_difference_at_vertices),
     mapping(1),
     fe(fe),
     dof_handler(triangulation),

--- a/tests/multigrid/step-39-02a.output
+++ b/tests/multigrid/step-39-02a.output
@@ -20,7 +20,7 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 11 value 9.37499e-13
+DEAL:cg::Convergence step 11 value 9.09099e-13
 DEAL::energy-error: 0.332582
 DEAL::L2-error:     0.00548996
 DEAL::Estimate 0.838060
@@ -32,43 +32,43 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 12 value 3.41649e-13
+DEAL:cg::Convergence step 12 value 1.66147e-13
 DEAL::energy-error: 0.237705
 DEAL::L2-error:     0.00250869
 DEAL::Estimate 0.611449
 DEAL::Step 3
-DEAL::Triangulation 58 cells, 5 levels
-DEAL::DoFHandler 522 dofs, level dofs 36 144 180 180 144
+DEAL::Triangulation 64 cells, 5 levels
+DEAL::DoFHandler 576 dofs, level dofs 36 144 216 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 23.4898
-DEAL:cg::Convergence step 12 value 5.58516e-13
-DEAL::energy-error: 0.170860
-DEAL::L2-error:     0.00120805
-DEAL::Estimate 0.452418
+DEAL:cg::Starting value 24.1546
+DEAL:cg::Convergence step 13 value 2.19190e-13
+DEAL::energy-error: 0.170175
+DEAL::L2-error:     0.00120328
+DEAL::Estimate 0.448676
 DEAL::Step 4
-DEAL::Triangulation 85 cells, 6 levels
-DEAL::DoFHandler 765 dofs, level dofs 36 144 360 180 180 108
+DEAL::Triangulation 91 cells, 6 levels
+DEAL::DoFHandler 819 dofs, level dofs 36 144 396 216 180 108
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 25.9490
-DEAL:cg::Convergence step 13 value 2.71720e-13
-DEAL::energy-error: 0.122755
-DEAL::L2-error:     0.000602816
-DEAL::Estimate 0.332525
+DEAL:cg::Starting value 26.5522
+DEAL:cg::Convergence step 13 value 2.44978e-13
+DEAL::energy-error: 0.121878
+DEAL::L2-error:     0.000591777
+DEAL::Estimate 0.327296
 DEAL::Step 5
-DEAL::Triangulation 130 cells, 7 levels
-DEAL::DoFHandler 1170 dofs, level dofs 36 144 432 432 180 180 144
+DEAL::Triangulation 142 cells, 7 levels
+DEAL::DoFHandler 1278 dofs, level dofs 36 144 432 432 288 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 27.1421
-DEAL:cg::Convergence step 13 value 2.50045e-13
-DEAL::energy-error: 0.0869445
-DEAL::L2-error:     0.000292783
-DEAL::Estimate 0.236647
+DEAL:cg::Convergence step 13 value 3.08737e-13
+DEAL::energy-error: 0.0863235
+DEAL::L2-error:     0.000292807
+DEAL::Estimate 0.232279

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -385,6 +385,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
+    triangulation(Triangulation<dim>::limit_level_difference_at_vertices),
     mapping(1),
     fe(fe),
     dof_handler(triangulation),

--- a/tests/multigrid/step-39-03.output
+++ b/tests/multigrid/step-39-03.output
@@ -8,7 +8,7 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:GMRES::Starting value 9.41508
-DEAL:GMRES::Convergence step 10 value 7.45877e-13
+DEAL:GMRES::Convergence step 10 value 7.45878e-13
 DEAL::energy-error: 0.439211
 DEAL::L2-error:     0.0109342
 DEAL::Estimate 0.979555
@@ -22,7 +22,7 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:GMRES::Starting value 10.0041
-DEAL:GMRES::Convergence step 21 value 1.79028e-13
+DEAL:GMRES::Convergence step 21 value 1.79039e-13
 DEAL::energy-error: 0.332582
 DEAL::L2-error:     0.00548996
 DEAL::Estimate 0.838060
@@ -36,51 +36,51 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:GMRES::Starting value 10.8018
-DEAL:GMRES::Convergence step 28 value 2.71140e-13
+DEAL:GMRES::Convergence step 28 value 2.71098e-13
 DEAL::energy-error: 0.237705
 DEAL::L2-error:     0.00250869
 DEAL::Estimate 0.611449
 DEAL::Writing solution to <sol-02.gnuplot>...
 DEAL::
 DEAL::Step 3
-DEAL::Triangulation 58 cells, 5 levels
-DEAL::DoFHandler 840 dofs, level dofs 63 229 285 285 233
+DEAL::Triangulation 64 cells, 5 levels
+DEAL::DoFHandler 917 dofs, level dofs 63 229 337 337 233
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:GMRES::Starting value 12.2055
-DEAL:GMRES::Convergence step 33 value 8.68786e-13
-DEAL::energy-error: 0.170860
-DEAL::L2-error:     0.00120805
-DEAL::Estimate 0.452418
+DEAL:GMRES::Starting value 13.4185
+DEAL:GMRES::Convergence step 32 value 6.11150e-13
+DEAL::energy-error: 0.170175
+DEAL::L2-error:     0.00120328
+DEAL::Estimate 0.448676
 DEAL::Writing solution to <sol-03.gnuplot>...
 DEAL::
 DEAL::Step 4
-DEAL::Triangulation 85 cells, 6 levels
-DEAL::DoFHandler 1218 dofs, level dofs 63 229 561 285 285 177
+DEAL::Triangulation 91 cells, 6 levels
+DEAL::DoFHandler 1295 dofs, level dofs 63 229 613 337 285 177
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:GMRES::Starting value 15.5679
-DEAL:GMRES::Convergence step 34 value 7.55616e-13
-DEAL::energy-error: 0.122755
-DEAL::L2-error:     0.000602816
-DEAL::Estimate 0.332525
+DEAL:GMRES::Starting value 16.6112
+DEAL:GMRES::Convergence step 32 value 7.81623e-13
+DEAL::energy-error: 0.121878
+DEAL::L2-error:     0.000591777
+DEAL::Estimate 0.327296
 DEAL::Writing solution to <sol-04.gnuplot>...
 DEAL::
 DEAL::Step 5
-DEAL::Triangulation 130 cells, 7 levels
-DEAL::DoFHandler 1841 dofs, level dofs 63 229 665 665 285 285 233
+DEAL::Triangulation 142 cells, 7 levels
+DEAL::DoFHandler 2005 dofs, level dofs 63 229 665 665 449 337 233
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:GMRES::Starting value 18.7682
-DEAL:GMRES::Convergence step 33 value 8.65709e-13
-DEAL::energy-error: 0.0869445
-DEAL::L2-error:     0.000292783
-DEAL::Estimate 0.236647
+DEAL:GMRES::Starting value 19.3095
+DEAL:GMRES::Convergence step 31 value 8.40512e-13
+DEAL::energy-error: 0.0863235
+DEAL::L2-error:     0.000292807
+DEAL::Estimate 0.232279
 DEAL::Writing solution to <sol-05.gnuplot>...
 DEAL::

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -379,6 +379,7 @@ namespace Step39
   template <int dim>
   InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(const FiniteElement<dim> &fe)
     :
+    triangulation(Triangulation<dim>::limit_level_difference_at_vertices),
     mapping(1),
     fe(fe),
     dof_handler(triangulation),

--- a/tests/multigrid/step-39.output
+++ b/tests/multigrid/step-39.output
@@ -20,7 +20,7 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 11 value 9.37499e-13
+DEAL:cg::Convergence step 11 value 9.09099e-13
 DEAL::energy-error: 0.332582
 DEAL::L2-error:     0.00548996
 DEAL::Estimate 0.838060
@@ -32,43 +32,43 @@ DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 23.0730
-DEAL:cg::Convergence step 12 value 3.41649e-13
+DEAL:cg::Convergence step 12 value 1.66147e-13
 DEAL::energy-error: 0.237705
 DEAL::L2-error:     0.00250869
 DEAL::Estimate 0.611449
 DEAL::Step 3
-DEAL::Triangulation 58 cells, 5 levels
-DEAL::DoFHandler 522 dofs, level dofs 36 144 180 180 144
+DEAL::Triangulation 64 cells, 5 levels
+DEAL::DoFHandler 576 dofs, level dofs 36 144 216 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 23.4898
-DEAL:cg::Convergence step 12 value 5.58516e-13
-DEAL::energy-error: 0.170860
-DEAL::L2-error:     0.00120805
-DEAL::Estimate 0.452418
+DEAL:cg::Starting value 24.1546
+DEAL:cg::Convergence step 13 value 2.19190e-13
+DEAL::energy-error: 0.170175
+DEAL::L2-error:     0.00120328
+DEAL::Estimate 0.448676
 DEAL::Step 4
-DEAL::Triangulation 85 cells, 6 levels
-DEAL::DoFHandler 765 dofs, level dofs 36 144 360 180 180 108
+DEAL::Triangulation 91 cells, 6 levels
+DEAL::DoFHandler 819 dofs, level dofs 36 144 396 216 180 108
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
-DEAL:cg::Starting value 25.9490
-DEAL:cg::Convergence step 13 value 2.71720e-13
-DEAL::energy-error: 0.122755
-DEAL::L2-error:     0.000602816
-DEAL::Estimate 0.332525
+DEAL:cg::Starting value 26.5522
+DEAL:cg::Convergence step 13 value 2.44978e-13
+DEAL::energy-error: 0.121878
+DEAL::L2-error:     0.000591777
+DEAL::Estimate 0.327296
 DEAL::Step 5
-DEAL::Triangulation 130 cells, 7 levels
-DEAL::DoFHandler 1170 dofs, level dofs 36 144 432 432 180 180 144
+DEAL::Triangulation 142 cells, 7 levels
+DEAL::DoFHandler 1278 dofs, level dofs 36 144 432 432 288 216 144
 DEAL::Assemble matrix
 DEAL::Assemble multilevel matrix
 DEAL::Assemble right hand side
 DEAL::Solve
 DEAL:cg::Starting value 27.1421
-DEAL:cg::Convergence step 13 value 2.50045e-13
-DEAL::energy-error: 0.0869445
-DEAL::L2-error:     0.000292783
-DEAL::Estimate 0.236647
+DEAL:cg::Convergence step 13 value 3.08737e-13
+DEAL::energy-error: 0.0863235
+DEAL::L2-error:     0.000292807
+DEAL::Estimate 0.232279

--- a/tests/multigrid/transfer_01.cc
+++ b/tests/multigrid/transfer_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -60,7 +60,7 @@ void check_simple(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_02.cc
+++ b/tests/multigrid/transfer_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -89,7 +89,7 @@ void check_simple(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   refine_mesh(tr);
   refine_mesh(tr);

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -94,7 +94,7 @@ void check_fe(FiniteElement<dim> &fe)
   deallog << fe.get_name() << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>::limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 

--- a/tests/multigrid/transfer_04a.cc
+++ b/tests/multigrid/transfer_04a.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2015 by the deal.II authors
+// Copyright (C) 2006 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -93,7 +93,7 @@ void check_fe(FiniteElement<dim> &fe)
   deallog << fe.get_name() << std::endl;
 
   parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD,
-                                               Triangulation<dim>::none,
+                                               Triangulation<dim>::limit_level_difference_at_vertices,
                                                parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   setup_tria(tr);
 

--- a/tests/multigrid/transfer_block.cc
+++ b/tests/multigrid/transfer_block.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -91,7 +91,7 @@ void check_block(const FiniteElement<dim> &fe,
       deallog << ' ' << i;
   deallog << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_block_select.cc
+++ b/tests/multigrid/transfer_block_select.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -77,7 +77,7 @@ void check_select(const FiniteElement<dim> &fe, unsigned int selected)
   deallog << fe.get_name()
           << " select " << selected << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_compare_01.cc
+++ b/tests/multigrid/transfer_compare_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -123,7 +123,7 @@ void check_block(const FiniteElement<dim> &fe)
   deallog << fe.get_name() << std::endl;
   std::vector<bool> selected(fe.n_blocks(), true);
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_prebuilt_01.cc
+++ b/tests/multigrid/transfer_prebuilt_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -45,7 +45,7 @@ void check_simple(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin_active()->set_refine_flag();

--- a/tests/multigrid/transfer_prebuilt_02.cc
+++ b/tests/multigrid/transfer_prebuilt_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -46,7 +46,7 @@ void check_simple(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin_active()->set_refine_flag();

--- a/tests/multigrid/transfer_prebuilt_03.cc
+++ b/tests/multigrid/transfer_prebuilt_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -47,7 +47,7 @@ void check_simple(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
   tr.begin_active()->set_refine_flag();

--- a/tests/multigrid/transfer_select.cc
+++ b/tests/multigrid/transfer_select.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -50,7 +50,7 @@ void check_select(const FiniteElement<dim> &fe,
           << " (global) and " << mg_selected
           << " (mg)" << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_01.cc
+++ b/tests/multigrid/transfer_system_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -90,7 +90,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_02.cc
+++ b/tests/multigrid/transfer_system_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -91,7 +91,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_03.cc
+++ b/tests/multigrid/transfer_system_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -91,7 +91,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_04.cc
+++ b/tests/multigrid/transfer_system_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -91,7 +91,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_05.cc
+++ b/tests/multigrid/transfer_system_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -44,7 +44,7 @@ void check (const FiniteElement<dim> &fe, const unsigned int selected_block)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(2);
 

--- a/tests/multigrid/transfer_system_adaptive_01.cc
+++ b/tests/multigrid/transfer_system_adaptive_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,7 +117,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,7 +117,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_03.cc
+++ b/tests/multigrid/transfer_system_adaptive_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,7 +118,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_04.cc
+++ b/tests/multigrid/transfer_system_adaptive_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,7 +117,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_05.cc
+++ b/tests/multigrid/transfer_system_adaptive_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,7 +118,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_06.cc
+++ b/tests/multigrid/transfer_system_adaptive_06.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -117,7 +117,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_07.cc
+++ b/tests/multigrid/transfer_system_adaptive_07.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -119,7 +119,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_08.cc
+++ b/tests/multigrid/transfer_system_adaptive_08.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,7 +118,7 @@ void check (const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
 
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;

--- a/tests/multigrid/transfer_system_adaptive_09.cc
+++ b/tests/multigrid/transfer_system_adaptive_09.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2015 by the deal.II authors
+// Copyright (C) 2000 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -71,7 +71,7 @@ void check (const FiniteElement<dim> &fe, const unsigned int selected_block)
 {
   deallog << fe.get_name() << std::endl;
 
-  Triangulation<dim> tr;
+  Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   std::vector<unsigned int> subdivisions (dim, 1);
   subdivisions[0] = 2;
 


### PR DESCRIPTION
This fixes #310 by asserting that `Triangulation::limit_level_difference_at_vertices` is set when `distribute_mg_dof` is called.
As discussed in #310, we already set this smoothing requirement for `parallel::distributed::Triangulation` in `copy_local_forest_to_triangulation` implicitly even if the Triangulation is initialized with. `Triangulation::none`.

This PR does not change any output in the related tests apart from `multigrid/step-39-02`, `multigrid/step-39-02a`, `multigrid/step-39-03` and `multigrid/step-39` where previously didn't require that smoothing requirement.