### PR TITLE
Provide additional test output.

### DIFF
--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.2
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.2
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::643
+DEAL:0::1525
+
+DEAL:1::563
+DEAL:1::1303
+


### PR DESCRIPTION
It turns out that the result of the memory consumption is indeed specific of the machine or the implementation of the C++ library. This provides an additional output to fix the failure here:
http://cdash.kyomu.43-1.org/testDetails.php?test=8938253&build=2399