### PR TITLE
Make a test compile.

### DIFF
--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -23,6 +23,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/grid/tria.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -119,9 +120,9 @@ void do_project (const parallel::distributed::Triangulation<dim> &triangulation,
                                            constraints);
   constraints.close ();
 
-  LinearAlgebra::distributed::Vector projection (locally_owned_dofs,
-                                                 locally_relevant_dofs,
-                                                 mpi_communicator);
+  LinearAlgebra::distributed::Vector<double> projection (locally_owned_dofs,
+                                                         locally_relevant_dofs,
+                                                         mpi_communicator);
   Vector<float>  error (triangulation.n_active_cells());
   for (unsigned int q=0; q<=p+2-order_difference; ++q)
     {


### PR DESCRIPTION
This is necessary to make |numerics/project_parallel_q_*| compile. We still need to do something
about #3636 to make it run successfully.