### PR TITLE
Remove exceptions without error messages.

### DIFF
--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -204,10 +204,6 @@ public:
   DifferenceFormula
   get_formula_of_order (const unsigned int ord);
 
-  /**
-   * Exception.
-   */
-  DeclException0(ExcInvalidFormula);
 
 private:
 

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -101,16 +101,6 @@ public:
    */
   std::size_t memory_consumption () const;
 
-  /**
-   * @addtogroup Exceptions
-   * @{
-   */
-
-  /**
-   * Exception.
-   */
-  DeclException0(ExcInvalidFormula);
-  //@}
 private:
   /**
    * Function for differentiation.

--- a/source/base/auto_derivative_function.cc
+++ b/source/base/auto_derivative_function.cc
@@ -47,6 +47,19 @@ template <int dim>
 void
 AutoDerivativeFunction<dim>::set_formula (const DifferenceFormula form)
 {
+  // go through all known formulas, reject ones we don't know about
+  // and don't handle in the member functions of this class
+  switch (form)
+    {
+    case Euler:
+    case UpwindEuler:
+    case FourthOrder:
+      break;
+    default:
+      Assert(false, ExcMessage("The argument passed to this function does not "
+                               "match any known difference formula."));
+    }
+
   formula = form;
 }
 
@@ -108,7 +121,7 @@ AutoDerivativeFunction<dim>::gradient (const Point<dim>   &p,
       break;
     }
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
   return grad;
 }
@@ -185,7 +198,7 @@ vector_gradient (const Point<dim>            &p,
     }
 
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
 }
 
@@ -246,7 +259,7 @@ gradient_list (const std::vector<Point<dim> > &points,
     }
 
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
 }
 
@@ -314,7 +327,7 @@ vector_gradient_list (const std::vector<Point<dim> >            &points,
     }
 
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
 }
 

--- a/source/base/function_derivative.cc
+++ b/source/base/function_derivative.cc
@@ -57,6 +57,19 @@ template <int dim>
 void
 FunctionDerivative<dim>::set_formula (typename AutoDerivativeFunction<dim>::DifferenceFormula form)
 {
+  // go through all known formulas, reject ones we don't know about
+  // and don't handle in the member functions of this class
+  switch (form)
+    {
+    case AutoDerivativeFunction<dim>::Euler:
+    case AutoDerivativeFunction<dim>::UpwindEuler:
+    case AutoDerivativeFunction<dim>::FourthOrder:
+      break;
+    default:
+      Assert(false, ExcMessage("The argument passed to this function does not "
+                               "match any known difference formula."));
+    }
+
   formula = form;
 }
 
@@ -91,7 +104,7 @@ FunctionDerivative<dim>::value (const Point<dim>   &p,
       return (-f.value(p+2*incr[0], component) + 8*f.value(p+incr[0], component)
               -8*f.value(p-incr[0], component) + f.value(p-2*incr[0], component))/(12*h);
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
   return 0.;
 }
@@ -134,7 +147,7 @@ FunctionDerivative<dim>::vector_value (
       result/=(12.*h);
       return;
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
 }
 
@@ -200,7 +213,7 @@ FunctionDerivative<dim>::value_list (const std::vector<Point<dim> > &points,
         values[i] = (values[i] - 8.*aux[i])/(12*h);
       return;
     default:
-      Assert(false, ExcInvalidFormula());
+      Assert(false, ExcNotImplemented());
     }
 }
 


### PR DESCRIPTION
Here, just check that a valid value is set for the finite difference formula. Later on,
we should then not ever get an invalid value any more, but if we do, we can just say
that whatever we got is not implemented.

Part of my eternal quest in #610.