### PR TITLE
Make SymmetricTensor trivially copyable.

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -570,11 +570,6 @@ public:
   SymmetricTensor (const SymmetricTensor<rank,dim,OtherNumber> &initializer);
 
   /**
-   * Assignment operator.
-   */
-  SymmetricTensor &operator = (const SymmetricTensor &);
-
-  /**
    * This operator assigns a scalar to a tensor. To avoid confusion with what
    * exactly it means to assign a scalar value to a tensor, zero is the only
    * value allowed for <tt>d</tt>, allowing the intuitive notation
@@ -1001,17 +996,6 @@ SymmetricTensor<rank,dim,Number>::SymmetricTensor (const Number (&array) [n_inde
   Assert (sizeof(typename base_tensor_type::array_type)
           == sizeof(array),
           ExcInternalError());
-}
-
-
-
-template <int rank, int dim, typename Number>
-inline
-SymmetricTensor<rank,dim,Number> &
-SymmetricTensor<rank,dim,Number>::operator = (const SymmetricTensor<rank,dim,Number> &t)
-{
-  data = t.data;
-  return *this;
 }
 
 

--- a/tests/base/symmetric_tensor_trivial_copy.cc
+++ b/tests/base/symmetric_tensor_trivial_copy.cc
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Verify that SymmetricTensor is trivially copyable.
+
+// TODO not all compilers that support enough of a subset of C++11 to compile
+// the library (notably GCC 4.8) implement std::is_trivally_copyable. At some
+// point in the future we should use that instead of the boost equivalent.
+
+#include <deal.II/base/symmetric_tensor.h>
+
+#include <boost/type_traits.hpp>
+
+#include <complex>
+
+#include "../tests.h"
+
+template <typename Number>
+void test()
+{
+  deallog << "SymmetricTensor<2, 1> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<2, 1, Number> >::value
+          << std::endl;
+  deallog << "SymmetricTensor<2, 2> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<2, 2, Number> >::value
+          << std::endl;
+  deallog << "SymmetricTensor<2, 3> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<2, 3, Number> >::value
+          << std::endl;
+
+  deallog << "SymmetricTensor<4, 1> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<4, 1, Number> >::value
+          << std::endl;
+  deallog << "SymmetricTensor<4, 2> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<4, 2, Number> >::value
+          << std::endl;
+  deallog << "SymmetricTensor<4, 3> is trivially copyable: "
+          << boost::has_trivial_copy<SymmetricTensor<4, 3, Number> >::value
+          << std::endl;
+}
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  deallog << std::boolalpha;
+  deallog << "testing float"
+          << std::endl;
+  test<float>();
+
+  deallog << "testing double"
+          << std::endl;
+  test<double>();
+
+  deallog << "testing std::complex<float>"
+          << std::endl;
+  test<std::complex<float> >();
+
+  deallog << "testing std::complex<double>"
+          << std::endl;
+  test<std::complex<double> >();
+}

--- a/tests/base/symmetric_tensor_trivial_copy.output
+++ b/tests/base/symmetric_tensor_trivial_copy.output
@@ -1,0 +1,29 @@
+
+DEAL::testing float
+DEAL::SymmetricTensor<2, 1> is trivially copyable: true
+DEAL::SymmetricTensor<2, 2> is trivially copyable: true
+DEAL::SymmetricTensor<2, 3> is trivially copyable: true
+DEAL::SymmetricTensor<4, 1> is trivially copyable: true
+DEAL::SymmetricTensor<4, 2> is trivially copyable: true
+DEAL::SymmetricTensor<4, 3> is trivially copyable: true
+DEAL::testing double
+DEAL::SymmetricTensor<2, 1> is trivially copyable: true
+DEAL::SymmetricTensor<2, 2> is trivially copyable: true
+DEAL::SymmetricTensor<2, 3> is trivially copyable: true
+DEAL::SymmetricTensor<4, 1> is trivially copyable: true
+DEAL::SymmetricTensor<4, 2> is trivially copyable: true
+DEAL::SymmetricTensor<4, 3> is trivially copyable: true
+DEAL::testing std::complex<float>
+DEAL::SymmetricTensor<2, 1> is trivially copyable: true
+DEAL::SymmetricTensor<2, 2> is trivially copyable: true
+DEAL::SymmetricTensor<2, 3> is trivially copyable: true
+DEAL::SymmetricTensor<4, 1> is trivially copyable: true
+DEAL::SymmetricTensor<4, 2> is trivially copyable: true
+DEAL::SymmetricTensor<4, 3> is trivially copyable: true
+DEAL::testing std::complex<double>
+DEAL::SymmetricTensor<2, 1> is trivially copyable: true
+DEAL::SymmetricTensor<2, 2> is trivially copyable: true
+DEAL::SymmetricTensor<2, 3> is trivially copyable: true
+DEAL::SymmetricTensor<4, 1> is trivially copyable: true
+DEAL::SymmetricTensor<4, 2> is trivially copyable: true
+DEAL::SymmetricTensor<4, 3> is trivially copyable: true


### PR DESCRIPTION
This is a follow up to #3805 which made `Tensor`s trivially copyable.