### PR TITLE
Avoid a memory leak.

### DIFF
--- a/tests/serialization/pointer_02.cc
+++ b/tests/serialization/pointer_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -76,9 +76,11 @@ private:
 
 void test ()
 {
+  C *backup;
   {
     C *p1 = new C();
-    C *p2 = new C();
+    C *p2 = new C(); // this is the pointer that will be overwritten
+    backup = p2;     // but save a pointer to the original object
 
     verify (p1, p2);
 
@@ -93,6 +95,11 @@ void test ()
   // original object pointed to as a memory
   // leak. assert that this behavior persists
   AssertThrow (objects_destroyed == 2, ExcInternalError());
+
+  // we've checked what we wanted to check, so now delete
+  // the original object to ensure we don't get undue
+  // error messages from memory checkers about leaked memory
+  delete backup;
 }
 
 

--- a/tests/serialization/pointer_02.output
+++ b/tests/serialization/pointer_02.output
@@ -9,4 +9,5 @@ DEAL::Default constructor. Object number 3
 DEAL::Serializing object number 3 via N5boost7archive13text_iarchiveE
 DEAL::destructor. Object number 1
 DEAL::destructor. Object number 3
+DEAL::destructor. Object number 2
 DEAL::OK


### PR DESCRIPTION
In fact, the test really tries very hard to create a memory leak, and
even verifies that it happens. But this then leads to downstream heartbreak
if you run a memory checker because you get pulled over for it.

Fix the issue by cleaning up the memory leak after we have verified that
the code that ran before really did leak the memory, by keeping a pointer
to the leaked object after all, and deleting it at the end of it all.

In response to #3513.