### PR TITLE
Proposed fix to problem with #3039

### DIFF
--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3681,6 +3681,8 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   this->fe_data.reset (fe_get_data.return_value());
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
+  else
+    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
 }
 
 
@@ -3930,6 +3932,8 @@ FEFaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   this->fe_data.reset (fe_get_data.return_value());
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
+  else
+    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
 }
 
 
@@ -4097,6 +4101,8 @@ FESubfaceValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   this->fe_data.reset (fe_get_data.return_value());
   if (flags & update_mapping)
     this->mapping_data.reset (mapping_get_data.return_value());
+  else
+    this->mapping_data.reset (new typename Mapping<dim,spacedim>::InternalDataBase());
 }
 
 


### PR DESCRIPTION
If C++11 is not in use #3039 causes problems.

This is a possible fix to the problem, which will construct a Mapping::InternalDataBase to be the target of the unique_ptr if C++11 is not in use. Depending on commentary it may be reasonable to use this approach for both code cases.