### PR TITLE
Make DerivativeForm trivially copyable.

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -79,11 +79,6 @@ public:
   /**
    * Assignment operator.
    */
-  DerivativeForm   &operator = (const DerivativeForm <order, dim, spacedim, Number> &);
-
-  /**
-   * Assignment operator.
-   */
   DerivativeForm   &operator = (const Tensor<order+1,dim, Number> &);
 
   /**
@@ -189,18 +184,6 @@ DerivativeForm<order, dim, spacedim, Number>::DerivativeForm(const Tensor<order+
       (*this)[j] = T[j];
 }
 
-
-
-template <int order, int dim, int spacedim, typename Number>
-inline
-DerivativeForm<order, dim, spacedim, Number> &
-DerivativeForm<order, dim, spacedim, Number>::
-operator = (const DerivativeForm<order, dim, spacedim, Number> &ta)
-{
-  for (unsigned int j=0; j<spacedim; ++j)
-    (*this)[j] = ta[j];
-  return *this;
-}
 
 
 

--- a/tests/base/derivative_form_trivial_copy.cc
+++ b/tests/base/derivative_form_trivial_copy.cc
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Verify that DerivativeForm is trivially copyable.
+
+// TODO not all compilers that support enough of a subset of C++11 to compile
+// the library (notably GCC 4.8) implement std::is_trivally_copyable. At some
+// point in the future we should use that instead of the boost equivalent.
+
+#include <deal.II/base/derivative_form.h>
+
+#include <boost/type_traits.hpp>
+
+#include <complex>
+
+#include "../tests.h"
+
+template <typename Number>
+void test()
+{
+  deallog << "DerivativeForm<1, 2, 2> is trivially copyable: "
+          << boost::has_trivial_copy<DerivativeForm<1, 2, 2, Number> >::value
+          << std::endl;
+  deallog << "DerivativeForm<2, 2, 2> is trivially copyable: "
+          << boost::has_trivial_copy<DerivativeForm<2, 2, 2, Number> >::value
+          << std::endl;
+  deallog << "DerivativeForm<2, 2, 3> is trivially copyable: "
+          << boost::has_trivial_copy<DerivativeForm<2, 2, 3, Number> >::value
+          << std::endl;
+  deallog << "DerivativeForm<2, 3, 3> is trivially copyable: "
+          << boost::has_trivial_copy<DerivativeForm<2, 3, 3, Number> >::value
+          << std::endl;
+}
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+
+  deallog << std::boolalpha;
+  deallog << "testing float"
+          << std::endl;
+  test<float>();
+
+  deallog << "testing double"
+          << std::endl;
+  test<double>();
+
+  deallog << "testing std::complex<float>"
+          << std::endl;
+  test<std::complex<float> >();
+
+  deallog << "testing std::complex<double>"
+          << std::endl;
+  test<std::complex<double> >();
+}

--- a/tests/base/derivative_form_trivial_copy.output
+++ b/tests/base/derivative_form_trivial_copy.output
@@ -1,0 +1,21 @@
+
+DEAL::testing float
+DEAL::DerivativeForm<1, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 3> is trivially copyable: true
+DEAL::DerivativeForm<2, 3, 3> is trivially copyable: true
+DEAL::testing double
+DEAL::DerivativeForm<1, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 3> is trivially copyable: true
+DEAL::DerivativeForm<2, 3, 3> is trivially copyable: true
+DEAL::testing std::complex<float>
+DEAL::DerivativeForm<1, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 3> is trivially copyable: true
+DEAL::DerivativeForm<2, 3, 3> is trivially copyable: true
+DEAL::testing std::complex<double>
+DEAL::DerivativeForm<1, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 2> is trivially copyable: true
+DEAL::DerivativeForm<2, 2, 3> is trivially copyable: true
+DEAL::DerivativeForm<2, 3, 3> is trivially copyable: true


### PR DESCRIPTION
We do not need to specify `operator=`: the ~~default version~~ implicit one generated by the compiler is identical.

edit: fix name