### PR TITLE
Revert #3861 "add new macro for static asserts"

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1228,18 +1228,6 @@ namespace StandardExceptions
                                            dealii::ExcCudaError(cudaGetErrorString(error_code)))
 #endif
 
-// A static assert which checks a compile-time condition. This is nothing more
-// than a wrapper around the C++11 <code>static_assert</code> declaration, which
-// we need to disable for non-C++11.
-
-// Just like <code>static_assert</code>, it takes two arguments, a
-// <code>constexpr</code> condition and an error message.
-#if defined(DEAL_II_WITH_CXX11)
-#define DEAL_II_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
-#else
-#define DEAL_II_STATIC_ASSERT(...) /* do nothing */
-#endif
-
 using namespace StandardExceptions;
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -21,7 +21,6 @@
 
 #ifdef DEAL_II_WITH_CXX11
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/grid/tria.h>
@@ -327,8 +326,8 @@ namespace parallel
     class ContinuousQuadratureDataTransfer
     {
     public:
-      DEAL_II_STATIC_ASSERT(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
-                            "User's DataType class should be derived from QPData");
+      static_assert(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
+                    "User's DataType class should be derived from QPData");
 
       /**
        * A typedef for a cell.
@@ -506,8 +505,8 @@ template<typename T>
 void CellDataStorage<CellIteratorType,DataType>::initialize(const CellIteratorType &cell,
                                                             const unsigned int n_q_points)
 {
-  DEAL_II_STATIC_ASSERT(std::is_base_of<DataType, T>::value,
-                        "User's T class should be derived from user's DataType class");
+  static_assert(std::is_base_of<DataType, T>::value,
+                "User's T class should be derived from user's DataType class");
 
   if (map.find(cell) == map.end())
     {
@@ -578,8 +577,8 @@ template <typename T>
 std::vector<std::shared_ptr<T> >
 CellDataStorage<CellIteratorType,DataType>::get_data(const CellIteratorType &cell)
 {
-  DEAL_II_STATIC_ASSERT(std::is_base_of<DataType, T>::value,
-                        "User's T class should be derived from user's DataType class");
+  static_assert(std::is_base_of<DataType, T>::value,
+                "User's T class should be derived from user's DataType class");
 
   auto it = map.find(cell);
   Assert(it != map.end(), ExcMessage("Could not find data for the cell"));
@@ -602,8 +601,8 @@ template <typename T>
 std::vector<std::shared_ptr<const T> >
 CellDataStorage<CellIteratorType,DataType>::get_data(const CellIteratorType &cell) const
 {
-  DEAL_II_STATIC_ASSERT(std::is_base_of<DataType, T>::value,
-                        "User's T class should be derived from user's DataType class");
+  static_assert(std::is_base_of<DataType, T>::value,
+                "User's T class should be derived from user's DataType class");
 
   auto it = map.find(cell);
   Assert(it != map.end(), ExcMessage("Could not find QP data for the cell"));
@@ -635,8 +634,8 @@ void pack_cell_data
  const CellDataStorage<CellIteratorType,DataType> *data_storage,
  FullMatrix<double> &matrix_data)
 {
-  DEAL_II_STATIC_ASSERT(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
-                        "User's DataType class should be derived from QPData");
+  static_assert(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
+                "User's DataType class should be derived from QPData");
 
   const std::vector<std::shared_ptr<const DataType> > qpd = data_storage->get_data(cell);
 
@@ -668,8 +667,8 @@ void unpack_to_cell_data
  const FullMatrix<double> &values_at_qp,
  CellDataStorage<CellIteratorType,DataType> *data_storage)
 {
-  DEAL_II_STATIC_ASSERT(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
-                        "User's DataType class should be derived from QPData");
+  static_assert(std::is_base_of<TransferableQuadraturePointData, DataType>::value,
+                "User's DataType class should be derived from QPData");
 
   std::vector<std::shared_ptr<DataType> > qpd = data_storage->get_data(cell);
 

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -17,7 +17,6 @@
 #define dealii__tensor_accessors_h
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/table_indices.h>
 
@@ -186,8 +185,10 @@ namespace TensorAccessors
   internal::ReorderedIndexView<index, rank, T>
   reordered_index_view(T &t)
   {
-    DEAL_II_STATIC_ASSERT(0 <= index && index < rank,
-                          "The specified index must lie within the range [0,rank)");
+#ifdef DEAL_II_WITH_CXX11
+    static_assert(0 <= index && index < rank,
+                  "The specified index must lie within the range [0,rank)");
+#endif
 
     return internal::ReorderedIndexView<index, rank, T>(t);
   }
@@ -265,12 +266,14 @@ namespace TensorAccessors
   inline DEAL_II_ALWAYS_INLINE
   void contract(T1 &result, const T2 &left, const T3 &right)
   {
-    DEAL_II_STATIC_ASSERT(rank_1 >= no_contr, "The rank of the left tensor must be "
-                          "equal or greater than the number of "
-                          "contractions");
-    DEAL_II_STATIC_ASSERT(rank_2 >= no_contr, "The rank of the right tensor must be "
-                          "equal or greater than the number of "
-                          "contractions");
+#ifdef DEAL_II_WITH_CXX11
+    static_assert(rank_1 >= no_contr, "The rank of the left tensor must be "
+                  "equal or greater than the number of "
+                  "contractions");
+    static_assert(rank_2 >= no_contr, "The rank of the right tensor must be "
+                  "equal or greater than the number of "
+                  "contractions");
+#endif
 
     internal::Contract<no_contr, rank_1, rank_2, dim>::template contract<T1, T2, T3>
     (result, left, right);

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1096,10 +1096,12 @@ private:
 
   // explicitly check for sensible template arguments, but not on windows
   // because MSVC creates bogus warnings during normal compilation
+#ifdef DEAL_II_WITH_CXX11
 #ifndef DEAL_II_MSVC
-  DEAL_II_STATIC_ASSERT (dim<=spacedim,
-                         "The dimension <dim> of a DoFHandler must be less than or "
-                         "equal to the space dimension <spacedim> in which it lives.");
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a DoFHandler must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 };
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -2725,10 +2725,12 @@ protected:
 
   // explicitly check for sensible template arguments, but not on windows
   // because MSVC creates bogus warnings during normal compilation
+#ifdef DEAL_II_WITH_CXX11
 #ifndef DEAL_II_MSVC
-  DEAL_II_STATIC_ASSERT (dim<=spacedim,
-                         "The dimension <dim> of a FiniteElement must be less than or "
-                         "equal to the space dimension <spacedim> in which it lives.");
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a FiniteElement must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 
 };

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -299,9 +299,11 @@ class Manifold : public Subscriptor
 public:
 
   // explicitly check for sensible template arguments
-  DEAL_II_STATIC_ASSERT (dim<=spacedim,
-                         "The dimension <dim> of a Manifold must be less than or "
-                         "equal to the space dimension <spacedim> in which it lives.");
+#ifdef DEAL_II_WITH_CXX11
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a Manifold must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 
 
   /**
@@ -886,9 +888,11 @@ class ChartManifold : public Manifold<dim,spacedim>
 {
 public:
   // explicitly check for sensible template arguments
-  DEAL_II_STATIC_ASSERT (dim<=spacedim,
-                         "The dimension <dim> of a ChartManifold must be less than or "
-                         "equal to the space dimension <spacedim> in which it lives.");
+#ifdef DEAL_II_WITH_CXX11
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a ChartManifold must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 
   /**
    * Constructor. The optional argument can be used to specify the periodicity

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3528,10 +3528,12 @@ private:
 
   // explicitly check for sensible template arguments, but not on windows
   // because MSVC creates bogus warnings during normal compilation
+#ifdef DEAL_II_WITH_CXX11
 #ifndef DEAL_II_MSVC
-  DEAL_II_STATIC_ASSERT (dim<=spacedim,
-                         "The dimension <dim> of a Triangulation must be less than or "
-                         "equal to the space dimension <spacedim> in which it lives.");
+  static_assert (dim<=spacedim,
+                 "The dimension <dim> of a Triangulation must be less than or "
+                 "equal to the space dimension <spacedim> in which it lives.");
+#endif
 #endif
 
 };

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -502,8 +502,8 @@ template <size_t m, size_t n, typename Range, typename Domain, typename BlockPay
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_operator(const std::array<std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType>, n>, m> &ops)
 {
-  DEAL_II_STATIC_ASSERT(m > 0 && n > 0,
-                        "a blocked LinearOperator must consist of at least one block");
+  static_assert(m > 0 && n > 0,
+                "a blocked LinearOperator must consist of at least one block");
 
   typedef typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType BlockType;
 
@@ -611,8 +611,8 @@ template <size_t m, typename Range, typename Domain, typename BlockPayload>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(const std::array<LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType>, m> &ops)
 {
-  DEAL_II_STATIC_ASSERT(m > 0,
-                        "a blockdiagonal LinearOperator must consist of at least one block");
+  static_assert(m > 0,
+                "a blockdiagonal LinearOperator must consist of at least one block");
 
   typedef typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType BlockType;
 
@@ -655,9 +655,9 @@ template <size_t m, typename Range, typename Domain, typename BlockPayload>
 BlockLinearOperator<Range, Domain, BlockPayload>
 block_diagonal_operator(const LinearOperator<typename Range::BlockType, typename Domain::BlockType, typename BlockPayload::BlockType> &op)
 {
-  DEAL_II_STATIC_ASSERT(m > 0,
-                        "a blockdiagonal LinearOperator must consist of at least "
-                        "one block");
+  static_assert(m > 0,
+                "a blockdiagonal LinearOperator must consist of at least "
+                "one block");
 
   typedef typename BlockLinearOperator<Range, Domain, BlockPayload>::BlockType BlockType;
   std::array<BlockType, m> new_ops;

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1044,9 +1044,9 @@ namespace internal
       // true). As mentioned above, try to check this at compile time if C++11
       // support is available.
 #ifdef DEAL_II_WITH_CXX11
-      DEAL_II_STATIC_ASSERT(Constness == true,
-                            "Constructing a non-const iterator from a const iterator "
-                            "does not make sense.");
+      static_assert(Constness == true,
+                    "Constructing a non-const iterator from a const iterator "
+                    "does not make sense.");
 #else
       Assert(Constness == true, ExcCastingAwayConstness());
 #endif

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -466,7 +466,7 @@ LinearOperator<Range, Domain, Payload>
 operator*(typename Range::value_type  number,
           const LinearOperator<Range, Domain, Payload> &op)
 {
-  DEAL_II_STATIC_ASSERT(
+  static_assert(
     std::is_convertible<typename Range::value_type, typename Domain::value_type>::value,
     "Range and Domain must have implicitly convertible 'value_type's");
 
@@ -536,7 +536,7 @@ LinearOperator<Range, Domain, Payload>
 operator*(const LinearOperator<Range, Domain, Payload> &op,
           typename Domain::value_type  number)
 {
-  DEAL_II_STATIC_ASSERT(
+  static_assert(
     std::is_convertible<typename Range::value_type, typename Domain::value_type>::value,
     "Range and Domain must have implicitly convertible 'value_type's");
 

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -19,7 +19,6 @@
 // This file contains simple preconditioners.
 
 #include <deal.II/base/config.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/parallel.h>
@@ -1255,9 +1254,11 @@ template<class VectorType>
 inline void
 PreconditionRichardson::vmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<size_type, typename VectorType::size_type>::value,
     "PreconditionRichardson and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   dst.equ(relaxation,src);
 }
@@ -1268,9 +1269,11 @@ template<class VectorType>
 inline void
 PreconditionRichardson::Tvmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<size_type, typename VectorType::size_type>::value,
     "PreconditionRichardson and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   dst.equ(relaxation,src);
 }
@@ -1279,9 +1282,11 @@ template<class VectorType>
 inline void
 PreconditionRichardson::vmult_add (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<size_type, typename VectorType::size_type>::value,
     "PreconditionRichardson and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   dst.add(relaxation,src);
 }
@@ -1292,9 +1297,11 @@ template<class VectorType>
 inline void
 PreconditionRichardson::Tvmult_add (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<size_type, typename VectorType::size_type>::value,
     "PreconditionRichardson and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   dst.add(relaxation,src);
 }
@@ -1355,9 +1362,11 @@ template<class VectorType>
 inline void
 PreconditionJacobi<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_Jacobi (dst, src, this->relaxation);
@@ -1370,9 +1379,11 @@ template<class VectorType>
 inline void
 PreconditionJacobi<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_Jacobi (dst, src, this->relaxation);
@@ -1385,9 +1396,11 @@ template<class VectorType>
 inline void
 PreconditionJacobi<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->Jacobi_step (dst, src, this->relaxation);
@@ -1400,9 +1413,11 @@ template<class VectorType>
 inline void
 PreconditionJacobi<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionJacobi<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionJacobi and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   step (dst, src);
 }
@@ -1416,9 +1431,11 @@ template<class VectorType>
 inline void
 PreconditionSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_SOR (dst, src, this->relaxation);
@@ -1431,9 +1448,11 @@ template<class VectorType>
 inline void
 PreconditionSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_TSOR (dst, src, this->relaxation);
@@ -1446,9 +1465,11 @@ template<class VectorType>
 inline void
 PreconditionSOR<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->SOR_step (dst, src, this->relaxation);
@@ -1461,9 +1482,11 @@ template<class VectorType>
 inline void
 PreconditionSOR<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->TSOR_step (dst, src, this->relaxation);
@@ -1512,9 +1535,11 @@ template<class VectorType>
 inline void
 PreconditionSSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_SSOR (dst, src, this->relaxation, pos_right_of_diagonal);
@@ -1527,9 +1552,11 @@ template<class VectorType>
 inline void
 PreconditionSSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->precondition_SSOR (dst, src, this->relaxation, pos_right_of_diagonal);
@@ -1542,9 +1569,11 @@ template<class VectorType>
 inline void
 PreconditionSSOR<MatrixType>::step (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   this->A->SSOR_step (dst, src, this->relaxation);
@@ -1557,9 +1586,11 @@ template<class VectorType>
 inline void
 PreconditionSSOR<MatrixType>::Tstep (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionSSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionSSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   step (dst, src);
 }
@@ -1599,9 +1630,11 @@ template <typename VectorType>
 inline void
 PreconditionPSOR<MatrixType>::vmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionPSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionPSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   dst = src;
@@ -1615,9 +1648,11 @@ template<class VectorType>
 inline void
 PreconditionPSOR<MatrixType>::Tvmult (VectorType &dst, const VectorType &src) const
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<typename PreconditionPSOR<MatrixType>::size_type, typename VectorType::size_type>::value,
     "PreconditionPSOR and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 
   Assert (this->A!=0, ExcNotInitialized());
   dst = src;
@@ -1981,9 +2016,11 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>::PreconditionChe
   delta          (1.),
   is_initialized (false)
 {
-  DEAL_II_STATIC_ASSERT(
+#ifdef DEAL_II_WITH_CXX11
+  static_assert(
     std::is_same<size_type, typename VectorType::size_type>::value,
     "PreconditionChebyshev and VectorType must have the same size_type.");
+#endif // DEAL_II_WITH_CXX11
 }
 
 

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -608,8 +608,8 @@ namespace TrilinosWrappers
         template <typename... Args>
         TrilinosBlockPayload (const Args &...)
         {
-          DEAL_II_STATIC_ASSERT(typeid(PayloadBlockType)==typeid(internal::LinearOperator::TrilinosPayload),
-                                "TrilinosBlockPayload can only accept a payload of type TrilinosPayload.");
+          static_assert(typeid(PayloadBlockType)==typeid(internal::LinearOperator::TrilinosPayload),
+                        "TrilinosBlockPayload can only accept a payload of type TrilinosPayload.");
         }
       };
 

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1097,9 +1097,13 @@ namespace MatrixFreeOperators
   MGInterfaceOperator<OperatorType>::vmult (VectorType &dst,
                                             const VectorType &src) const
   {
-    DEAL_II_STATIC_ASSERT (std::is_same<typename VectorType::value_type,value_type>::value,
-                           "The vector type must be based on the same value type as this"
-                           "operator");
+#ifdef DEAL_II_WITH_CXX11
+#ifndef DEAL_II_MSVC
+    static_assert (std::is_same<typename VectorType::value_type,value_type>::value,
+                   "The vector type must be based on the same value type as this"
+                   "operator");
+#endif
+#endif
 
     Assert(mf_base_operator != NULL,
            ExcNotInitialized());
@@ -1115,9 +1119,13 @@ namespace MatrixFreeOperators
   MGInterfaceOperator<OperatorType>::Tvmult (VectorType &dst,
                                              const VectorType &src) const
   {
-    DEAL_II_STATIC_ASSERT (std::is_same<typename VectorType::value_type,value_type>::value,
-                           "The vector type must be based on the same value type as this"
-                           "operator");
+#ifdef DEAL_II_WITH_CXX11
+#ifndef DEAL_II_MSVC
+    static_assert (std::is_same<typename VectorType::value_type,value_type>::value,
+                   "The vector type must be based on the same value type as this"
+                   "operator");
+#endif
+#endif
 
     Assert(mf_base_operator != NULL,
            ExcNotInitialized());


### PR DESCRIPTION
This reverts commit c9283e795004308c570f356da95f97562f62d112 (PR #3861)

See discussion in #3892. We will clean this up after the 8.5 release.