### PR TITLE
Cppcheck 2

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -639,12 +639,11 @@ void pack_cell_data
 
   const std::vector<std::shared_ptr<const DataType> > qpd = data_storage->get_data(cell);
 
-  const unsigned int m = matrix_data.m();
   const unsigned int n = matrix_data.n();
 
   std::vector<double> single_qp_data(n);
-  Assert (qpd.size() == m,
-          ExcDimensionMismatch(qpd.size(),m));
+  Assert (qpd.size() == matrix_data.m(),
+          ExcDimensionMismatch(qpd.size(), matrix_data.m()));
   for (unsigned int q = 0; q < qpd.size(); q++)
     {
       qpd[q]->pack_values(single_qp_data);
@@ -673,12 +672,11 @@ void unpack_to_cell_data
 
   std::vector<std::shared_ptr<DataType> > qpd = data_storage->get_data(cell);
 
-  const unsigned int m = values_at_qp.m();
   const unsigned int n = values_at_qp.n();
 
   std::vector<double> single_qp_data(n);
-  Assert(qpd.size() == m,
-         ExcDimensionMismatch(qpd.size(),m));
+  Assert(qpd.size() == values_at_qp.m(),
+         ExcDimensionMismatch(qpd.size(), values_at_qp.m()));
 
   for (unsigned int q = 0; q < qpd.size(); q++)
     {

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -312,11 +312,6 @@ namespace internal
                 const TableIndices<rank> &previous_indices);
 
       /**
-       * Default constructor. Not needed, and invisible, so private.
-       */
-      Accessor ();
-
-      /**
        * Copy constructor. Not needed, and invisible, so private.
        */
       Accessor (const Accessor &a);
@@ -844,17 +839,6 @@ namespace internal
   {
     template <int rank, int dim, bool constness, int P, typename Number>
     Accessor<rank,dim,constness,P,Number>::
-    Accessor ()
-      :
-      tensor (*static_cast<tensor_type *>(0)),
-      previous_indices ()
-    {
-      Assert (false, ExcMessage ("You can't call the default constructor of this class."));
-    }
-
-
-    template <int rank, int dim, bool constness, int P, typename Number>
-    Accessor<rank,dim,constness,P,Number>::
     Accessor (tensor_type              &tensor,
               const TableIndices<rank> &previous_indices)
       :
@@ -879,18 +863,6 @@ namespace internal
     {
       return Accessor<rank,dim,constness,P-1,Number> (tensor,
                                                       merge (previous_indices, i, rank-P));
-    }
-
-
-
-    template <int rank, int dim, bool constness, typename Number>
-    Accessor<rank,dim,constness,1,Number>::
-    Accessor ()
-      :
-      tensor (*static_cast<tensor_type *>(0)),
-      previous_indices ()
-    {
-      Assert (false, ExcMessage ("You can't call the default constructor of this class."));
     }
 
 
@@ -922,8 +894,6 @@ namespace internal
     {
       return tensor(merge (previous_indices, i, rank-1));
     }
-
-
   }
 }
 

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -49,12 +49,6 @@ class TensorProductPolynomialsBubbles : public TensorProductPolynomials<dim>
 {
 public:
   /**
-   * Access to the dimension of this object, for checking and automatic
-   * setting of dimension in other classes.
-   */
-  static const unsigned int dimension = dim;
-
-  /**
    * Constructor. <tt>pols</tt> is a vector of objects that should be derived
    * or otherwise convertible to one-dimensional polynomial objects. It will
    * be copied element by element into a private variable.

--- a/include/deal.II/integrators/maxwell.h
+++ b/include/deal.II/integrators/maxwell.h
@@ -225,11 +225,12 @@ namespace LocalIntegrators
       const FEValuesBase<dim> &fetest,
       double factor = 1.)
     {
-      unsigned int t_comp = (dim==3) ? dim : 1;
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
       AssertDimension(fe.get_fe().n_components(), dim);
-      AssertDimension(fetest.get_fe().n_components(), t_comp);
+      // There should be the right number of components (3 in 3D, otherwise 1)
+      // for the curl.
+      AssertDimension(fetest.get_fe().n_components(), (dim == 3) ? dim : 1);
       AssertDimension(M.m(), t_dofs);
       AssertDimension(M.n(), n_dofs);
 

--- a/include/deal.II/lac/iterative_inverse.h
+++ b/include/deal.II/lac/iterative_inverse.h
@@ -129,10 +129,9 @@ inline
 void
 IterativeInverse<VectorType>::initialize(const MatrixType &m, const PreconditionerType &p)
 {
-  // dummy variable
-  VectorType *v = 0;
-  matrix = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(m, *v));
-  preconditioner = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(p, *v));
+  VectorType v;
+  matrix = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(m, v));
+  preconditioner = std_cxx11::shared_ptr<PointerMatrixBase<VectorType> > (new_pointer_matrix_base(p, v));
 }
 
 

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -449,12 +449,12 @@ SolverCG<VectorType>::solve (const MatrixType         &A,
   // Should we build the matrix for
   // eigenvalue computations?
   const bool do_eigenvalues = !condition_number_signal.empty()
-                              |!all_condition_numbers_signal.empty()
-                              |!eigenvalues_signal.empty()
-                              |!all_eigenvalues_signal.empty()
-                              | additional_data.compute_condition_number
-                              | additional_data.compute_all_condition_numbers
-                              | additional_data.compute_eigenvalues;
+                              ||!all_condition_numbers_signal.empty()
+                              ||!eigenvalues_signal.empty()
+                              ||!all_eigenvalues_signal.empty()
+                              || additional_data.compute_condition_number
+                              || additional_data.compute_all_condition_numbers
+                              || additional_data.compute_eigenvalues;
 
   // vectors used for eigenvalue
   // computations

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -833,12 +833,12 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
 
   const bool do_eigenvalues=
     !condition_number_signal.empty()
-    |!all_condition_numbers_signal.empty()
-    |!eigenvalues_signal.empty()
-    |!all_eigenvalues_signal.empty()
-    |!hessenberg_signal.empty()
-    |!all_hessenberg_signal.empty()
-    |additional_data.compute_eigenvalues;
+    ||!all_condition_numbers_signal.empty()
+    ||!eigenvalues_signal.empty()
+    ||!all_eigenvalues_signal.empty()
+    ||!hessenberg_signal.empty()
+    ||!all_hessenberg_signal.empty()
+    ||additional_data.compute_eigenvalues;
   // for eigenvalue computation, need to collect the Hessenberg matrix (before
   // applying Givens rotations)
   FullMatrix<double> H_orig;

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -245,9 +245,9 @@ namespace internal
           std::vector<std_cxx11::shared_ptr<dealii::FEValues<dim> > >
           fe_values (current_data.quadrature.size());
           UpdateFlags update_flags_feval =
-            (update_flags & update_inverse_jacobians ? update_jacobians : update_default) |
-            (update_flags & update_jacobian_grads ? update_jacobian_grads : update_default) |
-            (update_flags & update_quadrature_points ? update_quadrature_points : update_default);
+            ((update_flags & update_inverse_jacobians) ? update_jacobians : update_default) |
+            ((update_flags & update_jacobian_grads) ? update_jacobian_grads : update_default) |
+            ((update_flags & update_quadrature_points) ? update_quadrature_points : update_default);
 
           // resize the fields that have fixed size or for which we know
           // something from an earlier loop

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -293,9 +293,9 @@ fill_fe_values (const typename Triangulation<dim,spacedim>::cell_iterator &,
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values((fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads((fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads((fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 
@@ -339,9 +339,9 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values((fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads((fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads((fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 
@@ -386,9 +386,9 @@ fill_fe_subface_values (const typename Triangulation<dim,spacedim>::cell_iterato
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(fe_internal.update_each & update_values ? this->dofs_per_cell : 0);
-  std::vector<Tensor<1,dim> > grads(fe_internal.update_each & update_gradients ? this->dofs_per_cell : 0);
-  std::vector<Tensor<2,dim> > grad_grads(fe_internal.update_each & update_hessians ? this->dofs_per_cell : 0);
+  std::vector<double> values((fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<1,dim> > grads((fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+  std::vector<Tensor<2,dim> > grad_grads((fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
   std::vector<Tensor<3,dim> > empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4,dim> > empty_vector_of_4th_order_tensors;
 


### PR DESCRIPTION
This is the follow up to #3729. These two PRs fix the majority of complaints that cppcheck raises (cppcheck does not like single argument constructors that are not `explicit`: we have hundreds of those and I don't think they are worth fixing).