### PR TITLE
Include the top XML sections in an error message.

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1936,11 +1936,29 @@ void ParameterHandler::parse_input_from_xml (std::istream &in)
 
   const std::size_t n_top_level_elements = std::distance (single_node_tree.begin(),
                                                           single_node_tree.end());
-  AssertThrow (n_top_level_elements == 1,
-               ExcInvalidXMLParameterFile ("There are "
-                                           + Utilities::to_string(n_top_level_elements)
-                                           + " top-level elements, but there "
-                                           "should only be one."));
+  if (n_top_level_elements != 1)
+    {
+      std::ostringstream top_level_message;
+      top_level_message << "The ParameterHandler input parser found "
+                        << n_top_level_elements
+                        << " top level elements while reading\n "
+                        << "    an XML format input file, but there should be"
+                        << " exactly one top level element.\n"
+                        << "    The top level elements are:\n";
+
+      unsigned int entry_n = 0;
+      for (boost::property_tree::ptree::iterator it = single_node_tree.begin();
+           it != single_node_tree.end(); ++it, ++entry_n)
+        {
+          top_level_message << "        "
+                            << it->first
+                            << (entry_n != n_top_level_elements - 1 ? "\n" : "");
+        }
+
+      // repeat assertion condition to make the printed version easier to read
+      AssertThrow (n_top_level_elements == 1,
+                   ExcInvalidXMLParameterFile (top_level_message.str()));
+    }
 
   // read the child elements recursively
   const boost::property_tree::ptree

--- a/tests/parameter_handler/parameter_handler_read_xml_error_03.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_03.output
@@ -1,3 +1,7 @@
 
-DEAL::ExcInvalidXMLParameterFile ("There are " + Utilities::to_string(n_top_level_elements) + " top-level elements, but there " "should only be one.")
-There are 2 top-level elements, but there should only be one.
+DEAL::ExcInvalidXMLParameterFile (top_level_message.str())
+    The ParameterHandler input parser found 2 top level elements while reading
+    an XML format input file, but there should be exactly one top level element.
+    The top level elements are:
+        ParameterHandler
+        secondtopleveltag


### PR DESCRIPTION
This commit improves ExcInvalidXMLParameterFile by printing out the names of the top level XML sections in an exception message.

Closes #3151.