### PR TITLE
Boost develop patches

### DIFF
--- a/bundled/boost-1.62.0/include/boost/algorithm/searching/boyer_moore.hpp
+++ b/bundled/boost-1.62.0/include/boost/algorithm/searching/boyer_moore.hpp
@@ -172,16 +172,16 @@ Requirements:
                 }
             }
 
-        void build_suffix_table ( patIter pat_first, patIter pat_last ) {
-            const std::size_t count = (std::size_t) std::distance ( pat_first, pat_last );
             
+        void build_suffix_table ( patIter first, patIter last ) {
+            const std::size_t count = (std::size_t) std::distance ( first, last );
             if ( count > 0 ) {  // empty pattern
                 std::vector<typename std::iterator_traits<patIter>::value_type> reversed(count);
-                (void) std::reverse_copy ( pat_first, pat_last, reversed.begin ());
                 
+                (void) std::reverse_copy ( first, last, reversed.begin ());
                 std::vector<difference_type> prefix (count);
-                compute_bm_prefix ( pat_first, pat_last, prefix );
         
+                compute_bm_prefix ( first, last, prefix );
                 std::vector<difference_type> prefix_reversed (count);
                 compute_bm_prefix ( reversed.begin (), reversed.end (), prefix_reversed );
                 

--- a/bundled/boost-1.62.0/include/boost/algorithm/string/detail/find_iterator.hpp
+++ b/bundled/boost-1.62.0/include/boost/algorithm/string/detail/find_iterator.hpp
@@ -40,7 +40,7 @@ namespace boost {
             // Protected construction/destruction
 
                 // Default constructor
-                find_iterator_base() {};
+                find_iterator_base() {}
                 // Copy construction
                 find_iterator_base( const find_iterator_base& Other ) :
                     m_Finder(Other.m_Finder) {}

--- a/bundled/boost-1.62.0/include/boost/chrono/duration.hpp
+++ b/bundled/boost-1.62.0/include/boost/chrono/duration.hpp
@@ -438,7 +438,7 @@ namespace chrono {
         BOOST_FORCEINLINE BOOST_CONSTEXPR
         duration() : rep_(duration_values<rep>::zero()) { }
 #else
-        BOOST_CONSTEXPR duration() BOOST_NOEXCEPT : rep_() {};
+        BOOST_CONSTEXPR duration() BOOST_NOEXCEPT : rep_() {}
 #endif
         template <class Rep2>
         BOOST_SYMBOL_VISIBLE BOOST_FORCEINLINE BOOST_CONSTEXPR

--- a/bundled/boost-1.62.0/include/boost/container/detail/copy_move_algo.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/detail/copy_move_algo.hpp
@@ -186,8 +186,9 @@ inline F memmove(I f, I l, F r) BOOST_NOEXCEPT_OR_NOTHROW
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-F memmove_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+F memmove_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    typedef typename boost::container::iterator_traits<I>::value_type value_type;
    if(n){
@@ -199,8 +200,9 @@ F memmove_n(I f, typename boost::container::iterator_traits<I>::difference_type 
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-I memmove_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+I memmove_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    if(n){
       typedef typename boost::container::iterator_traits<I>::value_type value_type;
@@ -212,8 +214,9 @@ I memmove_n_source(I f, typename boost::container::iterator_traits<I>::differenc
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-I memmove_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+I memmove_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    typedef typename boost::container::iterator_traits<I>::value_type value_type;
    if(n){
@@ -332,7 +335,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_move_alloc_n(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_move_alloc_n(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -356,7 +359,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_move_alloc_n(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_move_alloc_n(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -377,7 +380,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_move_alloc_n_source(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_move_alloc_n_source(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -401,7 +404,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_move_alloc_n_source(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_move_alloc_n_source(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -467,7 +470,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_copy_alloc_n(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_copy_alloc_n(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -491,7 +494,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_copy_alloc_n(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_copy_alloc_n(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -512,7 +515,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -536,7 +539,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_copy_alloc_n_source(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_copy_alloc_n_source(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -556,7 +559,7 @@ template
    <typename Allocator,
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memzero_initializable<F, F>::type
-   uninitialized_value_init_alloc_n(Allocator &a, typename allocator_traits<Allocator>::difference_type n, F r)
+   uninitialized_value_init_alloc_n(Allocator &a, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -579,7 +582,7 @@ template
    <typename Allocator,
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memzero_initializable<F, F>::type
-   uninitialized_value_init_alloc_n(Allocator &, typename allocator_traits<Allocator>::difference_type n, F r)
+   uninitialized_value_init_alloc_n(Allocator &, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    typedef typename boost::container::iterator_traits<F>::value_type value_type;
    std::memset((void*)container_detail::iterator_to_raw_pointer(r), 0, sizeof(value_type)*n);
@@ -603,7 +606,7 @@ inline typename container_detail::enable_if_memzero_initializable<F, F>::type
 template
    <typename Allocator,
     typename F> // F models ForwardIterator
-inline F uninitialized_default_init_alloc_n(Allocator &a, typename allocator_traits<Allocator>::difference_type n, F r)
+inline F uninitialized_default_init_alloc_n(Allocator &a, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -675,7 +678,7 @@ template
    <typename Allocator,
     typename T,
     typename F> // F models ForwardIterator
-inline F uninitialized_fill_alloc_n(Allocator &a, const T &v, typename allocator_traits<Allocator>::difference_type n, F r)
+inline F uninitialized_fill_alloc_n(Allocator &a, const T &v, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -728,9 +731,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F>::type
-   copy_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   copy_n(I f, U n, F r)
 {
    while (n--) {
       *r = *f;
@@ -741,9 +745,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>::type
-   copy_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -754,9 +759,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   copy_n_source(I f, U n, F r)
 {
    while (n--) {
       boost::container::assign_in_place(r, f);
@@ -767,9 +773,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -780,9 +787,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r)
+   copy_n_source_dest(I f, U n, F &r)
 {
    while (n--) {
       *r = *f;
@@ -793,9 +801,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source_dest(f, n, r);  }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -832,9 +841,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F>::type
-   move_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   move_n(I f, U n, F r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -845,9 +855,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>::type
-   move_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 
@@ -891,9 +902,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r)
+   move_n_source_dest(I f, U n, F &r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -904,9 +916,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source_dest(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -917,9 +930,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   move_n_source(I f, U n, F r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -930,9 +944,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/bundled/boost-1.62.0/include/boost/container/detail/flat_tree.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/detail/flat_tree.hpp
@@ -409,7 +409,6 @@ class flat_tree
    iterator insert_unique(const_iterator hint, const value_type& val)
    {
       BOOST_ASSERT(this->priv_in_range_or_end(hint));
-      std::pair<iterator,bool> ret;
       insert_commit_data data;
       return this->priv_insert_unique_prepare(hint, KeyOfValue()(val), data)
             ? this->priv_insert_commit(data, val)
@@ -419,7 +418,6 @@ class flat_tree
    iterator insert_unique(const_iterator hint, BOOST_RV_REF(value_type) val)
    {
       BOOST_ASSERT(this->priv_in_range_or_end(hint));
-      std::pair<iterator,bool> ret;
       insert_commit_data data;
       return this->priv_insert_unique_prepare(hint, KeyOfValue()(val), data)
          ? this->priv_insert_commit(data, boost::move(val))

--- a/bundled/boost-1.62.0/include/boost/container/detail/iterators.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/detail/iterators.hpp
@@ -809,6 +809,7 @@ class iterator_from_iiterator
    typedef typename types_t::value_type          value_type;
 
    BOOST_CONTAINER_FORCEINLINE iterator_from_iiterator()
+      : m_iit()
    {}
 
    BOOST_CONTAINER_FORCEINLINE explicit iterator_from_iiterator(IIterator iit) BOOST_NOEXCEPT_OR_NOTHROW

--- a/bundled/boost-1.62.0/include/boost/container/detail/pair.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/detail/pair.hpp
@@ -417,35 +417,6 @@ inline void swap(pair<T1, T2>& x, pair<T1, T2>& y)
 }  //namespace container {
 
 
-//Without this specialization recursive flat_(multi)map instantiation fails
-//because is_enum needs to instantiate the recursive pair, leading to a compilation error).
-//This breaks the cycle clearly stating that pair is not an enum avoiding any instantiation.
-template<class T>
-struct is_enum;
-
-template<class T, class U>
-struct is_enum< ::boost::container::container_detail::pair<T, U> >
-{
-   static const bool value = false;
-};
-
-template<class T, class U>
-struct is_enum< ::std::pair<T, U> >
-{
-   static const bool value = false;
-};
-
-template <class T>
-struct is_class;
-
-//This specialization is needed to avoid instantiation of pair in
-//is_class, and allow recursive maps.
-template <class T1, class T2>
-struct is_class< ::boost::container::container_detail::pair<T1, T2> >
-{
-   static const bool value = true;
-};
-
 #ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
 
 template<class T1, class T2>

--- a/bundled/boost-1.62.0/include/boost/container/uses_allocator_fwd.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/uses_allocator_fwd.hpp
@@ -30,8 +30,8 @@ namespace container {
       static ::std::allocator_arg_t *dummy;
    };
 
-   template <int Dummy>
-   ::std::allocator_arg_t *std_allocator_arg_holder<Dummy>::dummy;
+   template <int Dummy>                                             //Silence null-reference compiler warnings
+   ::std::allocator_arg_t *std_allocator_arg_holder<Dummy>::dummy = reinterpret_cast< ::std::allocator_arg_t * >(0x1234);
 
 typedef const std::allocator_arg_t & allocator_arg_t;
 

--- a/bundled/boost-1.62.0/include/boost/container/vector.hpp
+++ b/bundled/boost-1.62.0/include/boost/container/vector.hpp
@@ -3120,7 +3120,7 @@ class vector
             }
             else{ //If trivial destructor, we can uninitialized copy + copy in a single uninitialized copy
                ::boost::container::uninitialized_move_alloc_n
-                  (this->m_holder.alloc(), pos, old_finish - pos, new_start + before_plus_new);
+                  (this->m_holder.alloc(), pos, static_cast<size_type>(old_finish - pos), new_start + before_plus_new);
                this->m_holder.m_size = new_size;
                old_values_destroyer.release();
             }

--- a/bundled/boost-1.62.0/include/boost/exception/errinfo_api_function.hpp
+++ b/bundled/boost-1.62.0/include/boost/exception/errinfo_api_function.hpp
@@ -6,7 +6,7 @@
 #ifndef UUID_DDFBB4546C1211DEA4659E9055D89593
 #define UUID_DDFBB4546C1211DEA4659E9055D89593
 
-#include "boost/exception/error_info.hpp"
+#include <boost/exception/error_info.hpp>
 
 namespace
 boost

--- a/bundled/boost-1.62.0/include/boost/exception/errinfo_errno.hpp
+++ b/bundled/boost-1.62.0/include/boost/exception/errinfo_errno.hpp
@@ -13,7 +13,7 @@
 #pragma warning(disable:4996)
 #endif
 
-#include "boost/exception/info.hpp"
+#include <boost/exception/info.hpp>
 #include <errno.h>
 #include <string.h>
 

--- a/bundled/boost-1.62.0/include/boost/exception/info.hpp
+++ b/bundled/boost-1.62.0/include/boost/exception/info.hpp
@@ -205,7 +205,7 @@ boost
 		template <class T>
 		class set_info_rv;
 		template <class Tag,class T>
-		class
+		struct
 		set_info_rv<error_info<Tag,T> >
 			{
 			template <class E,class Tag1,class T1>
@@ -225,7 +225,7 @@ boost
 				}
 			};
 		template <>
-		class
+		struct
 		set_info_rv<throw_function>
 			{
 			template <class E,class Tag1,class T1>
@@ -240,7 +240,7 @@ boost
 				}
 			};
 		template <>
-		class
+		struct
 		set_info_rv<throw_file>
 			{
 			template <class E,class Tag1,class T1>
@@ -255,7 +255,7 @@ boost
 				}
 			};
 		template <>
-		class
+		struct
 		set_info_rv<throw_line>
 			{
 			template <class E,class Tag1,class T1>

--- a/bundled/boost-1.62.0/include/boost/functional/hash/hash.hpp
+++ b/bundled/boost-1.62.0/include/boost/functional/hash/hash.hpp
@@ -456,7 +456,7 @@ namespace boost
     BOOST_HASH_SPECIALIZE(long double)
 
     BOOST_HASH_SPECIALIZE_REF(std::string)
-#if !defined(BOOST_NO_STD_WSTRING)
+#if !defined(BOOST_NO_STD_WSTRING) && !defined(BOOST_NO_INTRINSIC_WCHAR_T)
     BOOST_HASH_SPECIALIZE_REF(std::wstring)
 #endif
 

--- a/bundled/boost-1.62.0/include/boost/functional/hash/hash.hpp
+++ b/bundled/boost-1.62.0/include/boost/functional/hash/hash.hpp
@@ -171,7 +171,7 @@ namespace boost
              const int size_t_bits = std::numeric_limits<std::size_t>::digits;
              // ceiling(std::numeric_limits<T>::digits / size_t_bits) - 1
              const int length = (std::numeric_limits<T>::digits - 1)
-                 / size_t_bits;
+                 / static_cast<int>(size_t_bits);
 
              std::size_t seed = 0;
              T positive = val < 0 ? -1 - val : val;
@@ -192,7 +192,7 @@ namespace boost
              const int size_t_bits = std::numeric_limits<std::size_t>::digits;
              // ceiling(std::numeric_limits<T>::digits / size_t_bits) - 1
              const int length = (std::numeric_limits<T>::digits - 1)
-                 / size_t_bits;
+                 / static_cast<int>(size_t_bits);
 
              std::size_t seed = 0;
 
@@ -236,7 +236,7 @@ namespace boost
         inline void hash_combine_impl(boost::uint64_t& h,
                 boost::uint64_t k)
         {
-            const uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+            const boost::uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
             const int r = 47;
 
             k *= m;

--- a/bundled/boost-1.62.0/include/boost/fusion/view/zip_view/zip_view.hpp
+++ b/bundled/boost-1.62.0/include/boost/fusion/view/zip_view/zip_view.hpp
@@ -126,7 +126,7 @@ namespace boost { namespace fusion {
         zip_view(
             const Sequences& seqs)
             : sequences_(seqs)
-        {};
+        {}
 
         sequences sequences_;
     };

--- a/bundled/boost-1.62.0/include/boost/graph/random.hpp
+++ b/bundled/boost-1.62.0/include/boost/graph/random.hpp
@@ -103,6 +103,7 @@ namespace boost {
       }
     }
     BOOST_ASSERT (false); // Should not get here
+    return typename graph_traits<Graph>::edge_descriptor();
   }
 
   namespace detail {

--- a/bundled/boost-1.62.0/include/boost/intrusive/member_value_traits.hpp
+++ b/bundled/boost-1.62.0/include/boost/intrusive/member_value_traits.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/intrusive/link_mode.hpp>
 #include <boost/intrusive/detail/parent_from_member.hpp>
+#include <boost/intrusive/detail/to_raw_pointer.hpp>
 #include <boost/intrusive/pointer_traits.hpp>
 
 #if defined(BOOST_HAS_PRAGMA_ONCE)

--- a/bundled/boost-1.62.0/include/boost/math/tools/polynomial.hpp
+++ b/bundled/boost-1.62.0/include/boost/math/tools/polynomial.hpp
@@ -337,7 +337,7 @@ public:
    }
    T evaluate(T z)const
    {
-      return boost::math::tools::evaluate_polynomial(&m_data[0], z, m_data.size());;
+      return m_data.size() > 0 ? boost::math::tools::evaluate_polynomial(&m_data[0], z, m_data.size()) : 0;
    }
    std::vector<T> chebyshev()const
    {

--- a/bundled/boost-1.62.0/include/boost/range/size_type.hpp
+++ b/bundled/boost-1.62.0/include/boost/range/size_type.hpp
@@ -83,11 +83,6 @@ namespace boost
         detail::range_size<T>
     { };
 
-    template< class T >
-    struct range_size<const T > :
-        detail::range_size<T>
-    { };
-
 } // namespace boost
 
 

--- a/bundled/boost-1.62.0/include/boost/signals2/detail/auto_buffer.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/detail/auto_buffer.hpp
@@ -971,7 +971,7 @@ namespace detail
 
         pointer uninitialized_grow( size_type n ) // strong
         {
-            if( size_ + n <= members_.capacity_ )
+            if( size_ + n > members_.capacity_ )
                 reserve( size_ + n );
 
             pointer res = end();

--- a/bundled/boost-1.62.0/include/boost/signals2/detail/auto_buffer.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/detail/auto_buffer.hpp
@@ -1116,7 +1116,7 @@ namespace detail
     inline bool operator<=( const auto_buffer<T,SBP,GP,A>& l,
                             const auto_buffer<T,SBP,GP,A>& r )
     {
-        return !(r > l);
+        return !(r < l);
     }
 
     template< class T, class SBP, class GP, class A >

--- a/bundled/boost-1.62.0/include/boost/signals2/slot_base.hpp
+++ b/bundled/boost-1.62.0/include/boost/signals2/slot_base.hpp
@@ -67,7 +67,7 @@ namespace boost
       typedef std::vector<detail::void_shared_ptr_variant> locked_container_type;
 
       const tracked_container_type& tracked_objects() const {return _tracked_objects;}
-    #if(!BOOST_NO_EXCEPTIONS)
+    #ifndef BOOST_NO_EXCEPTIONS
       locked_container_type lock() const
       {
         locked_container_type locked_objects;

--- a/bundled/boost-1.62.0/include/boost/thread/synchronized_value.hpp
+++ b/bundled/boost-1.62.0/include/boost/thread/synchronized_value.hpp
@@ -827,7 +827,7 @@ namespace boost
      * @effects loads the value type from the input stream @c is.
      */
     template <typename IStream>
-    void load(IStream& is) const
+    void load(IStream& is)
     {
       strict_lock<mutex_type> lk(mtx_);
       is >> value_;
@@ -999,7 +999,7 @@ namespace boost
     return os;
   }
   template <typename IStream, typename T, typename L>
-  inline IStream& operator>>(IStream& is, synchronized_value<T,L> const& rhs)
+  inline IStream& operator>>(IStream& is, synchronized_value<T,L>& rhs)
   {
     rhs.load(is);
     return is;

--- a/bundled/boost-1.62.0/include/boost/thread/synchronized_value.hpp
+++ b/bundled/boost-1.62.0/include/boost/thread/synchronized_value.hpp
@@ -971,22 +971,22 @@ namespace boost
   template <typename T, typename L>
   bool operator<(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs>=lhs;
+    return rhs>lhs;
   }
   template <typename T, typename L>
   bool operator<=(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs>lhs;
+    return rhs>=lhs;
   }
   template <typename T, typename L>
   bool operator>(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs<=lhs;
+    return rhs<lhs;
   }
   template <typename T, typename L>
   bool operator>=(T const& lhs, synchronized_value<T,L> const&rhs)
   {
-    return rhs<lhs;
+    return rhs<=lhs;
   }
 
   /**

--- a/bundled/boost-1.62.0/include/boost/variant/recursive_wrapper_fwd.hpp
+++ b/bundled/boost-1.62.0/include/boost/variant/recursive_wrapper_fwd.hpp
@@ -20,6 +20,7 @@
 #include <boost/mpl/aux_/lambda_support.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_constructible.hpp>
+#include <boost/type_traits/is_nothrow_move_constructible.hpp>
 
 namespace boost {
 
@@ -65,6 +66,9 @@ template <class T, class U> struct is_constructible<recursive_wrapper<T>, const 
 template <class T, class U> struct is_constructible<recursive_wrapper<T>, recursive_wrapper<U>& >       : boost::false_type{};
 template <class T, class U> struct is_constructible<recursive_wrapper<T>, const recursive_wrapper<U>& > : boost::false_type{};
 
+// recursive_wrapper is not nothrow move constructible, because it's constructor does dynamic memory allocation.
+// This specialisation is required to workaround GCC6 issue: https://svn.boost.org/trac/boost/ticket/12680
+template <class T> struct is_nothrow_move_constructible<recursive_wrapper<T> > : boost::false_type{};
 
 ///////////////////////////////////////////////////////////////////////////////
 // metafunction is_recursive_wrapper (modeled on code by David Abrahams)


### PR DESCRIPTION
I spent some time going through the recent changes to the boost libraries we use (including some development patches) and I extracted these changes.

The patches that were not also a part of 1.63 are all pretty trivial. I avoided adding any new features, just bug fixes, to keep this simple.