### PR TITLE
Fix output of test.

### DIFF
--- a/tests/base/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=off.output
@@ -49,9 +49,9 @@ DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 89
-DEAL::Memory consumption -- Triangulation: 5431
+DEAL::Memory consumption -- Triangulation: 5415
 DEAL::Memory consumption -- DoFHandler:    1936
-DEAL::Memory consumption -- FE:            3904
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      5736
 DEAL::Memory consumption -- Matrix:        10616
@@ -60,9 +60,9 @@ DEAL::Memory consumption -- Rhs:           816
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
-DEAL::Memory consumption -- Triangulation: 11215
+DEAL::Memory consumption -- Triangulation: 11183
 DEAL::Memory consumption -- DoFHandler:    3728
-DEAL::Memory consumption -- FE:            3904
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   3102
 DEAL::Memory consumption -- Sparsity:      13992
 DEAL::Memory consumption -- Matrix:        26168
@@ -71,9 +71,9 @@ DEAL::Memory consumption -- Rhs:           1776
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
-DEAL::Memory consumption -- Triangulation: 21927
+DEAL::Memory consumption -- Triangulation: 21895
 DEAL::Memory consumption -- DoFHandler:    7184
-DEAL::Memory consumption -- FE:            3904
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   10734
 DEAL::Memory consumption -- Sparsity:      31240
 DEAL::Memory consumption -- Matrix:        58744
@@ -82,9 +82,9 @@ DEAL::Memory consumption -- Rhs:           3696
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
-DEAL::Memory consumption -- Triangulation: 44055
+DEAL::Memory consumption -- Triangulation: 44023
 DEAL::Memory consumption -- DoFHandler:    14672
-DEAL::Memory consumption -- FE:            3904
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   19966
 DEAL::Memory consumption -- Sparsity:      64168
 DEAL::Memory consumption -- Matrix:        120824
@@ -95,9 +95,9 @@ DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
 DEAL::   Number of degrees of freedom: 517
-DEAL::Memory consumption -- Triangulation: 25043
+DEAL::Memory consumption -- Triangulation: 25011
 DEAL::Memory consumption -- DoFHandler:    9760
-DEAL::Memory consumption -- FE:            12280
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   78
 DEAL::Memory consumption -- Sparsity:      120280
 DEAL::Memory consumption -- Matrix:        236280
@@ -106,9 +106,9 @@ DEAL::Memory consumption -- Rhs:           4240
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
-DEAL::Memory consumption -- Triangulation: 98569
+DEAL::Memory consumption -- Triangulation: 98505
 DEAL::Memory consumption -- DoFHandler:    37996
-DEAL::Memory consumption -- FE:            12280
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   55262
 DEAL::Memory consumption -- Sparsity:      567152
 DEAL::Memory consumption -- Matrix:        1116424
@@ -117,9 +117,9 @@ DEAL::Memory consumption -- Rhs:           17840
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
-DEAL::Memory consumption -- Triangulation: 395091
+DEAL::Memory consumption -- Triangulation: 395027
 DEAL::Memory consumption -- DoFHandler:    151280
-DEAL::Memory consumption -- FE:            12280
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   367086
 DEAL::Memory consumption -- Sparsity:      2517208
 DEAL::Memory consumption -- Matrix:        4959288
@@ -128,9 +128,9 @@ DEAL::Memory consumption -- Rhs:           75088
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
-DEAL::Memory consumption -- Triangulation: 1390359
+DEAL::Memory consumption -- Triangulation: 1390231
 DEAL::Memory consumption -- DoFHandler:    542008
-DEAL::Memory consumption -- FE:            12280
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   1307806
 DEAL::Memory consumption -- Sparsity:      8321768
 DEAL::Memory consumption -- Matrix:        16383928


### PR DESCRIPTION
The memory consumption for Triangulation recently changed with #3163.
I have been seeing the difference for finite elements for longer already,
but don't recall which change broke the test.