### PR TITLE
Refactor documentation for TrilinosWrappers::BlockSparsityPattern.

### DIFF
--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -562,31 +562,38 @@ public:
   using BlockSparsityPatternBase<DynamicSparsityPattern>::reinit;
 };
 
+/*@}*/
+
 
 #ifdef DEAL_II_WITH_TRILINOS
 
 
-/**
- * This class extends the base class to implement an array of Trilinos
- * sparsity patterns that can be used to initialize Trilinos block sparse
- * matrices that can be distributed among different processors. It is used in
- * the same way as the BlockSparsityPattern except that it builds upon the
- * TrilinosWrappers::SparsityPattern instead of the dealii::SparsityPattern.
- * See the documentation of the BlockSparsityPattern for examples.
- *
- * This class is has properties of the "dynamic" type of
- * @ref Sparsity
- * (in the sense that it can extend the memory if too little elements were
- * allocated), but otherwise is more like the basic deal.II SparsityPattern
- * (in the sense that the method compress() needs to be called before the
- * pattern can be used).
- *
- * This class is used in step-32.
- *
- * @author Martin Kronbichler, 2008, 2009
- */
 namespace TrilinosWrappers
 {
+
+  /*! @addtogroup TrilinosWrappers
+   *@{
+   */
+
+  /**
+   * This class extends the base class to implement an array of Trilinos
+   * sparsity patterns that can be used to initialize Trilinos block sparse
+   * matrices that can be distributed among different processors. It is used in
+   * the same way as the dealii::BlockSparsityPattern except that it builds upon
+   * the TrilinosWrappers::SparsityPattern instead of the
+   * dealii::SparsityPattern.
+   *
+   * This class is has properties of the "dynamic" type of
+   * @ref Sparsity
+   * (in the sense that it can extend the memory if too little elements were
+   * allocated), but otherwise is more like the basic deal.II SparsityPattern
+   * (in the sense that the method compress() needs to be called before the
+   * pattern can be used).
+   *
+   * This class is used in step-32.
+   *
+   * @author Martin Kronbichler, 2008, 2009
+   */
   class BlockSparsityPattern :
     public dealii::BlockSparsityPatternBase<SparsityPattern>
   {
@@ -709,12 +716,13 @@ namespace TrilinosWrappers
      */
     using BlockSparsityPatternBase<SparsityPattern>::reinit;
   };
-}
+
+  /*@}*/
+
+} /* namespace TrilinosWrappers */
 
 #endif
 
-
-/*@}*/
 /*---------------------- Template functions -----------------------------------*/
 
 

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -53,6 +53,12 @@ template <typename number> class Vector;
  * @addtogroup TrilinosWrappers
  * @{
  */
+
+/**
+* A namespace in which wrapper classes for Trilinos objects reside.
+*
+* @ingroup TrilinosWrappers
+*/
 namespace TrilinosWrappers
 {
   // forward declaration


### PR DESCRIPTION
The documentation for this class now mirrors that provided in
`petsc_block_sparse_matrix.h` (and, for the namespace description,
`petsc_vector_base.h`).

Fixes #3267