### PR TITLE
Fix and enable compression of hp DoF indices.

### DIFF
--- a/doc/news/changes/minor/20170106Bangerth
+++ b/doc/news/changes/minor/20170106Bangerth
@@ -1,0 +1,4 @@
+New: hp::DoFHandler now uses a compressed data structure for its
+internal representation of DoF indices. This saves memory.
+<br>
+(Wolfgang Bangerth, 2017/01/06)

--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2016 by the deal.II authors
+// Copyright (C) 2003 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,6 +118,25 @@ namespace internal
        * index. We use this in computing binary complements.
        */
       typedef signed short int signed_active_fe_index_type;
+
+      /**
+       * Given an active_fe_index, return whether the corresponding
+       * set of DoF indices are compressed. See the general documentation
+       * of this class for a description of when this is the case.
+       */
+      static
+      bool
+      is_compressed_entry (const active_fe_index_type active_fe_index);
+
+      /**
+       * Given an active_fe_index (either corresponding to an uncompressed
+       * or compressed state), return the active_fe_index that corresponds
+       * to the respectively other state. See the general documentation
+       * of this class for a description of how compression is indicated.
+       */
+      static
+      active_fe_index_type
+      get_toggled_compression_state (const active_fe_index_type active_fe_index);
 
       /**
        * Indices specifying the finite element of hp::FECollection to use for
@@ -273,6 +292,27 @@ namespace internal
       template <int dim, int spacedim>
       void uncompress_data (const dealii::hp::FECollection<dim,spacedim> &fe_collection);
 
+
+      /**
+       * Restore the active fe indices stored by the current object to
+       * an uncompressed state. At the same time, do not touch any of
+       * the other data structures. This leaves the active_fe_indices
+       * array out-of-synch from the other member variables, and the
+       * function can consequently only be used when the remaining
+       * data structures are going to be rebuilt next. This is
+       * specifically the case in hp::DoFHandler::distribute_dofs()
+       * where we throw away all data in the DoFLevels objects *except
+       * for the active_fe_indices* array. This function therefore
+       * simply makes sure that that one array is in uncompressed
+       * format so that we can use the information about active
+       * fe_indices for all cells that were used in the previous mesh
+       * refinement cycle (or the previous time distribute_dofs() was
+       * called) without having to care about any of the other data
+       * fields.
+       */
+      void normalize_active_fe_indices ();
+
+
       /**
        * Make hp::DoFHandler and its auxiliary class a friend since it is the
        * class that needs to create these data structures.
@@ -285,6 +325,26 @@ namespace internal
 
     // -------------------- template functions --------------------------------
 
+
+    inline
+    bool DoFLevel::is_compressed_entry (const active_fe_index_type active_fe_index)
+    {
+      return ((signed_active_fe_index_type)active_fe_index < 0);
+    }
+
+
+
+    inline
+    DoFLevel::active_fe_index_type
+    DoFLevel::get_toggled_compression_state (const active_fe_index_type active_fe_index)
+    {
+      // convert the active_fe_index into a signed type, flip all
+      // bits, and get the unsigned representation back
+      return (active_fe_index_type)~(signed_active_fe_index_type)active_fe_index;
+    }
+
+
+
     inline
     types::global_dof_index
     DoFLevel::
@@ -296,20 +356,21 @@ namespace internal
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, dof_offsets.size()));
 
-      // make sure we are on an
-      // object for which DoFs have
-      // been allocated at all
+      // make sure we are on an object for which DoFs have been
+      // allocated at all
       Assert (dof_offsets[obj_index] != (offset_type)(-1),
               ExcMessage ("You are trying to access degree of freedom "
                           "information for an object on which no such "
                           "information is available"));
 
-      Assert (fe_index == active_fe_indices[obj_index],
+      Assert (fe_index == (is_compressed_entry(active_fe_indices[obj_index]) == false ?
+                           active_fe_indices[obj_index] :
+                           get_toggled_compression_state(active_fe_indices[obj_index])),
               ExcMessage ("FE index does not match that of the present cell"));
 
       // see if the dof_indices array has been compressed for this
       // particular cell
-      if ((signed_active_fe_index_type)active_fe_indices[obj_index]>=0)
+      if (is_compressed_entry(active_fe_indices[obj_index]) == false)
         return dof_indices[dof_offsets[obj_index]+local_index];
       else
         return dof_indices[dof_offsets[obj_index]]+local_index;
@@ -336,7 +397,7 @@ namespace internal
               ExcMessage ("You are trying to access degree of freedom "
                           "information for an object on which no such "
                           "information is available"));
-      Assert ((signed_active_fe_index_type)active_fe_indices[obj_index]>=0,
+      Assert (is_compressed_entry(active_fe_indices[obj_index]) == false,
               ExcMessage ("This function can no longer be called after compressing the dof_indices array"));
       Assert (fe_index == active_fe_indices[obj_index],
               ExcMessage ("FE index does not match that of the present cell"));
@@ -353,10 +414,10 @@ namespace internal
       Assert (obj_index < active_fe_indices.size(),
               ExcIndexRange (obj_index, 0, active_fe_indices.size()));
 
-      if (((signed_active_fe_index_type)active_fe_indices[obj_index]) >= 0)
+      if (is_compressed_entry(active_fe_indices[obj_index]) == false)
         return active_fe_indices[obj_index];
       else
-        return (active_fe_index_type)~(signed_active_fe_index_type)active_fe_indices[obj_index];
+        return get_toggled_compression_state(active_fe_indices[obj_index]);
     }
 
 
@@ -367,8 +428,12 @@ namespace internal
     fe_index_is_active (const unsigned int                obj_index,
                         const unsigned int                fe_index) const
     {
-      return (fe_index == active_fe_index(obj_index));
+      if (is_compressed_entry(active_fe_indices[obj_index]) == false)
+        return (fe_index == active_fe_index(obj_index));
+      else
+        return (fe_index == get_toggled_compression_state(active_fe_index(obj_index)));
     }
+
 
 
     inline
@@ -379,6 +444,16 @@ namespace internal
     {
       Assert (obj_index < active_fe_indices.size(),
               ExcIndexRange (obj_index, 0, active_fe_indices.size()));
+
+      // check whether the given fe_index is within the range of
+      // values that we interpret as "not compressed". if not, then
+      // the index is so large that we cannot accept it. (but this
+      // will not likely happen because it requires someone using an
+      // FECollection that has more than 32k entries.)
+      Assert (is_compressed_entry (fe_index) == false,
+              ExcMessage ("You are using an active_fe_index that is larger than an "
+                          "internal limitation for these objects. Try to work with "
+                          "hp::FECollection objects that have a more modest size."));
 
       active_fe_indices[obj_index] = fe_index;
     }
@@ -404,6 +479,8 @@ namespace internal
 
       return &cell_dof_indices_cache[cell_cache_offsets[obj_index]];
     }
+
+
 
     template <class Archive>
     inline

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2016 by the deal.II authors
+// Copyright (C) 2003 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -3175,6 +3175,14 @@ namespace hp
                     tria->n_raw_cells(level),
                     ExcInternalError ());
           }
+
+        // it may be that the previous table was compressed; in that
+        // case, restore the correct active_fe_index. the fact that
+        // this no longer matches the indices in the table is of no
+        // importance because the current function is called at a
+        // point where we have to recreate the dof_indices tables in
+        // the levels anyway
+        levels[level]->normalize_active_fe_indices ();
       }
   }
 


### PR DESCRIPTION
A previous patch, a long time ago, implemented a scheme to compress the data structure
that stores the DoF indices in the hp case. For reasons no longer clear, the functions
that do the compression and decompression just returned immediately, without actually
doing anything (see #3728). Maybe not surprisingly, the algorithm -- not executed after all -- did
not work.

This patch fixes the algorithm at various locations and enables the compression. To understand what the algorithm actually does, consider this comment from the class docs of `hp::DoFLevel`:
```
     * <h3>Compression</h3>
     *
     * It is common for the indices stored in @p dof_indices for one cell to
     * be numbered consecutively. For example, using the standard numbering
     * (without renumbering DoFs), the quad dofs on the first cell of a mesh
     * when using a $Q_3$ element will be numbered <tt>12, 13, 14, 15</tt>.
     * This allows for compression if we only store the first entry and have
     * some way to mark the DoFs on this object as compressed. Here,
     * compression means that we know that subsequent DoF indices can be
     * obtained from the previous ones by just incrementing them by one -- in
     * other words, we use a variant of doing run-length encoding. The way to
     * do this is that we use positive FE indices for uncompressed sets of
     * DoFs and if a set of indices is compressed, then we instead store the
     * FE index in binary complement (which we can identify by looking at the
     * sign bit when interpreting the number as a signed one). There are two
     * functions, compress_data() and uncompress_data() that convert between
     * the two possible representations.
     *
     * Note that compression is not always possible. For example, if one
     * renumbered the example above using DoFRenumbering::downstream with
     * $(1,0)^T$ as direction, then they would likely be numbered <tt>12, 14,
     * 13, 15</tt>, which can not be compressed using run-length encoding.
```

Passes the entire testsuite. Fixes #3728 .