### PR TITLE
Fix a variety of memory leaks in the testsuite.

### DIFF
--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -2124,6 +2124,11 @@ int main ()
       deallog.threshold_double(1.e-10);
 
       const unsigned int dim = 2;
+
+      Data::SetUp<Data::Exercise_2_3<dim>,dim> setup;
+      const Point<dim> evaluation_point (0.75, 0.75);
+      DualFunctional::PointValueEvaluation<dim> eval(evaluation_point);
+
       Framework<dim>::ProblemDescription descriptor;
 
       descriptor.refinement_criterion
@@ -2132,11 +2137,8 @@ int main ()
       descriptor.primal_fe_degree = 1;
       descriptor.dual_fe_degree   = 2;
 
-      descriptor.data = new Data::SetUp<Data::Exercise_2_3<dim>,dim> ();
-
-      const Point<dim> evaluation_point (0.75, 0.75);
-      descriptor.dual_functional
-        = new DualFunctional::PointValueEvaluation<dim> (evaluation_point);
+      descriptor.data = &setup;
+      descriptor.dual_functional = &eval;
 
       Evaluation::PointValueEvaluation<dim>
       postprocessor1 (evaluation_point);

--- a/tests/lac/constraints_block_01.cc
+++ b/tests/lac/constraints_block_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -114,8 +114,8 @@ int main ()
   std::string fluid_fe_name = "FESystem[FE_Nothing()^2-FE_Nothing()^2-FE_Q(2)^2-FE_Q(1)-FE_Q(2)^2]";
 
   hp::FECollection<dim> fe_collection;
-  FiniteElement<dim> *solid_fe = FETools::get_fe_by_name<dim, dim>(solid_fe_name);
-  FiniteElement<dim> *fluid_fe = FETools::get_fe_by_name<dim, dim>(fluid_fe_name);
+  std_cxx11::unique_ptr<FiniteElement<dim> > solid_fe (FETools::get_fe_by_name<dim, dim>(solid_fe_name));
+  std_cxx11::unique_ptr<FiniteElement<dim> > fluid_fe (FETools::get_fe_by_name<dim, dim>(fluid_fe_name));
 
   deallog << "Solid FE Space: " << solid_fe->get_name() << std::endl;
   deallog << "Fluid/Mesh FE Space: " << fluid_fe->get_name() << std::endl;

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -675,6 +675,8 @@ namespace Step39
     data_out.build_patches ();
 
     data_out.write_gnuplot(gnuplot_output);
+
+    delete[] fn;
   }
 
   template <int dim>

--- a/tests/parameter_handler/parameter_handler_double_02.cc
+++ b/tests/parameter_handler/parameter_handler_double_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2015 by the deal.II authors
+// Copyright (C) 2003 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,6 +33,7 @@ void test(const std::string &desc)
       return;
     }
   deallog << c->description() << std::endl;
+  delete c;
 }
 
 


### PR DESCRIPTION
Found while looking at #3513. I did verify that the version of step-14 that
is currently in examples/ is fixed. The version of step-39 that is in
examples/ is not fixed -- see #3520.