### PR TITLE
Remove Make.global_options from a content list.

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -17,7 +17,6 @@ config
 Contains configuration templates for
 
   * the project configuration (deal.IIConfig.cmake)
-  * the legacy Make.global_options mechanism
   * the C++ template expansion mechanism (template-arguments)
 
 configure


### PR DESCRIPTION
One more little commit for today :)

This feature was removed in commit 359e60b351c (March 2016).