### PR TITLE
Make compile without C++11 but Trilinos

### DIFF
--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -616,10 +616,10 @@ namespace TrilinosWrappers
     } /*namespace BlockLinearOperator*/
   } /* namespace internal */
 
+#endif // DEAL_II_WITH_CXX11
+
 }/* namespace TrilinosWrappers */
 
-
-#endif // DEAL_II_WITH_CXX11
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
With Trilinos enabled but C++11 disabled, the code below would forget to close the `TrilinosWrappers` namespace, which makes the `DEAL_II_NAMESPACE_CLOSE` close that namespace instead. As a result, the `dealii` namespace was opened twice, leading to all kind of strange compile errors as documented here:
https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=3984