### PR TITLE
Remove some extra semicolons.

### DIFF
--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -262,8 +262,7 @@ namespace Physics
          const Tensor<2, dim, Number> &dF_dt);
 
 //@}
-    };
-
+    }
   }
 }
 

--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -667,8 +667,7 @@ namespace Physics
                      const Tensor<2,dim,Number> &F);
 
 //@}
-  };
-
+  }
 }
 
 


### PR DESCRIPTION
These semicolons (at ends of namespaces) raise some pedantic warnings for me.