### PR TITLE
Parallelize the operation of compute_number_cache().

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -544,6 +544,11 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Improved: Some parts of mesh refinement are now parallelized.
+ <br/>
+ (Wolfgang Bangerth, 2016/09/27)
+ </li>
+
  <li> Improved: MGSmootherBlock is now able to use the shared memory pool for
  temporary vector allocation. The constructor requiring an external memory
  allocation has therefore been deprecated.


### PR DESCRIPTION
For these functions, the 3d version calls the 2d version which itself calls the
1d version. These operations can all run concurrently. All three include two
loops each over all cells/quads/lines, so there should be plenty to do to
amortize parallel execution.

The only tricky part is that the quad and hex functions accessed a variable
that was first set by the 1d function (number_cache.n_lines). This may now
no longer be available in time for the 2d/3d functions, and so they
need to compute this information themselves. This is cheap, fortunately.

This patch passes the testsuite in debug mode on my machine.