### PR TITLE
Sort DoFTools functions

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -266,41 +266,6 @@ namespace DoFTools
    */
 
   /**
-   * Take a vector of values which live on cells (e.g. an error per cell) and
-   * distribute it to the dofs in such a way that a finite element field
-   * results, which can then be further processed, e.g. for output. You should
-   * note that the resulting field will not be continuous at hanging nodes.
-   * This can, however, easily be arranged by calling the appropriate @p
-   * distribute function of a ConstraintMatrix object created for this
-   * DoFHandler object, after the vector has been fully assembled.
-   *
-   * It is assumed that the number of elements in @p cell_data equals the
-   * number of active cells and that the number of elements in @p dof_data
-   * equals <tt>dof_handler.n_dofs()</tt>.
-   *
-   * Note that the input vector may be a vector of any data type as long as it
-   * is convertible to @p double.  The output vector, being a data vector on a
-   * DoF handler, always consists of elements of type @p double.
-   *
-   * In case the finite element used by this DoFHandler consists of more than
-   * one component, you need to specify which component in the output vector
-   * should be used to store the finite element field in; the default is zero
-   * (no other value is allowed if the finite element consists only of one
-   * component). All other components of the vector remain untouched, i.e.
-   * their contents are not changed.
-   *
-   * This function cannot be used if the finite element in use has shape
-   * functions that are non-zero in more than one vector component (in deal.II
-   * speak: they are non-primitive).
-   */
-  template <typename DoFHandlerType, typename Number>
-  void
-  distribute_cell_to_dof_vector (const DoFHandlerType  &dof_handler,
-                                 const Vector<Number>  &cell_data,
-                                 Vector<double>        &dof_data,
-                                 const unsigned int     component = 0);
-
-  /**
    * @name Functions to support code that generically uses both DoFHandler and hp::DoFHandler
    * @{
    */
@@ -2265,6 +2230,47 @@ namespace DoFTools
    */
 
   /**
+   * @name Miscellaneous
+   * @{
+   */
+
+  /**
+   * Take a vector of values which live on cells (e.g. an error per cell) and
+   * distribute it to the dofs in such a way that a finite element field
+   * results, which can then be further processed, e.g. for output. You should
+   * note that the resulting field will not be continuous at hanging nodes.
+   * This can, however, easily be arranged by calling the appropriate @p
+   * distribute function of a ConstraintMatrix object created for this
+   * DoFHandler object, after the vector has been fully assembled.
+   *
+   * It is assumed that the number of elements in @p cell_data equals the
+   * number of active cells and that the number of elements in @p dof_data
+   * equals <tt>dof_handler.n_dofs()</tt>.
+   *
+   * Note that the input vector may be a vector of any data type as long as it
+   * is convertible to @p double.  The output vector, being a data vector on a
+   * DoF handler, always consists of elements of type @p double.
+   *
+   * In case the finite element used by this DoFHandler consists of more than
+   * one component, you need to specify which component in the output vector
+   * should be used to store the finite element field in; the default is zero
+   * (no other value is allowed if the finite element consists only of one
+   * component). All other components of the vector remain untouched, i.e.
+   * their contents are not changed.
+   *
+   * This function cannot be used if the finite element in use has shape
+   * functions that are non-zero in more than one vector component (in deal.II
+   * speak: they are non-primitive).
+   */
+  template <typename DoFHandlerType, typename Number>
+  void
+  distribute_cell_to_dof_vector (const DoFHandlerType  &dof_handler,
+                                 const Vector<Number>  &cell_data,
+                                 Vector<double>        &dof_data,
+                                 const unsigned int     component = 0);
+
+
+  /**
    * Generate text output readable by gnuplot with point data based on the
    * given map @p support_points.  For each support point location, a string
    * label containing a list of all DoFs from the map is generated.  The map
@@ -2359,6 +2365,8 @@ namespace DoFTools
                                   const ComponentMask                &component_mask = ComponentMask());
 
   /**
+   * @}
+   */
 
   /**
    * @name Exceptions

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2120,6 +2120,11 @@ namespace DoFTools
    */
 
   /**
+   * @name Functions that return different DoF mappings
+   * @{
+   */
+
+  /**
    * Create a mapping from degree of freedom indices to the index of that
    * degree of freedom on the boundary. After this operation,
    * <tt>mapping[dof]</tt> gives the index of the degree of freedom with
@@ -2255,6 +2260,9 @@ namespace DoFTools
   (const Mapping<DoFHandlerType::dimension, DoFHandlerType::space_dimension>       &mapping,
    const DoFHandlerType                                                            &dof_handler,
    std::map<Point<DoFHandlerType::space_dimension>, types::global_dof_index, Comp> &point_to_index_map);
+  /**
+   * @}
+   */
 
   /**
    * Generate text output readable by gnuplot with point data based on the

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2359,6 +2359,13 @@ namespace DoFTools
                                   const ComponentMask                &component_mask = ComponentMask());
 
   /**
+
+  /**
+   * @name Exceptions
+   * @{
+   */
+
+  /**
    * @todo Write description
    *
    * @ingroup Exceptions
@@ -2390,6 +2397,9 @@ namespace DoFTools
    * @ingroup Exceptions
    */
   DeclException0 (ExcInvalidBoundaryIndicator);
+  /**
+   * @}
+   */
 }
 
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -175,6 +175,7 @@ namespace GridTools
  */
 namespace DoFTools
 {
+
   /**
    * The flags used in tables by certain <tt>make_*_pattern</tt> functions to
    * describe whether two components of the solution couple in the bilinear
@@ -203,6 +204,66 @@ namespace DoFTools
      */
     nonzero
   };
+
+  /**
+   * @name DoF couplings
+   * @{
+   */
+
+  /**
+   * Map a coupling table from the user friendly organization by components to
+   * the organization by blocks. Specializations of this function for
+   * DoFHandler and hp::DoFHandler are required due to the different results
+   * of their finite element access.
+   *
+   * The return vector will be initialized to the correct length inside this
+   * function.
+   */
+  template <int dim, int spacedim>
+  void
+  convert_couplings_to_blocks (const hp::DoFHandler<dim,spacedim> &dof_handler,
+                               const Table<2, Coupling> &table_by_component,
+                               std::vector<Table<2,Coupling> > &tables_by_block);
+
+  /**
+   * Map a coupling table from the user friendly organization by components to
+   * the organization by blocks. Specializations of this function for
+   * DoFHandler and hp::DoFHandler are required due to the different results
+   * of their finite element access.
+   *
+   * The return vector will be initialized to the correct length inside this
+   * function.
+   */
+  template <int dim, int spacedim>
+  void
+  convert_couplings_to_blocks (const DoFHandler<dim,spacedim> &dof_handler,
+                               const Table<2, Coupling> &table_by_component,
+                               std::vector<Table<2,Coupling> > &tables_by_block);
+
+  /**
+   * Given a finite element and a table how the vector components of it couple
+   * with each other, compute and return a table that describes how the
+   * individual shape functions couple with each other.
+   */
+  template <int dim, int spacedim>
+  Table<2,Coupling>
+  dof_couplings_from_component_couplings (const FiniteElement<dim,spacedim> &fe,
+                                          const Table<2,Coupling> &component_couplings);
+
+  /**
+   * Same function as above for a collection of finite elements, returning a
+   * collection of tables.
+   *
+   * The function currently treats DoFTools::Couplings::nonzero the same as
+   * DoFTools::Couplings::always .
+   */
+  template <int dim, int spacedim>
+  std::vector<Table<2,Coupling> >
+  dof_couplings_from_component_couplings (const hp::FECollection<dim,spacedim> &fe,
+                                          const Table<2,Coupling> &component_couplings);
+  /**
+   * @}
+   */
 
   /**
    * Take a vector of values which live on cells (e.g. an error per cell) and
@@ -2227,21 +2288,6 @@ namespace DoFTools
 
 
   /**
-   * Map a coupling table from the user friendly organization by components to
-   * the organization by blocks. Specializations of this function for
-   * DoFHandler and hp::DoFHandler are required due to the different results
-   * of their finite element access.
-   *
-   * The return vector will be initialized to the correct length inside this
-   * function.
-   */
-  template <int dim, int spacedim>
-  void
-  convert_couplings_to_blocks (const hp::DoFHandler<dim,spacedim> &dof_handler,
-                               const Table<2, Coupling> &table_by_component,
-                               std::vector<Table<2,Coupling> > &tables_by_block);
-
-  /**
    * Make a constraint matrix for the constraints that result from zero
    * boundary values on the given boundary indicator.
    *
@@ -2304,43 +2350,6 @@ namespace DoFTools
                                   ConstraintMatrix                   &zero_boundary_constraints,
                                   const ComponentMask                &component_mask = ComponentMask());
 
-
-  /**
-   * Map a coupling table from the user friendly organization by components to
-   * the organization by blocks. Specializations of this function for
-   * DoFHandler and hp::DoFHandler are required due to the different results
-   * of their finite element access.
-   *
-   * The return vector will be initialized to the correct length inside this
-   * function.
-   */
-  template <int dim, int spacedim>
-  void
-  convert_couplings_to_blocks (const DoFHandler<dim,spacedim> &dof_handler,
-                               const Table<2, Coupling> &table_by_component,
-                               std::vector<Table<2,Coupling> > &tables_by_block);
-
-  /**
-   * Given a finite element and a table how the vector components of it couple
-   * with each other, compute and return a table that describes how the
-   * individual shape functions couple with each other.
-   */
-  template <int dim, int spacedim>
-  Table<2,Coupling>
-  dof_couplings_from_component_couplings (const FiniteElement<dim,spacedim> &fe,
-                                          const Table<2,Coupling> &component_couplings);
-
-  /**
-   * Same function as above for a collection of finite elements, returning a
-   * collection of tables.
-   *
-   * The function currently treats DoFTools::Couplings::nonzero the same as
-   * DoFTools::Couplings::always .
-   */
-  template <int dim, int spacedim>
-  std::vector<Table<2,Coupling> >
-  dof_couplings_from_component_couplings (const hp::FECollection<dim,spacedim> &fe,
-                                          const Table<2,Coupling> &component_couplings);
   /**
    * @todo Write description
    *


### PR DESCRIPTION
This PR fixes the issues pointed out by @jppelteret in #3056 and categorizes the rest of the functions in `DoFTools` into a few distinct groups.

Closes #3056.