### PR TITLE
Fix the polynomial degree the ABF element reports about itself.

### DIFF
--- a/doc/news/changes/minor/20170113Bangerth
+++ b/doc/news/changes/minor/20170113Bangerth
@@ -1,0 +1,6 @@
+Fixed: The FE_ABF class reported the maximal polynomial degree (via
+FiniteElement::degree) for elements of order $r$ as $r+1$, but this is
+wrong. It should be $r+2$ (see Section 5 of the original paper of
+Arnold, Boffi, and Falk). This is now fixed.
+<br>
+(Wolfgang Bangerth, 2017/01/13)

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -45,7 +45,9 @@ FE_ABF<dim>::FE_ABF (const unsigned int deg)
   FE_PolyTensor<PolynomialsABF<dim>, dim> (
     deg,
     FiniteElementData<dim>(get_dpo_vector(deg),
-                           dim, deg+1, FiniteElementData<dim>::Hdiv),
+                           dim,
+                           deg+2,
+                           FiniteElementData<dim>::Hdiv),
     std::vector<bool>(PolynomialsABF<dim>::compute_n_pols(deg), true),
     std::vector<ComponentMask>(PolynomialsABF<dim>::compute_n_pols(deg),
                                std::vector<bool>(dim,true))),

--- a/tests/fe/abf_degree.cc
+++ b/tests/fe/abf_degree.cc
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Verify that FE_ABF(r) returns that its polynomial degree is r+2, not r+1.
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/fe/fe_abf.h>
+
+#include <fstream>
+
+
+int main ()
+{
+  std::ofstream logfile ("output");
+  deallog.attach(logfile);
+
+  deallog << "dim=2:" << std::endl;
+  for (unsigned int degree=0; degree<2; ++degree)
+    deallog << degree << ": " << FE_ABF<2>(degree).degree << std::endl;
+}

--- a/tests/fe/abf_degree.output
+++ b/tests/fe/abf_degree.output
@@ -1,0 +1,4 @@
+
+DEAL::dim=2:
+DEAL::0: 2
+DEAL::1: 3


### PR DESCRIPTION
As stated in the original paper (http://www-users.math.umn.edu/~arnold/papers/vecquad.pdf),
section 5, and as also stated in our discussion of the PolynomialsABF element, the
ABF space of order 'r' actually contains polynomials of degree 'r+2'. Report this
accurately.

Without this, the computation of embedding matrices fails in 3d because we integrate
the least squares matrix terms with a quadrature formula of too low order.

This is the next step towards fixing #2785.