### PR TITLE
Add a (disabled) copy operator to ExceptionBase.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -143,6 +143,11 @@ protected:
 
 private:
   /**
+   * Copy operator. Made private since it is not used and not implemented.
+   */
+  ExceptionBase operator= (const ExceptionBase &exc);
+
+  /**
    * Internal function that generates the c_string. Called by what().
    */
   void generate_message() const;


### PR DESCRIPTION
This operator is not used, but PVS has a point in complaining about it.
Fixes #3350.