### PR TITLE
Implement Trilinos AztecOO_StatusTest for ReductionControl.

### DIFF
--- a/doc/news/changes/minor/20170128Jean-PaulPelteret
+++ b/doc/news/changes/minor/20170128Jean-PaulPelteret
@@ -1,0 +1,4 @@
+Fixed: Trilinos solvers now respect the convergence criterion specified by
+ReductionControl.
+<br>
+(Jean-Paul Pelteret, 2017/01/28)

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -324,6 +324,12 @@ namespace TrilinosWrappers
     std_cxx11::shared_ptr<Epetra_LinearProblem> linear_problem;
 
     /**
+     * A structure that contains a Trilinos object that can query the linear
+     * solver and determine whether the convergence criterion have been met.
+     */
+    std_cxx11::shared_ptr<AztecOO_StatusTest> status_test;
+
+    /**
      * A structure that contains the Trilinos solver and preconditioner
      * objects.
      */

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -22,7 +22,16 @@
 #  include <deal.II/lac/trilinos_vector_base.h>
 #  include <deal.II/lac/trilinos_precondition.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#  include <AztecOO_StatusTest.h>
+#  include <AztecOO_StatusTestMaxIters.h>
+#  include <AztecOO_StatusTestResNorm.h>
+#  include <AztecOO_StatusTestCombo.h>
+#  include <AztecOO_StatusType.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #  include <cmath>
+#  include <limits>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -282,6 +291,144 @@ namespace TrilinosWrappers
   }
 
 
+  namespace internal
+  {
+    namespace
+    {
+      double
+      compute_residual (const Epetra_MultiVector *const residual_vector)
+      {
+        Assert(residual_vector->NumVectors() == 1,
+               ExcMessage("Residual multivector holds more than one vector"));
+        TrilinosScalar res_l2_norm = 0.0;
+        const int ierr = residual_vector->Norm2 (&res_l2_norm);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
+        return res_l2_norm;
+      }
+
+      class TrilinosReductionControl : public AztecOO_StatusTest
+      {
+      public:
+        TrilinosReductionControl (const double               &max_steps,
+                                  const double               &tolerance,
+                                  const double               &reduction,
+                                  const Epetra_LinearProblem &linear_problem);
+
+        virtual ~TrilinosReductionControl() {}
+
+        virtual bool
+        ResidualVectorRequired () const
+        {
+          return status_test_collection->ResidualVectorRequired();
+        }
+
+        virtual AztecOO_StatusType
+        CheckStatus (int                 CurrentIter,
+                     Epetra_MultiVector *CurrentResVector,
+                     double              CurrentResNormEst,
+                     bool                SolutionUpdated)
+        {
+          // Note: CurrentResNormEst is set to -1.0 if no estimate of the
+          // residual value is available
+          current_residual = (CurrentResNormEst < 0.0 ?
+                              compute_residual(CurrentResVector) :
+                              CurrentResNormEst);
+          if (CurrentIter == 0)
+            initial_residual = current_residual;
+
+          return status_test_collection->CheckStatus(CurrentIter,
+                                                     CurrentResVector,
+                                                     CurrentResNormEst,
+                                                     SolutionUpdated);
+
+        }
+
+        virtual AztecOO_StatusType
+        GetStatus () const
+        {
+          return status_test_collection->GetStatus();
+        }
+
+        virtual std::ostream &
+        Print (std::ostream &stream,
+               int           indent = 0) const
+        {
+          return status_test_collection->Print(stream,indent);
+        }
+
+        double
+        get_initial_residual() const
+        {
+          return initial_residual;
+        }
+
+        double
+        get_current_residual() const
+        {
+          return current_residual;
+        }
+
+      private:
+        double initial_residual;
+        double current_residual;
+        std_cxx11::shared_ptr<AztecOO_StatusTestCombo>    status_test_collection;
+        std_cxx11::shared_ptr<AztecOO_StatusTestMaxIters> status_test_max_steps;
+        std_cxx11::shared_ptr<AztecOO_StatusTestResNorm>  status_test_abs_tol;
+        std_cxx11::shared_ptr<AztecOO_StatusTestResNorm>  status_test_rel_tol;
+      };
+
+
+      TrilinosReductionControl::TrilinosReductionControl(
+        const double               &max_steps,
+        const double               &tolerance,
+        const double               &reduction,
+        const Epetra_LinearProblem &linear_problem )
+        :
+        initial_residual (std::numeric_limits<double>::max()),
+        current_residual(std::numeric_limits<double>::max())
+      {
+        // Consider linear problem converged if any of the collection
+        // of criterion are met
+        status_test_collection.reset(
+          new AztecOO_StatusTestCombo (AztecOO_StatusTestCombo::OR) );
+
+        // Maximum number of iterations
+        status_test_max_steps.reset(
+          new AztecOO_StatusTestMaxIters(max_steps) );
+        status_test_collection->AddStatusTest(*status_test_max_steps);
+
+        Assert(linear_problem.GetRHS()->NumVectors() == 1,
+               ExcMessage("RHS multivector holds more than one vector"));
+
+        // Residual norm is below some absolute value
+        status_test_abs_tol.reset(
+          new AztecOO_StatusTestResNorm(*linear_problem.GetOperator(),
+                                        *(linear_problem.GetLHS()->operator()(0)),
+                                        *(linear_problem.GetRHS()->operator()(0)),
+                                        tolerance) );
+        status_test_abs_tol->DefineResForm(AztecOO_StatusTestResNorm::Explicit,
+                                           AztecOO_StatusTestResNorm::TwoNorm);
+        status_test_abs_tol->DefineScaleForm(AztecOO_StatusTestResNorm::None,
+                                             AztecOO_StatusTestResNorm::TwoNorm);
+        status_test_collection->AddStatusTest(*status_test_abs_tol);
+
+        // Residual norm, scaled by some initial value, is below some threshold
+        status_test_rel_tol.reset(
+          new AztecOO_StatusTestResNorm(*linear_problem.GetOperator(),
+                                        *(linear_problem.GetLHS()->operator()(0)),
+                                        *(linear_problem.GetRHS()->operator()(0)),
+                                        reduction) );
+        status_test_rel_tol->DefineResForm(AztecOO_StatusTestResNorm::Explicit,
+                                           AztecOO_StatusTestResNorm::TwoNorm);
+        status_test_rel_tol->DefineScaleForm(AztecOO_StatusTestResNorm::NormOfInitRes,
+                                             AztecOO_StatusTestResNorm::TwoNorm);
+        status_test_collection->AddStatusTest(*status_test_rel_tol);
+      }
+
+    }
+  }
+
+
   template<typename Preconditioner>
   void
   SolverBase::do_solve(const Preconditioner &preconditioner)
@@ -322,6 +469,33 @@ namespace TrilinosWrappers
                            AZ_all : AZ_none);
     solver.SetAztecOption (AZ_conv, AZ_noscaled);
 
+    // By default, the Trilinos solver chooses convergence criterion based on
+    // the number of iterations made and an absolute tolerance.
+    // This implies that the use of the standard Trilinos convergence test
+    // actually coincides with dealii::IterationNumberControl because the
+    // solver, unless explicitly told otherwise, will Iterate() until a number
+    // of max_steps() are taken or an absolute tolerance() is attained.
+    // It is therefore suitable for use with both SolverControl or
+    // IterationNumberControl. The final check at the end will determine whether
+    // failure to converge to the defined residual norm constitutes failure
+    // (SolverControl) or is alright (IterationNumberControl).
+    // In the case that the SolverControl wants to perform ReductionControl,
+    // then we have to do a little extra something by prescribing a custom
+    // status test.
+    if (!status_test)
+      {
+        if (const ReductionControl* const reduction_control
+            = dynamic_cast<const ReductionControl *const>(&solver_control))
+          {
+            status_test.reset(new internal::TrilinosReductionControl(
+                                reduction_control->max_steps(),
+                                reduction_control->tolerance(),
+                                reduction_control->reduction(),
+                                *linear_problem) );
+            solver.SetStatusTest(status_test.get());
+          }
+      }
+
     // ... and then solve!
     ierr = solver.Iterate (solver_control.max_steps(),
                            solver_control.tolerance());
@@ -350,7 +524,34 @@ namespace TrilinosWrappers
     // Finally, let the deal.II SolverControl object know what has
     // happened. If the solve succeeded, the status of the solver control will
     // turn into SolverControl::success.
-    solver_control.check (solver.NumIters(), solver.TrueResidual());
+    // If the residual is not computed/stored by the solver, as can happen for
+    // certain choices of solver or if a custom status test is set, then the
+    // result returned by TrueResidual() is equal to -1. In this case we must
+    // compute it ourself.
+    if (const internal::TrilinosReductionControl* const reduction_control_status
+        = dynamic_cast<const internal::TrilinosReductionControl *const>(status_test.get()))
+      {
+        Assert(dynamic_cast<const ReductionControl *const>(&solver_control), ExcInternalError());
+
+        // Check to see if solver converged in one step
+        // This can happen if the matrix is diagonal and a non-trivial
+        // preconditioner is used.
+        if (solver.NumIters() > 0)
+          {
+            // For ReductionControl, we must first register the initial residual
+            // value. This is the basis from which it will determine whether the
+            // current residual corresponds to a converged state.
+            solver_control.check (0, reduction_control_status->get_initial_residual());
+            solver_control.check (solver.NumIters(), reduction_control_status->get_current_residual());
+          }
+        else
+          solver_control.check (solver.NumIters(), reduction_control_status->get_current_residual());
+      }
+    else
+      {
+        Assert(solver.TrueResidual() >= 0.0, ExcInternalError());
+        solver_control.check (solver.NumIters(), solver.TrueResidual());
+      }
 
     if (solver_control.last_check() != SolverControl::success)
       AssertThrow(false, SolverControl::NoConvergence (solver_control.last_step(),

--- a/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=1.output
+++ b/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=1.output
@@ -3,10 +3,13 @@ Refinement cycle 0
    Solving...
 DEAL:ManualSchur:cg::Starting value 7.49608e-06
 DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 74 value 0
-DEAL:SchurComplementOp:Main::Convergence step 12 value 3.95620e-10
-DEAL:SchurComplementOp:Post::Convergence step 74 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000618353
+DEAL:SchurComplementOp:Pre::Starting value 12.7149
+DEAL:SchurComplementOp:Pre::Convergence step 43 value 1.05660e-05
+DEAL:SchurComplementOp:Main::Starting value 7.49608e-06
+DEAL:SchurComplementOp:Main::Convergence step 12 value 4.00858e-10
+DEAL:SchurComplementOp:Post::Starting value 12.7149
+DEAL:SchurComplementOp:Post::Convergence step 74 value 1.05660e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
 0.00000 0.632812	-1.58049	0.00000
 0.00000 0.757812	-1.31971	0.00000
 0.00000 0.882812	-1.13281	0.00000
@@ -16,10 +19,13 @@ Refinement cycle 1
    Solving...
 DEAL:ManualSchur:cg::Starting value 5.38429e-06
 DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 104 value 0
-DEAL:SchurComplementOp:Main::Convergence step 11 value 7.22417e-10
-DEAL:SchurComplementOp:Post::Convergence step 104 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000297273
+DEAL:SchurComplementOp:Pre::Starting value 16.9566
+DEAL:SchurComplementOp:Pre::Convergence step 59 value 1.46447e-05
+DEAL:SchurComplementOp:Main::Starting value 5.38429e-06
+DEAL:SchurComplementOp:Main::Convergence step 11 value 7.25724e-10
+DEAL:SchurComplementOp:Post::Starting value 16.9566
+DEAL:SchurComplementOp:Post::Convergence step 105 value 1.46447e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000296712
 0.00000 0.566406	-1.76557	0.00000
 0.00000 0.628906	-1.59010	0.00000
 0.00000 0.691406	-1.44635	0.00000
@@ -31,12 +37,15 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000297273
 Refinement cycle 2
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 6.10232e-06
+DEAL:ManualSchur:cg::Starting value 6.10267e-06
 DEAL:ManualSchur:cg::Convergence step 12 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 153 value 0
-DEAL:SchurComplementOp:Main::Convergence step 12 value 6.47021e-10
-DEAL:SchurComplementOp:Post::Convergence step 153 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000405072
+DEAL:SchurComplementOp:Pre::Starting value 21.9643
+DEAL:SchurComplementOp:Pre::Convergence step 96 value 2.04878e-05
+DEAL:SchurComplementOp:Main::Starting value 6.10267e-06
+DEAL:SchurComplementOp:Main::Convergence step 12 value 6.88788e-10
+DEAL:SchurComplementOp:Post::Starting value 21.9643
+DEAL:SchurComplementOp:Post::Convergence step 187 value 2.04878e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000406470
 0.00000 0.533203	-1.87543	0.00000
 0.00000 0.564453	-1.77163	0.00000
 0.00000 0.595703	-1.67869	0.00000

--- a/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=3.output
+++ b/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=3.output
@@ -3,10 +3,13 @@ Refinement cycle 0
    Solving...
 DEAL:ManualSchur:cg::Starting value 7.49608e-06
 DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 74 value 0
-DEAL:SchurComplementOp:Main::Convergence step 12 value 3.95620e-10
-DEAL:SchurComplementOp:Post::Convergence step 74 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000618353
+DEAL:SchurComplementOp:Pre::Starting value 12.7149
+DEAL:SchurComplementOp:Pre::Convergence step 43 value 1.05660e-05
+DEAL:SchurComplementOp:Main::Starting value 7.49608e-06
+DEAL:SchurComplementOp:Main::Convergence step 12 value 4.00858e-10
+DEAL:SchurComplementOp:Post::Starting value 12.7149
+DEAL:SchurComplementOp:Post::Convergence step 74 value 1.05660e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
 0.00000 0.632812	-1.58049	0.00000
 0.00000 0.757812	-1.31971	0.00000
 0.00000 0.882812	-1.13281	0.00000
@@ -16,10 +19,13 @@ Refinement cycle 1
    Solving...
 DEAL:ManualSchur:cg::Starting value 5.38732e-06
 DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 104 value 0
-DEAL:SchurComplementOp:Main::Convergence step 11 value 7.22417e-10
-DEAL:SchurComplementOp:Post::Convergence step 104 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000297050
+DEAL:SchurComplementOp:Pre::Starting value 16.9566
+DEAL:SchurComplementOp:Pre::Convergence step 59 value 1.30423e-05
+DEAL:SchurComplementOp:Main::Starting value 5.38732e-06
+DEAL:SchurComplementOp:Main::Convergence step 11 value 7.37537e-10
+DEAL:SchurComplementOp:Post::Starting value 16.9566
+DEAL:SchurComplementOp:Post::Convergence step 105 value 1.30423e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000296380
 0.00000 0.566406	-1.76557	0.00000
 0.00000 0.628906	-1.59010	0.00000
 0.00000 0.691406	-1.44635	0.00000
@@ -31,12 +37,15 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000297050
 Refinement cycle 2
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 6.10415e-06
+DEAL:ManualSchur:cg::Starting value 6.10237e-06
 DEAL:ManualSchur:cg::Convergence step 12 value 0
-DEAL:SchurComplementOp:Pre::Convergence step 153 value 0
-DEAL:SchurComplementOp:Main::Convergence step 12 value 6.47021e-10
-DEAL:SchurComplementOp:Post::Convergence step 153 value 0
-DEAL::Rel. norm of error in SchurOperator solve: 0.000404964
+DEAL:SchurComplementOp:Pre::Starting value 21.9643
+DEAL:SchurComplementOp:Pre::Convergence step 96 value 2.07585e-05
+DEAL:SchurComplementOp:Main::Starting value 6.10237e-06
+DEAL:SchurComplementOp:Main::Convergence step 12 value 6.88676e-10
+DEAL:SchurComplementOp:Post::Starting value 21.9643
+DEAL:SchurComplementOp:Post::Convergence step 187 value 2.07585e-05
+DEAL::Rel. norm of error in SchurOperator solve: 0.000406467
 0.00000 0.533203	-1.87543	0.00000
 0.00000 0.564453	-1.77163	0.00000
 0.00000 0.595703	-1.67869	0.00000

--- a/tests/lac/solver_control_01.cc
+++ b/tests/lac/solver_control_01.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test SolverControl
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_memory.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/solver_relaxation.h>
+#include <deal.II/lac/precondition.h>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  SolverCG<VectorType> solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    SparsityPattern structure(dim, dim, 5);
+    testproblem.five_point_structure(structure);
+    structure.compress();
+    SparseMatrix<double>  A(structure);
+    testproblem.five_point(A);
+
+    Vector<double>  f(dim);
+    Vector<double>  u(dim);
+    f = 1.;
+
+    PreconditionJacobi<> preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      SolverControl solver_control(2000, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects failure
+      SolverControl solver_control(20, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, false);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/lac/solver_control_01.output
+++ b/tests/lac/solver_control_01.output
@@ -1,0 +1,8 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Abs tol:cg::Starting value 31.0000
+DEAL:Abs tol:cg::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations:cg::Starting value 31.0000
+DEAL:Iterations:cg::Failure step 20 value 6.00198
+DEAL:Iterations::Failure. Solver stopped after 20 iterations

--- a/tests/lac/solver_control_02.cc
+++ b/tests/lac/solver_control_02.cc
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test ReductionControl
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_memory.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/solver_relaxation.h>
+#include <deal.II/lac/precondition.h>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  SolverCG<VectorType> solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    SparsityPattern structure(dim, dim, 5);
+    testproblem.five_point_structure(structure);
+    structure.compress();
+    SparseMatrix<double>  A(structure);
+    testproblem.five_point(A);
+
+    Vector<double>  f(dim);
+    Vector<double>  u(dim);
+    f = 1.;
+
+    PreconditionJacobi<> preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Rel tol");
+    {
+      // Expects success
+      ReductionControl solver_control(2000, 1.e-30, 1e-6);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      ReductionControl solver_control(2000, 1.e-3, 1e-9);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects failure
+      ReductionControl solver_control(20, 1.e-30, 1e-6);
+      check_solve (solver_control, A,u,f, preconditioner, false);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/lac/solver_control_02.output
+++ b/tests/lac/solver_control_02.output
@@ -1,0 +1,11 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Rel tol:cg::Starting value 31.0000
+DEAL:Rel tol:cg::Convergence step 50 value 2.11364e-05
+DEAL:Rel tol::Success. Solver stopped after 50 iterations
+DEAL:Abs tol:cg::Starting value 31.0000
+DEAL:Abs tol:cg::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations:cg::Starting value 31.0000
+DEAL:Iterations:cg::Failure step 20 value 6.00198
+DEAL:Iterations::Failure. Solver stopped after 20 iterations

--- a/tests/lac/solver_control_03.cc
+++ b/tests/lac/solver_control_03.cc
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test IterationNumberControl
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_memory.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/solver_relaxation.h>
+#include <deal.II/lac/precondition.h>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  SolverCG<VectorType> solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    SparsityPattern structure(dim, dim, 5);
+    testproblem.five_point_structure(structure);
+    structure.compress();
+    SparseMatrix<double>  A(structure);
+    testproblem.five_point(A);
+
+    Vector<double>  f(dim);
+    Vector<double>  u(dim);
+    f = 1.;
+
+    PreconditionJacobi<> preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      IterationNumberControl solver_control(2000, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects success
+      IterationNumberControl solver_control(20, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/lac/solver_control_03.output
+++ b/tests/lac/solver_control_03.output
@@ -1,0 +1,8 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Abs tol:cg::Starting value 31.0000
+DEAL:Abs tol:cg::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations:cg::Starting value 31.0000
+DEAL:Iterations:cg::Convergence step 20 value 6.00198
+DEAL:Iterations::Success. Solver stopped after 20 iterations

--- a/tests/trilinos/solver_control_01.cc
+++ b/tests/trilinos/solver_control_01.cc
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test SolverControl with Trilinos solver
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/vector_memory.h>
+#include <typeinfo>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  TrilinosWrappers::SolverCG solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    DynamicSparsityPattern csp (dim, dim);
+    testproblem.five_point_structure(csp);
+    TrilinosWrappers::SparseMatrix  A;
+    A.reinit(csp);
+    testproblem.five_point(A);
+
+    TrilinosWrappers::Vector  f(dim);
+    TrilinosWrappers::Vector  u(dim);
+    f = 1.;
+    A.compress (VectorOperation::insert);
+    f.compress (VectorOperation::insert);
+    u.compress (VectorOperation::insert);
+
+    TrilinosWrappers::PreconditionJacobi preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      SolverControl solver_control(2000, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects failure
+      SolverControl solver_control(20, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, false);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/trilinos/solver_control_01.output
+++ b/tests/trilinos/solver_control_01.output
@@ -1,0 +1,6 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Abs tol::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations::Failure step 20 value 6.00198
+DEAL:Iterations::Failure. Solver stopped after 20 iterations

--- a/tests/trilinos/solver_control_02.cc
+++ b/tests/trilinos/solver_control_02.cc
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test ReductionControl with Trilinos solver
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/vector_memory.h>
+#include <typeinfo>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  TrilinosWrappers::SolverCG solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    DynamicSparsityPattern csp (dim, dim);
+    testproblem.five_point_structure(csp);
+    TrilinosWrappers::SparseMatrix  A;
+    A.reinit(csp);
+    testproblem.five_point(A);
+
+    TrilinosWrappers::Vector  f(dim);
+    TrilinosWrappers::Vector  u(dim);
+    f = 1.;
+    A.compress (VectorOperation::insert);
+    f.compress (VectorOperation::insert);
+    u.compress (VectorOperation::insert);
+
+    TrilinosWrappers::PreconditionJacobi preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Rel tol");
+    {
+      // Expects success
+      ReductionControl solver_control(2000, 1.e-30, 1e-6);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      ReductionControl solver_control(2000, 1.e-3, 1e-9);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects failure
+      ReductionControl solver_control(20, 1.e-30, 1e-6);
+      check_solve (solver_control, A,u,f, preconditioner, false);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/trilinos/solver_control_02.output
+++ b/tests/trilinos/solver_control_02.output
@@ -1,0 +1,11 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Rel tol::Starting value 31.0000
+DEAL:Rel tol::Convergence step 50 value 2.11364e-05
+DEAL:Rel tol::Success. Solver stopped after 50 iterations
+DEAL:Abs tol::Starting value 31.0000
+DEAL:Abs tol::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations::Starting value 31.0000
+DEAL:Iterations::Failure step 20 value 6.00198
+DEAL:Iterations::Failure. Solver stopped after 20 iterations

--- a/tests/trilinos/solver_control_03.cc
+++ b/tests/trilinos/solver_control_03.cc
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test IterationNumberControl with Trilinos solver
+// This test is adapted from tests/trilinos/solver_03.cc
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/vector_memory.h>
+#include <typeinfo>
+
+template<typename MatrixType, typename VectorType, class PRECONDITION>
+void
+check_solve (SolverControl       &solver_control,
+             const MatrixType    &A,
+             VectorType          &u,
+             VectorType          &f,
+             const PRECONDITION  &P,
+             const bool           expected_result)
+{
+  TrilinosWrappers::SolverCG solver(solver_control);
+
+  u = 0.;
+  f = 1.;
+  bool success = false;
+  try
+    {
+      solver.solve(A,u,f,P);
+      deallog << "Success. ";
+      success = true;
+    }
+  catch (std::exception &e)
+    {
+      deallog << "Failure. ";
+    }
+
+  deallog << "Solver stopped after " << solver_control.last_step()
+          << " iterations" << std::endl;
+  Assert(success == expected_result, ExcMessage("Incorrect result."));
+}
+
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    DynamicSparsityPattern csp (dim, dim);
+    testproblem.five_point_structure(csp);
+    TrilinosWrappers::SparseMatrix  A;
+    A.reinit(csp);
+    testproblem.five_point(A);
+
+    TrilinosWrappers::Vector  f(dim);
+    TrilinosWrappers::Vector  u(dim);
+    f = 1.;
+    A.compress (VectorOperation::insert);
+    f.compress (VectorOperation::insert);
+    u.compress (VectorOperation::insert);
+
+    TrilinosWrappers::PreconditionJacobi preconditioner;
+    preconditioner.initialize(A);
+
+    deallog.push("Abs tol");
+    {
+      // Expects success
+      IterationNumberControl solver_control(2000, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+    deallog.push("Iterations");
+    {
+      // Expects success
+      IterationNumberControl solver_control(20, 1.e-3);
+      check_solve (solver_control, A,u,f, preconditioner, true);
+    }
+    deallog.pop();
+  }
+}

--- a/tests/trilinos/solver_control_03.output
+++ b/tests/trilinos/solver_control_03.output
@@ -1,0 +1,6 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:Abs tol::Convergence step 43 value 0.000818932
+DEAL:Abs tol::Success. Solver stopped after 43 iterations
+DEAL:Iterations::Convergence step 20 value 6.00198
+DEAL:Iterations::Success. Solver stopped after 20 iterations

--- a/tests/trilinos/solver_control_04.cc
+++ b/tests/trilinos/solver_control_04.cc
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test that we can reuse a Trilinos solver in a LinearOperator
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include "../testmatrix.h"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_linear_operator.h>
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/packaged_operation.h>
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+
+  {
+    const unsigned int size = 32;
+    unsigned int dim = (size-1)*(size-1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix testproblem(size, size);
+    DynamicSparsityPattern csp (dim, dim);
+    testproblem.five_point_structure(csp);
+    TrilinosWrappers::SparseMatrix  A;
+    A.reinit(csp);
+    testproblem.five_point(A);
+
+    TrilinosWrappers::Vector  f(dim);
+    TrilinosWrappers::Vector  u1(dim);
+    TrilinosWrappers::Vector  u2(dim);
+    f = 1.;
+    A.compress (VectorOperation::insert);
+    f.compress (VectorOperation::insert);
+    u1.compress (VectorOperation::insert);
+    u2.compress (VectorOperation::insert);
+
+    TrilinosWrappers::PreconditionJacobi preconditioner;
+    preconditioner.initialize(A);
+
+    SolverControl solver_control(2000, 1.e-3);
+    TrilinosWrappers::SolverCG solver(solver_control);
+
+    const auto lo_A = linear_operator<TrilinosWrappers::Vector>(A);
+    const auto lo_A_inv = inverse_operator(lo_A,
+                                           solver,
+                                           preconditioner);
+
+    deallog.push("First use");
+    {
+      u1 = lo_A_inv * f;
+      deallog << "OK" << std::endl;
+    }
+    deallog.pop();
+    deallog.push("Second use");
+    {
+      u2 = lo_A_inv * f;
+      deallog << "OK" << std::endl;
+    }
+    deallog.pop();
+  }
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/trilinos/solver_control_04.with_cxx11=on.output
+++ b/tests/trilinos/solver_control_04.with_cxx11=on.output
@@ -1,0 +1,7 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL:First use::Convergence step 43 value 0.000818932
+DEAL:First use::OK
+DEAL:Second use::Convergence step 43 value 0.000818932
+DEAL:Second use::OK
+DEAL::OK

--- a/tests/trilinos/solver_control_05.cc
+++ b/tests/trilinos/solver_control_05.cc
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2004 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test that we can reuse a Trilinos solver in a LinearOperator
+// This tests differs from solver_control_04 in that here we have a diagonal
+// matrix, i.e. one that will converge in 1 step.
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <deal.II/base/logstream.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_linear_operator.h>
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/packaged_operation.h>
+
+int main(int argc, char **argv)
+{
+  std::ofstream logfile("output");
+  logfile.precision(4);
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+
+  {
+    unsigned int dim = 10;
+
+    deallog << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    DynamicSparsityPattern csp (dim, dim);
+    for (unsigned int row=0; row<dim; row++)
+      csp.add(row,row);
+
+    TrilinosWrappers::SparseMatrix  A;
+    A.reinit(csp);
+    for (unsigned int row=0; row<dim; row++)
+      A.set(row,row, 2.0*(row+1));
+
+    TrilinosWrappers::Vector  f(dim);
+    TrilinosWrappers::Vector  u1(dim);
+    TrilinosWrappers::Vector  u2(dim);
+    f = 1.;
+    A.compress (VectorOperation::insert);
+    f.compress (VectorOperation::insert);
+    u1.compress (VectorOperation::insert);
+    u2.compress (VectorOperation::insert);
+
+    TrilinosWrappers::PreconditionJacobi preconditioner;
+    preconditioner.initialize(A);
+
+    SolverControl solver_control(2000, 1.e-3);
+    TrilinosWrappers::SolverCG solver(solver_control);
+
+    const auto lo_A = linear_operator<TrilinosWrappers::Vector>(A);
+    const auto lo_A_inv = inverse_operator(lo_A,
+                                           solver,
+                                           preconditioner);
+
+    deallog.push("First use");
+    {
+      u1 = lo_A_inv * f;
+      deallog << "OK" << std::endl;
+    }
+    deallog.pop();
+    deallog.push("Second use");
+    {
+      u2 = lo_A_inv * f;
+      deallog << "OK" << std::endl;
+    }
+    deallog.pop();
+  }
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/trilinos/solver_control_05.with_cxx11=on.output
+++ b/tests/trilinos/solver_control_05.with_cxx11=on.output
@@ -1,0 +1,7 @@
+
+DEAL:: Unknowns 10
+DEAL:First use::Convergence step 1 value 0
+DEAL:First use::OK
+DEAL:Second use::Convergence step 1 value 0
+DEAL:Second use::OK
+DEAL::OK


### PR DESCRIPTION
This patch ensures that Trilinos solvers now respect the convergence
criterion specified by ReductionControl. To do so, we create an
AztecOO_StatusTest that monitors the heuristics that ReductionControl
uses to test for convergence.

This hopefully corrects the issue in #3843, but we'll wait to see if it passes on the tester.