### PR TITLE
Ask neighbor, rather than cell_face, about children.

### DIFF
--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -807,7 +807,7 @@ namespace DoFTools
                                         cell->periodic_neighbor_face_no (face_n):
                                         cell->neighbor_face_no (face_n);
 
-                      if (cell_face->has_children ())
+                      if (neighbor->has_children ())
                         {
                           for (unsigned int sub_nr = 0;
                                sub_nr != cell_face->n_children ();
@@ -1080,7 +1080,7 @@ namespace DoFTools
                           neighbor->is_locally_owned ())
                         continue; // (the neighbor is finer)
 
-                      if (cell_face->has_children())
+                      if (neighbor->has_children())
                         {
                           for (unsigned int sub_nr = 0;
                                sub_nr != cell_face->n_children();


### PR DESCRIPTION
So this fixes the issue @lkaratun was having on the Aspect mailing list with `make_flux_sparsity_pattern()` calling an an inactive cell behind a periodic face.

This raises a technical question. The setting is that we have a periodic boundary, with the cell on one side more refined than the other: `cell` is active, but `neighbor` across the periodic boundary is inactive.

Calling `cell->face(face_n)->has_children()` gives the value `false`, while instead calling `cell->neighbor_or_periodic_neighbor(face_n)->has_children()` gives `true`. 
Is this the way this is designed to work, or should `cell->face(face_n)->has_children()` also respect periodicity?