### PR TITLE
fix STATIC_ASSERT trailing semicolon

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1239,7 +1239,8 @@ namespace StandardExceptions
 #define DEAL_II_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
 #else
 #define DEAL_II_STATIC_ASSERT_DUMMY(L) typedef char __static_assert__##L
-#define DEAL_II_STATIC_ASSERT(...) DEAL_II_STATIC_ASSERT_DUMMY(__LINE__)
+#define DEAL_II_STATIC_ASSERT_DUMMY2(L) DEAL_II_STATIC_ASSERT_DUMMY(L)
+#define DEAL_II_STATIC_ASSERT(...) DEAL_II_STATIC_ASSERT_DUMMY2(__LINE__)
 #endif
 
 using namespace StandardExceptions;

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1228,16 +1228,18 @@ namespace StandardExceptions
                                            dealii::ExcCudaError(cudaGetErrorString(error_code)))
 #endif
 
-// A static assert which checks a compile-time condition. This is nothing more
-// than a wrapper around the C++11 <code>static_assert</code> declaration, which
-// we need to disable for non-C++11.
 
+// A static assert which checks a compile-time condition. This is nothing more
+// than a wrapper around the C++11 <code>static_assert</code> declaration,
+// which we need to disable for non-C++11.
+//
 // Just like <code>static_assert</code>, it takes two arguments, a
 // <code>constexpr</code> condition and an error message.
 #if defined(DEAL_II_WITH_CXX11)
 #define DEAL_II_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
 #else
-#define DEAL_II_STATIC_ASSERT(...) /* do nothing */
+#define DEAL_II_STATIC_ASSERT_DUMMY(L) typedef char __static_assert__##L
+#define DEAL_II_STATIC_ASSERT(...) DEAL_II_STATIC_ASSERT_DUMMY(__LINE__)
 #endif
 
 using namespace StandardExceptions;


### PR DESCRIPTION
Without cxx11 we would get warnings about stray semicolons because the
macro introduced in  #3861 gets expanded to nothing. Now we put the semicolon inside the
assert macro.
Also fix doxygen formatting of the #define.