### PR TITLE
Make Tensors trivially copyable.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -133,11 +133,6 @@ public:
   Tensor ();
 
   /**
-   * Copy constructor.
-   */
-  Tensor (const Tensor<0,dim,Number> &initializer);
-
-  /**
    * Constructor from tensors with different underlying scalar type. This
    * obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
@@ -167,11 +162,6 @@ public:
    * This is the const conversion operator that returns a read-only reference.
    */
   operator const Number &() const;
-
-  /**
-   * Copy assignment operator.
-   */
-  Tensor<0,dim,Number> &operator = (const Tensor<0,dim,Number> &rhs);
 
   /**
    * Assignment from tensors with different underlying scalar type. This
@@ -372,11 +362,6 @@ public:
   Tensor ();
 
   /**
-   * Copy constructor.
-   */
-  Tensor (const Tensor<rank_,dim,Number> &initializer);
-
-  /**
    * Constructor, where the data is copied from a C-style array.
    */
   Tensor (const array_type &initializer);
@@ -420,11 +405,6 @@ public:
    * Read and write access using TableIndices <tt>indices</tt>
    */
   Number &operator [] (const TableIndices<rank_> &indices);
-
-  /**
-   * Copy assignment operator.
-   */
-  Tensor &operator = (const Tensor<rank_,dim,Number> &rhs);
 
   /**
    * Assignment operator from tensors with different underlying scalar type.
@@ -596,14 +576,6 @@ Tensor<0,dim,Number>::Tensor ()
 
 
 template <int dim, typename Number>
-inline
-Tensor<0,dim,Number>::Tensor (const Tensor<0,dim,Number> &p)
-{
-  value = p.value;
-}
-
-
-template <int dim, typename Number>
 template <typename OtherNumber>
 inline
 Tensor<0,dim,Number>::Tensor (const OtherNumber initializer)
@@ -636,15 +608,6 @@ Tensor<0,dim,Number>::operator const Number &() const
 {
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
   return value;
-}
-
-
-template <int dim, typename Number>
-inline
-Tensor<0,dim,Number> &Tensor<0,dim,Number>::operator = (const Tensor<0,dim,Number> &p)
-{
-  value = p.value;
-  return *this;
 }
 
 
@@ -788,15 +751,6 @@ Tensor<rank_,dim,Number>::Tensor ()
 
 template <int rank_, int dim, typename Number>
 inline
-Tensor<rank_,dim,Number>::Tensor (const Tensor<rank_,dim,Number> &initializer)
-{
-  if (dim > 0)
-    std::copy (&initializer[0], &initializer[0]+dim, &values[0]);
-}
-
-
-template <int rank_, int dim, typename Number>
-inline
 Tensor<rank_,dim,Number>::Tensor (const array_type &initializer)
 {
   for (unsigned int i=0; i<dim; ++i)
@@ -903,17 +857,6 @@ Tensor<rank_,dim,Number>::operator[] (const TableIndices<rank_> &indices)
   Assert(dim != 0, ExcMessage("Cannot access an object of type Tensor<rank_,0,Number>"));
 
   return TensorAccessors::extract<rank_>(*this, indices);
-}
-
-
-template <int rank_, int dim, typename Number>
-inline
-Tensor<rank_,dim,Number> &
-Tensor<rank_,dim,Number>::operator = (const Tensor<rank_,dim,Number> &t)
-{
-  if (dim > 0)
-    std::copy (&t.values[0], &t.values[0]+dim, &values[0]);
-  return *this;
 }
 
 

--- a/tests/base/tensor_trivial_copy.cc
+++ b/tests/base/tensor_trivial_copy.cc
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Verify that Tensor is trivially copyable.
+
+// TODO not all compilers that support enough of a subset of C++11 to compile
+// the library (notably GCC 4.8) implement std::is_trivally_copyable. At some
+// point in the future we should use that instead of the boost equivalent.
+
+#include <deal.II/base/tensor.h>
+
+#include <boost/type_traits.hpp>
+
+#include <complex>
+
+#include "../tests.h"
+
+template <typename Number>
+void test()
+{
+  deallog << "Tensor<0, 1> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<0, 1, Number> >::value
+          << std::endl;
+  deallog << "Tensor<0, 2> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<0, 2, Number> >::value
+          << std::endl;
+
+  deallog << "Tensor<1, 1> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<1, 1, Number> >::value
+          << std::endl;
+  deallog << "Tensor<1, 2> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<1, 2, Number> >::value
+          << std::endl;
+  deallog << "Tensor<1, 3> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<1, 3, Number> >::value
+          << std::endl;
+
+  deallog << "Tensor<2, 1> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<2, 1, Number> >::value
+          << std::endl;
+  deallog << "Tensor<2, 2> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<2, 2, Number> >::value
+          << std::endl;
+  deallog << "Tensor<2, 3> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<2, 3, Number> >::value
+          << std::endl;
+
+  deallog << "Tensor<3, 1> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<3, 1, Number> >::value
+          << std::endl;
+  deallog << "Tensor<3, 2> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<3, 2, Number> >::value
+          << std::endl;
+  deallog << "Tensor<3, 3> is trivially copyable: "
+          << boost::has_trivial_copy<Tensor<3, 3, Number> >::value
+          << std::endl;
+}
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  deallog << std::boolalpha;
+  deallog << "testing float"
+          << std::endl;
+  test<float>();
+
+  deallog << "testing double"
+          << std::endl;
+  test<double>();
+
+  deallog << "testing std::complex<float>"
+          << std::endl;
+  test<std::complex<float> >();
+
+  deallog << "testing std::complex<double>"
+          << std::endl;
+  test<std::complex<double> >();
+}

--- a/tests/base/tensor_trivial_copy.output
+++ b/tests/base/tensor_trivial_copy.output
@@ -1,0 +1,49 @@
+
+DEAL::testing float
+DEAL::Tensor<0, 1> is trivially copyable: true
+DEAL::Tensor<0, 2> is trivially copyable: true
+DEAL::Tensor<1, 1> is trivially copyable: true
+DEAL::Tensor<1, 2> is trivially copyable: true
+DEAL::Tensor<1, 3> is trivially copyable: true
+DEAL::Tensor<2, 1> is trivially copyable: true
+DEAL::Tensor<2, 2> is trivially copyable: true
+DEAL::Tensor<2, 3> is trivially copyable: true
+DEAL::Tensor<3, 1> is trivially copyable: true
+DEAL::Tensor<3, 2> is trivially copyable: true
+DEAL::Tensor<3, 3> is trivially copyable: true
+DEAL::testing double
+DEAL::Tensor<0, 1> is trivially copyable: true
+DEAL::Tensor<0, 2> is trivially copyable: true
+DEAL::Tensor<1, 1> is trivially copyable: true
+DEAL::Tensor<1, 2> is trivially copyable: true
+DEAL::Tensor<1, 3> is trivially copyable: true
+DEAL::Tensor<2, 1> is trivially copyable: true
+DEAL::Tensor<2, 2> is trivially copyable: true
+DEAL::Tensor<2, 3> is trivially copyable: true
+DEAL::Tensor<3, 1> is trivially copyable: true
+DEAL::Tensor<3, 2> is trivially copyable: true
+DEAL::Tensor<3, 3> is trivially copyable: true
+DEAL::testing std::complex<float>
+DEAL::Tensor<0, 1> is trivially copyable: true
+DEAL::Tensor<0, 2> is trivially copyable: true
+DEAL::Tensor<1, 1> is trivially copyable: true
+DEAL::Tensor<1, 2> is trivially copyable: true
+DEAL::Tensor<1, 3> is trivially copyable: true
+DEAL::Tensor<2, 1> is trivially copyable: true
+DEAL::Tensor<2, 2> is trivially copyable: true
+DEAL::Tensor<2, 3> is trivially copyable: true
+DEAL::Tensor<3, 1> is trivially copyable: true
+DEAL::Tensor<3, 2> is trivially copyable: true
+DEAL::Tensor<3, 3> is trivially copyable: true
+DEAL::testing std::complex<double>
+DEAL::Tensor<0, 1> is trivially copyable: true
+DEAL::Tensor<0, 2> is trivially copyable: true
+DEAL::Tensor<1, 1> is trivially copyable: true
+DEAL::Tensor<1, 2> is trivially copyable: true
+DEAL::Tensor<1, 3> is trivially copyable: true
+DEAL::Tensor<2, 1> is trivially copyable: true
+DEAL::Tensor<2, 2> is trivially copyable: true
+DEAL::Tensor<2, 3> is trivially copyable: true
+DEAL::Tensor<3, 1> is trivially copyable: true
+DEAL::Tensor<3, 2> is trivially copyable: true
+DEAL::Tensor<3, 3> is trivially copyable: true


### PR DESCRIPTION
The implicitly defined copy constructors and assignment operators are no different from the ones implemented prior to this patch, so we can clean things up a bit by just using the defaults here.

This has the nice effect of making the class "trivially copyable", which means compilers may optimize things by using `memcpy` to copy things instead of the copy constructor.