### PR TITLE
Change communication pattern in parallel vector.

### DIFF
--- a/doc/news/changes/minor/20170111MartinKronbichler-b
+++ b/doc/news/changes/minor/20170111MartinKronbichler-b
@@ -1,0 +1,7 @@
+Fixed: LinearAlgebra::distributed::Vector used persistent MPI communicators
+for data exchange, which are not as well-tuned as the usual MPI_Isend and
+MPI_Irecv calls on some implementations, including memory leaks on IBM MPI if
+the communicators are alive over a longer time. Therefore, the communication
+has been changed to non-blocking MPI_Isend and MPI_Irecv calls.
+<br>
+(Martin Kronbichler, 2017/01/11)


### PR DESCRIPTION
Without this patch, code that frequently resets `LinearAlgebra::distributed::Vector` objects and uses the MPI communication on them runs into a memory leak of IBM MPI and runs out of memory. After contacting IBM guys from my local supercomputer, I decided to switch to the better supported `MPI_Isend` and `MPI_Irecv` which are also slightly faster on the tests I performed.