### PR TITLE
Initialize a member variable to invalid values.

### DIFF
--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -63,7 +63,10 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::InternalData::InternalDa
   mask (mask),
   local_dof_indices(fe.dofs_per_cell),
   local_dof_values(fe.dofs_per_cell)
-{}
+{
+  for (unsigned int i=0; i<unit_tangentials.size(); ++i)
+    unit_tangentials[i] = numbers::signaling_nan<Tensor<1,dim> >();
+}
 
 
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -43,7 +43,10 @@ DEAL_II_NAMESPACE_OPEN
 
 template<int dim, int spacedim>
 MappingManifold<dim,spacedim>::InternalData::InternalData ()
-{}
+{
+  for (unsigned int i=0; i<unit_tangentials.size(); ++i)
+    unit_tangentials[i] = numbers::signaling_nan<Tensor<1,dim> >();
+}
 
 
 template<int dim, int spacedim>

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -667,7 +667,10 @@ MappingQGeneric<dim,spacedim>::InternalData::InternalData (const unsigned int po
   polynomial_degree (polynomial_degree),
   n_shape_functions (Utilities::fixed_power<dim>(polynomial_degree+1)),
   line_support_points (polynomial_degree + 1)
-{}
+{
+  for (unsigned int i=0; i<unit_tangentials.size(); ++i)
+    unit_tangentials[i] = numbers::signaling_nan<Tensor<1,dim> >();
+}
 
 
 


### PR DESCRIPTION
Upon second thought, there is something we can do about #3410, #3411, #3412.
We just can't do it in the initializer list.