### PR TITLE
Make a member variable const.

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -347,7 +347,7 @@ private:
   /**
    * Copy of the vector <tt>pols</tt> of polynomials given to the constructor.
    */
-  std::vector<std::vector<Polynomials::Polynomial<double> > > polynomials;
+  const std::vector<std::vector<Polynomials::Polynomial<double> > > polynomials;
 
   /**
    * Number of tensor product polynomials. This is <tt>Nx*Ny*Nz</tt>, or with


### PR DESCRIPTION
I noticed this while reading the source for #3754.

This is copied from an input parameter and never changed so it may as well be marked as const.