### PR TITLE
Small fixes.

### DIFF
--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -53,6 +53,7 @@ namespace TrilinosWrappers
 {
   // forward declarations
   class SparsityPattern;
+  class SparseMatrix;
 
   namespace SparsityPatternIterators
   {
@@ -1164,7 +1165,7 @@ namespace TrilinosWrappers
      */
     std_cxx11::shared_ptr<Epetra_CrsGraph> nonlocal_graph;
 
-    friend class SparseMatrix;
+    friend class TrilinosWrappers::SparseMatrix;
     friend class SparsityPatternIterators::Accessor;
     friend class SparsityPatternIterators::Iterator;
   };

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -132,7 +132,7 @@ namespace Utilities
   trim(const std::string &input)
   {
     std::string::size_type left = 0;
-    std::string::size_type right = input.size() - 1;
+    std::string::size_type right = input.size() > 0 ? input.size() - 1 : 0;
 
     for (; left < input.size(); ++left)
       {


### PR DESCRIPTION
- include/deal.II/lac/trilinos_sparsity_pattern.h - necessary to specify the namespace for MSVC to be able to compile (distinguish from dealii::SparseMatrix)
- source/base/utilities.cc - necessary for step-33 to be runnable on MSVC