### PR TITLE
Initialize a member variable.

### DIFF
--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -419,7 +419,8 @@ public:
    * then this is always the case.
    *
    * Since this is an extremely common operation, the result is cached in the
-   * #cached_primitivity variable which is computed in the constructor.
+   * #cached_primitivity variable which is computed in the constructor of the
+   * derived class FiniteElement.
    */
   bool is_primitive () const;
 

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -61,7 +61,12 @@ FiniteElementData (const std::vector<unsigned int> &dofs_per_object,
                      ?
                      BlockIndices(1, dofs_per_cell)
                      :
-                     block_indices)
+                     block_indices),
+  // the following field is only set in the FiniteElement
+  // constructor by calling set_primitivity() of this base
+  // class. however, to ensure that we always have boolean
+  // values, initialize it with the safe choice
+  cached_primitivity (false)
 {
   Assert(dofs_per_object.size()==dim+1, ExcDimensionMismatch(dofs_per_object.size()-1,dim));
 }


### PR DESCRIPTION
This is not strictly necessary, because the variable is later initialized in
constructors of derived classes, but the patch avoids copying uninitialized
variables when copying around objects of type FiniteElementData. (There are
cases when we pass around these objects, without actually using derived
classes; but in those cases, the flag appears to be unused.

This avoids an error by ubsan.