### PR TITLE
Initialize the 'matrix' and 'vector' members in the PETSc wrappers.

### DIFF
--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2015 by the deal.II authors
+// Copyright (C) 2004 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -76,6 +76,7 @@ namespace PETScWrappers
 
   MatrixBase::MatrixBase ()
     :
+    matrix (NULL),
     last_action (VectorOperation::unknown)
   {}
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2004 - 2015 by the deal.II authors
+// Copyright (C) 2004 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -150,6 +150,7 @@ namespace PETScWrappers
 
   VectorBase::VectorBase ()
     :
+    vector (NULL),
     ghosted(false),
     last_action (::dealii::VectorOperation::unknown),
     attained_ownership(true)


### PR DESCRIPTION
These members are of type 'Mat' and 'Vec', which are typedefed to pointers to otherwise
opaque types. Initialize these members to 'NULL'.

Fixes #3561. Fixes #3563.