### PR TITLE
Clarify the signature of a copy constructor.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -277,9 +277,9 @@ namespace internal
 
 
       /**
-       * Copy constructor.
+       * Copy constructor from an iterator with the same constness.
        */
-      Iterator (const Iterator<BlockVectorType,Constness> &c);
+      Iterator (const Iterator &c);
 
     private:
       /**


### PR DESCRIPTION
PVS studio claims that we do not implement a copy constructor for this iterator (we do). It is likely that (unnecessarily) including the template arguments here confused PVS studio, so remove them.

Fixes #3357.