### PR TITLE
Use static assert to check for correct template parameters at compile time

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1093,6 +1093,13 @@ private:
 
   friend struct dealii::internal::DoFHandler::Implementation;
   friend struct dealii::internal::DoFHandler::Policy::Implementation;
+
+  // explicitly check for sensible template arguments
+#ifdef DEAL_II_WITH_CXX11
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a DoFHandler must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 };
 
 


### PR DESCRIPTION
In #3594, it was suggested to add compile-time checks for correct template parameters, and this is an example provided by @bangerth of how that could be done. The benefit of this is that we get errors earlier; i.e. when we try to reference a template type which doesn't make sense, rather than at link time when those types should be resolved.

However, this raises the more broad question whether we should do this more widely in the code base. Secondly, this solution is C++11 only, meaning that we need some stand-in solution, perhaps based on [Boost](http://www.boost.org/doc/libs/1_61_0/doc/html/boost_staticassert.html).

What do you all think of this?