### PR TITLE
Tighten up error messages.

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -148,15 +148,32 @@ const char *ExceptionBase::get_exc_name () const
 
 void ExceptionBase::print_exc_data (std::ostream &out) const
 {
+  // print a header for the exception
   out << "An error occurred in line <" << line
       << "> of file <" << file
       << "> in function" << std::endl
       << "    " << function << std::endl
       << "The violated condition was: "<< std::endl
-      << "    " << cond << std::endl
-      << "The name and call sequence of the exception was:" << std::endl
-      << "    " << exc  << std::endl
-      << "Additional Information: " << std::endl;
+      << "    " << cond << std::endl;
+
+  // print the way the additional information message was generated.
+  // this is useful if the names of local variables appear in the
+  // generation of the error message, because it allows the identification
+  // of parts of the error text with what variables may have cause this
+  //
+  // On the other hand, this is almost never the case for ExcMessage
+  // exceptions which would simply print the same text twice: once for
+  // the way the message was composed, and once for the additional
+  // information. Furthermore, the former of these two is often spread
+  // between numerous "..."-enclosed strings that the preprocessor
+  // collates into a single string, making it awkward to read. Consequently,
+  // elide this text if the message was generated via an ExcMessage object
+  if (std::strstr(cond, "dealii::ExcMessage") != NULL)
+    out << "The name and call sequence of the exception was:" << std::endl
+        << "    " << exc  << std::endl;
+
+  // finally print the additional information the exception provides:
+  out << "Additional Information: " << std::endl;
 }
 
 


### PR DESCRIPTION
It has long annoyed me that when we print exception messages that were created
via ExcMessage, that the information is really duplicative. Example:

--------------------------------------------------------
An error occurred in line <710> of file <.../step-6.cc> in function
    int main()
The violated condition was:
    false
The name and call sequence of the exception was:
    ExcMessage ("abc" "def")
Additional Information:
abcdef

Stacktrace:
-----------
#0  ./step-6: main
--------------------------------------------------------

Here, the text that comes after 'The name and call sequence...'
is duplicative with what comes after 'Additional Information:'.

This is specifically the case for ExcMessage errors because
there *everything* that constructs the 'Additional information'
will actually be also under 'The name and...' part.

This patch cleans this up by omitting the first of these two
parts if the error message was created via ExcMessage.