### PR TITLE
Move the matrix-free project copy operation up the call stack. 

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -916,10 +916,6 @@ namespace VectorTools
       (void) project_to_boundary_first;
       (void) q_boundary;
 
-      const IndexSet locally_owned_dofs = dof.locally_owned_dofs();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
-
       typedef typename VectorType::value_type number;
       Assert (dof.get_fe().n_components() == function.n_components,
               ExcDimensionMismatch(dof.get_fe().n_components(),


### PR DESCRIPTION
The matrix-free projection solves the linear system with a specific vector type and then copies the result into the given one. This commit moves that copy operation into a separate function so that the actual matrix free function no longer depends on the type of the input vector. Put another way: we no longer have to instantiate the matrix free projections for all possible vector types.

Before moving the copy operation:
```
                                    File name Memory, MB    Time, s
      source/numerics/vector_tools_project.cc       2774         76
source/numerics/vector_tools_project_inst2.cc       2829         81
source/numerics/vector_tools_project_inst3.cc       2823         86
```
After:
```
                                    File name Memory, MB    Time, s
      source/numerics/vector_tools_project.cc       1855         47
source/numerics/vector_tools_project_inst2.cc       1995         51
source/numerics/vector_tools_project_inst3.cc       2183         55
```

I think that it is fair to say that this closes #3825. Here are the memory consumptions and times for all of the `numerics_obj_debug` targets:

```
                                    File name Memory, MB    Time, s
       cmake/scripts/expand_instantiations.cc         76          0
                        numerics/histogram.cc        213          1
               numerics/data_postprocessor.cc        224          1
                   numerics/time_dependent.cc        514          5
                numerics/matrix_tools_once.cc        548          5
                     numerics/matrix_tools.cc        566          5
              numerics/dof_output_operator.cc        603          6
                   numerics/data_out_stack.cc        629          7
                numerics/data_out_rotation.cc        754          8
                   numerics/data_out_faces.cc        797          8
          numerics/vector_tools_mean_value.cc        811         10
      numerics/vector_tools_point_gradient.cc        816         10
         numerics/vector_tools_constraints.cc        824         10
         numerics/vector_tools_point_value.cc        817         11
                 numerics/vector_tools_rhs.cc        845         13
                   numerics/matrix_creator.cc       1279         16
                         numerics/data_out.cc       1187         16
            numerics/vector_tools_boundary.cc       1143         17
          numerics/vector_tools_project_hp.cc       1169         17
numerics/vector_tools_integrate_difference.cc       1205         21
              numerics/point_value_history.cc       1159         21
       numerics/vector_tools_project_codim.cc       1816         24
               numerics/error_estimator_1d.cc       1297         27
          numerics/solution_transfer_inst4.cc       1389         27
                numerics/solution_transfer.cc       1458         29
          numerics/solution_transfer_inst3.cc       1466         29
          numerics/solution_transfer_inst2.cc       1503         31
             numerics/matrix_creator_inst2.cc       1974         32
            numerics/error_estimator_inst2.cc       1926         37
                  numerics/error_estimator.cc       1933         37
                numerics/fe_field_function.cc       1401         41
         numerics/derivative_approximation.cc       1981         44
             numerics/vector_tools_project.cc       1855         47
             numerics/matrix_creator_inst3.cc       2691         47
       numerics/vector_tools_project_inst2.cc       1995         51
        numerics/vector_tools_project_qpmf.cc       2048         53
       numerics/vector_tools_project_inst3.cc       2183         55
         numerics/vector_tools_interpolate.cc       2059         60
          numerics/vector_tools_project_qp.cc       2563         62
                numerics/data_out_dof_data.cc       2789         87
```

so there are much more expensive files in this module alone :)
