### PR TITLE
Remove logname variable in tests

### DIFF
--- a/tests/numerics/kelly_crash_02.cc
+++ b/tests/numerics/kelly_crash_02.cc
@@ -29,9 +29,6 @@
 //
 // the problem was fixed by fixing the code
 
-char logname[] = "output";
-
-
 #include "../tests.h"
 
 
@@ -235,7 +232,7 @@ void test ()
 
 int main ()
 {
-  std::ofstream logfile(logname);
+  std::ofstream logfile("output");
   logfile.precision (3);
 
   deallog.attach(logfile);

--- a/tests/numerics/project_common.h
+++ b/tests/numerics/project_common.h
@@ -339,7 +339,7 @@ void test_with_2d_deformed_refined_mesh (const FiniteElement<dim> &fe,
 
 int main ()
 {
-  std::ofstream logfile(logname);
+  std::ofstream logfile("output");
   deallog << std::setprecision (3);
 
   deallog.attach(logfile);

--- a/tests/numerics/project_dgp_01.cc
+++ b/tests/numerics/project_dgp_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGP elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_02.cc
+++ b/tests/numerics/project_dgp_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGP elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_03.cc
+++ b/tests/numerics/project_dgp_03.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_04.cc
+++ b/tests/numerics/project_dgp_04.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_05.cc
+++ b/tests/numerics/project_dgp_05.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_monomial_01.cc
+++ b/tests/numerics/project_dgp_monomial_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGP_Monomial elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_monomial_02.cc
+++ b/tests/numerics/project_dgp_monomial_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGP_Monomial elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_monomial_03.cc
+++ b/tests/numerics/project_dgp_monomial_03.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_monomial_04.cc
+++ b/tests/numerics/project_dgp_monomial_04.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgp_monomial_05.cc
+++ b/tests/numerics/project_dgp_monomial_05.cc
@@ -22,9 +22,6 @@
 // convergence, which we have to specify in the last argument to the
 // call below
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgq_01.cc
+++ b/tests/numerics/project_dgq_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGQ elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgq_02.cc
+++ b/tests/numerics/project_dgq_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGQ elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgq_03.cc
+++ b/tests/numerics/project_dgq_03.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGQ elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgq_04.cc
+++ b/tests/numerics/project_dgq_04.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGQ elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_dgq_05.cc
+++ b/tests/numerics/project_dgq_05.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for DGQ elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_nedelec_01.cc
+++ b/tests/numerics/project_nedelec_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Nedelec elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_nedelec_02.cc
+++ b/tests/numerics/project_nedelec_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Nedelec elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_nedelec_03.cc
+++ b/tests/numerics/project_nedelec_03.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Nedelec elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_nedelec_04.cc
+++ b/tests/numerics/project_nedelec_04.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Nedelec elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_nedelec_05.cc
+++ b/tests/numerics/project_nedelec_05.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Nedelec elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_01.cc
+++ b/tests/numerics/project_q_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Q elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_02.cc
+++ b/tests/numerics/project_q_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Q elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_03.cc
+++ b/tests/numerics/project_q_03.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Q elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_04.cc
+++ b/tests/numerics/project_q_04.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Q elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_05.cc
+++ b/tests/numerics/project_q_05.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for Q elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_hierarchical_01.cc
+++ b/tests/numerics/project_q_hierarchical_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for QHierarchical elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_hierarchical_02.cc
+++ b/tests/numerics/project_q_hierarchical_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for QHierarchical elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_hierarchical_03.cc
+++ b/tests/numerics/project_q_hierarchical_03.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for QHierarchical elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_hierarchical_04.cc
+++ b/tests/numerics/project_q_hierarchical_04.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for QHierarchical elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_hierarchical_05.cc
+++ b/tests/numerics/project_q_hierarchical_05.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for QHierarchical elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_system_01.cc
+++ b/tests/numerics/project_q_system_01.cc
@@ -18,9 +18,6 @@
 // check that VectorTools::project works for FESystem(FE_Q) elements correctly
 // on a uniformly refined mesh for functions of degree q
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_system_02.cc
+++ b/tests/numerics/project_q_system_02.cc
@@ -18,9 +18,6 @@
 // check that VectorTools::project works for FESystem(FE_Q) elements correctly
 // on a uniformly refined mesh for functions of degree q
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_system_03.cc
+++ b/tests/numerics/project_q_system_03.cc
@@ -18,9 +18,6 @@
 // check that VectorTools::project works for FESystem(FE_Q) elements correctly
 // on a uniformly refined mesh for functions of degree q
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_system_04.cc
+++ b/tests/numerics/project_q_system_04.cc
@@ -18,9 +18,6 @@
 // check that VectorTools::project works for FESystem(FE_Q) elements correctly
 // on a uniformly refined mesh for functions of degree q
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_q_system_05.cc
+++ b/tests/numerics/project_q_system_05.cc
@@ -18,9 +18,6 @@
 // check that VectorTools::project works for FESystem(FE_Q) elements correctly
 // on a uniformly refined mesh for functions of degree q
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_rt_01.cc
+++ b/tests/numerics/project_rt_01.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for RT elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_rt_02.cc
+++ b/tests/numerics/project_rt_02.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for RT elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_rt_04.cc
+++ b/tests/numerics/project_rt_04.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for RT elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 

--- a/tests/numerics/project_rt_05.cc
+++ b/tests/numerics/project_rt_05.cc
@@ -17,9 +17,6 @@
 
 // check that VectorTools::project works for RT elements correctly
 
-char logname[] = "output";
-
-
 #include "project_common.h"
 
 


### PR DESCRIPTION
The output file is always `output`. So there is no need for a variable here.