### PR TITLE
Correct ParameterHandler test outputs.

### DIFF
--- a/tests/parameter_handler/parameter_handler_10.output
+++ b/tests/parameter_handler/parameter_handler_10.output
@@ -1,9 +1,9 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <1> of file <input file>:
-    The entry value
+    The entry value 
         3.1415
     for the entry named
         test_1
-    does not match the given pattern
+    does not match the given pattern:
         [Integer range -2147483648...2147483647 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_11.output
+++ b/tests/parameter_handler/parameter_handler_11.output
@@ -1,9 +1,9 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <1> of file <input file>:
-    The entry value
+    The entry value 
         3.1415 something
     for the entry named
         test_1
-    does not match the given pattern
+    does not match the given pattern:
         [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_03.output
+++ b/tests/parameter_handler/parameter_handler_backslash_03.output
@@ -1,17 +1,17 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <prm/parameter_handler_backslash_03.prm>:
-    The entry value
+    The entry value 
         a,\
     for the entry named
         Function
-    does not match the given pattern
+    does not match the given pattern:
         [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <input file>:
-    The entry value
+    The entry value 
         a,\
     for the entry named
         Function
-    does not match the given pattern
+    does not match the given pattern:
         [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_04.output
+++ b/tests/parameter_handler/parameter_handler_backslash_04.output
@@ -1,17 +1,17 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <prm/parameter_handler_backslash_04.prm>:
-    The entry value
+    The entry value 
         a,\ b,
     for the entry named
         Function
-    does not match the given pattern
+    does not match the given pattern:
         [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <input file>:
-    The entry value
+    The entry value 
         a,\ b,
     for the entry named
         Function
-    does not match the given pattern
+    does not match the given pattern:
         [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_06.output
+++ b/tests/parameter_handler/parameter_handler_backslash_06.output
@@ -1,3 +1,3 @@
 
-DEAL::a, b, c
-DEAL::a, b, c
+DEAL::a,b,c
+DEAL::a,b,c

--- a/tests/parameter_handler/parameter_handler_read_xml_error_02.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_02.output
@@ -1,6 +1,6 @@
 
 DEAL::ParameterHandler::ExcInvalidEntryForPatternXML (Utilities::trim(new_value), p->first, patterns[pattern_index]->description())
-    The entry value
+    The entry value 
         __2
     for the entry named
         int_2aint

--- a/tests/parameter_handler/parameter_handler_read_xml_error_04.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_04.output
@@ -1,6 +1,6 @@
 
 DEAL::ParameterHandler::ExcInvalidEntryForPatternXML (Utilities::trim(new_value), p->first, patterns[pattern_index]->description())
-    The entry value
+    The entry value 
         2x
     for the entry named
         int1


### PR DESCRIPTION
On my desktop, I have not installed numdiff yet, and these tests fail because
there are either differences in whitespace, or there is a trailing colon on
a line. Neither seem to bother numdiff, but they bother regular diff. Fix this
by checking in corrected versions of these output files.