### PR TITLE
Correct LinearAlgebra::distributed::BlockVector::memory_consumption()

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -759,11 +759,9 @@ namespace LinearAlgebra
     std::size_t
     BlockVector<Number>::memory_consumption () const
     {
-      std::size_t mem = sizeof(this->n_blocks());
-      for (size_type i=0; i<this->components.size(); ++i)
-        mem += MemoryConsumption::memory_consumption (this->components[i]);
-      mem += MemoryConsumption::memory_consumption (this->block_indices);
-      return mem;
+      return (MemoryConsumption::memory_consumption (this->block_indices)
+              +
+              MemoryConsumption::memory_consumption (this->components));
     }
 
   } // end of namespace distributed

--- a/tests/mpi/parallel_block_vector_03.cc
+++ b/tests/mpi/parallel_block_vector_03.cc
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check memory consumption parallel vector
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+
+void test ()
+{
+  unsigned int myid = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int numproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  if (myid==0) deallog << "numproc=" << numproc << std::endl;
+
+
+  // each processor from processor 1 to 8 owns 2 indices (the other processors
+  // do not own any dof), and all processors are ghosting element 1
+  IndexSet local_owned(30);
+  if (myid == 0)
+    local_owned.add_range(0,20);
+  else
+    local_owned.add_range(std::min(20U,20*myid),30U);
+  IndexSet local_relevant(30);
+  local_relevant = local_owned;
+  local_relevant.add_range(19,20);
+
+  LinearAlgebra::distributed::Vector<double> v(local_owned, local_relevant,
+                                               MPI_COMM_WORLD);
+
+  deallog << v.memory_consumption() << std::endl;
+
+  LinearAlgebra::distributed::BlockVector<double> w(3);
+  for (unsigned int i=0; i<3; ++i)
+    {
+      w.block(i) = v;
+      w.block(i) *= (i+1);
+    }
+  w.collect_sizes();
+
+  deallog << w.memory_consumption() << std::endl;
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  MPILogInitAll log;
+  test();
+}

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::599
+DEAL:0::1476
+
+DEAL:1::519
+DEAL:1::1254
+

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::643
+DEAL:0::1501
+
+DEAL:1::563
+DEAL:1::1279
+

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.2
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.2
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::643
+DEAL:0::1525
+
+DEAL:1::563
+DEAL:1::1303
+


### PR DESCRIPTION
Fixes #3359.

PVS complained about a strange `sizeof() operator in terms of this->n_blocks()`. This was indeed wrong because that size is already contained in `MemoryConsumption::memory_consumption (this->block_indices);`