### PR TITLE
Tests: Do not run to example steps in tests

### DIFF
--- a/tests/build_tests/CMakeLists.txt
+++ b/tests/build_tests/CMakeLists.txt
@@ -51,7 +51,7 @@ SET(_release_steps
   step-1  step-2  step-3  step-4  step-5
   step-6  step-7  step-8  step-9  step-10
   step-11 step-12 step-13 step-14 step-16
-  step-20 step-23 step-25 step-26 step-27
+  step-20 step-25 step-26 step-27
   step-30 step-38 step-39 step-47 step-48
   step-49
   )

--- a/tests/build_tests/CMakeLists.txt
+++ b/tests/build_tests/CMakeLists.txt
@@ -52,7 +52,7 @@ SET(_release_steps
   step-6  step-7  step-8  step-9  step-10
   step-11 step-12 step-13 step-14 step-16
   step-20 step-25 step-26 step-27
-  step-30 step-38 step-39 step-47 step-48
+  step-30 step-38 step-39 step-47
   step-49
   )
 


### PR DESCRIPTION
This two example steps take a bit too much time to run in the testsuite.

In reference to #3908