### PR TITLE
Remove asserts that are no longer useful

### DIFF
--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -114,8 +114,6 @@ namespace Polynomials
                              const unsigned int n_derivatives,
                              number *values) const
   {
-    Assert(n_derivatives >= 0, ExcZero());
-
     // evaluate Lagrange polynomial and derivatives
     if (in_lagrange_product_form == true)
       {

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -58,8 +58,6 @@ namespace Polynomials
                                       const unsigned int n_derivatives,
                                       number *values) const
   {
-    Assert (n_derivatives >= 0, ExcZero());
-
     // shift polynomial if necessary
     number y = x;
     double derivative_change_sign = 1.;


### PR DESCRIPTION
The versions of these functions that take vectors as input arguments had these asserts, so I copied them in the new functions, but they are useless in their current form (and their original purpose to check if enough memory is allocated is not possible in the new functions, because they take a pointer). Remove them to remove the warnings. Fixes #3233.