### PR TITLE
Fix a get_ria_vector for FE_BDM

### DIFF
--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2003 - 2016 by the deal.II authors
+// Copyright (C) 2003 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -263,9 +263,9 @@ FE_BDM<dim>::get_ria_vector (const unsigned int deg)
     }
 
   const unsigned int dofs_per_cell = PolynomialsBDM<dim>::compute_n_pols(deg);
-  const unsigned int dofs_per_face = PolynomialSpace<dim-1>::compute_n_pols(deg);
+  const unsigned int dofs_per_face = PolynomialSpace<dim-1>::compute_n_pols(deg+1);
 
-  Assert(GeometryInfo<dim>::faces_per_cell*dofs_per_face < dofs_per_cell,
+  Assert(GeometryInfo<dim>::faces_per_cell*dofs_per_face <= dofs_per_cell,
          ExcInternalError());
 
   // all dofs need to be

--- a/tests/fe/bdm_16.cc
+++ b/tests/fe/bdm_16.cc
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// The test is used to check the restriction_is_additive flags. The
+// face degrees of freedom of a BDM element must be non-additive as
+// they have continuity requirements, however the interior DOFs must
+// be additive, e.g. for order 1 elements all DOFs are non-additive,
+// while for the order 2 element in 2d we have 12 non-additive face DOFs
+// and 2 additive interior ones. The test should output a vector
+// consisting of faces_per_cell * dofs_per_face zeros, followed by
+// interior_dofs ones.
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/fe/fe_bdm.h>
+
+#include <fstream>
+#include <string>
+
+
+std::ofstream logfile ("output");
+
+template<int dim>
+void
+test (const unsigned int degree)
+{
+  FE_BDM<dim> fe_bdm(degree);
+
+  deallog << "Degree=" << degree
+          << ", restriction is additive flags:"
+          << std::endl;
+
+  for (unsigned int i=0; i<fe_bdm.dofs_per_cell; ++i)
+    std::cout << fe_bdm.restriction_is_additive(i) << " ";
+
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << "Dimension 2: " << std::endl;
+  for (unsigned int i=1; i<4; ++i)
+    test<2>(i);
+
+  deallog << "Dimension 3: " << std::endl;
+  for (unsigned int i=1; i<4; ++i)
+    test<3>(i);
+
+  return 0;
+}
+
+
+

--- a/tests/fe/bdm_16.output
+++ b/tests/fe/bdm_16.output
@@ -1,0 +1,15 @@
+
+DEAL::Dimension 2: 
+DEAL::Degree=1, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 
+DEAL::Degree=2, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 0 0 0 0 1 1 
+DEAL::Degree=3, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 
+DEAL::Dimension 3: 
+DEAL::Degree=1, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
+DEAL::Degree=2, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 
+DEAL::Degree=3, restriction is additive flags:
+DEAL::0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 


### PR DESCRIPTION
The number of `dofs_per_face` in a BDM element is the number of polynomials of `deg+1`, rather than `deg`. The function `get_dpo_vector` actually uses the right number, so I modified this one accordingly.

Also, the assertion was modified, since it does not make sense in the lowest order case where the number of face degrees of freedom is exactly equal to the total number of degrees of freedom per cell, as there are no internal DOFs for BDM_1. It was working before because the number of face DOFs was less than it should have been.