### PR TITLE
Check for compute capability

### DIFF
--- a/cmake/configure/configure_1_cuda.cmake
+++ b/cmake/configure/configure_1_cuda.cmake
@@ -41,6 +41,34 @@ MACRO(FEATURE_CUDA_FIND_EXTERNAL var)
 
   IF(CUDA_FOUND)
 
+    IF("${CUDA_NVCC_FLAGS}" MATCHES "-arch")
+
+      # Compute Capability specified explicitly.
+      # Now parse:
+
+      IF("${CUDA_NVCC_FLAGS}" MATCHES "-arch[ ]*sm_([0-9]*)")
+        SET(CUDA_COMPUTE_CAPABILITY "${CMAKE_MATCH_1}")
+      ELSEIF("${CUDA_NVCC_FLAGS}" MATCHES "-arch=sm_([0-9]*)")
+        SET(CUDA_COMPUTE_CAPABILITY "${CMAKE_MATCH_1}")
+      ELSE()
+        MESSAGE( FATAL_ERROR "Missformed Compute Capability specified")
+      ENDIF()
+
+      IF("${CUDA_COMPUTE_CAPABILITY}" LESS "35")
+        MESSAGE( FATAL_ERROR "Too low CUDA Compute Capability specified -- deal.II requires at least 3.5 ")
+      ENDIF()
+    ENDIF()
+
+    IF( NOT DEFINED CUDA_COMPUTE_CAPABILITY)
+      # Set to use compute capability 3.5 by default
+      SET(CUDA_COMPUTE_CAPABILITY "35")
+      SET(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -arch=sm_35)
+    ENDIF()
+
+    # Export further definitions
+    STRING(SUBSTRING "${CUDA_COMPUTE_CAPABILITY}" 0 1 CUDA_COMPUTE_CAPABILITY_MAJOR)
+    STRING(SUBSTRING "${CUDA_COMPUTE_CAPABILITY}" 1 1 CUDA_COMPUTE_CAPABILITY_MINOR)
+
     SET(CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE FALSE)
 
     SET(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -std=c++11)

--- a/cmake/setup_write_config.cmake
+++ b/cmake/setup_write_config.cmake
@@ -201,6 +201,10 @@ FOREACH(_feature ${_deal_ii_features_sorted})
     IF(_feature MATCHES "MPI" AND DEFINED OMPI_VERSION)
       _detailed("#            OMPI_VERSION = ${OMPI_VERSION}\n")
     ENDIF()
+    IF(_feature MATCHES "CUDA" AND DEFINED CUDA_COMPUTE_CAPABILITY)
+      _detailed("#            CUDA_COMPUTE_CAPABILITY = ${CUDA_COMPUTE_CAPABILITY_MAJOR}.${CUDA_COMPUTE_CAPABILITY_MINOR}\n")
+    ENDIF()
+
 
     #
     # Print out ${_feature}_DIR:


### PR DESCRIPTION
We really require Compute Capability 3.5 for CUDA. Let's explicitly check for that, and otherwise use that as a default.

Fixes second half of #3037.