### PR TITLE
Fix undefined order of evaluation.

### DIFF
--- a/tests/base/index_set_25.cc
+++ b/tests/base/index_set_25.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,12 +30,21 @@ int main()
   is1.add_range(0, 2);
   is1.add_range(5,8);
 
-  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_front() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_front() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_front() << std::endl;
+
 
   is1.add_index(1);
 
-  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_front() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_front() << std::endl;
 }

--- a/tests/base/index_set_25.output
+++ b/tests/base/index_set_25.output
@@ -1,6 +1,6 @@
 
-DEAL::4, 0
+DEAL::5, 0
+DEAL::4, 1
+DEAL::3, 5
 DEAL::3, 1
-DEAL::2, 5
-DEAL::2, 1
-DEAL::1, 6
+DEAL::2, 6

--- a/tests/base/index_set_26.cc
+++ b/tests/base/index_set_26.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2015 by the deal.II authors
+// Copyright (C) 2010 - 2016 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -30,12 +30,21 @@ int main()
   is1.add_range(0, 2);
   is1.add_range(5,8);
 
-  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_back() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_back() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_back() << std::endl;
+
 
   is1.add_index(9);
 
-  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
-  deallog << is1.n_elements() << ", " << is1.pop_back() << std::endl;
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_back() << std::endl;
+
+  deallog << is1.n_elements() << ", ";
+  deallog << is1.pop_back() << std::endl;
 }

--- a/tests/base/index_set_26.output
+++ b/tests/base/index_set_26.output
@@ -1,6 +1,6 @@
 
-DEAL::4, 7
-DEAL::3, 6
-DEAL::2, 5
-DEAL::2, 9
-DEAL::1, 1
+DEAL::5, 7
+DEAL::4, 6
+DEAL::3, 5
+DEAL::3, 9
+DEAL::2, 1


### PR DESCRIPTION
Within a sequence such as
  deallog << is1.n_elements() << ", " << is1.pop_front() << std::endl;
the order of calls to 'n_elements()' and 'pop_front()' is undefined. Consequently,
there are two possible correct output files.

Fix this by splitting the line into two complete statements, separated by
a semicolon (which implies a sequence point).

Fixes #3704.