### PR TITLE
Use shared_ptr to store MatrixFree data in MatrixFreeOperators::Base

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -79,12 +79,12 @@ namespace MatrixFreeOperators
     /**
      * Initialize operator on fine scale.
      */
-    void initialize (const MatrixFree<dim,Number> &data);
+    void initialize (std_cxx11::shared_ptr<const MatrixFree<dim,Number> > data);
 
     /**
      * Initialize operator on a level @p level.
      */
-    void initialize (const MatrixFree<dim,Number> &data,
+    void initialize (std_cxx11::shared_ptr<const MatrixFree<dim,Number> > data,
                      const MGConstrainedDoFs &mg_constrained_dofs,
                      const unsigned int level);
 
@@ -199,7 +199,7 @@ namespace MatrixFreeOperators
     /**
      * MatrixFree object to be used with this operator.
      */
-    SmartPointer<const MatrixFree<dim,Number>, Base<dim,Number> > data;
+    std_cxx11::shared_ptr<const MatrixFree<dim,Number> > data;
 
     /**
      * A shared pointer to a diagonal matrix that stores the inverse of
@@ -758,9 +758,9 @@ namespace MatrixFreeOperators
   template <int dim, typename Number>
   void
   Base<dim,Number>::
-  initialize (const MatrixFree<dim,Number> &data_)
+  initialize (std_cxx11::shared_ptr<const MatrixFree<dim,Number> > data_)
   {
-    data =  SmartPointer<const MatrixFree<dim,Number>, Base<dim,Number> >(&data_,typeid(*this).name());
+    data = data_;
     edge_constrained_indices.clear();
     have_interface_matrices = false;
   }
@@ -770,19 +770,19 @@ namespace MatrixFreeOperators
   template <int dim, typename Number>
   void
   Base<dim,Number>::
-  initialize (const MatrixFree<dim,Number> &data_,
+  initialize (std_cxx11::shared_ptr<const MatrixFree<dim,Number> > data_,
               const MGConstrainedDoFs      &mg_constrained_dofs,
               const unsigned int            level)
   {
     AssertThrow (level != numbers::invalid_unsigned_int,
                  ExcMessage("level is not set"));
-    if (data_.n_macro_cells() > 0)
+    if (data_->n_macro_cells() > 0)
       {
         AssertDimension(static_cast<int>(level),
-                        data_.get_cell_iterator(0,0)->level());
+                        data_->get_cell_iterator(0,0)->level());
       }
 
-    data = SmartPointer<const MatrixFree<dim,Number>, Base<dim,Number> >(&data_,typeid(*this).name());
+    data = data_;
 
     // setup edge_constrained indices
     std::vector<types::global_dof_index> interface_indices;
@@ -795,7 +795,7 @@ namespace MatrixFreeOperators
       if (locally_owned.is_element(interface_indices[i]))
         edge_constrained_indices.push_back(locally_owned.index_within_set(interface_indices[i]));
     have_interface_matrices = Utilities::MPI::max((unsigned int)edge_constrained_indices.size(),
-                                                  data_.get_vector_partitioner()->get_mpi_communicator()) > 0;
+                                                  data->get_vector_partitioner()->get_mpi_communicator()) > 0;
   }
 
 

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -918,7 +918,7 @@ namespace VectorTools
    * which stores quadrature point data.
    */
   template <int dim, typename VectorType>
-  void project (const MatrixFree<dim,typename VectorType::value_type> &data,
+  void project (std_cxx11::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > data,
                 const ConstraintMatrix &constraints,
                 const unsigned int n_q_points_1d,
                 const std_cxx11::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
@@ -928,7 +928,7 @@ namespace VectorTools
    * Same as above but for <code>n_q_points_1d = matrix_free.get_dof_handler().get_fe().degree+1</code>.
    */
   template <int dim, typename VectorType>
-  void project (const MatrixFree<dim,typename VectorType::value_type> &data,
+  void project (std_cxx11::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > data,
                 const ConstraintMatrix &constraints,
                 const std_cxx11::function< VectorizedArray<typename VectorType::value_type> (const unsigned int, const unsigned int)> func,
                 VectorType &vec_result);

--- a/source/numerics/vector_tools_project_qpmf.inst.in
+++ b/source/numerics/vector_tools_project_qpmf.inst.in
@@ -21,14 +21,14 @@ for (VEC: REAL_NONBLOCK_VECTORS; deal_II_dimension : DIMENSIONS)
 
     template
     void project<deal_II_dimension, VEC>(
-        const MatrixFree<deal_II_dimension,VEC::value_type> &matrix_free,
+        std_cxx11::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
         const ConstraintMatrix &constraints,
         const std_cxx11::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)>,
         VEC &);
 
     template
     void project<deal_II_dimension, VEC>(
-        const MatrixFree<deal_II_dimension,VEC::value_type> &matrix_free,
+        std_cxx11::shared_ptr<const MatrixFree<deal_II_dimension,VEC::value_type> > matrix_free,
         const ConstraintMatrix &constraints,
         const unsigned int,
         const std_cxx11::function< VectorizedArray<VEC::value_type> (const unsigned int, const unsigned int)>,

--- a/tests/matrix_free/laplace_operator_01.cc
+++ b/tests/matrix_free/laplace_operator_01.cc
@@ -97,21 +97,21 @@ void test ()
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 
-  MatrixFree<dim,number> mf_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
-    mf_data.reinit (dof, constraints, quad, data);
+    mf_data->reinit (dof, constraints, quad, data);
   }
 
   MatrixFreeOperators::LaplaceOperator<dim,fe_degree,fe_degree+1, 1, number> mf;
   mf.initialize(mf_data);
   mf.compute_diagonal();
   LinearAlgebra::distributed::Vector<number> in, out, ref;
-  mf_data.initialize_dof_vector (in);
+  mf_data->initialize_dof_vector (in);
   out.reinit (in);
   ref.reinit (in);
 

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -141,7 +141,7 @@ void test ()
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 
-  MatrixFree<dim,number> mf_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
@@ -149,15 +149,15 @@ void test ()
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
     data.mapping_update_flags = update_quadrature_points | update_gradients | update_JxW_values;
-    mf_data.reinit (dof, constraints, quad, data);
+    mf_data->reinit (dof, constraints, quad, data);
   }
 
   std_cxx11::shared_ptr<Table<2, VectorizedArray<number> > > coefficient;
   coefficient = std_cxx11::make_shared<Table<2, VectorizedArray<number> > >();
   {
-    FEEvaluation<dim,fe_degree,fe_degree+1,1,number> fe_eval(mf_data);
+    FEEvaluation<dim,fe_degree,fe_degree+1,1,number> fe_eval(*mf_data);
 
-    const unsigned int n_cells = mf_data.n_macro_cells();
+    const unsigned int n_cells = mf_data->n_macro_cells();
     const unsigned int n_q_points = fe_eval.n_q_points;
 
     coefficient->reinit(n_cells, n_q_points);
@@ -174,7 +174,7 @@ void test ()
   mf.set_coefficient(coefficient);
   mf.compute_diagonal();
   LinearAlgebra::distributed::Vector<number> in, out, ref;
-  mf_data.initialize_dof_vector (in);
+  mf_data->initialize_dof_vector (in);
   out.reinit (in);
   ref.reinit (in);
 

--- a/tests/matrix_free/mass_operator_01.cc
+++ b/tests/matrix_free/mass_operator_01.cc
@@ -105,21 +105,21 @@ void test ()
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 
-  MatrixFree<dim,number> mf_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
-    mf_data.reinit (dof, constraints, quad, data);
+    mf_data->reinit (dof, constraints, quad, data);
   }
 
   MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, number> mf;
   mf.initialize(mf_data);
   mf.compute_diagonal();
   LinearAlgebra::distributed::Vector<number> in, out, ref;
-  mf_data.initialize_dof_vector (in);
+  mf_data->initialize_dof_vector (in);
   out.reinit (in);
   ref.reinit (in);
 

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -69,14 +69,14 @@ void test ()
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 
-  MatrixFree<dim,number> mf_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
-    mf_data.reinit (dof, constraints, quad, data);
+    mf_data->reinit (dof, constraints, quad, data);
   }
 
   MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, number> mf;
@@ -86,7 +86,7 @@ void test ()
     = mf.get_matrix_diagonal_inverse()->get_vector();
 
   LinearAlgebra::distributed::Vector<number> in, out, ref;
-  mf_data.initialize_dof_vector (in);
+  mf_data->initialize_dof_vector (in);
   out.reinit (in);
   ref.reinit (in);
 

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -68,14 +68,14 @@ void test ()
   //std::cout << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
   //std::cout << "Number of constraints: " << constraints.n_constraints() << std::endl;
 
-  MatrixFree<dim,number> mf_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > mf_data(new MatrixFree<dim,number> ());
   {
     const QGauss<1> quad (fe_degree+2);
     typename MatrixFree<dim,number>::AdditionalData data;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::none;
     data.tasks_block_size = 7;
-    mf_data.reinit (dof, constraints, quad, data);
+    mf_data->reinit (dof, constraints, quad, data);
   }
 
   MatrixFreeOperators::MassOperator<dim,fe_degree, fe_degree+2, 1, number> mf;
@@ -85,7 +85,7 @@ void test ()
     = mf.get_matrix_diagonal_inverse()->get_vector();
 
   LinearAlgebra::distributed::Vector<number> in, out, ref;
-  mf_data.initialize_dof_vector (in);
+  mf_data->initialize_dof_vector (in);
   out.reinit (in);
   ref.reinit (in);
 

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -114,12 +114,12 @@ void do_test (const DoFHandler<dim>  &dof)
   MappingQ<dim> mapping(fe_degree+1);
 
   LaplaceOperator<dim,fe_degree,n_q_points_1d,1,number> fine_matrix;
-  MatrixFree<dim,number> fine_level_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > fine_level_data(new MatrixFree<dim,number> ());
 
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
-  fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
-                          fine_level_additional_data);
+  fine_level_data->reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
+                           fine_level_additional_data);
 
   fine_matrix.initialize(fine_level_data);
   fine_matrix.compute_diagonal();
@@ -155,7 +155,8 @@ void do_test (const DoFHandler<dim>  &dof)
 
       mg_level_data[level].reinit (mapping, dof, level_constraints, QGauss<1>(n_q_points_1d),
                                    mg_additional_data);
-      mg_matrices[level].initialize(mg_level_data[level],
+      mg_matrices[level].initialize(std_cxx11::make_shared<MatrixFree<dim,number> >(
+                                      mg_level_data[level]),
                                     mg_constrained_dofs,
                                     level);
       mg_matrices[level].compute_diagonal();

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -151,13 +151,13 @@ void do_test (const DoFHandler<dim>  &dof)
   MappingQ<dim> mapping(fe_degree+1);
 
   LaplaceOperator<dim,fe_degree,n_q_points_1d,1,number> fine_matrix;
-  MatrixFree<dim,number> fine_level_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > fine_level_data(new MatrixFree<dim,number> ());
 
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
   fine_level_additional_data.tasks_block_size = 3;
-  fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
-                          fine_level_additional_data);
+  fine_level_data->reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
+                           fine_level_additional_data);
 
   fine_matrix.initialize(fine_level_data);
   fine_matrix.compute_diagonal();
@@ -204,7 +204,8 @@ void do_test (const DoFHandler<dim>  &dof)
 
       mg_level_data[level].reinit (mapping, dof, level_constraints, QGauss<1>(n_q_points_1d),
                                    mg_additional_data);
-      mg_matrices[level].initialize(mg_level_data[level],
+      mg_matrices[level].initialize(std_cxx11::make_shared<MatrixFree<dim,number> >(
+                                      mg_level_data[level]),
                                     mg_constrained_dofs,
                                     level);
       mg_matrices[level].compute_diagonal();

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -151,13 +151,13 @@ void do_test (const DoFHandler<dim>  &dof)
   MappingQ<dim> mapping(fe_degree+1);
 
   LaplaceOperator<dim,fe_degree,n_q_points_1d,1,number> fine_matrix;
-  MatrixFree<dim,number> fine_level_data;
+  std_cxx11::shared_ptr<MatrixFree<dim,number> > fine_level_data(new MatrixFree<dim,number> ());
 
   typename MatrixFree<dim,number>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme = MatrixFree<dim,number>::AdditionalData::none;
   fine_level_additional_data.tasks_block_size = 3;
-  fine_level_data.reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
-                          fine_level_additional_data);
+  fine_level_data->reinit (mapping, dof, constraints, QGauss<1>(n_q_points_1d),
+                           fine_level_additional_data);
 
   fine_matrix.initialize(fine_level_data);
   fine_matrix.compute_diagonal();
@@ -204,7 +204,8 @@ void do_test (const DoFHandler<dim>  &dof)
 
       mg_level_data[level].reinit (mapping, dof, level_constraints, QGauss<1>(n_q_points_1d),
                                    mg_additional_data);
-      mg_matrices[level].initialize(mg_level_data[level],
+      mg_matrices[level].initialize(std_cxx11::make_shared<MatrixFree<dim,number> > (
+                                      mg_level_data[level]),
                                     mg_constrained_dofs,
                                     level);
       mg_matrices[level].compute_diagonal();


### PR DESCRIPTION
fix #3606 
Since the `matrix_free/operators` is new, I just replaced the old interface by the new one. Is that what you had in mind @kronbichler @davydden ?