### PR TITLE
use conventional way of calling static method to please nvcc

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -2918,7 +2918,7 @@ namespace Threads
       task->set_ref_count (2);
 
       tbb::task *worker = new (task->allocate_child()) TaskEntryPoint<RT>(*this);
-      task->spawn (*worker);
+      tbb::task::spawn (*worker);
     }
 
 


### PR DESCRIPTION
When compiling CUDA code that includes `deal.II/base/thread_management.h`, such as the graph coloring in `deal.II/base/graph_coloring.h`, `nvcc` gets confused by when we try to access a function which is private in a base class but exported publicly in the subclass using `using`. It is triggered when accessing a static method using a pointer (`b->foo()`) rather than the class name (`Sub::foo()`). This is due to a presumed bug in `nvcc`, see [this question](http://stackoverflow.com/questions/41380602/using-private-method-from-base-in-friend-sub-class-compiler-bug-in-nvcc). I guess this remained from when spawn was a non-static method. This PR replaces the problematic call with a more conventional one.