### PR TITLE
Fix compilation with some matrix free tests.

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1008,7 +1008,7 @@ namespace MatrixFreeOperators
   clear ()
   {
     Base<dim, Number>::clear();
-    scalar_coefficient = NULL;
+    scalar_coefficient.reset();
   }
 
 


### PR DESCRIPTION
For some reason I don't really understand this works just fine with GCC 6 but not with older versions. In all cases this problem only shows up with the bundled copy of boost and C++03.

This fixes a compilation error with GCC 4.8:

```
error: no match for ‘operator=’
(operand types are ‘boost::shared_ptr<dealii::Table<2, dealii::VectorizedArray<double> > >’ and ‘long int’)

      scalar_coefficient = NULL;
                         ^
```