### PR TITLE
Fix typo in documentation.

### DIFF
--- a/doc/readme.html
+++ b/doc/readme.html
@@ -343,7 +343,7 @@
       displayed via the MathJax system by
       adding <code>-DDEAL_II_DOXYGEN_USE_MATHJAX=ON</code> to the
       CMake call above. These formulas are then rendered natively by the
-      browser. With <code>-DDEAL_II_DOXYGEN_USE_ONLINE_MATHJAX=OFF<code>
+      browser. With <code>-DDEAL_II_DOXYGEN_USE_ONLINE_MATHJAX=OFF</code>
       CMake will try to find a local installation of MathJax scripts,
       otherwise the online version of the scripts will be used in the
       documentation.


### PR DESCRIPTION
Otherwise everything from this point on is 'code'.