### PR TITLE
Improve an error message by duplicating text from the input file.

### DIFF
--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -510,6 +510,15 @@ public:
   /**
    * Exception
    */
+  DeclException3 (ExcInvalidVertexIndexGmsh,
+                  int, int, int,
+                  << "While creating cell " << arg1
+                  << " (which is numbered as " << arg2
+                  << " in the input file), you are referencing a vertex with index " << arg3
+                  << " but no vertex with this index has been described in the input file.");
+  /**
+   * Exception
+   */
   DeclException0 (ExcInvalidDBMeshFormat);
   /**
    * Exception

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2015 by the deal.II authors
+// Copyright (C) 1999 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1348,7 +1348,8 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
         material id.
       */
 
-      in >> dummy          // ELM-NUMBER
+      unsigned int elm_number;
+      in >> elm_number     // ELM-NUMBER
          >> cell_type;     // ELM-TYPE
 
       switch (gmsh_file_format)
@@ -1430,7 +1431,8 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
             {
               AssertThrow (vertex_indices.find (cells.back().vertices[i]) !=
                            vertex_indices.end(),
-                           ExcInvalidVertexIndex(cell, cells.back().vertices[i]));
+                           ExcInvalidVertexIndexGmsh(cell, elm_number,
+                                                     cells.back().vertices[i]));
 
               // vertex with this index exists
               cells.back().vertices[i] = vertex_indices[cells.back().vertices[i]];


### PR DESCRIPTION
This is motivated by a question on the mailing list. We only printed the internal
number of the cell, edge, or point, but should really be printing the number that
is used in the input file.