### PR TITLE
Rename some variables.

### DIFF
--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -276,10 +276,10 @@ FE_RaviartThomas<dim>::initialize_restriction()
       // Store shape values, since the
       // evaluation suffers if not
       // ordered by point
-      Table<2,double> cached_values(this->dofs_per_cell, q_face.size());
+      Table<2,double> cached_values_on_face(this->dofs_per_cell, q_face.size());
       for (unsigned int k=0; k<q_face.size(); ++k)
         for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
-          cached_values(i,k)
+          cached_values_on_face(i,k)
             = this->shape_value_component(i, q_face.point(k),
                                           GeometryInfo<dim>::unit_normal_direction[face]);
 
@@ -319,7 +319,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
                   this->restriction[iso][child](face*this->dofs_per_face+i_face,
                                                 i_child)
                   += Utilities::fixed_power<dim-1>(.5) * q_sub.weight(k)
-                     * cached_values(i_child, k)
+                     * cached_values_on_face(i_child, k)
                      * this->shape_value_component(face*this->dofs_per_face+i_face,
                                                    q_sub.point(k),
                                                    GeometryInfo<dim>::unit_normal_direction[face]);
@@ -350,11 +350,11 @@ FE_RaviartThomas<dim>::initialize_restriction()
   // Store shape values, since the
   // evaluation suffers if not
   // ordered by point
-  Table<3,double> cached_values(this->dofs_per_cell, q_cell.size(), dim);
+  Table<3,double> cached_values_on_cell(this->dofs_per_cell, q_cell.size(), dim);
   for (unsigned int k=0; k<q_cell.size(); ++k)
     for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
       for (unsigned int d=0; d<dim; ++d)
-        cached_values(i,k,d) = this->shape_value_component(i, q_cell.point(k), d);
+        cached_values_on_cell(i,k,d) = this->shape_value_component(i, q_cell.point(k), d);
 
   for (unsigned int child=0; child<GeometryInfo<dim>::max_children_per_cell; ++child)
     {
@@ -368,7 +368,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
                 this->restriction[iso][child](start_cell_dofs+i_weight*dim+d,
                                               i_child)
                 += q_sub.weight(k)
-                   * cached_values(i_child, k, d)
+                   * cached_values_on_cell(i_child, k, d)
                    * polynomials[d]->compute_value(i_weight, q_sub.point(k));
               }
     }


### PR DESCRIPTION
There are variables of the same name in the base class. Avoid the
confusion of having similarly named variables in the local scope.

Fixes #3407.