### PR TITLE
Fix DEAL_II_COMPILER_USE_VECTOR_ARITHMETICS with AVX512 and ICC

### DIFF
--- a/cmake/checks/check_01_compiler_features.cmake
+++ b/cmake/checks/check_01_compiler_features.cmake
@@ -51,6 +51,9 @@
 CHECK_CXX_SOURCE_COMPILES(
   "
   #include <emmintrin.h>
+#ifdef __AVX512F__
+  #include <immintrin.h>
+#endif
   int main()
   {
     __m128d a, b;
@@ -60,6 +63,16 @@ CHECK_CXX_SOURCE_COMPILES(
     __m128d d = b - c;
     __m128d e = c * a + d;
     __m128d f = e/a;
+#ifdef __AVX512F__
+    __m512d g, h;
+    g = _mm512_set1_pd (1.0);
+    h = _mm512_set1_pd (2.1);
+    __m512d i = g + h;
+    g = i - g;
+    h *= i;
+    i = h/i;
+    (void)i;
+#endif
     (void)f;
   }
   "


### PR DESCRIPTION
This PR fixes compilation of deal.II on Intel Knights Landing (Xeon Phi) processors with Intel compiler and flag `-xHOST`. The problem is that we apply arithmetics on SIMD types which are apparently not supported for AVX512F with the Intel compiler. Error messages are of the form:
```
test.cc(18): error: operation not supported for these simd operands
      __m512d i = g + h;
                    ^
test.cc(19): error: operation not supported for these simd operands
      g = i - g;
            ^
test.cc(20): error: operation not supported for these simd operands
      h *= i;
        ^
test.cc(21): error: operation not supported for these simd operands
      i = h/i;
           ^
```
To fix this case, we need to switch `VectorizedArray` to the actual AVX512F intrinsics which we provide alongside. (gcc works out of the box and had been tested by me before.)