### PR TITLE
Fix an issue with an MPI implementation.

### DIFF
--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -93,7 +93,7 @@ namespace Utilities
                        const std::size_t  size)
       {
 #ifdef DEAL_II_WITH_MPI
-        if (job_supports_mpi())
+        if (job_supports_mpi() && n_mpi_processes(mpi_communicator) > 1)
           {
             MPI_Allreduce (values != output
                            ?
@@ -129,7 +129,7 @@ namespace Utilities
                        const std::size_t               size)
       {
 #ifdef DEAL_II_WITH_MPI
-        if (job_supports_mpi())
+        if (job_supports_mpi() && n_mpi_processes(mpi_communicator) > 1)
           {
             T dummy_selector;
             MPI_Allreduce (values != output


### PR DESCRIPTION
I seem to be running into an MPI implementation problem whereby calling
MPI_Allreduce returns garbage in the output buffer if (i) we are
working on 'unsigned long long' data types, and (ii) we call the
allreduce function on only one processor. Initializing the output
buffer with something seems to help the problem, but the cheaper
alternative is to just not call MPI_Allreduce if we are on one processor
only.