### PR TITLE
Provide error texts to more exceptions.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1861,11 +1861,17 @@ namespace DataOutBase
   /**
    * An output function did not receive any patches for writing.
    */
-  DeclException0 (ExcNoPatches);
+  DeclExceptionMsg (ExcNoPatches,
+                    "You are trying to write graphical data into a file, but "
+                    "no data is available in the intermediate format that "
+                    "the DataOutBase functions require. Did you forget to "
+                    "call a function such as DataOut::build_patches()?");
   /**
    * Exception
    */
-  DeclException0 (ExcTecplotAPIError);
+  DeclExceptionMsg (ExcTecplotAPIError,
+                    "The error code of one of the Tecplot functions was "
+                    "not zero as expected.");
   /**
    * Exception
    */
@@ -2644,10 +2650,6 @@ public:
    */
   void merge (const DataOutReader<dim,spacedim> &other);
 
-  /**
-   * Exception
-   */
-  DeclException0 (ExcNoPatches);
   /**
    * Exception
    */

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7420,8 +7420,8 @@ merge (const DataOutReader<dim,spacedim> &source)
 
 
   const std::vector<Patch> source_patches = source.get_patches ();
-  Assert (patches.size () != 0,        ExcNoPatches ());
-  Assert (source_patches.size () != 0, ExcNoPatches ());
+  Assert (patches.size () != 0,        DataOutBase::ExcNoPatches ());
+  Assert (source_patches.size () != 0, DataOutBase::ExcNoPatches ());
   // check equality of component
   // names
   Assert (get_dataset_names() == source.get_dataset_names(),


### PR DESCRIPTION
Also remove one exception for which an equally named exception is
already available and for wihch I'm providing an error text as part of
this patch.

Part of #610.