### PR TITLE
Initialize member variables.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1126,11 +1126,21 @@ namespace DataOutBase
     /// Flags used to specify filtering behavior
     DataOutBase::DataOutFilterFlags   flags;
 
-    /// Dimensionality of the nodes, used to properly output filtered data
-    int         node_dim;
+    /**
+     * The number of space dimensions in which the vertices represented
+     * by the current object live. This corresponds to the usual
+     * <dim> argument, but since this class is not templated on the
+     * dimension, we need to store it here.
+     */
+    unsigned int      node_dim;
 
-    /// Number of vertices per cell
-    int         n_cell_verts;
+    /**
+     * The number of vertices per cell. Equal to
+     * GeometryInfo<node_dim>::vertices_per_cell. We need to store
+     * it as a run-time variable here because the dimension
+     * node_dim is also a run-time variable.
+     */
+    unsigned int      vertices_per_cell;
 
     /// Map of points to an internal index
     Map3DPoint        existing_points;
@@ -1156,8 +1166,19 @@ namespace DataOutBase
     void internal_add_cell(const unsigned int &cell_index, const unsigned int &pt_index);
 
   public:
-    DataOutFilter() : flags(false, true) {};
-    DataOutFilter(const DataOutBase::DataOutFilterFlags &flags) : flags(flags) {};
+    DataOutFilter()
+      :
+      flags(false, true),
+      node_dim (numbers::invalid_unsigned_int),
+      vertices_per_cell (numbers::invalid_unsigned_int)
+    {}
+
+    DataOutFilter(const DataOutBase::DataOutFilterFlags &flags)
+      :
+      flags(flags),
+      node_dim (numbers::invalid_unsigned_int),
+      vertices_per_cell (numbers::invalid_unsigned_int)
+    {}
 
     /**
      * Write a point with the specified index into the filtered data set. If
@@ -1233,7 +1254,7 @@ namespace DataOutBase
      */
     unsigned int n_cells() const
     {
-      return filtered_cells.size()/n_cell_verts;
+      return filtered_cells.size()/vertices_per_cell;
     };
 
     /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -489,7 +489,8 @@ void DataOutBase::DataOutFilter::fill_node_data(std::vector<double> &node_data) 
 
   for (it=existing_points.begin(); it!=existing_points.end(); ++it)
     {
-      for (int d=0; d<node_dim; ++d) node_data[node_dim*it->second+d] = it->first(d);
+      for (unsigned int d=0; d<node_dim; ++d)
+        node_data[node_dim*it->second+d] = it->first(d);
     }
 }
 
@@ -515,7 +516,7 @@ DataOutBase::DataOutFilter::write_cell(
   unsigned int d3)
 {
   unsigned int base_entry = index * GeometryInfo<dim>::vertices_per_cell;
-  n_cell_verts = GeometryInfo<dim>::vertices_per_cell;
+  vertices_per_cell = GeometryInfo<dim>::vertices_per_cell;
   internal_add_cell(base_entry+0, start);
   internal_add_cell(base_entry+1, start+d1);
   if (dim>=2)


### PR DESCRIPTION
Also rename one to match current coding practices. Add to the
variable's documentation.

Fixes #3349.

(As an aside, DataOutFilter violates basically all of our usual coding
practices. Fixing this is a bigger task than I'm after here, though.