### PR TITLE
Change default subdomain id to 0.

### DIFF
--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1419,7 +1419,7 @@ namespace DoFTools
     // If we have a distributed::Triangulation only allow locally_owned
     // subdomain.
     Assert (
-      (dof_handler.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof_handler.get_triangulation().locally_owned_subdomain() == 0)
       ||
       (subdomain == dof_handler.get_triangulation().locally_owned_subdomain()),
       ExcMessage ("For parallel::distributed::Triangulation objects and "

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -70,7 +70,7 @@ namespace DoFTools
     // subdomain. Not setting a subdomain is also okay, because we skip
     // ghost cells in the loop below.
     Assert (
-      (dof.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof.get_triangulation().locally_owned_subdomain() == 0)
       ||
       (subdomain_id == numbers::invalid_subdomain_id)
       ||
@@ -134,7 +134,7 @@ namespace DoFTools
     // subdomain. Not setting a subdomain is also okay, because we skip
     // ghost cells in the loop below.
     Assert (
-      (dof.get_triangulation().locally_owned_subdomain() == numbers::invalid_subdomain_id)
+      (dof.get_triangulation().locally_owned_subdomain() == 0)
       ||
       (subdomain_id == numbers::invalid_subdomain_id)
       ||

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11848,7 +11848,7 @@ template <int dim, int spacedim>
 types::subdomain_id
 Triangulation<dim,spacedim>::locally_owned_subdomain () const
 {
-  return numbers::invalid_subdomain_id;
+  return 0;
 }
 
 


### PR DESCRIPTION
On a serial triangulation, `cell->subdomain_id()` returns 0 on all cells, whereas `Triangulation::locally_owned_subdomain()` returns `numbers::invalid_subdomain_id`. I find this setting inconsistent. In my opinion these two values should be equal. Furthermore, it would be natural to have the subdomain id equal to the rank an MPI process would see in this case, which is 0.

Currently, this PR only only contains the changes necessary to have the testsuite passing. Still open:

- [ ] Update documentation in `tria.h`
- [ ] Remove a few places where we use queries of the kind `subdomain_id == numbers::invalid_subdomain_id || cell->subdomain_id() == subdomain_id` which become more complicated if the two ids are always the same.

Does anyone know about the rationale? Is there any argument against this change? If not, I will go ahead with the remaining issues.