### PR TITLE
Fixed typo in FunctionParser examples.

### DIFF
--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -155,7 +155,7 @@ template <typename> class Vector;
  * function by using a single string:
  * @code
  *    // Empty constants object
- *    std::map<std::string> constants;
+ *    std::map<std::string,double> constants;
  *
  *    // Variables that will be used inside the expressions
  *    std::string variables = "x,y";


### PR DESCRIPTION
fixes #3286 