### PR TITLE
Added warning for unsuccessful case in GridTools::collect_periodic_faces

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1434,6 +1434,12 @@ namespace GridTools
    * times with different boundary ids to generate a vector with all periodic
    * pairs.
    *
+   * @note Since the periodic face pairs are found on the coarsest mesh level,
+   * it is necessary to ensure that the coarsest level faces have the correct
+   * boundary indicators set. In general, this means that one must first set
+   * all boundary indicators on the coarse grid before performing any global
+   * or local grid refinement.
+   *
    * @author Daniel Arndt, Matthias Maier, 2013 - 2015
    */
   template <typename MeshType>

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3742,6 +3742,11 @@ next_cell:
     Assert (pairs1.size() == pairs2.size(),
             ExcMessage ("Unmatched faces on periodic boundaries"));
 
+    Assert (pairs1.size() > 0,
+            ExcMessage("No new periodic face pairs have been found. "
+                       "Are you sure that you've selected the correct boundary "
+                       "id's and that the coarsest level mesh is colorized?"));
+
     // and call match_periodic_face_pairs that does the actual matching:
     match_periodic_face_pairs(pairs1, pairs2, direction, matched_pairs, offset,
                               matrix);
@@ -3799,6 +3804,10 @@ next_cell:
     Assert (pairs1.size() == pairs2.size(),
             ExcMessage ("Unmatched faces on periodic boundaries"));
 
+    Assert (pairs1.size() > 0,
+            ExcMessage("No new periodic face pairs have been found. "
+                       "Are you sure that you've selected the correct boundary "
+                       "id's and that the coarsest level mesh is colorized?"));
 
 #ifdef DEBUG
     const unsigned int size_old = matched_pairs.size();


### PR DESCRIPTION
A note and assert has been added to provide a warning for the case where
`GridTools::collect_periodic_faces` doesn't find any matched faces. This may happen
if there is no colouring on the coarsest level mesh (i.e. grid
refinement before boundary id definition) or where they've accidentally
called the function with the wrong boundary id's (or direction?).

Fixes #3280