### PR TITLE
Adjust memory consumption output.

### DIFF
--- a/tests/base/memory_consumption_01.with_64bit_indices=off.output
+++ b/tests/base/memory_consumption_01.with_64bit_indices=off.output
@@ -44,7 +44,7 @@ DEAL::Memory consumption -- Sparsity:      936
 DEAL::Memory consumption -- Matrix:        1400
 DEAL::Memory consumption -- Solution:      432
 DEAL::Memory consumption -- Rhs:           432
-DEAL::Memory consumption -- DataOut:       3490
+DEAL::Memory consumption -- DataOut:       3394
 DEAL::2d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       20
@@ -90,7 +90,7 @@ DEAL::Memory consumption -- Sparsity:      64168
 DEAL::Memory consumption -- Matrix:        120824
 DEAL::Memory consumption -- Solution:      7472
 DEAL::Memory consumption -- Rhs:           7472
-DEAL::Memory consumption -- DataOut:       42950
+DEAL::Memory consumption -- DataOut:       42854
 DEAL::3d
 DEAL::Cycle 0:
 DEAL::   Number of active cells:       56
@@ -136,4 +136,4 @@ DEAL::Memory consumption -- Sparsity:      8321768
 DEAL::Memory consumption -- Matrix:        16383928
 DEAL::Memory consumption -- Solution:      259568
 DEAL::Memory consumption -- Rhs:           259568
-DEAL::Memory consumption -- DataOut:       1159886
+DEAL::Memory consumption -- DataOut:       1159790


### PR DESCRIPTION
One of the patches to ::memory_consumption() must have broken this because
I remember adjusting it after #3333. Anyway, the difference is small.

For strange reasons, the current output seems to work correctly for the
64-bit case.