### PR TITLE
Fix Trilinos SparsityPattern iterators.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -451,6 +451,12 @@ inconvenience this causes.
  <br>
  (Sebastian Gonzalez-Pintor, Wolfgang Bangerth, 2016/11/15)
  </li>
+ 
+ <li> Fixed: Objects of type TrilinosWrappers::SparsityPattern::const_iterator
+ were entirely unusable due to a bug. This is now fixed.
+ <br>
+ (Wolfgang Bangerth, 2016/11/15)
+ </li>
 
  <li> Fixed: There was a memory leak if a previously used SparsityPattern
  object was re-used by reading from a serialization archive via

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -89,11 +89,6 @@ namespace TrilinosWrappers
                 const size_type        index);
 
       /**
-       * Copy constructor.
-       */
-      Accessor (const Accessor &a);
-
-      /**
        * Row number of the element represented by this object.
        */
       size_type row() const;
@@ -1192,15 +1187,6 @@ namespace TrilinosWrappers
       visit_present_row ();
     }
 
-
-    inline
-    Accessor::Accessor (const Accessor &a)
-      :
-      sparsity_pattern(a.sparsity_pattern),
-      a_row(a.a_row),
-      a_index(a.a_index),
-      colnum_cache (a.colnum_cache)
-    {}
 
 
     inline

--- a/tests/trilinos/trilinos_sparsity_pattern_iterators_01.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_iterators_01.cc
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Tests Trilinos sparsity iterators, specifically copy construction
+// and assignment operators
+
+#include "../tests.h"
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <fstream>
+#include <iomanip>
+
+
+void test ()
+{
+  TrilinosWrappers::SparsityPattern sp;
+
+  sp.reinit(5,7,3);
+  for (unsigned int i=0; i<5; ++i)
+    for (unsigned int j=0; j<7; ++j)
+      if ((i+2*j+1) % 3 == 0)
+        {
+          deallog << "Creating sparsity pattern entry "
+                  << i << ' ' << j << std::endl;
+          sp.add (i,j);
+        }
+  sp.compress ();
+
+  for (TrilinosWrappers::SparsityPattern::const_iterator p = sp.begin(); p != sp.end(); ++p)
+    {
+      deallog << p->row() << ' ' << p->column() << std::endl;
+
+      // check copy construction
+      TrilinosWrappers::SparsityPattern::const_iterator q (p);
+      Assert (p == q, ExcInternalError());
+
+      // also check copy operation
+      q = p;
+      Assert (p == q, ExcInternalError());
+    }
+}
+
+
+
+int main (int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  try
+    {
+      test ();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      deallog << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    };
+}

--- a/tests/trilinos/trilinos_sparsity_pattern_iterators_01.output
+++ b/tests/trilinos/trilinos_sparsity_pattern_iterators_01.output
@@ -1,0 +1,23 @@
+
+DEAL::Creating sparsity pattern entry 0 1
+DEAL::Creating sparsity pattern entry 0 4
+DEAL::Creating sparsity pattern entry 1 2
+DEAL::Creating sparsity pattern entry 1 5
+DEAL::Creating sparsity pattern entry 2 0
+DEAL::Creating sparsity pattern entry 2 3
+DEAL::Creating sparsity pattern entry 2 6
+DEAL::Creating sparsity pattern entry 3 1
+DEAL::Creating sparsity pattern entry 3 4
+DEAL::Creating sparsity pattern entry 4 2
+DEAL::Creating sparsity pattern entry 4 5
+DEAL::0 1
+DEAL::0 4
+DEAL::1 2
+DEAL::1 5
+DEAL::2 0
+DEAL::2 3
+DEAL::2 6
+DEAL::3 1
+DEAL::3 4
+DEAL::4 2
+DEAL::4 5

--- a/tests/trilinos/trilinos_sparsity_pattern_iterators_02.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_iterators_02.cc
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Tests Trilinos sparsity iterators, specifically copy construction
+// and assignment operators
+//
+// The accessors keep a cache that is administered via a shared
+// pointer. make sure that copying these objects works as expected
+
+#include "../tests.h"
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <fstream>
+#include <iomanip>
+
+
+void test ()
+{
+  TrilinosWrappers::SparsityPattern sp;
+
+  sp.reinit(5,7,3);
+  for (unsigned int i=0; i<5; ++i)
+    for (unsigned int j=0; j<7; ++j)
+      if ((i+2*j+1) % 3 == 0)
+        {
+          deallog << "Creating sparsity pattern entry "
+                  << i << ' ' << j << std::endl;
+          sp.add (i,j);
+        }
+  sp.compress ();
+
+  // get an iterator to the first row, then copy it
+  TrilinosWrappers::SparsityPattern::const_iterator p = sp.begin(0);
+  TrilinosWrappers::SparsityPattern::const_iterator q (p);
+
+  // now reset 'p' to the second row, and output what elements both
+  // 'p' and 'q' point to
+  p = sp.begin(1);
+
+  for (unsigned int i=0; i<2; ++i, ++p)
+    deallog << "p[" << i << "]: "
+            << p->row() << ' ' << p->column()
+            << std::endl;
+
+  for (unsigned int i=0; i<2; ++i, ++q)
+    deallog << "q[" << i << "]: "
+            << q->row() << ' ' << q->column()
+            << std::endl;
+
+
+  // do the same with copy assignment
+  p = sp.begin(0);
+  q = p;
+  p = sp.begin(1);
+
+  for (unsigned int i=0; i<2; ++i, ++p)
+    deallog << "p[" << i << "]: "
+            << p->row() << ' ' << p->column()
+            << std::endl;
+
+  for (unsigned int i=0; i<2; ++i, ++q)
+    deallog << "q[" << i << "]: "
+            << q->row() << ' ' << q->column()
+            << std::endl;
+}
+
+
+
+int main (int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  try
+    {
+      test ();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      deallog << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    };
+}

--- a/tests/trilinos/trilinos_sparsity_pattern_iterators_02.output
+++ b/tests/trilinos/trilinos_sparsity_pattern_iterators_02.output
@@ -1,0 +1,20 @@
+
+DEAL::Creating sparsity pattern entry 0 1
+DEAL::Creating sparsity pattern entry 0 4
+DEAL::Creating sparsity pattern entry 1 2
+DEAL::Creating sparsity pattern entry 1 5
+DEAL::Creating sparsity pattern entry 2 0
+DEAL::Creating sparsity pattern entry 2 3
+DEAL::Creating sparsity pattern entry 2 6
+DEAL::Creating sparsity pattern entry 3 1
+DEAL::Creating sparsity pattern entry 3 4
+DEAL::Creating sparsity pattern entry 4 2
+DEAL::Creating sparsity pattern entry 4 5
+DEAL::p[0]: 1 2
+DEAL::p[1]: 1 5
+DEAL::q[0]: 0 1
+DEAL::q[1]: 0 4
+DEAL::p[0]: 1 2
+DEAL::p[1]: 1 5
+DEAL::q[0]: 0 1
+DEAL::q[1]: 0 4


### PR DESCRIPTION
These iterators were previously completely dysfunctional: one could not even create
an iterator without getting a segfault. This is now fixed by fixing the 
Accessor::visit_present_row class. I've also added testst that check the
slightly complicated internal memory management of this class.

While there, also remove the copy constructor of the Accessor class: It is the
default copy constructor, and by removing it, we also don't have to worry
about there being no copy operator.

Fixes #3586. Also fixes #3541. Supersedes #3583.