### PR TITLE
MSVC fixes

### DIFF
--- a/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
@@ -294,8 +294,9 @@
 #endif
 
 //
-// last known and checked version is 19.00.23026 (VC++ 2015 RTM):
-#if (_MSC_VER > 1900)
+// tjhei: taken from boost git repo
+// last known and checked version is 19.10.24629 (VC++ 2017 RC):
+#if (_MSC_VER > 1910)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1094,11 +1094,14 @@ private:
   friend struct dealii::internal::DoFHandler::Implementation;
   friend struct dealii::internal::DoFHandler::Policy::Implementation;
 
-  // explicitly check for sensible template arguments
+  // explicitly check for sensible template arguments, but not on windows
+  // because MSVC creates bogus warnings during normal compilation
 #ifdef DEAL_II_WITH_CXX11
+#ifndef DEAL_II_MSVC
   static_assert (dim<=spacedim,
                  "The dimension <dim> of a DoFHandler must be less than or "
                  "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 };
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2722,11 +2722,14 @@ protected:
   friend class FESubfaceValues<dim,spacedim>;
   friend class FESystem<dim,spacedim>;
 
-  // explicitly check for sensible template arguments
+  // explicitly check for sensible template arguments, but not on windows
+  // because MSVC creates bogus warnings during normal compilation
 #ifdef DEAL_II_WITH_CXX11
+#ifndef DEAL_II_MSVC
   static_assert (dim<=spacedim,
                  "The dimension <dim> of a FiniteElement must be less than or "
                  "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 
 };

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3526,11 +3526,14 @@ private:
   template <typename>
   friend class dealii::internal::Triangulation::TriaObjects;
 
-  // explicitly check for sensible template arguments
+  // explicitly check for sensible template arguments, but not on windows
+  // because MSVC creates bogus warnings during normal compilation
 #ifdef DEAL_II_WITH_CXX11
+#ifndef DEAL_II_MSVC
   static_assert (dim<=spacedim,
                  "The dimension <dim> of a Triangulation must be less than or "
                  "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 
 };


### PR DESCRIPTION
- enable compilation of bundled boost with MSVC 2017rc1
- remove static_assert that gets wrongly triggered during normal compilation