### PR TITLE
move operations for FullMatrix

### DIFF
--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -225,17 +225,6 @@ public:
               const size_type cols);
 
   /**
-   * Copy constructor. This constructor does a deep copy of the matrix.
-   * Therefore, it poses a possible efficiency problem, if for example,
-   * function arguments are passed by value rather than by reference.
-   * Unfortunately, we can't mark this copy constructor <tt>explicit</tt>,
-   * since that prevents the use of this class in containers, such as
-   * <tt>std::vector</tt>. The responsibility to check performance of programs
-   * must therefore remain with the user of this class.
-   */
-  FullMatrix (const FullMatrix &);
-
-  /**
    * Constructor initializing from an array of numbers. The array is arranged
    * line by line. No range checking is performed.
    */
@@ -262,14 +251,6 @@ public:
   /**
    * @{
    */
-
-  /**
-   * Assignment operator.
-   *
-   * @dealiiOperationIsMultithreaded
-   */
-  FullMatrix<number> &
-  operator = (const FullMatrix<number> &);
 
   /**
    * Variable assignment operator.

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -66,13 +66,6 @@ FullMatrix<number>::FullMatrix (const size_type m,
 }
 
 
-template <typename number>
-FullMatrix<number>::FullMatrix (const FullMatrix &m)
-  :
-  Table<2,number> (m)
-{}
-
-
 
 template <typename number>
 FullMatrix<number>::FullMatrix (const IdentityMatrix &id)
@@ -83,14 +76,6 @@ FullMatrix<number>::FullMatrix (const IdentityMatrix &id)
     (*this)(i,i) = 1;
 }
 
-
-template <typename number>
-FullMatrix<number> &
-FullMatrix<number>::operator = (const FullMatrix<number> &M)
-{
-  Table<2,number>::operator=(M);
-  return *this;
-}
 
 
 template <typename number>

--- a/tests/full_matrix/full_matrix_move.cc
+++ b/tests/full_matrix/full_matrix_move.cc
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that FullMatrix objects can be move constructed and assigned
+
+#include "../tests.h"
+
+#include <deal.II/lac/full_matrix.h>
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.0e-10);
+
+  size_t m = 2, n = 3;
+  FullMatrix<double> A(m, n);
+  for (size_t i = 0; i < m; ++i)
+    for (size_t j = 0; j < n; ++j)
+      A(i, j) = n * i + j;
+
+  deallog << "Size of A:" << std::endl
+          << A.m() << " " << A.n() << std::endl;
+
+  FullMatrix<double> B = std::move(A);
+
+  deallog << "Size of B:" << std::endl
+          << B.m() << " " << B.n() << std::endl;
+  deallog << "Size of A:" << std::endl
+          << A.m() << " " << A.n() << std::endl;
+
+  A = std::move(B);
+  deallog << "Size of B:" << std::endl
+          << B.m() << " " << B.n() << std::endl;
+  deallog << "Size of A:" << std::endl
+          << A.m() << " " << A.n() << std::endl;
+
+  return 0;
+}

--- a/tests/full_matrix/full_matrix_move.with_cxx11=on.output
+++ b/tests/full_matrix/full_matrix_move.with_cxx11=on.output
@@ -1,0 +1,11 @@
+
+DEAL::Size of A:
+DEAL::2 3
+DEAL::Size of B:
+DEAL::2 3
+DEAL::Size of A:
+DEAL::0 0
+DEAL::Size of B:
+DEAL::0 0
+DEAL::Size of A:
+DEAL::2 3


### PR DESCRIPTION
This PR adds move operations for `FullMatrix`, see #898 . It does so by removing the explicitly-defined copy constructor and copy assignment operator for the class. As per [the standard](http://en.cppreference.com/w/cpp/language/copy_constructor), copy operators are implicitly defined for `FullMatrix` because they are defined for the parent class `Table<2>`, so explicitly defining them for `FullMatrix` is unnecessary. Moreover, move operators are *not* implicitly defined if there are explicitly defined copy operators (see [here](http://en.cppreference.com/w/cpp/language/move_constructor)), so by having explicit copy operators, one prevents the use of the default move operators.