### PR TITLE
Work around OpenMPI problem in mpi_exceptions

### DIFF
--- a/tests/base/mpi_exceptions.mpirun=1.output
+++ b/tests/base/mpi_exceptions.mpirun=1.output
@@ -57,5 +57,5 @@ The description of the error provided by MPI is "MPI_ERR_INTERN: internal error"
 The numerical value of the original error code is 17.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "MPI_ERR_UNKNOWN: unknown error".
+This error code is not equal to any of the standard MPI error codes.
 The numerical value of the original error code is 92.

--- a/tests/base/mpi_exceptions.mpirun=1.output.mpich3-2
+++ b/tests/base/mpi_exceptions.mpirun=1.output.mpich3-2
@@ -25,7 +25,7 @@ The description of the error provided by MPI is "Invalid rank".
 The numerical value of the original error code is 6.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid MPI_Request".
+The description of the error provided by MPI is "Request pending due to failure".
 The numerical value of the original error code is 19.
 DEAL::
 deal.II encountered an error while calling an MPI function.

--- a/tests/base/mpi_exceptions.mpirun=1.output.openmpi1-6-5
+++ b/tests/base/mpi_exceptions.mpirun=1.output.openmpi1-6-5
@@ -1,61 +1,61 @@
 
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid buffer pointer".
+The description of the error provided by MPI is "MPI_ERR_BUFFER: invalid buffer pointer".
 The numerical value of the original error code is 1.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid count".
+The description of the error provided by MPI is "MPI_ERR_COUNT: invalid count argument".
 The numerical value of the original error code is 2.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid datatype".
+The description of the error provided by MPI is "MPI_ERR_TYPE: invalid datatype".
 The numerical value of the original error code is 3.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid tag".
+The description of the error provided by MPI is "MPI_ERR_TAG: invalid tag".
 The numerical value of the original error code is 4.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid communicator".
+The description of the error provided by MPI is "MPI_ERR_COMM: invalid communicator".
 The numerical value of the original error code is 5.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid rank".
+The description of the error provided by MPI is "MPI_ERR_RANK: invalid rank".
 The numerical value of the original error code is 6.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid MPI_Request".
-The numerical value of the original error code is 19.
-DEAL::
-deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid root".
+The description of the error provided by MPI is "MPI_ERR_REQUEST: invalid request".
 The numerical value of the original error code is 7.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid group".
+The description of the error provided by MPI is "MPI_ERR_ROOT: invalid root".
 The numerical value of the original error code is 8.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid MPI_Op".
+The description of the error provided by MPI is "MPI_ERR_GROUP: invalid group".
 The numerical value of the original error code is 9.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Invalid topology".
+The description of the error provided by MPI is "MPI_ERR_OP: invalid reduce operation".
 The numerical value of the original error code is 10.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Unknown error.  Please file a bug report.".
-The numerical value of the original error code is 13.
+The description of the error provided by MPI is "MPI_ERR_TOPOLOGY: invalid communicator topology".
+The numerical value of the original error code is 11.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Other MPI error".
-The numerical value of the original error code is 15.
+The description of the error provided by MPI is "MPI_ERR_UNKNOWN: unknown error".
+The numerical value of the original error code is 14.
 DEAL::
 deal.II encountered an error while calling an MPI function.
-The description of the error provided by MPI is "Internal MPI error!".
+The description of the error provided by MPI is "MPI_ERR_OTHER: known error not in list".
 The numerical value of the original error code is 16.
 DEAL::
 deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_INTERN: internal error".
+The numerical value of the original error code is 17.
+DEAL::
+deal.II encountered an error while calling an MPI function.
 This error code is not equal to any of the standard MPI error codes.
-The numerical value of the original error code is 1073741823.
+The numerical value of the original error code is 54.


### PR DESCRIPTION
`mpi_exceptions` failed for OpenMPI 1.6.5 due to `MPI_error_class` throwing for `MPI_ERR_LASTCODE` with `MPI_ERR_ARG`. This PR aims to work around this by treating `error_code>=MPI_ERR_LASTCODE` special.