### PR TITLE
split instantiations

### DIFF
--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1990,6 +1990,10 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::update_internal_dofs
 }
 
 // explicit instantiations
+#define SPLIT_INSTANTIATIONS_COUNT 2
+#ifndef SPLIT_INSTANTIATIONS_INDEX
+#define SPLIT_INSTANTIATIONS_INDEX 0
+#endif
 #include "mapping_fe_field.inst"
 
 

--- a/source/fe/mapping_fe_field_inst2.cc
+++ b/source/fe/mapping_fe_field_inst2.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2017 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -14,15 +14,5 @@
 // ---------------------------------------------------------------------
 
 
-#include <deal.II/numerics/vector_tools.templates.h>
-
-DEAL_II_NAMESPACE_OPEN
-
-// ---------------------------- explicit instantiations --------------------
-#define SPLIT_INSTANTIATIONS_COUNT 3
-#ifndef SPLIT_INSTANTIATIONS_INDEX
-#define SPLIT_INSTANTIATIONS_INDEX 0
-#endif
-#include "vector_tools_project.inst"
-
-DEAL_II_NAMESPACE_CLOSE
+#define SPLIT_INSTANTIATIONS_INDEX 1
+#include "mapping_fe_field.cc"

--- a/source/numerics/vector_tools_project_inst2.cc
+++ b/source/numerics/vector_tools_project_inst2.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2017 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -14,15 +14,5 @@
 // ---------------------------------------------------------------------
 
 
-#include <deal.II/numerics/vector_tools.templates.h>
-
-DEAL_II_NAMESPACE_OPEN
-
-// ---------------------------- explicit instantiations --------------------
-#define SPLIT_INSTANTIATIONS_COUNT 3
-#ifndef SPLIT_INSTANTIATIONS_INDEX
-#define SPLIT_INSTANTIATIONS_INDEX 0
-#endif
-#include "vector_tools_project.inst"
-
-DEAL_II_NAMESPACE_CLOSE
+#define SPLIT_INSTANTIATIONS_INDEX 1
+#include "vector_tools_project.cc"

--- a/source/numerics/vector_tools_project_inst3.cc
+++ b/source/numerics/vector_tools_project_inst3.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2017 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -14,15 +14,5 @@
 // ---------------------------------------------------------------------
 
 
-#include <deal.II/numerics/vector_tools.templates.h>
-
-DEAL_II_NAMESPACE_OPEN
-
-// ---------------------------- explicit instantiations --------------------
-#define SPLIT_INSTANTIATIONS_COUNT 3
-#ifndef SPLIT_INSTANTIATIONS_INDEX
-#define SPLIT_INSTANTIATIONS_INDEX 0
-#endif
-#include "vector_tools_project.inst"
-
-DEAL_II_NAMESPACE_CLOSE
+#define SPLIT_INSTANTIATIONS_INDEX 2
+#include "vector_tools_project.cc"


### PR DESCRIPTION
This splits some large files to compile with <2.5GB RAM with gcc again.

gcc 4.8.4 and using ulimit -v 2500000 except for the linking step.