### PR TITLE
Check for include guards

### DIFF
--- a/tests/all-headers/test_header.cc
+++ b/tests/all-headers/test_header.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+//include header twice to see if the include guards are set correctly
+#include HEADER
 #include HEADER
 
 #if !defined(DEAL_II_NAMESPACE_OPEN) && !defined(dealii__revision_h)


### PR DESCRIPTION
As follow-up to #3693 also check that include guards are working for all header files.