### PR TITLE
Remove SolverCG::res2.

### DIFF
--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -215,12 +215,6 @@ public:
 
 protected:
   /**
-   * Implementation of the computation of the norm of the residual. This can
-   * be replaced by a more problem oriented functional in a derived class.
-   */
-  virtual double criterion();
-
-  /**
    * Interface for derived class. This function gets the current iteration
    * vector, the residual and the update vector in each step. It can be used
    * for a graphical output of the convergence history.
@@ -253,14 +247,6 @@ protected:
   VectorType *Vr;
   VectorType *Vp;
   VectorType *Vz;
-
-  /**
-   * Within the iteration loop, the square of the residual vector is stored in
-   * this variable. The function @p criterion uses this variable to compute
-   * the convergence value, which in this class is the norm of the residual
-   * vector and thus the square root of the @p res2 value.
-   */
-  double res2;
 
   /**
    * Additional parameters.
@@ -359,15 +345,6 @@ SolverCG<VectorType>::SolverCG (SolverControl        &cn,
 template <typename VectorType>
 SolverCG<VectorType>::~SolverCG ()
 {}
-
-
-
-template <typename VectorType>
-double
-SolverCG<VectorType>::criterion()
-{
-  return std::sqrt(res2);
-}
 
 
 


### PR DESCRIPTION
This variable was only used inside the SolverCG::criterion() function that was
supposed to let derived classes overload when the solver terminates. But the
criterion() function was never called anywhere, so there is no point in
keeping it. Furthermore, the res2 variable it returns was never set. So
remove the whole shebang.

Fixes #3364.