### PR TITLE
Use a single if block

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -389,9 +389,10 @@ namespace internal
                           if (update_flags & update_JxW_values)
                             current_data.JxW_values.reserve (reserve_size);
                           if (update_flags & update_jacobian_grads)
-                            current_data.jacobians_grad_diag.reserve (reserve_size);
-                          if (update_flags & update_jacobian_grads)
-                            current_data.jacobians_grad_upper.reserve (reserve_size);
+                            {
+                              current_data.jacobians_grad_diag.reserve (reserve_size);
+                              current_data.jacobians_grad_upper.reserve (reserve_size);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fix warning from PVS about two if blocks with identical condition. Fixes #3369.