### PR TITLE
Fix manifold instantiations

### DIFF
--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -298,6 +298,14 @@ class Manifold : public Subscriptor
 {
 public:
 
+  // explicitly check for sensible template arguments
+#ifdef DEAL_II_WITH_CXX11
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a Manifold must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
+
+
   /**
    * Type keeping information about the normals at the vertices of a face of a
    * cell. Thus, there are <tt>GeometryInfo<dim>::vertices_per_face</tt>
@@ -879,6 +887,13 @@ template <int dim, int spacedim=dim, int chartdim=dim>
 class ChartManifold : public Manifold<dim,spacedim>
 {
 public:
+  // explicitly check for sensible template arguments
+#ifdef DEAL_II_WITH_CXX11
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a ChartManifold must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
+
   /**
    * Constructor. The optional argument can be used to specify the periodicity
    * of the chartdim-dimensional manifold (one period per direction). A

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -1028,8 +1028,15 @@ private:
   /**
    * The sub_manifold object is used to compute the average of the points in
    * the chart coordinates system.
+   *
+   * In an ideal world, it would have type
+   * FlatManifold<dim,chartdim>. However, this would instantiate cases
+   * where dim>spacedim, which leads to invalid situations. We instead
+   * use <chartdim,chartdim>, which is (i) always valid, and (ii) does
+   * not matter at all since the first (dim) argument of manifolds is,
+   * in fact, ignored as far as manifold functionality is concerned.
    */
-  const FlatManifold<dim,chartdim> sub_manifold;
+  const FlatManifold<chartdim,chartdim> sub_manifold;
 };
 
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3681,16 +3681,6 @@ template <> unsigned int Triangulation<1,3>::n_active_quads () const;
 template <> unsigned int Triangulation<1,3>::max_adjacent_cells () const;
 
 
-// -------------------------------------------------------------------
-// Explicit invalid things...
-template <>
-const Manifold<2,1> &Triangulation<2, 1>::get_manifold(const types::manifold_id) const;
-template <>
-const Manifold<3,1> &Triangulation<3, 1>::get_manifold(const types::manifold_id) const;
-template <>
-const Manifold<3,2> &Triangulation<3, 2>::get_manifold(const types::manifold_id) const;
-
-
 #endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/manifold.inst.in
+++ b/source/grid/manifold.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 1998 - 2014, 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -26,8 +26,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; deal_II_chart_dimension :  DIMENSIONS)
 {
 #if deal_II_dimension <= deal_II_space_dimension
-#if deal_II_chart_dimension <= deal_II_space_dimension
     template class ChartManifold<deal_II_dimension, deal_II_space_dimension, deal_II_chart_dimension>;
-#endif
 #endif
 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13586,39 +13586,6 @@ Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList () DEAL_II_N
 }
 
 
-template <>
-const Manifold<2,1> &Triangulation<2, 1>::get_manifold(const types::manifold_id) const
-{
-  Assert(false, ExcImpossibleInDim(1));
-  // We cannot simply create a temporary Manifold<2,1> because it is not
-  // instantiated and would lead to unresolved symbols. Given the fact that
-  // this function should be unreachable anyaway, just dereference a
-  // nullptr:
-  return *static_cast<FlatManifold<2,1>*>(0);
-}
-
-template <>
-const Manifold<3,1> &Triangulation<3, 1>::get_manifold(const types::manifold_id) const
-{
-  Assert(false, ExcImpossibleInDim(1));
-  // We cannot simply create a temporary Manifold<2,1> because it is not
-  // instantiated and would lead to unresolved symbols. Given the fact that
-  // this function should be unreachable anyaway, just dereference a
-  // nullptr:
-  return *static_cast<FlatManifold<3,1>*>(0);
-}
-
-template <>
-const Manifold<3,2> &Triangulation<3, 2>::get_manifold(const types::manifold_id) const
-{
-  Assert(false, ExcImpossibleInDim(2));
-  // We cannot simply create a temporary Manifold<2,1> because it is not
-  // instantiated and would lead to unresolved symbols. Given the fact that
-  // this function should be unreachable anyaway, just dereference a
-  // nullptr:
-  return *static_cast<FlatManifold<3,2>*>(0);
-}
-
 // explicit instantiations
 #include "tria.inst"
 


### PR DESCRIPTION
This pull request subsumes #3627 and #3634 by cherry-picking the relevant commits.

What I'm doing here is the following, as discussed in #3622:
* Change the type of `ChartManifold::sub_manifold`, as discussed there. In particular I give it a type so that it's template arguments satisfy `dim<=spacedim`.
* Remove instantiations of functions that reference manifolds with `dim>spacedim`. This is taken from #3726.
* Add a few explicit instantiations for `ChartManifold` which are apparently now needed. As discussed in #3622, there is no relationship between `chartdim` and `spacedim`, so we need to instantiate all combinations.
* Add `static_assert` statements to the `Manifold` class. This is taken from #3634.

All of this compiles just fine, and also passes the testsuite.