### PR TITLE
Fix BlockVectorBase::memory_consumption.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -2049,11 +2049,9 @@ template <class VectorType>
 std::size_t
 BlockVectorBase<VectorType>::memory_consumption () const
 {
-  std::size_t mem = MemoryConsumption::memory_consumption (this->block_indices);
-  for (size_type i=0; i<this->components.size(); ++i)
-    mem += MemoryConsumption::memory_consumption (this->components[i]);
-
-  return mem;
+  return (MemoryConsumption::memory_consumption (this->block_indices)
+          +
+          MemoryConsumption::memory_consumption (this->components));
 }
 
 


### PR DESCRIPTION
The existing implementation forgot to add the memory required for
the std::vector of blocks, it only added the memory required for
the blocks themselves. It turns out that fixing this also allows
to simplify the code significantly.

As pointed out by @tjhei in #3390.