### PR TITLE
Get rid of some unused friendship declarations.

### DIFF
--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -281,12 +281,6 @@ namespace SparseMatrixIterators
      */
     template <typename, bool>
     friend class Iterator;
-
-    /**
-     * Make the SparseMatrix class a friend so that it, in turn, can declare
-     * the Reference class a friend.
-     */
-    template <typename> friend class dealii::SparseMatrix;
   };
 
 
@@ -1637,13 +1631,6 @@ private:
    */
   template <typename,bool> friend class SparseMatrixIterators::Iterator;
   template <typename,bool> friend class SparseMatrixIterators::Accessor;
-
-#ifndef DEAL_II_MSVC
-  // Visual studio is choking on the following friend declaration, probably
-  // because Reference is only defined in a specialization. It looks like
-  // the library is compiling without this line, though.
-  template <typename number2> friend class SparseMatrixIterators::Accessor<number2, false>::Reference;
-#endif
 };
 
 #ifndef DOXYGEN


### PR DESCRIPTION
Clang warns about the second one with the following:
```
/home/drwells/Documents/Code/CPP/dealii-dev-clang/include/deal.II/lac/sparse_matrix.h:1645:93: warning:
      dependent nested name specifier 'SparseMatrixIterators::Accessor<number2, false>::' for friend
      class declaration is not supported; turning off access control for 'SparseMatrix'
      [-Wunsupported-friend]
  template <typename number2> friend class SparseMatrixIterators::Accessor<number2, false>::Reference;
```
Additionally, MSVC runs into errors with this friendship declaration (and can compile the library without it), so we can get rid of it.