### PR TITLE
Fix constness of argument in FE::interpolate()

### DIFF
--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -124,10 +124,10 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double>          &values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -73,10 +73,10 @@ public:
   virtual FiniteElement<dim> *clone () const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double>          &values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -81,10 +81,10 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double>          &values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -105,7 +105,7 @@ void
 FE_DGVector<PolynomialType,dim,spacedim>::interpolate
 (std::vector<double> & /*local_dofs*/,
  const std::vector<Vector<double> > & /*values*/,
- unsigned int /*offset*/) const
+ const unsigned int /*offset*/) const
 {
   Assert(false, ExcNotImplemented());
 }

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -260,7 +260,7 @@ public:
 
   virtual void interpolate (std::vector<double> &local_dofs,
                             const std::vector<Vector<double> > &values,
-                            unsigned int offset = 0) const;
+                            const unsigned int offset = 0) const;
   virtual void interpolate (std::vector<double> &local_dofs,
                             const VectorSlice<const std::vector<std::vector<double> > > &values)
   const;

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -123,7 +123,7 @@ public:
    */
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
 
   /**
    * Interpolate a set of vector values, computed in the generalized support

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -276,7 +276,7 @@ public:
    */
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
 
   /**
    * Interpolate a set of vector values, computed in the generalized support

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -701,7 +701,7 @@ public:
   void
   interpolate(std::vector<double>                &local_dofs,
               const std::vector<Vector<double> > &values,
-              unsigned int offset = 0) const;
+              const unsigned int offset = 0) const;
 
   /**
    * This function is not implemented and throws an exception if called.

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -73,7 +73,7 @@ public:
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const std::vector<Vector<double> > &values,
-    unsigned int offset) const;
+    const unsigned int offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -129,10 +129,10 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double>          &values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;
@@ -263,7 +263,7 @@ public:
                            const std::vector<double> &values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           unsigned int offset = 0) const;
+                           const unsigned int                  offset = 0) const;
   virtual void interpolate(
     std::vector<double> &local_dofs,
     const VectorSlice<const std::vector<std::vector<double> > > &values) const;

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -524,7 +524,7 @@ void
 FE_ABF<dim>::interpolate(
   std::vector<double>    &local_dofs,
   const std::vector<Vector<double> > &values,
-  unsigned int offset) const
+  const unsigned int offset) const
 {
   Assert (values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3105,7 +3105,7 @@ template <int dim>
 void
 FE_Nedelec<dim>::interpolate (std::vector<double> &local_dofs,
                               const std::vector<Vector<double> > &values,
-                              unsigned int offset) const
+                              const unsigned int offset) const
 {
   const unsigned int deg = this->degree-1;
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -355,7 +355,7 @@ template <int dim, int spacedim>
 void
 FE_Q_Bubbles<dim,spacedim>::interpolate(std::vector<double>    &local_dofs,
                                         const std::vector<Vector<double> > &values,
-                                        unsigned int offset) const
+                                        const unsigned int offset) const
 {
   Assert (values.size() == this->unit_support_points.size(),
           ExcDimensionMismatch(values.size(),

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -199,7 +199,7 @@ template <int dim, int spacedim>
 void
 FE_Q_DG0<dim,spacedim>::interpolate(std::vector<double>    &local_dofs,
                                     const std::vector<Vector<double> > &values,
-                                    unsigned int offset) const
+                                    const unsigned int offset) const
 {
   Assert (values.size() == this->unit_support_points.size(),
           ExcDimensionMismatch(values.size(),

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -133,7 +133,7 @@ template <int dim>
 void FE_RannacherTurek<dim>::interpolate(
   std::vector<double> &local_dofs,
   const std::vector<Vector<double> > &values,
-  unsigned int offset) const
+  const unsigned int offset) const
 {
   AssertDimension(values.size(), this->generalized_support_points.size());
   AssertDimension(local_dofs.size(), this->dofs_per_cell);

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -477,7 +477,7 @@ void
 FE_RaviartThomas<dim>::interpolate(
   std::vector<double>    &local_dofs,
   const std::vector<Vector<double> > &values,
-  unsigned int offset) const
+  const unsigned int offset) const
 {
   Assert (values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(values.size(), this->generalized_support_points.size()));

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -295,7 +295,7 @@ void
 FE_RaviartThomasNodal<dim>::interpolate(
   std::vector<double>    &local_dofs,
   const std::vector<Vector<double> > &values,
-  unsigned int offset) const
+  const unsigned int offset) const
 {
   Assert (values.size() == this->generalized_support_points.size(),
           ExcDimensionMismatch(values.size(), this->generalized_support_points.size()));


### PR DESCRIPTION
argument ``offset`` is marked const in the base class, so it should be the same in derived classes.

Reported by MSVC.