### PR TITLE
Add (private) BlockMatrixArray::Entry::operator=.

### DIFF
--- a/include/deal.II/lac/block_matrix_array.h
+++ b/include/deal.II/lac/block_matrix_array.h
@@ -334,6 +334,13 @@ private:
    * number of blocks per row.
    */
   unsigned int block_cols;
+
+  /**
+   * Assignment operator. Since the copy constructor is destructive (see its
+   * documentation) and only exists for convenience there is no reasonable way
+   * to implement this. Hence this operator is both private and unimplemented.
+   */
+  Entry &operator= (const Entry &);
 };
 
 /*@}*/


### PR DESCRIPTION
This class implements a (destructive) copy constructor more or less so that one can use it with `std::vector::push_back`, so it should disable `operator=`.

This fixes a warning caught by PVS studio.

Fixes #3356.