### PR TITLE
Avoid a pointless comparison.

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1737,7 +1737,7 @@ namespace GridGenerator
     tria.create_triangulation (points, cells, t);
 
     // set boundary indicator
-    if (colorize && dim>1)
+    if (colorize)
       {
         double eps = 0.01 * delta;
         Triangulation<dim>::cell_iterator cell = tria.begin(),


### PR DESCRIPTION
The function works in 3d, so checking for 'dim>1' makes no difference.

Fixes #3414.