### PR TITLE
Add missing 'update_JxW_values' flags.

### DIFF
--- a/tests/integrators/advection_01.cc
+++ b/tests/integrators/advection_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -242,14 +242,14 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl << "cell matrix" << std::endl;
   QGauss<dim> quadrature(fe.tensor_degree());
-  FEValues<dim> fev(fe, quadrature, update_values | update_gradients);
+  FEValues<dim> fev(fe, quadrature, update_values | update_gradients | update_JxW_values);
 
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
   fev.reinit(cell1);
   test_cell(fev);
 
   QGauss<dim-1> face_quadrature(fe.tensor_degree()+1);
-  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;
@@ -257,7 +257,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
       test_boundary(fef1);
     }
 
-  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell2 = cell1->neighbor(1);
 
   deallog << "face_matrix " << 0 << std::endl;

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -218,8 +218,8 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fv, FiniteElement<dim> &fs)
 {
   deallog << fv.get_name() << " x " << fs.get_name() << std::endl << "cell matrix" << std::endl;
   QGauss<dim> quadrature(fv.tensor_degree()+1);
-  FEValues<dim> fev(fv, quadrature, update_values | update_gradients);
-  FEValues<dim> fes(fs, quadrature, update_values | update_gradients);
+  FEValues<dim> fev(fv, quadrature, update_values | update_gradients | update_JxW_values);
+  FEValues<dim> fes(fs, quadrature, update_values | update_gradients | update_JxW_values);
 
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
   fev.reinit(cell1);
@@ -227,8 +227,8 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fv, FiniteElement<dim> &fs)
   test_cell(fev, fes);
 
   QGauss<dim-1> face_quadrature(fv.tensor_degree()+1);
-  FEFaceValues<dim> fev1(fv, face_quadrature, update_values | update_gradients | update_normal_vectors);
-  FEFaceValues<dim> fes1(fs, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fev1(fv, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
+  FEFaceValues<dim> fes1(fs, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;
@@ -237,8 +237,8 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fv, FiniteElement<dim> &fs)
       test_boundary(fev1, fes1);
     }
 
-  FEFaceValues<dim> fev2(fv, face_quadrature, update_values | update_gradients);
-  FEFaceValues<dim> fes2(fs, face_quadrature, update_values | update_gradients);
+  FEFaceValues<dim> fev2(fv, face_quadrature, update_values | update_gradients | update_JxW_values);
+  FEFaceValues<dim> fes2(fs, face_quadrature, update_values | update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell2 = cell1->neighbor(1);
 
   deallog << "face_matrix " << 0 << std::endl;

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -200,13 +200,13 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl << "cell matrix" << std::endl;
   QGauss<dim> quadrature(fe.tensor_degree()+1);
-  FEValues<dim> fev(fe, quadrature, update_gradients);
+  FEValues<dim> fev(fe, quadrature, update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
   fev.reinit(cell1);
   test_cell(fev);
 
   QGauss<dim-1> face_quadrature(fe.tensor_degree()+1);
-  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;
@@ -214,7 +214,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
       test_boundary(fef1);
     }
 
-  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients);
+  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell2 = cell1->neighbor(1);
 
   deallog << "face_matrix " << 0 << std::endl;

--- a/tests/integrators/elasticity_02.cc
+++ b/tests/integrators/elasticity_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -80,7 +80,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
 
   QGauss<dim-1> face_quadrature(fe.tensor_degree()+1);
-  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;

--- a/tests/integrators/grad_div_01.cc
+++ b/tests/integrators/grad_div_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -200,13 +200,13 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl << "cell matrix" << std::endl;
   QGauss<dim> quadrature(fe.tensor_degree()+1);
-  FEValues<dim> fev(fe, quadrature, update_gradients);
+  FEValues<dim> fev(fe, quadrature, update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
   fev.reinit(cell1);
   test_cell(fev);
 
   QGauss<dim-1> face_quadrature(fe.tensor_degree()+1);
-  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;
@@ -214,7 +214,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
       test_boundary(fef1);
     }
 
-  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients);
+  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell2 = cell1->neighbor(1);
 
   deallog << "face_matrix " << 0 << std::endl;

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -235,14 +235,14 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl << "cell matrix" << std::endl;
   QGauss<dim> quadrature(fe.tensor_degree());
-  FEValues<dim> fev(fe, quadrature, update_gradients);
+  FEValues<dim> fev(fe, quadrature, update_gradients | update_JxW_values);
 
   typename Triangulation<dim>::cell_iterator cell1 = tr.begin(1);
   fev.reinit(cell1);
   test_cell(fev);
 
   QGauss<dim-1> face_quadrature(fe.tensor_degree()+1);
-  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors);
+  FEFaceValues<dim> fef1(fe, face_quadrature, update_values | update_gradients | update_normal_vectors | update_JxW_values);
   for (unsigned int i=0; i<GeometryInfo<dim>::faces_per_cell; ++i)
     {
       deallog << "boundary_matrix " << i << std::endl;
@@ -250,7 +250,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
       test_boundary(fef1);
     }
 
-  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients);
+  FEFaceValues<dim> fef2(fe, face_quadrature, update_values | update_gradients | update_JxW_values);
   typename Triangulation<dim>::cell_iterator cell2 = cell1->neighbor(1);
 
   deallog << "face_matrix " << 0 << std::endl;


### PR DESCRIPTION
These tests *do* use the JxW values, but they are not explicitly specified
as necessary. Instead, some quirk of our internal machineries causes this
flag to be set anyway, but it's better not to rely on this.

Found while looking at #3226.