### PR TITLE
Change MGSmootherBlock to use shared memory pool

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -529,6 +529,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Improved: MGSmootherBlock is now able to use the shared memory pool for
+ temporary vector allocation. The constructor requiring an external memory
+ allocation has therefore been deprecated.
+ <br/>
+ (Jonathan Robey, 2016/09/21)
+ </li>
+
  <li> Fixed: EmbeddedRungeKutta methods now correctly increase delta_t_guess 
  when the error is below coarsen_tol.
  </br>

--- a/tests/multigrid/smoother_block.cc
+++ b/tests/multigrid/smoother_block.cc
@@ -126,7 +126,7 @@ void check_smoother(const MGLevelObject<MatrixType> &m,
                     const MGLevelObject<RELAX> &r)
 {
   GrowingVectorMemory<BlockVector<double> > mem;
-  MGSmootherBlock<MatrixType, RELAX, double> smoother(mem);
+  MGSmootherBlock<MatrixType, RELAX, double> smoother;
 
   smoother.initialize(m, r);
 


### PR DESCRIPTION
Old constructor has been deprecated, and the test (`multigrid/smoother_block`) has been modified to use the new constructor.

Should fix #392.

I would appreciate another set of eyes for style, etc as the change was made partially by referencing diffs from far back in the history, and therefore I may have missed some critical elements. Also, I was uncertain whether there was a reason for `MGSmootherBlock` to not be based on `MGSmoother` other than history. I decided to derive from `MGSmoother`, but if there is a reason this should not be done, I would appreciate the correction.