### PR TITLE
Doxygen link fixes

### DIFF
--- a/contrib/utilities/wrapcomments.py
+++ b/contrib/utilities/wrapcomments.py
@@ -27,7 +27,12 @@
 from __future__ import print_function
 import textwrap
 import sys, re
-wrapper = textwrap.TextWrapper()
+
+# As of python 2.6 we can tell the text wrapper to not break on hyphens. This is
+# usually what we want to do: we don't want to split URLs with hyphens and
+# doxygen will format 'non-primitive' as 'non- primitive' if it is
+# (inadvertantly) split across two lines.
+wrapper = textwrap.TextWrapper(break_on_hyphens=False)
 
 # take an array of lines and wrap them to 78 columns and let each line start
 # with @p startwith

--- a/include/deal.II/base/polynomials_bernstein.h
+++ b/include/deal.II/base/polynomials_bernstein.h
@@ -26,9 +26,9 @@ DEAL_II_NAMESPACE_OPEN
 
 /**
  * This class implements Bernstein basis polynomials of desire degree as
- * described in http://www.idav.ucdavis.edu/education/CAGDNotes/Bernstein-
- * Polynomials.pdf in the paragraph "Converting from the Bernstein Basis to
- * the Power Basis".
+ * described in
+ * http://www.idav.ucdavis.edu/education/CAGDNotes/Bernstein-Polynomials.pdf in
+ * the paragraph "Converting from the Bernstein Basis to the Power Basis".
  *
  * They are used to create the Bernstein finite element FE_Bernstein.
  *

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -155,15 +155,15 @@ template <int dim> struct CellData;
  * generator, see http://www.salome-platform.org/ . The sections of the format
  * that the GridIn::read_unv function supports are documented here:
  * <ul>
- * <li> section 2411: http://www.sdrl.uc.edu/universal-file-formats-for-modal-
- * analysis-testing-1/file-format-storehouse/unv_2411.htm
- * <li> section 2412: http://www.sdrl.uc.edu/universal-file-formats-for-modal-
- * analysis-testing-1/file-format-storehouse/unv_2412.htm
- * <li> section 2467: http://www.sdrl.uc.edu/universal-file-formats-for-modal-
- * analysis-testing-1/file-format-storehouse/unv_2467.htm
+ * <li> section 2411:
+ * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2411.htm
+ * <li> section 2412:
+ * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2412.htm
+ * <li> section 2467:
+ * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2467.htm
  * <li> all sections of this format, even if they may not be supported in our
- * reader, can be found here: http://www.sdrl.uc.edu/universal-file-formats-
- * for-modal-analysis-testing-1/file-format-storehouse/file-formats
+ * reader, can be found here:
+ * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/file-formats
  * </ul>
  * Note that Salome, let's say in 2D, can only make a quad mesh on an object
  * that has exactly 4 edges (or 4 pieces of the boundary). That means, that if

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -156,14 +156,14 @@ template <int dim> struct CellData;
  * that the GridIn::read_unv function supports are documented here:
  * <ul>
  * <li> section 2411:
- * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2411.htm
+ * http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2411
  * <li> section 2412:
- * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2412.htm
+ * http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2412
  * <li> section 2467:
- * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2467.htm
+ * http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2467
  * <li> all sections of this format, even if they may not be supported in our
  * reader, can be found here:
- * http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/file-formats
+ * http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse
  * </ul>
  * Note that Salome, let's say in 2D, can only make a quad mesh on an object
  * that has exactly 4 edges (or 4 pieces of the boundary). That means, that if

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -852,8 +852,7 @@ namespace PETScWrappers
      * Print the PETSc matrix object values using PETSc internal matrix viewer
      * function <tt>MatView</tt>. The default format prints the non- zero
      * matrix elements. For other valid view formats, consult
-     * http://www.mcs.anl.gov/petsc/petsc-
-     * current/docs/manualpages/Mat/MatView.html
+     * http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MatView.html
      */
     void write_ascii (const PetscViewerFormat format = PETSC_VIEWER_DEFAULT);
 

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -922,8 +922,7 @@ namespace PETScWrappers
    *
    * @note The class internally calls KSPSetFromOptions thus you are able to
    * use all the PETSc parameters for MATSOLVERMUMPS package. See
-   * http://www.mcs.anl.gov/petsc/petsc-
-   * current/docs/manualpages/Mat/MATSOLVERMUMPS.html
+   * http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MATSOLVERMUMPS.html
    *
    * @ingroup PETScWrappers
    * @author Daniel Brauss, Alexander Grayver, 2012

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -700,8 +700,8 @@ namespace PETScWrappers
      * Prints the PETSc vector object values using PETSc internal vector
      * viewer function <tt>VecView</tt>. The default format prints the
      * vector's contents, including indices of vector elements. For other
-     * valid view formats, consult http://www.mcs.anl.gov/petsc/petsc-
-     * current/docs/manualpages/Vec/VecView.html
+     * valid view formats, consult
+     * http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecView.html
      */
     void write_ascii (const PetscViewerFormat format = PETSC_VIEWER_DEFAULT) ;
 

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -86,8 +86,8 @@ namespace SLEPcWrappers
      * the spectral transformations.
      *
      * The possible values are given by the enumerator STMatMode in the SLEPc
-     * library http://www.grycap.upv.es/slepc/documentation/current/docs/manua
-     * lpages/ST/STMatMode.html
+     * library
+     * http://www.grycap.upv.es/slepc/documentation/current/docs/manualpages/ST/STMatMode.html
      */
     void set_matrix_mode(const STMatMode mode);
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -397,7 +397,9 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
   AssertThrow(in, ExcIO());
   in >> tmp;
 
-  AssertThrow(tmp == 2411, ExcUnknownSectionType(tmp)); // section 2411 describes vertices http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2411.htm/
+  // section 2411 describes vertices: see
+  // http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2411
+  AssertThrow(tmp == 2411, ExcUnknownSectionType(tmp));
 
   std::vector< Point<spacedim> > vertices; // vector of vertex coordinates
   std::map<int, int> vertex_indices; // # vert in unv (key) ---> # vert in deal.II (value)
@@ -437,7 +439,9 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
   AssertThrow(in, ExcIO());
   in >> tmp;
 
-  AssertThrow(tmp == 2412, ExcUnknownSectionType(tmp)); // section 2412 describes elements http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2412.htm/
+  // section 2412 describes elements: see
+  // http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2412
+  AssertThrow(tmp == 2412, ExcUnknownSectionType(tmp));
 
   std::vector< CellData<dim> > cells; // vector of cells
   SubCellData subcelldata;
@@ -540,8 +544,11 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
       AssertThrow(in, ExcIO());
       in >> tmp;
 
-      AssertThrow((tmp == 2467)||(tmp == 2477), ExcUnknownSectionType(tmp)); // section 2467 (2477) describes (materials - first and bcs - second) or (bcs - first and materials - second) - sequence depends on which group is created first
-      // http://www.sdrl.uc.edu/universal-file-formats-for-modal-analysis-testing-1/file-format-storehouse/unv_2467.htm/
+      // section 2467 (2477) describes (materials - first and bcs - second) or
+      // (bcs - first and materials - second) - sequence depends on which
+      // group is created first: see
+      // http://www.sdrl.uc.edu/sdrl/referenceinfo/universalfileformats/file-format-storehouse/universal-dataset-number-2467
+      AssertThrow((tmp == 2467)||(tmp == 2477), ExcUnknownSectionType(tmp));
 
       while (tmp != -1) // we do until reach end of 2467 or 2477
         {


### PR DESCRIPTION
This is something that I noticed while working on #3538: the line wrap script breaks things at hyphens. I disabled this behavior and fixed the broken links.