### PR TITLE
Initialize two DoFInfo fields.

### DIFF
--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -274,6 +274,8 @@ namespace MeshWorker
   template <int dim, int spacedim, typename number>
   DoFInfo<dim,spacedim,number>::DoFInfo(const DoFHandler<dim,spacedim> &dof_handler)
     :
+    face_number (numbers::invalid_unsigned_int),
+    sub_number (numbers::invalid_unsigned_int),
     level_cell (false)
   {
     std::vector<types::global_dof_index> aux(1);

--- a/include/deal.II/meshworker/dof_info.templates.h
+++ b/include/deal.II/meshworker/dof_info.templates.h
@@ -24,6 +24,8 @@ namespace MeshWorker
   template <int dim, int spacedim, typename number>
   DoFInfo<dim,spacedim,number>::DoFInfo(const BlockInfo &info)
     :
+    face_number (numbers::invalid_unsigned_int),
+    sub_number (numbers::invalid_unsigned_int),
     block_info(&info, typeid(*this).name()),
     level_cell (false)
   {


### PR DESCRIPTION
These are the same values used in the `reinit` function.

Fixes #3372 and fixes #3373.