### PR TITLE
silence update-to-date cmake install message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ FOREACH(_file ${_macro_files})
 ENDFOREACH()
 
 #
+# Avoid verbose "Up-to-date" status information during installation:
+#
+SET_IF_EMPTY(CMAKE_INSTALL_MESSAGE "LAZY")
+
+#
 # Check for the existence of various optional folders:
 #
 IF(EXISTS ${CMAKE_SOURCE_DIR}/bundled/CMakeLists.txt)


### PR DESCRIPTION
I would also be happy to have "NEVER" as the default, but I think the "up-to-date" messages are useless and slow things down.

see https://cmake.org/cmake/help/v3.6/variable/CMAKE_INSTALL_MESSAGE.html for more info.