### PR TITLE
Restrict the possible options for eigenvalues of symmetric problems in Arpack

### DIFF
--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -311,7 +311,20 @@ AdditionalData (const unsigned int number_of_arnoldi_vectors,
   number_of_arnoldi_vectors(number_of_arnoldi_vectors),
   eigenvalue_of_interest(eigenvalue_of_interest),
   symmetric(symmetric)
-{}
+{
+  //Check for possible options for symmetric problems
+  if (symmetric)
+    {
+      Assert(eigenvalue_of_interest!=largest_real_part,
+             ExcMessage("'largest real part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=smallest_real_part,
+             ExcMessage("'smallest real part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=largest_imaginary_part,
+             ExcMessage("'largest imaginary part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=smallest_imaginary_part,
+             ExcMessage("'smallest imaginary part' can only be used for non-symmetric problems!"));
+    }
+}
 
 
 inline

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -496,7 +496,20 @@ AdditionalData (const unsigned int     number_of_arnoldi_vectors,
   number_of_arnoldi_vectors(number_of_arnoldi_vectors),
   eigenvalue_of_interest(eigenvalue_of_interest),
   symmetric(symmetric)
-{}
+{
+  //Check for possible options for symmetric problems
+  if (symmetric)
+    {
+      Assert(eigenvalue_of_interest!=largest_real_part,
+             ExcMessage("'largest real part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=smallest_real_part,
+             ExcMessage("'smallest real part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=largest_imaginary_part,
+             ExcMessage("'largest imaginary part' can only be used for non-symmetric problems!"));
+      Assert(eigenvalue_of_interest!=smallest_imaginary_part,
+             ExcMessage("'smallest imaginary part' can only be used for non-symmetric problems!"));
+    }
+}
 
 template <typename VectorType>
 PArpackSolver<VectorType>::PArpackSolver (SolverControl        &control,
@@ -657,7 +670,6 @@ void PArpackSolver<VectorType>::solve
   // "LI" largest imaginary part
   // "SI" smallest imaginary part
   // "BE" both ends of spectrum simultaneous
-
   char which[3];
   switch (additional_data.eigenvalue_of_interest)
     {


### PR DESCRIPTION
The options "LR", "SR", "LI" and "SI" are only allowed in `dnaupd` and not in `dsaupd` which is used for symmetric problems. Choosing one of these options leads to the error message

> Error with dsaupd, info -5. Check documentation of ARPACK