### PR TITLE
Add a copy operator to TrilinosWrappers::SparsityPatternIterators::Accessor.

### DIFF
--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -94,6 +94,11 @@ namespace TrilinosWrappers
       Accessor (const Accessor &a);
 
       /**
+       * Copy operator.
+       */
+      Accessor &operator= (const Accessor &a);
+
+      /**
        * Row number of the element represented by this object.
        */
       size_type row() const;
@@ -1201,6 +1206,19 @@ namespace TrilinosWrappers
       a_index(a.a_index),
       colnum_cache (a.colnum_cache)
     {}
+
+
+    inline
+    Accessor &
+    Accessor::operator= (const Accessor &a)
+    {
+      sparsity_pattern = a.sparsity_pattern;
+      a_row = a.a_row;
+      a_index = a.a_index;
+      colnum_cache = a.colnum_cache;
+
+      return *this;
+    }
 
 
     inline


### PR DESCRIPTION
Fixes #3541.