### PR TITLE
Use 'order' instead of 'degree' in FE_RannacherTurek.

### DIFF
--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -55,13 +55,13 @@ class FE_RannacherTurek : public FE_Poly<PolynomialsRannacherTurek<dim>, dim>
 {
 public:
   /**
-   * Constructor for Rannacher-Turek element of degree @p degree, using @p
+   * Constructor for Rannacher-Turek element of given @p order, using @p
    * n_face_support_points quadrature points on each face for interpolation.
-   * Notice that the element of degree 0 contains polynomials of degree 2.
+   * Notice that the element of order 0 contains polynomials of degree 2.
    *
-   * Only implemented for degree 0 in 2D.
+   * The element is currently only implemented for order 0 in 2D.
    */
-  FE_RannacherTurek(const unsigned int degree = 0,
+  FE_RannacherTurek(const unsigned int order = 0,
                     const unsigned int n_face_support_points = 2);
 
   virtual std::string get_name() const;
@@ -79,14 +79,16 @@ public:
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;
 private:
   /**
-   * Degree of this element.
+   * Order of this element.
    */
-  const unsigned int degree;
+  const unsigned int order;
+
   /**
    * The number of quadrature points used on each face to evaluate node
    * functionals during interpolation.
    */
   const unsigned int n_face_support_points;
+
   /**
    * The weights used on the faces to evaluate node functionals.
    */

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -26,7 +26,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim>
-FE_RannacherTurek<dim>::FE_RannacherTurek(const unsigned int degree,
+FE_RannacherTurek<dim>::FE_RannacherTurek(const unsigned int order,
                                           const unsigned int n_face_support_points) :
   FE_Poly<PolynomialsRannacherTurek<dim>, dim>(
     PolynomialsRannacherTurek<dim>(),
@@ -36,11 +36,11 @@ FE_RannacherTurek<dim>::FE_RannacherTurek(const unsigned int degree,
                            FiniteElementData<dim>::L2),
     std::vector<bool>(4, false), // restriction not implemented
     std::vector<ComponentMask>(4, std::vector<bool>(1, true))),
-  degree(degree),
+  order(order),
   n_face_support_points(n_face_support_points)
 {
   Assert(dim == 2, ExcNotImplemented());
-  Assert(degree == 0, ExcNotImplemented());
+  Assert(order == 0, ExcNotImplemented());
   this->initialize_support_points();
 }
 
@@ -63,7 +63,7 @@ std::string FE_RannacherTurek<dim>::get_name() const
   std::ostringstream namebuf;
   namebuf << "FE_RannacherTurek"
           << "<" << dim << ">"
-          << "(" << this->degree << ", " << this->n_face_support_points << ")";
+          << "(" << this->order << ", " << this->n_face_support_points << ")";
   return namebuf.str();
 }
 
@@ -72,7 +72,7 @@ std::string FE_RannacherTurek<dim>::get_name() const
 template <int dim>
 FiniteElement<dim> *FE_RannacherTurek<dim>::clone() const
 {
-  return new FE_RannacherTurek<dim>(this->degree, this->n_face_support_points);
+  return new FE_RannacherTurek<dim>(this->order, this->n_face_support_points);
 }
 
 


### PR DESCRIPTION
The existing 'degree' member variable shadows a member of the base class,
but worse it does not have the same semantics: the former pertains to the
order of the element, the latter to the polynomial degree. Fix this.

Fixes #3355.