### PR TITLE
Add periodic_neighbor_face_no() call.

### DIFF
--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -803,7 +803,9 @@ namespace DoFTools
                         continue; // (the neighbor is finer)
 
                       const unsigned int
-                      neighbor_face_n = cell->neighbor_face_no (face_n);
+                      neighbor_face_n = periodic_neighbor?
+                                        cell->periodic_neighbor_face_no (face_n):
+                                        cell->neighbor_face_no (face_n);
 
                       if (cell_face->has_children ())
                         {


### PR DESCRIPTION
This fixes an issue where make_flux_sparsity_pattern was failing under periodic boundaries. This was brought to my attention by @lkaratun on the Aspect-devel mailing list.