### PR TITLE
Check that add_indices respects index_space_size

### DIFF
--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -393,6 +393,11 @@ IndexSet::add_indices(const IndexSet &other,
   if ((this == &other) && (offset == 0))
     return;
 
+  Assert (other.ranges.size() == 0
+          || other.ranges.back().end-1 < index_space_size,
+          ExcIndexRangeType<size_type> (other.ranges.back().end-1,
+                                        0, index_space_size));
+
   compress();
   other.compress();
 


### PR DESCRIPTION
Although the documentation said so, we did not check that the indices to be added lie inside the range `[0,size())`.