### PR TITLE
List FE_Enriched as a class only enabled with C++11.

### DIFF
--- a/doc/doxygen/headers/c++11.h
+++ b/doc/doxygen/headers/c++11.h
@@ -112,4 +112,5 @@
  * - The LinearOperator class and all associated functions such as
  *   linear_operator(), null_operator(), and everything else that is part of
  *   the LAOperators documentation module.
+ * - The FE_Enriched class.
  */


### PR DESCRIPTION
As pointed out in #3209.