### PR TITLE
Add another output file for a test.

### DIFF
--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.gcc4
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.gcc4
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::675
+DEAL:0::1533
+
+DEAL:1::595
+DEAL:1::1311
+

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.gcc6
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.gcc6
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::679
+DEAL:0::1536
+
+DEAL:1::599
+DEAL:1::1314
+

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.gcc4
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.gcc4
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::719
+DEAL:0::1582
+
+DEAL:1::639
+DEAL:1::1360
+

--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.gcc6
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=on.mpirun=2.output.gcc6
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::723
+DEAL:0::1585
+
+DEAL:1::643
+DEAL:1::1363
+


### PR DESCRIPTION
This test checks memory consumption so it is reasonable to have a few of these. These values make the test pass with GCC.