### PR TITLE
fix hp fe_index_is_active()

### DIFF
--- a/include/deal.II/hp/dof_level.h
+++ b/include/deal.II/hp/dof_level.h
@@ -428,10 +428,7 @@ namespace internal
     fe_index_is_active (const unsigned int                obj_index,
                         const unsigned int                fe_index) const
     {
-      if (is_compressed_entry(active_fe_indices[obj_index]) == false)
-        return (fe_index == active_fe_index(obj_index));
-      else
-        return (fe_index == get_toggled_compression_state(active_fe_index(obj_index)));
+      return (fe_index == active_fe_index(obj_index));
     }
 
 


### PR DESCRIPTION
the code would toggle the compression state twice and return a wrong result. Broken in #3739. This fixes the test hp/n_active_fe_indices.