### PR TITLE
Fix parpack test

### DIFF
--- a/tests/arpack/step-36_parpack_mf.cc
+++ b/tests/arpack/step-36_parpack_mf.cc
@@ -105,7 +105,7 @@ void test ()
 
   std::vector<LinearAlgebra::distributed::Vector<double> > eigenfunctions;
   std::vector<double>                                      eigenvalues;
-  MatrixFreeOperators::MassOperator<dim,fe_degree, 1, double> mass;
+  MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+1, 1, double> mass;
   MatrixFreeOperators::LaplaceOperator<dim,fe_degree, fe_degree+1, 1, double> laplace;
   mass.initialize(mf_data);
   laplace.initialize(mf_data);


### PR DESCRIPTION
We forgot to update MassOperator in #3393.