### PR TITLE
disable clangs expansion-to-defined warning

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -310,6 +310,7 @@ _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")     \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")  \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")  \
+_Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")     \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \


### PR DESCRIPTION
clang produces many warnings inside boost 1.62 of the following kind:
```
/ssd/deal-git/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp:69:7:
warning: macro expansion producing 'defined' has undefined behavior
[-Wexpansion-to-defined]
#if ! DONT_USE_HAS_NEW_OPERATOR
      ^
/ssd/deal-git/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp:63:12:
note: expanded from macro 'DONT_USE_HAS_NEW_OPERATOR'
        || defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590)   \
           ^
```
So I am adding this to DISABLE_EXTRA_DIAGNOSTICS because we can not fix
boost.