### PR TITLE
Bugfix: Add forgotten default parameter to function

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -241,7 +241,7 @@ namespace GridGenerator
                               const std::vector<std::vector<double> > &step_sizes,
                               const Point<dim>                        &p_1,
                               const Point<dim>                        &p_2,
-                              const bool                              colorize);
+                              const bool                              colorize=false);
 
   /**
    * Like the previous function, but with the following twist: the @p


### PR DESCRIPTION
One of the overloaded GridGenerator::subdivided_hyper_rectangle variants
has a missing default parameter for the last argument.

In reference to #3802