### PR TITLE
Increase the precision with which we output data in two tests.

### DIFF
--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -227,7 +227,7 @@ void test(const FiniteElement<dim> &fe, unsigned n_cycles, bool global, const Po
 int main ()
 {
   std::ofstream logfile ("output");
-  deallog << std::setprecision(6);
+  deallog << std::setprecision(7);
   deallog << std::fixed;
   deallog.attach(logfile);
   deallog.threshold_double (1e-8);

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -399,7 +399,7 @@ void test(const FiniteElement<dim> &fe, unsigned n_cycles, bool global, const Po
 int main ()
 {
   std::ofstream logfile ("output");
-  deallog << std::setprecision(6);
+  deallog << std::setprecision(7);
   deallog << std::fixed;
   deallog.attach(logfile);
   deallog.threshold_double (1e-8);


### PR DESCRIPTION
No update to the .output files is necessary because the difference between the numbers now
output and those still stored in the .output files is smaller than the tolerance we use
for numdiff.