### PR TITLE
Fix get_fe_by_name_01

### DIFF
--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -80,7 +80,7 @@ FE_ABF<dim>::FE_ABF (const unsigned int deg)
   // refinement
   this->reinit_restriction_and_prolongation_matrices(true);
   // Fill prolongation matrices with embedding operators
-  FETools::compute_embedding_matrices (*this, this->prolongation);
+  FETools::compute_embedding_matrices (*this, this->prolongation, false, 2.e-12);
 
   initialize_restriction ();
 


### PR DESCRIPTION
During the construction of  `FE_ABF`, it seems that `FETools::compute_embedding_matrices` fails with a gap that is slightly larger than the default threshold `1.e-12`.