### PR TITLE
Improve mpi checks

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -215,6 +215,13 @@ inconvenience this causes.
 <h3>General</h3>
 
 <ol>
+<li> Improved: the error codes for all MPI functions are now checked and, if the
+     MPI function failed for any reason, an exception with a helpful message is
+     thrown.
+     <br>
+     (David Wells, 2016/11/09)
+</li>
+
  <li>
  Fixed: We have run the PVS static analysis checker on the entire code base,
  to see what possible problems it uncovers (see
@@ -466,7 +473,7 @@ inconvenience this causes.
  <br>
  (Rajat Arora, 2016/10/29)
  </li>
- 
+
 <li> New: Add MatrixFreeOperators::MassOperator representing a mass matrix.
  <br>
  (Daniel Arndt, 2016/10/27)

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1082,6 +1082,40 @@ namespace StandardExceptions
                   << arg1);
 #endif
 //@}
+
+#ifdef DEAL_II_WITH_MPI
+  /**
+   * Exception for MPI errors. This exception is only defined if
+   * <code>deal.II</code> is compiled with MPI support. This exception should
+   * be used with <code>AssertThrow</code> to check error codes of MPI
+   * functions. For example:
+   * @code
+   * const int ierr = MPI_Isend(...);
+   * AssertThrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
+   * @endcode
+   * or, using the convenience macro <code>AssertThrowMPI</code>,
+   * @code
+   * const int ierr = MPI_Irecv(...);
+   * AssertThrowMPI(ierr);
+   * @endcode
+   *
+   * If the assertion fails then the error code will be used to print a helpful
+   * message to the screen by utilizing the <code>MPI_Error_string</code>
+   * function.
+   *
+   * @ingroup Exceptions
+   * @author David Wells, 2016
+   */
+  class ExcMPI : public dealii::ExceptionBase
+  {
+  public:
+    ExcMPI (const int error_code);
+
+    virtual void print_info (std::ostream &out) const;
+
+    const int error_code;
+  };
+#endif // DEAL_II_WITH_MPI
 } /*namespace StandardExceptions*/
 
 
@@ -1148,6 +1182,20 @@ namespace StandardExceptions
  */
 #define AssertIsFinite(number) Assert(dealii::numbers::is_finite(number), \
                                       dealii::ExcNumberNotFinite(std::complex<double>(number)))
+
+#ifdef DEAL_II_WITH_MPI
+/**
+ * An assertion that checks whether or not an error code returned by an MPI
+ * function is equal to <code>MPI_SUCCESS</code>. If the check fails then an
+ * exception of type ExcMPI is thrown with the given error code as an
+ * argument.
+ *
+ * @ingroup Exceptions
+ * @author David Wells, 2016
+ */
+#define AssertThrowMPI(error_code) AssertThrow(error_code == MPI_SUCCESS, \
+                                               dealii::ExcMPI(error_code))
+#endif // DEAL_II_WITH_MPI
 
 #ifdef DEAL_II_WITH_CUDA
 /**

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -95,21 +95,23 @@ namespace Utilities
 #ifdef DEAL_II_WITH_MPI
         if (job_supports_mpi())
           {
-            MPI_Allreduce (values != output
-                           ?
-                           // TODO This const_cast is only needed for older
-                           // (e.g., openMPI 1.6, released in 2012)
-                           // implementations of MPI-2. It is not needed as of
-                           // MPI-3 and we should remove it at some point in
-                           // the future.
-                           const_cast<void *>(static_cast<const void *>(values))
-                           :
-                           MPI_IN_PLACE,
-                           static_cast<void *>(output),
-                           static_cast<int>(size),
-                           internal::mpi_type_id(values),
-                           mpi_op,
-                           mpi_communicator);
+            const int ierr = MPI_Allreduce
+                             (values != output
+                              ?
+                              // TODO This const_cast is only needed for older
+                              // (e.g., openMPI 1.6, released in 2012)
+                              // implementations of MPI-2. It is not needed as
+                              // of MPI-3 and we should remove it at some
+                              // point in the future.
+                              const_cast<void *>(static_cast<const void *>(values))
+                              :
+                              MPI_IN_PLACE,
+                              static_cast<void *>(output),
+                              static_cast<int>(size),
+                              internal::mpi_type_id(values),
+                              mpi_op,
+                              mpi_communicator);
+            AssertThrowMPI(ierr);
           }
         else
 #endif
@@ -132,21 +134,23 @@ namespace Utilities
         if (job_supports_mpi())
           {
             T dummy_selector;
-            MPI_Allreduce (values != output
-                           ?
-                           // TODO This const_cast is only needed for older
-                           // (e.g., openMPI 1.6, released in 2012)
-                           // implementations of MPI-2. It is not needed as of
-                           // MPI-3 and we should remove it at some point in
-                           // the future.
-                           const_cast<void *>(static_cast<const void *>(values))
-                           :
-                           MPI_IN_PLACE,
-                           static_cast<void *>(output),
-                           static_cast<int>(size*2),
-                           internal::mpi_type_id(&dummy_selector),
-                           mpi_op,
-                           mpi_communicator);
+            const int ierr = MPI_Allreduce
+                             (values != output
+                              ?
+                              // TODO This const_cast is only needed for older
+                              // (e.g., openMPI 1.6, released in 2012)
+                              // implementations of MPI-2. It is not needed as
+                              // of MPI-3 and we should remove it at some
+                              // point in the future.
+                              const_cast<void *>(static_cast<const void *>(values))
+                              :
+                              MPI_IN_PLACE,
+                              static_cast<void *>(output),
+                              static_cast<int>(size*2),
+                              internal::mpi_type_id(&dummy_selector),
+                              mpi_op,
+                              mpi_communicator);
+            AssertThrowMPI(ierr);
           }
         else
 #endif

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -866,8 +866,9 @@ namespace internal
       // disable the check here only if no processor has any such data
 #ifdef DEAL_II_WITH_MPI
       unsigned int general_size_glob = 0, general_size_loc = jacobians.size();
-      MPI_Allreduce (&general_size_loc, &general_size_glob, 1, MPI_UNSIGNED,
-                     MPI_MAX, size_info.communicator);
+      int ierr = MPI_Allreduce (&general_size_loc, &general_size_glob, 1,
+                                MPI_UNSIGNED, MPI_MAX, size_info.communicator);
+      AssertThrowMPI (ierr);
 #else
       unsigned int general_size_glob = jacobians.size();
 #endif
@@ -885,8 +886,9 @@ namespace internal
 
 #ifdef DEAL_II_WITH_MPI
       unsigned int quad_size_glob = 0, quad_size_loc = quadrature_points.size();
-      MPI_Allreduce (&quad_size_loc, &quad_size_glob, 1, MPI_UNSIGNED,
-                     MPI_MAX, size_info.communicator);
+      ierr = MPI_Allreduce (&quad_size_loc, &quad_size_glob, 1, MPI_UNSIGNED,
+                            MPI_MAX, size_info.communicator);
+      AssertThrowMPI (ierr);
 #else
       unsigned int quad_size_glob = quadrature_points.size();
 #endif

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -85,8 +85,9 @@ namespace internal
         if (Utilities::MPI::job_supports_mpi())
           {
             int communicators_same = 0;
-            MPI_Comm_compare (dist_tria->get_communicator(), comm_mf,
-                              &communicators_same);
+            const int ierr = MPI_Comm_compare (dist_tria->get_communicator(), comm_mf,
+                                               &communicators_same);
+            AssertThrowMPI (ierr);
             Assert (communicators_same == MPI_IDENT ||
                     communicators_same == MPI_CONGRUENT,
                     ExcMessage ("MPI communicator in parallel::distributed::Triangulation "

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -203,7 +203,8 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg
   reinit_vector(mg_dof_handler, component_to_block_map, dst);
 #ifdef DEBUG_OUTPUT
   std::cout << "copy_to_mg src " << src.l2_norm() << std::endl;
-  MPI_Barrier(MPI_COMM_WORLD);
+  int ierr = MPI_Barrier(MPI_COMM_WORLD);
+  AssertThrowMPI(ierr);
 #endif
 
   if (perform_plain_copy)
@@ -220,7 +221,8 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg
     {
       --level;
 #ifdef DEBUG_OUTPUT
-      MPI_Barrier(MPI_COMM_WORLD);
+      ierr = MPI_Barrier(MPI_COMM_WORLD);
+      AssertThrowMPI(ierr);
 #endif
 
       typedef std::vector<std::pair<types::global_dof_index, types::global_dof_index> >::const_iterator dof_pair_iterator;
@@ -240,7 +242,8 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg
       dst_level.compress(VectorOperation::insert);
 
 #ifdef DEBUG_OUTPUT
-      MPI_Barrier(MPI_COMM_WORLD);
+      ierr = MPI_Barrier(MPI_COMM_WORLD);
+      AssertThrowMPI(ierr);
       std::cout << "copy_to_mg dst " << level << " " << dst_level.l2_norm() << std::endl;
 #endif
     }
@@ -273,9 +276,11 @@ MGLevelGlobalTransfer<VectorType>::copy_from_mg
   for (unsigned int level=src.min_level(); level<=src.max_level(); ++level)
     {
 #ifdef DEBUG_OUTPUT
-      MPI_Barrier(MPI_COMM_WORLD);
+      int ierr = MPI_Barrier(MPI_COMM_WORLD);
+      AssertThrowMPI(ierr);
       std::cout << "copy_from_mg src " << level << " " << src[level].l2_norm() << std::endl;
-      MPI_Barrier(MPI_COMM_WORLD);
+      ierr = MPI_Barrier(MPI_COMM_WORLD);
+      AssertThrowMPI(ierr);
 #endif
 
       typedef std::vector<std::pair<types::global_dof_index, types::global_dof_index> >::const_iterator dof_pair_iterator;
@@ -295,14 +300,16 @@ MGLevelGlobalTransfer<VectorType>::copy_from_mg
 #ifdef DEBUG_OUTPUT
       {
         dst.compress(VectorOperation::insert);
-        MPI_Barrier(MPI_COMM_WORLD);
+        ierr = MPI_Barrier(MPI_COMM_WORLD);
+        AssertThrowMPI(ierr);
         std::cout << "copy_from_mg level=" << level << " " << dst.l2_norm() << std::endl;
       }
 #endif
     }
   dst.compress(VectorOperation::insert);
 #ifdef DEBUG_OUTPUT
-  MPI_Barrier(MPI_COMM_WORLD);
+  const int ierr = MPI_Barrier(MPI_COMM_WORLD);
+  AssertThrowMPI(ierr);
   std::cout << "copy_from_mg " << dst.l2_norm() << std::endl;
 #endif
 }

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7607,9 +7607,10 @@ namespace VectorTools
         double my_values[3] = { mean_double.real(), mean_double.imag(), area };
         double global_values[3];
 
-        MPI_Allreduce (my_values, global_values, 3, MPI_DOUBLE,
-                       MPI_SUM,
-                       p_triangulation->get_communicator());
+        const int ierr = MPI_Allreduce (my_values, global_values, 3, MPI_DOUBLE,
+                                        MPI_SUM,
+                                        p_triangulation->get_communicator());
+        AssertThrowMPI (ierr);
 
         set_possibly_complex_number(global_values[0], global_values[1],
                                     mean);

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -578,9 +578,11 @@ IndexSet::is_ascending_and_one_to_one (const MPI_Comm &communicator) const
   const unsigned int gather_size = (my_rank==0)?n_ranks:1;
   std::vector<types::global_dof_index> global_dofs(gather_size);
 
-  MPI_Gather(&first_local_dof, 1, DEAL_II_DOF_INDEX_MPI_TYPE,
-             &(global_dofs[0]), 1, DEAL_II_DOF_INDEX_MPI_TYPE, 0,
-             communicator);
+  int ierr = MPI_Gather(&first_local_dof, 1, DEAL_II_DOF_INDEX_MPI_TYPE,
+                        &(global_dofs[0]), 1, DEAL_II_DOF_INDEX_MPI_TYPE, 0,
+                        communicator);
+  AssertThrowMPI(ierr);
+
   if (my_rank == 0)
     {
       // find out if the received std::vector is ascending
@@ -604,7 +606,8 @@ IndexSet::is_ascending_and_one_to_one (const MPI_Comm &communicator) const
 
   // now broadcast the result
   int is_ascending = is_globally_ascending ? 1 : 0;
-  MPI_Bcast(&is_ascending, 1, MPI_INT, 0, communicator);
+  ierr = MPI_Bcast(&is_ascending, 1, MPI_INT, 0, communicator);
+  AssertThrowMPI(ierr);
 
   return (is_ascending==1);
 #else

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -81,7 +81,8 @@ namespace Utilities
     unsigned int n_mpi_processes (const MPI_Comm &mpi_communicator)
     {
       int n_jobs=1;
-      (void) MPI_Comm_size (mpi_communicator, &n_jobs);
+      const int ierr = MPI_Comm_size (mpi_communicator, &n_jobs);
+      AssertThrowMPI(ierr);
 
       return n_jobs;
     }
@@ -90,7 +91,8 @@ namespace Utilities
     unsigned int this_mpi_process (const MPI_Comm &mpi_communicator)
     {
       int rank=0;
-      (void) MPI_Comm_rank (mpi_communicator, &rank);
+      const int ierr = MPI_Comm_rank (mpi_communicator, &rank);
+      AssertThrowMPI(ierr);
 
       return rank;
     }
@@ -99,7 +101,8 @@ namespace Utilities
     MPI_Comm duplicate_communicator (const MPI_Comm &mpi_communicator)
     {
       MPI_Comm new_communicator;
-      MPI_Comm_dup (mpi_communicator, &new_communicator);
+      const int ierr = MPI_Comm_dup (mpi_communicator, &new_communicator);
+      AssertThrowMPI(ierr);
       return new_communicator;
     }
 
@@ -142,9 +145,10 @@ namespace Utilities
       // processors in this case, which is more expensive than the reduction
       // operation above in MPI_Allreduce)
       std::vector<unsigned int> all_destinations (max_n_destinations * n_procs);
-      MPI_Allgather (&my_destinations[0], max_n_destinations, MPI_UNSIGNED,
-                     &all_destinations[0], max_n_destinations, MPI_UNSIGNED,
-                     mpi_comm);
+      const int ierr = MPI_Allgather (&my_destinations[0], max_n_destinations, MPI_UNSIGNED,
+                                      &all_destinations[0], max_n_destinations, MPI_UNSIGNED,
+                                      mpi_comm);
+      AssertThrowMPI(ierr);
 
       // now we know who is going to communicate with whom. collect who is
       // going to communicate with us!
@@ -236,7 +240,7 @@ namespace Utilities
 
       MPI_Op op;
       int ierr = MPI_Op_create((MPI_User_function *)&max_reduce, true, &op);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
 
       MinMaxAvg in;
       in.sum = in.min = in.max = my_value;
@@ -248,18 +252,18 @@ namespace Utilities
       MPI_Datatype types[]= {MPI_DOUBLE, MPI_INT};
 
       ierr = MPI_Type_struct(2, lengths, displacements, types, &type);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
 
       ierr = MPI_Type_commit(&type);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
       ierr = MPI_Allreduce (&in, &result, 1, type, op, mpi_communicator);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
 
       ierr = MPI_Type_free (&type);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
 
       ierr = MPI_Op_free(&op);
-      AssertThrow(ierr == MPI_SUCCESS, ExcInternalError());
+      AssertThrowMPI(ierr);
 
       result.avg = result.sum / numproc;
 
@@ -324,19 +328,19 @@ namespace Utilities
       // if we have PETSc, we will initialize it and let it handle MPI.
       // Otherwise, we will do it.
       int MPI_has_been_started = 0;
-      MPI_Initialized(&MPI_has_been_started);
+      int ierr = MPI_Initialized(&MPI_has_been_started);
+      AssertThrowMPI(ierr);
       AssertThrow (MPI_has_been_started == 0,
                    ExcMessage ("MPI error. You can only start MPI once!"));
 
-      int mpi_err, provided;
-      // this works like mpi_err = MPI_Init (&argc, &argv); but tells MPI that
+      int provided;
+      // this works like ierr = MPI_Init (&argc, &argv); but tells MPI that
       // we might use several threads but never call two MPI functions at the
       // same time. For an explanation see on why we do this see
       // http://www.open-mpi.org/community/lists/users/2010/03/12244.php
       int wanted = MPI_THREAD_SERIALIZED;
-      mpi_err = MPI_Init_thread(&argc, &argv, wanted, &provided);
-      AssertThrow (mpi_err == 0,
-                   ExcMessage ("MPI could not be initialized."));
+      ierr = MPI_Init_thread(&argc, &argv, wanted, &provided);
+      AssertThrowMPI(ierr);
 
       // disable for now because at least some implementations always return
       // MPI_THREAD_SINGLE.
@@ -397,9 +401,10 @@ namespace Utilities
 
           std::vector<char> all_hostnames(max_hostname_size *
                                           MPI::n_mpi_processes(MPI_COMM_WORLD));
-          MPI_Allgather (&hostname_array[0], max_hostname_size, MPI_CHAR,
-                         &all_hostnames[0], max_hostname_size, MPI_CHAR,
-                         MPI_COMM_WORLD);
+          const int ierr MPI_Allgather (&hostname_array[0], max_hostname_size, MPI_CHAR,
+                                        &all_hostnames[0], max_hostname_size, MPI_CHAR,
+                                        MPI_COMM_WORLD);
+          AssertThrowMPI(ierr);
 
           // search how often our own hostname appears and the how-manyth
           // instance the current process represents
@@ -517,9 +522,8 @@ namespace Utilities
             }
           else
             {
-              const int mpi_err = MPI_Finalize();
-              AssertThrow (mpi_err == 0,
-                           ExcMessage ("An error occurred while calling MPI_Finalize()"));
+              const int ierr = MPI_Finalize();
+              AssertThrowMPI(ierr);
             }
         }
 #endif
@@ -531,7 +535,8 @@ namespace Utilities
     {
 #ifdef DEAL_II_WITH_MPI
       int MPI_has_been_started = 0;
-      MPI_Initialized(&MPI_has_been_started);
+      const int ierr = MPI_Initialized(&MPI_has_been_started);
+      AssertThrowMPI(ierr);
 
       return (MPI_has_been_started > 0);
 #else

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -116,7 +116,10 @@ void Timer::start ()
 
 #ifdef DEAL_II_WITH_MPI
   if (sync_wall_time)
-    MPI_Barrier(mpi_communicator);
+    {
+      const int ierr = MPI_Barrier(mpi_communicator);
+      AssertThrowMPI(ierr);
+    }
 #endif
 
 #if defined(DEAL_II_HAVE_SYS_TIME_H) && defined(DEAL_II_HAVE_SYS_RESOURCE_H)

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -784,7 +784,8 @@ namespace Utilities
         {
           MPI_Comm comm = mpi_comm->GetMpiComm();
           *mpi_comm = Epetra_MpiComm(MPI_COMM_SELF);
-          MPI_Comm_free (&comm);
+          const int ierr = MPI_Comm_free (&comm);
+          AssertThrowMPI(ierr);
         }
 #endif
     }

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -97,8 +97,9 @@ namespace
 
     // compute the minimum on
     // processor zero
-    MPI_Reduce (comp, result, 2, MPI_DOUBLE,
-                MPI_MIN, 0, mpi_communicator);
+    const int ierr = MPI_Reduce (comp, result, 2, MPI_DOUBLE,
+                                 MPI_MIN, 0, mpi_communicator);
+    AssertThrowMPI(ierr);
 
     // make sure only processor zero
     // got something
@@ -131,8 +132,9 @@ namespace
     double result = 0;
     // compute the minimum on
     // processor zero
-    MPI_Reduce (&my_sum, &result, 1, MPI_DOUBLE,
-                MPI_SUM, 0, mpi_communicator);
+    const int ierr = MPI_Reduce (&my_sum, &result, 1, MPI_DOUBLE,
+                                 MPI_SUM, 0, mpi_communicator);
+    AssertThrowMPI(ierr);
 
     // make sure only processor zero
     // got something
@@ -274,8 +276,9 @@ namespace
 
       do
         {
-          MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
-                     master_mpi_rank, mpi_communicator);
+          int ierr = MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
+                                master_mpi_rank, mpi_communicator);
+          AssertThrowMPI(ierr);
 
           if (interesting_range[0] == interesting_range[1])
             return interesting_range[0];
@@ -300,8 +303,9 @@ namespace
                                                      test_threshold));
 
           unsigned int total_count;
-          MPI_Reduce (&my_count, &total_count, 1, MPI_UNSIGNED,
-                      MPI_SUM, master_mpi_rank, mpi_communicator);
+          ierr = MPI_Reduce (&my_count, &total_count, 1, MPI_UNSIGNED,
+                             MPI_SUM, master_mpi_rank, mpi_communicator);
+          AssertThrowMPI(ierr);
 
           // now adjust the range. if
           // we have to many cells, we
@@ -369,8 +373,9 @@ namespace
 
       do
         {
-          MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
-                     master_mpi_rank, mpi_communicator);
+          int ierr = MPI_Bcast (&interesting_range[0], 2, MPI_DOUBLE,
+                                master_mpi_rank, mpi_communicator);
+          AssertThrowMPI(ierr);
 
           if (interesting_range[0] == interesting_range[1])
             {
@@ -384,8 +389,9 @@ namespace
               // actual largest value
               double final_threshold =  std::min (interesting_range[0],
                                                   global_min_and_max.second);
-              MPI_Bcast (&final_threshold, 1, MPI_DOUBLE,
-                         master_mpi_rank, mpi_communicator);
+              ierr = MPI_Bcast (&final_threshold, 1, MPI_DOUBLE,
+                                master_mpi_rank, mpi_communicator);
+              AssertThrowMPI(ierr);
 
               return final_threshold;
             }
@@ -406,8 +412,9 @@ namespace
               my_error += criteria(i);
 
           double total_error;
-          MPI_Reduce (&my_error, &total_error, 1, MPI_DOUBLE,
-                      MPI_SUM, master_mpi_rank, mpi_communicator);
+          ierr = MPI_Reduce (&my_error, &total_error, 1, MPI_DOUBLE,
+                             MPI_SUM, master_mpi_rank, mpi_communicator);
+          AssertThrowMPI(ierr);
 
           // now adjust the range. if we have to many cells, we take
           // the upper half of the previous range, otherwise the lower

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -197,13 +197,14 @@ namespace parallel
 
     unsigned int send_value
       = number_cache.n_locally_owned_active_cells[my_subdomain];
-    MPI_Allgather (&send_value,
-                   1,
-                   MPI_UNSIGNED,
-                   &number_cache.n_locally_owned_active_cells[0],
-                   1,
-                   MPI_UNSIGNED,
-                   this->mpi_communicator);
+    const int ierr = MPI_Allgather (&send_value,
+                                    1,
+                                    MPI_UNSIGNED,
+                                    &number_cache.n_locally_owned_active_cells[0],
+                                    1,
+                                    MPI_UNSIGNED,
+                                    this->mpi_communicator);
+    AssertThrowMPI(ierr);
 
     number_cache.n_global_active_cells
       = std::accumulate (number_cache.n_locally_owned_active_cells.begin(),

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1160,9 +1160,10 @@ namespace internal
               types::global_dof_index shift = 0;
               //set rcounts based on new_numbers:
               int cur_count = new_numbers_copy.size ();
-              MPI_Allgather (&cur_count,  1, MPI_INT,
-                             &rcounts[0], 1, MPI_INT,
-                             tr->get_communicator ());
+              int ierr = MPI_Allgather (&cur_count,  1, MPI_INT,
+                                        &rcounts[0], 1, MPI_INT,
+                                        tr->get_communicator ());
+              AssertThrowMPI(ierr);
 
               for (unsigned int i = 0; i < n_cpu; i++)
                 {
@@ -1172,12 +1173,13 @@ namespace internal
               Assert(((int)new_numbers_copy.size()) ==
                      rcounts[Utilities::MPI::this_mpi_process (tr->get_communicator ())],
                      ExcInternalError());
-              MPI_Allgatherv (&new_numbers_copy[0],     new_numbers_copy.size (),
-                              DEAL_II_DOF_INDEX_MPI_TYPE,
-                              &gathered_new_numbers[0], &rcounts[0],
-                              &displs[0],
-                              DEAL_II_DOF_INDEX_MPI_TYPE,
-                              tr->get_communicator ());
+              ierr = MPI_Allgatherv (&new_numbers_copy[0],     new_numbers_copy.size (),
+                                     DEAL_II_DOF_INDEX_MPI_TYPE,
+                                     &gathered_new_numbers[0], &rcounts[0],
+                                     &displs[0],
+                                     DEAL_II_DOF_INDEX_MPI_TYPE,
+                                     tr->get_communicator ());
+              AssertThrowMPI(ierr);
             }
 
             // put new numbers according to the current locally_owned_dofs_per_processor IndexSets
@@ -1641,9 +1643,10 @@ namespace internal
               // that the packet has been
               // received
               it->second.pack_data (sendbuffers[idx]);
-              MPI_Isend(sendbuffers[idx].data(), sendbuffers[idx].size(),
-                        MPI_BYTE, it->first,
-                        1100101, tria.get_communicator(), &requests[idx]);
+              const int ierr = MPI_Isend(sendbuffers[idx].data(), sendbuffers[idx].size(),
+                                         MPI_BYTE, it->first,
+                                         1100101, tria.get_communicator(), &requests[idx]);
+              AssertThrowMPI(ierr);
             }
 
           //* receive requests and reply
@@ -1657,13 +1660,16 @@ namespace internal
 
               MPI_Status status;
               int len;
-              MPI_Probe(MPI_ANY_SOURCE, 1100101, tria.get_communicator(), &status);
-              MPI_Get_count(&status, MPI_BYTE, &len);
+              int ierr = MPI_Probe(MPI_ANY_SOURCE, 1100101, tria.get_communicator(), &status);
+              AssertThrowMPI(ierr);
+              ierr = MPI_Get_count(&status, MPI_BYTE, &len);
+              AssertThrowMPI(ierr);
               receive.resize(len);
 
               char *ptr = &receive[0];
-              MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
-                       tria.get_communicator(), &status);
+              ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
+                              tria.get_communicator(), &status);
+              AssertThrowMPI(ierr);
 
               cellinfo.unpack_data(receive);
 
@@ -1688,9 +1694,10 @@ namespace internal
 
               //send reply
               cellinfo.pack_data(reply_buffers[idx]);
-              MPI_Isend(&(reply_buffers[idx])[0], reply_buffers[idx].size(),
-                        MPI_BYTE, status.MPI_SOURCE,
-                        1100102, tria.get_communicator(), &reply_requests[idx]);
+              ierr = MPI_Isend(&(reply_buffers[idx])[0], reply_buffers[idx].size(),
+                               MPI_BYTE, status.MPI_SOURCE,
+                               1100102, tria.get_communicator(), &reply_requests[idx]);
+              AssertThrowMPI(ierr);
             }
 
           // * finally receive the replies
@@ -1701,13 +1708,16 @@ namespace internal
 
               MPI_Status status;
               int len;
-              MPI_Probe(MPI_ANY_SOURCE, 1100102, tria.get_communicator(), &status);
-              MPI_Get_count(&status, MPI_BYTE, &len);
+              int ierr = MPI_Probe(MPI_ANY_SOURCE, 1100102, tria.get_communicator(), &status);
+              AssertThrowMPI(ierr);
+              ierr = MPI_Get_count(&status, MPI_BYTE, &len);
+              AssertThrowMPI(ierr);
               receive.resize(len);
 
               char *ptr = &receive[0];
-              MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
-                       tria.get_communicator(), &status);
+              ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
+                              tria.get_communicator(), &status);
+              AssertThrowMPI(ierr);
 
               cellinfo.unpack_data(receive);
               if (cellinfo.tree_index.size()==0)
@@ -1739,9 +1749,15 @@ namespace internal
           // complete all sends, so that we can
           // safely destroy the buffers.
           if (requests.size() > 0)
-            MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+            {
+              const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+              AssertThrowMPI(ierr);
+            }
           if (reply_requests.size() > 0)
-            MPI_Waitall(reply_requests.size(), &reply_requests[0], MPI_STATUSES_IGNORE);
+            {
+              const int ierr = MPI_Waitall(reply_requests.size(), &reply_requests[0], MPI_STATUSES_IGNORE);
+              AssertThrowMPI(ierr);
+            }
 
         }
 
@@ -1909,9 +1925,10 @@ namespace internal
               // that the packet has been
               // received
               it->second.pack_data (*buffer);
-              MPI_Isend(&(*buffer)[0], buffer->size(),
-                        MPI_BYTE, it->first,
-                        123, tr->get_communicator(), &requests[idx]);
+              const int ierr = MPI_Isend(&(*buffer)[0], buffer->size(),
+                                         MPI_BYTE, it->first,
+                                         123, tr->get_communicator(), &requests[idx]);
+              AssertThrowMPI(ierr);
             }
 
 
@@ -1955,13 +1972,16 @@ namespace internal
             {
               MPI_Status status;
               int len;
-              MPI_Probe(MPI_ANY_SOURCE, 123, tr->get_communicator(), &status);
-              MPI_Get_count(&status, MPI_BYTE, &len);
+              int ierr = MPI_Probe(MPI_ANY_SOURCE, 123, tr->get_communicator(), &status);
+              AssertThrowMPI(ierr);
+              ierr = MPI_Get_count(&status, MPI_BYTE, &len);
+              AssertThrowMPI(ierr);
               receive.resize(len);
 
               char *ptr = &receive[0];
-              MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
-                       tr->get_communicator(), &status);
+              ierr = MPI_Recv(ptr, len, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG,
+                              tr->get_communicator(), &status);
+              AssertThrowMPI(ierr);
 
               typename types<dim>::cellinfo cellinfo;
               cellinfo.unpack_data(receive);
@@ -1994,7 +2014,10 @@ namespace internal
           // complete all sends, so that we can
           // safely destroy the buffers.
           if (requests.size() > 0)
-            MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+            {
+              const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+              AssertThrowMPI(ierr);
+            }
 
 
 #ifdef DEBUG
@@ -2005,8 +2028,10 @@ namespace internal
             unsigned int sent=needs_to_get_cells.size();
             unsigned int recv=senders.size();
 
-            MPI_Allreduce(&sent, &sum_send, 1, MPI_UNSIGNED, MPI_SUM, tr->get_communicator());
-            MPI_Allreduce(&recv, &sum_recv, 1, MPI_UNSIGNED, MPI_SUM, tr->get_communicator());
+            int ierr = MPI_Allreduce(&sent, &sum_send, 1, MPI_UNSIGNED, MPI_SUM, tr->get_communicator());
+            AssertThrowMPI(ierr);
+            ierr = MPI_Allreduce(&recv, &sum_recv, 1, MPI_UNSIGNED, MPI_SUM, tr->get_communicator());
+            AssertThrowMPI(ierr);
             Assert(sum_send==sum_recv, ExcInternalError());
           }
 #endif
@@ -2037,7 +2062,8 @@ namespace internal
           // processors from which we expect
           // messages, and by using different
           // tags for phase 1 and 2
-          MPI_Barrier(tr->get_communicator());
+          const int ierr = MPI_Barrier(tr->get_communicator());
+          AssertThrowMPI(ierr);
 #endif
         }
 
@@ -2132,11 +2158,12 @@ namespace internal
         //shift ids to make them unique
         number_cache.n_locally_owned_dofs_per_processor.resize(n_cpus);
 
-        MPI_Allgather ( &number_cache.n_locally_owned_dofs,
-                        1, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        &number_cache.n_locally_owned_dofs_per_processor[0],
-                        1, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        tr->get_communicator());
+        const int ierr = MPI_Allgather ( &number_cache.n_locally_owned_dofs,
+                                         1, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         &number_cache.n_locally_owned_dofs_per_processor[0],
+                                         1, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         tr->get_communicator());
+        AssertThrowMPI(ierr);
 
         const dealii::types::global_dof_index
         shift = std::accumulate (number_cache
@@ -2365,11 +2392,12 @@ namespace internal
             //shift ids to make them unique
             number_cache.n_locally_owned_dofs_per_processor.resize(n_cpus);
 
-            MPI_Allgather ( &number_cache.n_locally_owned_dofs,
-                            1, DEAL_II_DOF_INDEX_MPI_TYPE,
-                            &number_cache.n_locally_owned_dofs_per_processor[0],
-                            1, DEAL_II_DOF_INDEX_MPI_TYPE,
-                            tr->get_communicator());
+            int ierr = MPI_Allgather ( &number_cache.n_locally_owned_dofs,
+                                       1, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                       &number_cache.n_locally_owned_dofs_per_processor[0],
+                                       1, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                       tr->get_communicator());
+            AssertThrowMPI(ierr);
 
             const dealii::types::global_dof_index
             shift = std::accumulate (number_cache
@@ -2466,7 +2494,8 @@ namespace internal
 
           // This barrier is crucial so that messages between phase 1&2 don't
           // mix.
-          MPI_Barrier(tr->get_communicator());
+          const int ierr = MPI_Barrier(tr->get_communicator());
+          AssertThrowMPI(ierr);
 
           // Phase 2, only request the cells that were not completed in Phase
           // 1.
@@ -2724,9 +2753,10 @@ namespace internal
           my_data.resize(max_size);
 
           std::vector<char> buffer(max_size*n_cpus);
-          MPI_Allgather(&my_data[0], max_size, MPI_BYTE,
-                        &buffer[0], max_size, MPI_BYTE,
-                        tr->get_communicator());
+          const int ierr = MPI_Allgather(&my_data[0], max_size, MPI_BYTE,
+                                         &buffer[0], max_size, MPI_BYTE,
+                                         tr->get_communicator());
+          AssertThrowMPI(ierr);
 
           number_cache.locally_owned_dofs_per_processor.resize (n_cpus);
           number_cache.n_locally_owned_dofs_per_processor.resize (n_cpus);

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -770,11 +770,12 @@ namespace DoFRenumbering
         all_dof_counts(fe_collection.n_components() *
                        Utilities::MPI::n_mpi_processes (tria->get_communicator()));
 
-        MPI_Allgather ( &local_dof_count[0],
-                        n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        &all_dof_counts[0],
-                        n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        tria->get_communicator());
+        const int ierr = MPI_Allgather ( &local_dof_count[0],
+                                         n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         &all_dof_counts[0],
+                                         n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         tria->get_communicator());
+        AssertThrowMPI(ierr);
 
         for (unsigned int i=0; i<n_buckets; ++i)
           Assert (all_dof_counts[n_buckets*tria->locally_owned_subdomain()+i]
@@ -1057,11 +1058,12 @@ namespace DoFRenumbering
         all_dof_counts(fe_collection.n_components() *
                        Utilities::MPI::n_mpi_processes (tria->get_communicator()));
 
-        MPI_Allgather ( &local_dof_count[0],
-                        n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        &all_dof_counts[0],
-                        n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
-                        tria->get_communicator());
+        const int ierr = MPI_Allgather ( &local_dof_count[0],
+                                         n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         &all_dof_counts[0],
+                                         n_buckets, DEAL_II_DOF_INDEX_MPI_TYPE,
+                                         tria->get_communicator());
+        AssertThrowMPI(ierr);
 
         for (unsigned int i=0; i<n_buckets; ++i)
           Assert (all_dof_counts[n_buckets*tria->locally_owned_subdomain()+i]

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1704,9 +1704,10 @@ namespace DoFTools
       {
         std::vector<types::global_dof_index> local_dof_count = dofs_per_component;
 
-        MPI_Allreduce ( &local_dof_count[0], &dofs_per_component[0], n_target_components,
-                        DEAL_II_DOF_INDEX_MPI_TYPE,
-                        MPI_SUM, tria->get_communicator());
+        const int ierr = MPI_Allreduce (&local_dof_count[0], &dofs_per_component[0], n_target_components,
+                                        DEAL_II_DOF_INDEX_MPI_TYPE,
+                                        MPI_SUM, tria->get_communicator());
+        AssertThrowMPI (ierr);
       }
 #endif
   }
@@ -1781,10 +1782,11 @@ namespace DoFTools
                (&dof_handler.get_triangulation())))
           {
             std::vector<types::global_dof_index> local_dof_count = dofs_per_block;
-            MPI_Allreduce ( &local_dof_count[0], &dofs_per_block[0],
-                            n_target_blocks,
-                            DEAL_II_DOF_INDEX_MPI_TYPE,
-                            MPI_SUM, tria->get_communicator());
+            const int ierr = MPI_Allreduce (&local_dof_count[0], &dofs_per_block[0],
+                                            n_target_blocks,
+                                            DEAL_II_DOF_INDEX_MPI_TYPE,
+                                            MPI_SUM, tria->get_communicator());
+            AssertThrowMPI (ierr);
           }
 #endif
       }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1800,8 +1800,9 @@ next_cell:
     // processors and shifting the indices accordingly
     const unsigned int n_cpu = Utilities::MPI::n_mpi_processes(triangulation.get_communicator());
     std::vector<types::global_vertex_index> indices(n_cpu);
-    MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, &indices[0],
-                  indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
+    int ierr = MPI_Allgather(&next_index, 1, DEAL_II_DOF_INDEX_MPI_TYPE, &indices[0],
+                             indices.size(), DEAL_II_DOF_INDEX_MPI_TYPE, triangulation.get_communicator());
+    AssertThrowMPI(ierr);
     const types::global_vertex_index shift = std::accumulate(&indices[0],
                                                              &indices[0]+triangulation.locally_owned_subdomain(),0);
 
@@ -1841,8 +1842,9 @@ next_cell:
           }
 
         // Send the message
-        MPI_Isend(&vertices_send_buffers[i][0],buffer_size,DEAL_II_VERTEX_INDEX_MPI_TYPE,
-                  destination, 0, triangulation.get_communicator(), &first_requests[i]);
+        ierr = MPI_Isend(&vertices_send_buffers[i][0],buffer_size,DEAL_II_VERTEX_INDEX_MPI_TYPE,
+                         destination, 0, triangulation.get_communicator(), &first_requests[i]);
+        AssertThrowMPI(ierr);
       }
 
     // Receive the first message
@@ -1859,8 +1861,9 @@ next_cell:
         vertices_recv_buffers[i].resize(buffer_size);
 
         // Receive the message
-        MPI_Recv(&vertices_recv_buffers[i][0],buffer_size,DEAL_II_VERTEX_INDEX_MPI_TYPE,
-                 source, 0, triangulation.get_communicator(), MPI_STATUS_IGNORE);
+        ierr = MPI_Recv(&vertices_recv_buffers[i][0],buffer_size,DEAL_II_VERTEX_INDEX_MPI_TYPE,
+                        source, 0, triangulation.get_communicator(), MPI_STATUS_IGNORE);
+        AssertThrowMPI(ierr);
       }
 
 
@@ -1893,8 +1896,9 @@ next_cell:
           }
 
         // Send the message
-        MPI_Isend(&cellids_send_buffers[i][0], buffer_size, MPI_CHAR,
-                  destination, 0, triangulation.get_communicator(), &second_requests[i]);
+        ierr = MPI_Isend(&cellids_send_buffers[i][0], buffer_size, MPI_CHAR,
+                         destination, 0, triangulation.get_communicator(), &second_requests[i]);
+        AssertThrowMPI(ierr);
       }
 
     // Receive the second message
@@ -1908,8 +1912,9 @@ next_cell:
         cellids_recv_buffers[i].resize(buffer_size);
 
         // Receive the message
-        MPI_Recv(&cellids_recv_buffers[i][0],buffer_size, MPI_CHAR,
-                 source, 0, triangulation.get_communicator(), MPI_STATUS_IGNORE);
+        ierr = MPI_Recv(&cellids_recv_buffers[i][0],buffer_size, MPI_CHAR,
+                        source, 0, triangulation.get_communicator(), MPI_STATUS_IGNORE);
+        AssertThrowMPI(ierr);
       }
 
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -207,6 +207,8 @@ namespace PETScWrappers
   void
   MatrixBase::compress (const VectorOperation::values operation)
   {
+    int ierr;
+    (void)ierr;
 #ifdef DEBUG
 #ifdef DEAL_II_WITH_MPI
     // Check that all processors agree that last_action is the same (or none!)
@@ -214,8 +216,9 @@ namespace PETScWrappers
     int my_int_last_action = last_action;
     int all_int_last_action;
 
-    MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
-                  MPI_BOR, get_mpi_communicator());
+    ierr = MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
+                         MPI_BOR, get_mpi_communicator());
+    AssertThrowMPI(ierr);
 
     AssertThrow(all_int_last_action != (VectorOperation::add | VectorOperation::insert),
                 ExcMessage("Error: not all processors agree on the last VectorOperation before this compress() call."));
@@ -227,7 +230,6 @@ namespace PETScWrappers
                 ExcMessage("Missing compress() or calling with wrong VectorOperation argument."));
 
     // flush buffers
-    int ierr;
     ierr = MatAssemblyBegin (matrix,MAT_FINAL_ASSEMBLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -121,8 +121,9 @@ namespace PETScWrappers
       // mismatch (may not be true for every proc)
 
       int k_global, k = ((size() != n) || (local_size() != local_sz));
-      MPI_Allreduce (&k, &k_global, 1,
-                     MPI_INT, MPI_LOR, communicator);
+      int ierr = MPI_Allreduce (&k, &k_global, 1,
+                                MPI_INT, MPI_LOR, communicator);
+      AssertThrowMPI(ierr);
 
       if (k_global || has_ghost_elements())
         {
@@ -134,7 +135,6 @@ namespace PETScWrappers
 //         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
           // so let's go the slow way:
-          int ierr;
 
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
           ierr = VecDestroy (vector);
@@ -413,7 +413,8 @@ namespace PETScWrappers
             i++)
         {
           // This is slow, but most likely only used to debug.
-          MPI_Barrier(communicator);
+          ierr = MPI_Barrier(communicator);
+          AssertThrowMPI(ierr);
           if (i == Utilities::MPI::this_mpi_process(communicator))
             {
               if (across)

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -405,6 +405,8 @@ namespace PETScWrappers
   void
   VectorBase::compress (const VectorOperation::values operation)
   {
+    int ierr;
+    (void)ierr;
 #ifdef DEBUG
 #ifdef DEAL_II_WITH_MPI
     // Check that all processors agree that last_action is the same (or none!)
@@ -412,8 +414,9 @@ namespace PETScWrappers
     int my_int_last_action = last_action;
     int all_int_last_action;
 
-    MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
-                  MPI_BOR, get_mpi_communicator());
+    ierr = MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
+                         MPI_BOR, get_mpi_communicator());
+    AssertThrowMPI(ierr);
 
     AssertThrow(all_int_last_action != (::dealii::VectorOperation::add | ::dealii::VectorOperation::insert),
                 ExcMessage("Error: not all processors agree on the last VectorOperation before this compress() call."));
@@ -438,7 +441,6 @@ namespace PETScWrappers
     // we still need to call
     // VecAssemblyBegin/End on all
     // processors.
-    int ierr;
     ierr = VecAssemblyBegin(vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     ierr = VecAssemblyEnd(vector);

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -595,13 +595,16 @@ namespace SparsityTools
     {
       unsigned int idx=0;
       for (map_vec_t::iterator it=send_data.begin(); it!=send_data.end(); ++it, ++idx)
-        MPI_Isend(&(it->second[0]),
-                  it->second.size(),
-                  DEAL_II_DOF_INDEX_MPI_TYPE,
-                  it->first,
-                  124,
-                  mpi_comm,
-                  &requests[idx]);
+        {
+          const int ierr = MPI_Isend(&(it->second[0]),
+                                     it->second.size(),
+                                     DEAL_II_DOF_INDEX_MPI_TYPE,
+                                     it->first,
+                                     124,
+                                     mpi_comm,
+                                     &requests[idx]);
+          AssertThrowMPI(ierr);
+        }
     }
 
     {
@@ -611,13 +614,16 @@ namespace SparsityTools
         {
           MPI_Status status;
           int len;
-          MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, mpi_comm, &status);
+          int ierr = MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, mpi_comm, &status);
+          AssertThrowMPI(ierr);
           Assert (status.MPI_TAG==124, ExcInternalError());
 
-          MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
+          ierr = MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
+          AssertThrowMPI(ierr);
           recv_buf.resize(len);
-          MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
-                   status.MPI_TAG, mpi_comm, &status);
+          ierr = MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
+                          status.MPI_TAG, mpi_comm, &status);
+          AssertThrowMPI(ierr);
 
           std::vector<DynamicSparsityPattern::size_type>::const_iterator ptr = recv_buf.begin();
           std::vector<DynamicSparsityPattern::size_type>::const_iterator end = recv_buf.end();
@@ -639,7 +645,10 @@ namespace SparsityTools
 
     // complete all sends, so that we can safely destroy the buffers.
     if (requests.size())
-      MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+      {
+        const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+        AssertThrowMPI(ierr);
+      }
 
   }
 
@@ -717,13 +726,16 @@ namespace SparsityTools
     {
       unsigned int idx=0;
       for (map_vec_t::iterator it=send_data.begin(); it!=send_data.end(); ++it, ++idx)
-        MPI_Isend(&(it->second[0]),
-                  it->second.size(),
-                  DEAL_II_DOF_INDEX_MPI_TYPE,
-                  it->first,
-                  124,
-                  mpi_comm,
-                  &requests[idx]);
+        {
+          const int ierr = MPI_Isend(&(it->second[0]),
+                                     it->second.size(),
+                                     DEAL_II_DOF_INDEX_MPI_TYPE,
+                                     it->first,
+                                     124,
+                                     mpi_comm,
+                                     &requests[idx]);
+          AssertThrowMPI(ierr);
+        }
     }
 
     {
@@ -733,13 +745,16 @@ namespace SparsityTools
         {
           MPI_Status status;
           int len;
-          MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, mpi_comm, &status);
+          int ierr = MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, mpi_comm, &status);
+          AssertThrowMPI(ierr);
           Assert (status.MPI_TAG==124, ExcInternalError());
 
-          MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
+          ierr = MPI_Get_count(&status, DEAL_II_DOF_INDEX_MPI_TYPE, &len);
+          AssertThrowMPI(ierr);
           recv_buf.resize(len);
-          MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
-                   status.MPI_TAG, mpi_comm, &status);
+          ierr = MPI_Recv(&recv_buf[0], len, DEAL_II_DOF_INDEX_MPI_TYPE, status.MPI_SOURCE,
+                          status.MPI_TAG, mpi_comm, &status);
+          AssertThrowMPI(ierr);
 
           std::vector<BlockDynamicSparsityPattern::size_type>::const_iterator ptr = recv_buf.begin();
           std::vector<BlockDynamicSparsityPattern::size_type>::const_iterator end = recv_buf.end();
@@ -761,7 +776,10 @@ namespace SparsityTools
 
     // complete all sends, so that we can safely destroy the buffers.
     if (requests.size())
-      MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+      {
+        const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+        AssertThrowMPI(ierr);
+      }
   }
 #endif
 }

--- a/tests/base/mpi_exceptions.cc
+++ b/tests/base/mpi_exceptions.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that we can catch all MPI-1 error codes and print appropriate
+// exception messages to the screen.
+
+#include "../tests.h"
+#include <deal.II/base/exceptions.h>
+#include <fstream>
+
+#include <mpi.h>
+
+#include <vector>
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  std::vector<int> mpi_error_codes;
+  mpi_error_codes.push_back(MPI_ERR_BUFFER);
+  mpi_error_codes.push_back(MPI_ERR_COUNT);
+  mpi_error_codes.push_back(MPI_ERR_TYPE);
+  mpi_error_codes.push_back(MPI_ERR_TAG);
+  mpi_error_codes.push_back(MPI_ERR_COMM);
+  mpi_error_codes.push_back(MPI_ERR_RANK);
+  mpi_error_codes.push_back(MPI_ERR_REQUEST);
+  mpi_error_codes.push_back(MPI_ERR_ROOT);
+  mpi_error_codes.push_back(MPI_ERR_GROUP);
+  mpi_error_codes.push_back(MPI_ERR_OP);
+  mpi_error_codes.push_back(MPI_ERR_TOPOLOGY);
+  mpi_error_codes.push_back(MPI_ERR_UNKNOWN);
+  mpi_error_codes.push_back(MPI_ERR_OTHER);
+  mpi_error_codes.push_back(MPI_ERR_INTERN);
+  mpi_error_codes.push_back(MPI_ERR_LASTCODE);
+
+  for (unsigned int i = 0; i < mpi_error_codes.size(); ++i)
+    {
+      try
+        {
+          throw ExcMPI(mpi_error_codes[i]);
+        }
+      catch (const ExceptionBase &exc)
+        {
+          deallog << exc.get_exc_name() << std::endl;
+          exc.print_info(deallog.get_file_stream());
+        }
+    }
+
+
+  return 0;
+}

--- a/tests/base/mpi_exceptions.mpirun=1.output
+++ b/tests/base/mpi_exceptions.mpirun=1.output
@@ -1,0 +1,61 @@
+
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_BUFFER: invalid buffer pointer".
+The numerical value of the original error code is 1.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_COUNT: invalid count argument".
+The numerical value of the original error code is 2.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TYPE: invalid datatype".
+The numerical value of the original error code is 3.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TAG: invalid tag".
+The numerical value of the original error code is 4.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_COMM: invalid communicator".
+The numerical value of the original error code is 5.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_RANK: invalid rank".
+The numerical value of the original error code is 6.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_REQUEST: invalid request".
+The numerical value of the original error code is 7.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_ROOT: invalid root".
+The numerical value of the original error code is 8.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_GROUP: invalid group".
+The numerical value of the original error code is 9.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_OP: invalid reduce operation".
+The numerical value of the original error code is 10.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TOPOLOGY: invalid communicator topology".
+The numerical value of the original error code is 11.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_UNKNOWN: unknown error".
+The numerical value of the original error code is 14.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_OTHER: known error not in list".
+The numerical value of the original error code is 16.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_INTERN: internal error".
+The numerical value of the original error code is 17.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_UNKNOWN: unknown error".
+The numerical value of the original error code is 92.

--- a/tests/base/mpi_exceptions.mpirun=1.output.mpich
+++ b/tests/base/mpi_exceptions.mpirun=1.output.mpich
@@ -1,0 +1,61 @@
+
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid buffer pointer".
+The numerical value of the original error code was 1.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid count".
+The numerical value of the original error code was 2.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid datatype".
+The numerical value of the original error code was 3.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid tag".
+The numerical value of the original error code was 4.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid communicator".
+The numerical value of the original error code was 5.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid rank".
+The numerical value of the original error code was 6.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid MPI_Request".
+The numerical value of the original error code was 19.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid root".
+The numerical value of the original error code was 7.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid group".
+The numerical value of the original error code was 8.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid MPI_Op".
+The numerical value of the original error code was 9.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Invalid topology".
+The numerical value of the original error code was 10.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Unknown error.  Please file a bug report.".
+The numerical value of the original error code was 13.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Other MPI error".
+The numerical value of the original error code was 15.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Internal MPI error!".
+The numerical value of the original error code was 16.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "Unknown error class".
+The numerical value of the original error code was 1073741823.


### PR DESCRIPTION
This PR adds a new exception `ExcMPI` that prints nice messages based on the MPI error code. It also checks the return codes of all MPI functions.

I have consistently used `AssertThrow`, not `Assert`, for these calls.

Fixes #3516.