### PR TITLE
Allocate an even number of elements in TBBReduceFactor

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1146,7 +1146,9 @@ namespace internal
 
       if (n_chunks > threshold_array_allocate)
         {
-          large_array.resize(n_chunks);
+          // make sure we allocate an even number of elements,
+          // access to the new last element is needed in do_sum()
+          large_array.resize(2*((n_chunks+1)/2));
           array_ptr = &large_array[0];
         }
       else


### PR DESCRIPTION
The following test were failing for me

- multigrid/step-16-04.debug
- multigrid/step-16-04.release
- multigrid/step-16-05.debug
- multigrid/step-16-05.release
- multigrid/step-16-06.debug
- multigrid/step-16-06.release

`TBBReduceFunctor::do_sum() const` accesses `array_ptr[n_chunks]` if `n_chunks` is odd.
Now, we make sure that this element is accessible.

edit: changed array index