### PR TITLE
Give the hp version of VectorTools::project its own file.

### DIFF
--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -50,6 +50,7 @@ SET(_src
   vector_tools_project.cc
   vector_tools_project_inst2.cc
   vector_tools_project_inst3.cc
+  vector_tools_project_hp.cc
   vector_tools_project_qp.cc
   vector_tools_project_qpmf.cc
   vector_tools_rhs.cc
@@ -80,6 +81,7 @@ SET(_inst
   vector_tools_point_value.inst.in
   vector_tools_point_gradient.inst.in
   vector_tools_project.inst.in
+  vector_tools_project_hp.inst.in
   vector_tools_project_qp.inst.in
   vector_tools_project_qpmf.inst.in
   vector_tools_rhs.inst.in

--- a/source/numerics/vector_tools_project_hp.cc
+++ b/source/numerics/vector_tools_project_hp.cc
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/numerics/vector_tools.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+// ---------------------------- explicit instantiations --------------------
+
+#include "vector_tools_project_hp.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/vector_tools_project_hp.inst.in
+++ b/source/numerics/vector_tools_project_hp.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -20,26 +20,26 @@ for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_d
     namespace VectorTools \{
 
     template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const Mapping<deal_II_dimension,deal_II_space_dimension>      &,
-     const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
+    void project
+    (const hp::MappingCollection<deal_II_dimension,deal_II_space_dimension>      &,
+     const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
      const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
+     const hp::QCollection<deal_II_dimension>   &,
      const Function<deal_II_space_dimension,VEC::value_type>     &,
      VEC                                   &,
      const bool,
-     const Quadrature<deal_II_dimension-1> &,
+     const hp::QCollection<deal_II_dimension-1> &,
      const bool);
 
     template
-    void project<deal_II_dimension, VEC, deal_II_space_dimension>
-    (const DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
+    void project
+    (const hp::DoFHandler<deal_II_dimension,deal_II_space_dimension>   &,
      const ConstraintMatrix                &,
-     const Quadrature<deal_II_dimension>   &,
+     const hp::QCollection<deal_II_dimension>   &,
      const Function<deal_II_space_dimension,VEC::value_type>     &,
      VEC                                   &,
      const bool,
-     const Quadrature<deal_II_dimension-1> &,
+     const hp::QCollection<deal_II_dimension-1> &,
      const bool);
     \}
 #endif


### PR DESCRIPTION
I spent a little time looking into ways to help #3825 and came across one that is pretty easy to do.

This new file takes about 17 seconds to compile and improves the performance of the non-hp (i.e., the matrix free) projections a little bit.

before splitting out the hp files:
```
                                    File name Memory, MB    Time, s
      source/numerics/vector_tools_project.cc       2860         81
source/numerics/vector_tools_project_inst2.cc       2970        100
source/numerics/vector_tools_project_inst3.cc       3956        114
```

After:
```
                                    File name Memory, MB    Time, s
      source/numerics/vector_tools_project.cc       2775         79
source/numerics/vector_tools_project_inst2.cc       2882         92
source/numerics/vector_tools_project_inst3.cc       3948        102
```
These numbers come from setting the C++ compiler as a shell script containing
```sh
/usr/bin/time -v g++ ${1+"$@"}
```
and then parsing the output.
