### PR TITLE
Add a mutex to IndexSet and use it to make IndexSet::do_compress() thread-safe.

### DIFF
--- a/doc/news/changes/minor/20161220Bangerth
+++ b/doc/news/changes/minor/20161220Bangerth
@@ -1,0 +1,6 @@
+ <li> Changed: IndexSet::compress() and, by extension, all of the
+ "const" member functions of the IndexSet class, are now thread-safe.
+ <br>
+ (Wolfgang Bangerth, 2016/12/20)
+ </li>
+

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/thread_management.h>
 #include <boost/serialization/vector.hpp>
 #include <vector>
 #include <algorithm>
@@ -852,6 +853,12 @@ private:
    * (ghosts).
    */
   mutable size_type largest_range;
+
+  /**
+   * A mutex that is used to synchronize operations of the do_compress() function
+   * that is called from many 'const' functions via compress().
+   */
+  mutable Threads::Mutex compress_mutex;
 
   /**
    * Actually perform the compress() operation.
@@ -1751,7 +1758,7 @@ IndexSet::print (StreamType &out) const
       else
         out << "[" << p->begin << "," << p->end-1 << "]";
 
-      if (p !=--ranges.end())
+      if (p != --ranges.end())
         out << ", ";
     }
   out << "}" << std::endl;


### PR DESCRIPTION
IndexSet has a number of 'mutable' member variables. The only function that modifies them is
'do_compress', which is called by 'compress', which is in turn called by all of the
'const' member functions. To make all of these 'const' member functions thread-safe, we
need to use a mutex in 'do_compress'. This patch does this.

I have verified that no other 'const' function actually modifies any of the 'mutable'
member variables, so only guarding 'do_compress' by the mutex is sufficient.

Fixes #3681. Passes all IndexSet tests.