### PR TITLE
Add an include file necessary when not using multithreading.

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 #include <string>
+#include <cstring>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
I can't compile deal.II with `DEAL_II_WITH_THREADS=OFF` without this include.