### PR TITLE
Make exception messages more consistent.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -393,7 +393,7 @@ namespace deal_II_exceptions
     Exception (const std::string &msg = defaulttext) : arg (msg) {}       \
     virtual ~Exception () DEAL_II_NOEXCEPT {}                             \
     virtual void print_info (std::ostream &out) const {                   \
-      out << arg << std::endl;                                            \
+      out << "    " << arg << std::endl;                                  \
     }                                                                     \
   private:                                                                \
     const std::string arg;                                                \
@@ -411,7 +411,7 @@ namespace deal_II_exceptions
     Exception1 (const type1 a1) : arg1 (a1) {}                            \
     virtual ~Exception1 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
-      out outsequence << std::endl;                                       \
+      out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
     const type1 arg1;                                                     \
@@ -431,7 +431,7 @@ namespace deal_II_exceptions
       arg1 (a1), arg2(a2) {}                                              \
     virtual ~Exception2 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
-      out outsequence << std::endl;                                       \
+      out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
     const type1 arg1;                                                     \
@@ -452,7 +452,7 @@ namespace deal_II_exceptions
       arg1 (a1), arg2(a2), arg3(a3) {}                                    \
     virtual ~Exception3 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
-      out outsequence << std::endl;                                       \
+      out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
     const type1 arg1;                                                     \
@@ -475,7 +475,7 @@ namespace deal_II_exceptions
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4) {}                          \
     virtual ~Exception4 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
-      out outsequence << std::endl;                                       \
+      out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
     const type1 arg1;                                                     \
@@ -499,7 +499,7 @@ namespace deal_II_exceptions
       arg1 (a1), arg2(a2), arg3(a3), arg4(a4), arg5(a5) {}                \
     virtual ~Exception5 () DEAL_II_NOEXCEPT {}                            \
     virtual void print_info (std::ostream &out) const {                   \
-      out outsequence << std::endl;                                       \
+      out << "    " outsequence << std::endl;                             \
     }                                                                     \
   private:                                                                \
     const type1 arg1;                                                     \

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -173,14 +173,14 @@ void ExceptionBase::print_exc_data (std::ostream &out) const
         << "    " << exc  << std::endl;
 
   // finally print the additional information the exception provides:
-  out << "Additional Information: " << std::endl;
+  out << "Additional information: " << std::endl;
 }
 
 
 
 void ExceptionBase::print_info (std::ostream &out) const
 {
-  out << "(none)" << std::endl;
+  out << "    (none)" << std::endl;
 }
 
 


### PR DESCRIPTION
In particular, change the following two things: (i) Say 'Additional information'
instead of 'Additional Information' because the rest of the text is also
capitalized in the common way. (ii) Indent the actual (additional) error text
by four characters, just like the other additional pieces of information.

The result is that errors now look like this:
```
--------------------------------------------------------
An error occurred in line <710> of file </home/fac/f/bangerth/p/deal.II/1/install/examples/step-6/step-6.cc> in function
    int main()
The violated condition was:
    false
Additional information:
    abcdef

Stacktrace:
-----------
#0  ./step-6: main
--------------------------------------------------------
```

This is a follow-up to #3189.