### PR TITLE
Fix a digraph problem.

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1833,7 +1833,7 @@ namespace internal
     inline
     void
     vector_updates (const ::dealii::Vector<Number> &src,
-                    const DiagonalMatrix<::dealii::Vector<Number> > &jacobi,
+                    const DiagonalMatrix< ::dealii::Vector<Number> > &jacobi,
                     const bool    start_zero,
                     const double  factor1,
                     const double  factor2,


### PR DESCRIPTION
The C++03 standard interprets '<:' as '['.