### PR TITLE
Add convenience functions to IndexSet

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -218,6 +218,12 @@ public:
   bool is_contiguous () const;
 
   /**
+   * Return whether the index set stored by this object contains no elements.
+   * This is similar, but faster than checking <code>n_elements() == 0</code>.
+   */
+  bool is_empty () const;
+
+  /**
    * Return whether the IndexSets are ascending with respect to MPI process
    * number and 1:1, i.e., each index is contained in exactly one IndexSet
    * (among those stored on the different processes), each process stores
@@ -314,6 +320,18 @@ public:
    * \leftarrow x \backslash o$.
    */
   void subtract_set (const IndexSet &other);
+
+  /**
+   * Removes and returns the last element of the last range.
+   * Throws an exception if the IndexSet is empty.
+   */
+  size_type pop_back ();
+
+  /**
+   * Removes and returns the first element of the first range.
+   * Throws an exception if the IndexSet is empty.
+   */
+  size_type pop_front ();
 
   /**
    * Fills the given vector with all indices contained in this IndexSet.
@@ -1516,6 +1534,14 @@ IndexSet::is_contiguous () const
 {
   compress ();
   return (ranges.size() <= 1);
+}
+
+
+inline
+bool
+IndexSet::is_empty () const
+{
+  return ranges.empty();
 }
 
 

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -341,6 +341,44 @@ IndexSet::subtract_set (const IndexSet &other)
 
 
 
+IndexSet::size_type
+IndexSet::pop_back ()
+{
+  Assert(ranges.size() != 0,
+         ExcMessage("pop_back() failed, because this IndexSet contains no entries."));
+
+  const size_type index = ranges.back().end-1;
+  --ranges.back().end;
+
+  if (ranges.back().begin == ranges.back().end)
+    ranges.pop_back();
+
+  return index;
+}
+
+
+
+IndexSet::size_type
+IndexSet::pop_front ()
+{
+  Assert(ranges.size() != 0,
+         ExcMessage("pop_front() failed, because this IndexSet contains no entries."));
+
+  const size_type index = ranges.front().begin;
+  ++ranges.front().begin;
+
+  if (ranges.front().begin == ranges.front().end)
+    ranges.erase(ranges.begin());
+
+  // We have to set this in any case, because nth_index_in_set is not longer
+  // up to date for all but the first range
+  is_compressed = false;
+
+  return index;
+}
+
+
+
 void
 IndexSet::add_indices(const IndexSet &other,
                       const unsigned int offset)

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -344,7 +344,7 @@ IndexSet::subtract_set (const IndexSet &other)
 IndexSet::size_type
 IndexSet::pop_back ()
 {
-  Assert(ranges.size() != 0,
+  Assert(is_empty() == false,
          ExcMessage("pop_back() failed, because this IndexSet contains no entries."));
 
   const size_type index = ranges.back().end-1;
@@ -361,7 +361,7 @@ IndexSet::pop_back ()
 IndexSet::size_type
 IndexSet::pop_front ()
 {
-  Assert(ranges.size() != 0,
+  Assert(is_empty() == false,
          ExcMessage("pop_front() failed, because this IndexSet contains no entries."));
 
   const size_type index = ranges.front().begin;
@@ -370,7 +370,7 @@ IndexSet::pop_front ()
   if (ranges.front().begin == ranges.front().end)
     ranges.erase(ranges.begin());
 
-  // We have to set this in any case, because nth_index_in_set is not longer
+  // We have to set this in any case, because nth_index_in_set is no longer
   // up to date for all but the first range
   is_compressed = false;
 

--- a/tests/base/index_set_25.cc
+++ b/tests/base/index_set_25.cc
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2010 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check that pop_front() for `IndexSet` works properly
+
+#include "../tests.h"
+#include <fstream>
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/index_set.h>
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  IndexSet is1(10);
+  is1.add_range(0, 2);
+  is1.add_range(5,8);
+
+  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+
+  is1.add_index(1);
+
+  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+}

--- a/tests/base/index_set_25.output
+++ b/tests/base/index_set_25.output
@@ -1,0 +1,6 @@
+
+DEAL::4, 0
+DEAL::3, 1
+DEAL::2, 5
+DEAL::2, 1
+DEAL::1, 6

--- a/tests/base/index_set_26.cc
+++ b/tests/base/index_set_26.cc
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2010 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check that pop_back() for `IndexSet` works properly
+
+#include "../tests.h"
+#include <fstream>
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/index_set.h>
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  IndexSet is1(10);
+  is1.add_range(0, 2);
+  is1.add_range(5,8);
+
+  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+
+  is1.add_index(9);
+
+  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+}

--- a/tests/base/index_set_26.output
+++ b/tests/base/index_set_26.output
@@ -1,0 +1,6 @@
+
+DEAL::4, 7
+DEAL::3, 6
+DEAL::2, 5
+DEAL::2, 9
+DEAL::1, 1


### PR DESCRIPTION
This PR adds a number of convenience functions to the `IndexSet` class, when one is simply interested in getting the first or the last index in the IndexSet and remove it at the same time from the list of indices.

It also allows to quickly check if the IndexSet is empty (much faster than `n_elements() == 0` because it does not need to compress the IndexSet first).