### PR TITLE
make an Assert in LA::distributed::Vector::compress_finish() less rigid

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -680,7 +680,7 @@ namespace LinearAlgebra
                    j++, read_position++)
                 Assert(*read_position == Number() ||
                        std::abs(local_element(j) - *read_position) <=
-                       std::abs(local_element(j)) * 1000. *
+                       std::abs(local_element(j)) * 10000. *
                        std::numeric_limits<real_type>::epsilon(),
                        ExcNonMatchingElements(*read_position, local_element(j),
                                               part.this_mpi_process()));


### PR DESCRIPTION
Otherwise p::d::SolutionTransfer::interpolate() could trigger the
Assert presumably due to round-off errors in certain scenarios.

Fixes the issue discussed in https://groups.google.com/d/topic/dealii/RHw7hhCM2z8/discussion where `2.059635156599626e-06 != 2.059635156600494e-06` with the difference of `-0.000000000000868e-06`.

p.s. i don't have a unit test for that.