### PR TITLE
Make instantiations fulfill chartdim<=spacedim

### DIFF
--- a/source/grid/manifold.inst.in
+++ b/source/grid/manifold.inst.in
@@ -20,12 +20,14 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 #if deal_II_dimension <= deal_II_space_dimension
     template class Manifold<deal_II_dimension, deal_II_space_dimension>;
     template class FlatManifold<deal_II_dimension, deal_II_space_dimension>;
-
-    template class ChartManifold<deal_II_dimension, deal_II_space_dimension, 1>;
-    template class ChartManifold<deal_II_dimension, deal_II_space_dimension, 2>;
-    template class ChartManifold<deal_II_dimension, deal_II_space_dimension, 3>;
 #endif
 }
 
-
-
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; deal_II_chart_dimension :  DIMENSIONS)
+{
+#if deal_II_dimension <= deal_II_space_dimension
+#if deal_II_chart_dimension <= deal_II_space_dimension
+    template class ChartManifold<deal_II_dimension, deal_II_space_dimension, deal_II_chart_dimension>;
+#endif
+#endif
+}

--- a/source/grid/manifold_lib.inst.in
+++ b/source/grid/manifold_lib.inst.in
@@ -20,12 +20,17 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     template class PolarManifold<deal_II_dimension, deal_II_space_dimension>;
     template class SphericalManifold<deal_II_dimension, deal_II_space_dimension>;
     template class CylindricalManifold<deal_II_dimension, deal_II_space_dimension>;
-    template class FunctionManifold<deal_II_dimension, deal_II_space_dimension, 1>;
-    template class FunctionManifold<deal_II_dimension, deal_II_space_dimension, 2>;
-    template class FunctionManifold<deal_II_dimension, deal_II_space_dimension, 3>;
 #endif
 #if deal_II_dimension == deal_II_space_dimension
     template class TorusManifold<deal_II_dimension>;
 #endif
 }
 
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; deal_II_chart_dimension :  DIMENSIONS)
+{
+#if deal_II_dimension <= deal_II_space_dimension
+#if deal_II_chart_dimension <= deal_II_space_dimension
+    template class FunctionManifold<deal_II_dimension, deal_II_space_dimension, deal_II_chart_dimension>;
+#endif
+#endif
+}


### PR DESCRIPTION
According to documentation for `ChartManifold`,

> The dimension arguments `chartdim`, `dim` and `spacedim` must satisfy the following relationships:
>```
>dim <= spacedim
>chartdim <= spacedim
>```

However, in the `inst.in` file, these conditions are not respected, which gives rise to incorrectly configured instantiations of `Triangulation`. This fixes that, and also does the same thing for `FunctionManifold`.

There is still a case where invalid `Triangulation`s are referred, namely when `dim>chartdim`, since `Triangulation<dim,chartdim>` which is may be considered invalid. We should await the discussion on this in #3622.