### PR TITLE
Improve documentation of matrix dimensions.

### DIFF
--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -413,13 +413,13 @@ public:
          const unsigned int column) const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -579,13 +579,13 @@ public:
   bool empty () const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -65,8 +65,8 @@ public:
   size_type m () const;
 
   /**
-   * Number of columns of this matrix. To remember: this matrix is an <i>n x
-   * n</i>-matrix.
+   * Number of columns of this matrix. This number corresponds to the size of
+   * the underlying vector.
    */
   size_type n () const;
 

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -464,14 +464,14 @@ public:
   bool operator == (const FullMatrix<number> &) const;
 
   /**
-   * Number of rows of this matrix.  To remember: this matrix is an <i>m x
-   * n</i>-matrix.
+   * Number of rows of this matrix.  Note that the matrix is of dimension <i>m
+   * x n</i>.
    */
   size_type m () const;
 
   /**
-   * Number of columns of this matrix.  To remember: this matrix is an <i>m x
-   * n</i>-matrix.
+   * Number of columns of this matrix.  Note that the matrix is of dimension
+   * <i>m x n</i>.
    */
   size_type n () const;
 

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -136,7 +136,7 @@ public:
   void clear () {}
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been
@@ -145,7 +145,7 @@ public:
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been
@@ -258,7 +258,7 @@ public:
   void clear () {}
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been
@@ -267,7 +267,7 @@ public:
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been
@@ -420,13 +420,13 @@ public:
   void clear();
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;
@@ -1024,13 +1024,13 @@ public:
   void clear ();
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -119,13 +119,13 @@ public:
   void use_matrix(const MatrixType &M);
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/sparse_decomposition.h
+++ b/include/deal.II/lac/sparse_decomposition.h
@@ -220,14 +220,14 @@ public:
 
   /**
    * Return the dimension of the codomain (or range) space. It calls the
-   * inherited SparseMatrix::m() function. To remember: the matrix is of
+   * inherited SparseMatrix::m() function. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type m () const;
 
   /**
    * Return the dimension of the domain space. It calls the  inherited
-   * SparseMatrix::n() function. To remember: the matrix is of dimension $m
+   * SparseMatrix::n() function. Note that the matrix is of dimension $m
    * \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -189,13 +189,13 @@ public:
                const BlockVector<double> &src) const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -664,13 +664,13 @@ public:
   bool empty () const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -374,13 +374,13 @@ public:
   bool empty () const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    */
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    */
   size_type n () const;

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -240,7 +240,7 @@ public:
                const Vector<number2> &src) const;
 
   /**
-   * Return the dimension of the codomain (or range) space. To remember: the
+   * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been
@@ -249,7 +249,7 @@ public:
   size_type m () const;
 
   /**
-   * Return the dimension of the domain space. To remember: the matrix is of
+   * Return the dimension of the domain space. Note that the matrix is of
    * dimension $m \times n$.
    *
    * @note This function should only be called if the preconditioner has been

--- a/include/deal.II/lac/tridiagonal_matrix.h
+++ b/include/deal.II/lac/tridiagonal_matrix.h
@@ -78,14 +78,14 @@ public:
 //@{
 
   /**
-   * Number of rows of this matrix. To remember: this matrix is an <i>m x
-   * m</i>-matrix.
+   * Number of rows of this matrix. Note that the matrix is an <i>m x
+   * m</i> matrix.
    */
   size_type m () const;
 
   /**
-   * Number of columns of this matrix. To remember: this matrix is an <i>n x
-   * n</i>-matrix.
+   * Number of columns of this matrix. Note that the matrix is an <i>n x
+   * n</i> matrix.
    */
   size_type n () const;
 
@@ -398,4 +398,3 @@ TridiagonalMatrix<number>::print (
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-


### PR DESCRIPTION
As noted by @bangerth in #3294, we used a somewhat odd "To remember: ..." in the description of the matrix sizes. This commit tries to fix all old occurences by a more positive language. I'm happy to hear even better suggestions, especially from our native speakers. :-)