### PR TITLE
Add note to enable linking against LAPACK 3.6.0 and later.

### DIFF
--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -116,6 +116,29 @@
 
     <h5>BLAS and LAPACK</h5>
 
+    <p style="color: red">
+      Note: At the time of writing (November 2016) Trilinos (at least up to 
+      v12.8.1) cannot link against LAPACK 3.6.0 or later, due to two symbols 
+      that were deprecated (and removed by default) in LAPACK 3.6.0 (see the 
+      <a href="http://www.netlib.org/lapack/lapack-3.6.0.html">
+      release notes</a>). To fix this, edit the Trilinos file 
+      <code>packages/epetra/src/Epetra_LAPACK_wrappers.h</code> and change the 
+      lines
+      <pre>
+    
+    #define DGGSVD_F77  F77_BLAS_MANGLE(dggsvd,DGGSVD)
+    #define SGGSVD_F77  F77_BLAS_MANGLE(sggsvd,SGGSVD)
+      </pre>
+      to
+      <pre>
+    
+    #define DGGSVD_F77  F77_BLAS_MANGLE(dggsvd3,DGGSVD3)
+    #define SGGSVD_F77  F77_BLAS_MANGLE(sggsvd3,SGGSVD3)
+      </pre>
+      before installing Trilinos. (Credit for this fix goes to 
+      <a href="https://github.com/gahansen/Albany/wiki/ALCF-Vesta">this page</a>.)
+    </p>
+    
     <p>
       Trilinos sometimes searches for other libraries but can't find
       them if they are not in the usual directories or have other


### PR DESCRIPTION
My new local cluster has only LAPACK 3.6.1, and when building Trilinos 12.0.1 I got linker errors 
```../../../../../epetra/src/libepetra.so.12.0.1: undefined reference to `sggsvd_'```
```../../../../../epetra/src/libepetra.so.12.0.1: undefined reference to `dggsvd_'```
which are caused by the deprecation of these symbols for `sggsvd3_` and `dggsvd3_`in LAPACK 3.6.0.

This evidently hasn't been fixed in any version of Trilinos yet: https://github.com/trilinos/Trilinos/issues/480

It took me far too long to discover the reason, so I've popped it on here, for anyone else who comes up against LAPACK 3.6.0+. I'm not certain whether this is the best place for this note - if anyone prefers it could go into `doc/readme.html` directly, or somewhere in the Wiki.