### PR TITLE
Tests: Provide output variant

### DIFF
--- a/tests/distributed_grids/2d_coarse_grid_01.debug.output.1
+++ b/tests/distributed_grids/2d_coarse_grid_01.debug.output.1
@@ -1,0 +1,100 @@
+
+DEAL:2d::hyper_cube
+DEAL:2d::Checksum: 786433
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="4" NumberOfCells="1">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   0.00000000e+00
+            9.75000024e-01   2.50000004e-02   0.00000000e+00
+            2.50000004e-02   9.75000024e-01   0.00000000e+00
+            9.75000024e-01   9.75000024e-01   0.00000000e+00
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+        </DataArray>
+        <DataArray type="Int32" Name="offsets" format="ascii">
+          4
+        </DataArray>
+DEAL:2d::hyper_ball
+DEAL:2d::Checksum: 3932161
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="20" NumberOfCells="5">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -1.98574162e+00  -2.09025431e+00   0.00000000e+00
+            1.98574162e+00  -2.09025431e+00   0.00000000e+00
+           -8.64258409e-01  -9.09745693e-01   0.00000000e+00
+            8.64258409e-01  -9.09745693e-01   0.00000000e+00
+           -2.09025431e+00  -1.98574162e+00   0.00000000e+00
+           -9.09745693e-01  -8.64258409e-01   0.00000000e+00
+           -2.09025431e+00   1.98574162e+00   0.00000000e+00
+           -9.09745693e-01   8.64258409e-01   0.00000000e+00
+           -8.34745646e-01  -8.34745646e-01   0.00000000e+00
+            8.34745646e-01  -8.34745646e-01   0.00000000e+00
+           -8.34745646e-01   8.34745646e-01   0.00000000e+00
+            8.34745646e-01   8.34745646e-01   0.00000000e+00
+            2.09025431e+00  -1.98574162e+00   0.00000000e+00
+DEAL:2d::half_hyper_ball
+DEAL:2d::Checksum: 3145729
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="3_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="4">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            5.22563569e-02  -2.92554927e+00   0.00000000e+00
+            2.03799796e+00  -2.11167216e+00   0.00000000e+00
+            2.27436423e-02  -9.31163490e-01   0.00000000e+00
+            8.87002051e-01  -9.10294831e-01   0.00000000e+00
+            2.19669919e-02  -8.34745646e-01   0.00000000e+00
+            8.56712639e-01  -8.34745646e-01   0.00000000e+00
+            2.19669919e-02   8.34745646e-01   0.00000000e+00
+            8.56712639e-01   8.34745646e-01   0.00000000e+00
+            2.09025431e+00  -1.98574162e+00   0.00000000e+00
+            2.09025431e+00   1.98574162e+00   0.00000000e+00
+            9.09745693e-01  -8.64258409e-01   0.00000000e+00
+            9.09745693e-01   8.64258409e-01   0.00000000e+00
+            5.22563569e-02   2.92554927e+00   0.00000000e+00

--- a/tests/distributed_grids/2d_coarse_grid_02.debug.output.1
+++ b/tests/distributed_grids/2d_coarse_grid_02.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2d::Checksum: 1364131841
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="116140" NumberOfCells="29035">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.77301884e-01  -2.00948361e-02   0.00000000e+00
+            6.77316308e-01  -2.01247111e-02   0.00000000e+00
+            6.77398026e-01  -1.99942756e-02   0.00000000e+00
+            6.77417815e-01  -2.00294759e-02   0.00000000e+00
+            6.77287698e-01  -2.00633854e-02   0.00000000e+00
+            6.77301168e-01  -2.00932641e-02   0.00000000e+00
+            6.77377164e-01  -1.99571289e-02   0.00000000e+00
+            6.77396953e-01  -1.99924204e-02   0.00000000e+00
+            6.77472293e-01  -1.98453721e-02   0.00000000e+00
+            6.77381933e-01  -1.99515391e-02   0.00000000e+00
+            6.77497804e-01  -1.98861789e-02   0.00000000e+00
+            6.77402020e-01  -1.99871119e-02   0.00000000e+00
+            6.77499175e-01  -1.98883284e-02   0.00000000e+00

--- a/tests/distributed_grids/2d_coarse_grid_03.debug.output.1
+++ b/tests/distributed_grids/2d_coarse_grid_03.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2d::Checksum: 7864321
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="40" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.75480619e-02  -9.84311759e-01   0.00000000e+00
+            6.84374452e-01  -7.09163249e-01   0.00000000e+00
+            1.26294373e-02  -6.66413248e-01   0.00000000e+00
+            4.92548048e-01  -5.09311736e-01   0.00000000e+00
+            1.23542501e-02  -6.49414361e-01   0.00000000e+00
+            4.81815755e-01  -4.98150617e-01   0.00000000e+00
+            6.81575015e-03  -3.21355611e-01   0.00000000e+00
+            2.65814245e-01  -2.73879379e-01   0.00000000e+00
+            7.09163249e-01  -6.84374452e-01   0.00000000e+00
+            9.84311759e-01  -1.75480619e-02   0.00000000e+00
+            5.09311736e-01  -4.92548048e-01   0.00000000e+00
+            6.66413248e-01  -1.26294373e-02   0.00000000e+00
+            4.98150617e-01  -4.81815755e-01   0.00000000e+00

--- a/tests/distributed_grids/2d_coarse_grid_04.debug.output.1
+++ b/tests/distributed_grids/2d_coarse_grid_04.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2d::Checksum: 15728641
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="20">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -6.84374452e-01  -7.09163249e-01   0.00000000e+00
+           -1.75480619e-02  -9.84311759e-01   0.00000000e+00
+           -4.92548048e-01  -5.09311736e-01   0.00000000e+00
+           -1.26294373e-02  -6.66413248e-01   0.00000000e+00
+            1.75480619e-02  -9.84311759e-01   0.00000000e+00
+            6.84374452e-01  -7.09163249e-01   0.00000000e+00
+            1.26294373e-02  -6.66413248e-01   0.00000000e+00
+            4.92548048e-01  -5.09311736e-01   0.00000000e+00
+            1.23542501e-02  -6.49414361e-01   0.00000000e+00
+            4.81815755e-01  -4.98150617e-01   0.00000000e+00
+            6.81575015e-03  -3.21355611e-01   0.00000000e+00
+            2.65814245e-01  -2.73879379e-01   0.00000000e+00
+           -4.81815755e-01  -4.98150617e-01   0.00000000e+00

--- a/tests/distributed_grids/2d_coarsening_01.debug.output.1
+++ b/tests/distributed_grids/2d_coarsening_01.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2d::Checksum: 3115647706
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="52" NumberOfCells="13">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   0.00000000e+00
+            4.87500012e-01   1.25000002e-02   0.00000000e+00
+            1.25000002e-02   4.87500012e-01   0.00000000e+00
+            4.87500012e-01   4.87500012e-01   0.00000000e+00
+            5.06250024e-01   6.25000009e-03   0.00000000e+00
+            7.43749976e-01   6.25000009e-03   0.00000000e+00
+            5.06250024e-01   2.43750006e-01   0.00000000e+00
+            7.43749976e-01   2.43750006e-01   0.00000000e+00
+            7.56250024e-01   6.25000009e-03   0.00000000e+00
+            9.93749976e-01   6.25000009e-03   0.00000000e+00
+            7.56250024e-01   2.43750006e-01   0.00000000e+00
+            9.93749976e-01   2.43750006e-01   0.00000000e+00
+            5.06250024e-01   2.56249994e-01   0.00000000e+00

--- a/tests/distributed_grids/2d_coarsening_02.debug.output.1
+++ b/tests/distributed_grids/2d_coarsening_02.debug.output.1
@@ -1,0 +1,375 @@
+
+DEAL:2d::Checksum: 2509440563
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="124" NumberOfCells="31">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   0.00000000e+00
+            1.21875003e-01   3.12500005e-03   0.00000000e+00
+            3.12500005e-03   1.21875003e-01   0.00000000e+00
+            1.21875003e-01   1.21875003e-01   0.00000000e+00
+            1.28124997e-01   3.12500005e-03   0.00000000e+00
+            2.46875003e-01   3.12500005e-03   0.00000000e+00
+            1.28124997e-01   1.21875003e-01   0.00000000e+00
+            2.46875003e-01   1.21875003e-01   0.00000000e+00
+            3.12500005e-03   1.28124997e-01   0.00000000e+00
+            1.21875003e-01   1.28124997e-01   0.00000000e+00
+            3.12500005e-03   2.46875003e-01   0.00000000e+00
+            1.21875003e-01   2.46875003e-01   0.00000000e+00
+            1.28124997e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::0 Number of cells: 31 31
+DEAL:2d::Checksum: 618073961
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="292" NumberOfCells="73">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   0.00000000e+00
+            1.21875003e-01   3.12500005e-03   0.00000000e+00
+            3.12500005e-03   1.21875003e-01   0.00000000e+00
+            1.21875003e-01   1.21875003e-01   0.00000000e+00
+            1.26562506e-01   1.56250002e-03   0.00000000e+00
+            1.85937494e-01   1.56250002e-03   0.00000000e+00
+            1.26562506e-01   6.09375015e-02   0.00000000e+00
+            1.85937494e-01   6.09375015e-02   0.00000000e+00
+            1.89062506e-01   1.56250002e-03   0.00000000e+00
+            2.48437494e-01   1.56250002e-03   0.00000000e+00
+            1.89062506e-01   6.09375015e-02   0.00000000e+00
+            2.48437494e-01   6.09375015e-02   0.00000000e+00
+            1.26562506e-01   6.40624985e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::1 Number of cells: 73 73
+DEAL:2d::Checksum: 3105364016
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="436" NumberOfCells="109">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   0.00000000e+00
+            1.21875003e-01   3.12500005e-03   0.00000000e+00
+            3.12500005e-03   1.21875003e-01   0.00000000e+00
+            1.21875003e-01   1.21875003e-01   0.00000000e+00
+            1.28124997e-01   3.12500005e-03   0.00000000e+00
+            2.46875003e-01   3.12500005e-03   0.00000000e+00
+            1.28124997e-01   1.21875003e-01   0.00000000e+00
+            2.46875003e-01   1.21875003e-01   0.00000000e+00
+            3.12500005e-03   1.28124997e-01   0.00000000e+00
+            1.21875003e-01   1.28124997e-01   0.00000000e+00
+            3.12500005e-03   2.46875003e-01   0.00000000e+00
+            1.21875003e-01   2.46875003e-01   0.00000000e+00
+            1.28124997e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::2 Number of cells: 109 109
+DEAL:2d::Checksum: 4161549821
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="928" NumberOfCells="232">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   0.00000000e+00
+            1.21875003e-01   3.12500005e-03   0.00000000e+00
+            3.12500005e-03   1.21875003e-01   0.00000000e+00
+            1.21875003e-01   1.21875003e-01   0.00000000e+00
+            1.26562506e-01   1.56250002e-03   0.00000000e+00
+            1.85937494e-01   1.56250002e-03   0.00000000e+00
+            1.26562506e-01   6.09375015e-02   0.00000000e+00
+            1.85937494e-01   6.09375015e-02   0.00000000e+00
+            1.89062506e-01   1.56250002e-03   0.00000000e+00
+            2.48437494e-01   1.56250002e-03   0.00000000e+00
+            1.89062506e-01   6.09375015e-02   0.00000000e+00
+            2.48437494e-01   6.09375015e-02   0.00000000e+00
+            1.26562506e-01   6.40624985e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::3 Number of cells: 232 232
+DEAL:2d::Checksum: 3780281340
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="1972" NumberOfCells="493">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   0.00000000e+00
+            6.09375015e-02   1.56250002e-03   0.00000000e+00
+            1.56250002e-03   6.09375015e-02   0.00000000e+00
+            6.09375015e-02   6.09375015e-02   0.00000000e+00
+            6.40624985e-02   1.56250002e-03   0.00000000e+00
+            1.23437501e-01   1.56250002e-03   0.00000000e+00
+            6.40624985e-02   6.09375015e-02   0.00000000e+00
+            1.23437501e-01   6.09375015e-02   0.00000000e+00
+            1.56250002e-03   6.40624985e-02   0.00000000e+00
+            6.09375015e-02   6.40624985e-02   0.00000000e+00
+            1.56250002e-03   1.23437501e-01   0.00000000e+00
+            6.09375015e-02   1.23437501e-01   0.00000000e+00
+            6.40624985e-02   6.40624985e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::4 Number of cells: 493 493
+DEAL:2d::Checksum: 3050318079
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="3616" NumberOfCells="904">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   0.00000000e+00
+            6.09375015e-02   1.56250002e-03   0.00000000e+00
+            1.56250002e-03   6.09375015e-02   0.00000000e+00
+            6.09375015e-02   6.09375015e-02   0.00000000e+00
+            6.40624985e-02   1.56250002e-03   0.00000000e+00
+            1.23437501e-01   1.56250002e-03   0.00000000e+00
+            6.40624985e-02   6.09375015e-02   0.00000000e+00
+            1.23437501e-01   6.09375015e-02   0.00000000e+00
+            1.56250002e-03   6.40624985e-02   0.00000000e+00
+            6.09375015e-02   6.40624985e-02   0.00000000e+00
+            1.56250002e-03   1.23437501e-01   0.00000000e+00
+            6.09375015e-02   1.23437501e-01   0.00000000e+00
+            6.40624985e-02   6.40624985e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::5 Number of cells: 904 904
+DEAL:2d::Checksum: 3215447093
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="6772" NumberOfCells="1693">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            7.81250012e-04   7.81250012e-04   0.00000000e+00
+            3.04687507e-02   7.81250012e-04   0.00000000e+00
+            7.81250012e-04   3.04687507e-02   0.00000000e+00
+            3.04687507e-02   3.04687507e-02   0.00000000e+00
+            3.20312493e-02   7.81250012e-04   0.00000000e+00
+            6.17187507e-02   7.81250012e-04   0.00000000e+00
+            3.20312493e-02   3.04687507e-02   0.00000000e+00
+            6.17187507e-02   3.04687507e-02   0.00000000e+00
+            7.81250012e-04   3.20312493e-02   0.00000000e+00
+            3.04687507e-02   3.20312493e-02   0.00000000e+00
+            7.81250012e-04   6.17187507e-02   0.00000000e+00
+            3.04687507e-02   6.17187507e-02   0.00000000e+00
+            3.20312493e-02   3.20312493e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::6 Number of cells: 1693 1693
+DEAL:2d::Checksum: 3706718963
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="12712" NumberOfCells="3178">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   0.00000000e+00
+            6.09375015e-02   1.56250002e-03   0.00000000e+00
+            1.56250002e-03   6.09375015e-02   0.00000000e+00
+            6.09375015e-02   6.09375015e-02   0.00000000e+00
+            6.32812530e-02   7.81250012e-04   0.00000000e+00
+            9.29687470e-02   7.81250012e-04   0.00000000e+00
+            6.32812530e-02   3.04687507e-02   0.00000000e+00
+            9.29687470e-02   3.04687507e-02   0.00000000e+00
+            9.41406265e-02   3.90625006e-04   0.00000000e+00
+            1.08984374e-01   3.90625006e-04   0.00000000e+00
+            9.41406265e-02   1.52343754e-02   0.00000000e+00
+            1.08984374e-01   1.52343754e-02   0.00000000e+00
+            1.09765626e-01   3.90625006e-04   0.00000000e+00
+DEAL:2d::
+DEAL:2d::7 Number of cells: 3178 3178
+DEAL:2d::Checksum: 1891273522
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="23920" NumberOfCells="5980">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            7.81250012e-04   7.81250012e-04   0.00000000e+00
+            3.04687507e-02   7.81250012e-04   0.00000000e+00
+            7.81250012e-04   3.04687507e-02   0.00000000e+00
+            3.04687507e-02   3.04687507e-02   0.00000000e+00
+            3.20312493e-02   7.81250012e-04   0.00000000e+00
+            6.17187507e-02   7.81250012e-04   0.00000000e+00
+            3.20312493e-02   3.04687507e-02   0.00000000e+00
+            6.17187507e-02   3.04687507e-02   0.00000000e+00
+            7.81250012e-04   3.20312493e-02   0.00000000e+00
+            3.04687507e-02   3.20312493e-02   0.00000000e+00
+            7.81250012e-04   6.17187507e-02   0.00000000e+00
+            3.04687507e-02   6.17187507e-02   0.00000000e+00
+            3.20312493e-02   3.20312493e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::8 Number of cells: 5980 5980
+DEAL:2d::Checksum: 1235001238
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="46732" NumberOfCells="11683">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            7.81250012e-04   7.81250012e-04   0.00000000e+00
+            3.04687507e-02   7.81250012e-04   0.00000000e+00
+            7.81250012e-04   3.04687507e-02   0.00000000e+00
+            3.04687507e-02   3.04687507e-02   0.00000000e+00
+            3.16406265e-02   3.90625006e-04   0.00000000e+00
+            4.64843735e-02   3.90625006e-04   0.00000000e+00
+            3.16406265e-02   1.52343754e-02   0.00000000e+00
+            4.64843735e-02   1.52343754e-02   0.00000000e+00
+            4.72656265e-02   3.90625006e-04   0.00000000e+00
+            6.21093735e-02   3.90625006e-04   0.00000000e+00
+            4.72656265e-02   1.52343754e-02   0.00000000e+00
+            6.21093735e-02   1.52343754e-02   0.00000000e+00
+            3.16406265e-02   1.60156246e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::9 Number of cells: 11683 11683
+DEAL:2d::Checksum: 565285806
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="89080" NumberOfCells="22270">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.90625006e-04   3.90625006e-04   0.00000000e+00
+            1.52343754e-02   3.90625006e-04   0.00000000e+00
+            3.90625006e-04   1.52343754e-02   0.00000000e+00
+            1.52343754e-02   1.52343754e-02   0.00000000e+00
+            1.60156246e-02   3.90625006e-04   0.00000000e+00
+            3.08593754e-02   3.90625006e-04   0.00000000e+00
+            1.60156246e-02   1.52343754e-02   0.00000000e+00
+            3.08593754e-02   1.52343754e-02   0.00000000e+00
+            3.90625006e-04   1.60156246e-02   0.00000000e+00
+            1.52343754e-02   1.60156246e-02   0.00000000e+00
+            3.90625006e-04   3.08593754e-02   0.00000000e+00
+            1.52343754e-02   3.08593754e-02   0.00000000e+00
+            1.60156246e-02   1.60156246e-02   0.00000000e+00
+DEAL:2d::
+DEAL:2d::10 Number of cells: 22270 22270

--- a/tests/distributed_grids/2d_refinement_01.debug.output.1
+++ b/tests/distributed_grids/2d_refinement_01.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2d::Checksum: 167510149
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="4">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   0.00000000e+00
+            4.87500012e-01   1.25000002e-02   0.00000000e+00
+            1.25000002e-02   4.87500012e-01   0.00000000e+00
+            4.87500012e-01   4.87500012e-01   0.00000000e+00
+            5.12499988e-01   1.25000002e-02   0.00000000e+00
+            9.87500012e-01   1.25000002e-02   0.00000000e+00
+            5.12499988e-01   4.87500012e-01   0.00000000e+00
+            9.87500012e-01   4.87500012e-01   0.00000000e+00
+            1.25000002e-02   5.12499988e-01   0.00000000e+00
+            4.87500012e-01   5.12499988e-01   0.00000000e+00
+            1.25000002e-02   9.87500012e-01   0.00000000e+00
+            4.87500012e-01   9.87500012e-01   0.00000000e+00
+            5.12499988e-01   5.12499988e-01   0.00000000e+00

--- a/tests/distributed_grids/2d_refinement_02.debug.output.1
+++ b/tests/distributed_grids/2d_refinement_02.debug.output.1
@@ -1,0 +1,386 @@
+
+DEAL:2d::Refining cell 3
+DEAL:2d::Checksum: 845349260
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="28" NumberOfCells="7">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   0.00000000e+00
+            4.87500012e-01   1.25000002e-02   0.00000000e+00
+            1.25000002e-02   4.87500012e-01   0.00000000e+00
+            4.87500012e-01   4.87500012e-01   0.00000000e+00
+            5.12499988e-01   1.25000002e-02   0.00000000e+00
+            9.87500012e-01   1.25000002e-02   0.00000000e+00
+            5.12499988e-01   4.87500012e-01   0.00000000e+00
+            9.87500012e-01   4.87500012e-01   0.00000000e+00
+            1.25000002e-02   5.12499988e-01   0.00000000e+00
+            4.87500012e-01   5.12499988e-01   0.00000000e+00
+            1.25000002e-02   9.87500012e-01   0.00000000e+00
+            4.87500012e-01   9.87500012e-01   0.00000000e+00
+            5.06250024e-01   5.06250024e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::0 Number of cells: 7 7
+DEAL:2d::Refining cell 4
+DEAL:2d::Checksum: 3572237133
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="52" NumberOfCells="13">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   0.00000000e+00
+            4.87500012e-01   1.25000002e-02   0.00000000e+00
+            1.25000002e-02   4.87500012e-01   0.00000000e+00
+            4.87500012e-01   4.87500012e-01   0.00000000e+00
+            5.06250024e-01   6.25000009e-03   0.00000000e+00
+            7.43749976e-01   6.25000009e-03   0.00000000e+00
+            5.06250024e-01   2.43750006e-01   0.00000000e+00
+            7.43749976e-01   2.43750006e-01   0.00000000e+00
+            7.56250024e-01   6.25000009e-03   0.00000000e+00
+            9.93749976e-01   6.25000009e-03   0.00000000e+00
+            7.56250024e-01   2.43750006e-01   0.00000000e+00
+            9.93749976e-01   2.43750006e-01   0.00000000e+00
+            5.06250024e-01   2.56249994e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::1 Number of cells: 13 13
+DEAL:2d::Refining cell 11
+DEAL:2d::Checksum: 85461166
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="124" NumberOfCells="31">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.56249994e-01   6.25000009e-03   0.00000000e+00
+            4.93750006e-01   6.25000009e-03   0.00000000e+00
+            2.56249994e-01   2.43750006e-01   0.00000000e+00
+            4.93750006e-01   2.43750006e-01   0.00000000e+00
+            6.25000009e-03   2.56249994e-01   0.00000000e+00
+            2.43750006e-01   2.56249994e-01   0.00000000e+00
+            6.25000009e-03   4.93750006e-01   0.00000000e+00
+            2.43750006e-01   4.93750006e-01   0.00000000e+00
+            2.56249994e-01   2.56249994e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::2 Number of cells: 31 31
+DEAL:2d::Refining cell 7
+DEAL:2d::Checksum: 3376286008
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="136" NumberOfCells="34">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.56249994e-01   6.25000009e-03   0.00000000e+00
+            4.93750006e-01   6.25000009e-03   0.00000000e+00
+            2.56249994e-01   2.43750006e-01   0.00000000e+00
+            4.93750006e-01   2.43750006e-01   0.00000000e+00
+            6.25000009e-03   2.56249994e-01   0.00000000e+00
+            2.43750006e-01   2.56249994e-01   0.00000000e+00
+            6.25000009e-03   4.93750006e-01   0.00000000e+00
+            2.43750006e-01   4.93750006e-01   0.00000000e+00
+            2.53125012e-01   2.53125012e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::3 Number of cells: 34 34
+DEAL:2d::Refining cell 15
+DEAL:2d::Checksum: 3159296977
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="172" NumberOfCells="43">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.56249994e-01   6.25000009e-03   0.00000000e+00
+            4.93750006e-01   6.25000009e-03   0.00000000e+00
+            2.56249994e-01   2.43750006e-01   0.00000000e+00
+            4.93750006e-01   2.43750006e-01   0.00000000e+00
+            6.25000009e-03   2.56249994e-01   0.00000000e+00
+            2.43750006e-01   2.56249994e-01   0.00000000e+00
+            6.25000009e-03   4.93750006e-01   0.00000000e+00
+            2.43750006e-01   4.93750006e-01   0.00000000e+00
+            2.53125012e-01   2.53125012e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::4 Number of cells: 43 43
+DEAL:2d::Refining cell 34
+DEAL:2d::Checksum: 2423393502
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="184" NumberOfCells="46">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.56249994e-01   6.25000009e-03   0.00000000e+00
+            4.93750006e-01   6.25000009e-03   0.00000000e+00
+            2.56249994e-01   2.43750006e-01   0.00000000e+00
+            4.93750006e-01   2.43750006e-01   0.00000000e+00
+            6.25000009e-03   2.56249994e-01   0.00000000e+00
+            2.43750006e-01   2.56249994e-01   0.00000000e+00
+            6.25000009e-03   4.93750006e-01   0.00000000e+00
+            2.43750006e-01   4.93750006e-01   0.00000000e+00
+            2.53125012e-01   2.53125012e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::5 Number of cells: 46 46
+DEAL:2d::Refining cell 14
+DEAL:2d::Checksum: 1740180971
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="196" NumberOfCells="49">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.56249994e-01   6.25000009e-03   0.00000000e+00
+            4.93750006e-01   6.25000009e-03   0.00000000e+00
+            2.56249994e-01   2.43750006e-01   0.00000000e+00
+            4.93750006e-01   2.43750006e-01   0.00000000e+00
+            6.25000009e-03   2.56249994e-01   0.00000000e+00
+            2.43750006e-01   2.56249994e-01   0.00000000e+00
+            6.25000009e-03   4.93750006e-01   0.00000000e+00
+            2.43750006e-01   4.93750006e-01   0.00000000e+00
+            2.53125012e-01   2.53125012e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::6 Number of cells: 49 49
+DEAL:2d::Refining cell 23
+DEAL:2d::Checksum: 4005236580
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="232" NumberOfCells="58">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.53125012e-01   3.12500005e-03   0.00000000e+00
+            3.71874988e-01   3.12500005e-03   0.00000000e+00
+            2.53125012e-01   1.21875003e-01   0.00000000e+00
+            3.71874988e-01   1.21875003e-01   0.00000000e+00
+            3.78125012e-01   3.12500005e-03   0.00000000e+00
+            4.96874988e-01   3.12500005e-03   0.00000000e+00
+            3.78125012e-01   1.21875003e-01   0.00000000e+00
+            4.96874988e-01   1.21875003e-01   0.00000000e+00
+            2.53125012e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::7 Number of cells: 58 58
+DEAL:2d::Refining cell 47
+DEAL:2d::Checksum: 2695303719
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="268" NumberOfCells="67">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.53125012e-01   3.12500005e-03   0.00000000e+00
+            3.71874988e-01   3.12500005e-03   0.00000000e+00
+            2.53125012e-01   1.21875003e-01   0.00000000e+00
+            3.71874988e-01   1.21875003e-01   0.00000000e+00
+            3.78125012e-01   3.12500005e-03   0.00000000e+00
+            4.96874988e-01   3.12500005e-03   0.00000000e+00
+            3.78125012e-01   1.21875003e-01   0.00000000e+00
+            4.96874988e-01   1.21875003e-01   0.00000000e+00
+            2.53125012e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::8 Number of cells: 67 67
+DEAL:2d::Refining cell 7
+DEAL:2d::Checksum: 1187058508
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="280" NumberOfCells="70">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.53125012e-01   3.12500005e-03   0.00000000e+00
+            3.71874988e-01   3.12500005e-03   0.00000000e+00
+            2.53125012e-01   1.21875003e-01   0.00000000e+00
+            3.71874988e-01   1.21875003e-01   0.00000000e+00
+            3.78125012e-01   3.12500005e-03   0.00000000e+00
+            4.96874988e-01   3.12500005e-03   0.00000000e+00
+            3.78125012e-01   1.21875003e-01   0.00000000e+00
+            4.96874988e-01   1.21875003e-01   0.00000000e+00
+            2.53125012e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::9 Number of cells: 70 70
+DEAL:2d::Refining cell 2
+DEAL:2d::Checksum: 1372132310
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="292" NumberOfCells="73">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   0.00000000e+00
+            2.43750006e-01   6.25000009e-03   0.00000000e+00
+            6.25000009e-03   2.43750006e-01   0.00000000e+00
+            2.43750006e-01   2.43750006e-01   0.00000000e+00
+            2.53125012e-01   3.12500005e-03   0.00000000e+00
+            3.71874988e-01   3.12500005e-03   0.00000000e+00
+            2.53125012e-01   1.21875003e-01   0.00000000e+00
+            3.71874988e-01   1.21875003e-01   0.00000000e+00
+            3.78125012e-01   3.12500005e-03   0.00000000e+00
+            4.96874988e-01   3.12500005e-03   0.00000000e+00
+            3.78125012e-01   1.21875003e-01   0.00000000e+00
+            4.96874988e-01   1.21875003e-01   0.00000000e+00
+            2.53125012e-01   1.28124997e-01   0.00000000e+00
+DEAL:2d::
+DEAL:2d::10 Number of cells: 73 73

--- a/tests/distributed_grids/3d_coarse_grid_01.debug.output.1
+++ b/tests/distributed_grids/3d_coarse_grid_01.debug.output.1
@@ -1,0 +1,100 @@
+
+DEAL:3d::hyper_cube
+DEAL:3d::Checksum: 1048577
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="8" NumberOfCells="1">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   2.50000004e-02
+            9.75000024e-01   2.50000004e-02   2.50000004e-02
+            2.50000004e-02   9.75000024e-01   2.50000004e-02
+            9.75000024e-01   9.75000024e-01   2.50000004e-02
+            2.50000004e-02   2.50000004e-02   9.75000024e-01
+            9.75000024e-01   2.50000004e-02   9.75000024e-01
+            2.50000004e-02   9.75000024e-01   9.75000024e-01
+            9.75000024e-01   9.75000024e-01   9.75000024e-01
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3 4 5 6 7
+DEAL:3d::hyper_ball
+DEAL:3d::Checksum: 7340033
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="56" NumberOfCells="7">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -1.61936891e+00  -1.61936891e+00  -1.70459890e+00
+            1.61936891e+00  -1.61936891e+00  -1.70459890e+00
+           -1.61936891e+00   1.61936891e+00  -1.70459890e+00
+            1.61936891e+00   1.61936891e+00  -1.70459890e+00
+           -6.28355205e-01  -6.28355205e-01  -6.61426485e-01
+            6.28355205e-01  -6.28355205e-01  -6.61426485e-01
+           -6.28355205e-01   6.28355205e-01  -6.61426485e-01
+            6.28355205e-01   6.28355205e-01  -6.61426485e-01
+           -6.02275848e-01  -6.02275848e-01  -6.02275848e-01
+            6.02275848e-01  -6.02275848e-01  -6.02275848e-01
+           -6.02275848e-01   6.02275848e-01  -6.02275848e-01
+            6.02275848e-01   6.02275848e-01  -6.02275848e-01
+           -6.02275848e-01  -6.02275848e-01   6.02275848e-01
+DEAL:3d::half_hyper_ball
+DEAL:3d::Checksum: 6291457
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="3_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="48" NumberOfCells="6">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.41400069e-02   1.96091986e+00  -2.06412625e+00
+            6.41400069e-02  -1.96091986e+00  -2.06412625e+00
+            2.50146031e+00   1.01769257e+00  -1.07125533e+00
+            2.50146031e+00  -1.01769257e+00  -1.07125533e+00
+            3.32878530e-02   8.53455186e-01  -8.98373842e-01
+            3.32878530e-02  -8.53455186e-01  -8.98373842e-01
+            1.29822624e+00   4.42932427e-01  -4.66244668e-01
+            1.29822624e+00  -4.42932427e-01  -4.66244668e-01
+            6.41400069e-02   2.06412625e+00  -1.96091986e+00
+            3.32878530e-02   8.98373842e-01  -8.53455186e-01
+            2.50146031e+00   1.07125533e+00  -1.01769257e+00
+            1.29822624e+00   4.66244668e-01  -4.42932427e-01
+            6.41400069e-02   2.06412625e+00   1.96091986e+00

--- a/tests/distributed_grids/3d_coarse_grid_02.debug.output.1
+++ b/tests/distributed_grids/3d_coarse_grid_02.debug.output.1
@@ -1,0 +1,289 @@
+
+DEAL:3d:/1.in::Checksum: 104595457
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="131840" NumberOfCells="16480">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            5.51919341e-02  -3.90941426e-02  -6.21875003e-02
+            5.51798381e-02  -4.00331989e-02  -5.03125004e-02
+            5.86938001e-02  -3.88724431e-02  -6.21875003e-02
+            5.86873293e-02  -3.98202837e-02  -5.03125004e-02
+            5.50497361e-02  -3.52824479e-02  -6.21875003e-02
+            5.50404675e-02  -3.63764688e-02  -5.03125004e-02
+            5.86281009e-02  -3.50800939e-02  -6.21875003e-02
+            5.86238652e-02  -3.61800008e-02  -5.03125004e-02
+            5.88136576e-02  -3.48702818e-02  -6.21875003e-02
+            5.88097423e-02  -3.59786488e-02  -5.03125004e-02
+            6.24054782e-02  -3.46984826e-02  -6.21875003e-02
+            6.24053776e-02  -3.58158909e-02  -5.03125004e-02
+            5.87597229e-02  -3.10645066e-02  -6.21875003e-02
+DEAL:3d:/2.in::Checksum: 377487361
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="2880" NumberOfCells="360">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -7.80780554e+00   9.80410635e-01  -4.52799606e+00
+           -8.62988472e+00   9.80302572e-01  -5.00264025e+00
+           -7.50098801e+00   7.11014032e-01  -5.11685324e+00
+           -8.29856586e+00   7.06799686e-01  -5.57797384e+00
+           -7.80992079e+00   5.11296868e-01  -4.52298355e+00
+           -8.63375092e+00   5.09972155e-01  -4.99590969e+00
+           -7.58348560e+00   4.65578675e-01  -4.92136383e+00
+           -8.44934082e+00   4.13914233e-01  -5.31547403e+00
+           -7.34671783e+00   1.99435167e-02  -5.37556648e+00
+           -8.14987946e+00   1.75505243e-02  -5.83528852e+00
+           -7.52194309e+00   1.24226082e-02  -5.01260138e+00
+           -8.41725159e+00   1.03183659e-02  -5.37066269e+00
+           -7.48916531e+00   6.86386645e-01  -5.13858604e+00
+DEAL:3d:/3.in::Checksum: 2097153
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="2">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -9.75000024e-01  -4.74999994e-01   4.74999994e-01
+           -9.75000024e-01  -4.74999994e-01  -4.74999994e-01
+           -9.75000024e-01   4.74999994e-01   4.74999994e-01
+           -9.75000024e-01   4.74999994e-01  -4.74999994e-01
+           -2.50000004e-02  -4.74999994e-01   4.74999994e-01
+           -2.50000004e-02  -4.74999994e-01  -4.74999994e-01
+           -2.50000004e-02   4.74999994e-01   4.74999994e-01
+           -2.50000004e-02   4.74999994e-01  -4.74999994e-01
+            2.50000004e-02  -4.74999994e-01   4.74999994e-01
+            2.50000004e-02  -4.74999994e-01  -4.74999994e-01
+            2.50000004e-02   4.74999994e-01   4.74999994e-01
+            2.50000004e-02   4.74999994e-01  -4.74999994e-01
+            9.75000024e-01  -4.74999994e-01   4.74999994e-01
+DEAL:3d:/4.in::Checksum: 1613561857
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="110592" NumberOfCells="13824">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            4.33607197e+00   3.66235805e+00  -3.84730983e+00
+            4.30278492e+00   3.63598943e+00  -3.83869958e+00
+            4.34494209e+00   3.65346289e+00  -3.84328175e+00
+            4.30969715e+00   3.62810087e+00  -3.83509350e+00
+            4.32731342e+00   3.67119169e+00  -3.81286883e+00
+            4.29449701e+00   3.64719224e+00  -3.80249405e+00
+            4.33600807e+00   3.66247177e+00  -3.80780435e+00
+            4.30134106e+00   3.63938117e+00  -3.79790640e+00
+            4.30096149e+00   3.63467479e+00  -3.83827162e+00
+            4.26496315e+00   3.61108732e+00  -3.83061385e+00
+            4.30778122e+00   3.62683320e+00  -3.83468533e+00
+            4.27021790e+00   3.60402799e+00  -3.82735610e+00
+            4.29270458e+00   3.64599633e+00  -3.80197859e+00
+DEAL:3d:/evil_0.in::Checksum: 10485761
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            9.95225430e-01   1.46946246e-02  -1.89999998e-01
+            8.06132615e-01   1.19026462e-02   2.34187669e-17
+            1.18431830e+00   1.74866039e-02   0.00000000e+00
+            9.95225430e-01   1.46946246e-02   1.89999998e-01
+            8.13791573e-01   5.73090374e-01  -1.89999998e-01
+            6.59171522e-01   4.64203209e-01   2.34187669e-17
+            9.68411624e-01   6.81977570e-01   0.00000000e+00
+            8.13791573e-01   5.73090374e-01   1.89999998e-01
+            7.96517015e-01   5.96866786e-01  -1.89999998e-01
+            6.45179152e-01   4.83462095e-01   2.34187669e-17
+            9.47854877e-01   7.10271537e-01   0.00000000e+00
+            7.96517015e-01   5.96866786e-01   1.89999998e-01
+            3.21516991e-01   9.41975236e-01  -1.89999998e-01
+DEAL:3d:/evil_1.in::Checksum: 10485761
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            9.95826602e-01   1.51313879e-02  -1.89941525e-01
+            8.06179941e-01   1.19370362e-02  -7.43063865e-04
+            1.18427098e+00   1.74522381e-02   7.43063865e-04
+            9.94624257e-01   1.42578632e-02   1.89941525e-01
+            8.37236822e-01   5.90124130e-01  -1.87719569e-01
+            6.61016643e-01   4.65544403e-01  -2.89794914e-02
+            9.66566503e-01   6.80637240e-01   2.89794914e-02
+            7.90346324e-01   5.56056678e-01   1.87719569e-01
+            8.20415795e-01   6.15296662e-01  -1.87487081e-01
+            6.47096038e-01   4.85024422e-01  -3.04473210e-02
+            9.45937932e-01   7.08710134e-01   3.04473210e-02
+            7.72618175e-01   5.78437090e-01   1.87487081e-01
+            3.39807689e-01   9.96859729e-01  -1.80874467e-01
+DEAL:3d:/evil_2.in::Checksum: 10485761
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            9.96412933e-01   1.55573916e-02  -1.89767510e-01
+            8.06320667e-01   1.20393038e-02  -1.46783073e-03
+            1.18413019e+00   1.73499696e-02   1.46783073e-03
+            9.94037926e-01   1.38318595e-02   1.89767510e-01
+            8.60104084e-01   6.06738269e-01  -1.80932939e-01
+            6.66506529e-01   4.69532847e-01  -5.72453998e-02
+            9.61076617e-01   6.76648855e-01   5.72453998e-02
+            7.67479062e-01   5.39442539e-01   1.80932939e-01
+            8.43692243e-01   6.33170009e-01  -1.80025756e-01
+            6.52794421e-01   4.89654511e-01  -6.00373782e-02
+            9.40239549e-01   7.04079986e-01   6.00373782e-02
+            7.49341726e-01   5.60563564e-01   1.80025756e-01
+            3.56352389e-01   1.04639542e+00  -1.54387534e-01
+DEAL:3d:/evil_3.in::Checksum: 10485761
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            9.96970057e-01   1.59621630e-02  -1.89482272e-01
+            8.06551456e-01   1.22069549e-02  -2.15645484e-03
+            1.18389940e+00   1.71822943e-02   2.15645484e-03
+            9.93480802e-01   1.34270871e-02   1.89482272e-01
+            8.81831110e-01   6.22524321e-01  -1.69808671e-01
+            6.75505936e-01   4.76071239e-01  -8.41017365e-02
+            9.52077210e-01   6.70109510e-01   8.41017365e-02
+            7.45752037e-01   5.23656428e-01   1.69808671e-01
+            8.65744054e-01   6.49955511e-01  -1.67850658e-01
+            6.62118614e-01   4.97192323e-01  -8.79445598e-02
+            9.30915356e-01   6.96541250e-01   8.79445598e-02
+            7.27289975e-01   5.43778062e-01   1.67850658e-01
+            3.69574100e-01   1.08577681e+00  -1.13119446e-01
+DEAL:3d:/evil_4.in::Checksum: 10485761
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="80" NumberOfCells="10">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            9.97484207e-01   1.63357276e-02  -1.89092815e-01
+            8.06866527e-01   1.24358814e-02  -2.79197865e-03
+            1.18358433e+00   1.69533938e-02   2.79197865e-03
+            9.92966652e-01   1.30535485e-02   1.89092815e-01
+            9.01883483e-01   6.37093365e-01  -1.54620022e-01
+            6.87793612e-01   4.84999388e-01  -1.08887173e-01
+            9.39789534e-01   6.61182344e-01   1.08887173e-01
+            7.25699663e-01   5.09088397e-01   1.54620022e-01
+            8.86004925e-01   6.65166199e-01  -1.51337862e-01
+            6.74815416e-01   5.07379830e-01  -1.13404684e-01
+            9.18218553e-01   6.86354876e-01   1.13404684e-01
+            7.07029045e-01   5.28568387e-01   1.51337862e-01
+            3.78219813e-01   1.11117780e+00  -6.10882193e-02

--- a/tests/distributed_grids/3d_coarse_grid_03.debug.output.1
+++ b/tests/distributed_grids/3d_coarse_grid_03.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 1585446913
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="12096" NumberOfCells="1512">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.64583623e-01   2.52083331e-01   9.14583623e-01
+            6.64583623e-01   2.52083331e-01   8.35416377e-01
+            5.85416377e-01   2.52083331e-01   9.14583623e-01
+            5.85416377e-01   2.52083331e-01   8.35416377e-01
+            6.64583623e-01   3.31249684e-01   9.14583623e-01
+            6.64583623e-01   3.31249684e-01   8.35416377e-01
+            5.85416377e-01   3.31249684e-01   9.14583623e-01
+            5.85416377e-01   3.31249684e-01   8.35416377e-01
+            6.64583623e-01   1.68750331e-01   9.14583623e-01
+            6.64583623e-01   1.68750331e-01   8.35416377e-01
+            5.85416377e-01   1.68750331e-01   9.14583623e-01
+            5.85416377e-01   1.68750331e-01   8.35416377e-01
+            6.64583623e-01   2.47916669e-01   9.14583623e-01

--- a/tests/distributed_grids/3d_coarse_grid_04.debug.output.1
+++ b/tests/distributed_grids/3d_coarse_grid_04.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 2097153
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="2">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   9.75000024e-01
+            9.75000024e-01   2.50000004e-02   9.75000024e-01
+            2.50000004e-02   2.50000004e-02   2.50000004e-02
+            9.75000024e-01   2.50000004e-02   2.50000004e-02
+            2.50000004e-02   9.75000024e-01   9.75000024e-01
+            9.75000024e-01   9.75000024e-01   9.75000024e-01
+            2.50000004e-02   9.75000024e-01   2.50000004e-02
+            9.75000024e-01   9.75000024e-01   2.50000004e-02
+           -2.50000004e-02   2.50000004e-02   9.75000024e-01
+           -2.50000004e-02   9.75000024e-01   9.75000024e-01
+           -2.50000004e-02   2.50000004e-02   2.50000004e-02
+           -2.50000004e-02   9.75000024e-01   2.50000004e-02
+           -9.75000024e-01   2.50000004e-02   9.75000024e-01

--- a/tests/distributed_grids/3d_coarse_grid_05.debug.output.1
+++ b/tests/distributed_grids/3d_coarse_grid_05.debug.output.1
@@ -1,0 +1,65 @@
+
+DEAL:2d::Checksum: 1572865
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="8" NumberOfCells="2">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   0.00000000e+00
+            9.75000024e-01   2.50000004e-02   0.00000000e+00
+            2.50000004e-02   9.75000024e-01   0.00000000e+00
+            9.75000024e-01   9.75000024e-01   0.00000000e+00
+            2.02500010e+00   2.50000004e-02   0.00000000e+00
+            2.97499990e+00   2.50000004e-02   0.00000000e+00
+            2.02500010e+00   9.75000024e-01   0.00000000e+00
+            2.97499990e+00   9.75000024e-01   0.00000000e+00
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+DEAL:3d::Checksum: 2097153
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="2">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   2.50000004e-02
+            9.75000024e-01   2.50000004e-02   2.50000004e-02
+            2.50000004e-02   9.75000024e-01   2.50000004e-02
+            9.75000024e-01   9.75000024e-01   2.50000004e-02
+            2.50000004e-02   2.50000004e-02   9.75000024e-01
+            9.75000024e-01   2.50000004e-02   9.75000024e-01
+            2.50000004e-02   9.75000024e-01   9.75000024e-01
+            9.75000024e-01   9.75000024e-01   9.75000024e-01
+            2.02500010e+00   2.50000004e-02   2.50000004e-02
+            2.97499990e+00   2.50000004e-02   2.50000004e-02
+            2.02500010e+00   9.75000024e-01   2.50000004e-02
+            2.97499990e+00   9.75000024e-01   2.50000004e-02
+            2.02500010e+00   2.50000004e-02   9.75000024e-01

--- a/tests/distributed_grids/3d_coarsening_01.debug.output.1
+++ b/tests/distributed_grids/3d_coarsening_01.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 141886106
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="456" NumberOfCells="57">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.06250024e-01   6.25000009e-03   6.25000009e-03
+            7.43749976e-01   6.25000009e-03   6.25000009e-03
+            5.06250024e-01   2.43750006e-01   6.25000009e-03
+            7.43749976e-01   2.43750006e-01   6.25000009e-03
+            5.06250024e-01   6.25000009e-03   2.43750006e-01

--- a/tests/distributed_grids/3d_coarsening_02.debug.output.1
+++ b/tests/distributed_grids/3d_coarsening_02.debug.output.1
@@ -1,0 +1,205 @@
+
+DEAL:3d::Checksum: 353044419
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="1240" NumberOfCells="155">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   3.12500005e-03
+            1.21875003e-01   3.12500005e-03   3.12500005e-03
+            3.12500005e-03   1.21875003e-01   3.12500005e-03
+            1.21875003e-01   1.21875003e-01   3.12500005e-03
+            3.12500005e-03   3.12500005e-03   1.21875003e-01
+            1.21875003e-01   3.12500005e-03   1.21875003e-01
+            3.12500005e-03   1.21875003e-01   1.21875003e-01
+            1.21875003e-01   1.21875003e-01   1.21875003e-01
+            1.28124997e-01   3.12500005e-03   3.12500005e-03
+            2.46875003e-01   3.12500005e-03   3.12500005e-03
+            1.28124997e-01   1.21875003e-01   3.12500005e-03
+            2.46875003e-01   1.21875003e-01   3.12500005e-03
+            1.28124997e-01   3.12500005e-03   1.21875003e-01
+DEAL:3d::
+DEAL:3d::0 Number of cells: 155 155
+DEAL:3d::Checksum: 4074805283
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="4880" NumberOfCells="610">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            3.12500005e-03   3.12500005e-03   3.12500005e-03
+            1.21875003e-01   3.12500005e-03   3.12500005e-03
+            3.12500005e-03   1.21875003e-01   3.12500005e-03
+            1.21875003e-01   1.21875003e-01   3.12500005e-03
+            3.12500005e-03   3.12500005e-03   1.21875003e-01
+            1.21875003e-01   3.12500005e-03   1.21875003e-01
+            3.12500005e-03   1.21875003e-01   1.21875003e-01
+            1.21875003e-01   1.21875003e-01   1.21875003e-01
+            1.28124997e-01   3.12500005e-03   3.12500005e-03
+            2.46875003e-01   3.12500005e-03   3.12500005e-03
+            1.28124997e-01   1.21875003e-01   3.12500005e-03
+            2.46875003e-01   1.21875003e-01   3.12500005e-03
+            1.28124997e-01   3.12500005e-03   1.21875003e-01
+DEAL:3d::
+DEAL:3d::1 Number of cells: 610 610
+DEAL:3d::Checksum: 3041338616
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="17200" NumberOfCells="2150">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   1.56250002e-03
+            6.09375015e-02   1.56250002e-03   1.56250002e-03
+            1.56250002e-03   6.09375015e-02   1.56250002e-03
+            6.09375015e-02   6.09375015e-02   1.56250002e-03
+            1.56250002e-03   1.56250002e-03   6.09375015e-02
+            6.09375015e-02   1.56250002e-03   6.09375015e-02
+            1.56250002e-03   6.09375015e-02   6.09375015e-02
+            6.09375015e-02   6.09375015e-02   6.09375015e-02
+            6.40624985e-02   1.56250002e-03   1.56250002e-03
+            1.23437501e-01   1.56250002e-03   1.56250002e-03
+            6.40624985e-02   6.09375015e-02   1.56250002e-03
+            1.23437501e-01   6.09375015e-02   1.56250002e-03
+            6.40624985e-02   1.56250002e-03   6.09375015e-02
+DEAL:3d::
+DEAL:3d::2 Number of cells: 2150 2150
+DEAL:3d::Checksum: 272602556
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="57128" NumberOfCells="7141">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   1.56250002e-03
+            6.09375015e-02   1.56250002e-03   1.56250002e-03
+            1.56250002e-03   6.09375015e-02   1.56250002e-03
+            6.09375015e-02   6.09375015e-02   1.56250002e-03
+            1.56250002e-03   1.56250002e-03   6.09375015e-02
+            6.09375015e-02   1.56250002e-03   6.09375015e-02
+            1.56250002e-03   6.09375015e-02   6.09375015e-02
+            6.09375015e-02   6.09375015e-02   6.09375015e-02
+            6.40624985e-02   1.56250002e-03   1.56250002e-03
+            1.23437501e-01   1.56250002e-03   1.56250002e-03
+            6.40624985e-02   6.09375015e-02   1.56250002e-03
+            1.23437501e-01   6.09375015e-02   1.56250002e-03
+            6.40624985e-02   1.56250002e-03   6.09375015e-02
+DEAL:3d::
+DEAL:3d::3 Number of cells: 7141 7141
+DEAL:3d::Checksum: 1092886437
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="208328" NumberOfCells="26041">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   1.56250002e-03
+            6.09375015e-02   1.56250002e-03   1.56250002e-03
+            1.56250002e-03   6.09375015e-02   1.56250002e-03
+            6.09375015e-02   6.09375015e-02   1.56250002e-03
+            1.56250002e-03   1.56250002e-03   6.09375015e-02
+            6.09375015e-02   1.56250002e-03   6.09375015e-02
+            1.56250002e-03   6.09375015e-02   6.09375015e-02
+            6.09375015e-02   6.09375015e-02   6.09375015e-02
+            6.32812530e-02   7.81250012e-04   7.81250012e-04
+            9.29687470e-02   7.81250012e-04   7.81250012e-04
+            6.32812530e-02   3.04687507e-02   7.81250012e-04
+            9.29687470e-02   3.04687507e-02   7.81250012e-04
+            6.32812530e-02   7.81250012e-04   3.04687507e-02
+DEAL:3d::
+DEAL:3d::4 Number of cells: 26041 26041
+DEAL:3d::Checksum: 2787894795
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="735456" NumberOfCells="91932">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.56250002e-03   1.56250002e-03   1.56250002e-03
+            6.09375015e-02   1.56250002e-03   1.56250002e-03
+            1.56250002e-03   6.09375015e-02   1.56250002e-03
+            6.09375015e-02   6.09375015e-02   1.56250002e-03
+            1.56250002e-03   1.56250002e-03   6.09375015e-02
+            6.09375015e-02   1.56250002e-03   6.09375015e-02
+            1.56250002e-03   6.09375015e-02   6.09375015e-02
+            6.09375015e-02   6.09375015e-02   6.09375015e-02
+            6.32812530e-02   7.81250012e-04   7.81250012e-04
+            9.29687470e-02   7.81250012e-04   7.81250012e-04
+            6.32812530e-02   3.04687507e-02   7.81250012e-04
+            9.29687470e-02   3.04687507e-02   7.81250012e-04
+            6.32812530e-02   7.81250012e-04   3.04687507e-02
+DEAL:3d::
+DEAL:3d::5 Number of cells: 91932 91932

--- a/tests/distributed_grids/3d_refinement_01.debug.output.1
+++ b/tests/distributed_grids/3d_refinement_01.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 190316601
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="2_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="64" NumberOfCells="8">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.12499988e-01   1.25000002e-02   1.25000002e-02
+            9.87500012e-01   1.25000002e-02   1.25000002e-02
+            5.12499988e-01   4.87500012e-01   1.25000002e-02
+            9.87500012e-01   4.87500012e-01   1.25000002e-02
+            5.12499988e-01   1.25000002e-02   4.87500012e-01

--- a/tests/distributed_grids/3d_refinement_02.debug.output.1
+++ b/tests/distributed_grids/3d_refinement_02.debug.output.1
@@ -1,0 +1,316 @@
+
+DEAL:3d::Refining cell 7
+DEAL:3d::Checksum: 1061879988
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="120" NumberOfCells="15">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.12499988e-01   1.25000002e-02   1.25000002e-02
+            9.87500012e-01   1.25000002e-02   1.25000002e-02
+            5.12499988e-01   4.87500012e-01   1.25000002e-02
+            9.87500012e-01   4.87500012e-01   1.25000002e-02
+            5.12499988e-01   1.25000002e-02   4.87500012e-01
+DEAL:3d::
+DEAL:3d::0 Number of cells: 15 15
+DEAL:3d::Refining cell 1
+DEAL:3d::Checksum: 2270560503
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="176" NumberOfCells="22">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.06250024e-01   6.25000009e-03   6.25000009e-03
+            7.43749976e-01   6.25000009e-03   6.25000009e-03
+            5.06250024e-01   2.43750006e-01   6.25000009e-03
+            7.43749976e-01   2.43750006e-01   6.25000009e-03
+            5.06250024e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::1 Number of cells: 22 22
+DEAL:3d::Refining cell 17
+DEAL:3d::Checksum: 2925396400
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="288" NumberOfCells="36">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.06250024e-01   6.25000009e-03   6.25000009e-03
+            7.43749976e-01   6.25000009e-03   6.25000009e-03
+            5.06250024e-01   2.43750006e-01   6.25000009e-03
+            7.43749976e-01   2.43750006e-01   6.25000009e-03
+            5.06250024e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::2 Number of cells: 36 36
+DEAL:3d::Refining cell 7
+DEAL:3d::Checksum: 1537540822
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="456" NumberOfCells="57">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            1.25000002e-02   1.25000002e-02   1.25000002e-02
+            4.87500012e-01   1.25000002e-02   1.25000002e-02
+            1.25000002e-02   4.87500012e-01   1.25000002e-02
+            4.87500012e-01   4.87500012e-01   1.25000002e-02
+            1.25000002e-02   1.25000002e-02   4.87500012e-01
+            4.87500012e-01   1.25000002e-02   4.87500012e-01
+            1.25000002e-02   4.87500012e-01   4.87500012e-01
+            4.87500012e-01   4.87500012e-01   4.87500012e-01
+            5.06250024e-01   6.25000009e-03   6.25000009e-03
+            7.43749976e-01   6.25000009e-03   6.25000009e-03
+            5.06250024e-01   2.43750006e-01   6.25000009e-03
+            7.43749976e-01   2.43750006e-01   6.25000009e-03
+            5.06250024e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::3 Number of cells: 57 57
+DEAL:3d::Refining cell 29
+DEAL:3d::Checksum: 1304691596
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="624" NumberOfCells="78">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   6.25000009e-03
+            2.43750006e-01   6.25000009e-03   6.25000009e-03
+            6.25000009e-03   2.43750006e-01   6.25000009e-03
+            2.43750006e-01   2.43750006e-01   6.25000009e-03
+            6.25000009e-03   6.25000009e-03   2.43750006e-01
+            2.43750006e-01   6.25000009e-03   2.43750006e-01
+            6.25000009e-03   2.43750006e-01   2.43750006e-01
+            2.43750006e-01   2.43750006e-01   2.43750006e-01
+            2.56249994e-01   6.25000009e-03   6.25000009e-03
+            4.93750006e-01   6.25000009e-03   6.25000009e-03
+            2.56249994e-01   2.43750006e-01   6.25000009e-03
+            4.93750006e-01   2.43750006e-01   6.25000009e-03
+            2.56249994e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::4 Number of cells: 78 78
+DEAL:3d::Refining cell 1
+DEAL:3d::Checksum: 2660631649
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="736" NumberOfCells="92">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   6.25000009e-03
+            2.43750006e-01   6.25000009e-03   6.25000009e-03
+            6.25000009e-03   2.43750006e-01   6.25000009e-03
+            2.43750006e-01   2.43750006e-01   6.25000009e-03
+            6.25000009e-03   6.25000009e-03   2.43750006e-01
+            2.43750006e-01   6.25000009e-03   2.43750006e-01
+            6.25000009e-03   2.43750006e-01   2.43750006e-01
+            2.43750006e-01   2.43750006e-01   2.43750006e-01
+            2.56249994e-01   6.25000009e-03   6.25000009e-03
+            4.93750006e-01   6.25000009e-03   6.25000009e-03
+            2.56249994e-01   2.43750006e-01   6.25000009e-03
+            4.93750006e-01   2.43750006e-01   6.25000009e-03
+            2.56249994e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::5 Number of cells: 92 92
+DEAL:3d::Refining cell 14
+DEAL:3d::Checksum: 2875720905
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="792" NumberOfCells="99">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   6.25000009e-03
+            2.43750006e-01   6.25000009e-03   6.25000009e-03
+            6.25000009e-03   2.43750006e-01   6.25000009e-03
+            2.43750006e-01   2.43750006e-01   6.25000009e-03
+            6.25000009e-03   6.25000009e-03   2.43750006e-01
+            2.43750006e-01   6.25000009e-03   2.43750006e-01
+            6.25000009e-03   2.43750006e-01   2.43750006e-01
+            2.43750006e-01   2.43750006e-01   2.43750006e-01
+            2.56249994e-01   6.25000009e-03   6.25000009e-03
+            4.93750006e-01   6.25000009e-03   6.25000009e-03
+            2.56249994e-01   2.43750006e-01   6.25000009e-03
+            4.93750006e-01   2.43750006e-01   6.25000009e-03
+            2.56249994e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::6 Number of cells: 99 99
+DEAL:3d::Refining cell 39
+DEAL:3d::Checksum: 3630367993
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="848" NumberOfCells="106">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   6.25000009e-03
+            2.43750006e-01   6.25000009e-03   6.25000009e-03
+            6.25000009e-03   2.43750006e-01   6.25000009e-03
+            2.43750006e-01   2.43750006e-01   6.25000009e-03
+            6.25000009e-03   6.25000009e-03   2.43750006e-01
+            2.43750006e-01   6.25000009e-03   2.43750006e-01
+            6.25000009e-03   2.43750006e-01   2.43750006e-01
+            2.43750006e-01   2.43750006e-01   2.43750006e-01
+            2.56249994e-01   6.25000009e-03   6.25000009e-03
+            4.93750006e-01   6.25000009e-03   6.25000009e-03
+            2.56249994e-01   2.43750006e-01   6.25000009e-03
+            4.93750006e-01   2.43750006e-01   6.25000009e-03
+            2.56249994e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::7 Number of cells: 106 106
+DEAL:3d::Refining cell 59
+DEAL:3d::Checksum: 2062748577
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="960" NumberOfCells="120">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            6.25000009e-03   6.25000009e-03   6.25000009e-03
+            2.43750006e-01   6.25000009e-03   6.25000009e-03
+            6.25000009e-03   2.43750006e-01   6.25000009e-03
+            2.43750006e-01   2.43750006e-01   6.25000009e-03
+            6.25000009e-03   6.25000009e-03   2.43750006e-01
+            2.43750006e-01   6.25000009e-03   2.43750006e-01
+            6.25000009e-03   2.43750006e-01   2.43750006e-01
+            2.43750006e-01   2.43750006e-01   2.43750006e-01
+            2.56249994e-01   6.25000009e-03   6.25000009e-03
+            4.93750006e-01   6.25000009e-03   6.25000009e-03
+            2.56249994e-01   2.43750006e-01   6.25000009e-03
+            4.93750006e-01   2.43750006e-01   6.25000009e-03
+            2.56249994e-01   6.25000009e-03   2.43750006e-01
+DEAL:3d::
+DEAL:3d::8 Number of cells: 120 120

--- a/tests/distributed_grids/3d_refinement_03.debug.output.1
+++ b/tests/distributed_grids/3d_refinement_03.debug.output.1
@@ -1,0 +1,35 @@
+
+DEAL:3d::Checksum: 1276076431
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="266608" NumberOfCells="33326">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            4.33607197e+00   3.66235805e+00  -3.84730983e+00
+            4.30278492e+00   3.63598943e+00  -3.83869958e+00
+            4.34494209e+00   3.65346289e+00  -3.84328175e+00
+            4.30969715e+00   3.62810087e+00  -3.83509350e+00
+            4.32731342e+00   3.67119169e+00  -3.81286883e+00
+            4.29449701e+00   3.64719224e+00  -3.80249405e+00
+            4.33600807e+00   3.66247177e+00  -3.80780435e+00
+            4.30134106e+00   3.63938117e+00  -3.79790640e+00
+            4.30145407e+00   3.63493991e+00  -3.83889675e+00
+            4.28346062e+00   3.62312698e+00  -3.83507586e+00
+            4.30487442e+00   3.63101339e+00  -3.83710790e+00
+            4.28648949e+00   3.61939621e+00  -3.83336902e+00
+            4.29732132e+00   3.64058614e+00  -3.82076693e+00
+DEAL:3d::
+DEAL:3d::0 Number of cells: 33326 33326

--- a/tests/distributed_grids/codim_01.debug.output.1
+++ b/tests/distributed_grids/codim_01.debug.output.1
@@ -1,0 +1,33 @@
+
+DEAL:2-3::Checksum: 1736441989
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="file_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="76" NumberOfCells="19">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            7.92468727e-01   2.49999994e-03   1.00312503e-02
+            4.11281258e-01   2.49999994e-03   3.91218752e-01
+            8.86281252e-01   9.74999964e-02   1.12187499e-02
+            4.59968746e-01   9.74999964e-02   4.37531263e-01
+            3.91218752e-01   2.49999994e-03   4.11281258e-01
+            1.00312503e-02   2.49999994e-03   7.92468727e-01
+            4.37531263e-01   9.74999964e-02   4.59968746e-01
+            1.12187499e-02   9.74999964e-02   8.86281252e-01
+            8.91218722e-01   1.02499999e-01   1.12812500e-02
+            4.62531239e-01   1.02499999e-01   4.39968765e-01
+            9.85031247e-01   1.97500005e-01   1.24687497e-02
+            5.11218727e-01   1.97500005e-01   4.86281246e-01
+            4.39968765e-01   1.02499999e-01   4.62531239e-01

--- a/tests/mpi/codim_01.mpirun=3.with_zlib=on.debug.output.1
+++ b/tests/mpi/codim_01.mpirun=3.with_zlib=on.debug.output.1
@@ -1,0 +1,591 @@
+
+DEAL:0:2-3::Checksum: 339413295
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="file_0000.vtu"/>
+    <Piece Source="file_0001.vtu"/>
+    <Piece Source="file_0002.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="88" NumberOfCells="22">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            7.96242177e-01   1.24999997e-03   5.00781229e-03
+            6.05945289e-01   1.24999997e-03   1.95304692e-01
+            8.43445301e-01   4.87499982e-02   5.30468766e-03
+            6.41867161e-01   4.87499982e-02   2.06882820e-01
+            5.95929682e-01   1.24999997e-03   2.05320314e-01
+            4.05632824e-01   1.24999997e-03   3.95617187e-01
+            6.31257832e-01   4.87499982e-02   2.17492193e-01
+            4.29679692e-01   4.87499982e-02   4.19070303e-01
+            8.45929682e-01   5.12499996e-02   5.32031246e-03
+            6.43757820e-01   5.12499996e-02   2.07492188e-01
+            8.93132806e-01   9.87500027e-02   5.61718736e-03
+            6.79679692e-01   9.87500027e-02   2.19070315e-01
+            6.33117199e-01   5.12499996e-02   2.18132809e-01
+            4.30945307e-01   5.12499996e-02   4.20304686e-01
+            6.68445289e-01   9.87500027e-02   2.30304688e-01
+            4.54992175e-01   9.87500027e-02   4.43757802e-01
+            3.95617187e-01   1.24999997e-03   4.05632824e-01
+            2.05320314e-01   1.24999997e-03   5.95929682e-01
+            4.19070303e-01   4.87499982e-02   4.29679692e-01
+            2.17492193e-01   4.87499982e-02   6.31257832e-01
+            1.95304692e-01   1.24999997e-03   6.05945289e-01
+            5.00781229e-03   1.24999997e-03   7.96242177e-01
+            2.06882820e-01   4.87499982e-02   6.41867161e-01
+            5.30468766e-03   4.87499982e-02   8.43445301e-01
+            4.20304686e-01   5.12499996e-02   4.30945307e-01
+            2.18132809e-01   5.12499996e-02   6.33117199e-01
+            4.43757802e-01   9.87500027e-02   4.54992175e-01
+            2.30304688e-01   9.87500027e-02   6.68445289e-01
+            2.07492188e-01   5.12499996e-02   6.43757820e-01
+            5.32031246e-03   5.12499996e-02   8.45929682e-01
+            2.19070315e-01   9.87500027e-02   6.79679692e-01
+            5.61718736e-03   9.87500027e-02   8.93132806e-01
+            8.91218722e-01   1.02499999e-01   1.12812500e-02
+            4.62531239e-01   1.02499999e-01   4.39968765e-01
+            9.85031247e-01   1.97500005e-01   1.24687497e-02
+            5.11218727e-01   1.97500005e-01   4.86281246e-01
+            4.39968765e-01   1.02499999e-01   4.62531239e-01
+            1.12812500e-02   1.02499999e-01   8.91218722e-01
+            4.86281246e-01   1.97500005e-01   5.11218727e-01
+            1.24687497e-02   1.97500005e-01   9.85031247e-01
+            9.85031247e-01  -1.97500005e-01   1.24687497e-02
+            5.11218727e-01  -1.97500005e-01   4.86281246e-01
+            8.91218722e-01  -1.02499999e-01   1.12812500e-02
+            4.62531239e-01  -1.02499999e-01   4.39968765e-01
+            4.86281246e-01  -1.97500005e-01   5.11218727e-01
+            1.24687497e-02  -1.97500005e-01   9.85031247e-01
+            4.39968765e-01  -1.02499999e-01   4.62531239e-01
+            1.12812500e-02  -1.02499999e-01   8.91218722e-01
+            8.86281252e-01  -9.74999964e-02   1.12187499e-02
+            4.59968746e-01  -9.74999964e-02   4.37531263e-01
+            7.92468727e-01  -2.49999994e-03   1.00312503e-02
+            4.11281258e-01  -2.49999994e-03   3.91218752e-01
+            4.37531263e-01  -9.74999964e-02   4.59968746e-01
+            1.12187499e-02  -9.74999964e-02   8.86281252e-01
+            3.91218752e-01  -2.49999994e-03   4.11281258e-01
+            1.00312503e-02  -2.49999994e-03   7.92468727e-01
+            9.89968777e-01   1.97500005e-01   1.25312498e-02
+            5.13781250e-01   1.97500005e-01   4.88718748e-01
+            1.08378124e+00   1.02499999e-01   1.37187503e-02
+            5.62468767e-01   1.02499999e-01   5.35031259e-01
+            4.88718748e-01   1.97500005e-01   5.13781250e-01
+            1.25312498e-02   1.97500005e-01   9.89968777e-01
+            5.35031259e-01   1.02499999e-01   5.62468767e-01
+            1.37187503e-02   1.02499999e-01   1.08378124e+00
+            1.08871877e+00   9.74999964e-02   1.37812505e-02
+            5.65031230e-01   9.74999964e-02   5.37468731e-01
+            1.18253124e+00   2.49999994e-03   1.49687501e-02
+            6.13718748e-01   2.49999994e-03   5.83781242e-01
+            5.37468731e-01   9.74999964e-02   5.65031230e-01
+            1.37812505e-02   9.74999964e-02   1.08871877e+00
+            5.83781242e-01   2.49999994e-03   6.13718748e-01
+            1.49687501e-02   2.49999994e-03   1.18253124e+00
+           -1.00312503e-02   2.49999994e-03   7.92468727e-01
+           -3.91218752e-01   2.49999994e-03   4.11281258e-01
+           -1.12187499e-02   9.74999964e-02   8.86281252e-01
+           -4.37531263e-01   9.74999964e-02   4.59968746e-01
+           -4.11281258e-01   2.49999994e-03   3.91218752e-01
+           -7.92468727e-01   2.49999994e-03   1.00312503e-02
+           -4.59968746e-01   9.74999964e-02   4.37531263e-01
+           -8.86281252e-01   9.74999964e-02   1.12187499e-02
+           -1.12812500e-02   1.02499999e-01   8.91218722e-01
+           -4.39968765e-01   1.02499999e-01   4.62531239e-01
+           -1.24687497e-02   1.97500005e-01   9.85031247e-01
+           -4.86281246e-01   1.97500005e-01   5.11218727e-01
+           -4.62531239e-01   1.02499999e-01   4.39968765e-01
+           -8.91218722e-01   1.02499999e-01   1.12812500e-02
+           -5.11218727e-01   1.97500005e-01   4.86281246e-01
+           -9.85031247e-01   1.97500005e-01   1.24687497e-02
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+          4 5 6 7
+          8 9 10 11
+          12 13 14 15
+          16 17 18 19
+          20 21 22 23
+          24 25 26 27
+          28 29 30 31
+          32 33 34 35
+          36 37 38 39
+          40 41 42 43
+          44 45 46 47
+          48 49 50 51
+          52 53 54 55
+          56 57 58 59
+          60 61 62 63
+          64 65 66 67
+          68 69 70 71
+          72 73 74 75
+          76 77 78 79
+          80 81 82 83
+          84 85 86 87
+        </DataArray>
+        <DataArray type="Int32" Name="offsets" format="ascii">
+          4 8 12 16 20 24 28 32
+          36 40 44 48 52 56 60 64
+          68 72 76 80 84 88
+        </DataArray>
+        <DataArray type="UInt8" Name="types" format="ascii">
+          8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8
+          8 8
+        </DataArray>
+      </Cells>
+      <CellData Scalars="treeid,level,mpirank">
+        <DataArray type="Int32" Name="treeid" format="ascii">
+          0 0 0 0 0 0 0 0 0 0 1 1 1 1 2 2 2 2 3 3
+          3 3
+        </DataArray>
+        <DataArray type="UInt8" Name="level" format="ascii">
+          2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1
+          1 1
+        </DataArray>
+        <DataArray type="Int32" Name="mpirank" format="ascii">
+          0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+          0 0
+        </DataArray>
+      </CellData>
+    </Piece>
+  </UnstructuredGrid>
+</VTKFile>
+
+DEAL:0:2-3::dofs 73
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="88" NumberOfCells="22" >
+  <Points>
+    <DataArray type="Float64" NumberOfComponents="3" format="binary">
+AQAAAEAIAABACAAAKQEAAA==eNqVVUESgjAM5E9672/0TfoDnuApZwZ4gIMHHOXAyEHHDziQNkxTtmNyy1I2223Sts0ckzuf5ri4wke74DfBQ85f3x6vZD1Hr/De5XmKIsYnh3ji9ZXoUHoI6KFYj+yXwH4p1pnyKD0UdOR5ZL8UdFj1cD4q3wPv1encqgfxbNcbzf3A+SfpN87vgofc2g95nrXfYh3/69kt8U38YPzhdG7Vg3i2633hufhzo3x/rHPn+4L0nCIeX4d0fcTj65D22aonfw/0BO4fo56Ux9ch3edoHvfq3MJ/jL+8f6V8Px7meArO62qHeNCc5nk6hXdmPS14Lzgf1D3fmPUgHvSOIB/0OQUf8z7Ugse6Ux40d4gnXleK71Y9yIfgU3yfDGY9iAfN6Q9wul4M
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+AQAAAGABAABgAQAAkQAAAA==eNoNw4dWAVAAANCnqaWiNGmXFS2R0NagVNb//4l7z7khhBBx0gmnnHbWGaPOueC8iy65bMwVV00Yd811N0y66ZY7brtryj3T7nvgkYcee+KZp2bMmjdnwXNLFr3w0muvvLFsxVur3nlvzboNH2z66JMvPvvqm++2/PDTtl92/Lbrj7/+2fPfvgNHDh0D8IIO9Q==
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+AQAAAFgAAABYAAAAPwAAAA==eNoNw5ESgEAUAMAHB0EQBMFBEAQHQRAEQXBwEAT9/5e0O7MpIjp7B0cns7OLq8XN3cPTy9tq8/H18wd+2AP1
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+AQAAABYAAAAWAAAACwAAAA==eNrj5MQGAAj7AMc=
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float64" Name="subdomain" format="binary">
+AQAAAMACAADAAgAADwAAAA==eNpjYBgFo2DoAgACwAAB    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+
+
+DEAL:1:2-3::Checksum: 0
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="96" NumberOfCells="24">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -1.24687497e-02  -1.97500005e-01   9.85031247e-01
+           -4.86281246e-01  -1.97500005e-01   5.11218727e-01
+           -1.12812500e-02  -1.02499999e-01   8.91218722e-01
+           -4.39968765e-01  -1.02499999e-01   4.62531239e-01
+           -5.11218727e-01  -1.97500005e-01   4.86281246e-01
+           -9.85031247e-01  -1.97500005e-01   1.24687497e-02
+           -4.62531239e-01  -1.02499999e-01   4.39968765e-01
+           -8.91218722e-01  -1.02499999e-01   1.12812500e-02
+           -1.12187499e-02  -9.74999964e-02   8.86281252e-01
+           -4.37531263e-01  -9.74999964e-02   4.59968746e-01
+           -1.00312503e-02  -2.49999994e-03   7.92468727e-01
+           -3.91218752e-01  -2.49999994e-03   4.11281258e-01
+           -4.59968746e-01  -9.74999964e-02   4.37531263e-01
+           -8.86281252e-01  -9.74999964e-02   1.12187499e-02
+           -4.11281258e-01  -2.49999994e-03   3.91218752e-01
+           -7.92468727e-01  -2.49999994e-03   1.00312503e-02
+           -1.25312498e-02   1.97500005e-01   9.89968777e-01
+           -4.88718748e-01   1.97500005e-01   5.13781250e-01
+           -1.37187503e-02   1.02499999e-01   1.08378124e+00
+           -5.35031259e-01   1.02499999e-01   5.62468767e-01
+           -5.13781250e-01   1.97500005e-01   4.88718748e-01
+           -9.89968777e-01   1.97500005e-01   1.25312498e-02
+           -5.62468767e-01   1.02499999e-01   5.35031259e-01
+           -1.08378124e+00   1.02499999e-01   1.37187503e-02
+           -1.37812505e-02   9.74999964e-02   1.08871877e+00
+           -5.37468731e-01   9.74999964e-02   5.65031230e-01
+           -1.49687501e-02   2.49999994e-03   1.18253124e+00
+           -5.83781242e-01   2.49999994e-03   6.13718748e-01
+           -5.65031230e-01   9.74999964e-02   5.37468731e-01
+           -1.08871877e+00   9.74999964e-02   1.37812505e-02
+           -6.13718748e-01   2.49999994e-03   5.83781242e-01
+           -1.18253124e+00   2.49999994e-03   1.49687501e-02
+            1.00312503e-02   2.49999994e-03  -7.92468727e-01
+            3.91218752e-01   2.49999994e-03  -4.11281258e-01
+            1.12187499e-02   9.74999964e-02  -8.86281252e-01
+            4.37531263e-01   9.74999964e-02  -4.59968746e-01
+            4.11281258e-01   2.49999994e-03  -3.91218752e-01
+            7.92468727e-01   2.49999994e-03  -1.00312503e-02
+            4.59968746e-01   9.74999964e-02  -4.37531263e-01
+            8.86281252e-01   9.74999964e-02  -1.12187499e-02
+            1.12812500e-02   1.02499999e-01  -8.91218722e-01
+            4.39968765e-01   1.02499999e-01  -4.62531239e-01
+            1.24687497e-02   1.97500005e-01  -9.85031247e-01
+            4.86281246e-01   1.97500005e-01  -5.11218727e-01
+            4.62531239e-01   1.02499999e-01  -4.39968765e-01
+            8.91218722e-01   1.02499999e-01  -1.12812500e-02
+            5.11218727e-01   1.97500005e-01  -4.86281246e-01
+            9.85031247e-01   1.97500005e-01  -1.24687497e-02
+            1.24687497e-02  -1.97500005e-01  -9.85031247e-01
+            4.86281246e-01  -1.97500005e-01  -5.11218727e-01
+            1.12812500e-02  -1.02499999e-01  -8.91218722e-01
+            4.39968765e-01  -1.02499999e-01  -4.62531239e-01
+            5.11218727e-01  -1.97500005e-01  -4.86281246e-01
+            9.85031247e-01  -1.97500005e-01  -1.24687497e-02
+            4.62531239e-01  -1.02499999e-01  -4.39968765e-01
+            8.91218722e-01  -1.02499999e-01  -1.12812500e-02
+            1.12187499e-02  -9.74999964e-02  -8.86281252e-01
+            4.37531263e-01  -9.74999964e-02  -4.59968746e-01
+            1.00312503e-02  -2.49999994e-03  -7.92468727e-01
+            3.91218752e-01  -2.49999994e-03  -4.11281258e-01
+            4.59968746e-01  -9.74999964e-02  -4.37531263e-01
+            8.86281252e-01  -9.74999964e-02  -1.12187499e-02
+            4.11281258e-01  -2.49999994e-03  -3.91218752e-01
+            7.92468727e-01  -2.49999994e-03  -1.00312503e-02
+            1.25312498e-02   1.97500005e-01  -9.89968777e-01
+            4.88718748e-01   1.97500005e-01  -5.13781250e-01
+            1.37187503e-02   1.02499999e-01  -1.08378124e+00
+            5.35031259e-01   1.02499999e-01  -5.62468767e-01
+            5.13781250e-01   1.97500005e-01  -4.88718748e-01
+            9.89968777e-01   1.97500005e-01  -1.25312498e-02
+            5.62468767e-01   1.02499999e-01  -5.35031259e-01
+            1.08378124e+00   1.02499999e-01  -1.37187503e-02
+            1.37812505e-02   9.74999964e-02  -1.08871877e+00
+            5.37468731e-01   9.74999964e-02  -5.65031230e-01
+            1.49687501e-02   2.49999994e-03  -1.18253124e+00
+            5.83781242e-01   2.49999994e-03  -6.13718748e-01
+            5.65031230e-01   9.74999964e-02  -5.37468731e-01
+            1.08871877e+00   9.74999964e-02  -1.37812505e-02
+            6.13718748e-01   2.49999994e-03  -5.83781242e-01
+            1.18253124e+00   2.49999994e-03  -1.49687501e-02
+            1.18253124e+00  -2.49999994e-03   1.49687501e-02
+            6.13718748e-01  -2.49999994e-03   5.83781242e-01
+            1.08871877e+00  -9.74999964e-02   1.37812505e-02
+            5.65031230e-01  -9.74999964e-02   5.37468731e-01
+            5.83781242e-01  -2.49999994e-03   6.13718748e-01
+            1.49687501e-02  -2.49999994e-03   1.18253124e+00
+            5.37468731e-01  -9.74999964e-02   5.65031230e-01
+            1.37812505e-02  -9.74999964e-02   1.08871877e+00
+            1.08378124e+00  -1.02499999e-01   1.37187503e-02
+            5.62468767e-01  -1.02499999e-01   5.35031259e-01
+            9.89968777e-01  -1.97500005e-01   1.25312498e-02
+            5.13781250e-01  -1.97500005e-01   4.88718748e-01
+            5.35031259e-01  -1.02499999e-01   5.62468767e-01
+            1.37187503e-02  -1.02499999e-01   1.08378124e+00
+            4.88718748e-01  -1.97500005e-01   5.13781250e-01
+            1.25312498e-02  -1.97500005e-01   9.89968777e-01
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+          4 5 6 7
+          8 9 10 11
+          12 13 14 15
+          16 17 18 19
+          20 21 22 23
+          24 25 26 27
+          28 29 30 31
+          32 33 34 35
+          36 37 38 39
+          40 41 42 43
+          44 45 46 47
+          48 49 50 51
+          52 53 54 55
+          56 57 58 59
+          60 61 62 63
+          64 65 66 67
+          68 69 70 71
+          72 73 74 75
+          76 77 78 79
+          80 81 82 83
+          84 85 86 87
+          88 89 90 91
+          92 93 94 95
+        </DataArray>
+        <DataArray type="Int32" Name="offsets" format="ascii">
+          4 8 12 16 20 24 28 32
+          36 40 44 48 52 56 60 64
+          68 72 76 80 84 88 92 96
+        </DataArray>
+        <DataArray type="UInt8" Name="types" format="ascii">
+          8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8
+          8 8 8 8
+        </DataArray>
+      </Cells>
+      <CellData Scalars="treeid,level,mpirank">
+        <DataArray type="Int32" Name="treeid" format="ascii">
+          4 4 4 4 5 5 5 5 6 6 6 6 7 7 7 7 8 8 8 8
+          9 9 9 9
+        </DataArray>
+        <DataArray type="UInt8" Name="level" format="ascii">
+          1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+          1 1 1 1
+        </DataArray>
+        <DataArray type="Int32" Name="mpirank" format="ascii">
+          1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+          1 1 1 1
+        </DataArray>
+      </CellData>
+    </Piece>
+  </UnstructuredGrid>
+</VTKFile>
+
+DEAL:1:2-3::dofs 73
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="96" NumberOfCells="24" >
+  <Points>
+    <DataArray type="Float64" NumberOfComponents="3" format="binary">
+AQAAAAAJAAAACQAAKAEAAA==eNqdVsENgzAQ604ZIHO2m/Dyu1I7ABIPUF+V+ghigYqSRIpTc4R8UEzrM47vwLl1Lf5C6we7l+f97bquOV47pPvbfsp42iue//UWr3jKOgmfm/Vsd0PE7yhVjISPzXoUT/n7hAcDH7HP0+H5WNfHb9cBJT4YPAHsg+KJdcA+n9PD/3tHv3o6v9636lE8sU6lm/z3wn8v/Kf8TSjxyeAJhOfcVjyxTsaF/wf11H0X+xL/+/24HsUT60j/KQ9I57Z/rl3OQcpFiQ+SJ+WO6yuelGvLf0uPyBvNm5wTnNNT89DcE/rz/IGYYxD9zjpRPq/iqeew4qHnteaPoed43lr1tOatNQ+i30Hvqdy3rXlQPPSeteaPoaeaPxDfCWjVo3ic+M75AgN1oUQ=
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+AQAAAIABAACAAQAAnQAAAA==eNoNw4c2QgEAANCnSJJVRsmmYUV2SLISQigz/v8v3HvODYIg6DFsyF777Ddi1AEHjRl3yBGHHXXMpAnHnXDKSVOmzTjtjLPOO+eCiy675IpZ8+YsuOq6a2646ZZFty2564577nvogUeWPfHYUytWPfPcmpdeeOW1dW+8teG9dz7Y9MlHn2356otvtn2344effvvlj13//PUfAicR0Q==
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+AQAAAGAAAABgAAAAQgAAAA==eNoNw5ESgEAUAMAHQRAEQRAcBEEQBMFBcBAEQRAE/f9XtDuzVUTUNrZ29g4mRydnF1c3s7vFw9PL28fXzx+i4ASx
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+AQAAABgAAAAYAAAACwAAAA==eNrj5MQOAAqkANk=
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float64" Name="subdomain" format="binary">
+AQAAAAADAAAAAwAAFAAAAA==eNpjYACBD/YMo/QoPQJpAIIHcaE=    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+
+
+
+DEAL:2:2-3::Checksum: 0
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="96" NumberOfCells="24">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+           -1.49687501e-02  -2.49999994e-03   1.18253124e+00
+           -5.83781242e-01  -2.49999994e-03   6.13718748e-01
+           -1.37812505e-02  -9.74999964e-02   1.08871877e+00
+           -5.37468731e-01  -9.74999964e-02   5.65031230e-01
+           -6.13718748e-01  -2.49999994e-03   5.83781242e-01
+           -1.18253124e+00  -2.49999994e-03   1.49687501e-02
+           -5.65031230e-01  -9.74999964e-02   5.37468731e-01
+           -1.08871877e+00  -9.74999964e-02   1.37812505e-02
+           -1.37187503e-02  -1.02499999e-01   1.08378124e+00
+           -5.35031259e-01  -1.02499999e-01   5.62468767e-01
+           -1.25312498e-02  -1.97500005e-01   9.89968777e-01
+           -4.88718748e-01  -1.97500005e-01   5.13781250e-01
+           -5.62468767e-01  -1.02499999e-01   5.35031259e-01
+           -1.08378124e+00  -1.02499999e-01   1.37187503e-02
+           -5.13781250e-01  -1.97500005e-01   4.88718748e-01
+           -9.89968777e-01  -1.97500005e-01   1.25312498e-02
+            1.49687501e-02  -2.49999994e-03  -1.18253124e+00
+            5.83781242e-01  -2.49999994e-03  -6.13718748e-01
+            1.37812505e-02  -9.74999964e-02  -1.08871877e+00
+            5.37468731e-01  -9.74999964e-02  -5.65031230e-01
+            6.13718748e-01  -2.49999994e-03  -5.83781242e-01
+            1.18253124e+00  -2.49999994e-03  -1.49687501e-02
+            5.65031230e-01  -9.74999964e-02  -5.37468731e-01
+            1.08871877e+00  -9.74999964e-02  -1.37812505e-02
+            1.37187503e-02  -1.02499999e-01  -1.08378124e+00
+            5.35031259e-01  -1.02499999e-01  -5.62468767e-01
+            1.25312498e-02  -1.97500005e-01  -9.89968777e-01
+            4.88718748e-01  -1.97500005e-01  -5.13781250e-01
+            5.62468767e-01  -1.02499999e-01  -5.35031259e-01
+            1.08378124e+00  -1.02499999e-01  -1.37187503e-02
+            5.13781250e-01  -1.97500005e-01  -4.88718748e-01
+            9.89968777e-01  -1.97500005e-01  -1.25312498e-02
+           -7.92468727e-01   2.49999994e-03  -1.00312503e-02
+           -4.11281258e-01   2.49999994e-03  -3.91218752e-01
+           -8.86281252e-01   9.74999964e-02  -1.12187499e-02
+           -4.59968746e-01   9.74999964e-02  -4.37531263e-01
+           -3.91218752e-01   2.49999994e-03  -4.11281258e-01
+           -1.00312503e-02   2.49999994e-03  -7.92468727e-01
+           -4.37531263e-01   9.74999964e-02  -4.59968746e-01
+           -1.12187499e-02   9.74999964e-02  -8.86281252e-01
+           -8.91218722e-01   1.02499999e-01  -1.12812500e-02
+           -4.62531239e-01   1.02499999e-01  -4.39968765e-01
+           -9.85031247e-01   1.97500005e-01  -1.24687497e-02
+           -5.11218727e-01   1.97500005e-01  -4.86281246e-01
+           -4.39968765e-01   1.02499999e-01  -4.62531239e-01
+           -1.12812500e-02   1.02499999e-01  -8.91218722e-01
+           -4.86281246e-01   1.97500005e-01  -5.11218727e-01
+           -1.24687497e-02   1.97500005e-01  -9.85031247e-01
+           -9.85031247e-01  -1.97500005e-01  -1.24687497e-02
+           -5.11218727e-01  -1.97500005e-01  -4.86281246e-01
+           -8.91218722e-01  -1.02499999e-01  -1.12812500e-02
+           -4.62531239e-01  -1.02499999e-01  -4.39968765e-01
+           -4.86281246e-01  -1.97500005e-01  -5.11218727e-01
+           -1.24687497e-02  -1.97500005e-01  -9.85031247e-01
+           -4.39968765e-01  -1.02499999e-01  -4.62531239e-01
+           -1.12812500e-02  -1.02499999e-01  -8.91218722e-01
+           -8.86281252e-01  -9.74999964e-02  -1.12187499e-02
+           -4.59968746e-01  -9.74999964e-02  -4.37531263e-01
+           -7.92468727e-01  -2.49999994e-03  -1.00312503e-02
+           -4.11281258e-01  -2.49999994e-03  -3.91218752e-01
+           -4.37531263e-01  -9.74999964e-02  -4.59968746e-01
+           -1.12187499e-02  -9.74999964e-02  -8.86281252e-01
+           -3.91218752e-01  -2.49999994e-03  -4.11281258e-01
+           -1.00312503e-02  -2.49999994e-03  -7.92468727e-01
+           -9.89968777e-01   1.97500005e-01  -1.25312498e-02
+           -5.13781250e-01   1.97500005e-01  -4.88718748e-01
+           -1.08378124e+00   1.02499999e-01  -1.37187503e-02
+           -5.62468767e-01   1.02499999e-01  -5.35031259e-01
+           -4.88718748e-01   1.97500005e-01  -5.13781250e-01
+           -1.25312498e-02   1.97500005e-01  -9.89968777e-01
+           -5.35031259e-01   1.02499999e-01  -5.62468767e-01
+           -1.37187503e-02   1.02499999e-01  -1.08378124e+00
+           -1.08871877e+00   9.74999964e-02  -1.37812505e-02
+           -5.65031230e-01   9.74999964e-02  -5.37468731e-01
+           -1.18253124e+00   2.49999994e-03  -1.49687501e-02
+           -6.13718748e-01   2.49999994e-03  -5.83781242e-01
+           -5.37468731e-01   9.74999964e-02  -5.65031230e-01
+           -1.37812505e-02   9.74999964e-02  -1.08871877e+00
+           -5.83781242e-01   2.49999994e-03  -6.13718748e-01
+           -1.49687501e-02   2.49999994e-03  -1.18253124e+00
+           -1.18253124e+00  -2.49999994e-03  -1.49687501e-02
+           -6.13718748e-01  -2.49999994e-03  -5.83781242e-01
+           -1.08871877e+00  -9.74999964e-02  -1.37812505e-02
+           -5.65031230e-01  -9.74999964e-02  -5.37468731e-01
+           -5.83781242e-01  -2.49999994e-03  -6.13718748e-01
+           -1.49687501e-02  -2.49999994e-03  -1.18253124e+00
+           -5.37468731e-01  -9.74999964e-02  -5.65031230e-01
+           -1.37812505e-02  -9.74999964e-02  -1.08871877e+00
+           -1.08378124e+00  -1.02499999e-01  -1.37187503e-02
+           -5.62468767e-01  -1.02499999e-01  -5.35031259e-01
+           -9.89968777e-01  -1.97500005e-01  -1.25312498e-02
+           -5.13781250e-01  -1.97500005e-01  -4.88718748e-01
+           -5.35031259e-01  -1.02499999e-01  -5.62468767e-01
+           -1.37187503e-02  -1.02499999e-01  -1.08378124e+00
+           -4.88718748e-01  -1.97500005e-01  -5.13781250e-01
+           -1.25312498e-02  -1.97500005e-01  -9.89968777e-01
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int32" Name="connectivity" format="ascii">
+          0 1 2 3
+          4 5 6 7
+          8 9 10 11
+          12 13 14 15
+          16 17 18 19
+          20 21 22 23
+          24 25 26 27
+          28 29 30 31
+          32 33 34 35
+          36 37 38 39
+          40 41 42 43
+          44 45 46 47
+          48 49 50 51
+          52 53 54 55
+          56 57 58 59
+          60 61 62 63
+          64 65 66 67
+          68 69 70 71
+          72 73 74 75
+          76 77 78 79
+          80 81 82 83
+          84 85 86 87
+          88 89 90 91
+          92 93 94 95
+        </DataArray>
+        <DataArray type="Int32" Name="offsets" format="ascii">
+          4 8 12 16 20 24 28 32
+          36 40 44 48 52 56 60 64
+          68 72 76 80 84 88 92 96
+        </DataArray>
+        <DataArray type="UInt8" Name="types" format="ascii">
+          8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8
+          8 8 8 8
+        </DataArray>
+      </Cells>
+      <CellData Scalars="treeid,level,mpirank">
+        <DataArray type="Int32" Name="treeid" format="ascii">
+          10 10 10 10 11 11 11 11 12 12 12 12 13 13 13 13 14 14 14 14
+          15 15 15 15
+        </DataArray>
+        <DataArray type="UInt8" Name="level" format="ascii">
+          1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+          1 1 1 1
+        </DataArray>
+        <DataArray type="Int32" Name="mpirank" format="ascii">
+          2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2
+          2 2 2 2
+        </DataArray>
+      </CellData>
+    </Piece>
+  </UnstructuredGrid>
+</VTKFile>
+
+DEAL:2:2-3::dofs 73
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="96" NumberOfCells="24" >
+  <Points>
+    <DataArray type="Float64" NumberOfComponents="3" format="binary">
+AQAAAAAJAAAACQAAGAEAAA==eNqdVcENwzAIzE4dgDnbTfriXakdoFIfifKK1EerLFClNo4AXxzCxzJKjgMO03XaTn+bKZ0ja/9Icr+cF7tyOr+UzoG1f4A4OQ6b8B3CyXGKv/5fm4/+/pZxPtnfs/b3dIyPx8lxjF94TCCfJ9v7477YW+KWfJL/Vfz67nHq8SZGOKbOJDyifEwdCNSt9CPKB+GYvpd+oL6APtp8GeTLmqfHATrkbZxV56D+TT7H9LafT1Rv6B0A7wajuQNzyginHm9mhAPemTCfqN6ifKJ6i86jyZdAvqR57p/HbZx13kH9m3yO6W0/n6jekN/uW4tT16HsJad/hyN7Huxfh6P3anP/Qj7bOpR96/Qf5ONxZM/bufsBt7upBg==
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+AQAAAIABAACAAQAAnQAAAA==eNoNw4c2QgEAANCnSJJVRsmmYUV2SLISQigz/v8v3HvODYIg6DFsyF777Ddi1AEHjRl3yBGHHXXMpAnHnXDKSVOmzTjtjLPOO+eCiy675IpZ8+YsuOq6a2646ZZFty2564577nvogUeWPfHYUytWPfPcmpdeeOW1dW+8teG9dz7Y9MlHn2356otvtn2344effvvlj13//PUfAicR0Q==
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+AQAAAGAAAABgAAAAQgAAAA==eNoNw5ESgEAUAMAHQRAEQRAcBEEQBMFBcBAEQRAE/f9XtDuzVUTUNrZ29g4mRydnF1c3s7vFw9PL28fXzx+i4ASx
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+AQAAABgAAAAYAAAACwAAAA==eNrj5MQOAAqkANk=
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float64" Name="subdomain" format="binary">
+AQAAAAADAAAAAwAAEwAAAA==eNpjYAADB4ZRepQegTQAvQ0YAQ==    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+
+


### PR DESCRIPTION
p4est after 1.1 outputs slightly different vtk files:
```
      </PPoints>
        <PDataArray type="Int32" Name="treeid" format="ascii"/>
      </PCellData>
-     <PPointData>
-     </PPointData>
      <Piece Source="1_0000.vtu"/>
    </PUnstructuredGrid>
  </VTKFile>
```
Simply provide output alternatives that don't have this empty section.

In reference to #3908