### PR TITLE
Reorder loop over tensor polynomials.

### DIFF
--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -105,16 +105,16 @@ namespace Polynomials
 
     /**
      * Return the values and the derivatives of the Polynomial at point
-     * <tt>x</tt>.  <tt>values[i], i=0,...,values_size-1</tt> includes the
+     * <tt>x</tt>.  <tt>values[i], i=0,...,n_derivatives</tt> includes the
      * <tt>i</tt>th derivative. The number of derivatives to be computed is
-     * determined by @p values_size and @p values has to provide sufficient
-     * space for @p values_size values.
+     * determined by @p n_derivatives and @p values has to provide sufficient
+     * space for @p n_derivatives + 1 values.
      *
      * This function uses the Horner scheme for numerical stability of the
      * evaluation.
      */
     void value (const number         x,
-                const unsigned int values_size,
+                const unsigned int n_derivatives,
                 number *values) const;
 
     /**

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -104,6 +104,20 @@ namespace Polynomials
                 std::vector<number> &values) const;
 
     /**
+     * Return the values and the derivatives of the Polynomial at point
+     * <tt>x</tt>.  <tt>values[i], i=0,...,values_size-1</tt> includes the
+     * <tt>i</tt>th derivative. The number of derivatives to be computed is
+     * determined by @p values_size and @p values has to provide sufficient
+     * space for @p values_size values.
+     *
+     * This function uses the Horner scheme for numerical stability of the
+     * evaluation.
+     */
+    void value (const number         x,
+                const unsigned int values_size,
+                number *values) const;
+
+    /**
      * Degree of the polynomial. This is the degree reflected by the number of
      * coefficients provided by the constructor. Leading non-zero coefficients
      * are not treated separately.

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -98,10 +98,10 @@ namespace Polynomials
 
     /**
      * Return the values and the derivatives of the Polynomial at point
-     * <tt>x</tt>.  <tt>values[i], i=0,...,values_size-1</tt> includes the
+     * <tt>x</tt>.  <tt>values[i], i=0,...,n_derivatives</tt> includes the
      * <tt>i</tt>th derivative.The number of derivatives to be computed is
-     * determined by @p values_size and @p values has to provide sufficient
-     * space for @p values_size values.
+     * determined by @p n_derivatives and @p values has to provide sufficient
+     * space for @p n_derivatives + 1 values.
      *
      * Note that all the derivatives evaluate to zero at the border between
      * intervals (assuming exact arithmetics) in the interior of the unit
@@ -112,7 +112,7 @@ namespace Polynomials
      * make sense.
      */
     void value (const number         x,
-                const unsigned int values_size,
+                const unsigned int n_derivatives,
                 number *values) const;
 
     /**

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -83,7 +83,7 @@ namespace Polynomials
      * Return the values and the derivatives of the Polynomial at point
      * <tt>x</tt>.  <tt>values[i], i=0,...,values.size()-1</tt> includes the
      * <tt>i</tt>th derivative. The number of derivatives to be computed is
-     * thus determined by the size of the array passed.
+     * thus determined by the size of the vector passed.
      *
      * Note that all the derivatives evaluate to zero at the border between
      * intervals (assuming exact arithmetics) in the interior of the unit
@@ -95,6 +95,25 @@ namespace Polynomials
      */
     void value (const number         x,
                 std::vector<number> &values) const;
+
+    /**
+     * Return the values and the derivatives of the Polynomial at point
+     * <tt>x</tt>.  <tt>values[i], i=0,...,values_size-1</tt> includes the
+     * <tt>i</tt>th derivative.The number of derivatives to be computed is
+     * determined by @p values_size and @p values has to provide sufficient
+     * space for @p values_size values.
+     *
+     * Note that all the derivatives evaluate to zero at the border between
+     * intervals (assuming exact arithmetics) in the interior of the unit
+     * interval, as there is no unique gradient value in that case for a
+     * piecewise polynomial. This is not always desired (e.g., when evaluating
+     * jumps of gradients on the element boundary), but it is the user's
+     * responsibility to avoid evaluation at these points when it does not
+     * make sense.
+     */
+    void value (const number         x,
+                const unsigned int values_size,
+                number *values) const;
 
     /**
      * Degree of the polynomial. This is the degree of the underlying base

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -102,7 +102,19 @@ namespace Polynomials
                              std::vector<number> &values) const
   {
     Assert (values.size() > 0, ExcZero());
-    const unsigned int values_size=values.size();
+
+    value(x,values.size(),&values[0]);
+  }
+
+
+
+  template <typename number>
+  void
+  Polynomial<number>::value (const number         x,
+                             const unsigned int values_size,
+                             number *values) const
+  {
+    Assert(values_size > 0, ExcZero());
 
     // evaluate Lagrange polynomial and derivatives
     if (in_lagrange_product_form == true)

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -103,7 +103,7 @@ namespace Polynomials
   {
     Assert (values.size() > 0, ExcZero());
 
-    value(x,values.size(),&values[0]);
+    value(x,values.size()-1,&values[0]);
   }
 
 
@@ -111,10 +111,10 @@ namespace Polynomials
   template <typename number>
   void
   Polynomial<number>::value (const number         x,
-                             const unsigned int values_size,
+                             const unsigned int n_derivatives,
                              number *values) const
   {
-    Assert(values_size > 0, ExcZero());
+    Assert(n_derivatives >= 0, ExcZero());
 
     // evaluate Lagrange polynomial and derivatives
     if (in_lagrange_product_form == true)
@@ -123,11 +123,11 @@ namespace Polynomials
         // form (x-x_1)*(x-x_2)*...*(x-x_n), expand the derivatives like
         // automatic differentiation does.
         const unsigned int n_supp = lagrange_support_points.size();
-        switch (values_size)
+        switch (n_derivatives)
           {
           default:
             values[0] = 1;
-            for (unsigned int d=1; d<values_size; ++d)
+            for (unsigned int d=1; d<=n_derivatives; ++d)
               values[d] = 0;
             for (unsigned int i=0; i<n_supp; ++i)
               {
@@ -139,7 +139,7 @@ namespace Polynomials
                 // i.e., expand value v and derivative one). since we reuse a
                 // value from the next lower derivative from the steps before,
                 // need to start from the highest derivative
-                for (unsigned int k=values_size-1; k>0; --k)
+                for (unsigned int k=n_derivatives; k>0; --k)
                   values[k] = (values[k] * v + values[k-1]);
                 values[0] *= v;
               }
@@ -153,7 +153,7 @@ namespace Polynomials
             // p^(n)(x)/k! into the actual form of the derivative
             {
               number k_faculty = 1;
-              for (unsigned int k=0; k<values_size; ++k)
+              for (unsigned int k=0; k<=n_derivatives; ++k)
                 {
                   values[k] *= k_faculty * lagrange_weight;
                   k_faculty *= static_cast<number>(k+1);
@@ -161,10 +161,10 @@ namespace Polynomials
             }
             break;
 
-          // manually implement size 1 (values only), size 2 (value + first
-          // derivative), and size 3 (up to second derivative) since they
+          // manually implement case 0 (values only), case 1 (value + first
+          // derivative), and case 2 (up to second derivative) since they
           // might be called often. then, we can unroll the loop.
-          case 1:
+          case 0:
             values[0] = 1;
             for (unsigned int i=0; i<n_supp; ++i)
               {
@@ -174,7 +174,7 @@ namespace Polynomials
             values[0] *= lagrange_weight;
             break;
 
-          case 2:
+          case 1:
             values[0] = 1;
             values[1] = 0;
             for (unsigned int i=0; i<n_supp; ++i)
@@ -187,7 +187,7 @@ namespace Polynomials
             values[1] *= lagrange_weight;
             break;
 
-          case 3:
+          case 2:
             values[0] = 1;
             values[1] = 0;
             values[2] = 0;
@@ -211,7 +211,7 @@ namespace Polynomials
     // if we only need the value, then call the other function since that is
     // significantly faster (there is no need to allocate and free memory,
     // which is really expensive compared to all the other operations!)
-    if (values_size == 1)
+    if (n_derivatives == 0)
       {
         values[0] = value(x);
         return;
@@ -226,7 +226,7 @@ namespace Polynomials
     // loop over all requested derivatives. note that derivatives @p{j>m} are
     // necessarily zero, as they differentiate the polynomial more often than
     // the highest power is
-    const unsigned int min_valuessize_m=std::min(values_size, m);
+    const unsigned int min_valuessize_m=std::min(n_derivatives+1, m);
     for (unsigned int j=0; j<min_valuessize_m; ++j)
       {
         for (int k=m-2; k>=static_cast<int>(j); --k)
@@ -237,7 +237,7 @@ namespace Polynomials
       }
 
     // fill higher derivatives by zero
-    for (unsigned int j=min_valuessize_m; j<values_size; ++j)
+    for (unsigned int j=min_valuessize_m; j<=n_derivatives; ++j)
       values[j] = 0;
   }
 

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -46,7 +46,19 @@ namespace Polynomials
                                       std::vector<number> &values) const
   {
     Assert (values.size() > 0, ExcZero());
-    const unsigned int values_size=values.size();
+
+    value(x,values.size(),&values[0]);
+  }
+
+
+
+  template <typename number>
+  void
+  PiecewisePolynomial<number>::value (const number         x,
+                                      const unsigned int values_size,
+                                      number *values) const
+  {
+    Assert (values_size > 0, ExcZero());
 
     // shift polynomial if necessary
     number y = x;
@@ -60,7 +72,7 @@ namespace Polynomials
             const double offset = step * interval;
             if (x<offset || x>offset+step+step)
               {
-                for (unsigned int k=0; k<values.size(); ++k)
+                for (unsigned int k=0; k<values_size; ++k)
                   values[k] = 0;
                 return;
               }
@@ -77,7 +89,7 @@ namespace Polynomials
             const double offset = step * interval;
             if (x<offset || x>offset+step)
               {
-                for (unsigned int k=0; k<values.size(); ++k)
+                for (unsigned int k=0; k<values_size; ++k)
                   values[k] = 0;
                 return;
               }
@@ -100,7 +112,7 @@ namespace Polynomials
           }
       }
 
-    polynomial.value(y, values);
+    polynomial.value(y, values_size, values);
 
     // change sign if necessary
     for (unsigned int j=1; j<values_size; j+=2)

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -47,7 +47,7 @@ namespace Polynomials
   {
     Assert (values.size() > 0, ExcZero());
 
-    value(x,values.size(),&values[0]);
+    value(x,values.size()-1,&values[0]);
   }
 
 
@@ -55,10 +55,10 @@ namespace Polynomials
   template <typename number>
   void
   PiecewisePolynomial<number>::value (const number         x,
-                                      const unsigned int values_size,
+                                      const unsigned int n_derivatives,
                                       number *values) const
   {
-    Assert (values_size > 0, ExcZero());
+    Assert (n_derivatives >= 0, ExcZero());
 
     // shift polynomial if necessary
     number y = x;
@@ -72,7 +72,7 @@ namespace Polynomials
             const double offset = step * interval;
             if (x<offset || x>offset+step+step)
               {
-                for (unsigned int k=0; k<values_size; ++k)
+                for (unsigned int k=0; k<=n_derivatives; ++k)
                   values[k] = 0;
                 return;
               }
@@ -89,7 +89,7 @@ namespace Polynomials
             const double offset = step * interval;
             if (x<offset || x>offset+step)
               {
-                for (unsigned int k=0; k<values_size; ++k)
+                for (unsigned int k=0; k<=n_derivatives; ++k)
                   values[k] = 0;
                 return;
               }
@@ -106,16 +106,16 @@ namespace Polynomials
              (interval < n_intervals-1 || derivative_change_sign == -1.)))
           {
             values[0] = value(x);
-            for (unsigned int d=1; d<values_size; ++d)
+            for (unsigned int d=1; d<=n_derivatives; ++d)
               values[d] = 0;
             return;
           }
       }
 
-    polynomial.value(y, values_size, values);
+    polynomial.value(y, n_derivatives, values);
 
     // change sign if necessary
-    for (unsigned int j=1; j<values_size; j+=2)
+    for (unsigned int j=1; j<=n_derivatives; j+=2)
       values[j] *= derivative_change_sign;
   }
 

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -18,6 +18,8 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/table.h>
 
+#include <deal.II/base/std_cxx11/array.h>
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -254,7 +256,7 @@ compute (const Point<dim>            &p,
   Assert (fourth_derivatives.size()==n_tensor_pols|| fourth_derivatives.size()==0,
           ExcDimensionMismatch2(fourth_derivatives.size(), n_tensor_pols, 0));
 
-  const bool update_values     = (values.size() == n_tensor_pols),
+  const bool update_values     = (values.size()==n_tensor_pols),
              update_grads      = (grads.size()==n_tensor_pols),
              update_grad_grads = (grad_grads.size()==n_tensor_pols),
              update_3rd_derivatives      = (third_derivatives.size()==n_tensor_pols),
@@ -275,26 +277,68 @@ compute (const Point<dim>            &p,
   if (update_4th_derivatives)
     n_values_and_derivatives = 5;
 
+  // Provide a shortcut if only values are requested. For this case usually the
+  // temporary memory allocation below does not pay off. Also we loop over all
+  // tensor polynomials in a peculiar way to avoid all dynamic memory allocation.
+  // We need to evaluate the polynomial value n_polynomials*dim times, and
+  // need to compute n_polynomials^dim tensor polynomials. Therefore we can split
+  // the loop over the tensor polynomials into one loop over n_polynomials,
+  // evaluate this polynomial for each dimension and multiply it with the
+  // associated n_polynomials^(dim-1) tensor polynomials before moving to the
+  // next polynomial.
+  if (n_values_and_derivatives == 1)
+    {
+      const unsigned int n_polynomials = polynomials.size();
+      const unsigned int factor = n_tensor_pols/n_polynomials;
 
-  // compute the values (and derivatives, if
-  // necessary) of all polynomials at this
-  // evaluation point. to avoid many
-  // reallocation, use one std::vector for
-  // polynomial evaluation and store the
-  // result as Tensor<1,5> (that has enough
-  // fields for any evaluation of values and
-  // derivatives, up to the 4th derivative)
-  Table<2,Tensor<1,5> > v(dim, polynomials.size());
-  {
-    std::vector<double> tmp (n_values_and_derivatives);
-    for (unsigned int d=0; d<dim; ++d)
-      for (unsigned int i=0; i<polynomials.size(); ++i)
+      std::fill(values.begin(),values.end(),1.0);
+
+      for (unsigned int polynomial=0; polynomial<n_polynomials; ++polynomial)
         {
-          polynomials[i].value(p(d), tmp);
-          for (unsigned int e=0; e<n_values_and_derivatives; ++e)
-            v(d,i)[e] = tmp[e];
-        };
-  }
+          for (unsigned int d=0; d<dim; ++d)
+            {
+              const double value = polynomials[polynomial].value(p(d));
+
+              for (unsigned int f=0; f<factor; ++f)
+                {
+                  unsigned int index = 0;
+                  switch (d)
+                    {
+                    case 0:
+                      index = polynomial+f*n_polynomials;
+                      break;
+                    case 1:
+                      index = polynomial*n_polynomials + (f/n_polynomials)*n_polynomials*n_polynomials + f%n_polynomials;
+                      break;
+                    case 2:
+                      index = polynomial*factor + f;
+                      break;
+                    }
+
+                  const unsigned int i = index_map_inverse[index];
+                  values[i] *= value;
+                }
+            }
+        }
+      return;
+    }
+
+
+  // Compute the values (and derivatives, if
+  // necessary) of all polynomials at this
+  // evaluation point. To avoid expensive memory allocations,
+  // use alloca to allocate a (small) amount of memory
+  // on the stack and store the
+  // result in a vector of arrays (that has enough
+  // fields for any evaluation of values and
+  // derivatives, up to the 4th derivative).
+  std_cxx11::array<std_cxx11::array<double, 5>, dim> *v =
+    (std_cxx11::array<std_cxx11::array<double, 5>, dim> *)
+    alloca(sizeof(std_cxx11::array<std_cxx11::array<double, 5>, dim>) * polynomials.size());
+
+  for (unsigned int i=0; i<polynomials.size(); ++i)
+    for (unsigned int d=0; d<dim; ++d)
+      polynomials[i].value(p(d), n_values_and_derivatives, &v[i][d][0]);
 
   for (unsigned int i=0; i<n_tensor_pols; ++i)
     {
@@ -309,7 +353,7 @@ compute (const Point<dim>            &p,
         {
           values[i] = 1;
           for (unsigned int x=0; x<dim; ++x)
-            values[i] *= v(x,indices[x])[0];
+            values[i] *= v[indices[x]][x][0];
         }
 
       if (update_grads)
@@ -317,7 +361,7 @@ compute (const Point<dim>            &p,
           {
             grads[i][d] = 1.;
             for (unsigned int x=0; x<dim; ++x)
-              grads[i][d] *= v(x,indices[x])[d==x];
+              grads[i][d] *= v[indices[x]][x][d==x];
           }
 
       if (update_grad_grads)
@@ -332,7 +376,7 @@ compute (const Point<dim>            &p,
                   if (d2==x) ++derivative;
 
                   grad_grads[i][d1][d2]
-                  *= v(x,indices[x])[derivative];
+                  *= v[indices[x]][x][derivative];
                 }
             }
 
@@ -350,7 +394,7 @@ compute (const Point<dim>            &p,
                     if (d3==x) ++derivative;
 
                     third_derivatives[i][d1][d2][d3]
-                    *= v(x,indices[x])[derivative];
+                    *= v[indices[x]][x][derivative];
                   }
               }
 
@@ -370,7 +414,7 @@ compute (const Point<dim>            &p,
                       if (d4==x) ++derivative;
 
                       fourth_derivatives[i][d1][d2][d3][d4]
-                      *= v(x,indices[x])[derivative];
+                      *= v[indices[x]][x][derivative];
                     }
                 }
     }


### PR DESCRIPTION
As discussed with @bangerth: In `TensorProductPolynomials` we currently store the results of the polynomial evaluations in a table in order to reduce the number of evaluations from `n_polynomials^dim` to `n_polynomials*dim`. But the allocation of the table memory makes up 30% of the total runtime of this function, and in my application I am calling this function a lot (because I need to create new `FEValues` objects for every cell, since every cell needs different quadrature points). This PR reorders the loop and splits it into one over `n_polynomials`, one over `dim`, and one over `n_polynomials^(dim-1)`. This way we only need to store the results of one polynomial evaluation, apply this result to all affected tensor products and then move on to the next polynomial.
In this order the innermost `if` statements are evaluated `dim` times as often as before, but this is far offset by not longer allocating the table memory. 
I feel like the new loop order is less clear, so feel free to comment on how to improve that. Also I had to adjust at least two tests, because the new calculation is not longer done in the same order as for the other `compute_value, compute_...` functions in that class, so the floating point tolerance needed to be increased. 