### PR TITLE
fix clang 3.9.1 linker error

### DIFF
--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -176,7 +176,7 @@ namespace LinearAlgebra
     /**
      * Return the mean value of all the entries of this vector.
      */
-    virtual typename VectorSpaceVector<Number>::value_type mean_value() const;
+    virtual value_type mean_value() const;
 
     /**
      * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -283,7 +283,7 @@ namespace LinearAlgebra
 
 
   template <typename Number>
-  typename VectorSpaceVector<Number>::value_type Vector<Number>::mean_value() const
+  typename Vector<Number>::value_type Vector<Number>::mean_value() const
   {
     Assert (this->size(), ExcEmptyObject());
 


### PR DESCRIPTION
clang 3.9.1 complains about

undefined reference to `non-virtual thunk to
dealii::LinearAlgebra::Vector<double>::mean_value() const'

Work around it by using a different typedef for the return value.

fixes #3708