### PR TITLE
Make a test run faster.

### DIFF
--- a/tests/mappings/mapping_q_convergence.cc
+++ b/tests/mappings/mapping_q_convergence.cc
@@ -176,8 +176,6 @@ void create_tria(Triangulation<dim> &triangulation, const Geometry<dim> &geometr
   for (Triangulation<3>::active_cell_iterator cell=triangulation.begin_active();
        cell!=triangulation.end(); ++cell)
     cell->set_all_manifold_ids(0);
-
-  triangulation.refine_global(1);
 }
 
 
@@ -191,7 +189,7 @@ void test(const FiniteElement<dim> &fe)
   constraints.close();
 
   deallog << "FE degree: " << fe.degree << std::endl;
-  for (unsigned mapping_p = 1; mapping_p < fe.degree + 3; ++mapping_p)
+  for (unsigned mapping_p = 2; mapping_p < fe.degree + 3; ++mapping_p)
     {
       deallog << "mapping order: " << mapping_p << std::endl;
       Triangulation<dim> triangulation;

--- a/tests/mappings/mapping_q_convergence.output
+++ b/tests/mappings/mapping_q_convergence.output
@@ -1,76 +1,58 @@
 
 DEAL::FE degree: 1
-DEAL::mapping order: 1
-DEAL::current slope: 2.0935
-DEAL::current slope: 2.0244
-DEAL::Last number of DoFs: 4913
-DEAL::Last L2 error: 0.0099885
-DEAL::regression slope: 2.0589
 DEAL::mapping order: 2
+DEAL::current slope: 2.3791
 DEAL::current slope: 2.0933
-DEAL::current slope: 2.0244
-DEAL::Last number of DoFs: 4913
-DEAL::Last L2 error: 0.0099885
-DEAL::regression slope: 2.0588
+DEAL::Last number of DoFs: 729
+DEAL::Last L2 error: 0.040634
+DEAL::regression slope: 2.2362
 DEAL::mapping order: 3
+DEAL::current slope: 2.3791
 DEAL::current slope: 2.0933
-DEAL::current slope: 2.0244
-DEAL::Last number of DoFs: 4913
-DEAL::Last L2 error: 0.0099885
-DEAL::regression slope: 2.0588
+DEAL::Last number of DoFs: 729
+DEAL::Last L2 error: 0.040634
+DEAL::regression slope: 2.2362
 DEAL::FE degree: 2
-DEAL::mapping order: 1
-DEAL::current slope: 2.8710
-DEAL::current slope: 2.9558
-DEAL::Last number of DoFs: 35937
-DEAL::Last L2 error: 0.00031701
-DEAL::regression slope: 2.9134
 DEAL::mapping order: 2
+DEAL::current slope: 2.5735
 DEAL::current slope: 2.8700
-DEAL::current slope: 2.9556
-DEAL::Last number of DoFs: 35937
-DEAL::Last L2 error: 0.00031699
-DEAL::regression slope: 2.9128
+DEAL::Last number of DoFs: 4913
+DEAL::Last L2 error: 0.0024590
+DEAL::regression slope: 2.7217
 DEAL::mapping order: 3
+DEAL::current slope: 2.5735
 DEAL::current slope: 2.8700
-DEAL::current slope: 2.9556
-DEAL::Last number of DoFs: 35937
-DEAL::Last L2 error: 0.00031699
-DEAL::regression slope: 2.9128
+DEAL::Last number of DoFs: 4913
+DEAL::Last L2 error: 0.0024590
+DEAL::regression slope: 2.7217
 DEAL::mapping order: 4
+DEAL::current slope: 2.5735
 DEAL::current slope: 2.8700
-DEAL::current slope: 2.9556
-DEAL::Last number of DoFs: 35937
-DEAL::Last L2 error: 0.00031699
-DEAL::regression slope: 2.9128
+DEAL::Last number of DoFs: 4913
+DEAL::Last L2 error: 0.0024590
+DEAL::regression slope: 2.7217
 DEAL::FE degree: 3
-DEAL::mapping order: 1
-DEAL::current slope: 4.0630
-DEAL::current slope: 4.0165
-DEAL::Last number of DoFs: 117649
-DEAL::Last L2 error: 3.3894e-06
-DEAL::regression slope: 4.0398
 DEAL::mapping order: 2
+DEAL::current slope: 4.2590
 DEAL::current slope: 4.0627
-DEAL::current slope: 4.0164
-DEAL::Last number of DoFs: 117649
-DEAL::Last L2 error: 3.3894e-06
-DEAL::regression slope: 4.0396
+DEAL::Last number of DoFs: 15625
+DEAL::Last L2 error: 5.4851e-05
+DEAL::regression slope: 4.1609
 DEAL::mapping order: 3
+DEAL::current slope: 4.2590
 DEAL::current slope: 4.0627
-DEAL::current slope: 4.0164
-DEAL::Last number of DoFs: 117649
-DEAL::Last L2 error: 3.3894e-06
-DEAL::regression slope: 4.0396
+DEAL::Last number of DoFs: 15625
+DEAL::Last L2 error: 5.4851e-05
+DEAL::regression slope: 4.1609
 DEAL::mapping order: 4
+DEAL::current slope: 4.2590
 DEAL::current slope: 4.0627
-DEAL::current slope: 4.0164
-DEAL::Last number of DoFs: 117649
-DEAL::Last L2 error: 3.3894e-06
-DEAL::regression slope: 4.0396
+DEAL::Last number of DoFs: 15625
+DEAL::Last L2 error: 5.4851e-05
+DEAL::regression slope: 4.1609
 DEAL::mapping order: 5
+DEAL::current slope: 4.2591
 DEAL::current slope: 4.0627
-DEAL::current slope: 4.0164
-DEAL::Last number of DoFs: 117649
-DEAL::Last L2 error: 3.3894e-06
-DEAL::regression slope: 4.0396
+DEAL::Last number of DoFs: 15625
+DEAL::Last L2 error: 5.4851e-05
+DEAL::regression slope: 4.1609


### PR DESCRIPTION
This test previously tended to time out on clang in debug mode (it took about 580 seconds). This commit skips an extra refinement level to get the computation time down to about 70 seconds.

Closes #3787.