### PR TITLE
Silence unused typedef warnings

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -158,6 +158,13 @@ IF (CMAKE_BUILD_TYPE MATCHES "Release")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-funroll-loops")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-funroll-all-loops")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-fstrict-aliasing")
+
+  #
+  # There are many places in the library where we create a new typedef and then
+  # immediately use it in an Assert. Hence, only ignore unused typedefs in Release
+  # mode.
+  #
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-Wno-unused-local-typedefs")
 ENDIF()
 
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -3203,11 +3203,10 @@ namespace FEValuesViews
   Scalar<dim,spacedim>::value (const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            ((typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values"))));
 
     // an adaptation of the FEValuesBase::shape_value_component function
     // except that here we know the component as fixed and we have
@@ -3229,11 +3228,10 @@ namespace FEValuesViews
   Scalar<dim,spacedim>::gradient (const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     // an adaptation of the
     // FEValuesBase::shape_grad_component
@@ -3256,11 +3254,10 @@ namespace FEValuesViews
   Scalar<dim,spacedim>::hessian (const unsigned int shape_function,
                                  const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
 
     // an adaptation of the
     // FEValuesBase::shape_hessian_component
@@ -3282,11 +3279,10 @@ namespace FEValuesViews
   Scalar<dim,spacedim>::third_derivative (const unsigned int shape_function,
                                           const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_3rd_derivatives,
-            typename FVB::ExcAccessToUninitializedField("update_3rd_derivatives"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_3rd_derivatives")));
 
     // an adaptation of the
     // FEValuesBase::shape_3rdderivative_component
@@ -3308,11 +3304,10 @@ namespace FEValuesViews
   Vector<dim,spacedim>::value (const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3346,11 +3341,10 @@ namespace FEValuesViews
   Vector<dim,spacedim>::gradient (const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3386,11 +3380,10 @@ namespace FEValuesViews
   {
     // this function works like in
     // the case above
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3420,12 +3413,11 @@ namespace FEValuesViews
   Vector<dim,spacedim>::curl (const unsigned int shape_function, const unsigned int q_point) const
   {
     // this function works like in the case above
-    typedef FEValuesBase<dim,spacedim> FVB;
 
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     // same as for the scalar case except that we have one more index
     const int snc = shape_function_data[shape_function].single_nonzero_component;
 
@@ -3559,11 +3551,10 @@ namespace FEValuesViews
   {
     // this function works like in
     // the case above
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3597,11 +3588,10 @@ namespace FEValuesViews
   {
     // this function works like in
     // the case above
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_3rd_derivatives,
-            typename FVB::ExcAccessToUninitializedField("update_3rd_derivatives"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_3rd_derivatives")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3711,11 +3701,10 @@ namespace FEValuesViews
   Vector<dim,spacedim>::symmetric_gradient (const unsigned int shape_function,
                                             const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     // same as for the scalar case except
     // that we have one more index
@@ -3745,11 +3734,10 @@ namespace FEValuesViews
   SymmetricTensor<2, dim, spacedim>::value (const unsigned int shape_function,
                                             const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
 
     // similar to the vector case where we
     // have more then one index and we need
@@ -3792,11 +3780,10 @@ namespace FEValuesViews
   SymmetricTensor<2, dim, spacedim>::divergence(const unsigned int shape_function,
                                                 const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     const int snc = shape_function_data[shape_function].single_nonzero_component;
 
@@ -3882,11 +3869,10 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::value (const unsigned int shape_function,
                                    const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
 
     // similar to the vector case where we
     // have more then one index and we need
@@ -3932,11 +3918,10 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::divergence(const unsigned int shape_function,
                                        const unsigned int q_point) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (shape_function < fe_values->fe->dofs_per_cell,
             ExcIndexRange (shape_function, 0, fe_values->fe->dofs_per_cell));
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
 
     const int snc = shape_function_data[shape_function].single_nonzero_component;
 
@@ -4601,9 +4586,8 @@ inline
 const Tensor<1,spacedim> &
 FEValuesBase<dim,spacedim>::normal_vector (const unsigned int i) const
 {
-  typedef FEValuesBase<dim,spacedim> FVB;
   Assert (this->update_flags & update_normal_vectors,
-          typename FVB::ExcAccessToUninitializedField("update_normal_vectors"));
+          (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_normal_vectors")));
   Assert (i<this->mapping_output.normal_vectors.size(),
           ExcIndexRange(i, 0, this->mapping_output.normal_vectors.size()));
 
@@ -4683,11 +4667,10 @@ inline
 const Tensor<1,spacedim> &
 FEFaceValuesBase<dim,spacedim>::boundary_form (const unsigned int i) const
 {
-  typedef FEValuesBase<dim,spacedim> FVB;
   Assert (i<this->mapping_output.boundary_forms.size(),
           ExcIndexRange(i, 0, this->mapping_output.boundary_forms.size()));
   Assert (this->update_flags & update_boundary_forms,
-          typename FVB::ExcAccessToUninitializedField("update_boundary_forms"));
+          (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_boundary_forms")));
 
   return this->mapping_output.boundary_forms[i];
 }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1269,9 +1269,8 @@ namespace FEValuesViews
   get_function_values (const InputVector &fe_function,
                        std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1293,9 +1292,8 @@ namespace FEValuesViews
   get_function_gradients (const InputVector &fe_function,
                           std::vector<typename ProductType<gradient_type,typename InputVector::value_type>::type> &gradients) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1317,9 +1315,8 @@ namespace FEValuesViews
   get_function_hessians (const InputVector &fe_function,
                          std::vector<typename ProductType<hessian_type,typename InputVector::value_type>::type> &hessians) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1341,9 +1338,8 @@ namespace FEValuesViews
   get_function_laplacians (const InputVector &fe_function,
                            std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &laplacians) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1365,9 +1361,8 @@ namespace FEValuesViews
   get_function_third_derivatives (const InputVector &fe_function,
                                   std::vector<typename ProductType<third_derivative_type,typename InputVector::value_type>::type> &third_derivatives) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_3rd_derivatives,
-            typename FVB::ExcAccessToUninitializedField("update_3rd_derivatives"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_3rd_derivatives")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1389,9 +1384,8 @@ namespace FEValuesViews
   get_function_values (const InputVector &fe_function,
                        std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_values,
-            typename FVB::ExcAccessToUninitializedField("update_values"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1414,9 +1408,8 @@ namespace FEValuesViews
   get_function_gradients (const InputVector &fe_function,
                           std::vector<typename ProductType<gradient_type,typename InputVector::value_type>::type> &gradients) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1438,9 +1431,8 @@ namespace FEValuesViews
   get_function_symmetric_gradients (const InputVector &fe_function,
                                     std::vector<typename ProductType<symmetric_gradient_type,typename InputVector::value_type>::type> &symmetric_gradients) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1463,9 +1455,8 @@ namespace FEValuesViews
   get_function_divergences (const InputVector &fe_function,
                             std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1486,10 +1477,8 @@ namespace FEValuesViews
   get_function_curls (const InputVector &fe_function,
                       std::vector<typename ProductType<curl_type,typename InputVector::value_type>::type> &curls) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
-
     Assert (fe_values->update_flags & update_gradients,
-            typename FVB::ExcAccessToUninitializedField("update_gradients"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert (fe_values->present_cell.get () != 0,
             ExcMessage ("FEValues object is not reinited to any cell"));
     AssertDimension (fe_function.size (),
@@ -1510,9 +1499,8 @@ namespace FEValuesViews
   get_function_hessians (const InputVector &fe_function,
                          std::vector<typename ProductType<hessian_type,typename InputVector::value_type>::type> &hessians) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1534,9 +1522,8 @@ namespace FEValuesViews
   get_function_laplacians (const InputVector &fe_function,
                            std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &laplacians) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_hessians,
-            typename FVB::ExcAccessToUninitializedField("update_hessians"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_hessians")));
     Assert (laplacians.size() == fe_values->n_quadrature_points,
             ExcDimensionMismatch(laplacians.size(), fe_values->n_quadrature_points));
     Assert (fe_values->present_cell.get() != 0,
@@ -1560,9 +1547,8 @@ namespace FEValuesViews
   get_function_third_derivatives (const InputVector &fe_function,
                                   std::vector<typename ProductType<third_derivative_type,typename InputVector::value_type>::type> &third_derivatives) const
   {
-    typedef FEValuesBase<dim,spacedim> FVB;
     Assert (fe_values->update_flags & update_3rd_derivatives,
-            typename FVB::ExcAccessToUninitializedField("update_3rd_derivatives"));
+            (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_3rd_derivatives")));
     Assert (fe_values->present_cell.get() != 0,
             ExcMessage ("FEValues object is not reinit'ed to any cell"));
     AssertDimension (fe_function.size(),
@@ -1584,9 +1570,8 @@ namespace FEValuesViews
   get_function_values(const InputVector &fe_function,
                       std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
-    typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values->update_flags & update_values,
-           typename FVB::ExcAccessToUninitializedField("update_values"));
+           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
     Assert(fe_values->present_cell.get() != 0,
            ExcMessage("FEValues object is not reinit'ed to any cell"));
     AssertDimension(fe_function.size(),
@@ -1608,9 +1593,8 @@ namespace FEValuesViews
   get_function_divergences(const InputVector &fe_function,
                            std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
-    typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values->update_flags & update_gradients,
-           typename FVB::ExcAccessToUninitializedField("update_gradients"));
+           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert(fe_values->present_cell.get() != 0,
            ExcMessage("FEValues object is not reinit'ed to any cell"));
     AssertDimension(fe_function.size(),
@@ -1631,9 +1615,8 @@ namespace FEValuesViews
   get_function_values(const InputVector &fe_function,
                       std::vector<typename ProductType<value_type,typename InputVector::value_type>::type> &values) const
   {
-    typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values->update_flags & update_values,
-           typename FVB::ExcAccessToUninitializedField("update_values"));
+           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_values")));
     Assert(fe_values->present_cell.get() != 0,
            ExcMessage("FEValues object is not reinit'ed to any cell"));
     AssertDimension(fe_function.size(),
@@ -1655,9 +1638,8 @@ namespace FEValuesViews
   get_function_divergences(const InputVector &fe_function,
                            std::vector<typename ProductType<divergence_type,typename InputVector::value_type>::type> &divergences) const
   {
-    typedef FEValuesBase<dim, spacedim> FVB;
     Assert(fe_values->update_flags & update_gradients,
-           typename FVB::ExcAccessToUninitializedField("update_gradients"));
+           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_gradients")));
     Assert(fe_values->present_cell.get() != 0,
            ExcMessage("FEValues object is not reinit'ed to any cell"));
     AssertDimension(fe_function.size(),
@@ -3389,9 +3371,8 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1,spacedim> > &
 FEValuesBase<dim,spacedim>::get_all_normal_vectors () const
 {
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (this->update_flags & update_normal_vectors,
-          typename FEVB::ExcAccessToUninitializedField("update_normal_vectors"));
+          (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_normal_vectors")));
   return this->mapping_output.normal_vectors;
 }
 
@@ -3401,9 +3382,8 @@ template <int dim, int spacedim>
 std::vector<Point<spacedim> >
 FEValuesBase<dim,spacedim>::get_normal_vectors () const
 {
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (this->update_flags & update_normal_vectors,
-          typename FEVB::ExcAccessToUninitializedField("update_normal_vectors"));
+          (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_normal_vectors")));
 
   // copy things into a vector of Points, then return that
   std::vector<Point<spacedim> > tmp (this->mapping_output.normal_vectors.size());
@@ -3641,10 +3621,9 @@ FEValues<dim,spacedim>::initialize (const UpdateFlags update_flags)
   // You can compute normal vectors
   // to the cells only in the
   // codimension one case.
-  typedef FEValuesBase<dim,spacedim> FEVB;
   if (dim != spacedim-1)
     Assert ((update_flags & update_normal_vectors) == false,
-            typename FEVB::ExcInvalidUpdateFlag());
+            (typename FEValuesBase<dim,spacedim>::ExcInvalidUpdateFlag()));
 
   const UpdateFlags flags = this->compute_update_flags (update_flags);
 
@@ -3744,10 +3723,9 @@ FEValues<dim,spacedim>::reinit
   // passed to the constructor and
   // used by the DoFHandler used by
   // this cell, are the same
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
           static_cast<const FiniteElementData<dim>&>(cell->get_fe()),
-          typename FEVB::ExcFEDontMatch());
+          (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
 
   this->maybe_invalidate_previous_present_cell (cell);
   this->check_cell_similarity(cell);
@@ -3835,9 +3813,8 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1,spacedim> > &
 FEFaceValuesBase<dim,spacedim>::get_boundary_forms () const
 {
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (this->update_flags & update_boundary_forms,
-          typename FEVB::ExcAccessToUninitializedField("update_boundary_forms"));
+          (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_boundary_forms")));
   return this->mapping_output.boundary_forms;
 }
 
@@ -3945,11 +3922,10 @@ FEFaceValues<dim,spacedim>::reinit
   // passed to the constructor and
   // used by the DoFHandler used by
   // this cell, are the same
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
           static_cast<const FiniteElementData<dim>&>(
             cell->get_dof_handler().get_fe()[cell->active_fe_index ()]),
-          typename FEVB::ExcFEDontMatch());
+          (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
 
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));
@@ -4113,11 +4089,10 @@ void FESubfaceValues<dim,spacedim>::reinit
   // passed to the constructor and
   // used by the hp::DoFHandler used by
   // this cell, are the same
-  typedef FEValuesBase<dim,spacedim> FEVB;
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
           static_cast<const FiniteElementData<dim>&>(
             cell->get_dof_handler().get_fe()[cell->active_fe_index ()]),
-          typename FEVB::ExcFEDontMatch());
+          (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));
   // We would like to check for


### PR DESCRIPTION
It looks like both GCC and Clang will accept `-Wno-unused-local-typedefs`, so I turned this flag on in release mode. As noted in #1754 these typedefs just show up in assertions so this is not a problem in debug mode.

While looking into this I went ahead and got rid of all of the one-use typedefs just to clean things up a bit.

Closes #1754.

Edit: grammar