### PR TITLE
deprecates static support_distributed_data member of vector declarations

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -192,6 +192,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_NAMESPACE_CLOSE= \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
+                         DEAL_II_DEPRECATED = \
                          DEAL_II_P4EST_VERSION_GTE=1 \
                          DEAL_II_TRILINOS_VERSION_GTE=1
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -569,8 +569,11 @@ public:
    *
    * For the current class, the variable equals the value declared for the
    * type of the individual blocks.
+   *
+   * @deprecated instead of using this variable, please use the type trait value
+   * <code>is_serial_vector< VectorType >::value</code>
    */
-  static const bool supports_distributed_data = BlockType::supports_distributed_data;
+  static const bool supports_distributed_data DEAL_II_DEPRECATED = BlockType::supports_distributed_data;
 
   /**
    * Default constructor.

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -196,8 +196,11 @@ namespace LinearAlgebra
        *
        * For the current class, the variable equals true, since it does
        * support parallel data storage.
+       *
+       * @deprecated instead of using this variable, please use the type trait
+       * value <code>is_serial_vector< VectorType >::value</code>
        */
-      static const bool supports_distributed_data = true;
+      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
 
       /**
        * @name 1: Basic Object-handling

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -172,8 +172,11 @@ namespace PETScWrappers
        *
        * For the current class, the variable equals true, since it does
        * support parallel data storage.
+       *
+       * @deprecated instead of using this variable, please use the type trait
+       * value <code>is_serial_vector< VectorType >::value</code>
        */
-      static const bool supports_distributed_data = true;
+      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
 
       /**
        * Default constructor. Initialize the vector as empty.

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -68,8 +68,11 @@ namespace PETScWrappers
      * For the current class, the variable equals false, since it does not
      * support parallel data storage. If you do need parallel data storage,
      * use PETScWrappers::MPI::Vector.
+     *
+     * @deprecated instead of using this variable, please use the type trait
+     * value <code>is_serial_vector< VectorType >::value</code>
      */
-    static const bool supports_distributed_data = false;
+    static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
 
     /**
      * Default constructor. Initialize the vector as empty.

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -268,8 +268,11 @@ namespace TrilinosWrappers
        *
        * For the current class, the variable equals true, since it does
        * support parallel data storage.
+       *
+       * @deprecated instead of using this variable, please use the type trait
+       * value <code>is_serial_vector< VectorType >::value</code>
        */
-      static const bool supports_distributed_data = true;
+      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
 
       /**
        * @name Basic constructors and initialization.
@@ -767,8 +770,11 @@ namespace TrilinosWrappers
      * For the current class, the variable equals false, since it does not
      * support parallel data storage.  If you do need parallel data storage,
      * use TrilinosWrappers::MPI::Vector.
+     *
+     * @deprecated instead of using this variable, please use the type trait
+     * value <code>is_serial_vector< VectorType >::value</code>
      */
-    static const bool supports_distributed_data = false;
+    static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
 
     /**
      * Default constructor that generates an empty (zero size) vector. The

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -161,8 +161,11 @@ public:
    *
    * For the current class, the variable equals false, since it does not
    * support parallel data storage.
+   *
+   * @deprecated instead of using this variable, please use the type trait value
+   * <code>is_serial_vector< VectorType >::value</code>
    */
-  static const bool supports_distributed_data = false;
+  static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
 
 public:
 


### PR DESCRIPTION
Deprecates the `static const bool supports_distributed_data` member. This field should not be used and should be removed in a future release.
Instead of using this member, the vector type trait `is_serial_vector< VectorType >::value` delivers the information about the support for distributed storage.