### PR TITLE
Disable an assertion in BOOST that GCC 6.x warns about.

### DIFF
--- a/bundled/boost-1.56.0/include/boost/archive/detail/basic_serializer.hpp
+++ b/bundled/boost-1.56.0/include/boost/archive/detail/basic_serializer.hpp
@@ -42,7 +42,6 @@ protected:
     ) : 
         m_eti(& eti)
     {
-        BOOST_ASSERT(NULL != & eti);
     }
 public:
     inline bool 


### PR DESCRIPTION
GCC says that the compiler can assume that the address of the object that a reference
points to must be nonzero. That's correct. But the warning happens many times during
a build. Since this is more of a sanity check for what the BOOST people are doing
internally, I think there is little harm in just removing the assertion -- we
don't change the BOOST code anyway.