### PR TITLE
Use an easier to read style for declaring iterator variables.

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -146,7 +146,7 @@ void second_grid ()
       // Next, we need an iterator that points to a cell and which we will
       // move over all active cells one by one. In a sense, you can think of a
       // triangulation as a collection of cells. If it was an array, you would
-      // just get a pointer that you move from one to the next. In
+      // just get a pointer that you move from one array element to the next. In
       // triangulations, cells aren't stored as an array, so simple pointers
       // do not work, but one can generalize pointers to iterators (see <a
       // href="http://en.wikipedia.org/wiki/Iterator#C.2B.2B">this wikipedia
@@ -173,9 +173,8 @@ void second_grid ()
       // After declaring the iterator variable, the loop over all cells is
       // then rather trivial, and looks like any loop involving pointers
       // instead of iterators:
-      Triangulation<2>::active_cell_iterator
-      cell = triangulation.begin_active(),
-      endc = triangulation.end();
+      Triangulation<2>::active_cell_iterator cell = triangulation.begin_active();
+      Triangulation<2>::active_cell_iterator endc = triangulation.end();
       for (; cell!=endc; ++cell)
         {
           // @note Writing a loop like this requires a lot of typing, but it

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -93,9 +93,8 @@ void make_grid (Triangulation<2> &triangulation)
 
   for (unsigned int step=0; step<3; ++step)
     {
-      Triangulation<2>::active_cell_iterator
-      cell = triangulation.begin_active(),
-      endc = triangulation.end();
+      Triangulation<2>::active_cell_iterator cell = triangulation.begin_active();
+      Triangulation<2>::active_cell_iterator endc = triangulation.end();
 
       for (; cell!=endc; ++cell)
         for (unsigned int v=0;

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -390,9 +390,8 @@ void Step3::assemble_system ()
   // Now for the loop over all cells. We have seen before how this works, so
   // the following code should be familiar including the conventional names
   // for these variables:
-  DoFHandler<2>::active_cell_iterator
-  cell = dof_handler.begin_active(),
-  endc = dof_handler.end();
+  DoFHandler<2>::active_cell_iterator cell = dof_handler.begin_active();
+  DoFHandler<2>::active_cell_iterator endc = dof_handler.end();
   for (; cell!=endc; ++cell)
     {
       // @note As already mentioned in step-1, there is a more convenient way


### PR DESCRIPTION
For first-time readers of deal.II programs (who may be used to other languages than C++),
our declarations of 'cell' and 'endc' that span multiple lines may be difficult to read.

For the first three tutorial programs, use a simpler syntax where each variable declaration
only requires a single line of code.