### PR TITLE
disable MGTransferPrebuilt without Trilinos

### DIFF
--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -99,6 +99,23 @@ namespace internal
     {
     }
   };
+#else
+  // ! DEAL_II_WITH_TRILINOS
+  template <typename Number>
+  struct MatrixSelector<LinearAlgebra::distributed::Vector<Number> >
+  {
+    typedef ::dealii::SparsityPattern Sparsity;
+    typedef ::dealii::SparseMatrix<Number> Matrix;
+
+    template <typename SparsityPatternType, typename DoFHandlerType>
+    static void reinit(Matrix &, Sparsity &, int, const SparsityPatternType &, const DoFHandlerType &)
+    {
+      AssertThrow(false, ExcNotImplemented(
+                    "ERROR: MGTransferPrebuilt with LinearAlgebra::distributed::Vector currently "
+                    "needs deal.II to be configured with Trilinos."));
+    }
+  };
+
 #endif
 }
 

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -16,7 +16,7 @@
 
 // Deadlock reported by Kronbichler (github
 // https://github.com/dealii/dealii/issues/2051) with 3 processes
-// in MgTransferPrebuilt
+// in MGTransferPrebuilt
 
 
 #include "../tests.h"
@@ -27,6 +27,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/multigrid/mg_transfer.h>
+#include <deal.II/multigrid/mg_transfer_matrix_free.h>
 #include <deal.II/grid/grid_out.h>
 
 
@@ -76,10 +77,23 @@ void check()
 
           grid_out.write_svg (tr, grid_output);
         }
+#ifdef DEAL_II_WITH_TRILINOS
+      {
+        // MGTransferPrebuilt internally uses Trilinos matrices, so only
+        // create this if we have Trilinos
+        MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double> >
+        transfer_ref(mg_constrained_dofs);
+        transfer_ref.build_matrices(mgdof);
+      }
+#endif
+      {
+        // but the matrix free transfer will work without Trilinos
+        MGTransferMatrixFree<dim, double>
+        transfer_ref(mg_constrained_dofs);
+        transfer_ref.build(mgdof);
+      }
 
-      MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double> >
-      transfer_ref(mg_constrained_dofs);
-      transfer_ref.build_matrices(mgdof);
+
     }
 }
 


### PR DESCRIPTION
Do not allow MGTransferPrebuilt to work with distributed::Vector if we
don't have Trilinos. This used to compile and crash at runtime because
we wrongly created serial matrices.
This also fixes the tests/multigrid/transfer_prebuilt_04 error message:
```
An error occurred in line <361> of file
</mnt/data/testsuite/dealii/source/lac/dynamic_sparsity_pattern.cc> in
function
    bool
dealii::DynamicSparsityPattern::exists(dealii::DynamicSparsityPattern::size_type,
dealii::DynamicSparsityPattern::size_type) const
The violated condition was:
    rowset.size()==0 || rowset.is_element(i)
```