### PR TITLE
Optimize SphericalManifold::get_new_point()

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -275,13 +275,17 @@ SphericalManifold<dim,spacedim>::
 get_new_point (const std::vector<Point<spacedim> > &vertices,
                const std::vector<double> &weights) const
 {
+  const unsigned int n_points = vertices.size();
+
   double rho = 0.0;
   Tensor<1,spacedim> candidate;
-  for (unsigned int i = 0; i<vertices.size(); i++)
+  for (unsigned int i = 0; i<n_points; i++)
     {
-      rho += (vertices[i]-center).norm()*weights[i];
-      candidate += (vertices[i]-center)*weights[i];
+      const Tensor<1,spacedim> direction (vertices[i]-center);
+      rho += direction.norm()*weights[i];
+      candidate += direction*weights[i];
     }
+
   // Unit norm direction.
   candidate /= candidate.norm();
 


### PR DESCRIPTION
This harmless looking change speeds up `SphericalManifold::get_new_point()` by 30%.
For my application (ASPECT, with millions of calls to Mapping::transform_real_to_unit_cell) this can reduce the total model runtime by 3-10% (depending on the number of particles I use).

The improvement originates mostly from reducing the number of calls to `Point::operator -`, which results in a lot less conversions from points to tensors.