### PR TITLE
Make code in steps 1 and 2 more obvious.

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -135,9 +135,9 @@ void second_grid ()
   // topic; if you're confused about what exactly is happening here,
   // you may want to look at the @ref GlossManifoldIndicator "glossary
   // entry on this topic".)
-  triangulation.set_all_manifold_ids(0);
   const SphericalManifold<2> manifold_description(center);
   triangulation.set_manifold (0, manifold_description);
+  triangulation.set_all_manifold_ids(0);
 
   // In order to demonstrate how to write a loop over all cells, we will
   // refine the grid in five steps towards the inner circle of the domain:

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -88,8 +88,8 @@ void make_grid (Triangulation<2> &triangulation)
                               5 );
 
   static const SphericalManifold<2> manifold_description(center);
-  triangulation.set_all_manifold_ids(0);
   triangulation.set_manifold (0, manifold_description);
+  triangulation.set_all_manifold_ids(0);
 
   for (unsigned int step=0; step<3; ++step)
     {


### PR DESCRIPTION
In the current setup, steps-1 and 2 first set all manifold ids, and only
then attach a manifold object. This invites the question what the triangulation
would do in between. On the other hand, we can easily fix this by first
attaching a manifold object to the triangulation for manifold_id zero,
and only then set the manifold_ids of cells and faces to zero.