### PR TITLE
Fix compilation of documentation.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -68,7 +68,6 @@ INSTALL(FILES
 
 FILE(GLOB _misc
   ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/headers/*.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/news/changes.h
   )
 
 ADD_LIBRARY(doxygen_headers OBJECT ${_misc})

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -158,10 +158,12 @@ file(GLOB _doxygen_depend
 # are captured via a GLOB since they may not exist (and so not
 # be captured via the GLOB) at the time cmake runs
 LIST(APPEND _doxygen_depend
-  ${CMAKE_BINARY_DIR}/doc/news/changes.h
   ${CMAKE_BINARY_DIR}/include/deal.II/base/config.h
   ${CMAKE_CURRENT_BINARY_DIR}/tutorial/tutorial.h
   )
+
+# Add the changelog (a CMake custom target) as a dependency for doxygen too
+LIST(APPEND _doxygen_depend changelog)
 
 # find all tutorial programs so we can add dependencies as appropriate
 FILE(GLOB _deal_ii_steps


### PR DESCRIPTION
Since c60382365dc removed changes.h, we should also update our CMake scripts to not look for build rules that use this (nonexistant) file.

Running `make documentation` currently also installs the documentation. I think that this is unrelated.