### PR TITLE
Petsc matrix accessor copy operator

### DIFF
--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -83,11 +83,6 @@ namespace PETScWrappers
                   const size_type   index);
 
         /**
-         * Copy constructor.
-         */
-        Accessor (const Accessor &a);
-
-        /**
          * Row number of the element represented by this object.
          */
         size_type row() const;
@@ -999,17 +994,6 @@ namespace PETScWrappers
       visit_present_row ();
     }
 
-
-    inline
-    const_iterator::Accessor::
-    Accessor (const Accessor &a)
-      :
-      matrix(a.matrix),
-      a_row(a.a_row),
-      a_index(a.a_index),
-      colnum_cache (a.colnum_cache),
-      value_cache (a.value_cache)
-    {}
 
 
     inline

--- a/tests/petsc/sparse_matrix_iterator_02.cc
+++ b/tests/petsc/sparse_matrix_iterator_02.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test PETScWrappers::MatrixBase::const_iterator::operator=
+
+#include "../tests.h"
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <fstream>
+#include <iostream>
+
+
+void test ()
+{
+  const types::global_dof_index n_rows = 5;
+  PETScWrappers::SparseMatrix matrix(n_rows, n_rows, 2);
+  matrix.set(0, 0, 1.0);
+  matrix.set(0, n_rows - 1, -1.0);
+  for (unsigned int row_n = 1; row_n < n_rows; ++row_n)
+    {
+      matrix.set(row_n, row_n, 1.0);
+      matrix.set(row_n, row_n - 1, -1.0);
+    }
+  matrix.compress (VectorOperation::insert);
+
+  for (PETScWrappers::SparseMatrix::const_iterator iterator = matrix.begin();
+       iterator != matrix.end(); ++iterator)
+    {
+      // This is what we want to test.
+      PETScWrappers::SparseMatrix::const_iterator duplicate = iterator;
+      deallog << "row: " << duplicate->row() << std::endl;
+      deallog << "column: " << duplicate->column() << std::endl;
+      deallog << "value: " << duplicate->value() << std::endl;
+    }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main (int argc,char **argv)
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+      {
+        test ();
+      }
+
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+}

--- a/tests/petsc/sparse_matrix_iterator_02.output
+++ b/tests/petsc/sparse_matrix_iterator_02.output
@@ -1,0 +1,32 @@
+
+DEAL::row: 0
+DEAL::column: 0
+DEAL::value: 1.00000
+DEAL::row: 0
+DEAL::column: 4
+DEAL::value: -1.00000
+DEAL::row: 1
+DEAL::column: 0
+DEAL::value: -1.00000
+DEAL::row: 1
+DEAL::column: 1
+DEAL::value: 1.00000
+DEAL::row: 2
+DEAL::column: 1
+DEAL::value: -1.00000
+DEAL::row: 2
+DEAL::column: 2
+DEAL::value: 1.00000
+DEAL::row: 3
+DEAL::column: 2
+DEAL::value: -1.00000
+DEAL::row: 3
+DEAL::column: 3
+DEAL::value: 1.00000
+DEAL::row: 4
+DEAL::column: 3
+DEAL::value: -1.00000
+DEAL::row: 4
+DEAL::column: 4
+DEAL::value: 1.00000
+DEAL::OK


### PR DESCRIPTION
PVS studio rightfully complains that we should define operator= whenever we explicitly define a copy constructor. However, since our copy constructor does nothing special it is in fact equivalent to the default copy constructor, so we can just get get rid of it and let the compiler generate the correct copying code.

Fixes #3537.