### PR TITLE
Initialize an IntegrationInfo field.

### DIFF
--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -556,7 +556,8 @@ namespace MeshWorker
     :
     fevalv(0),
     multigrid(false),
-    global_data(std_cxx11::shared_ptr<VectorDataBase<dim, sdim> >(new VectorDataBase<dim, sdim>))
+    global_data(std_cxx11::shared_ptr<VectorDataBase<dim, sdim> >(new VectorDataBase<dim, sdim>)),
+    n_components(numbers::invalid_unsigned_int)
   {}
 
 


### PR DESCRIPTION
This number is correctly filled by `IntegrationInfo::initialize`, but this way it starts out with a bogus value (instead of an undefined one).

Fixes #3374.