### PR TITLE
Better track which UpdateFlags are required for which operation.

### DIFF
--- a/doc/news/changes/incompatibilities/20170116Bangerth
+++ b/doc/news/changes/incompatibilities/20170116Bangerth
@@ -1,0 +1,12 @@
+Fixed: The MappingQGeneric class (which is a base class of MappingQ)
+sometimes set the update_JxW_values flag internally, even though this
+was not necessary. This resulted in doing more work than was actually
+necessary, and this has been rectified. On the other hand, this change
+means that in some circumstances, codes may not have <i>explicitly</i>
+told an FEValues or FEFaceValues object that they actually need the
+JxW values, but could access them anyway without getting an
+error. This will now yield an error that is easily fixed by
+explicitly listing update_JxW_values as a required flag where you
+create the FEValues object.
+<br>
+(Wolfgang Bangerth, 2017/01/16)


### PR DESCRIPTION
A more complete description is given in the changelog entry. This required a bit of
code churn to fix because I had to more carefully track which flag is actually required
for which operation. I also took the opportunity to clean things up in a couple of corners.

Passes all tests with 'fe' or 'mapping' in their names (of which we have 650 in debug mode).
I suspect that this is good enough coverage -- I broke a number of tests during
development of this patch. Specifically, I allows the tests mentioned in #3226 to pass.

Fixes #3226.