### PR TITLE
[WIP] Forward declare Tensor and similar classes in one place.

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -17,6 +17,7 @@
 #define dealii__derivative_form_h
 
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -52,7 +53,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Sebastian Pauletti, 2011, Luca Heltai, 2015
  */
-template <int order, int dim, int spacedim, typename Number=double>
+template <int order, int dim, int spacedim, typename Number>
 class DerivativeForm
 {
 public:

--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -53,7 +53,14 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @author Sebastian Pauletti, 2011, Luca Heltai, 2015
  */
+#ifdef DOXYGEN
+// Repeat the forward declaration's default template argument for Doxygen
+// (recall that repeating a default template argument from a forward
+// declaration is not allowed).
+template <int order, int dim, int spacedim, typename Number = double>
+#else
 template <int order, int dim, int spacedim, typename Number>
+#endif // ifdef DOXYGEN
 class DerivativeForm
 {
 public:

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_management.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -21,9 +21,9 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function_time.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/tensor.h>
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/std_cxx11/function.h>
 
 #include <vector>

--- a/include/deal.II/base/function_bessel.h
+++ b/include/deal.II/base/function_bessel.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_GSL
 #include <deal.II/base/function.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <gsl/gsl_spline.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -16,10 +16,10 @@
 #ifndef dealii__function_derivative_h
 #define dealii__function_derivative_h
 
-#include <deal.II/base/config.h>
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/function.h>
 #include <deal.II/base/auto_derivative_function.h>
+#include <deal.II/base/config.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -19,8 +19,9 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/table_indices.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 
 #include <deal.II/base/std_cxx11/array.h>
 

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -20,8 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/thread_local_storage.h>
 #include <vector>
 #include <map>

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -17,6 +17,7 @@
 #define dealii__mpi_h
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 
 #include <vector>
 
@@ -36,10 +37,6 @@ static const int MPI_SUM = 0;
 
 DEAL_II_NAMESPACE_OPEN
 
-
-//Forward type declarations to allow MPI sums over tensorial types
-template <int rank, int dim, typename Number> class Tensor;
-template <int rank, int dim, typename Number> class SymmetricTensor;
 
 //Forward type declaration to allow MPI sums over Vector<number> type
 template <typename Number> class Vector;

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
@@ -85,7 +86,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup geomprimitives
  * @author Wolfgang Bangerth, 1997
  */
-template <int dim, typename Number = double>
+template <int dim, typename Number>
 class Point : public Tensor<1,dim,Number>
 {
 public:

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -86,7 +86,14 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup geomprimitives
  * @author Wolfgang Bangerth, 1997
  */
+#ifdef DOXYGEN
+// Repeat the forward declaration's default template argument for Doxygen
+// (recall that repeating a default template argument from a forward
+// declaration is not allowed).
+template <int dim, typename Number = double>
+#else
 template <int dim, typename Number>
+#endif // ifdef DOXYGEN
 class Point : public Tensor<1,dim,Number>
 {
 public:

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/std_cxx11/shared_ptr.h>
 
 #include <vector>

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -19,10 +19,9 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/thread_management.h>

--- a/include/deal.II/base/polynomials_adini.h
+++ b/include/deal.II/base/polynomials_adini.h
@@ -17,8 +17,8 @@
 #ifndef dealii__polynomials_adini_h
 #define dealii__polynomials_adini_h
 
-#include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/table.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -20,8 +20,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor_product_polynomials.h>

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -19,8 +19,6 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/polynomial.h>
-#include <deal.II/base/point.h>
 
 #include <vector>
 

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -19,8 +19,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor_product_polynomials.h>

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -502,7 +502,14 @@ namespace internal
  * @ingroup geomprimitives
  * @author Wolfgang Bangerth, 2005
  */
+#ifdef DOXYGEN
+// Repeat the forward declaration's default template argument for Doxygen
+// (recall that repeating a default template argument from a forward
+// declaration is not allowed).
+template <int rank, int dim, typename Number = double>
+#else
 template <int rank, int dim, typename Number>
+#endif // DOXYGEN
 class SymmetricTensor
 {
 public:

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -18,13 +18,12 @@
 
 
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/template_constraints.h>
 
 DEAL_II_NAMESPACE_OPEN
-
-template <int rank, int dim, typename Number=double> class SymmetricTensor;
 
 template <int dim, typename Number> SymmetricTensor<2,dim,Number>
 unit_symmetric_tensor ();

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/tensor_accessors.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/utilities.h>
 
@@ -29,10 +30,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-// Forward declarations:
-
-template <int dim, typename Number> class Point;
-template <int rank_, int dim, typename Number = double> class Tensor;
+// Forward declaration:
 template <typename Number> class Vector;
 
 #ifndef DOXYGEN

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -312,7 +312,14 @@ private:
  * @ingroup geomprimitives
  * @author Wolfgang Bangerth, 1998-2005, Matthias Maier, 2015
  */
+#ifdef DOXYGEN
+// Repeat the forward declaration's default template argument for Doxygen
+// (recall that repeating a default template argument from a forward
+// declaration is not allowed).
+template <int rank_, int dim, typename Number = double>
+#else
 template <int rank_, int dim, typename Number>
+#endif // DOXYGEN
 class Tensor
 {
 public:

--- a/include/deal.II/base/tensor_classes_fwd.h
+++ b/include/deal.II/base/tensor_classes_fwd.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 // C++ does not permit repeated forward declarations of template classes with
-// default template arguments. Hence, collect the three most common
+// default template arguments. Hence, collect the four most common
 // Tensor-like classes here so that we can just include this file (with the
 // <code>#ifndef</code> guards) to avoid this problem.
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/tensor_classes_fwd.h
+++ b/include/deal.II/base/tensor_classes_fwd.h
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef dealii_tensor_classes_fwd_h
+#define dealii_tensor_classes_fwd_h
+
+#include <deal.II/base/config.h>
+
+// C++ does not permit repeated forward declarations of template classes with
+// default template arguments. Hence, collect the three most common
+// Tensor-like classes here so that we can just include this file (with the
+// <code>#ifndef</code> guards) to avoid this problem.
+DEAL_II_NAMESPACE_OPEN
+
+template <int spacedim, typename Number = double>
+class Point;
+template <int rank, int dim, typename Number = double>
+class Tensor;
+template <int rank, int dim, typename Number = double>
+class SymmetricTensor;
+template <int order, int dim, int spacedim, typename Number = double>
+class DerivativeForm;
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // dealii_tensor_classes_fwd_h

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/function_time.h>
+#include <deal.II/base/tensor.h>
 
 #include <vector>
 

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -19,9 +19,9 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -19,8 +19,6 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/point.h>
-#include <deal.II/base/tensor.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/vector_slice.h>
 #include <deal.II/base/geometry_info.h>

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/polynomials_nedelec.h>
 #include <deal.II/base/polynomials_bdm.h>
 #include <deal.II/base/polynomial.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/fe/fe.h>

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -21,9 +21,8 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/geometry_info.h>
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/fe/component_mask.h>
 #include <deal.II/lac/parallel_vector.h>

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -23,6 +23,7 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/vector_slice.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -18,7 +18,7 @@
 
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/derivative_form.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/array_view.h>
 #include <deal.II/grid/tria.h>

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -19,12 +19,16 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/table.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/qprojector.h>
-#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/base/table.h>
+
 #include <deal.II/dofs/dof_accessor.h>
+
 #include <deal.II/fe/mapping.h>
+
+#include <deal.II/grid/tria_iterator.h>
 
 #include <cmath>
 

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -19,9 +19,13 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/derivative_form.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/grid/tria_iterator.h>
+
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/fe_q.h>
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -20,9 +20,10 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
-#include <deal.II/base/function.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/grid/tria.h>
 #include <map>
 

--- a/include/deal.II/grid/grid_reordering.h
+++ b/include/deal.II/grid/grid_reordering.h
@@ -18,6 +18,8 @@
 
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/point.h>
+
 #include <deal.II/grid/tria.h>
 
 #include <vector>

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -23,8 +23,8 @@
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/thread_management.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/derivative_form.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/grid/tria.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/grid/tensor_product_manifold.h
+++ b/include/deal.II/grid/tensor_product_manifold.h
@@ -19,6 +19,8 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
+
 #include <deal.II/grid/manifold.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/grid/tria_boundary.h
+++ b/include/deal.II/grid/tria_boundary.h
@@ -20,10 +20,12 @@
 /*----------------------------   boundary-function.h     ---------------------------*/
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/subscriptor.h>
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/subscriptor.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/thread_management.h>
+
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/manifold.h>
 

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 
-#include <deal.II/base/point.h>
 #include <deal.II/grid/tria_iterator_base.h>
 
 #include <iterator>

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -18,12 +18,13 @@
 
 
 #include <deal.II/base/config.h>
-#include <vector>
+
 #include <deal.II/grid/tria_object.h>
-#include <deal.II/base/point.h>
 #include <deal.II/grid/tria_objects.h>
 
 #include <boost/serialization/utility.hpp>
+
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -20,9 +20,9 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/identity_matrix.h>
-#include <deal.II/base/tensor.h>
 
 #include <vector>
 #include <iomanip>

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -26,6 +26,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/lapack_full_matrix.h>

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -20,10 +20,12 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/template_constraints.h>
-#include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/vectorization.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/smartpointer.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/template_constraints.h>
+#include <deal.II/base/vectorization.h>
+
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/mapping_data_on_the_fly.h>

--- a/include/deal.II/matrix_free/helper_functions.h
+++ b/include/deal.II/matrix_free/helper_functions.h
@@ -22,7 +22,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/utilities.h>
-#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/vectorization.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/algorithms/any_data.h>
 #include <deal.II/algorithms/named_selection.h>
-#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/mg_level_object.h>
 

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -19,8 +19,8 @@
 
 
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/tensor.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/fe/fe_update_flags.h>
 #include <deal.II/numerics/data_component_interpretation.h>

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -21,8 +21,8 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/mapping_q1.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/thread_local_storage.h>
 
 #include <deal.II/lac/vector.h>

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -21,6 +21,7 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/mapping_q1.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_classes_fwd.h>
 #include <deal.II/base/thread_local_storage.h>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -20,10 +20,12 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/point.h>
 #include <deal.II/base/std_cxx11/function.h>
+#include <deal.II/base/tensor_fwd.h>
+
 #include <deal.II/dofs/function_map.h>
 #include <deal.II/dofs/dof_handler.h>
+
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/mapping_collection.h>
 

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/std_cxx11/function.h>
-#include <deal.II/base/tensor_fwd.h>
+#include <deal.II/base/tensor_classes_fwd.h>
 
 #include <deal.II/dofs/function_map.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -19,9 +19,11 @@
 
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/polynomials_piecewise.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/qprojector.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/distributed/tria_base.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/function_parser.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/lac/vector.h>

--- a/source/base/polynomials_adini.cc
+++ b/source/base/polynomials_adini.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 
+#include <deal.II/base/point.h>
 #include <deal.II/base/polynomials_adini.h>
 
 #define ENTER_COEFFICIENTS(koefs,z,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11)       \


### PR DESCRIPTION
I noticed, while working on #3805 and #3811, that `symmetric_tensor.h` and `tensor.h` are included in so many files that (nearly) the entire library must be recompiled if one of those files changes. I did a bit of work to try and make the situation better by adding more forward declarations.

Since `DerivativeForm`, `Point`, `Tensor`, and `SymmetricTensor` all have default template arguments, they cannot be forward declared (properly) more than once in a translation unit so I put the forward declarations with optional arguments in a separate file, `tensor_classes_fwd.h` (I picked the name to look like `iosfwd.h`). I would be happy to hear about a better approach or name for this.

Edit: fixed typo