### PR TITLE
Matrixfree projection fixes

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2455,6 +2455,8 @@ namespace internal
   void check_vector_compatibility (const LinearAlgebra::distributed::Vector<Number> &vec,
                                    const internal::MatrixFreeFunctions::DoFInfo     &dof_info)
   {
+    (void)vec;
+    (void)dof_info;
     Assert (vec.partitioners_are_compatible(*dof_info.vector_partitioner),
             ExcMessage("The parallel layout of the given vector is not "
                        "compatible with the parallel partitioning in MatrixFree. "

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -495,6 +495,7 @@ namespace MatrixFreeOperators
   Base<dim,Number>::el (const unsigned int row,
                         const unsigned int col) const
   {
+    (void)col;
     Assert (row == col, ExcNotImplemented());
     Assert (inverse_diagonal_entries.size() > 0, ExcNotInitialized());
     return 1.0/inverse_diagonal_entries(row);
@@ -815,7 +816,7 @@ namespace MatrixFreeOperators
   template <int dim, int fe_degree, int n_components, typename Number>
   void
   MassOperator<dim, fe_degree, n_components, Number>::
-  local_apply_cell (const MatrixFree<dim,Number>                     &data,
+  local_apply_cell (const MatrixFree<dim,Number>                     &/*data*/,
                     LinearAlgebra::distributed::Vector<Number>       &dst,
                     const LinearAlgebra::distributed::Vector<Number> &src,
                     const std::pair<unsigned int,unsigned int>  &cell_range) const

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1110,6 +1110,7 @@ namespace VectorTools
   {
     const unsigned int fe_degree = matrix_free.get_dof_handler().get_fe().degree;
 
+    (void)n_q_points_1d;
     Assert (fe_degree+1 == n_q_points_1d,
             ExcNotImplemented());
 

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1117,28 +1117,28 @@ namespace VectorTools
     switch (fe_degree)
       {
       case 1:
-        project_parallel<dim, VectorType,1,2> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 2> (matrix_free,constraints,func,vec_result);
         break;
       case 2:
-        project_parallel<dim, VectorType,2,3> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 3> (matrix_free, constraints, func, vec_result);
         break;
       case 3:
-        project_parallel<dim, VectorType,3,4> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 4> (matrix_free, constraints, func, vec_result);
         break;
       case 4:
-        project_parallel<dim, VectorType,4,5> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 5> (matrix_free, constraints, func, vec_result);
         break;
       case 5:
-        project_parallel<dim, VectorType,5,6> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 6> (matrix_free, constraints, func, vec_result);
         break;
       case 6:
-        project_parallel<dim, VectorType,6,7> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 7> (matrix_free, constraints, func, vec_result);
         break;
       case 7:
-        project_parallel<dim, VectorType,7,8> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 8> (matrix_free, constraints, func, vec_result);
         break;
       case 8:
-        project_parallel<dim, VectorType,8,9> (matrix_free,constraints,func,vec_result);
+        project_parallel<dim, VectorType, dim, 9> (matrix_free, constraints, func, vec_result);
         break;
       default:
         Assert (false, ExcNotImplemented());


### PR DESCRIPTION
This PR silences some warnings in release mode and fixes compilation.

Since the third template argument is `spacedim` but the `MatrixFree` class assumes `dim == spacedim`` this substitution should be okay.