### PR TITLE
Initialize two member variables.

### DIFF
--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -667,6 +667,8 @@ namespace internal
     inline
     TriaObjects<G>::TriaObjects()
       :
+      next_free_single (numbers::invalid_unsigned_int),
+      next_free_pair (numbers::invalid_unsigned_int),
       reverse_order_next_free_single (false),
       user_data_type(data_unknown)
     {}


### PR DESCRIPTION
While tracking down an ubsan warning in a really old version of deal.II that will,
one day, hopefully be part of the next SPEC CPU benchmark, I came to realize that we
do not initialize two member variables of class TriaObjects. This is not a problem:
these members are initialized once, in a member function, we actually allocate
the memory that this class provides. But it may lead to warnings about reading
from uninitialized memory locations when a newly created TriaObjects object
is copied to another one, as happens when a std::vector<TriaObjects> is resized.

In other words, this patch really doesn't fix anything that was actively wrong
before, it is just keeping to good sanitary conditions throughout our code base.