### PR TITLE
Improve the output of PETSc exceptions.

### DIFF
--- a/include/deal.II/lac/exceptions.h
+++ b/include/deal.II/lac/exceptions.h
@@ -43,13 +43,22 @@ namespace LACExceptions
   DeclException0 (ExcDifferentBlockIndices);
 
   /**
-   * An error of a PETSc function was encountered. Check the PETSc
-   * documentation for details.
+   * Exception thrown when a PETSc function reports an error. If possible,
+   * this exception uses the message provided by
+   * <code>PetscErrorMessage</code> to print a description of the error.
+   *
+   * @note For backwards compatibility this is defined whether or not deal.II
+   * is compiled with PETSc.
    */
-  DeclException1 (ExcPETScError,
-                  int,
-                  << "An error with error number " << arg1
-                  << " occurred while calling a PETSc function");
+  class ExcPETScError : public dealii::ExceptionBase
+  {
+  public:
+    ExcPETScError (const int error_code);
+
+    virtual void print_info (std::ostream &out) const;
+
+    const int error_code;
+  };
 
   /**
    * An error of a Trilinos function was encountered. Check the Trilinos

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1256,9 +1256,9 @@ namespace PETScWrappers
         col_value_ptr = &column_values[0];
       }
 
-    const int ierr
-      = MatSetValues (matrix, 1, &petsc_i, n_columns, col_index_ptr,
-                      col_value_ptr, INSERT_VALUES);
+    const int ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
+                                   col_index_ptr,
+                                   col_value_ptr, INSERT_VALUES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1398,9 +1398,8 @@ namespace PETScWrappers
         col_value_ptr = &column_values[0];
       }
 
-    const int ierr
-      = MatSetValues (matrix, 1, &petsc_i, n_columns, col_index_ptr,
-                      col_value_ptr, ADD_VALUES);
+    const int ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
+                                   col_index_ptr, col_value_ptr, ADD_VALUES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -163,12 +163,15 @@ namespace PETScWrappers
     void initialize(const PreconditionerBase &preconditioner);
 
     /**
-     * Exception
+     * Exception.
+     *
+     * @deprecated This function has been deprecated in favor of the more
+     * general LACExceptions::ExcPETScError exception class.
      */
     DeclException1 (ExcPETScError,
                     int,
                     << "An error with error number " << arg1
-                    << " occurred while calling a PETSc function");
+                    << " occurred while calling a PETSc function") DEAL_II_DEPRECATED;
 
   protected:
 

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -878,8 +878,7 @@ namespace PETScWrappers
 
       const PetscInt petsc_i = index;
 
-      const int ierr
-        = VecSetValues (vector, 1, &petsc_i, &value, INSERT_VALUES);
+      const int ierr = VecSetValues (vector, 1, &petsc_i, &value, INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       vector.last_action = VectorOperation::insert;
@@ -915,8 +914,7 @@ namespace PETScWrappers
 
       // use the PETSc function to add something
       const PetscInt petsc_i = index;
-      const int ierr
-        = VecSetValues (vector, 1, &petsc_i, &value, ADD_VALUES);
+      const int ierr = VecSetValues (vector, 1, &petsc_i, &value, ADD_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 
@@ -953,8 +951,7 @@ namespace PETScWrappers
       // add something
       const PetscInt petsc_i = index;
       const PetscScalar subtractand = -value;
-      const int ierr
-        = VecSetValues (vector, 1, &petsc_i, &subtractand, ADD_VALUES);
+      const int ierr = VecSetValues (vector, 1, &petsc_i, &subtractand, ADD_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;
@@ -990,8 +987,7 @@ namespace PETScWrappers
       const PetscScalar new_value
         = static_cast<PetscScalar>(*this) * value;
 
-      const int ierr
-        = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
+      const int ierr = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;
@@ -1027,8 +1023,7 @@ namespace PETScWrappers
       const PetscScalar new_value
         = static_cast<PetscScalar>(*this) / value;
 
-      const int ierr
-        = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
+      const int ierr = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -48,6 +48,7 @@
 #  ifdef DEAL_II_WITH_MPI
 #    include <slepcsys.h>
 #  endif
+#  include <deal.II/lac/slepc_solver.h>
 #endif
 
 #ifdef DEAL_II_WITH_P4EST
@@ -357,10 +358,12 @@ namespace Utilities
 #ifdef DEAL_II_WITH_PETSC
 #  ifdef DEAL_II_WITH_SLEPC
       // Initialize SLEPc (with PETSc):
-      SlepcInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);
+      ierr = SlepcInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);
+      AssertThrow (ierr == 0, SLEPcWrappers::SolverBase::ExcSLEPcError(ierr));
 #  else
       // or just initialize PETSc alone:
-      PetscInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);
+      ierr = PetscInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);
+      AssertThrow (ierr == 0, ExcPETScError(ierr));
 #  endif
 #endif
 

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -23,8 +23,9 @@ SET(_src
   block_vector.cc
   chunk_sparse_matrix.cc
   chunk_sparsity_pattern.cc
-  dynamic_sparsity_pattern.cc
   constraint_matrix.cc
+  dynamic_sparsity_pattern.cc
+  exceptions.cc
   full_matrix.cc
   lapack_full_matrix.cc
   la_vector.cc

--- a/source/lac/exceptions.cc
+++ b/source/lac/exceptions.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/exceptions.h>
+
+#ifdef DEAL_II_WITH_PETSC
+#include <petscconf.h>
+#include <petscsys.h>
+#include <petscerror.h>
+#endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace LACExceptions
+{
+  ExcPETScError::ExcPETScError (const int error_code)
+    :
+    error_code (error_code)
+  {}
+
+  void ExcPETScError::print_info (std::ostream &out) const
+  {
+    out << "deal.II encountered an error while calling a PETSc function."
+        << std::endl;
+#ifdef DEAL_II_WITH_PETSC
+    // PetscErrorMessage changes the value in a pointer to refer to a
+    // statically allocated description of the current error message.
+    const char *petsc_message;
+    const int ierr = PetscErrorMessage (error_code, &petsc_message, /*specific=*/NULL);
+    if (ierr == 0 && petsc_message != NULL)
+      {
+        out << "The description of the error provided by PETSc is \""
+            << petsc_message
+            << "\"."
+            << std::endl;
+      }
+    else
+      {
+        out << "PETSc was not able to determine a description for this particular error code."
+            << std::endl;
+      }
+#endif // DEAL_II_WITH_PETSC
+    out << "The numerical value of the original error code is "
+        << error_code
+        << "."
+        << std::endl;
+  }
+} // namespace LACExceptions
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -55,10 +55,8 @@ namespace PETScWrappers
   {
     // use the call sequence indicating only a maximal number of
     // elements per row for all rows globally
-    const int ierr
-      = MatCreateSeqDense (PETSC_COMM_SELF, m, n, PETSC_NULL,
-                           &matrix);
-
+    const int ierr = MatCreateSeqDense (PETSC_COMM_SELF, m, n, PETSC_NULL,
+                                        &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -561,11 +561,13 @@ namespace PETScWrappers
     assert_is_compressed ();
 
     // Set options
-    PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
-                          format);
+    int ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
+                                     format);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
-    MatView (matrix, PETSC_VIEWER_STDOUT_WORLD);
+    ierr = MatView (matrix, PETSC_VIEWER_STDOUT_WORLD);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
   void
@@ -603,7 +605,8 @@ namespace PETScWrappers
   MatrixBase::memory_consumption() const
   {
     MatInfo info;
-    MatGetInfo(matrix, MAT_LOCAL, &info);
+    const int ierr = MatGetInfo(matrix, MAT_LOCAL, &info);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return sizeof(*this) + static_cast<size_type>(info.memory);
   }

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -158,11 +158,10 @@ namespace PETScWrappers
 #endif
 
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr
-      = MatZeroRowsIS(matrix, index_set, new_diag_value);
+    const int ierr = MatZeroRowsIS(matrix, index_set, new_diag_value);
 #else
-    const int ierr
-      = MatZeroRowsIS(matrix, index_set, new_diag_value, PETSC_NULL, PETSC_NULL);
+    const int ierr = MatZeroRowsIS(matrix, index_set, new_diag_value, PETSC_NULL,
+                                   PETSC_NULL);
 #endif
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -183,9 +182,8 @@ namespace PETScWrappers
 
     PetscScalar value;
 
-    const int ierr
-      = MatGetValues (matrix, 1, &petsc_i, 1, &petsc_j,
-                      &value);
+    const int ierr = MatGetValues (matrix, 1, &petsc_i, 1, &petsc_j,
+                                   &value);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return value;
@@ -247,7 +245,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    int ierr = MatGetSize (matrix, &n_rows, &n_cols);
+    const int ierr = MatGetSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_rows;
@@ -260,7 +258,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    int ierr = MatGetSize (matrix, &n_rows, &n_cols);
+    const int ierr = MatGetSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_cols;
@@ -273,7 +271,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    int ierr = MatGetLocalSize (matrix, &n_rows, &n_cols);
+    const int ierr = MatGetLocalSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_rows;
@@ -299,8 +297,7 @@ namespace PETScWrappers
   MatrixBase::n_nonzero_elements () const
   {
     MatInfo mat_info;
-    const int ierr
-      = MatGetInfo (matrix, MAT_GLOBAL_SUM, &mat_info);
+    const int ierr = MatGetInfo (matrix, MAT_GLOBAL_SUM, &mat_info);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return static_cast<size_type>(mat_info.nz_used);
@@ -328,8 +325,7 @@ namespace PETScWrappers
 
 //TODO: this is probably horribly inefficient; we should lobby for a way to
 //query this information from PETSc
-    int ierr;
-    ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
+    int ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then restore the matrix and return the number of columns in this row as
@@ -350,8 +346,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr
-      = MatNorm (matrix, NORM_1, &result);
+    const int ierr = MatNorm (matrix, NORM_1, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -364,8 +359,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr
-      = MatNorm (matrix, NORM_INFINITY, &result);
+    const int ierr = MatNorm (matrix, NORM_INFINITY, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -378,8 +372,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr
-      = MatNorm (matrix, NORM_FROBENIUS, &result);
+    const int ierr = MatNorm (matrix, NORM_FROBENIUS, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -411,8 +404,7 @@ namespace PETScWrappers
   {
     PetscScalar result;
 
-    const int ierr
-      = MatGetTrace (matrix, &result);
+    const int ierr = MatGetTrace (matrix, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -437,7 +429,6 @@ namespace PETScWrappers
   {
     const PetscScalar factor = 1./a;
     const int ierr = MatScale (matrix, factor);
-
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -450,9 +441,7 @@ namespace PETScWrappers
   {
     const int ierr = MatAXPY (matrix, factor,
                               other, DIFFERENT_NONZERO_PATTERN);
-    (void)ierr;
-
-    Assert (ierr == 0, ExcPETScError(ierr));
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
   }
@@ -474,7 +463,6 @@ namespace PETScWrappers
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
     const int ierr = MatMult (matrix, src, dst);
-    (void)ierr;
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -487,7 +475,6 @@ namespace PETScWrappers
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
     const int ierr = MatMultTranspose (matrix, src, dst);
-    (void)ierr;
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -513,7 +500,6 @@ namespace PETScWrappers
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
     const int ierr = MatMultTransposeAdd (matrix, src, dst, dst);
-    (void)ierr;
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -543,8 +529,7 @@ namespace PETScWrappers
   void
   MatrixBase::transpose ()
   {
-    int ierr = MatTranspose(matrix, MAT_REUSE_MATRIX, &matrix);
-    (void)ierr;
+    const int ierr = MatTranspose(matrix, MAT_REUSE_MATRIX, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -553,8 +538,7 @@ namespace PETScWrappers
   {
     PetscBooleanType truth;
     assert_is_compressed ();
-    int ierr = MatIsSymmetric (matrix, tolerance, &truth);
-    (void)ierr;
+    const int ierr = MatIsSymmetric (matrix, tolerance, &truth);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     return truth;
   }
@@ -565,8 +549,7 @@ namespace PETScWrappers
     PetscBooleanType truth;
 
     assert_is_compressed ();
-    int ierr = MatIsHermitian (matrix, tolerance, &truth);
-    (void)ierr;
+    const int ierr = MatIsHermitian (matrix, tolerance, &truth);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return truth;
@@ -600,7 +583,6 @@ namespace PETScWrappers
     for (row = loc_range.first; row < loc_range.second; ++row)
       {
         int ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
-        (void)ierr;
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         for (PetscInt col = 0; col < ncols; ++col)

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -239,7 +239,7 @@ namespace PETScWrappers
     // to the matrix-vector multiplication
     // of this MatrixFree object,
     void  *this_object;
-    int ierr = MatShellGetContext (A, &this_object);
+    const int ierr = MatShellGetContext (A, &this_object);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // call vmult of this object:

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -660,10 +660,11 @@ namespace PETScWrappers
             for (size_type i=local_row_start; i<local_row_end; ++i)
               {
                 PetscInt petsc_i = i;
-                MatSetValues (matrix, 1, &petsc_i,
-                              sparsity_pattern.row_length(i),
-                              &colnums_in_window[rowstart_in_window[i-local_row_start]],
-                              &values[0], INSERT_VALUES);
+                ierr = MatSetValues (matrix, 1, &petsc_i,
+                                     sparsity_pattern.row_length(i),
+                                     &colnums_in_window[rowstart_in_window[i-local_row_start]],
+                                     &values[0], INSERT_VALUES);
+                AssertThrow (ierr == 0, ExcPETScError(ierr));
               }
           }
 

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -132,7 +132,7 @@ namespace PETScWrappers
 
       this->communicator = other.communicator;
 
-      int ierr = MatCopy(other.matrix, matrix, SAME_NONZERO_PATTERN);
+      const int ierr = MatCopy(other.matrix, matrix, SAME_NONZERO_PATTERN);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
     }
 
@@ -239,23 +239,19 @@ namespace PETScWrappers
       int ierr;
 
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-      ierr
-        = MatCreateMPIAIJ (communicator,
+      ierr = MatCreateMPIAIJ (communicator,
+                              local_rows, local_columns,
+                              m, n,
+                              n_nonzero_per_row, 0,
+                              n_offdiag_nonzero_per_row, 0,
+                              &matrix);
+#else
+      ierr = MatCreateAIJ (communicator,
                            local_rows, local_columns,
                            m, n,
                            n_nonzero_per_row, 0,
                            n_offdiag_nonzero_per_row, 0,
                            &matrix);
-#else
-      ierr
-        = MatCreateAIJ (communicator,
-                        local_rows, local_columns,
-                        m, n,
-                        n_nonzero_per_row, 0,
-                        n_offdiag_nonzero_per_row, 0,
-                        &matrix);
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
-
       set_matrix_option (matrix, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
 #endif
       AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -311,22 +307,19 @@ namespace PETScWrappers
       int ierr;
 
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-      ierr
-        = MatCreateMPIAIJ (communicator,
+      ierr = MatCreateMPIAIJ (communicator,
+                              local_rows, local_columns,
+                              m, n,
+                              0, &int_row_lengths[0],
+                              0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
+                              &matrix);
+#else
+      ierr = MatCreateAIJ (communicator,
                            local_rows, local_columns,
                            m, n,
                            0, &int_row_lengths[0],
                            0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
                            &matrix);
-#else
-      ierr
-        = MatCreateAIJ (communicator,
-                        local_rows, local_columns,
-                        m, n,
-                        0, &int_row_lengths[0],
-                        0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
-                        &matrix);
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 //TODO: Sometimes the actual number of nonzero entries allocated is greater than the number of nonzero entries, which petsc will complain about unless explicitly disabled with MatSetOption. There is probably a way to prevent a different number nonzero elements being allocated in the first place. (See also previous TODO).
       set_matrix_option (matrix, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
@@ -456,20 +449,20 @@ namespace PETScWrappers
           // then call the petsc function
           // that summarily allocates these
           // entries:
-          MatMPIAIJSetPreallocationCSR (matrix,
-                                        &rowstart_in_window[0],
-                                        &colnums_in_window[0],
-                                        0);
+          ierr = MatMPIAIJSetPreallocationCSR (matrix,
+                                               &rowstart_in_window[0],
+                                               &colnums_in_window[0],
+                                               0);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
         }
       else
         {
           PetscInt i=0;
-          MatMPIAIJSetPreallocationCSR (matrix,
-                                        &i,
-                                        &i,
-                                        0);
-
-
+          ierr = MatMPIAIJSetPreallocationCSR (matrix,
+                                               &i,
+                                               &i,
+                                               0);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
         }
       compress (dealii::VectorOperation::insert);
 
@@ -548,24 +541,21 @@ namespace PETScWrappers
       // the first _local_ row, i.e. it
       // doesn't index into an array for
       // _all_ rows.
-      const int ierr
-        = MatCreateMPIAIJ(communicator,
-                          local_rows_per_process[this_process],
-                          local_columns_per_process[this_process],
-                          sparsity_pattern.n_rows(),
-                          sparsity_pattern.n_cols(),
-                          0, &row_lengths_in_window[0],
-                          0, &row_lengths_out_of_window[0],
-                          &matrix);
+      const int ierr = MatCreateMPIAIJ(communicator,
+                                       local_rows_per_process[this_process],
+                                       local_columns_per_process[this_process],
+                                       sparsity_pattern.n_rows(),
+                                       sparsity_pattern.n_cols(),
+                                       0, &row_lengths_in_window[0],
+                                       0, &row_lengths_out_of_window[0],
+                                       &matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 #else //PETSC_VERSION>=2.3.3
       // create the matrix. We
       // do not set row length but set the
       // correct SparsityPattern later.
-      int ierr;
-
-      ierr = MatCreate(communicator,&matrix);
+      int ierr = MatCreate(communicator,&matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = MatSetSizes(matrix,
@@ -636,10 +626,11 @@ namespace PETScWrappers
           // then call the petsc function
           // that summarily allocates these
           // entries:
-          MatMPIAIJSetPreallocationCSR (matrix,
-                                        &rowstart_in_window[0],
-                                        &colnums_in_window[0],
-                                        0);
+          ierr = MatMPIAIJSetPreallocationCSR (matrix,
+                                               &rowstart_in_window[0],
+                                               &colnums_in_window[0],
+                                               0);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 #if DEAL_II_PETSC_VERSION_LT(2,3,3)
           // this is only needed for old

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -141,7 +141,6 @@ namespace PETScWrappers
 #else
           ierr = VecDestroy (&vector);
 #endif
-
           AssertThrow (ierr == 0, ExcPETScError(ierr));
 
           create_vector (n, local_sz);
@@ -164,7 +163,7 @@ namespace PETScWrappers
           reinit (v.locally_owned_elements(), v.ghost_indices, v.communicator);
           if (!omit_zeroing_entries)
             {
-              int ierr = VecSet(vector, 0.0);
+              const int ierr = VecSet(vector, 0.0);
               AssertThrow (ierr == 0, ExcPETScError(ierr));
             }
         }
@@ -272,9 +271,8 @@ namespace PETScWrappers
       Assert (local_size <= n, ExcIndexRange (local_size, 0, n));
       ghosted = false;
 
-      const int ierr
-        = VecCreateMPI (communicator, local_size, PETSC_DETERMINE,
-                        &vector);
+      const int ierr = VecCreateMPI (communicator, local_size, PETSC_DETERMINE,
+                                     &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       Assert (size() == n,
@@ -303,14 +301,12 @@ namespace PETScWrappers
            :
            0);
 
-      int ierr
-        = VecCreateGhost(communicator,
-                         local_size,
-                         PETSC_DETERMINE,
-                         ghostindices.size(),
-                         ptr,
-                         &vector);
-
+      int ierr = VecCreateGhost(communicator,
+                                local_size,
+                                PETSC_DETERMINE,
+                                ghostindices.size(),
+                                ptr,
+                                &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       Assert (size() == n,
@@ -387,15 +383,12 @@ namespace PETScWrappers
       PetscInt    nlocal, istart, iend;
 
       int ierr = VecGetArray (vector, &val);
-
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = VecGetLocalSize (vector, &nlocal);
-
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = VecGetOwnershipRange (vector, &istart, &iend);
-
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       // save the state of out stream

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -393,12 +393,11 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCICC));
+    int ierr = PCSetType (pc, const_cast<char *>(PCICC));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags
-    PCFactorSetLevels (pc, additional_data.levels);
+    ierr = PCFactorSetLevels (pc, additional_data.levels);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions (pc);
@@ -445,7 +444,7 @@ namespace PETScWrappers
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags
-    PCFactorSetLevels (pc, additional_data.levels);
+    ierr = PCFactorSetLevels (pc, additional_data.levels);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions (pc);

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -310,12 +310,10 @@ namespace PETScWrappers
     // completely pointless change in
     // spelling Chebyshev between PETSc 3.2
     // and 3.3...
-    int ierr;
-
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-    ierr = KSPSetType (ksp, KSPCHEBYCHEV);
+    int ierr = KSPSetType (ksp, KSPCHEBYCHEV);
 #else
-    ierr = KSPSetType (ksp, KSPCHEBYSHEV);
+    int ierr = KSPSetType (ksp, KSPCHEBYSHEV);
 #endif
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -340,8 +338,7 @@ namespace PETScWrappers
   void
   SolverCG::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPCG);
+    int ierr = KSPSetType (ksp, KSPCG);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -365,8 +362,7 @@ namespace PETScWrappers
   void
   SolverBiCG::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPBICG);
+    int ierr = KSPSetType (ksp, KSPBICG);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -400,8 +396,7 @@ namespace PETScWrappers
   void
   SolverGMRES::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPGMRES);
+    int ierr = KSPSetType (ksp, KSPGMRES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set the restart parameter from the
@@ -467,8 +462,7 @@ namespace PETScWrappers
   void
   SolverBicgstab::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPBCGS);
+    int ierr = KSPSetType (ksp, KSPBCGS);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -492,8 +486,7 @@ namespace PETScWrappers
   void
   SolverCGS::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPCGS);
+    int ierr = KSPSetType (ksp, KSPCGS);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -542,8 +535,7 @@ namespace PETScWrappers
   void
   SolverTCQMR::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPTCQMR);
+    int ierr = KSPSetType (ksp, KSPTCQMR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -592,8 +584,7 @@ namespace PETScWrappers
   void
   SolverLSQR::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPLSQR);
+    int ierr = KSPSetType (ksp, KSPLSQR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -664,8 +655,7 @@ namespace PETScWrappers
     * preconditioner.  Its use is due to SparseDirectMUMPS being a direct
     * (rather than iterative) solver
     */
-    int ierr;
-    ierr = KSPSetType (ksp, KSPPREONLY);
+    int ierr = KSPSetType (ksp, KSPPREONLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     /**

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -110,9 +110,10 @@ namespace PETScWrappers
         // checks with the solver_control
         // object we have in this object for
         // convergence
-        KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
-                               reinterpret_cast<void *>(&solver_control),
-                               PETSC_NULL);
+        ierr = KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
+                                      reinterpret_cast<void *>(&solver_control),
+                                      PETSC_NULL);
+        AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
 
     // set the command line option prefix name
@@ -227,9 +228,10 @@ namespace PETScWrappers
     // checks with the solver_control
     // object we have in this object for
     // convergence
-    KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
-                           reinterpret_cast<void *>(&solver_control),
-                           PETSC_NULL);
+    ierr = KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
+                                  reinterpret_cast<void *>(&solver_control),
+                                  PETSC_NULL);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set the command line options provided
     // by the user to override the defaults
@@ -272,7 +274,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // Hand over the absolute
     // tolerance and the maximum
@@ -287,8 +290,9 @@ namespace PETScWrappers
     // the Richardson iteration,
     // where no residual is
     // available.
-    KSPSetTolerances(ksp, PETSC_DEFAULT, this->solver_control.tolerance(),
-                     PETSC_DEFAULT, this->solver_control.max_steps()+1);
+    ierr = KSPSetTolerances(ksp, PETSC_DEFAULT, this->solver_control.tolerance(),
+                            PETSC_DEFAULT, this->solver_control.max_steps()+1);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -320,7 +324,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -344,7 +349,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -368,7 +374,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -444,7 +451,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -468,7 +476,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -492,7 +501,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -510,14 +520,14 @@ namespace PETScWrappers
   void
   SolverTFQMR::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPTFQMR);
+    int ierr = KSPSetType (ksp, KSPTFQMR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -541,7 +551,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -559,14 +570,14 @@ namespace PETScWrappers
   void
   SolverCR::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPCR);
+    int ierr = KSPSetType (ksp, KSPCR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -590,7 +601,8 @@ namespace PETScWrappers
     // in the deal.II solvers, we always
     // honor the initial guess in the
     // solution vector. do so here as well:
-    KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_TRUE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -608,8 +620,7 @@ namespace PETScWrappers
   void
   SolverPreOnly::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPPREONLY);
+    int ierr = KSPSetType (ksp, KSPPREONLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // The KSPPREONLY solver of
@@ -625,7 +636,8 @@ namespace PETScWrappers
     // Using the PREONLY solver with
     // a nonzero initial guess leads
     // PETSc to produce some error messages.
-    KSPSetInitialGuessNonzero (ksp, PETSC_FALSE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_FALSE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -670,7 +682,8 @@ namespace PETScWrappers
      * Using a PREONLY solver with a nonzero initial guess leads PETSc to
      * produce some error messages.
      */
-    KSPSetInitialGuessNonzero (ksp, PETSC_FALSE);
+    ierr = KSPSetInitialGuessNonzero (ksp, PETSC_FALSE);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
   void
@@ -752,9 +765,10 @@ namespace PETScWrappers
          * convergence monitor function that checks with the solver_control
          * object for convergence
          */
-        KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
-                               reinterpret_cast<void *>(&solver_control),
-                               PETSC_NULL);
+        ierr = KSPSetConvergenceTest (solver_data->ksp, &convergence_test,
+                                      reinterpret_cast<void *>(&solver_control),
+                                      PETSC_NULL);
+        AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         /**
          * set the software that is to be used to perform the lu

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -129,7 +129,8 @@ namespace PETScWrappers
   SparseMatrix::get_mpi_communicator () const
   {
     static MPI_Comm comm;
-    PetscObjectGetComm((PetscObject)matrix, &comm);
+    const int ierr = PetscObjectGetComm((PetscObject)matrix, &comm);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
     return comm;
   }
 
@@ -229,9 +230,10 @@ namespace PETScWrappers
               row_entries[j] = sparsity_pattern.column_number (i,j);
 
             const PetscInt int_row = i;
-            MatSetValues (matrix, 1, &int_row,
-                          row_lengths[i], &row_entries[0],
-                          &row_values[0], INSERT_VALUES);
+            const int ierr = MatSetValues (matrix, 1, &int_row,
+                                           row_lengths[i], &row_entries[0],
+                                           &row_values[0], INSERT_VALUES);
+            AssertThrow (ierr == 0, ExcPETScError(ierr));
           }
         compress (VectorOperation::insert);
 

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -31,9 +31,8 @@ namespace PETScWrappers
   SparseMatrix::SparseMatrix ()
   {
     const int m=0, n=0, n_nonzero_per_row=0;
-    const int ierr
-      = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
-                        0, &matrix);
+    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
+                                     0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -145,9 +144,9 @@ namespace PETScWrappers
     // use the call sequence indicating only
     // a maximal number of elements per row
     // for all rows globally
-    const int ierr
-      = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
-                        0, &matrix);
+    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n,
+                                     n_nonzero_per_row,
+                                     0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set symmetric flag, if so requested
@@ -179,9 +178,8 @@ namespace PETScWrappers
     const std::vector<PetscInt>
     int_row_lengths (row_lengths.begin(), row_lengths.end());
 
-    const int ierr
-      = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, 0,
-                        &int_row_lengths[0], &matrix);
+    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, 0,
+                                     &int_row_lengths[0], &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set symmetric flag, if so requested
@@ -246,7 +244,7 @@ namespace PETScWrappers
   SparseMatrix::m () const
   {
     PetscInt m,n;
-    PetscErrorCode ierr = MatGetSize(matrix, &m, &n);
+    const PetscErrorCode ierr = MatGetSize(matrix, &m, &n);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return m;
@@ -256,7 +254,7 @@ namespace PETScWrappers
   SparseMatrix::n () const
   {
     PetscInt m,n;
-    PetscErrorCode ierr = MatGetSize(matrix, &m, &n);
+    const PetscErrorCode ierr = MatGetSize(matrix, &m, &n);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n;

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -1052,11 +1052,13 @@ namespace PETScWrappers
     //TODO[TH]:assert(is_compressed())
 
     // Set options
-    PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
-                          format);
+    int ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
+                                     format);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
-    VecView (vector, PETSC_VIEWER_STDOUT_WORLD);
+    ierr = VecView (vector, PETSC_VIEWER_STDOUT_WORLD);
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -1178,9 +1178,8 @@ namespace PETScWrappers
 #endif
 
         const InsertMode mode = (add_values ? ADD_VALUES : INSERT_VALUES);
-        const int ierr
-          = VecSetValues (vector, n_elements, petsc_indices, values,
-                          mode);
+        const int ierr = VecSetValues (vector, n_elements, petsc_indices,
+                                       values, mode);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
 

--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -63,9 +63,9 @@ namespace SLEPcWrappers
       {
         // Destroy the solver object.
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        int ierr = EPSDestroy (eps);
+        const int ierr = EPSDestroy (eps);
 #else
-        int ierr = EPSDestroy (&eps);
+        const int ierr = EPSDestroy (&eps);
 #endif
         AssertThrow (ierr == 0, ExcSLEPcError(ierr));
       }
@@ -75,7 +75,7 @@ namespace SLEPcWrappers
   SolverBase::set_matrices (const PETScWrappers::MatrixBase &A)
   {
     // standard eigenspectrum problem
-    int ierr = EPSSetOperators (eps, A, PETSC_NULL);
+    const int ierr = EPSSetOperators (eps, A, PETSC_NULL);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -84,7 +84,7 @@ namespace SLEPcWrappers
                             const PETScWrappers::MatrixBase &B)
   {
     // generalized eigenspectrum problem
-    int ierr = EPSSetOperators (eps, A, B);
+    const int ierr = EPSSetOperators (eps, A, B);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -93,7 +93,7 @@ namespace SLEPcWrappers
   {
     // set transformation type if any
     // STSetShift is called inside
-    int ierr = EPSSetST(eps,transformation.st);
+    const int ierr = EPSSetST(eps,transformation.st);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
@@ -103,12 +103,11 @@ namespace SLEPcWrappers
     Assert(this_initial_vector.l2_norm()>0.0,
            ExcMessage("Initial vector should be nonzero."));
 
-    int ierr;
     Vec vec = this_initial_vector;
 #if DEAL_II_PETSC_VERSION_LT(3,1,0)
-    ierr = EPSSetInitialVector (eps, &vec);
+    const int ierr = EPSSetInitialVector (eps, &vec);
 #else
-    ierr = EPSSetInitialSpace (eps, 1, &vec);
+    const int ierr = EPSSetInitialSpace (eps, 1, &vec);
 #endif
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
@@ -119,7 +118,7 @@ namespace SLEPcWrappers
     // set target eigenvalues to solve for
     // in all transformation except STSHIFT there is a direct connection between
     // the target and the shift, read more on p41 of SLEPc manual.
-    int ierr = EPSSetTarget (eps, this_target );
+    const int ierr = EPSSetTarget (eps, this_target );
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -127,14 +126,14 @@ namespace SLEPcWrappers
   SolverBase::set_which_eigenpairs (const EPSWhich eps_which)
   {
     // set which portion of the eigenspectrum to solve for
-    int ierr = EPSSetWhichEigenpairs (eps, eps_which);
+    const int ierr = EPSSetWhichEigenpairs (eps, eps_which);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
   void
   SolverBase::set_problem_type (const EPSProblemType eps_problem)
   {
-    int ierr = EPSSetProblemType (eps, eps_problem);
+    const int ierr = EPSSetProblemType (eps, eps_problem);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -142,11 +141,9 @@ namespace SLEPcWrappers
   SolverBase::solve (const unsigned int  n_eigenpairs,
                      unsigned int       *n_converged)
   {
-    int ierr;
-
     // set number of eigenvectors to compute
-    ierr = EPSSetDimensions (eps, n_eigenpairs,
-                             PETSC_DECIDE, PETSC_DECIDE);
+    int ierr = EPSSetDimensions (eps, n_eigenpairs,
+                                 PETSC_DECIDE, PETSC_DECIDE);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     // set the solve options to the eigenvalue problem solver context
@@ -233,9 +230,9 @@ namespace SLEPcWrappers
                              PETScWrappers::VectorBase &eigenvectors)
   {
     // get converged eigenpair
-    int ierr = EPSGetEigenpair (eps, index,
-                                &eigenvalues, PETSC_NULL,
-                                eigenvectors, PETSC_NULL);
+    const int ierr = EPSGetEigenpair (eps, index,
+                                      &eigenvalues, PETSC_NULL,
+                                      eigenvectors, PETSC_NULL);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -249,9 +246,9 @@ namespace SLEPcWrappers
   {
 #ifndef PETSC_USE_COMPLEX
     // get converged eigenpair
-    int ierr = EPSGetEigenpair (eps, index,
-                                &real_eigenvalues, &imag_eigenvalues,
-                                real_eigenvectors, imag_eigenvectors);
+    const int ierr = EPSGetEigenpair (eps, index,
+                                      &real_eigenvalues, &imag_eigenvalues,
+                                      real_eigenvectors, imag_eigenvectors);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 #else
     Assert ((false),
@@ -323,7 +320,7 @@ namespace SLEPcWrappers
     SolverBase (cn, mpi_communicator),
     additional_data (data)
   {
-    int ierr = EPSSetType (eps, const_cast<char *>(EPSKRYLOVSCHUR));
+    const int ierr = EPSSetType (eps, const_cast<char *>(EPSKRYLOVSCHUR));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -33,7 +33,7 @@ namespace SLEPcWrappers
 {
   TransformationBase::TransformationBase (const MPI_Comm &mpi_communicator)
   {
-    int ierr = STCreate(mpi_communicator, &st);
+    const int ierr = STCreate(mpi_communicator, &st);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
@@ -41,14 +41,14 @@ namespace SLEPcWrappers
   {
     if (st!=NULL)
       {
-        int ierr = STDestroy(&st);
+        const int ierr = STDestroy(&st);
         AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
       }
   }
 
   void TransformationBase::set_matrix_mode(const STMatMode mode)
   {
-    int ierr = STSetMatMode(st,mode);
+    const int ierr = STSetMatMode(st,mode);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 

--- a/tests/petsc/exception_messages.cc
+++ b/tests/petsc/exception_messages.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that we can catch some standard PETSc error codes and print
+// appropriate exception messages to the screen.
+
+#include "../tests.h"
+#include <deal.II/lac/exceptions.h>
+
+#include <petscconf.h>
+#include <petscsys.h>
+#include <petscerror.h>
+
+#include <fstream>
+#include <vector>
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  std::vector<int> petsc_error_codes;
+  petsc_error_codes.push_back(PETSC_ERR_MIN_VALUE);
+  petsc_error_codes.push_back(PETSC_ERR_MEM);
+  petsc_error_codes.push_back(PETSC_ERR_LIB);
+  petsc_error_codes.push_back(PETSC_ERR_ARG_WRONGSTATE);
+  petsc_error_codes.push_back(PETSC_ERR_ARG_NOTSAMETYPE);
+
+  for (unsigned int i = 0; i < petsc_error_codes.size(); ++i)
+    {
+      try
+        {
+          throw ExcPETScError(petsc_error_codes[i]);
+        }
+      catch (const ExceptionBase &exc)
+        {
+          deallog << exc.get_exc_name() << std::endl;
+          exc.print_info(deallog.get_file_stream());
+        }
+    }
+
+  return 0;
+}

--- a/tests/petsc/exception_messages.mpirun=1.output
+++ b/tests/petsc/exception_messages.mpirun=1.output
@@ -1,0 +1,21 @@
+
+DEAL::
+deal.II encountered an error while calling a PETSc function.
+PETSc was not able to determine a description for this particular error code.
+The numerical value of the original error code is 54.
+DEAL::
+deal.II encountered an error while calling a PETSc function.
+The description of the error provided by PETSc is "Out of memory".
+The numerical value of the original error code is 55.
+DEAL::
+deal.II encountered an error while calling a PETSc function.
+The description of the error provided by PETSc is "Error in external library".
+The numerical value of the original error code is 76.
+DEAL::
+deal.II encountered an error while calling a PETSc function.
+The description of the error provided by PETSc is "Object is in wrong state".
+The numerical value of the original error code is 73.
+DEAL::
+deal.II encountered an error while calling a PETSc function.
+The description of the error provided by PETSc is "Arguments must have same type".
+The numerical value of the original error code is 69.


### PR DESCRIPTION
After doing #3517 I realized that we could do the same trick to print better PETSc error messages. 

I marked this as a work in progress since I want to go back and check all of our calls to PETSc to ensure that we check their return codes.