### PR TITLE
Fix the memory_consumption output for 64bit indices

### DIFF
--- a/tests/base/memory_consumption_01.with_64bit_indices=on.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=on.output
@@ -49,9 +49,9 @@ DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
 DEAL::   Number of degrees of freedom: 89
-DEAL::Memory consumption -- Triangulation: 5431
+DEAL::Memory consumption -- Triangulation: 5415
 DEAL::Memory consumption -- DoFHandler:    3288
-DEAL::Memory consumption -- FE:            3888
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      11352
 DEAL::Memory consumption -- Matrix:        10616
@@ -60,9 +60,9 @@ DEAL::Memory consumption -- Rhs:           824
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       44
 DEAL::   Number of degrees of freedom: 209
-DEAL::Memory consumption -- Triangulation: 11215
+DEAL::Memory consumption -- Triangulation: 11183
 DEAL::Memory consumption -- DoFHandler:    6808
-DEAL::Memory consumption -- FE:            3888
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   4594
 DEAL::Memory consumption -- Sparsity:      27864
 DEAL::Memory consumption -- Matrix:        26168
@@ -71,9 +71,9 @@ DEAL::Memory consumption -- Rhs:           1784
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       92
 DEAL::   Number of degrees of freedom: 449
-DEAL::Memory consumption -- Triangulation: 21927
+DEAL::Memory consumption -- Triangulation: 21895
 DEAL::Memory consumption -- DoFHandler:    13672
-DEAL::Memory consumption -- FE:            3888
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   15250
 DEAL::Memory consumption -- Sparsity:      62360
 DEAL::Memory consumption -- Matrix:        58744
@@ -82,9 +82,9 @@ DEAL::Memory consumption -- Rhs:           3704
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       200
 DEAL::   Number of degrees of freedom: 921
-DEAL::Memory consumption -- Triangulation: 44055
+DEAL::Memory consumption -- Triangulation: 44023
 DEAL::Memory consumption -- DoFHandler:    28648
-DEAL::Memory consumption -- FE:            3888
+DEAL::Memory consumption -- FE:            3896
 DEAL::Memory consumption -- Constraints:   28082
 DEAL::Memory consumption -- Sparsity:      128216
 DEAL::Memory consumption -- Matrix:        120824
@@ -95,9 +95,9 @@ DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
 DEAL::   Number of degrees of freedom: 517
-DEAL::Memory consumption -- Triangulation: 25043
+DEAL::Memory consumption -- Triangulation: 25011
 DEAL::Memory consumption -- DoFHandler:    18912
-DEAL::Memory consumption -- FE:            12264
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   82
 DEAL::Memory consumption -- Sparsity:      240440
 DEAL::Memory consumption -- Matrix:        236280
@@ -106,9 +106,9 @@ DEAL::Memory consumption -- Rhs:           4248
 DEAL::Cycle 1:
 DEAL::   Number of active cells:       217
 DEAL::   Number of degrees of freedom: 2217
-DEAL::Memory consumption -- Triangulation: 98569
+DEAL::Memory consumption -- Triangulation: 98505
 DEAL::Memory consumption -- DoFHandler:    75320
-DEAL::Memory consumption -- FE:            12264
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   78450
 DEAL::Memory consumption -- Sparsity:      1134184
 DEAL::Memory consumption -- Matrix:        1116424
@@ -117,9 +117,9 @@ DEAL::Memory consumption -- Rhs:           17848
 DEAL::Cycle 2:
 DEAL::   Number of active cells:       896
 DEAL::   Number of degrees of freedom: 9373
-DEAL::Memory consumption -- Triangulation: 395091
+DEAL::Memory consumption -- Triangulation: 395027
 DEAL::Memory consumption -- DoFHandler:    301840
-DEAL::Memory consumption -- FE:            12264
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   487314
 DEAL::Memory consumption -- Sparsity:      5034296
 DEAL::Memory consumption -- Matrix:        4959288
@@ -128,9 +128,9 @@ DEAL::Memory consumption -- Rhs:           75096
 DEAL::Cycle 3:
 DEAL::   Number of active cells:       3248
 DEAL::   Number of degrees of freedom: 32433
-DEAL::Memory consumption -- Triangulation: 1390359
+DEAL::Memory consumption -- Triangulation: 1390231
 DEAL::Memory consumption -- DoFHandler:    1083216
-DEAL::Memory consumption -- FE:            12264
+DEAL::Memory consumption -- FE:            12272
 DEAL::Memory consumption -- Constraints:   1729778
 DEAL::Memory consumption -- Sparsity:      16643416
 DEAL::Memory consumption -- Matrix:        16383928


### PR DESCRIPTION
Addition to #3191 for `64bit_indices =on`