### PR TITLE
Only show TimerOutput percentages down to 0.1%.

### DIFF
--- a/doc/news/changes.h
+++ b/doc/news/changes.h
@@ -459,6 +459,13 @@ inconvenience this causes.
 <h3>Specific improvements</h3>
 
 <ol>
+ <li> Changed: To improve readability, TimerOutput::print_summary()
+ now simply outputs "0%" if a particular section's time requires
+ less than 0.1 per cent of the overall run time.
+ <br>
+ (Wolfgang Bangerth, 2016/12/03)
+ </li>
+
  <li> Improved: The trait class has_vmult_add in linear_operators.h
  has been restricted to test if there is a vmult_add and a Tvmult_add
  method that takes two arguments. This check now also works with

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -533,9 +533,22 @@ TimerOutput::print_summary () const
           out_stream << std::setprecision(3);
           out_stream << i->second.total_cpu_time << "s |";
           out_stream << std::setw(10);
-          out_stream << std::setprecision(2);
           if (total_cpu_time != 0)
-            out_stream << i->second.total_cpu_time/total_cpu_time * 100 << "% |";
+            {
+              // if run time was less than 0.1%, just print a zero to avoid
+              // printing silly things such as "2.45e-6%". otherwise print
+              // the actual percentage
+              const double fraction = i->second.total_cpu_time/total_cpu_time;
+              if (fraction > 0.001)
+                {
+                  out_stream << std::setprecision(2);
+                  out_stream << fraction * 100;
+                }
+              else
+                out_stream << 0.0;
+
+              out_stream << "% |";
+            }
           else
             out_stream << 0.0 << "% |";
         }
@@ -591,11 +604,25 @@ TimerOutput::print_summary () const
           out_stream << std::setprecision(3);
           out_stream << i->second.total_wall_time << "s |";
           out_stream << std::setw(10);
-          out_stream << std::setprecision(2);
-          double value = i->second.total_wall_time/total_wall_time * 100;
-          if (!numbers::is_finite(value))
-            value = 0.0;
-          out_stream << value << "% |";
+
+          if (total_wall_time != 0)
+            {
+              // if run time was less than 0.1%, just print a zero to avoid
+              // printing silly things such as "2.45e-6%". otherwise print
+              // the actual percentage
+              const double fraction = i->second.total_wall_time/total_wall_time;
+              if (fraction > 0.001)
+                {
+                  out_stream << std::setprecision(2);
+                  out_stream << fraction * 100;
+                }
+              else
+                out_stream << 0.0;
+
+              out_stream << "% |";
+            }
+          else
+            out_stream << 0.0 << "% |";
         }
       out_stream << std::endl
                  << "+---------------------------------+-----------+"


### PR DESCRIPTION
Currently, if a TimerOutput section takes a very small fraction of the overall
time, we happily output in the last column that it took 6.5e-4%. This is not
only visually awkward compared to all of the other numbers that are not using
the e-04 notation, but also pretty pointless: nobody cares whether something took
that small a fraction of the overall time, and if they happen to do anyway: the
absolute amount of time is printed in the previous column.

Consequently, show everything that takes less than 0.1% of time as 0%.