### PR TITLE
Add a missing template instantiation.

### DIFF
--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -724,6 +724,13 @@ namespace PETScWrappers
     SparseMatrix::
     reinit (const IndexSet &,
             const IndexSet &,
+            const SparsityPattern &,
+            const MPI_Comm &);
+
+    template void
+    SparseMatrix::
+    reinit (const IndexSet &,
+            const IndexSet &,
             const DynamicSparsityPattern &,
             const MPI_Comm &);
 
@@ -739,6 +746,12 @@ namespace PETScWrappers
                              const std::vector<size_type> &,
                              const unsigned int ,
                              const bool);
+
+    template void
+    SparseMatrix::
+    do_reinit (const IndexSet &,
+               const IndexSet &,
+               const SparsityPattern &);
 
     template void
     SparseMatrix::


### PR DESCRIPTION
This PR adds some missing template instantiations for `PETScWrappers::MPI::SparseMatrix`.

I tried to use the `reinit` function a minute ago and got a linker error. This fixes things.