### PR TITLE
Initialize member variables in class ExceptionBase.

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -70,7 +70,12 @@ ExceptionBase::ExceptionBase ()
   stacktrace (NULL),
   n_stacktrace_frames (0),
   what_str("")
-{}
+{
+#ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
+  for (unsigned int i=0; i<sizeof(raw_stacktrace)/sizeof(raw_stacktrace[0]); ++i)
+    raw_stacktrace[0] = NULL;
+#endif
+}
 
 
 
@@ -84,7 +89,12 @@ ExceptionBase::ExceptionBase (const ExceptionBase &exc)
   stacktrace (NULL), // don't copy stacktrace to avoid double de-allocation problem
   n_stacktrace_frames (0),
   what_str("") // don't copy the error message, it gets generated dynamically by what()
-{}
+{
+#ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
+  for (unsigned int i=0; i<sizeof(raw_stacktrace)/sizeof(raw_stacktrace[0]); ++i)
+    raw_stacktrace[0] = NULL;
+#endif
+}
 
 
 


### PR DESCRIPTION
Fixes #3379.