### PR TITLE
Make the doxygen table color consistent with other documentation.

### DIFF
--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -29,13 +29,13 @@ div.doxygen-generated-exception-message {
 
 /*
  * Fix the default table settings to be readable: this overrides the first row
- * and column background to grey (instead of dark blue, upon which links are
- * impossible to read) and the text color to black (instead of white, which
- * would no longer be visable).
+ * and column background to light blue (instead of dark blue, upon which links
+ * are impossible to read) and the text color to black (instead of white, which
+ * would no longer be visible).
  */
 table.doxtable th {
-	background-color: #d6d6d6;
-	color: #000000;
+    background-color: #D6E2FA;
+    color: #000000;
 }
 
 div.image img[src="fe_enriched_1d.png"] {


### PR DESCRIPTION
I noticed this after #3837: we can just reuse the same shade of blue used in the doxygen method block to make things consistent. Here is the table:
![fe-table](https://cloud.githubusercontent.com/assets/3917035/22407481/14854658-e635-11e6-9e2a-c4649caa2380.png)
and here is a method (doxygen 1.8.12 is a little different from 1.8.9):
![fe-data](https://cloud.githubusercontent.com/assets/3917035/22407484/1cbeac2e-e635-11e6-90b2-6db0f784d05e.png)
so this blue matches and looks nicer than the grey :)


