### PR TITLE
Fix a quicktest.

### DIFF
--- a/tests/quick_tests/mpi.cc
+++ b/tests/quick_tests/mpi.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -47,6 +47,14 @@ int main(int argc, char *argv[] )
     err = MPI_Send(&value, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
   else if (myrank==0)
     err = MPI_Recv(&value, 1, MPI_INT, 1, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+  if (err != MPI_SUCCESS)
+    {
+      std::cerr << "MPI_Send/Recv error code = "
+                << err
+                << std::endl;
+      abort ();
+    }
 
   if (myrank==0 && value!=1)
     {


### PR DESCRIPTION
The test assigned MPI return codes to a variable, but then did not do anything with this
variable. We may as well test for errors.