### PR TITLE
Avoid using 'defined' inside a macro.

### DIFF
--- a/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp
+++ b/bundled/boost-1.62.0/include/boost/archive/detail/iserializer.hpp
@@ -57,11 +57,8 @@ namespace std{
 
 #include <boost/serialization/assume_abstract.hpp>
 
-#ifndef BOOST_MSVC
-    #define DONT_USE_HAS_NEW_OPERATOR (                    \
-           BOOST_WORKAROUND(__IBMCPP__, < 1210)            \
-        || defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590)   \
-    )
+#if BOOST_WORKAROUND(__IBMCPP__, < 1210) || (defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590))
+    #define DONT_USE_HAS_NEW_OPERATOR 1
 #else
     #define DONT_USE_HAS_NEW_OPERATOR 0
 #endif


### PR DESCRIPTION
This is technically illegal and clang rightfully complains.

Patch from https://github.com/boostorg/serialization/pull/49