### PR TITLE
Initialize a member variable of LogStream.

### DIFF
--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -57,6 +57,7 @@ LogStream::LogStream()
   double_threshold(0.),
   float_threshold(0.),
   offset(0),
+  print_thread_id(false),
   old_cerr(0),
   at_newline(true)
 {


### PR DESCRIPTION
The variable really was never initialized, even though some
output depended on it. I suspect that it just happened to always
be initialized to 'false'. Make this explicit.

Fixes #3397.