### PR TITLE
parallelize block inversion

### DIFF
--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -249,6 +249,12 @@ protected:
    * Control information.
    */
   SmartPointer<const AdditionalData, RelaxationBlock<MatrixType, InverseNumberType, VectorType> > additional_data;
+
+private:
+  /**
+   * Computes (the inverse of) a range of blocks.
+   */
+  void block_kernel(const size_type block_begin, const size_type block_end);
 };
 
 


### PR DESCRIPTION
Compute blocks (and their inverses) in parallel for RelaxationBlock. Class is already being tested in `lac/solver_relaxation_0{2,3,4}.cclac/solver_relaxation_0{2,3,4}.cc`. I also tried to compute multiple blocks per task but didn't see much of a difference in performance and thus went with the simplest solution.