### PR TITLE
Allow for nonlinear contiguous IndexSets for creating EpetraMaps

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -521,6 +521,20 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Fixed: IndexSet::make_trilinos_map now treats non-ascending but
+ contiguous IndexSets correctly. It creates a linear EpetraMap only
+ if the IndexSets are ascending and 1:1.
+ <br>
+ (Daniel Arndt, 2016/09/11)
+ </li>
+
+ <li> New: IndexSet::is_ascending_and_one_to_one allows to find out 
+ whether the nth range of indices is stored on the nth process in case 
+ the IndexSets are contiguous.
+ <br>
+ (Daniel Arndt, 2016/09/11)
+ </li>
+
  <li> Fixed: FE_TraceQ now provides unit support points.
  <br>
  (Martin Kronbichler, 2016/09/08)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -218,13 +218,14 @@ public:
   bool is_contiguous () const;
 
   /**
-   * Return whether the index set stored by this object defines a linear
-   * range, i.e., each index is contained in exactly one IndexSet,
+   * Return whether the IndexSets are ascending with respect to MPI process
+   * number, i.e., each index is contained in exactly one IndexSet,
    * the first indices are contained in the IndexSet of the first MPI process,
    * the second indices are contained in the IndexSet of the second MPI process
    * and so on.
+   * In case there is only one MPI process, this is always true.
    */
-  bool is_linear() const;
+  bool is_globally_ascending() const;
 
   /**
    * Return the number of elements stored in this index set.

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -218,6 +218,15 @@ public:
   bool is_contiguous () const;
 
   /**
+   * Return whether the index set stored by this object defines a linear
+   * range, i.e., each index is contained in exactly one IndexSet,
+   * the first indices are contained in the IndexSet of the first MPI process,
+   * the second indices are contained in the IndexSet of the second MPI process
+   * and so on.
+   */
+  bool is_linear() const;
+
+  /**
    * Return the number of elements stored in this index set.
    */
   size_type n_elements () const;

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -219,13 +219,14 @@ public:
 
   /**
    * Return whether the IndexSets are ascending with respect to MPI process
-   * number, i.e., each index is contained in exactly one IndexSet,
-   * the first indices are contained in the IndexSet of the first MPI process,
-   * the second indices are contained in the IndexSet of the second MPI process
-   * and so on.
-   * In case there is only one MPI process, this is always true.
+   * number and 1:1, i.e., each index is contained in exactly one IndexSet
+   * (among those stored on the different processes), each process stores
+   * contiguous subset of indices, and the index set on process $p+1$ starts
+   * at the index one larger than the last one stored on process $p$.
+   * In case there is only one MPI process, this just means that the IndexSet
+   * is complete.
    */
-  bool is_globally_ascending() const;
+  bool is_ascending_and_one_to_one(const MPI_Comm &communicator) const;
 
   /**
    * Return the number of elements stored in this index set.

--- a/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
@@ -149,8 +149,8 @@ namespace PETScWrappers
        * the BlockSparsityPattern of the Simple type can efficiently store
        * large sparsity patterns in parallel, so this is the only supported
        * argument. The IndexSets describe the locally owned range of DoFs for
-       * each block. Note that each IndexSet needs to be contiguous. For a
-       * symmetric structure hand in the same vector for the first two
+       * each block. Note that the IndexSets needs to be ascending and 1:1.
+       * For a symmetric structure hand in the same vector for the first two
        * arguments.
        */
       void reinit(const std::vector<IndexSet> &rows,

--- a/include/deal.II/lac/petsc_parallel_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_sparse_matrix.h
@@ -317,7 +317,7 @@ namespace PETScWrappers
        * Create a matrix where the size() of the IndexSets determine the
        * global number of rows and columns and the entries of the IndexSet
        * give the rows and columns for the calling processor. Note that only
-       * contiguous IndexSets are supported.
+       * ascending, 1:1 IndexSets are supported.
        */
       template <typename SparsityPatternType>
       void reinit (const IndexSet            &local_rows,

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -230,10 +230,11 @@ namespace PETScWrappers
                        const size_type     local_size);
 
       /**
-       * Construct a new parallel ghosted PETSc vector from an IndexSet. Note
-       * that @p local must be contiguous and the global size of the vector is
-       * determined by local.size(). The global indices in @p ghost are
-       * supplied as ghost indices that can also be read locally.
+       * Construct a new parallel ghosted PETSc vector from an IndexSet.
+       * Note that @p local must be ascending and 1:1.
+       * The global size of the vector is determined by local.size().
+       * The global indices in @p ghost are supplied as ghost indices
+       * that can also be read locally.
        *
        * Note that the @p ghost IndexSet may be empty and that any indices
        * already contained in @p local are ignored during construction. That

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -354,6 +354,7 @@ namespace PETScWrappers
              ExcMessage("SparsityPattern and IndexSet have different number of columns"));
       Assert(local_rows.is_contiguous() && local_columns.is_contiguous(),
              ExcMessage("PETSc only supports contiguous row/column ranges"));
+      Assert(local_rows.is_ascending_and_one_to_one(communicator), ExcNotImplemented());
 
 #ifdef DEBUG
       {

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -72,7 +72,7 @@ namespace PETScWrappers
       :
       communicator (communicator)
     {
-      Assert(local.is_contiguous(), ExcNotImplemented());
+      Assert(local.is_ascending_and_one_to_one(communicator), ExcNotImplemented());
 
       IndexSet ghost_set = ghost;
       ghost_set.subtract_set(local);
@@ -87,7 +87,7 @@ namespace PETScWrappers
       :
       communicator (communicator)
     {
-      Assert(local.is_contiguous(), ExcNotImplemented());
+      Assert(local.is_ascending_and_one_to_one(communicator), ExcNotImplemented());
       Vector::create_vector(local.size(), local.n_elements());
     }
 
@@ -189,7 +189,7 @@ namespace PETScWrappers
 
       communicator = comm;
 
-      Assert(local.is_contiguous(), ExcNotImplemented());
+      Assert(local.is_ascending_and_one_to_one(comm), ExcNotImplemented());
 
       IndexSet ghost_set = ghost;
       ghost_set.subtract_set(local);
@@ -211,7 +211,7 @@ namespace PETScWrappers
 
       communicator = comm;
 
-      Assert(local.is_contiguous(), ExcNotImplemented());
+      Assert(local.is_ascending_and_one_to_one(comm), ExcNotImplemented());
       Assert(local.size()>0, ExcMessage("can not create vector of size 0."));
       create_vector(local.size(), local.n_elements());
     }

--- a/tests/trilinos/precondition_muelu_q_iso_q1.cc
+++ b/tests/trilinos/precondition_muelu_q_iso_q1.cc
@@ -276,7 +276,7 @@ void Step4<dim>::solve ()
     check_solver_within_range(
       solver.solve (system_matrix, solution, system_rhs,
                     preconditioner),
-      solver_control.last_step(), 25, 34);
+      solver_control.last_step(), 20, 34);
   }
   deallog.pop();
 
@@ -290,7 +290,7 @@ void Step4<dim>::solve ()
     check_solver_within_range(
       solver.solve (system_matrix, solution, system_rhs,
                     preconditioner),
-      solver_control.last_step(), 24, 40);
+      solver_control.last_step(), 20, 40);
   }
   deallog.pop();
   deallog << std::endl;

--- a/tests/trilinos/precondition_muelu_q_iso_q1.with_trilinos.geq.11.14.with_64bit_indices=off.output
+++ b/tests/trilinos/precondition_muelu_q_iso_q1.with_trilinos.geq.11.14.with_64bit_indices=off.output
@@ -1,7 +1,7 @@
 
-DEAL:02401:MueLu_Q::Solver stopped within 25 - 34 iterations
-DEAL:02401:MueLu_Q_iso_Q1::Solver stopped within 24 - 40 iterations
+DEAL:02401:MueLu_Q::Solver stopped within 20 - 34 iterations
+DEAL:02401:MueLu_Q_iso_Q1::Solver stopped within 20 - 40 iterations
 DEAL:02401::
-DEAL:09409:MueLu_Q::Solver stopped within 25 - 34 iterations
-DEAL:09409:MueLu_Q_iso_Q1::Solver stopped within 24 - 40 iterations
+DEAL:09409:MueLu_Q::Solver stopped within 20 - 34 iterations
+DEAL:09409:MueLu_Q_iso_Q1::Solver stopped within 20 - 40 iterations
 DEAL:09409::

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test that dof renumbering is also reflected in TrilinosWrappers::SparseMatrix
+
+#include "../tests.h"
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_renumbering.h>
+
+#include <mpi.h>
+
+#include <vector>
+#include <iostream>
+
+using namespace dealii;
+
+class Test
+{
+private:
+  MPI_Comm mpi_communicator;
+
+  const unsigned int rank;
+  const unsigned int n_ranks;
+
+  parallel::distributed::Triangulation<2> triangulation;
+
+  DoFHandler<2> dof_handler;
+
+  FE_Q<2> fe;
+
+  ConstraintMatrix constraints;
+
+  IndexSet locally_owned_dofs;
+  IndexSet locally_relevant_dofs;
+
+  TrilinosWrappers::SparseMatrix system_matrix;
+
+public:
+  Test(const bool do_renumber) :
+    mpi_communicator(MPI_COMM_WORLD),
+    rank(Utilities::MPI::this_mpi_process(mpi_communicator)),
+    n_ranks(Utilities::MPI::n_mpi_processes(mpi_communicator)),
+    triangulation(mpi_communicator),
+    dof_handler(triangulation),
+    fe(1)
+  {
+    deallog << "Start";
+
+    if (do_renumber)
+      deallog << " with renumbering" << std::endl;
+    else
+      deallog << " without renumbering" << std::endl;
+
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(2);
+
+    dof_handler.distribute_dofs(fe);
+
+    constraints.clear();
+    constraints.close();
+
+    if (do_renumber) renumber();
+
+    init_structures();
+
+    deallog << "Finished";
+
+    if (do_renumber)
+      deallog << " with renumbering" << std::endl;
+    else
+      deallog << " without renumbering" << std::endl;
+  }
+
+  ~Test ()
+  {
+    dof_handler.clear();
+  }
+
+private:
+
+  void init_structures()
+  {
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+    locally_owned_dofs.print(deallog);
+    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs.print(deallog);
+
+    DynamicSparsityPattern sparsity_pattern (locally_relevant_dofs);
+    DoFTools::make_sparsity_pattern (dof_handler, sparsity_pattern,
+                                     constraints, /*keep constrained dofs*/ false);
+    SparsityTools::distribute_sparsity_pattern (sparsity_pattern,
+                                                dof_handler.n_locally_owned_dofs_per_processor(),
+                                                MPI_COMM_WORLD,
+                                                locally_relevant_dofs);
+
+    system_matrix.reinit (locally_owned_dofs,
+                          locally_owned_dofs,
+                          sparsity_pattern,
+                          MPI_COMM_WORLD);
+    deallog << "local_range: " << system_matrix.local_range().first << " - "
+            << system_matrix.local_range().second << std::endl;
+  }
+
+  void renumber()
+  {
+    //DoFRenumbering::Cuthill_McKee(dof_handler);
+
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+
+    std::vector<types::global_dof_index> new_number(dof_handler.n_dofs());
+    for (types::global_dof_index i = 0; i < dof_handler.n_dofs(); i++)
+      new_number[i] = dof_handler.n_dofs() - i - 1;
+
+    std::vector<types::global_dof_index> local_new_number;
+    for (IndexSet::ElementIterator dof = locally_owned_dofs.begin();
+         dof != locally_owned_dofs.end(); ++dof)
+      local_new_number.push_back(new_number[*dof]);
+
+    deallog << "n_dofs = " << dof_handler.n_dofs() << std::endl;
+    deallog << "before renumbering:" << std::endl;
+    locally_owned_dofs.print(dealii::deallog);
+    dof_handler.renumber_dofs(local_new_number);
+
+    deallog << "after renumbering:" << std::endl;
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+    locally_owned_dofs.print(dealii::deallog);
+  }
+};
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  MPILogInitAll log;
+
+  Test test1(false);
+  MPI_Barrier(MPI_COMM_WORLD);
+  Test test2(true);
+
+  return 0;
+}

--- a/tests/trilinos/renumbering_01.mpirun=1.output
+++ b/tests/trilinos/renumbering_01.mpirun=1.output
@@ -1,0 +1,16 @@
+
+DEAL:0::Start without renumbering
+DEAL:0::{[0,24]}
+DEAL:0::{[0,24]}
+DEAL:0::local_range: 0 - 25
+DEAL:0::Finished without renumbering
+DEAL:0::Start with renumbering
+DEAL:0::n_dofs = 25
+DEAL:0::before renumbering:
+DEAL:0::{[0,24]}
+DEAL:0::after renumbering:
+DEAL:0::{[0,24]}
+DEAL:0::{[0,24]}
+DEAL:0::{[0,24]}
+DEAL:0::local_range: 0 - 25
+DEAL:0::Finished with renumbering

--- a/tests/trilinos/renumbering_01.mpirun=2.output
+++ b/tests/trilinos/renumbering_01.mpirun=2.output
@@ -1,0 +1,33 @@
+
+DEAL:0::Start without renumbering
+DEAL:0::{[0,14]}
+DEAL:0::{[0,17], [21,22]}
+DEAL:0::local_range: 0 - 15
+DEAL:0::Finished without renumbering
+DEAL:0::Start with renumbering
+DEAL:0::n_dofs = 25
+DEAL:0::before renumbering:
+DEAL:0::{[0,14]}
+DEAL:0::after renumbering:
+DEAL:0::{[10,24]}
+DEAL:0::{[10,24]}
+DEAL:0::{[2,3], [7,24]}
+DEAL:0::local_range: 10 - 25
+DEAL:0::Finished with renumbering
+
+DEAL:1::Start without renumbering
+DEAL:1::{[15,24]}
+DEAL:1::{[2,3], [5,8], 10, [12,24]}
+DEAL:1::local_range: 15 - 25
+DEAL:1::Finished without renumbering
+DEAL:1::Start with renumbering
+DEAL:1::n_dofs = 25
+DEAL:1::before renumbering:
+DEAL:1::{[15,24]}
+DEAL:1::after renumbering:
+DEAL:1::{[0,9]}
+DEAL:1::{[0,9]}
+DEAL:1::{[0,12], 14, [16,19], [21,22]}
+DEAL:1::local_range: 0 - 10
+DEAL:1::Finished with renumbering
+


### PR DESCRIPTION
Part of the problems in #2966 that an IndexSet creates a linear EpetraMap if it is contiguous.
We should just check ourselves for the linearity of the IndexSet or always provide the local elements.

For some reason trilinos/trilinos_sparsity_pattern_04.mpirun=3.debug is failing on this.