### PR TITLE
Add another test for MatrixFreeOperators::MassOperator 

### DIFF
--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -1,0 +1,193 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// this tests the correctness of matrix_diagonal_inverse of
+// MatrixFreeOperators::MassOperator for FE_Q_Hierarchical
+// This caused problems with positivity of the lumped mass matrix
+
+#include "../tests.h"
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/function.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <deal.II/matrix_free/operators.h>
+#include <deal.II/fe/fe_q_hierarchical.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <iostream>
+
+
+
+
+template <int dim, int fe_degree>
+void test ()
+{
+  typedef double number;
+
+  parallel::distributed::Triangulation<dim> tria (MPI_COMM_WORLD);
+  GridGenerator::hyper_cube (tria);
+  tria.refine_global(3);
+
+  FE_Q_Hierarchical<dim> fe (fe_degree);
+  DoFHandler<dim> dof (tria);
+  dof.distribute_dofs(fe);
+
+  IndexSet owned_set = dof.locally_owned_dofs();
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs (dof, relevant_set);
+
+  ConstraintMatrix constraints (relevant_set);
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+  //std::cout << "Number of cells: " << tria.n_global_active_cells() << std::endl;
+  //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
+  //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
+
+  MatrixFree<dim,number> mf_data;
+  {
+    const QGauss<1> quad (fe_degree+2);
+    typename MatrixFree<dim,number>::AdditionalData data;
+    data.mpi_communicator = MPI_COMM_WORLD;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim,number>::AdditionalData::none;
+    data.tasks_block_size = 7;
+    mf_data.reinit (dof, constraints, quad, data);
+  }
+
+  MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, number> mf;
+  mf.initialize(mf_data);
+  mf.compute_diagonal();
+  const LinearAlgebra::distributed::Vector<double> &diagonal
+    = mf.get_matrix_diagonal_inverse()->get_vector();
+
+  LinearAlgebra::distributed::Vector<number> in, out, ref;
+  mf_data.initialize_dof_vector (in);
+  out.reinit (in);
+  ref.reinit (in);
+
+  for (unsigned int i=0; i<in.local_size(); ++i)
+    {
+      const unsigned int glob_index =
+        owned_set.nth_index_in_set (i);
+      if (constraints.is_constrained(glob_index))
+        continue;
+      in.local_element(i) = 1.;
+    }
+
+  in.update_ghost_values();
+  out = diagonal;
+
+  // assemble trilinos sparse matrix with
+  // (v, u) for reference
+  TrilinosWrappers::SparseMatrix sparse_matrix;
+  {
+    TrilinosWrappers::SparsityPattern csp (owned_set, MPI_COMM_WORLD);
+    DoFTools::make_sparsity_pattern (dof, csp, constraints, true,
+                                     Utilities::MPI::this_mpi_process(MPI_COMM_WORLD));
+    csp.compress();
+    sparse_matrix.reinit (csp);
+  }
+  {
+    QGauss<dim>  quadrature_formula(fe_degree+2);
+
+    FEValues<dim> fe_values (dof.get_fe(), quadrature_formula,
+                             update_values    |  update_gradients |
+                             update_JxW_values);
+
+    const unsigned int   dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int   n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double>   cell_matrix (dofs_per_cell, dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
+
+    typename DoFHandler<dim>::active_cell_iterator
+    cell = dof.begin_active(),
+    endc = dof.end();
+    for (; cell!=endc; ++cell)
+      if (cell->is_locally_owned())
+        {
+          cell_matrix = 0;
+          fe_values.reinit (cell);
+
+          for (unsigned int q_point=0; q_point<n_q_points; ++q_point)
+            for (unsigned int i=0; i<dofs_per_cell; ++i)
+              {
+                for (unsigned int j=0; j<dofs_per_cell; ++j)
+                  cell_matrix(i,j) += (fe_values.shape_value(i,q_point) *
+                                       fe_values.shape_value(j,q_point)) *
+                                      fe_values.JxW(q_point);
+              }
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global (cell_matrix,
+                                                  local_dof_indices,
+                                                  sparse_matrix);
+        }
+  }
+  sparse_matrix.compress(VectorOperation::add);
+
+  sparse_matrix.vmult (ref, in);
+
+  for (unsigned int i=0; i<ref.local_size(); ++i)
+    {
+      const unsigned int glob_index =
+        owned_set.nth_index_in_set (i);
+      if (constraints.is_constrained(glob_index))
+        ref.local_element(i)=1.;
+      else
+        ref.local_element(i) = 1./ref.local_element(i);
+    }
+  ref.compress(VectorOperation::insert);
+
+  out -= ref;
+  const double diff_norm = out.linfty_norm();
+
+  deallog << "Norm of difference: " << diff_norm << std::endl;
+  deallog << "l2_norm: " << diagonal.l2_norm() << std::endl;
+  deallog << "l1_norm: " << diagonal.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << diagonal.linfty_norm() << std::endl << std::endl;
+}
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  mpi_initlog();
+
+  deallog.push("2d");
+  test<2,1>();
+  test<2,2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3,1>();
+  test<3,2>();
+  deallog.pop();
+}
+

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,25 @@
+
+DEAL:2d::Testing FE_Q_Hierarchical<2>(1)
+DEAL:2d::Norm of difference: 1.13687e-13
+DEAL:2d::l2_norm: 960.000
+DEAL:2d::l1_norm: 7744.00
+DEAL:2d::linfty_norm: 256.000
+DEAL:2d::
+DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
+DEAL:2d::Norm of difference: 3.22871e-11
+DEAL:2d::l2_norm: 37440.0
+DEAL:2d::l1_norm: 553536.
+DEAL:2d::linfty_norm: 3600.00
+DEAL:2d::
+DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
+DEAL:3d::Norm of difference: 1.81899e-12
+DEAL:3d::l2_norm: 29744.5
+DEAL:3d::l1_norm: 681472.
+DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::
+DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
+DEAL:3d::Norm of difference: 1.39116e-08
+DEAL:3d::l2_norm: 7.24442e+06
+DEAL:3d::l1_norm: 4.11831e+08
+DEAL:3d::linfty_norm: 216000.
+DEAL:3d::

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,0 +1,25 @@
+
+DEAL:2d::Testing FE_Q_Hierarchical<2>(1)
+DEAL:2d::Norm of difference: 1.13687e-13
+DEAL:2d::l2_norm: 960.000
+DEAL:2d::l1_norm: 7744.00
+DEAL:2d::linfty_norm: 256.000
+DEAL:2d::
+DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
+DEAL:2d::Norm of difference: 3.22871e-11
+DEAL:2d::l2_norm: 37440.0
+DEAL:2d::l1_norm: 553536.
+DEAL:2d::linfty_norm: 3600.00
+DEAL:2d::
+DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
+DEAL:3d::Norm of difference: 1.81899e-12
+DEAL:3d::l2_norm: 29744.5
+DEAL:3d::l1_norm: 681472.
+DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::
+DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
+DEAL:3d::Norm of difference: 1.39116e-08
+DEAL:3d::l2_norm: 7.24442e+06
+DEAL:3d::l1_norm: 4.11831e+08
+DEAL:3d::linfty_norm: 216000.
+DEAL:3d::


### PR DESCRIPTION
This failed for a insufficient (`QGauss<dim>(fe_degree+1)`) quadrature rule and passes for `QGauss<dim>(fe_degree+2)`. In the first case, some entries of the lumped mass matrix were negative.