### PR TITLE
fix >=0 comparison warning

### DIFF
--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -2797,7 +2797,7 @@ namespace internal
           if (update_flags & update_JxW_values)
             AssertDimension (output_data.JxW_values.size(), n_q_points);
 
-          Assert (data.aux.size() >= dim-1, ExcInternalError());
+          Assert (data.aux.size()+1 >= dim, ExcInternalError());
 
           // first compute some common data that is used for evaluating
           // all of the flags below


### PR DESCRIPTION
gcc 4.8 complained:
```
/ssd/deal-git/source/fe/mapping_q_generic.cc:2800:11: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
```