### PR TITLE
Fix the default doxygen table colors.

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1255,7 +1255,7 @@
  *
  * <table><tr>
  *   <th>Element</th>
- *   <th>Function space</th>
+ *   <th>%Function space</th>
  *   <th>Node values</th></tr>
  *   <tr><th>FE_Q, FE_DGQ</th>
  *     <td><i>Q<sub>k</sub></i></td>

--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -27,6 +27,17 @@ div.doxygen-generated-exception-message {
     font-size: 95%;
 }
 
+/*
+ * Fix the default table settings to be readable: this overrides the first row
+ * and column background to grey (instead of dark blue, upon which links are
+ * impossible to read) and the text color to black (instead of white, which
+ * would no longer be visable).
+ */
+table.doxtable th {
+	background-color: #d6d6d6;
+	color: #000000;
+}
+
 div.image img[src="fe_enriched_1d.png"] {
     width:500px;
 }


### PR DESCRIPTION
Fixes #3836. Here is a picture:

![screenshot](https://cloud.githubusercontent.com/assets/3917035/22204325/65edd3ca-e13f-11e6-80a2-4789ea56e341.png)

If anyone wants a different color let me know.