### PR TITLE
Use PetscErrorCode instead of int.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -436,7 +436,8 @@ namespace LinearAlgebra
 
       // get a representation of the vector and copy it
       PetscScalar *start_ptr;
-      int ierr = VecGetArray (static_cast<const Vec &>(petsc_vec), &start_ptr);
+      PetscErrorCode ierr = VecGetArray (static_cast<const Vec &>(petsc_vec),
+                                         &start_ptr);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       const size_type vec_size = local_size();

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -55,8 +55,7 @@ namespace PETScWrappers
 #else
     const PetscErrorCode ierr = PetscOptionsSetValue (NULL, name.c_str (), value.c_str ());
 #endif
-    (void)ierr;
-    Assert (ierr == 0, ExcPETScError(ierr));
+    AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -117,9 +116,9 @@ namespace PETScWrappers
                                  const PetscBooleanType option_value = PETSC_FALSE)
   {
 #if DEAL_II_PETSC_VERSION_LT(3,0,0)
-    const int ierr = MatSetOption (matrix, option_name);
+    const PetscErrorCode ierr = MatSetOption (matrix, option_name);
 #else
-    const int ierr = MatSetOption (matrix, option_name, option_value);
+    const PetscErrorCode ierr = MatSetOption (matrix, option_name, option_value);
 #endif
 
     AssertThrow (ierr == 0, ExcPETScError(ierr));

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1256,9 +1256,9 @@ namespace PETScWrappers
         col_value_ptr = &column_values[0];
       }
 
-    const int ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
-                                   col_index_ptr,
-                                   col_value_ptr, INSERT_VALUES);
+    const PetscErrorCode ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
+                                              col_index_ptr,
+                                              col_value_ptr, INSERT_VALUES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1398,8 +1398,9 @@ namespace PETScWrappers
         col_value_ptr = &column_values[0];
       }
 
-    const int ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
-                                   col_index_ptr, col_value_ptr, ADD_VALUES);
+    const PetscErrorCode ierr = MatSetValues (matrix, 1, &petsc_i, n_columns,
+                                              col_index_ptr, col_value_ptr,
+                                              ADD_VALUES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1472,8 +1473,8 @@ namespace PETScWrappers
   {
     PetscInt begin, end;
 
-    const int ierr = MatGetOwnershipRange (static_cast<const Mat &>(matrix),
-                                           &begin, &end);
+    const PetscErrorCode ierr = MatGetOwnershipRange (static_cast<const Mat &>(matrix),
+                                                      &begin, &end);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return ((index >= static_cast<size_type>(begin)) &&

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -486,11 +486,10 @@ namespace PETScWrappers
           // we skip the code below and create a simple serial vector of
           // length 0
 
-          int ierr;
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-          ierr = VecDestroy (vector);
+          PetscErrorCode ierr = VecDestroy (vector);
 #else
-          ierr = VecDestroy (&vector);
+          PetscErrorCode ierr = VecDestroy (&vector);
 #endif
           AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -512,13 +511,11 @@ namespace PETScWrappers
             reinit (v.communicator, v.size(), v.local_size(), true);
         }
 
-      const int ierr = VecCopy (v.vector, vector);
+      PetscErrorCode ierr = VecCopy (v.vector, vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       if (has_ghost_elements())
         {
-          int ierr;
-
           ierr = VecGhostUpdateBegin(vector, INSERT_VALUES, SCATTER_FORWARD);
           AssertThrow (ierr == 0, ExcPETScError(ierr));
           ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -249,7 +249,7 @@ namespace PETScWrappers
     if (size() != v.size())
       reinit (v.size(), true);
 
-    const int ierr = VecCopy (v.vector, vector);
+    const PetscErrorCode ierr = VecCopy (v.vector, vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -261,7 +261,7 @@ namespace PETScWrappers
   Vector &
   Vector::operator = (const MPI::Vector &v)
   {
-    int ierr;
+    PetscErrorCode ierr;
     if (attained_ownership)
       {
         // the petsc function we call wants to

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -878,7 +878,8 @@ namespace PETScWrappers
 
       const PetscInt petsc_i = index;
 
-      const int ierr = VecSetValues (vector, 1, &petsc_i, &value, INSERT_VALUES);
+      const PetscErrorCode ierr = VecSetValues (vector, 1, &petsc_i, &value,
+                                                INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       vector.last_action = VectorOperation::insert;
@@ -914,7 +915,8 @@ namespace PETScWrappers
 
       // use the PETSc function to add something
       const PetscInt petsc_i = index;
-      const int ierr = VecSetValues (vector, 1, &petsc_i, &value, ADD_VALUES);
+      const PetscErrorCode ierr = VecSetValues (vector, 1, &petsc_i, &value,
+                                                ADD_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 
@@ -951,7 +953,8 @@ namespace PETScWrappers
       // add something
       const PetscInt petsc_i = index;
       const PetscScalar subtractand = -value;
-      const int ierr = VecSetValues (vector, 1, &petsc_i, &subtractand, ADD_VALUES);
+      const PetscErrorCode ierr = VecSetValues (vector, 1, &petsc_i, &subtractand,
+                                                ADD_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;
@@ -987,7 +990,8 @@ namespace PETScWrappers
       const PetscScalar new_value
         = static_cast<PetscScalar>(*this) * value;
 
-      const int ierr = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
+      const PetscErrorCode ierr = VecSetValues (vector, 1, &petsc_i, &new_value,
+                                                INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;
@@ -1023,7 +1027,8 @@ namespace PETScWrappers
       const PetscScalar new_value
         = static_cast<PetscScalar>(*this) / value;
 
-      const int ierr = VecSetValues (vector, 1, &petsc_i, &new_value, INSERT_VALUES);
+      const PetscErrorCode ierr = VecSetValues (vector, 1, &petsc_i, &new_value,
+                                                INSERT_VALUES);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       return *this;
@@ -1062,8 +1067,8 @@ namespace PETScWrappers
   VectorBase::in_local_range (const size_type index) const
   {
     PetscInt begin, end;
-    const int ierr = VecGetOwnershipRange (static_cast<const Vec &>(vector),
-                                           &begin, &end);
+    const PetscErrorCode ierr = VecGetOwnershipRange (static_cast<const Vec &>(vector),
+                                                      &begin, &end);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return ((index >= static_cast<size_type>(begin)) &&
@@ -1158,9 +1163,6 @@ namespace PETScWrappers
     // with a parallel vector
     if (ghosted )
       {
-
-        int ierr;
-
         // there is the possibility
         // that the vector has
         // ghost elements. in that
@@ -1179,7 +1181,7 @@ namespace PETScWrappers
         // position we can get from
         // an index set
         PetscInt begin, end;
-        ierr = VecGetOwnershipRange (vector, &begin, &end);
+        PetscErrorCode ierr = VecGetOwnershipRange (vector, &begin, &end);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         Vec locally_stored_elements = PETSC_NULL;
@@ -1226,10 +1228,8 @@ namespace PETScWrappers
     // element we are interested in
     else
       {
-        int ierr;
-
         PetscInt begin, end;
-        ierr = VecGetOwnershipRange (vector, &begin, &end);
+        PetscErrorCode ierr = VecGetOwnershipRange (vector, &begin, &end);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         PetscScalar *ptr;

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -278,7 +278,7 @@ namespace LinearAlgebra
 
     // get a representation of the vector and copy it
     PetscScalar *start_ptr;
-    int ierr = VecGetArray (static_cast<const Vec &>(petsc_vec), &start_ptr);
+    PetscErrorCode ierr = VecGetArray (static_cast<const Vec &>(petsc_vec), &start_ptr);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     const size_type vec_size = petsc_vec.local_size();

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -789,7 +789,6 @@ namespace SLEPcWrappers
   void
   SolverBase::set_initial_space(const std::vector<Vector> &this_initial_space)
   {
-    int ierr;
     std::vector<Vec> vecs(this_initial_space.size());
 
     for (unsigned int i = 0; i < this_initial_space.size(); i++)
@@ -805,9 +804,9 @@ namespace SLEPcWrappers
     // by taking a linear combination of them. (TODO: make function virtual?)
 
 #if DEAL_II_PETSC_VERSION_LT(3,1,0)
-    ierr = EPSSetInitialVector (eps, &vecs[0]);
+    const PetscErrorCode ierr = EPSSetInitialVector (eps, &vecs[0]);
 #else
-    ierr = EPSSetInitialSpace (eps, vecs.size(), &vecs[0]);
+    const PetscErrorCode ierr = EPSSetInitialSpace (eps, vecs.size(), &vecs[0]);
 #endif
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -113,7 +113,7 @@ Vector<Number>::Vector (const PETScWrappers::Vector &v)
       // get a representation of the vector
       // and copy it
       PetscScalar *start_ptr;
-      int ierr = VecGetArray (static_cast<const Vec &>(v), &start_ptr);
+      PetscErrorCode ierr = VecGetArray (static_cast<const Vec &>(v), &start_ptr);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       internal::copy (start_ptr, start_ptr+vec_size, begin());
@@ -876,7 +876,7 @@ Vector<Number>::operator= (const PETScWrappers::Vector &v)
       // get a representation of the vector
       // and copy it
       PetscScalar *start_ptr;
-      int ierr = VecGetArray (static_cast<const Vec &>(v), &start_ptr);
+      PetscErrorCode ierr = VecGetArray (static_cast<const Vec &>(v), &start_ptr);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       internal::copy (start_ptr, start_ptr+vec_size, begin());

--- a/source/lac/exceptions.cc
+++ b/source/lac/exceptions.cc
@@ -40,7 +40,8 @@ namespace LACExceptions
     // PetscErrorMessage changes the value in a pointer to refer to a
     // statically allocated description of the current error message.
     const char *petsc_message;
-    const int ierr = PetscErrorMessage (error_code, &petsc_message, /*specific=*/NULL);
+    const PetscErrorCode ierr = PetscErrorMessage (error_code, &petsc_message,
+                                                   /*specific=*/NULL);
     if (ierr == 0 && petsc_message != NULL)
       {
         out << "The description of the error provided by PETSc is \""

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -55,8 +55,8 @@ namespace PETScWrappers
   {
     // use the call sequence indicating only a maximal number of
     // elements per row for all rows globally
-    const int ierr = MatCreateSeqDense (PETSC_COMM_SELF, m, n, PETSC_NULL,
-                                        &matrix);
+    const PetscErrorCode ierr = MatCreateSeqDense (PETSC_COMM_SELF, m, n,
+                                                   PETSC_NULL, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -51,9 +51,8 @@ namespace PETScWrappers
       const PetscInt    *colnums;
       const PetscScalar *values;
 
-      int ierr;
-      (void)ierr;
-      ierr = MatGetRow(*matrix, this->a_row, &ncols, &colnums, &values);
+      PetscErrorCode ierr = MatGetRow(*matrix, this->a_row, &ncols, &colnums,
+                                      &values);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       // copy it into our caches if the line
@@ -101,8 +100,9 @@ namespace PETScWrappers
     // ...and replace it by an empty
     // sequential matrix
     const int m=0, n=0, n_nonzero_per_row=0;
-    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
-                                     0, &matrix);
+    const PetscErrorCode ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n,
+                                                n_nonzero_per_row,
+                                                0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -116,7 +116,7 @@ namespace PETScWrappers
 
     assert_is_compressed ();
 
-    const int ierr = MatZeroEntries (matrix);
+    const PetscErrorCode ierr = MatZeroEntries (matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -158,10 +158,10 @@ namespace PETScWrappers
 #endif
 
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-    const int ierr = MatZeroRowsIS(matrix, index_set, new_diag_value);
+    const PetscErrorCode ierr = MatZeroRowsIS(matrix, index_set, new_diag_value);
 #else
-    const int ierr = MatZeroRowsIS(matrix, index_set, new_diag_value, PETSC_NULL,
-                                   PETSC_NULL);
+    const PetscErrorCode ierr = MatZeroRowsIS(matrix, index_set, new_diag_value,
+                                              PETSC_NULL, PETSC_NULL);
 #endif
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -182,8 +182,8 @@ namespace PETScWrappers
 
     PetscScalar value;
 
-    const int ierr = MatGetValues (matrix, 1, &petsc_i, 1, &petsc_j,
-                                   &value);
+    const PetscErrorCode ierr = MatGetValues (matrix, 1, &petsc_i, 1, &petsc_j,
+                                              &value);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return value;
@@ -206,30 +206,32 @@ namespace PETScWrappers
   void
   MatrixBase::compress (const VectorOperation::values operation)
   {
-    int ierr;
-    (void)ierr;
+    {
 #ifdef DEBUG
 #ifdef DEAL_II_WITH_MPI
-    // Check that all processors agree that last_action is the same (or none!)
+      // Check that all processors agree that last_action is the same (or none!)
 
-    int my_int_last_action = last_action;
-    int all_int_last_action;
+      int my_int_last_action = last_action;
+      int all_int_last_action;
 
-    ierr = MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
-                         MPI_BOR, get_mpi_communicator());
-    AssertThrowMPI(ierr);
+      const int ierr = MPI_Allreduce
+                       (&my_int_last_action, &all_int_last_action, 1, MPI_INT, MPI_BOR,
+                        get_mpi_communicator());
+      AssertThrowMPI(ierr);
 
-    AssertThrow(all_int_last_action != (VectorOperation::add | VectorOperation::insert),
-                ExcMessage("Error: not all processors agree on the last VectorOperation before this compress() call."));
+      AssertThrow(all_int_last_action != (VectorOperation::add | VectorOperation::insert),
+                  ExcMessage("Error: not all processors agree on the last "
+                             "VectorOperation before this compress() call."));
 #endif
 #endif
+    }
 
     AssertThrow(last_action == VectorOperation::unknown
                 || last_action == operation,
                 ExcMessage("Missing compress() or calling with wrong VectorOperation argument."));
 
     // flush buffers
-    ierr = MatAssemblyBegin (matrix,MAT_FINAL_ASSEMBLY);
+    PetscErrorCode ierr = MatAssemblyBegin (matrix,MAT_FINAL_ASSEMBLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = MatAssemblyEnd (matrix,MAT_FINAL_ASSEMBLY);
@@ -245,7 +247,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    const int ierr = MatGetSize (matrix, &n_rows, &n_cols);
+    const PetscErrorCode ierr = MatGetSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_rows;
@@ -258,7 +260,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    const int ierr = MatGetSize (matrix, &n_rows, &n_cols);
+    const PetscErrorCode ierr = MatGetSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_cols;
@@ -271,7 +273,7 @@ namespace PETScWrappers
   {
     PetscInt n_rows, n_cols;
 
-    const int ierr = MatGetLocalSize (matrix, &n_rows, &n_cols);
+    const PetscErrorCode ierr = MatGetLocalSize (matrix, &n_rows, &n_cols);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return n_rows;
@@ -284,8 +286,8 @@ namespace PETScWrappers
   {
     PetscInt begin, end;
 
-    const int ierr = MatGetOwnershipRange (static_cast<const Mat &>(matrix),
-                                           &begin, &end);
+    const PetscErrorCode ierr = MatGetOwnershipRange (static_cast<const Mat &>(matrix),
+                                                      &begin, &end);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return std::make_pair (begin, end);
@@ -297,7 +299,7 @@ namespace PETScWrappers
   MatrixBase::n_nonzero_elements () const
   {
     MatInfo mat_info;
-    const int ierr = MatGetInfo (matrix, MAT_GLOBAL_SUM, &mat_info);
+    const PetscErrorCode ierr = MatGetInfo (matrix, MAT_GLOBAL_SUM, &mat_info);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return static_cast<size_type>(mat_info.nz_used);
@@ -325,7 +327,7 @@ namespace PETScWrappers
 
 //TODO: this is probably horribly inefficient; we should lobby for a way to
 //query this information from PETSc
-    int ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
+    PetscErrorCode ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then restore the matrix and return the number of columns in this row as
@@ -346,7 +348,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr = MatNorm (matrix, NORM_1, &result);
+    const PetscErrorCode ierr = MatNorm (matrix, NORM_1, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -359,7 +361,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr = MatNorm (matrix, NORM_INFINITY, &result);
+    const PetscErrorCode ierr = MatNorm (matrix, NORM_INFINITY, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -372,7 +374,7 @@ namespace PETScWrappers
   {
     PetscReal result;
 
-    const int ierr = MatNorm (matrix, NORM_FROBENIUS, &result);
+    const PetscErrorCode ierr = MatNorm (matrix, NORM_FROBENIUS, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -404,7 +406,7 @@ namespace PETScWrappers
   {
     PetscScalar result;
 
-    const int ierr = MatGetTrace (matrix, &result);
+    const PetscErrorCode ierr = MatGetTrace (matrix, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -416,7 +418,7 @@ namespace PETScWrappers
   MatrixBase &
   MatrixBase::operator *= (const PetscScalar a)
   {
-    const int ierr = MatScale (matrix, a);
+    const PetscErrorCode ierr = MatScale (matrix, a);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -428,7 +430,7 @@ namespace PETScWrappers
   MatrixBase::operator /= (const PetscScalar a)
   {
     const PetscScalar factor = 1./a;
-    const int ierr = MatScale (matrix, factor);
+    const PetscErrorCode ierr = MatScale (matrix, factor);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -439,8 +441,8 @@ namespace PETScWrappers
   MatrixBase::add (const PetscScalar factor,
                    const MatrixBase &other)
   {
-    const int ierr = MatAXPY (matrix, factor,
-                              other, DIFFERENT_NONZERO_PATTERN);
+    const PetscErrorCode ierr = MatAXPY (matrix, factor,
+                                         other, DIFFERENT_NONZERO_PATTERN);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -462,7 +464,7 @@ namespace PETScWrappers
   {
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
-    const int ierr = MatMult (matrix, src, dst);
+    const PetscErrorCode ierr = MatMult (matrix, src, dst);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -474,7 +476,7 @@ namespace PETScWrappers
   {
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
-    const int ierr = MatMultTranspose (matrix, src, dst);
+    const PetscErrorCode ierr = MatMultTranspose (matrix, src, dst);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -486,8 +488,7 @@ namespace PETScWrappers
   {
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
-    const int ierr = MatMultAdd (matrix, src, dst, dst);
-    (void)ierr;
+    const PetscErrorCode ierr = MatMultAdd (matrix, src, dst, dst);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -499,7 +500,7 @@ namespace PETScWrappers
   {
     Assert (&src != &dst, ExcSourceEqualsDestination());
 
-    const int ierr = MatMultTransposeAdd (matrix, src, dst, dst);
+    const PetscErrorCode ierr = MatMultTransposeAdd (matrix, src, dst, dst);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -529,7 +530,7 @@ namespace PETScWrappers
   void
   MatrixBase::transpose ()
   {
-    const int ierr = MatTranspose(matrix, MAT_REUSE_MATRIX, &matrix);
+    const PetscErrorCode ierr = MatTranspose(matrix, MAT_REUSE_MATRIX, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -538,7 +539,7 @@ namespace PETScWrappers
   {
     PetscBooleanType truth;
     assert_is_compressed ();
-    const int ierr = MatIsSymmetric (matrix, tolerance, &truth);
+    const PetscErrorCode ierr = MatIsSymmetric (matrix, tolerance, &truth);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     return truth;
   }
@@ -549,7 +550,7 @@ namespace PETScWrappers
     PetscBooleanType truth;
 
     assert_is_compressed ();
-    const int ierr = MatIsHermitian (matrix, tolerance, &truth);
+    const PetscErrorCode ierr = MatIsHermitian (matrix, tolerance, &truth);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return truth;
@@ -561,8 +562,8 @@ namespace PETScWrappers
     assert_is_compressed ();
 
     // Set options
-    int ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
-                                     format);
+    PetscErrorCode ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
+                                                format);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
@@ -584,7 +585,7 @@ namespace PETScWrappers
     MatrixBase::size_type row;
     for (row = loc_range.first; row < loc_range.second; ++row)
       {
-        int ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
+        PetscErrorCode ierr = MatGetRow(*this, row, &ncols, &colnums, &values);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         for (PetscInt col = 0; col < ncols; ++col)
@@ -605,7 +606,7 @@ namespace PETScWrappers
   MatrixBase::memory_consumption() const
   {
     MatInfo info;
-    const int ierr = MatGetInfo(matrix, MAT_LOCAL, &info);
+    const PetscErrorCode ierr = MatGetInfo(matrix, MAT_LOCAL, &info);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return sizeof(*this) + static_cast<size_type>(info.memory);

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -191,7 +191,7 @@ namespace PETScWrappers
     // and reinit x and y with
     // dealii::PETScWrappers::*::Vector:
     const char  *vec_type;
-    int ierr = VecGetType (src, &vec_type);
+    PetscErrorCode ierr = VecGetType (src, &vec_type);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     PetscInt  local_size;
@@ -239,7 +239,7 @@ namespace PETScWrappers
     // to the matrix-vector multiplication
     // of this MatrixFree object,
     void  *this_object;
-    const int ierr = MatShellGetContext (A, &this_object);
+    const PetscErrorCode ierr = MatShellGetContext (A, &this_object);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // call vmult of this object:
@@ -258,11 +258,11 @@ namespace PETScWrappers
     Assert (local_rows <= m, ExcDimensionMismatch (local_rows, m));
     Assert (local_columns <= n, ExcDimensionMismatch (local_columns, n));
 
-    int ierr;
     // create a PETSc MatShell matrix-type
     // object of dimension m x n and local size
     // local_rows x local_columns
-    ierr = MatCreateShell(communicator, local_rows, local_columns, m, n, (void *)this, &matrix);
+    PetscErrorCode ierr = MatCreateShell(communicator, local_rows, local_columns,
+                                         m, n, (void *)this, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     // register the MatrixFree::matrix_free_mult function
     // as the matrix multiplication used by this matrix

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -36,7 +36,7 @@ namespace PETScWrappers
       // create an empty matrix, we can as
       // well make it sequential
       const int m=0, n=0, n_nonzero_per_row=0;
-      const int ierr
+      const PetscErrorCode ierr
         = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
                           0, &matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -132,7 +132,8 @@ namespace PETScWrappers
 
       this->communicator = other.communicator;
 
-      const int ierr = MatCopy(other.matrix, matrix, SAME_NONZERO_PATTERN);
+      const PetscErrorCode ierr = MatCopy(other.matrix, matrix,
+                                          SAME_NONZERO_PATTERN);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
     }
 
@@ -236,22 +237,22 @@ namespace PETScWrappers
       // use the call sequence indicating only
       // a maximal number of elements per row
       // for all rows globally
-      int ierr;
-
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-      ierr = MatCreateMPIAIJ (communicator,
-                              local_rows, local_columns,
-                              m, n,
-                              n_nonzero_per_row, 0,
-                              n_offdiag_nonzero_per_row, 0,
-                              &matrix);
+      const PetscErrorCode ierr = MatCreateMPIAIJ
+                                  (communicator,
+                                   local_rows, local_columns,
+                                   m, n,
+                                   n_nonzero_per_row, 0,
+                                   n_offdiag_nonzero_per_row, 0,
+                                   &matrix);
 #else
-      ierr = MatCreateAIJ (communicator,
-                           local_rows, local_columns,
-                           m, n,
-                           n_nonzero_per_row, 0,
-                           n_offdiag_nonzero_per_row, 0,
-                           &matrix);
+      const PetscErrorCode ierr = MatCreateAIJ
+                                  (communicator,
+                                   local_rows, local_columns,
+                                   m, n,
+                                   n_nonzero_per_row, 0,
+                                   n_offdiag_nonzero_per_row, 0,
+                                   &matrix);
       set_matrix_option (matrix, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
 #endif
       AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -303,23 +304,23 @@ namespace PETScWrappers
                                                            offdiag_row_lengths.end());
 
 //TODO: There must be a significantly better way to provide information about the off-diagonal blocks of the matrix. this way, petsc keeps allocating tiny chunks of memory, and gets completely hung up over this
-
-      int ierr;
-
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-      ierr = MatCreateMPIAIJ (communicator,
-                              local_rows, local_columns,
-                              m, n,
-                              0, &int_row_lengths[0],
-                              0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
-                              &matrix);
+      const PetscErrorCode ierr = MatCreateMPIAIJ
+                                  (communicator,
+                                   local_rows, local_columns,
+                                   m, n,
+                                   0, &int_row_lengths[0],
+                                   0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
+                                   &matrix);
 #else
-      ierr = MatCreateAIJ (communicator,
-                           local_rows, local_columns,
-                           m, n,
-                           0, &int_row_lengths[0],
-                           0, offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
-                           &matrix);
+      const PetscErrorCode ierr = MatCreateAIJ
+                                  (communicator,
+                                   local_rows, local_columns,
+                                   m, n,
+                                   0, &int_row_lengths[0],
+                                   0,
+                                   offdiag_row_lengths.size() ? &int_offdiag_row_lengths[0] : 0,
+                                   &matrix);
 
 //TODO: Sometimes the actual number of nonzero entries allocated is greater than the number of nonzero entries, which petsc will complain about unless explicitly disabled with MatSetOption. There is probably a way to prevent a different number nonzero elements being allocated in the first place. (See also previous TODO).
       set_matrix_option (matrix, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
@@ -372,9 +373,7 @@ namespace PETScWrappers
 
       // create the matrix. We do not set row length but set the
       // correct SparsityPattern later.
-      int ierr;
-
-      ierr = MatCreate(communicator,&matrix);
+      PetscErrorCode ierr = MatCreate(communicator,&matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = MatSetSizes(matrix,
@@ -541,21 +540,21 @@ namespace PETScWrappers
       // the first _local_ row, i.e. it
       // doesn't index into an array for
       // _all_ rows.
-      const int ierr = MatCreateMPIAIJ(communicator,
-                                       local_rows_per_process[this_process],
-                                       local_columns_per_process[this_process],
-                                       sparsity_pattern.n_rows(),
-                                       sparsity_pattern.n_cols(),
-                                       0, &row_lengths_in_window[0],
-                                       0, &row_lengths_out_of_window[0],
-                                       &matrix);
+      const PetscErrorCode ierr = MatCreateMPIAIJ(communicator,
+                                                  local_rows_per_process[this_process],
+                                                  local_columns_per_process[this_process],
+                                                  sparsity_pattern.n_rows(),
+                                                  sparsity_pattern.n_cols(),
+                                                  0, &row_lengths_in_window[0],
+                                                  0, &row_lengths_out_of_window[0],
+                                                  &matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 #else //PETSC_VERSION>=2.3.3
       // create the matrix. We
       // do not set row length but set the
       // correct SparsityPattern later.
-      int ierr = MatCreate(communicator,&matrix);
+      PetscErrorCode ierr = MatCreate(communicator,&matrix);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = MatSetSizes(matrix,

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -34,8 +34,7 @@ namespace PETScWrappers
       // this is an invalid empty vector, so we can just as well create a
       // sequential one to avoid all the overhead incurred by parallelism
       const int n = 0;
-      const int ierr
-        = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
+      const PetscErrorCode ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
       ghosted = false;
     }
@@ -103,7 +102,7 @@ namespace PETScWrappers
       VectorBase::clear ();
 
       const int n = 0;
-      int ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
+      const PetscErrorCode ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
     }
 
@@ -121,9 +120,11 @@ namespace PETScWrappers
       // mismatch (may not be true for every proc)
 
       int k_global, k = ((size() != n) || (local_size() != local_sz));
-      int ierr = MPI_Allreduce (&k, &k_global, 1,
-                                MPI_INT, MPI_LOR, communicator);
-      AssertThrowMPI(ierr);
+      {
+        const int ierr = MPI_Allreduce (&k, &k_global, 1,
+                                        MPI_INT, MPI_LOR, communicator);
+        AssertThrowMPI(ierr);
+      }
 
       if (k_global || has_ghost_elements())
         {
@@ -131,15 +132,15 @@ namespace PETScWrappers
           // but somehow it leads to odd errors
           // somewhere down the line in some of
           // the tests:
-//         const int ierr = VecSetSizes (vector, n, n);
+//         const PetscErrorCode ierr = VecSetSizes (vector, n, n);
 //         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
           // so let's go the slow way:
 
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-          ierr = VecDestroy (vector);
+          const PetscErrorCode ierr = VecDestroy (vector);
 #else
-          ierr = VecDestroy (&vector);
+          const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
           AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -163,7 +164,7 @@ namespace PETScWrappers
           reinit (v.locally_owned_elements(), v.ghost_indices, v.communicator);
           if (!omit_zeroing_entries)
             {
-              const int ierr = VecSet(vector, 0.0);
+              const PetscErrorCode ierr = VecSet(vector, 0.0);
               AssertThrow (ierr == 0, ExcPETScError(ierr));
             }
         }
@@ -178,11 +179,10 @@ namespace PETScWrappers
                     const IndexSet &ghost,
                     const MPI_Comm     &comm)
     {
-      int ierr;
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      ierr = VecDestroy (vector);
+      const PetscErrorCode ierr = VecDestroy (vector);
 #else
-      ierr = VecDestroy (&vector);
+      const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -200,11 +200,10 @@ namespace PETScWrappers
     Vector::reinit (const IndexSet &local,
                     const MPI_Comm &comm)
     {
-      int ierr;
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-      ierr = VecDestroy (vector);
+      const PetscErrorCode ierr = VecDestroy (vector);
 #else
-      ierr = VecDestroy (&vector);
+      const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -224,12 +223,11 @@ namespace PETScWrappers
       //TODO [TH]: can not access v.last_action here. Implement is_compressed()?
       //Assert(v.last_action==VectorOperation::unknown,
       //    ExcMessage("Call to compress() required before calling operator=."));
-      int ierr;
 
       // get a pointer to the local memory of
       // this vector
       PetscScalar *dest_array;
-      ierr = VecGetArray (vector, &dest_array);
+      PetscErrorCode ierr = VecGetArray (vector, &dest_array);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       // then also a pointer to the source
@@ -271,8 +269,8 @@ namespace PETScWrappers
       Assert (local_size <= n, ExcIndexRange (local_size, 0, n));
       ghosted = false;
 
-      const int ierr = VecCreateMPI (communicator, local_size, PETSC_DETERMINE,
-                                     &vector);
+      const PetscErrorCode ierr = VecCreateMPI (communicator, local_size, PETSC_DETERMINE,
+                                                &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       Assert (size() == n,
@@ -301,12 +299,12 @@ namespace PETScWrappers
            :
            0);
 
-      int ierr = VecCreateGhost(communicator,
-                                local_size,
-                                PETSC_DETERMINE,
-                                ghostindices.size(),
-                                ptr,
-                                &vector);
+      PetscErrorCode ierr = VecCreateGhost(communicator,
+                                           local_size,
+                                           PETSC_DETERMINE,
+                                           ghostindices.size(),
+                                           ptr,
+                                           &vector);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       Assert (size() == n,
@@ -382,7 +380,7 @@ namespace PETScWrappers
       PetscScalar *val;
       PetscInt    nlocal, istart, iend;
 
-      int ierr = VecGetArray (vector, &val);
+      PetscErrorCode ierr = VecGetArray (vector, &val);
       AssertThrow (ierr == 0, ExcPETScError(ierr));
 
       ierr = VecGetLocalSize (vector, &nlocal);
@@ -406,8 +404,8 @@ namespace PETScWrappers
             i++)
         {
           // This is slow, but most likely only used to debug.
-          ierr = MPI_Barrier(communicator);
-          AssertThrowMPI(ierr);
+          const int mpi_ierr = MPI_Barrier(communicator);
+          AssertThrowMPI(mpi_ierr);
           if (i == Utilities::MPI::this_mpi_process(communicator))
             {
               if (across)

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -48,9 +48,9 @@ namespace PETScWrappers
     if (pc!=NULL)
       {
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        int ierr = PCDestroy(pc);
+        PetscErrorCode ierr = PCDestroy(pc);
 #else
-        int ierr = PCDestroy(&pc);
+        PetscErrorCode ierr = PCDestroy(&pc);
 #endif
         pc = NULL;
         AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -64,8 +64,7 @@ namespace PETScWrappers
   {
     AssertThrow (pc != NULL, StandardExceptions::ExcInvalidState ());
 
-    int ierr;
-    ierr = PCApply(pc, src, dst);
+    const PetscErrorCode ierr = PCApply(pc, src, dst);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -78,11 +77,11 @@ namespace PETScWrappers
     AssertThrow (pc == NULL, StandardExceptions::ExcInvalidState ());
 
     MPI_Comm comm;
-    int ierr;
     // this ugly cast is necessary because the
     // type Mat and PETScObject are
     // unrelated.
-    ierr = PetscObjectGetComm(reinterpret_cast<PetscObject>(matrix), &comm);
+    PetscErrorCode ierr = PetscObjectGetComm(reinterpret_cast<PetscObject>(matrix),
+                                             &comm);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCCreate(comm, &pc);
@@ -116,7 +115,7 @@ namespace PETScWrappers
   {
     additional_data = additional_data_;
 
-    int ierr = PCCreate(comm, &pc);
+    PetscErrorCode ierr = PCCreate(comm, &pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     initialize();
@@ -138,8 +137,7 @@ namespace PETScWrappers
   {
     AssertThrow (pc != NULL, StandardExceptions::ExcInvalidState ());
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCJACOBI));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCJACOBI));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions (pc);
@@ -158,7 +156,7 @@ namespace PETScWrappers
     create_pc();
     initialize();
 
-    int ierr = PCSetUp (pc);
+    PetscErrorCode ierr = PCSetUp (pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -169,7 +167,7 @@ namespace PETScWrappers
   {
     additional_data = additional_data_;
 
-    int ierr = PCCreate(comm, &pc);
+    PetscErrorCode ierr = PCCreate(comm, &pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     initialize();
@@ -190,8 +188,7 @@ namespace PETScWrappers
   void
   PreconditionBlockJacobi::initialize()
   {
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCBJACOBI));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCBJACOBI));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions (pc);
@@ -211,7 +208,7 @@ namespace PETScWrappers
     create_pc();
     initialize();
 
-    int ierr = PCSetUp (pc);
+    PetscErrorCode ierr = PCSetUp (pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -247,8 +244,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCSOR));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCSOR));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags as given
@@ -294,8 +290,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCSOR));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCSOR));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags as given
@@ -345,8 +340,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCEISENSTAT));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCEISENSTAT));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags as given
@@ -393,7 +387,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr = PCSetType (pc, const_cast<char *>(PCICC));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCICC));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags
@@ -439,8 +433,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCILU));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCILU));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // then set flags
@@ -481,7 +474,7 @@ namespace PETScWrappers
   {
     additional_data = additional_data_;
 
-    int ierr = PCCreate(comm, &pc);
+    PetscErrorCode ierr = PCCreate(comm, &pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 #ifdef PETSC_HAVE_HYPRE
@@ -505,8 +498,7 @@ namespace PETScWrappers
   PreconditionBoomerAMG::initialize ()
   {
 #ifdef PETSC_HAVE_HYPRE
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCHYPRE));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCHYPRE));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCHYPRESetType(pc, "boomeramg");
@@ -563,7 +555,7 @@ namespace PETScWrappers
     create_pc();
     initialize ();
 
-    int ierr = PCSetUp (pc);
+    PetscErrorCode ierr = PCSetUp (pc);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 #else // PETSC_HAVE_HYPRE
@@ -616,8 +608,7 @@ namespace PETScWrappers
 #ifdef PETSC_HAVE_HYPRE
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCHYPRE));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCHYPRE));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCHYPRESetType(pc, "parasails");
@@ -712,8 +703,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCNONE));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCNONE));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions (pc);
@@ -759,8 +749,7 @@ namespace PETScWrappers
 
     create_pc();
 
-    int ierr;
-    ierr = PCSetType (pc, const_cast<char *>(PCLU));
+    PetscErrorCode ierr = PCSetType (pc, const_cast<char *>(PCLU));
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set flags as given

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -60,8 +60,6 @@ namespace PETScWrappers
                      const VectorBase         &b,
                      const PreconditionerBase &preconditioner)
   {
-    int ierr;
-
     /*
       TODO: PETSc duplicates communicators, so this does not work (you put MPI_COMM_SELF in, but get something other out when you ask PETSc for the communicator. This mainly fails due to the MatrixFree classes, that can not ask PETSc for a communicator. //Timo Heister
     Assert(A.get_mpi_communicator()==mpi_communicator, ExcMessage("PETSc Solver and Matrix need to use the same MPI_Comm."));
@@ -75,7 +73,7 @@ namespace PETScWrappers
       {
         solver_data.reset (new SolverData());
 
-        ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
+        PetscErrorCode ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         // let derived classes set the solver
@@ -117,7 +115,7 @@ namespace PETScWrappers
       }
 
     // set the command line option prefix name
-    ierr = KSPSetOptionsPrefix(solver_data->ksp, prefix_name.c_str());
+    PetscErrorCode ierr = KSPSetOptionsPrefix(solver_data->ksp, prefix_name.c_str());
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set the command line options provided
@@ -207,7 +205,7 @@ namespace PETScWrappers
   void
   SolverBase::initialize(const PreconditionerBase &preconditioner)
   {
-    int ierr;
+    PetscErrorCode ierr;
 
     solver_data.reset (new SolverData());
 
@@ -263,8 +261,7 @@ namespace PETScWrappers
   void
   SolverRichardson::set_solver_type (KSP &ksp) const
   {
-    int ierr;
-    ierr = KSPSetType (ksp, KSPRICHARDSON);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPRICHARDSON);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set the damping factor from the data
@@ -315,9 +312,9 @@ namespace PETScWrappers
     // spelling Chebyshev between PETSc 3.2
     // and 3.3...
 #if DEAL_II_PETSC_VERSION_LT(3,3,0)
-    int ierr = KSPSetType (ksp, KSPCHEBYCHEV);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPCHEBYCHEV);
 #else
-    int ierr = KSPSetType (ksp, KSPCHEBYSHEV);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPCHEBYSHEV);
 #endif
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -343,7 +340,7 @@ namespace PETScWrappers
   void
   SolverCG::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPCG);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPCG);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -368,7 +365,7 @@ namespace PETScWrappers
   void
   SolverBiCG::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPBICG);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPBICG);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -403,7 +400,7 @@ namespace PETScWrappers
   void
   SolverGMRES::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPGMRES);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPGMRES);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set the restart parameter from the
@@ -470,7 +467,7 @@ namespace PETScWrappers
   void
   SolverBicgstab::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPBCGS);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPBCGS);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -495,7 +492,7 @@ namespace PETScWrappers
   void
   SolverCGS::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPCGS);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPCGS);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -520,7 +517,7 @@ namespace PETScWrappers
   void
   SolverTFQMR::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPTFQMR);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPTFQMR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -545,7 +542,7 @@ namespace PETScWrappers
   void
   SolverTCQMR::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPTCQMR);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPTCQMR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -570,7 +567,7 @@ namespace PETScWrappers
   void
   SolverCR::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPCR);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPCR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -595,7 +592,7 @@ namespace PETScWrappers
   void
   SolverLSQR::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPLSQR);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPLSQR);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // in the deal.II solvers, we always
@@ -620,7 +617,7 @@ namespace PETScWrappers
   void
   SolverPreOnly::set_solver_type (KSP &ksp) const
   {
-    int ierr = KSPSetType (ksp, KSPPREONLY);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPPREONLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // The KSPPREONLY solver of
@@ -667,7 +664,7 @@ namespace PETScWrappers
     * preconditioner.  Its use is due to SparseDirectMUMPS being a direct
     * (rather than iterative) solver
     */
-    int ierr = KSPSetType (ksp, KSPPREONLY);
+    PetscErrorCode ierr = KSPSetType (ksp, KSPPREONLY);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     /**
@@ -692,8 +689,6 @@ namespace PETScWrappers
                             const VectorBase &b)
   {
 #ifdef PETSC_HAVE_MUMPS
-    int ierr;
-
     /**
      * factorization matrix to be obtained from MUMPS
      */
@@ -725,7 +720,7 @@ namespace PETScWrappers
          * creates the default KSP context and puts it in the location
          * solver_data->ksp
          */
-        ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
+        PetscErrorCode ierr = KSPCreate (mpi_communicator, &solver_data->ksp);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         /**
@@ -820,7 +815,7 @@ namespace PETScWrappers
     /**
      * solve the linear system
      */
-    ierr = KSPSolve (solver_data->ksp, b, x);
+    PetscErrorCode ierr = KSPSolve (solver_data->ksp, b, x);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     /**

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -31,8 +31,8 @@ namespace PETScWrappers
   SparseMatrix::SparseMatrix ()
   {
     const int m=0, n=0, n_nonzero_per_row=0;
-    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, n_nonzero_per_row,
-                                     0, &matrix);
+    const PetscErrorCode ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n,
+                                                n_nonzero_per_row, 0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -129,7 +129,7 @@ namespace PETScWrappers
   SparseMatrix::get_mpi_communicator () const
   {
     static MPI_Comm comm;
-    const int ierr = PetscObjectGetComm((PetscObject)matrix, &comm);
+    const PetscErrorCode ierr = PetscObjectGetComm((PetscObject)matrix, &comm);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     return comm;
   }
@@ -145,9 +145,9 @@ namespace PETScWrappers
     // use the call sequence indicating only
     // a maximal number of elements per row
     // for all rows globally
-    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n,
-                                     n_nonzero_per_row,
-                                     0, &matrix);
+    const PetscErrorCode ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n,
+                                                n_nonzero_per_row,
+                                                0, &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set symmetric flag, if so requested
@@ -179,8 +179,8 @@ namespace PETScWrappers
     const std::vector<PetscInt>
     int_row_lengths (row_lengths.begin(), row_lengths.end());
 
-    const int ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, 0,
-                                     &int_row_lengths[0], &matrix);
+    const PetscErrorCode ierr = MatCreateSeqAIJ(PETSC_COMM_SELF, m, n, 0,
+                                                &int_row_lengths[0], &matrix);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // set symmetric flag, if so requested
@@ -230,9 +230,9 @@ namespace PETScWrappers
               row_entries[j] = sparsity_pattern.column_number (i,j);
 
             const PetscInt int_row = i;
-            const int ierr = MatSetValues (matrix, 1, &int_row,
-                                           row_lengths[i], &row_entries[0],
-                                           &row_values[0], INSERT_VALUES);
+            const PetscErrorCode ierr = MatSetValues (matrix, 1, &int_row,
+                                                      row_lengths[i], &row_entries[0],
+                                                      &row_values[0], INSERT_VALUES);
             AssertThrow (ierr == 0, ExcPETScError(ierr));
           }
         compress (VectorOperation::insert);

--- a/source/lac/petsc_vector.cc
+++ b/source/lac/petsc_vector.cc
@@ -84,16 +84,16 @@ namespace PETScWrappers
         // but somehow it leads to odd errors
         // somewhere down the line in some of
         // the tests:
-//         const int ierr = VecSetSizes (vector, n, n);
+//         const PetscErrorCode ierr = VecSetSizes (vector, n, n);
 //         AssertThrow (ierr == 0, ExcPETScError(ierr));
 
         // so let's go the slow way:
         if (attained_ownership)
           {
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-            int ierr = VecDestroy (vector);
+            PetscErrorCode ierr = VecDestroy (vector);
 #else
-            int ierr = VecDestroy (&vector);
+            PetscErrorCode ierr = VecDestroy (&vector);
 #endif
             AssertThrow (ierr == 0, ExcPETScError(ierr));
           }
@@ -121,7 +121,7 @@ namespace PETScWrappers
   void
   Vector::create_vector (const size_type n)
   {
-    const int ierr
+    const PetscErrorCode ierr
       = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     attained_ownership = true;

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -43,7 +43,7 @@ namespace PETScWrappers
         {
           PetscInt idx = index;
           PetscScalar value;
-          int ierr = VecGetValues(vector.vector, 1, &idx, &value);
+          PetscErrorCode ierr = VecGetValues(vector.vector, 1, &idx, &value);
           AssertThrow (ierr == 0, ExcPETScError(ierr));
           return value;
         }
@@ -51,8 +51,6 @@ namespace PETScWrappers
       // with a parallel vector
       else if (dynamic_cast<const PETScWrappers::MPI::Vector *>(&vector) != 0)
         {
-          int ierr;
-
           // there is the possibility
           // that the vector has
           // ghost elements. in that
@@ -73,7 +71,8 @@ namespace PETScWrappers
           if (vector.ghosted)
             {
               PetscInt begin, end;
-              ierr = VecGetOwnershipRange (vector.vector, &begin, &end);
+              PetscErrorCode ierr = VecGetOwnershipRange (vector.vector, &begin,
+                                                          &end);
               AssertThrow (ierr == 0, ExcPETScError(ierr));
 
               Vec locally_stored_elements = PETSC_NULL;
@@ -121,7 +120,7 @@ namespace PETScWrappers
           // available
           PetscInt begin, end;
 
-          ierr = VecGetOwnershipRange (vector.vector, &begin, &end);
+          PetscErrorCode ierr = VecGetOwnershipRange (vector.vector, &begin, &end);
           AssertThrow (ierr == 0, ExcPETScError(ierr));
 
 
@@ -174,7 +173,7 @@ namespace PETScWrappers
             ExcMessage("PETSc does not support multi-threaded access, set "
                        "the thread limit to 1 in MPI_InitFinalize()."));
 
-    int ierr = VecDuplicate (v.vector, &vector);
+    PetscErrorCode ierr = VecDuplicate (v.vector, &vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     ierr = VecCopy (v.vector, vector);
@@ -203,9 +202,9 @@ namespace PETScWrappers
     if (attained_ownership)
       {
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        const int ierr = VecDestroy (vector);
+        const PetscErrorCode ierr = VecDestroy (vector);
 #else
-        const int ierr = VecDestroy (&vector);
+        const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
         AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
@@ -219,9 +218,9 @@ namespace PETScWrappers
     if (attained_ownership)
       {
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        const int ierr = VecDestroy (vector);
+        const PetscErrorCode ierr = VecDestroy (vector);
 #else
-        const int ierr = VecDestroy (&vector);
+        const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
         AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
@@ -241,7 +240,7 @@ namespace PETScWrappers
 
     //TODO[TH]: assert(is_compressed())
 
-    int ierr = VecSet (vector, s);
+    PetscErrorCode ierr = VecSet (vector, s);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     if (has_ghost_elements())
@@ -269,7 +268,7 @@ namespace PETScWrappers
             ExcDimensionMismatch(size(), v.size()));
 
     PetscBooleanType flag;
-    const int ierr = VecEqual (vector, v.vector, &flag);
+    const PetscErrorCode ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return (flag == PETSC_TRUE);
@@ -284,7 +283,7 @@ namespace PETScWrappers
             ExcDimensionMismatch(size(), v.size()));
 
     PetscBooleanType flag;
-    const int ierr = VecEqual (vector, v.vector, &flag);
+    const PetscErrorCode ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return (flag == PETSC_FALSE);
@@ -296,7 +295,7 @@ namespace PETScWrappers
   VectorBase::size () const
   {
     PetscInt sz;
-    const int ierr = VecGetSize (vector, &sz);
+    const PetscErrorCode ierr = VecGetSize (vector, &sz);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return sz;
@@ -308,7 +307,7 @@ namespace PETScWrappers
   VectorBase::local_size () const
   {
     PetscInt sz;
-    const int ierr = VecGetLocalSize (vector, &sz);
+    const PetscErrorCode ierr = VecGetLocalSize (vector, &sz);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return sz;
@@ -320,8 +319,8 @@ namespace PETScWrappers
   VectorBase::local_range () const
   {
     PetscInt begin, end;
-    const int ierr = VecGetOwnershipRange (static_cast<const Vec &>(vector),
-                                           &begin, &end);
+    const PetscErrorCode ierr = VecGetOwnershipRange (static_cast<const Vec &>(vector),
+                                                      &begin, &end);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return std::make_pair (begin, end);
@@ -384,7 +383,7 @@ namespace PETScWrappers
     //    val = (x,y) = y^H x,
     //where y^H denotes the conjugate transpose of y.
     //Note that this corresponds to the usual "mathematicians" complex inner product where the SECOND argument gets the complex conjugate.
-    const int ierr = VecDot (vec.vector, vector, &result);
+    const PetscErrorCode ierr = VecDot (vec.vector, vector, &result);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return result;
@@ -406,23 +405,26 @@ namespace PETScWrappers
   void
   VectorBase::compress (const VectorOperation::values operation)
   {
-    int ierr;
-    (void)ierr;
+    {
 #ifdef DEBUG
 #ifdef DEAL_II_WITH_MPI
-    // Check that all processors agree that last_action is the same (or none!)
+      // Check that all processors agree that last_action is the same (or none!)
 
-    int my_int_last_action = last_action;
-    int all_int_last_action;
+      int my_int_last_action = last_action;
+      int all_int_last_action;
 
-    ierr = MPI_Allreduce(&my_int_last_action, &all_int_last_action, 1, MPI_INT,
-                         MPI_BOR, get_mpi_communicator());
-    AssertThrowMPI(ierr);
+      const int ierr = MPI_Allreduce
+                       (&my_int_last_action, &all_int_last_action, 1, MPI_INT, MPI_BOR,
+                        get_mpi_communicator());
+      AssertThrowMPI(ierr);
 
-    AssertThrow(all_int_last_action != (::dealii::VectorOperation::add | ::dealii::VectorOperation::insert),
-                ExcMessage("Error: not all processors agree on the last VectorOperation before this compress() call."));
+      AssertThrow(all_int_last_action !=
+                  (::dealii::VectorOperation::add | ::dealii::VectorOperation::insert),
+                  ExcMessage("Error: not all processors agree on the last "
+                             "VectorOperation before this compress() call."));
 #endif
 #endif
+    }
 
     AssertThrow(last_action == ::dealii::VectorOperation::unknown
                 || last_action == operation,
@@ -442,7 +444,7 @@ namespace PETScWrappers
     // we still need to call
     // VecAssemblyBegin/End on all
     // processors.
-    ierr = VecAssemblyBegin(vector);
+    PetscErrorCode ierr = VecAssemblyBegin(vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     ierr = VecAssemblyEnd(vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -467,14 +469,12 @@ namespace PETScWrappers
   PetscScalar
   VectorBase::mean_value () const
   {
-    int ierr;
-
     // We can only use our more efficient
     // routine in the serial case.
     if (dynamic_cast<const PETScWrappers::MPI::Vector *>(this) != 0)
       {
         PetscScalar sum;
-        ierr = VecSum(vector, &sum);
+        const PetscErrorCode ierr = VecSum(vector, &sum);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
         return sum/static_cast<PetscReal>(size());
       }
@@ -482,7 +482,7 @@ namespace PETScWrappers
     // get a representation of the vector and
     // loop over all the elements
     PetscScalar *start_ptr;
-    ierr = VecGetArray (vector, &start_ptr);
+    PetscErrorCode ierr = VecGetArray (vector, &start_ptr);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     PetscScalar mean = 0;
@@ -525,7 +525,7 @@ namespace PETScWrappers
   {
     real_type d;
 
-    const int ierr = VecNorm (vector, NORM_1, &d);
+    const PetscErrorCode ierr = VecNorm (vector, NORM_1, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -538,7 +538,7 @@ namespace PETScWrappers
   {
     real_type d;
 
-    const int ierr = VecNorm (vector, NORM_2, &d);
+    const PetscErrorCode ierr = VecNorm (vector, NORM_2, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -552,7 +552,7 @@ namespace PETScWrappers
     // get a representation of the vector and
     // loop over all the elements
     PetscScalar *start_ptr;
-    int ierr = VecGetArray (vector, &start_ptr);
+    PetscErrorCode ierr = VecGetArray (vector, &start_ptr);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     real_type norm = 0;
@@ -597,7 +597,7 @@ namespace PETScWrappers
   {
     real_type d;
 
-    const int ierr = VecNorm (vector, NORM_INFINITY, &d);
+    const PetscErrorCode ierr = VecNorm (vector, NORM_INFINITY, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -610,7 +610,7 @@ namespace PETScWrappers
   {
     real_type d;
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecNormalize (vector, &d);
+    const PetscErrorCode ierr = VecNormalize (vector, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -623,7 +623,7 @@ namespace PETScWrappers
     PetscInt  p;
     real_type d;
 
-    const int ierr = VecMin (vector, &p, &d);
+    const PetscErrorCode ierr = VecMin (vector, &p, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -636,7 +636,7 @@ namespace PETScWrappers
     PetscInt  p;
     real_type d;
 
-    const int ierr = VecMax (vector, &p, &d);
+    const PetscErrorCode ierr = VecMax (vector, &p, &d);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return d;
@@ -648,7 +648,7 @@ namespace PETScWrappers
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
 
-    const int ierr = VecAbs (vector);
+    const PetscErrorCode ierr = VecAbs (vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -661,7 +661,7 @@ namespace PETScWrappers
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
 
-    const int ierr = VecConjugate (vector);
+    const PetscErrorCode ierr = VecConjugate (vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -674,7 +674,7 @@ namespace PETScWrappers
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
 
-    const int ierr = VecPointwiseMult (vector,vector,vector);
+    const PetscErrorCode ierr = VecPointwiseMult (vector,vector,vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -685,7 +685,7 @@ namespace PETScWrappers
   VectorBase::mult (const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecPointwiseMult (vector,vector,v);
+    const PetscErrorCode ierr = VecPointwiseMult (vector,vector,v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -697,7 +697,7 @@ namespace PETScWrappers
                     const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecPointwiseMult (vector,u,v);
+    const PetscErrorCode ierr = VecPointwiseMult (vector,u,v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -709,7 +709,7 @@ namespace PETScWrappers
     // get a representation of the vector and
     // loop over all the elements
     PetscScalar *start_ptr;
-    int ierr = VecGetArray (vector, &start_ptr);
+    PetscErrorCode ierr = VecGetArray (vector, &start_ptr);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     const PetscScalar *ptr  = start_ptr,
@@ -762,7 +762,7 @@ namespace PETScWrappers
     // get a representation of the vector and
     // loop over all the elements
     PetscScalar *start_ptr;
-    int ierr = VecGetArray (vector, &start_ptr);
+    PetscErrorCode ierr = VecGetArray (vector, &start_ptr);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     const PetscScalar *ptr  = start_ptr,
@@ -794,7 +794,7 @@ namespace PETScWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
     AssertIsFinite(a);
 
-    const int ierr = VecScale (vector, a);
+    const PetscErrorCode ierr = VecScale (vector, a);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -811,7 +811,7 @@ namespace PETScWrappers
     const PetscScalar factor = 1./a;
     AssertIsFinite(factor);
 
-    const int ierr = VecScale (vector, factor);
+    const PetscErrorCode ierr = VecScale (vector, factor);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -823,7 +823,7 @@ namespace PETScWrappers
   VectorBase::operator += (const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecAXPY (vector, 1, v);
+    const PetscErrorCode ierr = VecAXPY (vector, 1, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -835,7 +835,7 @@ namespace PETScWrappers
   VectorBase::operator -= (const VectorBase &v)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecAXPY (vector, -1, v);
+    const PetscErrorCode ierr = VecAXPY (vector, -1, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     return *this;
@@ -849,7 +849,7 @@ namespace PETScWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
     AssertIsFinite(s);
 
-    const int ierr = VecShift (vector, s);
+    const PetscErrorCode ierr = VecShift (vector, s);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -870,7 +870,7 @@ namespace PETScWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
     AssertIsFinite(a);
 
-    const int ierr = VecAXPY (vector, a, v);
+    const PetscErrorCode ierr = VecAXPY (vector, a, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -889,7 +889,7 @@ namespace PETScWrappers
     const PetscScalar weights[2] = {a,b};
     Vec               addends[2] = {v.vector, w.vector};
 
-    const int ierr = VecMAXPY (vector, 2, weights, addends);
+    const PetscErrorCode ierr = VecMAXPY (vector, 2, weights, addends);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -902,7 +902,7 @@ namespace PETScWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
     AssertIsFinite(s);
 
-    const int ierr = VecAYPX (vector, s, v);
+    const PetscErrorCode ierr = VecAYPX (vector, s, v);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -945,7 +945,7 @@ namespace PETScWrappers
     const PetscScalar weights[2] = {a,b};
     Vec               addends[2] = {v.vector,w.vector};
 
-    const int ierr = VecMAXPY (vector, 2, weights, addends);
+    const PetscErrorCode ierr = VecMAXPY (vector, 2, weights, addends);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -973,7 +973,7 @@ namespace PETScWrappers
     const PetscScalar weights[3] = {a,b,c};
     Vec               addends[3] = {v.vector, w.vector, x.vector};
 
-    const int ierr = VecMAXPY (vector, 3, weights, addends);
+    const PetscErrorCode ierr = VecMAXPY (vector, 3, weights, addends);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -983,7 +983,7 @@ namespace PETScWrappers
   VectorBase::scale (const VectorBase &factors)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr
+    const PetscErrorCode ierr
       = VecPointwiseMult (vector, factors, vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
@@ -1003,7 +1003,7 @@ namespace PETScWrappers
     // there is no simple operation for this
     // in PETSc. there are multiple ways to
     // emulate it, we choose this one:
-    const int ierr = VecCopy (v.vector, vector);
+    const PetscErrorCode ierr = VecCopy (v.vector, vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     *this *= a;
@@ -1027,7 +1027,7 @@ namespace PETScWrappers
     // there is no simple operation for this
     // in PETSc. there are multiple ways to
     // emulate it, we choose this one:
-    const int ierr = VecCopy (v.vector, vector);
+    const PetscErrorCode ierr = VecCopy (v.vector, vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     sadd (a, b, w);
@@ -1040,7 +1040,7 @@ namespace PETScWrappers
                      const VectorBase &b)
   {
     Assert (!has_ghost_elements(), ExcGhostsPresent());
-    const int ierr = VecPointwiseDivide (vector, a, b);
+    const PetscErrorCode ierr = VecPointwiseDivide (vector, a, b);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1052,8 +1052,8 @@ namespace PETScWrappers
     //TODO[TH]:assert(is_compressed())
 
     // Set options
-    int ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
-                                     format);
+    PetscErrorCode ierr = PetscViewerSetFormat (PETSC_VIEWER_STDOUT_WORLD,
+                                                format);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
@@ -1074,7 +1074,7 @@ namespace PETScWrappers
     // get a representation of the vector and
     // loop over all the elements
     PetscScalar *val;
-    int ierr = VecGetArray (vector, &val);
+    PetscErrorCode ierr = VecGetArray (vector, &val);
 
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -1113,7 +1113,7 @@ namespace PETScWrappers
   void
   VectorBase::swap (VectorBase &v)
   {
-    const int ierr = VecSwap (vector, v.vector);
+    const PetscErrorCode ierr = VecSwap (vector, v.vector);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1180,8 +1180,8 @@ namespace PETScWrappers
 #endif
 
         const InsertMode mode = (add_values ? ADD_VALUES : INSERT_VALUES);
-        const int ierr = VecSetValues (vector, n_elements, petsc_indices,
-                                       values, mode);
+        const PetscErrorCode ierr = VecSetValues (vector, n_elements, petsc_indices,
+                                                  values, mode);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
       }
 

--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -40,7 +40,7 @@ namespace SLEPcWrappers
     mpi_communicator (mpi_communicator)
   {
     // create eigensolver context
-    int ierr = EPSCreate (mpi_communicator, &eps);
+    PetscErrorCode ierr = EPSCreate (mpi_communicator, &eps);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     // hand over the absolute tolerance and the maximum number of
@@ -63,9 +63,9 @@ namespace SLEPcWrappers
       {
         // Destroy the solver object.
 #if DEAL_II_PETSC_VERSION_LT(3,2,0)
-        const int ierr = EPSDestroy (eps);
+        const PetscErrorCode ierr = EPSDestroy (eps);
 #else
-        const int ierr = EPSDestroy (&eps);
+        const PetscErrorCode ierr = EPSDestroy (&eps);
 #endif
         AssertThrow (ierr == 0, ExcSLEPcError(ierr));
       }
@@ -75,7 +75,7 @@ namespace SLEPcWrappers
   SolverBase::set_matrices (const PETScWrappers::MatrixBase &A)
   {
     // standard eigenspectrum problem
-    const int ierr = EPSSetOperators (eps, A, PETSC_NULL);
+    const PetscErrorCode ierr = EPSSetOperators (eps, A, PETSC_NULL);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -84,7 +84,7 @@ namespace SLEPcWrappers
                             const PETScWrappers::MatrixBase &B)
   {
     // generalized eigenspectrum problem
-    const int ierr = EPSSetOperators (eps, A, B);
+    const PetscErrorCode ierr = EPSSetOperators (eps, A, B);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -93,7 +93,7 @@ namespace SLEPcWrappers
   {
     // set transformation type if any
     // STSetShift is called inside
-    const int ierr = EPSSetST(eps,transformation.st);
+    const PetscErrorCode ierr = EPSSetST(eps,transformation.st);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
@@ -105,9 +105,9 @@ namespace SLEPcWrappers
 
     Vec vec = this_initial_vector;
 #if DEAL_II_PETSC_VERSION_LT(3,1,0)
-    const int ierr = EPSSetInitialVector (eps, &vec);
+    const PetscErrorCode ierr = EPSSetInitialVector (eps, &vec);
 #else
-    const int ierr = EPSSetInitialSpace (eps, 1, &vec);
+    const PetscErrorCode ierr = EPSSetInitialSpace (eps, 1, &vec);
 #endif
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
@@ -118,7 +118,7 @@ namespace SLEPcWrappers
     // set target eigenvalues to solve for
     // in all transformation except STSHIFT there is a direct connection between
     // the target and the shift, read more on p41 of SLEPc manual.
-    const int ierr = EPSSetTarget (eps, this_target );
+    const PetscErrorCode ierr = EPSSetTarget (eps, this_target );
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -126,14 +126,14 @@ namespace SLEPcWrappers
   SolverBase::set_which_eigenpairs (const EPSWhich eps_which)
   {
     // set which portion of the eigenspectrum to solve for
-    const int ierr = EPSSetWhichEigenpairs (eps, eps_which);
+    const PetscErrorCode ierr = EPSSetWhichEigenpairs (eps, eps_which);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
   void
   SolverBase::set_problem_type (const EPSProblemType eps_problem)
   {
-    const int ierr = EPSSetProblemType (eps, eps_problem);
+    const PetscErrorCode ierr = EPSSetProblemType (eps, eps_problem);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -142,8 +142,8 @@ namespace SLEPcWrappers
                      unsigned int       *n_converged)
   {
     // set number of eigenvectors to compute
-    int ierr = EPSSetDimensions (eps, n_eigenpairs,
-                                 PETSC_DECIDE, PETSC_DECIDE);
+    PetscErrorCode ierr = EPSSetDimensions (eps, n_eigenpairs,
+                                            PETSC_DECIDE, PETSC_DECIDE);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     // set the solve options to the eigenvalue problem solver context
@@ -230,9 +230,9 @@ namespace SLEPcWrappers
                              PETScWrappers::VectorBase &eigenvectors)
   {
     // get converged eigenpair
-    const int ierr = EPSGetEigenpair (eps, index,
-                                      &eigenvalues, PETSC_NULL,
-                                      eigenvectors, PETSC_NULL);
+    const PetscErrorCode ierr = EPSGetEigenpair (eps, index,
+                                                 &eigenvalues, PETSC_NULL,
+                                                 eigenvectors, PETSC_NULL);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -246,9 +246,11 @@ namespace SLEPcWrappers
   {
 #ifndef PETSC_USE_COMPLEX
     // get converged eigenpair
-    const int ierr = EPSGetEigenpair (eps, index,
-                                      &real_eigenvalues, &imag_eigenvalues,
-                                      real_eigenvectors, imag_eigenvectors);
+    const PetscErrorCode ierr = EPSGetEigenpair (eps, index,
+                                                 &real_eigenvalues,
+                                                 &imag_eigenvalues,
+                                                 real_eigenvectors,
+                                                 imag_eigenvectors);
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 #else
     Assert ((false),
@@ -320,7 +322,8 @@ namespace SLEPcWrappers
     SolverBase (cn, mpi_communicator),
     additional_data (data)
   {
-    const int ierr = EPSSetType (eps, const_cast<char *>(EPSKRYLOVSCHUR));
+    const PetscErrorCode ierr = EPSSetType (eps,
+                                            const_cast<char *>(EPSKRYLOVSCHUR));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -338,7 +341,7 @@ namespace SLEPcWrappers
     SolverBase (cn, mpi_communicator),
     additional_data (data)
   {
-    int ierr = EPSSetType (eps, const_cast<char *>(EPSARNOLDI));
+    PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSARNOLDI));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     // if requested, set delayed reorthogonalization in the Arnoldi
@@ -364,7 +367,7 @@ namespace SLEPcWrappers
     SolverBase (cn, mpi_communicator),
     additional_data (data)
   {
-    int ierr = EPSSetType (eps, const_cast<char *>(EPSLANCZOS));
+    PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSLANCZOS));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     ierr = EPSLanczosSetReorthog(eps,additional_data.reorthog);
@@ -379,7 +382,7 @@ namespace SLEPcWrappers
     SolverBase (cn, mpi_communicator),
     additional_data (data)
   {
-    int ierr = EPSSetType (eps, const_cast<char *>(EPSPOWER));
+    PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSPOWER));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
   }
 
@@ -397,7 +400,7 @@ namespace SLEPcWrappers
     additional_data (data)
   {
 #if DEAL_II_PETSC_VERSION_GTE(3,1,0)
-    int ierr = EPSSetType (eps, const_cast<char *>(EPSGD));
+    PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSGD));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 
     if (additional_data.double_expansion)
@@ -422,8 +425,7 @@ namespace SLEPcWrappers
     additional_data (data)
   {
 #if DEAL_II_PETSC_VERSION_GTE(3,1,0)
-    int ierr;
-    ierr = EPSSetType (eps, const_cast<char *>(EPSJD));
+    const PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSJD));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 #else
     // PETSc/SLEPc version must be > 3.1.0.
@@ -444,8 +446,7 @@ namespace SLEPcWrappers
     // 'Tis overwhelmingly likely that PETSc/SLEPc *always* has
     // BLAS/LAPACK, but let's be defensive.
 #if PETSC_HAVE_BLASLAPACK
-    int ierr;
-    ierr = EPSSetType (eps, const_cast<char *>(EPSLAPACK));
+    const PetscErrorCode ierr = EPSSetType (eps, const_cast<char *>(EPSLAPACK));
     AssertThrow (ierr == 0, ExcSLEPcError(ierr));
 #else
     Assert ((false),

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -33,7 +33,7 @@ namespace SLEPcWrappers
 {
   TransformationBase::TransformationBase (const MPI_Comm &mpi_communicator)
   {
-    const int ierr = STCreate(mpi_communicator, &st);
+    const PetscErrorCode ierr = STCreate(mpi_communicator, &st);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
@@ -41,20 +41,20 @@ namespace SLEPcWrappers
   {
     if (st!=NULL)
       {
-        const int ierr = STDestroy(&st);
+        const PetscErrorCode ierr = STDestroy(&st);
         AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
       }
   }
 
   void TransformationBase::set_matrix_mode(const STMatMode mode)
   {
-    const int ierr = STSetMatMode(st,mode);
+    const PetscErrorCode ierr = STSetMatMode(st,mode);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
   void TransformationBase::set_solver(const PETScWrappers::SolverBase &solver)
   {
-    int ierr = STSetKSP(st,solver.solver_data->ksp);
+    PetscErrorCode ierr = STSetKSP(st,solver.solver_data->ksp);
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
   }
 
@@ -72,8 +72,7 @@ namespace SLEPcWrappers
     TransformationBase(mpi_communicator),
     additional_data (data)
   {
-    int ierr;
-    ierr = STSetType (st, const_cast<char *>(STSHIFT));
+    PetscErrorCode ierr = STSetType (st, const_cast<char *>(STSHIFT));
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
     ierr = STSetShift (st, additional_data.shift_parameter);
@@ -94,11 +93,10 @@ namespace SLEPcWrappers
     TransformationBase(mpi_communicator),
     additional_data (data)
   {
-    int ierr;
 #if DEAL_II_PETSC_VERSION_LT(3,1,0)
-    ierr = STSetType (st, const_cast<char *>(STSINV));
+    PetscErrorCode ierr = STSetType (st, const_cast<char *>(STSINV));
 #else
-    ierr = STSetType (st, const_cast<char *>(STSINVERT));
+    PetscErrorCode ierr = STSetType (st, const_cast<char *>(STSINVERT));
 #endif
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
@@ -121,13 +119,10 @@ namespace SLEPcWrappers
     additional_data (data)
   {
 #if DEAL_II_PETSC_VERSION_LT(3,5,0)
-    int ierr;
-    ierr = STSetType (st, const_cast<char *>(STFOLD));
-    (void)ierr;
+    PetscErrorCode ierr = STSetType (st, const_cast<char *>(STFOLD));
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
     ierr = STSetShift (st, additional_data.shift_parameter);
-    (void)ierr;
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 #else
     // PETSc/SLEPc version must be < 3.5.0.
@@ -155,7 +150,7 @@ namespace SLEPcWrappers
     TransformationBase(mpi_communicator),
     additional_data (data)
   {
-    int ierr = STSetType (st, const_cast<char *>(STCAYLEY));
+    PetscErrorCode ierr = STSetType (st, const_cast<char *>(STCAYLEY));
     AssertThrow (ierr == 0, SolverBase::ExcSLEPcError(ierr));
 
     ierr = STSetShift (st, additional_data.shift_parameter);


### PR DESCRIPTION
PETSc typedefs PetscErrorCode to be int (so these are equivalent) but this makes things a bit clearer.

This fixes a review comment mentioned in #3576.