### PR TITLE
Improve has_vmult_add check

### DIFF
--- a/cmake/checks/check_03_compiler_bugs.cmake
+++ b/cmake/checks/check_03_compiler_bugs.cmake
@@ -389,52 +389,6 @@ ENDIF()
 
 
 #
-# Intel (at least 14, 15) has a bug where it incorrectly detects multiple
-# matching function candidates and dies during type resolution in a
-# perfectly valid SFINAE scenario. This seems to happen because the templated
-# variant is not discarded (where it should be):
-#
-# error: more than one instance of overloaded function
-#     "has_vmult_add<Range, T>::test [with Range=double, T=MyMatrix]"
-# matches the argument list:
-#     function template "void has_vmult_add<Range, T>::test<C>(decltype((<expression>))) [with Range=double, T=MyMatrix]"
-#     function template "void has_vmult_add<Range, T>::test<C>(decltype((&C::vmult_add<double>))) [with Range=double, T=MyMatrix]"
-# [...]
-#
-# - Matthias Maier, 2015
-#
-
-IF(DEAL_II_WITH_CXX11)
-  PUSH_CMAKE_REQUIRED("${DEAL_II_CXX_VERSION_FLAG}")
-  CHECK_CXX_COMPILER_BUG(
-    "
-    template <typename Range, typename T> struct has_vmult_add
-    {
-      template <typename C>
-      static void test(decltype(&C::vmult_add));
-
-      template <typename C>
-      static void test(decltype(&C::template vmult_add<Range>));
-
-      typedef decltype(test<T>(0)) type;
-    };
-
-    struct MyMatrix
-    {
-      void vmult_add() const;
-    };
-
-    int main()
-    {
-      typedef has_vmult_add<double, MyMatrix>::type test;
-    }
-    "
-    DEAL_II_ICC_SFINAE_BUG
-    )
-  RESET_CMAKE_REQUIRED()
-ENDIF()
-
-#
 # Intel 16.0.1 produces wrong code that creates a race condition in
 # tests/fe/curl_curl_01.debug but 16.0.2 is known to work. Blacklist this
 # version. Also see github.com/dealii/dealii/issues/2203

--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -451,6 +451,14 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Improved: The trait class has_vmult_add in linear_operators.h
+ has been restricted to test if there is a vmult_add and a Tvmult_add
+ method that takes two arguments. This check now also works with
+ ICC 13 and ICC 14.
+ <br>
+ (Daniel Arndt, 2016/11/25)
+ </li>
+
  <li> Fixed: DataOut::build_patches() ignored a higher order
  or Eulerian mapping if no data had previously been attached
  via DataOut::add_data_vector(), i.e., if all that was to be output

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -71,7 +71,6 @@
 #cmakedefine DEAL_II_BOOST_BIND_COMPILER_BUG
 #cmakedefine DEAL_II_BIND_NO_CONST_OP_PARENTHESES
 #cmakedefine DEAL_II_CONSTEXPR_BUG
-#cmakedefine DEAL_II_ICC_SFINAE_BUG
 
 
 /***********************************************************************

--- a/tests/lac/linear_operator_05.cc
+++ b/tests/lac/linear_operator_05.cc
@@ -218,12 +218,6 @@ public:
   {
     deallog << "MyMatrix6::vmult_add" << std::endl;
   }
-
-  template<typename number, typename number2>
-  void Tvmult_add(Vector<number> &, const Vector<number2> &, bool = true) const
-  {
-    deallog << "MyMatrix6::Tvmult_add" << std::endl;
-  }
 };
 
 using namespace dealii;
@@ -253,8 +247,6 @@ int main()
   linear_operator(m2).vmult_add(v, u);
   linear_operator(m2).Tvmult_add(v, u);
 
-#ifndef DEAL_II_ICC_SFINAE_BUG
-
   linear_operator(m3).vmult(v, u);
   linear_operator(m3).Tvmult(v, u);
   linear_operator(m3).vmult_add(v, u);
@@ -274,28 +266,4 @@ int main()
   linear_operator(m6).Tvmult(v, u);
   linear_operator(m6).vmult_add(v, u);
   linear_operator(m6).Tvmult_add(v, u);
-
-#else
-
-  deallog << "MyMatrix3::vmult" << std::endl;
-  deallog << "MyMatrix3::Tvmult" << std::endl;
-  deallog << "MyMatrix3::vmult_add" << std::endl;
-  deallog << "MyMatrix3::Tvmult_add" << std::endl;
-
-  deallog << "MyMatrix4::vmult" << std::endl;
-  deallog << "MyMatrix4::Tvmult" << std::endl;
-  deallog << "MyMatrix4::vmult_add" << std::endl;
-  deallog << "MyMatrix4::Tvmult_add" << std::endl;
-
-  deallog << "MyMatrix5::vmult" << std::endl;
-  deallog << "MyMatrix5::Tvmult" << std::endl;
-  deallog << "MyMatrix5::vmult_add" << std::endl;
-  deallog << "MyMatrix5::Tvmult_add" << std::endl;
-
-  deallog << "MyMatrix6::vmult" << std::endl;
-  deallog << "MyMatrix6::Tvmult" << std::endl;
-  deallog << "MyMatrix6::vmult_add" << std::endl;
-  deallog << "MyMatrix6::Tvmult_add" << std::endl;
-
-#endif
 }

--- a/tests/lac/linear_operator_05.with_cxx11=on.output
+++ b/tests/lac/linear_operator_05.with_cxx11=on.output
@@ -21,5 +21,5 @@ DEAL::MyMatrix5::vmult_add
 DEAL::MyMatrix5::Tvmult_add
 DEAL::MyMatrix6::vmult
 DEAL::MyMatrix6::Tvmult
-DEAL::MyMatrix6::vmult_add
-DEAL::MyMatrix6::Tvmult_add
+DEAL::MyMatrix6::vmult
+DEAL::MyMatrix6::Tvmult


### PR DESCRIPTION
The `has_vmult_add` check now also works for ICC 14 and ICC 15. According to http://gcc.godbolt.org/
there is also a problem with ICC 16 and ICC 17 with the old code.
Finally, a test in #1783 breaks for gcc-4.8.4 and gcc-4.9.4 with the old code.

Since `DEAL_II_ICC_SFINAE_BUG` just tests exactly the changed code and is used nowhere else than in `linear_operator.h`, remove that preprocessor variable as well.

The test `tests/lac/linear_operator_05` only checked classes that have both `vmult_add` and `Tvmult_add`. Now we only check the output if just `vmult_add` is provided.