### PR TITLE
Give the codim > 0 VectorTools::project functions their own file.

### DIFF
--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(_src
   vector_tools_project_inst2.cc
   vector_tools_project_inst3.cc
   vector_tools_project_hp.cc
+  vector_tools_project_codim.cc
   vector_tools_project_qp.cc
   vector_tools_project_qpmf.cc
   vector_tools_rhs.cc
@@ -81,6 +82,7 @@ SET(_inst
   vector_tools_point_value.inst.in
   vector_tools_point_gradient.inst.in
   vector_tools_project.inst.in
+  vector_tools_project_codim.inst.in
   vector_tools_project_hp.inst.in
   vector_tools_project_qp.inst.in
   vector_tools_project_qpmf.inst.in

--- a/source/numerics/vector_tools_project_codim.cc
+++ b/source/numerics/vector_tools_project_codim.cc
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/numerics/vector_tools.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+// ---------------------------- explicit instantiations --------------------
+
+#include "vector_tools_project_codim.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/vector_tools_project_codim.inst.in
+++ b/source/numerics/vector_tools_project_codim.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2014 by the deal.II authors
+// Copyright (C) 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -16,7 +16,7 @@
 
 for (VEC : REAL_SERIAL_VECTORS ; deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS)
 {
-#if deal_II_dimension == deal_II_space_dimension
+#if deal_II_dimension < deal_II_space_dimension
     namespace VectorTools \{
 
     template


### PR DESCRIPTION
Since these functions don't go into the MatrixFree code we can split them off with a very small amount of overhead for the additional parallelization. This lowers the required memory for the last projection instantiation by about a gigabyte.

Before:
```
                                    File name Memory, MB    Time, s
      source/numerics/vector_tools_project.cc       2775         79
source/numerics/vector_tools_project_inst2.cc       2882         92
source/numerics/vector_tools_project_inst3.cc       3948        102
```

After:
```
                                    File name Memory, MB    Time, s
source/numerics/vector_tools_project_codim.cc       1843         28
      source/numerics/vector_tools_project.cc       2774         76
source/numerics/vector_tools_project_inst2.cc       2829         81
source/numerics/vector_tools_project_inst3.cc       2823         86
```