### PR TITLE
Use subdomain_ids consistently.

### DIFF
--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -137,7 +137,8 @@ namespace parallel
      * @note: If @p i is contained in the list of processor @p j, then @p j
      * will also be contained in the list of processor @p i.
      */
-    const std::set<unsigned int> &ghost_owners () const;
+    const std::set<types::subdomain_id> &
+    ghost_owners () const;
 
     /**
      * Return a set of MPI ranks of the processors that have at least one
@@ -148,7 +149,8 @@ namespace parallel
      * @note: If @p i is contained in the list of processor @p j, then @p j
      * will also be contained in the list of processor @p i.
      */
-    const std::set<unsigned int> &level_ghost_owners () const;
+    const std::set<types::subdomain_id> &
+    level_ghost_owners () const;
 
   protected:
     /**
@@ -179,28 +181,28 @@ namespace parallel
        * This vector stores the number of locally owned active cells per MPI
        * rank.
        */
-      std::vector<unsigned int> n_locally_owned_active_cells;
+      std::vector<unsigned int>     n_locally_owned_active_cells;
       /**
        * The total number of active cells (sum of @p
        * n_locally_owned_active_cells).
        */
-      types::global_dof_index   n_global_active_cells;
+      types::global_dof_index       n_global_active_cells;
       /**
        * The global number of levels computed as the maximum number of levels
        * taken over all MPI ranks, so <tt>n_levels()<=n_global_levels =
        * max(n_levels() on proc i)</tt>.
        */
-      unsigned int              n_global_levels;
+      unsigned int                  n_global_levels;
       /**
        * A set containing the subdomain_id (MPI rank) of the owners of the
        * ghost cells on this processor.
        */
-      std::set<unsigned int> ghost_owners;
+      std::set<types::subdomain_id> ghost_owners;
       /**
        * A set containing the MPI ranks of the owners of the level ghost cells
        * on this processor (for all levels).
        */
-      std::set<unsigned int> level_ghost_owners;
+      std::set<types::subdomain_id> level_ghost_owners;
 
       NumberCache();
     };
@@ -211,8 +213,6 @@ namespace parallel
      * Update the number_cache variable after mesh creation or refinement.
      */
     virtual void update_number_cache ();
-
-
   };
 
 } // namespace parallel

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -623,7 +623,7 @@ namespace DoFTools
                               SparsityPatternType       &sparsity_pattern,
                               const ConstraintMatrix    &constraints,
                               const bool                 keep_constrained_dofs = true,
-                              const types::subdomain_id  subdomain_id          = numbers::invalid_unsigned_int);
+                              const types::subdomain_id  subdomain_id          = numbers::invalid_subdomain_id);
 
   /**
    * This function does essentially the same as the other

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -93,7 +93,7 @@ namespace parallel
     }
 
     template <int dim, int spacedim>
-    const std::vector<unsigned int> &
+    const std::vector<types::subdomain_id> &
     Triangulation<dim,spacedim>::get_true_subdomain_ids_of_cells() const
     {
       return true_subdomain_ids_of_cells;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -516,10 +516,10 @@ namespace
 
   template <int dim, int spacedim>
   void
-  match_quadrant (const dealii::Triangulation<dim,spacedim> *tria,
-                  unsigned int dealii_index,
+  match_quadrant (const dealii::Triangulation<dim,spacedim>      *tria,
+                  unsigned int                                    dealii_index,
                   typename internal::p4est::types<dim>::quadrant &ghost_quadrant,
-                  unsigned int ghost_owner)
+                  types::subdomain_id                             ghost_owner)
   {
     int i, child_id;
     int l = ghost_quadrant.level;
@@ -937,7 +937,7 @@ namespace
 
     void build_lists (const typename Triangulation<dim,spacedim>::cell_iterator &cell,
                       const typename internal::p4est::types<dim>::quadrant &p4est_cell,
-                      const unsigned int myid);
+                      const types::subdomain_id myid);
   };
 
 
@@ -1935,21 +1935,27 @@ namespace parallel
             int dummy = 0;
             unsigned int req_counter = 0;
 
-            for (std::set<unsigned int>::iterator it = this->number_cache.level_ghost_owners.begin();
+            for (std::set<types::subdomain_id>::iterator it = this->number_cache.level_ghost_owners.begin();
                  it != this->number_cache.level_ghost_owners.end();
                  ++it, ++req_counter)
               {
-                MPI_Isend(&dummy, 1, MPI_INT,
+                Assert (typeid(types::subdomain_id)
+                        == typeid(unsigned int),
+                        ExcNotImplemented());
+                MPI_Isend(&dummy, 1, MPI_UNSIGNED,
                           *it, 9001, this->mpi_communicator,
                           &requests[req_counter]);
               }
 
-            for (std::set<unsigned int>::iterator it = this->number_cache.level_ghost_owners.begin();
+            for (std::set<types::subdomain_id>::iterator it = this->number_cache.level_ghost_owners.begin();
                  it != this->number_cache.level_ghost_owners.end();
                  ++it)
               {
-                int dummy;
-                MPI_Recv(&dummy, 1, MPI_INT,
+                Assert (typeid(types::subdomain_id)
+                        == typeid(unsigned int),
+                        ExcNotImplemented());
+                unsigned int dummy;
+                MPI_Recv(&dummy, 1, MPI_UNSIGNED,
                          *it, 9001, this->mpi_communicator,
                          MPI_STATUS_IGNORE);
               }
@@ -1961,7 +1967,8 @@ namespace parallel
           }
 #endif
 
-          Assert(this->number_cache.level_ghost_owners.size() < Utilities::MPI::n_mpi_processes(this->mpi_communicator), ExcInternalError());
+          Assert(this->number_cache.level_ghost_owners.size() < Utilities::MPI::n_mpi_processes(this->mpi_communicator),
+                 ExcInternalError());
         }
     }
 
@@ -2629,7 +2636,7 @@ namespace parallel
           // every ghostquadrant, find corresponding deal coarsecell and
           // recurse.
           typename dealii::internal::p4est::types<dim>::quadrant *quadr;
-          unsigned int ghost_owner=0;
+          types::subdomain_id ghost_owner=0;
           typename dealii::internal::p4est::types<dim>::topidx ghost_tree=0;
 
           for (unsigned int g_idx=0; g_idx<parallel_ghost->ghosts.elem_count; ++g_idx)

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -230,7 +230,7 @@ namespace parallel
   }
 
   template <int dim, int spacedim>
-  const std::set<unsigned int> &
+  const std::set<types::subdomain_id> &
   Triangulation<dim,spacedim>::
   ghost_owners () const
   {
@@ -238,7 +238,7 @@ namespace parallel
   }
 
   template <int dim, int spacedim>
-  const std::set<unsigned int> &
+  const std::set<types::subdomain_id> &
   Triangulation<dim,spacedim>::
   level_ghost_owners () const
   {

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1599,10 +1599,10 @@ namespace internal
                                    const std::vector<dealii::types::global_dof_index> &p4est_tree_to_coarse_cell_permutation)
         {
           // build list of cells to request for each neighbor
-          std::set<unsigned int> level_ghost_owners = tria.level_ghost_owners();
+          std::set<dealii::types::subdomain_id> level_ghost_owners = tria.level_ghost_owners();
           typedef std::map<dealii::types::subdomain_id, typename types<dim>::cellinfo> cellmap_t;
           cellmap_t neighbor_cell_list;
-          for (std::set<unsigned int>::iterator it = level_ghost_owners.begin();
+          for (std::set<dealii::types::subdomain_id>::iterator it = level_ghost_owners.begin();
                it != level_ghost_owners.end();
                ++it)
             neighbor_cell_list.insert(std::make_pair(*it, typename types<dim>::cellinfo()));

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1376,7 +1376,7 @@ namespace DoFTools
         // one, where we take "random" to be "once this way once that way"
         for (unsigned int i=0; i<dofs_per_cell; ++i)
           if (subdomain_association[local_dof_indices[i]] ==
-              numbers::invalid_unsigned_int)
+              numbers::invalid_subdomain_id)
             subdomain_association[local_dof_indices[i]] = subdomain_id;
           else
             {

--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -121,7 +121,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
@@ -129,7 +129,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
@@ -138,7 +138,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
@@ -147,7 +147,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension>, SP>
@@ -189,7 +189,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const Table<2,Coupling>&,
      const Table<2,Coupling>&,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
@@ -199,21 +199,23 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      const bool,
      const Table<2,Coupling>&,
      const Table<2,Coupling>&,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_flux_sparsity_pattern<DoFHandler<deal_II_dimension>,SP>
     (const DoFHandler<deal_II_dimension> &dof,
      SP    &sparsity,
      const ConstraintMatrix &constraints,
-     const bool, const unsigned int);
+     const bool,
+     const types::subdomain_id);
 
     template void
     DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
     (const hp::DoFHandler<deal_II_dimension> &dof,
      SP    &sparsity,
      const ConstraintMatrix &constraints,
-     const bool, const unsigned int);
+     const bool,
+     const types::subdomain_id);
 
 #if deal_II_dimension > 1
 
@@ -223,7 +225,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const Table<2,Coupling>&,
      const Table<2,Coupling>&,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_flux_sparsity_pattern<hp::DoFHandler<deal_II_dimension>,SP>
@@ -233,7 +235,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      const bool,
      const Table<2,Coupling>&,
      const Table<2,Coupling>&,
-     const unsigned int);
+     const types::subdomain_id);
 
 #endif
 
@@ -245,7 +247,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
@@ -253,7 +255,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
@@ -262,7 +264,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
@@ -271,7 +273,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<deal_II_dimension,deal_II_dimension+1>, SP>
@@ -308,7 +310,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<1,3>, SP>
@@ -316,7 +318,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP    &sparsity,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<1,3>, SP>
@@ -325,7 +327,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<hp::DoFHandler<1,3>, SP>
@@ -334,7 +336,7 @@ for (SP : SPARSITY_PATTERNS; deal_II_dimension : DIMENSIONS)
      SP &,
      const ConstraintMatrix &,
      const bool,
-     const unsigned int);
+     const types::subdomain_id);
 
     template void
     DoFTools::make_sparsity_pattern<DoFHandler<1,3>, SP>

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -172,13 +172,13 @@ namespace
         // inefficient. Please fix this, Timo.
         // The list of neighbors is symmetric (our neighbors have us as a neighbor),
         // so we can use it to send and to know how many messages we will get.
-        std::set<unsigned int> neighbors = tria->level_ghost_owners();
+        std::set<types::subdomain_id> neighbors = tria->level_ghost_owners();
         std::map<int, std::vector<DoFPair> > send_data;
 
         // * find owners of the level dofs and insert into send_data accordingly
         for (typename std::vector<DoFPair>::iterator dofpair=send_data_temp.begin(); dofpair != send_data_temp.end(); ++dofpair)
           {
-            std::set<unsigned int>::iterator it;
+            std::set<types::subdomain_id>::iterator it;
             for (it = neighbors.begin(); it != neighbors.end(); ++it)
               {
                 if (mg_dof.locally_owned_mg_dofs_per_processor(dofpair->level)[*it].is_element(dofpair->level_dof_index))
@@ -195,7 +195,7 @@ namespace
         // * send
         std::vector<MPI_Request> requests;
         {
-          for (std::set<unsigned int>::iterator it = neighbors.begin(); it != neighbors.end(); ++it)
+          for (std::set<types::subdomain_id>::iterator it = neighbors.begin(); it != neighbors.end(); ++it)
             {
               requests.push_back(MPI_Request());
               unsigned int dest = *it;

--- a/source/numerics/error_estimator.inst.in
+++ b/source/numerics/error_estimator.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -37,7 +37,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id,
             const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -53,7 +53,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id,
         const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -69,7 +69,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id,
             const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -85,7 +85,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id,
         const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -101,7 +101,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id,
             const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -117,7 +117,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id,
         const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -133,7 +133,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id,
             const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 
@@ -149,7 +149,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id,
         const KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::Strategy);
 

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2014 by the deal.II authors
+// Copyright (C) 2010 - 2014, 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,7 +30,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id);
 
     template
@@ -45,7 +45,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id);
 
     template
@@ -60,7 +60,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id);
 
     template
@@ -75,7 +75,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id);
 
     template
@@ -90,7 +90,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id);
 
     template
@@ -105,7 +105,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id);
 
     template
@@ -120,7 +120,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
             const ComponentMask &,
             const Function<deal_II_space_dimension>     *,
             const unsigned int       ,
-            const unsigned int       ,
+            const types::subdomain_id,
             const types::material_id);
 
     template
@@ -135,7 +135,7 @@ for (VEC : SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimens
         const ComponentMask &,
         const Function<deal_II_space_dimension>     *,
         const unsigned int       ,
-        const unsigned int       ,
+        const types::subdomain_id,
         const types::material_id);
 
 #endif

--- a/tests/bits/subdomain_ids_01.cc
+++ b/tests/bits/subdomain_ids_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -73,7 +73,7 @@ void test ()
   deallog << dof_handler.n_dofs() << std::endl;
 
   std::vector<bool> selected_dofs (dof_handler.n_dofs());
-  for (unsigned int subdomain=0; subdomain<(1<<dim); ++subdomain)
+  for (types::subdomain_id subdomain=0; subdomain<(1<<dim); ++subdomain)
     {
       // count number on dofs on
       // subdomain. note that they add up to

--- a/tests/bits/subdomain_ids_02.cc
+++ b/tests/bits/subdomain_ids_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -72,7 +72,7 @@ void test ()
   dof_handler.distribute_dofs (fe);
   deallog << dof_handler.n_dofs() << std::endl;
 
-  std::vector<unsigned int> subdomain_association (dof_handler.n_dofs());
+  std::vector<types::subdomain_id> subdomain_association (dof_handler.n_dofs());
   DoFTools::get_subdomain_association (dof_handler,
                                        subdomain_association);
   for (unsigned int subdomain=0; subdomain<(1<<dim); ++subdomain)

--- a/tests/bits/subdomain_ids_04.cc
+++ b/tests/bits/subdomain_ids_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -82,7 +82,7 @@ void test ()
   // subdomain numbers. first output these
   // numbers, then also check that this is
   // indeed so
-  std::vector<unsigned int> subdomain_association (dof_handler.n_dofs());
+  std::vector<types::subdomain_id> subdomain_association (dof_handler.n_dofs());
   DoFTools::get_subdomain_association (dof_handler, subdomain_association);
 
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)

--- a/tests/bits/subdomain_ids_05.cc
+++ b/tests/bits/subdomain_ids_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -72,7 +72,7 @@ void test ()
   dof_handler.distribute_dofs (fe);
   deallog << dof_handler.n_dofs() << std::endl;
 
-  std::vector<unsigned int> subdomain_association (dof_handler.n_dofs());
+  std::vector<types::subdomain_id> subdomain_association (dof_handler.n_dofs());
   DoFTools::get_subdomain_association (dof_handler,
                                        subdomain_association);
   for (unsigned int subdomain=0; subdomain<(1<<dim); ++subdomain)

--- a/tests/bits/subdomain_ids_06.cc
+++ b/tests/bits/subdomain_ids_06.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -65,7 +65,7 @@ void test ()
       cell->set_subdomain_id (subdomain);
     }
 
-  std::vector<unsigned int> subdomain_association (tria.n_active_cells());
+  std::vector<types::subdomain_id> subdomain_association (tria.n_active_cells());
   GridTools::get_subdomain_association (tria,
                                         subdomain_association);
   for (unsigned int subdomain=0; subdomain<(1<<dim); ++subdomain)

--- a/tests/bits/subdomain_ids_07.cc
+++ b/tests/bits/subdomain_ids_07.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2015 by the deal.II authors
+// Copyright (C) 2001 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -72,7 +72,7 @@ void test ()
   dof_handler.distribute_dofs (fe);
   deallog << dof_handler.n_dofs() << std::endl;
 
-  std::vector<unsigned int> subdomain_association (dof_handler.n_dofs());
+  std::vector<types::subdomain_id> subdomain_association (dof_handler.n_dofs());
   DoFTools::get_subdomain_association (dof_handler,
                                        subdomain_association);
   for (unsigned int subdomain=0; subdomain<(1<<dim); ++subdomain)

--- a/tests/mpi/p4est_2d_coarse_01.cc
+++ b/tests/mpi/p4est_2d_coarse_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,8 +61,7 @@ void test()
                 << tr.begin_active()->subdomain_id()
                 << std::endl;
 
-//      std::vector< unsigned int > cell_subd;
-//      cell_subd.resize(tr.n_active_cells());
+//      std::vector<types::subdomain_id> cell_subd(tr.n_active_cells());
 
 //      GridTools::get_subdomain_association(tr, cell_subd);
 //       for (unsigned int i=0;i<tr.n_active_cells();++i)

--- a/tests/mpi/p4est_2d_ghost_01.cc
+++ b/tests/mpi/p4est_2d_ghost_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -50,8 +50,7 @@ void test()
       if (myid==0)
         {
 
-          std::vector< unsigned int > cell_subd;
-          cell_subd.resize(tr.n_active_cells());
+          std::vector<types::subdomain_id> cell_subd(tr.n_active_cells());
 
           GridTools::get_subdomain_association(tr, cell_subd);
           for (unsigned int i=0; i<tr.n_active_cells(); ++i)

--- a/tests/mpi/p4est_2d_ghost_02.cc
+++ b/tests/mpi/p4est_2d_ghost_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -56,8 +56,7 @@ void test()
           if (myid==0)
             {
 
-              std::vector< unsigned int > cell_subd;
-              cell_subd.resize(tr.n_active_cells());
+              std::vector<types::subdomain_id> cell_subd(tr.n_active_cells());
 
               GridTools::get_subdomain_association(tr, cell_subd);
               for (unsigned int i=0; i<tr.n_active_cells(); ++i)

--- a/tests/mpi/p4est_2d_refine_01.cc
+++ b/tests/mpi/p4est_2d_refine_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -47,8 +47,7 @@ void test()
       GridGenerator::hyper_cube(tr);
       tr.refine_global(1);
 
-      std::vector< unsigned int > cell_subd;
-      cell_subd.resize(tr.n_active_cells());
+      std::vector<types::subdomain_id> cell_subd(tr.n_active_cells());
 
       GridTools::get_subdomain_association(tr, cell_subd);
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)

--- a/tests/mpi/p4est_3d_ghost_01.cc
+++ b/tests/mpi/p4est_3d_ghost_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,8 +61,7 @@ void test()
       if (myid==0)
         {
 
-          std::vector< unsigned int > cell_subd;
-          cell_subd.resize(tr.n_active_cells());
+          std::vector<types::subdomain_id> cell_subd(tr.n_active_cells());
 
           GridTools::get_subdomain_association(tr, cell_subd);
           for (unsigned int i=0; i<tr.n_active_cells(); ++i)

--- a/tests/mpi/tria_ghost_owners_01.cc
+++ b/tests/mpi/tria_ghost_owners_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -37,11 +37,11 @@
 
 
 // make sure if i is in s on proc j, j is in s on proc i
-void mpi_check(const std::set<unsigned int> &s)
+void mpi_check(const std::set<types::subdomain_id> &s)
 {
   MPI_Barrier(MPI_COMM_WORLD);
   unsigned int tag = 1234;
-  for (std::set<unsigned int>::iterator it = s.begin();
+  for (std::set<types::subdomain_id>::iterator it = s.begin();
        it != s.end(); ++it)
     MPI_Send(NULL, 0, MPI_INT, *it, tag, MPI_COMM_WORLD);
 
@@ -84,16 +84,16 @@ void test()
       deallog << "* cycle " << ref << std::endl;
 
       deallog << "ghost owners: ";
-      std::set<unsigned int> ghost_owners = tr.ghost_owners();
-      for (std::set<unsigned int>::iterator it = ghost_owners.begin(); it!=ghost_owners.end(); ++it)
+      std::set<types::subdomain_id> ghost_owners = tr.ghost_owners();
+      for (std::set<types::subdomain_id>::iterator it = ghost_owners.begin(); it!=ghost_owners.end(); ++it)
         deallog << *it << " ";
       deallog << std::endl;
 
       mpi_check(ghost_owners);
 
       deallog << "level ghost owners: ";
-      std::set<unsigned int> level_ghost_owners = tr.level_ghost_owners();
-      for (std::set<unsigned int>::iterator it = level_ghost_owners.begin(); it!=level_ghost_owners.end(); ++it)
+      std::set<types::subdomain_id> level_ghost_owners = tr.level_ghost_owners();
+      for (std::set<types::subdomain_id>::iterator it = level_ghost_owners.begin(); it!=level_ghost_owners.end(); ++it)
         deallog << *it << " ";
       deallog << std::endl;
 
@@ -104,7 +104,7 @@ void test()
       Assert(is_subset, ExcInternalError());
 
       Vector<float> indicators (tr.n_active_cells());
-      std::set<unsigned int> neighbors;
+      std::set<types::subdomain_id> neighbors;
       {
         for (typename Triangulation<dim>::active_cell_iterator
              cell = tr.begin_active(); cell != tr.end(); ++cell)

--- a/tests/mpi/tria_ghost_owners_02.cc
+++ b/tests/mpi/tria_ghost_owners_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2015 by the deal.II authors
+// Copyright (C) 2009 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -40,11 +40,11 @@
 
 
 // make sure if i is in s on proc j, j is in s on proc i
-void mpi_check(const std::set<unsigned int> &s)
+void mpi_check(const std::set<types::subdomain_id> &s)
 {
   MPI_Barrier(MPI_COMM_WORLD);
   unsigned int tag = 1234;
-  for (std::set<unsigned int>::iterator it = s.begin();
+  for (std::set<types::subdomain_id>::iterator it = s.begin();
        it != s.end(); ++it)
     MPI_Send(NULL, 0, MPI_INT, *it, tag, MPI_COMM_WORLD);
 
@@ -77,16 +77,16 @@ void test()
       deallog << "* cycle " << ref << std::endl;
 
       deallog << "ghost owners: ";
-      std::set<unsigned int> ghost_owners = tr.ghost_owners();
-      for (std::set<unsigned int>::iterator it = ghost_owners.begin(); it!=ghost_owners.end(); ++it)
+      std::set<types::subdomain_id> ghost_owners = tr.ghost_owners();
+      for (std::set<types::subdomain_id>::iterator it = ghost_owners.begin(); it!=ghost_owners.end(); ++it)
         deallog << *it << " ";
       deallog << std::endl;
 
       mpi_check(ghost_owners);
 
       deallog << "level ghost owners: ";
-      std::set<unsigned int> level_ghost_owners = tr.level_ghost_owners();
-      for (std::set<unsigned int>::iterator it = level_ghost_owners.begin(); it!=level_ghost_owners.end(); ++it)
+      std::set<types::subdomain_id> level_ghost_owners = tr.level_ghost_owners();
+      for (std::set<types::subdomain_id>::iterator it = level_ghost_owners.begin(); it!=level_ghost_owners.end(); ++it)
         deallog << *it << " ";
       deallog << std::endl;
 
@@ -97,7 +97,7 @@ void test()
       Assert(is_subset, ExcInternalError());
 
       Vector<float> indicators (tr.n_active_cells());
-      std::set<unsigned int> neighbors;
+      std::set<types::subdomain_id> neighbors;
       {
         for (typename Triangulation<dim>::active_cell_iterator
              cell = tr.begin_active(); cell != tr.end(); ++cell)


### PR DESCRIPTION
I found this because https://github.com/geodynamics/aspect/pull/1259 uses
`std::vector<unsigned int>` for lists of ghost neighbors, but this should
really be `std::vector<types::subdomain_id>\'. So I changed this in the
parallel triangulation classes. I then went to see where else things are
used inconsistently and found many other places.