### PR TITLE
Fix some minor documentation errors from #3034

### DIFF
--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -223,7 +223,7 @@ namespace Physics
        * gradient).
        * The result is expressed as
        * @f[
-       *  \mathbf{d} := \frac{1}{2} \left[ \mathbf{l} + \mathbf{l}^{T} \right] \, .
+       *  \mathbf{d} := \frac{1}{2} \left[ \mathbf{l} + \mathbf{l}^{T} \right]
        * @f]
        * where
        * @f[
@@ -246,7 +246,7 @@ namespace Physics
        * gradient).
        * The result is expressed as
        * @f[
-       *  \mathbf{w} := \frac{1}{2} \left[ \mathbf{l} - \mathbf{l}^{T} \right] \, .
+       *  \mathbf{w} := \frac{1}{2} \left[ \mathbf{l} - \mathbf{l}^{T} \right]
        * @f]
        * where
        * @f[

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -212,9 +212,9 @@ namespace Physics
        * as constructed from the deformation gradient tensor @p F.
        * The result performs the following operation:
        * @f[
-       *  \texttt{Dev_P_T} \{ \bullet \} = J^{-2/\textrm{dim}} \left[ \{ \bullet \} -
-       *  \frac{1}{\textrm{dim}} \left[\mathbf{C}^{-1} : \{ \bullet \}\right] \mathbf{C} \right]
-       *  := \hat{\mathcal{P}}^{T} : \{ \bullet \}
+       *  \hat{\mathcal{P}}^{T} : \{ \bullet \}
+       *    = J^{-2/\textrm{dim}} \left[ \{ \bullet \} - \frac{1}{\textrm{dim}} \left[\mathbf{C}^{-1} : \{ \bullet \}\right] \mathbf{C} \right]
+       *    = \texttt{Dev_P_T} \{ \bullet \}
        * @f]
        */
       template <typename Number>

--- a/source/physics/elasticity/standard_tensors.cc
+++ b/source/physics/elasticity/standard_tensors.cc
@@ -18,6 +18,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifndef DOXYGEN
 
 template <int dim>
 const SymmetricTensor<2, dim>
@@ -42,6 +43,7 @@ template <int dim>
 const SymmetricTensor<4, dim>
 Physics::Elasticity::StandardTensors<dim>::dev_P = deviator_tensor<dim>();
 
+#endif // DOXYGEN
 
 // explicit instantiations
 #include "standard_tensors.inst"


### PR DESCRIPTION
Predictably some minor errors were only spotted after a merge! The
biggest point is ensuring that definitions of static members of the
Elasticity::StandardTensors class don't get inlined in their description
as "Initial values".