### PR TITLE
use std::vector for the prolongation matrix

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_internal.h
+++ b/include/deal.II/multigrid/mg_transfer_internal.h
@@ -97,7 +97,7 @@ namespace internal
        * Holds the one-dimensional embedding (prolongation) matrix from mother
        * element to all the children.
        */
-      AlignedVector<VectorizedArray<Number> > prolongation_matrix_1d;
+      std::vector<Number> prolongation_matrix_1d;
 
     };
 

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -115,8 +115,11 @@ void MGTransferMatrixFree<dim,Number>::build
   element_is_continuous    = elem_info.element_is_continuous;
   n_components             = elem_info.n_components;
   n_child_cell_dofs        = elem_info.n_child_cell_dofs;
-  prolongation_matrix_1d   = elem_info.prolongation_matrix_1d;
 
+  // duplicate and put into vectorized array
+  prolongation_matrix_1d.resize(elem_info.prolongation_matrix_1d.size());
+  for (unsigned int i=0; i<elem_info.prolongation_matrix_1d.size(); i++)
+    prolongation_matrix_1d[i] = elem_info.prolongation_matrix_1d[i];
 
   // reshuffle into aligned vector of vectorized arrays
   const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;


### PR DESCRIPTION
This removes implementation details from the setup code

Perhaps we want to add an assignment operator taking an `std::vector` to `AlignedVector` which duplicates the scalar values into `VectorizedArray`s. What do you think about that @kronbichler? Are there more existing cases in the library where that would be used?