### PR TITLE
Update generic linear algebra: Includes more solvers and base classes.

### DIFF
--- a/doc/doxygen/headers/generic_linear_algebra.h
+++ b/doc/doxygen/headers/generic_linear_algebra.h
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+/**
+ * @defgroup GenericLinearAlgebra Generic Linear Algebra
+ *
+ * This module encapsulates several namespaces that aggregate the various
+ * vectors, sparse matrices, solvers and preconditioners for sparse linear
+ * systems. So far it includes a subset of the native deal.II data types
+ * and, if deal.II is built with them enabled, PETSc and Trilinos data for
+ * both serial and MPI types as well.
+ *
+ * The deal.II type definitions can be found in the LinearAlgebraDealII
+ * namespace (supporting real-valued problems) and LinearAlgebraDealII::Complex
+ * (for complex-valued problems). Similarly, those for Trilinos are in
+ * LinearAlgebraTrilinos (serial) and LinearAlgebraTrilinos::MPI (parallel),
+ * and those for PETSc are in LinearAlgebraPETSc (serial) and
+ * LinearAlgebraPETSc::MPI (parallel). Note that the underlying number type
+ * for Trilinos and PETSc linear algebra is determined at the time of
+ * compilation of the deal.II library.
+ *
+ * The main idea behind offering such a collection of namespaces is the
+ * facilitation of easy switching between the variety options with
+ * which one can solve a linear system. An example that takes advantage
+ * of this is shown below (this uses Trilinos and PETSc types only):
+ *
+ * @code
+ * #include <deal.II/lac/generic_linear_algebra.h>
+ *
+ * #define USE_TRILINOS_LA
+ * #define USE_MPI_LA
+ * namespace LA
+ * {
+ * #ifdef USE_TRILINOS_LA
+ *
+ * #if defined(DEAL_II_WITH_MPI) && defined(USE_MPI_LA)
+ *   using namespace dealii::LinearAlgebraTrilinos::MPI;
+ * #else
+ *   using namespace dealii::LinearAlgebraTrilinos;
+ * #endif
+ *
+ * #else
+ *
+ * #if defined(DEAL_II_WITH_MPI) && defined(USE_MPI_LA)
+ *   using namespace dealii::LinearAlgebraPETSc::MPI;
+ * #else
+ *   using namespace dealii::LinearAlgebraPETSc;
+ * #endif
+ *
+ * #endif
+ * }
+ * @endcode
+ *
+ * This set of preprocessor directives select the appropriate
+ * namespace based on the existence some predefined identifier,
+ * and import them into a local namespace @p LA .
+ * Now one can create and use, for example, a generic
+ * vector of switchable type by
+ *
+ * @code
+ * const LA::BlockVector solution = ...
+ * @endcode
+ *
+ * @note For this to be used most effectively, the common
+ * elements of the vector/sparse matrix/solver/preconditioner interface
+ * must be called during initialisation and operation.
+ * For examples of this, see step-40, step-50 and step-55.
+ *
+ * @author Timo Heister 2008, Jean-Paul Pelteret, 2016
+ *
+ * @ingroup LAC
+ */

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -38,6 +38,12 @@ inconvenience this causes.
 </p>
 
 <ol>
+ <li> Changed: Some typedefs (both names and definitions) within the
+ <tt>generic_linear_algebra.h</tt> header have been altered.
+ <br>
+ (Jean-Paul Pelteret, 2016/10/21)
+ </li>
+
  <li> Deprecated: ParameterHandler::read_input,
  ParameterHandler::read_input_from_xml, and
  ParameterHandler::read_input_from_string are now deprecated in favor of
@@ -221,6 +227,13 @@ inconvenience this causes.
  of that class.
  <br>
  (Wolfgang Bangerth, 2016/10/28)
+ </li>
+ 
+ <li> Changed: The <tt>generic_linear_algebra.h</tt> has been updated to
+ include more type definitions for vectors, sparse matrices, solvers and
+ preconditioners for native deal.II, PETSc and Trilinos data types.
+ <br>
+ (Jean-Paul Pelteret, 2016/10/21)
  </li>
 
  <li> Improved: deal.II now bundles a subset of BOOST 1.62 instead of a subset

--- a/include/deal.II/lac/generic_linear_algebra.h
+++ b/include/deal.II/lac/generic_linear_algebra.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2015 by the deal.II authors
+// Copyright (C) 2008 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -18,30 +18,259 @@
 
 #include <deal.II/base/config.h>
 
-
-#include <deal.II/lac/vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/block_sparse_matrix.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_selector.h>
 #include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparse_direct.h>
 #include <deal.II/lac/precondition.h>
+#include <deal.II/lac/precondition_selector.h>
+#include <deal.II/lac/vector.h>
+
+#include <complex>
 
 
 DEAL_II_NAMESPACE_OPEN
 
+/**
+ * @addtogroup GenericLinearAlgebra
+ * @{
+ */
 
 /**
- * A namespace in which the deal.II linear algebra classes are typedef'ed to
- * generic names. There are similar namespaces LinearAlgebraPETSc and
- * LinearAlgebraTrilinos for typedefs to classes that interface with the PETSc
- * and Trilinos libraries.
+ * A namespace in which the real valued deal.II linear algebra classes are
+ * typedef'ed to generic names. There are similar namespaces LinearAlgebraPETSc
+ * and LinearAlgebraTrilinos for typedefs to classes that interface with the
+ * PETSc and Trilinos libraries.
+ *
+ * @ingroup GenericLinearAlgebra
+ * @author Timo Heister 2008, Jean-Paul Pelteret 2016
  */
 namespace LinearAlgebraDealII
 {
+  /**
+   * Typedef for the vector type used.
+   */
   typedef Vector<double> Vector;
+
+  /**
+  * Typedef for the type used to describe vectors that consist of multiple
+  * blocks.
+  */
   typedef BlockVector<double> BlockVector;
 
+  /**
+   * Typedef for the sparse matrix type used.
+   */
   typedef SparseMatrix<double> SparseMatrix;
 
-  typedef PreconditionSSOR<SparseMatrix > PreconditionSSOR;
+  /**
+   * Typedef for the type used to describe sparse matrices that consist of
+   * multiple blocks.
+   */
+  typedef BlockSparseMatrix<double> BlockSparseMatrix;
+
+  /**
+   * Typedef for the Jacobi preconditioner type.
+   */
+  typedef PreconditionJacobi<SparseMatrix> PreconditionJacobi;
+
+  /**
+  * Typedef for the generic preconditioner selector.
+  */
+  typedef PreconditionSelector<SparseMatrix> PreconditionSelector;
+
+  /**
+  * Typedef for the SOR preconditioner type.
+  */
+  typedef PreconditionSOR<SparseMatrix> PreconditionSOR;
+  /**
+  * Typedef for the SSOR preconditioner type.
+  */
+  typedef PreconditionSSOR<SparseMatrix> PreconditionSSOR;
+
+  /**
+   * Typedef for the base class for linear solvers.
+   *
+   * This typedef is useful when wanting to create a generic solver interface
+   * wherein one can switch between linear solvers. For example:
+   * @code
+   * std_cxx11::unique_ptr<LA::SolverBase> solver;
+   * if (parameters.solver_type == "CG")
+   * {
+   *   solver.reset(new LA::SolverCG(solver_control));
+   * }
+   * @endcode
+   */
+  typedef Solver<Vector> SolverBase;
+
+  /**
+   * Typedef for the BiCGStab linear solver.
+   */
+  typedef SolverBicgstab<Vector> SolverBicgstab;
+
+  /**
+   * Typedef for the CG linear solver.
+   */
+  typedef SolverCG<Vector> SolverCG;
+
+  /**
+   * Typedef for the GMRES linear solver.
+   */
+  typedef SolverGMRES<Vector> SolverGMRES;
+
+  /**
+   * Typedef for the generic linear solver selector.
+   */
+  typedef SolverSelector<Vector> SolverSelector;
+
+  // ----------------------------------------------------
+  // Below are the common elements between this namespace
+  // and any namespaces nested within this one
+  // ----------------------------------------------------
+
+  /**
+   * Typedef for dynamic sparsity patterns.
+   */
+  typedef DynamicSparsityPattern DynamicSparsityPattern;
+
+  /**
+   * Typedef for block dynamic sparsity patterns.
+   */
+  typedef BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+#ifdef DEAL_II_WITH_UMFPACK
+
+  /**
+   * Typedef for the UMFPACK direct linear solver.
+   */
+  typedef SparseDirectUMFPACK SparseDirectUMFPACK;
+
+#endif
+
+  /**
+  * Typedef for the identity preconditioner.
+  */
+  typedef PreconditionIdentity PreconditionIdentity;
+
+  /**
+   * A namespace in which the complex valued deal.II linear algebra classes are
+   * typedef'ed to generic names.
+   *
+   * @ingroup GenericLinearAlgebra
+   * @author Jean-Paul Pelteret 2016
+   */
+  namespace Complex
+  {
+    /**
+     * Typedef for the vector type used.
+     */
+    typedef dealii::Vector< std::complex<double> > Vector;
+
+    /**
+    * Typedef for the type used to describe vectors that consist of multiple
+    * blocks.
+    */
+    typedef dealii::BlockVector< std::complex<double> > BlockVector;
+
+    /**
+     * Typedef for the sparse matrix type used.
+     */
+    typedef dealii::SparseMatrix< std::complex<double> > SparseMatrix;
+
+    /**
+     * Typedef for the type used to describe sparse matrices that consist of
+     * multiple blocks.
+     */
+    typedef dealii::BlockSparseMatrix< std::complex<double> > BlockSparseMatrix;
+
+    /**
+     * Typedef for the Jacobi preconditioner type.
+     */
+    typedef dealii::PreconditionJacobi<SparseMatrix> PreconditionJacobi;
+
+    /**
+    * Typedef for the generic preconditioner selector.
+    */
+    typedef dealii::PreconditionSelector<SparseMatrix> PreconditionSelector;
+
+    /**
+    * Typedef for the SOR preconditioner type.
+    */
+    typedef dealii::PreconditionSOR<SparseMatrix> PreconditionSOR;
+    /**
+    * Typedef for the SSOR preconditioner type.
+    */
+    typedef dealii::PreconditionSSOR<SparseMatrix> PreconditionSSOR;
+
+    /**
+     * Typedef for the base class for linear solvers.
+     *
+     * This typedef is useful when wanting to create a generic solver interface
+     * wherein one can switch between linear solvers. For example:
+     * @code
+     * std_cxx11::unique_ptr<LA::SolverBase> solver;
+     * if (parameters.solver_type == "CG")
+     * {
+     *   solver.reset(new LA::SolverCG(solver_control));
+     * }
+     * @endcode
+     */
+    typedef dealii::Solver<Vector> SolverBase;
+
+    /**
+     * Typedef for the BiCGStab linear solver.
+     */
+    typedef dealii::SolverBicgstab<Vector> SolverBicgstab;
+
+    /**
+     * Typedef for the CG linear solver.
+     */
+    typedef dealii::SolverCG<Vector> SolverCG;
+
+    /**
+     * Typedef for the GMRES linear solver.
+     */
+    typedef dealii::SolverGMRES<Vector> SolverGMRES;
+
+    /**
+     * Typedef for the generic linear solver selector.
+     */
+    typedef dealii::SolverSelector<Vector> SolverSelector;
+
+    // ----------------------------------------------------
+    // Below are the common elements between this namespace
+    // and the namespaces that it is nested within
+    // ----------------------------------------------------
+
+    /**
+     * Typedef for dynamic sparsity patterns.
+     */
+    typedef DynamicSparsityPattern DynamicSparsityPattern;
+
+    /**
+     * Typedef for block dynamic sparsity patterns.
+     */
+    typedef BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+#ifdef DEAL_II_WITH_UMFPACK
+
+    /**
+     * Typedef for the UMFPACK direct linear solver.
+     */
+    typedef SparseDirectUMFPACK SparseDirectUMFPACK;
+
+#endif
+
+    /**
+    * Typedef for the identity preconditioner.
+    */
+    typedef PreconditionIdentity PreconditionIdentity;
+  }
 }
 
 
@@ -51,10 +280,16 @@ DEAL_II_NAMESPACE_CLOSE
 #ifdef DEAL_II_WITH_PETSC
 
 #include <deal.II/lac/block_sparsity_pattern.h>
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
 #include <deal.II/lac/petsc_parallel_sparse_matrix.h>
 #include <deal.II/lac/petsc_parallel_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_parallel_vector.h>
 #include <deal.II/lac/petsc_precondition.h>
 #include <deal.II/lac/petsc_solver.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -63,69 +298,308 @@ DEAL_II_NAMESPACE_OPEN
  * typedef'ed to generic names. There are similar namespaces
  * LinearAlgebraDealII and LinearAlgebraTrilinos for typedefs to deal.II's own
  * classes and classes that interface with Trilinos.
+ *
+ * @ingroup GenericLinearAlgebra
+ * @author Timo Heister 2008, Jean-Paul Pelteret 2016
  */
 namespace LinearAlgebraPETSc
 {
-  using namespace dealii;
+  /**
+   * Typedef for the vector type used.
+   */
+  typedef dealii::PETScWrappers::Vector Vector;
 
-  typedef PETScWrappers::SolverCG SolverCG;
-  typedef PETScWrappers::SolverGMRES SolverGMRES;
+  /**
+   * Typedef for the type used to describe vectors that consist of multiple
+   * blocks.
+   */
+  typedef dealii::PETScWrappers::BlockVector BlockVector;
+
+  /**
+   * Typedef for the sparse matrix type used.
+   */
+  typedef dealii::PETScWrappers::SparseMatrix SparseMatrix;
+
+  /**
+   * Typedef for the type used to describe sparse matrices that consist of
+   * multiple blocks.
+   */
+  typedef dealii::PETScWrappers::BlockSparseMatrix BlockSparseMatrix;
+
+  // ----------------------------------------------------
+  // Below are the common elements between this namespace
+  // and any namespaces nested within this one
+  // ----------------------------------------------------
+
+  /**
+   * Typedef for dynamic sparsity patterns.
+   */
+  typedef dealii::DynamicSparsityPattern DynamicSparsityPattern;
+
+  /**
+   * Typedef for block dynamic sparsity patterns.
+   */
+  typedef dealii::BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+  /**
+   * Typedef for the base class for linear solvers.
+   *
+   * This typedef is useful when wanting to create a generic solver interface
+   * wherein one can switch between linear solvers. For example:
+   * @code
+   * std_cxx11::unique_ptr<LA::SolverBase> solver;
+   * if (parameters.solver_type == "CG")
+   * {
+   *   solver.reset(new LA::SolverCG(solver_control));
+   * }
+   * @endcode
+   */
+  typedef dealii::PETScWrappers::SolverBase SolverBase;
+
+  /**
+   * Typedef for the BiCGStab linear solver.
+   */
+  typedef dealii::PETScWrappers::SolverBicgstab SolverBicgstab;
+
+  /**
+   * Typedef for the CG linear solver.
+   */
+  typedef dealii::PETScWrappers::SolverCG SolverCG;
+
+  /**
+   * Typedef for the CG Squared linear solver.
+   */
+  typedef dealii::PETScWrappers::SolverCGS SolverCGS;
+
+#ifdef DEAL_II_PETSC_WITH_MUMPS
+
+  /**
+   * Typedef for the MUMPS direct linear solver.
+   */
+  typedef dealii::PETScWrappers::SparseDirectMUMPS SparseDirectMUMPS;
+
+#endif
+
+  /**
+   * Typedef for the GMRES linear solver.
+   */
+  typedef dealii::PETScWrappers::SolverGMRES SolverGMRES;
+
+  /**
+   * Typedef for the TFQMR linear solver.
+   */
+  typedef dealii::PETScWrappers::SolverTFQMR SolverTFQMR;
+
+  /**
+   * Typedef for the base class for preconditioners.
+   *
+   * This typedef is useful when wanting to create a generic solver interface
+   * wherein one can switch between preconditioners. For example:
+   * @code
+   * std_cxx11::unique_ptr<LA::PreconditionBase> preconditioner;
+   * if (parameters.preconditioner_type == "Jacobi")
+   * {
+   *   LA::MPI::PreconditionJacobi* ptr_prec
+   *     = new LA::MPI::PreconditionJacobi ();
+   *
+   *   LA::MPI::PreconditionJacobi::AdditionalData
+   *     additional_data (parameters.preconditioner_relaxation);
+   *
+   *   ptr_prec->initialize(tangent_matrix.block(u_block,u_block),
+   *                        additional_data);
+   *   preconditioner.reset(ptr_prec);
+   * }
+   * @endcode
+   */
+  typedef dealii::PETScWrappers::PreconditionerBase PreconditionBase;
+
+  /**
+   * Typedef for the AMG preconditioner type.
+   */
+  typedef dealii::PETScWrappers::PreconditionBoomerAMG PreconditionAMG;
+
+  /**
+   * Typedef for the Incomplete Cholesky preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionICC PreconditionIC;
+
+  /**
+   * Typedef for the identity preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionNone PreconditionIdentity;
+
+  /**
+   * Typedef for the Incomplete LU decomposition preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionILU PreconditionILU;
+
+  /**
+   * Typedef for the Incomplete Jacobi decomposition preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionJacobi PreconditionJacobi;
+
+  /**
+   * Typedef for the SOR preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionSOR PreconditionSOR;
+
+  /**
+   * Typedef for the SSOR preconditioner.
+   */
+  typedef dealii::PETScWrappers::PreconditionSSOR PreconditionSSOR;
 
   /**
    * A namespace with typedefs to generic names for parallel PETSc linear
    * algebra objects.
+   *
+   * @ingroup GenericLinearAlgebra
+   * @author Timo Heister 2008, Jean-Paul Pelteret 2016
    */
   namespace MPI
   {
     /**
      * Typedef for the vector type used.
      */
-    typedef PETScWrappers::MPI::Vector Vector;
+    typedef dealii::PETScWrappers::MPI::Vector Vector;
 
     /**
      * Typedef for the type used to describe vectors that consist of multiple
      * blocks.
      */
-    typedef PETScWrappers::MPI::BlockVector BlockVector;
+    typedef dealii::PETScWrappers::MPI::BlockVector BlockVector;
 
     /**
      * Typedef for the sparse matrix type used.
      */
-    typedef PETScWrappers::MPI::SparseMatrix SparseMatrix;
+    typedef dealii::PETScWrappers::MPI::SparseMatrix SparseMatrix;
 
     /**
      * Typedef for the type used to describe sparse matrices that consist of
      * multiple blocks.
      */
-    typedef PETScWrappers::MPI::BlockSparseMatrix BlockSparseMatrix;
+    typedef dealii::PETScWrappers::MPI::BlockSparseMatrix BlockSparseMatrix;
 
-    typedef dealii::BlockDynamicSparsityPattern BlockCompressedSparsityPattern;
+    // ----------------------------------------------------
+    // Below are the common elements between this namespace
+    // and the namespaces that it is nested within
+    // ----------------------------------------------------
+
+    /**
+     * Typedef for dynamic sparsity patterns.
+     */
+    typedef dealii::DynamicSparsityPattern DynamicSparsityPattern;
+
+    /**
+     * Typedef for block dynamic sparsity patterns.
+     */
+    typedef dealii::BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+    /**
+     * Typedef for the base class for linear solvers.
+     *
+     * This typedef is useful when wanting to create a generic solver interface
+     * wherein one can switch between linear solvers. For example:
+     * @code
+     * std_cxx11::unique_ptr<LA::SolverBase> solver;
+     * if (parameters.solver_type == "CG")
+     * {
+     *   solver.reset(new LA::SolverCG(solver_control));
+     * }
+     * @endcode
+     */
+    typedef dealii::PETScWrappers::SolverBase SolverBase;
+
+    /**
+     * Typedef for the BiCGStab linear solver.
+     */
+    typedef dealii::PETScWrappers::SolverBicgstab SolverBicgstab;
+
+    /**
+     * Typedef for the CG linear solver.
+     */
+    typedef dealii::PETScWrappers::SolverCG SolverCG;
+
+    /**
+     * Typedef for the CG Squared linear solver.
+     */
+    typedef dealii::PETScWrappers::SolverCGS SolverCGS;
+
+#ifdef DEAL_II_PETSC_WITH_MUMPS
+
+    /**
+     * Typedef for the MUMPS direct linear solver.
+     */
+    typedef dealii::PETScWrappers::SparseDirectMUMPS SparseDirectMUMPS;
+
+#endif
+
+    /**
+     * Typedef for the GMRES linear solver.
+     */
+    typedef dealii::PETScWrappers::SolverGMRES SolverGMRES;
+
+    /**
+     * Typedef for the TFQMR linear solver.
+     */
+    typedef dealii::PETScWrappers::SolverTFQMR SolverTFQMR;
+
+    /**
+     * Typedef for the base class for preconditioners.
+     *
+     * This typedef is useful when wanting to create a generic solver interface
+     * wherein one can switch between preconditioners. For example:
+     * @code
+     * std_cxx11::unique_ptr<LA::PreconditionBase> preconditioner;
+     * if (parameters.preconditioner_type == "Jacobi")
+     * {
+     *   LA::MPI::PreconditionJacobi* ptr_prec
+     *     = new LA::MPI::PreconditionJacobi ();
+     *
+     *   LA::MPI::PreconditionJacobi::AdditionalData
+     *     additional_data (parameters.preconditioner_relaxation);
+     *
+     *   ptr_prec->initialize(tangent_matrix.block(u_block,u_block),
+     *                        additional_data);
+     *   preconditioner.reset(ptr_prec);
+     * }
+     * @endcode
+     */
+    typedef dealii::PETScWrappers::PreconditionerBase PreconditionBase;
 
     /**
      * Typedef for the AMG preconditioner type.
      */
-    typedef PETScWrappers::PreconditionBoomerAMG PreconditionAMG;
+    typedef dealii::PETScWrappers::PreconditionBoomerAMG PreconditionAMG;
 
     /**
      * Typedef for the Incomplete Cholesky preconditioner.
      */
-    typedef PETScWrappers::PreconditionICC PreconditionIC;
+    typedef dealii::PETScWrappers::PreconditionICC PreconditionIC;
+
+    /**
+     * Typedef for the identity preconditioner.
+     */
+    typedef dealii::PETScWrappers::PreconditionNone PreconditionIdentity;
 
     /**
      * Typedef for the Incomplete LU decomposition preconditioner.
      */
-    typedef PETScWrappers::PreconditionILU PreconditionILU;
+    typedef dealii::PETScWrappers::PreconditionILU PreconditionILU;
 
     /**
      * Typedef for the Incomplete Jacobi decomposition preconditioner.
      */
-    typedef PETScWrappers::PreconditionJacobi PreconditionJacobi;
+    typedef dealii::PETScWrappers::PreconditionJacobi PreconditionJacobi;
+
+    /**
+     * Typedef for the SOR preconditioner.
+     */
+    typedef dealii::PETScWrappers::PreconditionSOR PreconditionSOR;
 
     /**
      * Typedef for the SSOR preconditioner.
      */
-    typedef PETScWrappers::PreconditionSSOR PreconditionSSOR;
-
+    typedef dealii::PETScWrappers::PreconditionSSOR PreconditionSSOR;
   }
 
 }
@@ -136,11 +610,15 @@ DEAL_II_NAMESPACE_CLOSE
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-#include <deal.II/lac/trilinos_block_sparse_matrix.h>
-#include <deal.II/lac/trilinos_sparse_matrix.h>
-#include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
+#include <deal.II/lac/trilinos_block_sparse_matrix.h>
+#include <deal.II/lac/trilinos_block_vector.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
 #include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -149,73 +627,325 @@ DEAL_II_NAMESPACE_OPEN
  * are typedef'ed to generic names. There are similar namespaces
  * LinearAlgebraDealII and LinearAlgebraPETSc for typedefs to deal.II's own
  * classes and classes that interface with PETSc.
+ *
+ * @ingroup GenericLinearAlgebra
+ * @author Timo Heister 2008, Jean-Paul Pelteret 2016
  */
 namespace LinearAlgebraTrilinos
 {
-  using namespace dealii;
+  /**
+   * Typedef for the vector type used.
+   */
+  typedef dealii::TrilinosWrappers::Vector Vector;
 
-  typedef TrilinosWrappers::SolverCG SolverCG;
-  typedef TrilinosWrappers::SolverGMRES SolverGMRES;
+  /**
+   * Typedef for the type used to describe vectors that consist of multiple
+   * blocks.
+   */
+  typedef dealii::TrilinosWrappers::BlockVector BlockVector;
+
+  // ----------------------------------------------------
+  // Below are the common elements between this namespace
+  // and any namespaces nested within this one
+  // ----------------------------------------------------
+
+  /**
+   * Typedef for the sparse matrix type used.
+   */
+  typedef dealii::TrilinosWrappers::SparseMatrix SparseMatrix;
+
+  /**
+   * Typedef for dynamic sparsity patterns.
+   */
+  typedef dealii::DynamicSparsityPattern DynamicSparsityPattern;
+
+  /**
+   * Typedef for sparsity patterns.
+   */
+  typedef dealii::TrilinosWrappers::SparsityPattern SparsityPattern;
+
+  /**
+   * Typedef for the type used to describe sparse matrices that consist of
+   * multiple blocks.
+   */
+  typedef dealii::TrilinosWrappers::BlockSparseMatrix BlockSparseMatrix;
+
+  /**
+   * Typedef for block dynamic sparsity patterns.
+   */
+  typedef dealii::BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+  /**
+   * Typedef for block sparsity patterns.
+   */
+  typedef dealii::TrilinosWrappers::BlockSparsityPattern BlockSparsityPattern;
+
+  /**
+   * Typedef for the base class for linear solvers.
+   *
+   * This typedef is useful when wanting to create a generic solver interface
+   * wherein one can switch between linear solvers. For example:
+   * @code
+   * std_cxx11::unique_ptr<LA::SolverBase> solver;
+   * if (parameters.solver_type == "CG")
+   * {
+   *   solver.reset(new LA::SolverCG(solver_control));
+   * }
+   * @endcode
+   */
+  typedef dealii::TrilinosWrappers::SolverBase SolverBase;
+
+  /**
+   * Typedef for the BiCGStab linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverBicgstab SolverBicgstab;
+
+  /**
+   * Typedef for the CG linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverCG SolverCG;
+
+  /**
+   * Typedef for the CG Squared linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverCGS SolverCGS;
+
+  /**
+   * Typedef for the direct linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverDirect SolverDirect;
+
+  /**
+   * Typedef for the GMRES linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverGMRES SolverGMRES;
+
+  /**
+   * Typedef for the TFQMR linear solver.
+   */
+  typedef dealii::TrilinosWrappers::SolverTFQMR SolverTFQMR;
+
+  /**
+   * Typedef for the base class for preconditioners.
+   *
+   * This typedef is useful when wanting to create a generic solver interface
+   * wherein one can switch between preconditioners. For example:
+   * @code
+   * std_cxx11::unique_ptr<LA::PreconditionBase> preconditioner;
+   * if (parameters.preconditioner_type == "Jacobi")
+   * {
+   *   LA::MPI::PreconditionJacobi* ptr_prec
+   *     = new LA::MPI::PreconditionJacobi ();
+   *
+   *   LA::MPI::PreconditionJacobi::AdditionalData
+   *     additional_data (parameters.preconditioner_relaxation);
+   *
+   *   ptr_prec->initialize(tangent_matrix.block(u_block,u_block),
+   *                        additional_data);
+   *   preconditioner.reset(ptr_prec);
+   * }
+   * @endcode
+   */
+  typedef dealii::TrilinosWrappers::PreconditionBase PreconditionBase;
+
+  /**
+   * Typedef for the AMG preconditioner type.
+   */
+  typedef dealii::TrilinosWrappers::PreconditionAMG PreconditionAMG;
+
+  /**
+   * Typedef for the Incomplete Cholesky preconditioner.
+   */
+  typedef dealii::TrilinosWrappers::PreconditionIC PreconditionIC;
+
+  /**
+   * Typedef for the identity preconditioner.
+   */
+  typedef dealii::TrilinosWrappers::PreconditionIdentity PreconditionIdentity;
+
+  /**
+   * Typedef for the Incomplete LU decomposition preconditioner.
+   */
+  typedef dealii::TrilinosWrappers::PreconditionILU PreconditionILU;
+
+  /**
+   * Typedef for the Incomplete Jacobi decomposition preconditioner.
+   */
+  typedef dealii::TrilinosWrappers::PreconditionJacobi PreconditionJacobi;
+
+  /**
+   * Typedef for the SOR preconditioner
+   */
+  typedef dealii::TrilinosWrappers::PreconditionSOR PreconditionSOR;
+
+  /**
+   * Typedef for the SSOR preconditioner
+   */
+  typedef dealii::TrilinosWrappers::PreconditionSSOR PreconditionSSOR;
 
   /**
    * A namespace with typedefs to generic names for parallel Trilinos linear
    * algebra objects.
+   *
+   * @ingroup GenericLinearAlgebra
+   * @author Timo Heister 2008, Jean-Paul Pelteret 2016
    */
   namespace MPI
   {
     /**
      * Typedef for the vector type used.
      */
-    typedef TrilinosWrappers::MPI::Vector Vector;
+    typedef dealii::TrilinosWrappers::MPI::Vector Vector;
 
     /**
      * Typedef for the type used to describe vectors that consist of multiple
      * blocks.
      */
-    typedef TrilinosWrappers::MPI::BlockVector BlockVector;
+    typedef dealii::TrilinosWrappers::MPI::BlockVector BlockVector;
+
+    // ----------------------------------------------------
+    // Below are the common elements between this namespace
+    // and the namespaces that it is nested within
+    // ----------------------------------------------------
 
     /**
      * Typedef for the sparse matrix type used.
      */
-    typedef TrilinosWrappers::SparseMatrix SparseMatrix;
+    typedef dealii::TrilinosWrappers::SparseMatrix SparseMatrix;
+
+    /**
+     * Typedef for dynamic sparsity patterns.
+     */
+    typedef dealii::DynamicSparsityPattern DynamicSparsityPattern;
+
+    /**
+     * Typedef for sparsity patterns.
+     */
+    typedef dealii::TrilinosWrappers::SparsityPattern SparsityPattern;
 
     /**
      * Typedef for the type used to describe sparse matrices that consist of
      * multiple blocks.
      */
-    typedef TrilinosWrappers::BlockSparseMatrix BlockSparseMatrix;
+    typedef dealii::TrilinosWrappers::BlockSparseMatrix BlockSparseMatrix;
 
-    typedef TrilinosWrappers::BlockSparsityPattern BlockCompressedSparsityPattern;
+    /**
+     * Typedef for block dynamic sparsity patterns.
+     */
+    typedef dealii::BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
+
+    /**
+     * Typedef for block sparsity patterns.
+     */
+    typedef dealii::TrilinosWrappers::BlockSparsityPattern BlockSparsityPattern;
+
+    /**
+     * Typedef for the base class for linear solvers.
+     *
+     * This typedef is useful when wanting to create a generic solver interface
+     * wherein one can switch between linear solvers. For example:
+     * @code
+     * std_cxx11::unique_ptr<LA::SolverBase> solver;
+     * if (parameters.solver_type == "CG")
+     * {
+     *   solver.reset(new LA::SolverCG(solver_control));
+     * }
+     * @endcode
+     */
+    typedef dealii::TrilinosWrappers::SolverBase SolverBase;
+
+    /**
+     * Typedef for the BiCGStab linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverBicgstab SolverBicgstab;
+
+    /**
+     * Typedef for the CG linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverCG SolverCG;
+
+    /**
+     * Typedef for the CG Squared linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverCGS SolverCGS;
+
+    /**
+     * Typedef for the direct linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverDirect SolverDirect;
+
+    /**
+     * Typedef for the GMRES linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverGMRES SolverGMRES;
+
+    /**
+     * Typedef for the TFQMR linear solver.
+     */
+    typedef dealii::TrilinosWrappers::SolverTFQMR SolverTFQMR;
+
+    /**
+     * Typedef for the base class for preconditioners.
+     *
+     * This typedef is useful when wanting to create a generic solver interface
+     * wherein one can switch between preconditioners. For example:
+     * @code
+     * std_cxx11::unique_ptr<LA::PreconditionBase> preconditioner;
+     * if (parameters.preconditioner_type == "Jacobi")
+     * {
+     *   LA::MPI::PreconditionJacobi* ptr_prec
+     *     = new LA::MPI::PreconditionJacobi ();
+     *
+     *   LA::MPI::PreconditionJacobi::AdditionalData
+     *     additional_data (parameters.preconditioner_relaxation);
+     *
+     *   ptr_prec->initialize(tangent_matrix.block(u_block,u_block),
+     *                        additional_data);
+     *   preconditioner.reset(ptr_prec);
+     * }
+     * @endcode
+     */
+    typedef dealii::TrilinosWrappers::PreconditionBase PreconditionBase;
 
     /**
      * Typedef for the AMG preconditioner type.
      */
-    typedef TrilinosWrappers::PreconditionAMG PreconditionAMG;
+    typedef dealii::TrilinosWrappers::PreconditionAMG PreconditionAMG;
 
     /**
      * Typedef for the Incomplete Cholesky preconditioner.
      */
-    typedef TrilinosWrappers::PreconditionIC PreconditionIC;
+    typedef dealii::TrilinosWrappers::PreconditionIC PreconditionIC;
+
+    /**
+     * Typedef for the identity preconditioner.
+     */
+    typedef dealii::TrilinosWrappers::PreconditionIdentity PreconditionIdentity;
 
     /**
      * Typedef for the Incomplete LU decomposition preconditioner.
      */
-    typedef TrilinosWrappers::PreconditionILU PreconditionILU;
+    typedef dealii::TrilinosWrappers::PreconditionILU PreconditionILU;
 
     /**
      * Typedef for the Incomplete Jacobi decomposition preconditioner.
      */
-    typedef TrilinosWrappers::PreconditionJacobi PreconditionJacobi;
+    typedef dealii::TrilinosWrappers::PreconditionJacobi PreconditionJacobi;
+
+    /**
+     * Typedef for the SOR preconditioner
+     */
+    typedef dealii::TrilinosWrappers::PreconditionSOR PreconditionSOR;
 
     /**
      * Typedef for the SSOR preconditioner
      */
-    typedef TrilinosWrappers::PreconditionSSOR PreconditionSSOR;
-
-
+    typedef dealii::TrilinosWrappers::PreconditionSSOR PreconditionSSOR;
   }
 
 }
+
+/*@}*/
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
TODO list:
- [x] Complete documentation (find out how to get `doxygen` to list the typedefs in the imported namespaces)
- [x] Update tests (not necessary)
- [x] Update tutorials / code gallery examples (as they were not written referencing `LA::CompressedSparsityParrtern`, this appears to be unnecessary)
