### PR TITLE
add distribute_local_to_global of diagonal entries to a vector

### DIFF
--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -874,6 +874,20 @@ public:
                               const std::vector<size_type> &local_dof_indices,
                               MatrixType                   &global_matrix) const;
 
+
+  /**
+   * Same as above but distributes only diagonal elements of the assembled matrix.
+   *
+   * This function is useful in matrix-free methods to obtain a vector of
+   * diagonal elements fully consistent with the sparse matrix.
+   */
+  template <typename VectorType>
+  void
+  distribute_local_to_global (VectorType                   &global_diagonal_vector,
+                              const FullMatrix<typename VectorType::value_type> &local_matrix,
+                              const std::vector<size_type> &local_dof_indices) const;
+
+
   /**
    * Does almost the same as the function above but can treat general
    * rectangular matrices.  The main difference to achieve this is that the

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -22,6 +22,7 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::distribute_local_to_global<T<S> > (
         const Vector<S>&, const std::vector<types::global_dof_index> &, const std::vector<types::global_dof_index> &, T<S> &, const FullMatrix<S>&, bool) const;
     template void ConstraintMatrix::set_zero<T<S> >(T<S> &) const;
+    template void ConstraintMatrix::distribute_local_to_global<T<S> > (T<S>&, const FullMatrix<S>&, const std::vector<types::global_dof_index> &) const;
 }
 
 

--- a/tests/lac/constraints_local_to_global_diagonal.cc
+++ b/tests/lac/constraints_local_to_global_diagonal.cc
@@ -77,7 +77,7 @@ void test ()
 
   // loop over cells, fill local matrix with
   // random values, insert both into sparse and
-  // full matrix. Make some random entries equal
+  // diagonal vector. Make some random entries equal
   // to zero
   typename DoFHandler<dim>::active_cell_iterator
   cell = dof.begin_active(), endc = dof.end();

--- a/tests/lac/constraints_local_to_global_diagonal.cc
+++ b/tests/lac/constraints_local_to_global_diagonal.cc
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this function tests the correctness of the implementation of
+// ConstraintMatrix::distribute_local_to_global for VectorType by comparing
+// the results with a sparse matrix. As a test case, we use a square mesh that
+// is refined once globally and then the first cell is refined adaptively.
+
+#include "../tests.h"
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
+#include <fstream>
+#include <iostream>
+#include <complex>
+
+std::ofstream logfile("output");
+
+template <int dim>
+void test ()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube (tria);
+  tria.begin()->face(0)->set_boundary_id(1);
+  tria.refine_global(1);
+  tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  FE_Q<dim> fe (1);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+
+  ConstraintMatrix constraints;
+  DoFTools::make_hanging_node_constraints (dof, constraints);
+  VectorTools::interpolate_boundary_values (dof, 1, ZeroFunction<dim>(),
+                                            constraints);
+  constraints.close();
+
+  SparsityPattern sparsity;
+  {
+    DynamicSparsityPattern csp (dof.n_dofs(), dof.n_dofs());
+    DoFTools::make_sparsity_pattern (dof, csp, constraints, false);
+    sparsity.copy_from (csp);
+  }
+  SparseMatrix<double> sparse (sparsity);
+  Vector<double> diag_vector (dof.n_dofs());
+
+  FullMatrix<double> local_mat (fe.dofs_per_cell, fe.dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices (fe.dofs_per_cell);
+
+  // loop over cells, fill local matrix with
+  // random values, insert both into sparse and
+  // full matrix. Make some random entries equal
+  // to zero
+  typename DoFHandler<dim>::active_cell_iterator
+  cell = dof.begin_active(), endc = dof.end();
+  unsigned int counter = 0;
+  for ( ; cell != endc; ++cell)
+    {
+      for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
+        for (unsigned int j=0; j<fe.dofs_per_cell; ++j, ++counter)
+          if (counter % 42 == 0)
+            local_mat(i,j) = 0;
+          else
+            local_mat (i,j) = (double)Testing::rand() / RAND_MAX;
+      cell->get_dof_indices (local_dof_indices);
+      constraints.distribute_local_to_global (local_mat, local_dof_indices,
+                                              sparse);
+      constraints.distribute_local_to_global (diag_vector, local_mat, local_dof_indices);
+    }
+
+  // now check that the diagonal entries are indeed the
+  // same
+  Vector<double> diff_vector (dof.n_dofs());
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    diff_vector[i] = sparse.diag_element(i);
+
+  diff_vector.add(-1., diag_vector);
+  deallog << "Difference between diagonals: "
+          << diff_vector.l2_norm() << std::endl;
+}
+
+
+int main ()
+{
+  deallog << std::setprecision (2);
+  logfile << std::setprecision (2);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-14);
+
+  test<2>();
+}
+

--- a/tests/lac/constraints_local_to_global_diagonal.output
+++ b/tests/lac/constraints_local_to_global_diagonal.output
@@ -1,0 +1,2 @@
+
+DEAL::Difference between full and sparse matrix: 0

--- a/tests/lac/constraints_local_to_global_diagonal.output
+++ b/tests/lac/constraints_local_to_global_diagonal.output
@@ -1,2 +1,2 @@
 
-DEAL::Difference between full and sparse matrix: 0
+DEAL::Difference between diagonals: 0


### PR DESCRIPTION
in reference to https://github.com/dealii/dealii/pull/3184#issuecomment-252429781

The idea is to make `distribute_local_to_global()` distribute local matrix with applied constraints to a vector of diagonal elements.

Current solution is not the most beutifull as I had to distinguish between
```
template <typename MatrixType>
  void
  distribute_local_to_global (const FullMatrix<typename MatrixType::value_type> &local_matrix,
                              const std::vector<size_type> &local_dof_indices,
                              MatrixType                   &global_matrix) const;
```
and
```
template <typename VectorType>
  void
  distribute_local_to_global (VectorType                   &global_diagonal_vector,
                              const FullMatrix<typename VectorType::value_type> &local_matrix,
                              const std::vector<size_type> &local_dof_indices) const;
```
by changing arguments order. There is also quite  a lot of code duplication.


I think the better approach is just enhance vector class to have a function similar to matrix classes (i.e. https://www.dealii.org/developer/doxygen/deal.II/classSparseMatrix.html#ac97efa0f970b0bcf40da82584f71d39c) 
```
VectorClass:add	(	const size_type 	row,
const size_type 	n_cols,
const size_type * 	col_indices,
const number2 * 	values,
const bool 	elide_zero_values = true,
const bool 	col_indices_are_sorted = false 
)	
```
and then take diagonals only. This way everything should work out-of-the-box. Thoughts?


TODO
- [ ] check test
