### PR TITLE
Redo boost/system commit 241f69c55e.

### DIFF
--- a/bundled/boost-1.62.0/include/boost/system/error_code.hpp
+++ b/bundled/boost-1.62.0/include/boost/system/error_code.hpp
@@ -218,9 +218,9 @@ namespace boost
     inline const error_category &  get_system_category() { return system_category(); }
     inline const error_category &  get_generic_category() { return generic_category(); }
     inline const error_category &  get_posix_category() { return generic_category(); }
-    static const error_category &  posix_category = generic_category();
-    static const error_category &  errno_ecat     = generic_category();
-    static const error_category &  native_ecat    = system_category();
+    static const error_category &  posix_category BOOST_ATTRIBUTE_UNUSED = generic_category();
+    static const error_category &  errno_ecat     BOOST_ATTRIBUTE_UNUSED = generic_category();
+    static const error_category &  native_ecat    BOOST_ATTRIBUTE_UNUSED = system_category();
 # endif
 
     //  class error_condition  -----------------------------------------------//


### PR DESCRIPTION
This commit from November 2015 silences a GCC warning due to unused variables.

I can't seem to reproduce this warning myself so there is a small chance that this won't work.

Closes #3310.