### PR TITLE
add LinearAlgebra::distributed::Vector::add() with pointers

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -695,6 +695,15 @@ namespace LinearAlgebra
                 const ::dealii::Vector<OtherNumber> &values);
 
       /**
+       * Take an address where n_elements are stored contiguously and add them
+       * into the vector.
+       */
+      template <typename OtherNumber>
+      void add (const size_type n_elements,
+                const size_type *indices,
+                const OtherNumber *values);
+
+      /**
        * Scaling and simple vector addition, i.e.  <tt>*this =
        * s*(*this)+V</tt>.
        */
@@ -1386,6 +1395,24 @@ namespace LinearAlgebra
           Assert (numbers::is_finite(values[i]),
                   ExcMessage("The given value is not finite but either infinite or Not A Number (NaN)"));
           this->operator()(indices[i]) += values(i);
+        }
+    }
+
+
+
+    template <typename Number>
+    template <typename OtherNumber>
+    inline
+    void
+    Vector<Number>::add (const size_type n_elements,
+                         const size_type *indices,
+                         const OtherNumber *values)
+    {
+      for (size_type i=0; i<n_elements; ++i, ++indices, ++values)
+        {
+          Assert (numbers::is_finite(*values),
+                  ExcMessage("The given value is not finite but either infinite or Not A Number (NaN)"));
+          this->operator()(*indices) += *values;
         }
     }
 

--- a/tests/mpi/parallel_vector_18.cc
+++ b/tests/mpi/parallel_vector_18.cc
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// use same partition as in prarallel_vector_06 to check add() with pointers.
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+
+void test ()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  if (myid==0) deallog << "numproc=" << numproc << std::endl;
+
+
+  // each processor from processor 1 to 8
+  // owns 2 indices (the other processors do
+  // not own any dof), and all processors are
+  // ghosting element 1 (the second)
+  IndexSet local_owned(std::min(16U,numproc*2));
+  if (myid < 8)
+    local_owned.add_range(myid*2,myid*2+2);
+  IndexSet local_relevant(numproc*2);
+  local_relevant = local_owned;
+  local_relevant.add_range(1,2);
+
+  LinearAlgebra::distributed::Vector<double> v(local_owned, local_owned, MPI_COMM_WORLD);
+
+  // set local values
+  if (myid < 8)
+    {
+      unsigned int indices[2];
+      indices[0] = myid*2;
+      indices[1] = myid*2+1;
+      float values[2];
+      values[0] = myid*2.0;
+      values[1] = myid*2.0+1.0;
+      v.add (2, &indices[0], &values[0]);
+    }
+  v.compress(VectorOperation::insert);
+  v*=2.0;
+  if (myid < 8)
+    {
+      AssertThrow(v(myid*2) == myid*4.0, ExcInternalError());
+      AssertThrow(v(myid*2+1) == myid*4.0+2.0, ExcInternalError());
+    }
+
+  if (myid == 0)
+    deallog << "OK" << std::endl;
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  deallog.push(Utilities::int_to_string(myid));
+
+  if (myid == 0)
+    {
+      std::ofstream logfile("output");
+      deallog.attach(logfile);
+      deallog << std::setprecision(4);
+      deallog.threshold_double(1.e-10);
+
+      test();
+    }
+  else
+    test();
+
+}

--- a/tests/mpi/parallel_vector_18.mpirun=1.output
+++ b/tests/mpi/parallel_vector_18.mpirun=1.output
@@ -1,0 +1,3 @@
+
+DEAL:0::numproc=1
+DEAL:0::OK

--- a/tests/mpi/parallel_vector_18.mpirun=10.output
+++ b/tests/mpi/parallel_vector_18.mpirun=10.output
@@ -1,0 +1,3 @@
+
+DEAL:0::numproc=10
+DEAL:0::OK

--- a/tests/mpi/parallel_vector_18.mpirun=4.output
+++ b/tests/mpi/parallel_vector_18.mpirun=4.output
@@ -1,0 +1,3 @@
+
+DEAL:0::numproc=4
+DEAL:0::OK


### PR DESCRIPTION
@kronbichler :  If you could point me where unit tests for another `add()` are, i would be happy to add one more for the one in this PR.