### PR TITLE
Fix bug in AnyData::try_read_ptr()

### DIFF
--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -275,6 +275,8 @@ AnyData::try_read_ptr(const unsigned int i) const
   const type *const *p = boost::any_cast<type *>(&data[i]);
   if (p==0)
     p = boost::any_cast<const type *>(&data[i]);
+  if (p==0)
+    return 0;
   return *p;
 }
 


### PR DESCRIPTION
AnyData::try_read_ptr() would return the correct const pointer, whether the stored data was const or not. But it produced a segmentation fault if a completely different type was asked for.

Now, it will return a null pointer for any mismatch.