### PR TITLE
Fix a memory leak in de-serializing a SparsityPattern object.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -437,6 +437,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Fixed: There was a memory leak if a previously used SparsityPattern
+ object was re-used by reading from a serialization archive via
+ SparsityPattern::load(). This is now fixed.
+ <br>
+ (Wolfgang Bangerth, 2016/11/10)
+ </li>
+
  <li> New: Add PArpackSolver::reinit(const VectorType &distributed_vector) to
  initialize internal data structures based on a vector. This makes PArpack
  usable with MatrixFree operators.

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -1430,8 +1430,13 @@ SparsityPattern::load (Archive &ar, const unsigned int)
 
   ar &max_dim &rows &cols &max_vec_len &max_row_length &compressed &store_diagonal_first_in_row;
 
-  rowstart = new std::size_t [max_dim + 1];
-  colnums = new size_type [max_vec_len];
+  if (rowstart != 0)
+    delete[] rowstart;
+  rowstart = new std::size_t[max_dim + 1];
+
+  if (colnums != 0)
+    delete[] colnums;
+  colnums = new size_type[max_vec_len];
 
   ar &boost::serialization::make_array(rowstart, max_dim + 1);
   ar &boost::serialization::make_array(colnums, max_vec_len);


### PR DESCRIPTION
Fixes one of the issues found as part of #3522. This is in fact the
only memory leak I have found so far that is in fact in the library
and not just in testsuite programs.