### PR TITLE
Make VectorSpaceVector's destructor virtual.

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -168,11 +168,6 @@ namespace LinearAlgebra
                    const MPI_Comm  communicator);
 
       /**
-       * Destructor. Clears memory.
-       */
-      ~BlockVector ();
-
-      /**
        * Copy operator: fill all components of the vector with the given
        * scalar value.
        */

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -147,12 +147,6 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    BlockVector<Number>::~BlockVector ()
-    {}
-
-
-
-    template <typename Number>
     BlockVector<Number> &
     BlockVector<Number>::operator = (const value_type s)
     {

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -87,11 +87,6 @@ namespace LinearAlgebra
     Vector(const InputIterator first, const InputIterator last);
 
     /**
-     * Destructor, deallocates memory.
-     */
-    virtual ~Vector();
-
-    /**
      * Copies the data of the input vector @p in_vector.
      */
     Vector<Number> &operator= (const Vector<Number> &in_vector);
@@ -324,12 +319,6 @@ namespace LinearAlgebra
     this->reinit(complete_index_set(std::distance (first, last)), true);
     std::copy(first, last, this->begin());
   }
-
-
-
-  template <typename Number>
-  inline
-  Vector<Number>::~Vector() {}
 
 
 

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -207,8 +207,25 @@ namespace LinearAlgebra
      * Return the memory consumption of this class in bytes.
      */
     virtual std::size_t memory_consumption() const = 0;
+
+    /**
+     * Destructor. Declared as virtual so that inheriting classes (which may
+     * manage their own memory) are destroyed correctly.
+     */
+    virtual ~VectorSpaceVector();
   };
   /*@}*/
+
+
+
+#ifndef DOXYGEN
+  // TODO we can get rid of this when we require C++11 by using '=default'
+  // above
+  template <typename Number>
+  inline
+  VectorSpaceVector<Number>::~VectorSpaceVector()
+  {}
+#endif // DOXYGEN
 }
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
GCC warns that this destructor should be virtual when `-Wnon-virtual-dtor` is enabled.