### PR TITLE
Update the documentation of Manifold::normal_vector().

### DIFF
--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -548,6 +548,24 @@ public:
    * mapped surface, however, will not usually coincide with the
    * actual surface.)
    *
+   * This function only makes sense if dim==spacedim because
+   * otherwise there is no unique normal vector but in fact a
+   * (spacedim-dim+1)-dimensional tangent space of vectors that
+   * are all both normal to the face and normal to the dim-dimensional
+   * surface that lives in spacedim-dimensional space. For example,
+   * think of a two-dimensional mesh that covers a two-dimensional
+   * surface in three-dimensional space. In that case, each
+   * face (edge) is one-dimensional, and there are two linearly independent
+   * vectors that are both normal to the edge: one is normal to the
+   * edge and tangent to the surface (intuitively, that would be the
+   * one that points from the current cell to the neighboring one,
+   * if the surface was locally flat), and the other one is rooted
+   * in the edge but points perpendicular to the surface (which is
+   * also perpendicular to the edge that lives within the surface).
+   * Thus, because there are no obviously correct semantics for this function
+   * if spacedim is greater than dim, the function will simply throw
+   * an error in that situation.
+   *
    * The face iterator gives an indication which face this function is
    * supposed to compute the normal vector for.  This is useful if the
    * boundary of the domain is composed of different nondifferential
@@ -556,10 +574,22 @@ public:
    * mesh, with piecewise (bi-)linear components between the vertices,
    * but where the boundary may have a kink at the vertices itself).
    *
-   * @note The default implementation of this function computes the
-   * normal vector by taking the cross product between the tangent
-   * vectors from p to the most orthogonal and further non consecutive
-   * vertices of the face.
+   * @note In 2d, the default implementation of this function computes the
+   * normal vector by taking the tangent direction from p to
+   * the further one of the two vertices that make up an edge, and then
+   * rotates it outward (with respect to the coordinate system of the edge)
+   * by 90 degrees. In 3d, the default implementation is more
+   * complicated, aiming at avoiding problems with numerical round-off
+   * for points close to one of the vertices. If the point p is closer
+   * to the center of the face than to any of the vertices, the
+   * normal vector is computed by the cross product of the tangent
+   * vectors from p to either vertex zero and one of the face (if
+   * the closest vertex is either vertex two or three), or of the tangent
+   * vectors from p to vertices two and three (if the closest vertex is
+   * either vertex zero or one). On the other hand, if the point p
+   * is closer to one of the vertices than to the center of the face,
+   * then we take the cross product of the tangent vectors from p
+   * to the two vertices that are adjacent to the closest one.
    */
   virtual
   Tensor<1,spacedim>


### PR DESCRIPTION
I think that documents what the function actually does, and why it's only implemented for dim==spacedim.

@luca-heltai -- can you confirm?