### PR TITLE
Allow for FE_DGQLegendre in MGTransferMatrixFree

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_internal.h
+++ b/include/deal.II/multigrid/mg_transfer_internal.h
@@ -20,7 +20,6 @@
 #include <deal.II/base/mg_level_object.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -88,10 +87,17 @@ namespace internal
       unsigned int n_child_cell_dofs;
 
       /**
-       * Holds the one-dimensional embedding (prolongation) matrix from mother
-       * element to the children.
+       * Holds the numbering between the numbering of degrees of freedom in
+       * the finite element and the lexicographic numbering needed for the
+       * tensor product application.
        */
-      internal::MatrixFreeFunctions::ShapeInfo<Number> shape_info;
+      std::vector<unsigned int> lexicographic_numbering;
+
+      /**
+       * Holds the one-dimensional embedding (prolongation) matrix from mother
+       * element to all the children.
+       */
+      AlignedVector<VectorizedArray<Number> > prolongation_matrix_1d;
 
     };
 

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -23,7 +23,6 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/base/mg_level_object.h>
 #include <deal.II/multigrid/mg_transfer.h>
-#include <deal.II/matrix_free/shape_info.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
@@ -188,9 +187,9 @@ private:
 
   /**
    * Holds the one-dimensional embedding (prolongation) matrix from mother
-   * element to the children.
+   * element to all the children.
    */
-  internal::MatrixFreeFunctions::ShapeInfo<Number> shape_info;
+  AlignedVector<VectorizedArray<Number> > prolongation_matrix_1d;
 
   /**
    * Holds the temporary values for the tensor evaluation

--- a/tests/multigrid/transfer_matrix_free_07.cc
+++ b/tests/multigrid/transfer_matrix_free_07.cc
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check MGTransferMatrixFree by comparison with MGTransferPrebuilt on a
+// series of meshes with adaptive meshes for FE_DGQLegendre (except for the
+// different element the same test as transfer_matrix_free_05)
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
+
+
+template <int dim, typename Number>
+void check(const unsigned int fe_degree)
+{
+  deallog.threshold_double(std::max(5e2*(double)std::numeric_limits<Number>::epsilon(),
+                                    1e-11));
+  FE_DGQLegendre<dim> fe(fe_degree);
+  deallog << "FE: " << fe.get_name() << std::endl;
+
+  // run a few different sizes...
+  unsigned int sizes [] = {1, 2, 3};
+  for (unsigned int cycle=0; cycle<sizeof(sizes)/sizeof(unsigned int); ++cycle)
+    {
+      unsigned int n_refinements = 0;
+      unsigned int n_subdiv = sizes[cycle];
+      if (n_subdiv > 1)
+        while (n_subdiv%2 == 0)
+          {
+            n_refinements += 1;
+            n_subdiv /= 2;
+          }
+      n_refinements += 3-dim;
+      if (fe_degree < 3)
+        n_refinements += 1;
+
+      parallel::distributed::Triangulation<dim>
+      tr(MPI_COMM_WORLD,
+         Triangulation<dim>::limit_level_difference_at_vertices,
+         parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+      GridGenerator::subdivided_hyper_cube(tr, n_subdiv);
+      tr.refine_global(n_refinements);
+
+      // adaptive refinement into a circle
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() < 0.5)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.3 && cell->center().norm() < 0.4)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+      for (typename Triangulation<dim>::active_cell_iterator cell=tr.begin_active(); cell != tr.end(); ++cell)
+        if (cell->is_locally_owned() &&
+            cell->center().norm() > 0.33 && cell->center().norm() < 0.37)
+          cell->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "no. cells: " << tr.n_global_active_cells() << std::endl;
+
+      DoFHandler<dim> mgdof(tr);
+      mgdof.distribute_dofs(fe);
+      mgdof.distribute_mg_dofs(fe);
+
+      // build reference
+      MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double> > transfer_ref;
+      transfer_ref.build_matrices(mgdof);
+
+      // build matrix-free transfer
+      MGTransferMatrixFree<dim, Number> transfer;
+      transfer.build(mgdof);
+
+      // check prolongation for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          LinearAlgebra::distributed::Vector<Number> v1, v2;
+          LinearAlgebra::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.prolongate(level, v2, v1);
+          transfer_ref.prolongate(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff prolongate   l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+
+      // check restriction for all levels using random vector
+      for (unsigned int level=1; level<mgdof.get_triangulation().n_global_levels(); ++level)
+        {
+          LinearAlgebra::distributed::Vector<Number> v1, v2;
+          LinearAlgebra::distributed::Vector<double> v1_cpy, v2_cpy, v3;
+          v1.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          v3.reinit(mgdof.locally_owned_mg_dofs(level-1), MPI_COMM_WORLD);
+          for (unsigned int i=0; i<v1.local_size(); ++i)
+            v1.local_element(i) = (double)Testing::rand()/RAND_MAX;
+          v1_cpy = v1;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict     l" << level << ": " << v3.l2_norm() << std::endl;
+
+          v2 = 1.;
+          v3 = 1.;
+          transfer.restrict_and_add(level, v2, v1);
+          transfer_ref.restrict_and_add(level, v3, v1_cpy);
+          v2_cpy = v2;
+          v3 -= v2_cpy;
+          deallog << "Diff restrict add l" << level << ": " << v3.l2_norm() << std::endl;
+        }
+      deallog << std::endl;
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+  // no threading in this test...
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  mpi_initlog();
+
+  check<2,double>(1);
+  check<2,double>(3);
+  check<3,double>(1);
+  check<3,double>(3);
+  check<2,float> (2);
+  check<3,float> (2);
+}

--- a/tests/multigrid/transfer_matrix_free_07.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=5.output
+++ b/tests/multigrid/transfer_matrix_free_07.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=5.output
@@ -1,0 +1,259 @@
+
+DEAL::FE: FE_DGQLegendre<2>(1)
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQLegendre<2>(3)
+DEAL::no. cells: 34
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 141
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQLegendre<3>(1)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::
+DEAL::FE: FE_DGQLegendre<3>(3)
+DEAL::no. cells: 1
+DEAL::
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 223
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::
+DEAL::FE: FE_DGQLegendre<2>(2)
+DEAL::no. cells: 88
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 250
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff prolongate   l6: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::Diff restrict     l6: 0
+DEAL::Diff restrict add l6: 0
+DEAL::
+DEAL::no. cells: 510
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::FE: FE_DGQLegendre<3>(2)
+DEAL::no. cells: 15
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::
+DEAL::no. cells: 694
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff prolongate   l5: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::Diff restrict     l5: 0
+DEAL::Diff restrict add l5: 0
+DEAL::
+DEAL::no. cells: 1791
+DEAL::Diff prolongate   l1: 0
+DEAL::Diff prolongate   l2: 0
+DEAL::Diff prolongate   l3: 0
+DEAL::Diff prolongate   l4: 0
+DEAL::Diff restrict     l1: 0
+DEAL::Diff restrict add l1: 0
+DEAL::Diff restrict     l2: 0
+DEAL::Diff restrict add l2: 0
+DEAL::Diff restrict     l3: 0
+DEAL::Diff restrict add l3: 0
+DEAL::Diff restrict     l4: 0
+DEAL::Diff restrict add l4: 0
+DEAL::


### PR DESCRIPTION
Simplify the code a bit by computing the `dim`-dimensional prolongation matrix by the product of the 1d matrix, rather than using the nodal points of the polynomials which only work for FE_Q and FE_DGQ.

This needs to be merged after #3770.