### PR TITLE
Update DataPostprocessor in examples

### DIFF
--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2011 - 2015 by the deal.II authors
+ * Copyright (C) 2011 - 2016 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -903,14 +903,13 @@ namespace Step47
   class Postprocessor : public DataPostprocessor<dim>
   {
   public:
+    using DataPostprocessor<dim>::compute_derived_quantities_vector;
+
     virtual
     void
-    compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
-                                       const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
-                                       const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
-                                       const std::vector<Point<dim> >                  &normals,
-                                       const std::vector<Point<dim> >                  &evaluation_points,
-                                       std::vector<Vector<double> >                    &computed_quantities) const;
+    compute_derived_quantities_vector
+    (const dealii::DataPostprocessorInputs::Vector<dim> &inputs,
+     std::vector<Vector<double> >                       &computed_quantities) const;
 
     virtual std::vector<std::string> get_names () const;
 
@@ -955,28 +954,27 @@ namespace Step47
   template <int dim>
   void
   Postprocessor<dim>::
-  compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
-                                     const std::vector<std::vector<Tensor<1,dim> > > &/*solution_gradients*/,
-                                     const std::vector<std::vector<Tensor<2,dim> > > &/*solution_hessians*/,
-                                     const std::vector<Point<dim> >                  &/*normals*/,
-                                     const std::vector<Point<dim> >                  &evaluation_points,
-                                     std::vector<Vector<double> >                    &computed_quantities) const
+  compute_derived_quantities_vector
+  (const dealii::DataPostprocessorInputs::Vector<dim> &inputs,
+   std::vector<Vector<double> >                       &computed_quantities) const
   {
-    const unsigned int n_quadrature_points = solution_values.size();
-    Assert (computed_quantities.size() == n_quadrature_points,  ExcInternalError());
-    Assert (solution_values[0].size() == 2,                                  ExcInternalError());
+    const unsigned int n_quadrature_points = inputs.solution_values.size();
+    Assert (computed_quantities.size() == n_quadrature_points,
+            ExcInternalError());
+    Assert (inputs.solution_values[0].size() == 2,
+            ExcInternalError());
 
     for (unsigned int q=0; q<n_quadrature_points; ++q)
       {
         computed_quantities[q](0)
-          = (solution_values[q](0)
+          = (inputs.solution_values[q](0)
              +
 //TODO: shift in weight function is missing!
-             solution_values[q](1) * std::fabs(level_set(evaluation_points[q])));
+             inputs.solution_values[q](1) * std::fabs(level_set(inputs.evaluation_points[q])));
         computed_quantities[q](1)
           = (computed_quantities[q](0)
              -
-             exact_solution (evaluation_points[q]));
+             exact_solution (inputs.evaluation_points[q]));
       }
   }
 


### PR DESCRIPTION
Resolves #3429.
Unfortunately, we need to deal with the deprecated version of `compute_derived_quantities_*` somehow.
The least ugly way seemed to be using `using DataPostprocessor*::compute_derived_quantities_*`.