### PR TITLE
Automatically set MPI_Comm in MatrixFree

### DIFF
--- a/doc/news/changes/minor/2017DanielArndt20170108DanielArndt
+++ b/doc/news/changes/minor/2017DanielArndt20170108DanielArndt
@@ -1,0 +1,4 @@
+Improved: The MPI_Comm used in MatrixFree is not configurable via 
+AdditionalData anymore but set to the MPI_Comm of the Triangulation.
+<br>
+(Daniel Arndt, 2017/01/08)

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2009 - 2016 by the deal.II authors
+ * Copyright (C) 2009 - 2017 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -840,7 +840,6 @@ namespace Step37
         MatrixFree<dim,double>::AdditionalData::none;
       additional_data.mapping_update_flags = (update_gradients | update_JxW_values |
                                               update_quadrature_points);
-      additional_data.mpi_communicator = MPI_COMM_WORLD;
       system_mf_storage.reinit (dof_handler, constraints, QGauss<1>(fe.degree+1),
                                 additional_data);
     }
@@ -889,7 +888,6 @@ namespace Step37
           MatrixFree<dim,float>::AdditionalData::none;
         additional_data.mapping_update_flags = (update_gradients | update_JxW_values |
                                                 update_quadrature_points);
-        additional_data.mpi_communicator = MPI_COMM_WORLD;
         additional_data.level_mg_handler = level;
 
         mg_mf_storage[level].reinit(dof_handler, level_constraints,

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2011 - 2016 by the deal.II authors
+ * Copyright (C) 2011 - 2017 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -415,7 +415,6 @@ namespace Step48
 
     QGaussLobatto<1> quadrature (fe_degree+1);
     typename MatrixFree<dim>::AdditionalData additional_data;
-    additional_data.mpi_communicator = MPI_COMM_WORLD;
     additional_data.tasks_parallel_scheme =
       MatrixFree<dim>::AdditionalData::partition_partition;
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2011 - 2016 by the deal.II authors
+// Copyright (C) 2011 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -166,7 +166,30 @@ public:
     /**
      * Constructor for AdditionalData.
      */
-    AdditionalData (const MPI_Comm            mpi_communicator   = MPI_COMM_SELF,
+    AdditionalData (const TasksParallelScheme tasks_parallel_scheme = partition_partition,
+                    const unsigned int        tasks_block_size   = 0,
+                    const UpdateFlags         mapping_update_flags  = update_gradients | update_JxW_values,
+                    const unsigned int level_mg_handler = numbers::invalid_unsigned_int,
+                    const bool                store_plain_indices = true,
+                    const bool                initialize_indices = true,
+                    const bool                initialize_mapping = true)
+      :
+      tasks_parallel_scheme (tasks_parallel_scheme),
+      tasks_block_size      (tasks_block_size),
+      mapping_update_flags  (mapping_update_flags),
+      level_mg_handler      (level_mg_handler),
+      store_plain_indices   (store_plain_indices),
+      initialize_indices    (initialize_indices),
+      initialize_mapping    (initialize_mapping)
+    {};
+
+    /**
+     * Constructor for AdditionalData.
+     *
+     * @deprecated @p mpi_communicator should not be specified here
+     * since it is not used in the MatrixFree class.
+     */
+    AdditionalData (const MPI_Comm            mpi_communicator,
                     const TasksParallelScheme tasks_parallel_scheme = partition_partition,
                     const unsigned int        tasks_block_size   = 0,
                     const UpdateFlags         mapping_update_flags  = update_gradients | update_JxW_values,
@@ -183,15 +206,18 @@ public:
       store_plain_indices   (store_plain_indices),
       initialize_indices    (initialize_indices),
       initialize_mapping    (initialize_mapping)
-    {};
+    {} DEAL_II_DEPRECATED
 
     /**
      * Set the MPI communicator that the parallel layout of the operator
      * should be based upon. Defaults to MPI_COMM_SELF, but should be set to a
      * communicator similar to the one used for a distributed triangulation in
      * order to inform this class over all cells that are present.
+     *
+     * @deprecated This variable is not used anymore. The @p mpi_communicator
+     * is automatically set to the one used by the triangulation.
      */
-    MPI_Comm            mpi_communicator;
+    MPI_Comm            mpi_communicator DEAL_II_DEPRECATED;
 
     /**
      * Set the scheme for task parallelism. There are four options available.

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2016 by the deal.II authors
+// Copyright (C) 2005 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -935,9 +935,6 @@ namespace VectorTools
       typename MatrixFree<dim,number>::AdditionalData additional_data;
       additional_data.tasks_parallel_scheme =
         MatrixFree<dim,number>::AdditionalData::partition_color;
-      if (const parallel::Triangulation<dim,spacedim> *parallel_tria =
-            dynamic_cast<const parallel::Triangulation<dim,spacedim>*>(&dof.get_tria()))
-        additional_data.mpi_communicator = parallel_tria->get_communicator();
       additional_data.mapping_update_flags = (update_values | update_JxW_values);
       MatrixFree<dim, number> matrix_free;
       matrix_free.reinit (mapping, dof, constraints,
@@ -1184,9 +1181,6 @@ namespace VectorTools
       typename MatrixFree<dim,Number>::AdditionalData additional_data;
       additional_data.tasks_parallel_scheme =
         MatrixFree<dim,Number>::AdditionalData::partition_color;
-      if (const parallel::Triangulation<dim,spacedim> *parallel_tria =
-            dynamic_cast<const parallel::Triangulation<dim,spacedim>*>(&dof.get_tria()))
-        additional_data.mpi_communicator = parallel_tria->get_communicator();
       additional_data.mapping_update_flags = (update_values | update_JxW_values);
       MatrixFree<dim, Number> matrix_free;
       matrix_free.reinit (mapping, dof, constraints,

--- a/tests/arpack/step-36_parpack_mf.cc
+++ b/tests/arpack/step-36_parpack_mf.cc
@@ -95,7 +95,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,double>::AdditionalData data;
-    data.mpi_communicator = mpi_communicator;
     data.tasks_parallel_scheme =
       MatrixFree<dim,double>::AdditionalData::partition_color;
     data.mapping_update_flags = update_values | update_gradients | update_JxW_values;

--- a/tests/matrix_free/laplace_operator_01.cc
+++ b/tests/matrix_free/laplace_operator_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -101,7 +101,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -145,7 +145,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/mass_operator_01.cc
+++ b/tests/matrix_free/mass_operator_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -109,7 +109,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -73,7 +73,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -72,7 +72,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_10.cc
+++ b/tests/matrix_free/matrix_vector_10.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -109,7 +109,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_11.cc
+++ b/tests/matrix_free/matrix_vector_11.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -102,7 +102,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
@@ -130,7 +129,6 @@ void test ()
     {
       const QGauss<1> quad (fe_degree+1);
       typename MatrixFree<dim,number>::AdditionalData data;
-      data.mpi_communicator = MPI_COMM_WORLD;
       if (parallel_option == 0)
         {
           data.tasks_parallel_scheme =

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -164,7 +164,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2015 by the deal.II authors
+// Copyright (C) 2013 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -164,7 +164,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_19.cc
+++ b/tests/matrix_free/matrix_vector_19.cc
@@ -99,7 +99,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -62,7 +62,6 @@ public:
     typename MatrixFree<dim,number>::AdditionalData addit_data;
     addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
     addit_data.level_mg_handler = level;
-    addit_data.mpi_communicator = MPI_COMM_WORLD;
 
     // extract the constraints due to Dirichlet boundary conditions
     ConstraintMatrix constraints;

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,7 +118,6 @@ void do_test (const DoFHandler<dim>  &dof)
 
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
-  fine_level_additional_data.mpi_communicator = MPI_COMM_WORLD;
   fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
                           fine_level_additional_data);
 
@@ -144,7 +143,6 @@ void do_test (const DoFHandler<dim>  &dof)
     {
       typename MatrixFree<dim,number>::AdditionalData mg_additional_data;
       mg_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
-      mg_additional_data.mpi_communicator = MPI_COMM_WORLD;
       mg_additional_data.level_mg_handler = level;
 
       ConstraintMatrix level_constraints;

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -65,7 +65,6 @@ public:
     addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
     addit_data.tasks_block_size = 3;
     addit_data.level_mg_handler = level;
-    addit_data.mpi_communicator = MPI_COMM_WORLD;
     ConstraintMatrix constraints;
     if (level == numbers::invalid_unsigned_int)
       {

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -156,7 +156,6 @@ void do_test (const DoFHandler<dim>  &dof)
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
   fine_level_additional_data.tasks_block_size = 3;
-  fine_level_additional_data.mpi_communicator = MPI_COMM_WORLD;
   fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
                           fine_level_additional_data);
 
@@ -193,7 +192,6 @@ void do_test (const DoFHandler<dim>  &dof)
       typename MatrixFree<dim,number>::AdditionalData mg_additional_data;
       mg_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
       mg_additional_data.tasks_block_size = 3;
-      mg_additional_data.mpi_communicator = MPI_COMM_WORLD;
       mg_additional_data.level_mg_handler = level;
 
       ConstraintMatrix level_constraints;

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -70,7 +70,6 @@ public:
       addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
     addit_data.tasks_block_size = 3;
     addit_data.level_mg_handler = level;
-    addit_data.mpi_communicator = MPI_COMM_WORLD;
     ConstraintMatrix constraints;
     if (level == numbers::invalid_unsigned_int)
       {

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -156,7 +156,6 @@ void do_test (const DoFHandler<dim>  &dof)
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
   fine_level_additional_data.tasks_block_size = 3;
-  fine_level_additional_data.mpi_communicator = MPI_COMM_WORLD;
   fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
                           fine_level_additional_data);
 
@@ -193,7 +192,6 @@ void do_test (const DoFHandler<dim>  &dof)
       typename MatrixFree<dim,number>::AdditionalData mg_additional_data;
       mg_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
       mg_additional_data.tasks_block_size = 3;
-      mg_additional_data.mpi_communicator = MPI_COMM_WORLD;
       mg_additional_data.level_mg_handler = level;
 
       ConstraintMatrix level_constraints;

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2016 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,7 +61,6 @@ public:
     typename MatrixFree<dim,number>::AdditionalData addit_data;
     addit_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
     addit_data.level_mg_handler = level;
-    addit_data.mpi_communicator = MPI_COMM_WORLD;
 
     // extract the constraints due to Dirichlet boundary conditions
     ConstraintMatrix constraints;

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -295,7 +295,6 @@ namespace Step48
 
     QGaussLobatto<1> quadrature (fe_degree+1);
     typename MatrixFree<dim>::AdditionalData additional_data;
-    additional_data.mpi_communicator = MPI_COMM_WORLD;
     additional_data.tasks_parallel_scheme =
       MatrixFree<dim>::AdditionalData::partition_partition;
 

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -266,7 +266,6 @@ namespace Step48
 
     QGaussLobatto<1> quadrature (fe_degree+1);
     typename MatrixFree<dim>::AdditionalData additional_data;
-    additional_data.mpi_communicator = MPI_COMM_WORLD;
     additional_data.tasks_parallel_scheme =
       MatrixFree<dim>::AdditionalData::partition_partition;
 

--- a/tests/numerics/project_parallel_qpmf_common.h
+++ b/tests/numerics/project_parallel_qpmf_common.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -118,7 +118,6 @@ void do_project (const parallel::distributed::Triangulation<dim> &triangulation,
 
   typename MatrixFree<dim,double>::AdditionalData additional_data;
   additional_data.tasks_parallel_scheme = MatrixFree<dim,double>::AdditionalData::partition_color;
-  additional_data.mpi_communicator = MPI_COMM_WORLD;
   additional_data.mapping_update_flags = update_values | update_JxW_values | update_quadrature_points;
   MatrixFree<dim,double>  data;
   data.reinit (dof_handler, constraints, quadrature_formula_1d, additional_data);


### PR DESCRIPTION
Fixes #3607. As mentioned there, there is no real use in specifying an `MPI_Comm` in `MatrixFree::AdditionalData` that is different from the one provided by the triangulation.