### PR TITLE
Refactor schur_complement operator

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2198,7 +2198,7 @@ namespace TrilinosWrappers
         /**
         * Destructor
         */
-        virtual ~TrilinosPayload() {}
+        virtual ~TrilinosPayload();
 
         /**
         * Returns a payload configured for identity operations

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2763,6 +2763,12 @@ namespace TrilinosWrappers
 
 
 
+      // Destructor
+      TrilinosPayload::~TrilinosPayload ()
+      { }
+
+
+
       TrilinosPayload
       TrilinosPayload::identity_payload () const
       {

--- a/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=1.output
+++ b/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=1.output
@@ -1,15 +1,8 @@
 Refinement cycle 0
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 7.49608e-06
-DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Starting value 12.7149
-DEAL:SchurComplementOp:Pre::Convergence step 43 value 1.05660e-05
-DEAL:SchurComplementOp:Main::Starting value 7.49608e-06
-DEAL:SchurComplementOp:Main::Convergence step 12 value 4.00858e-10
-DEAL:SchurComplementOp:Post::Starting value 12.7149
-DEAL:SchurComplementOp:Post::Convergence step 74 value 1.05660e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.632812	-1.58049	0.00000
 0.00000 0.757812	-1.31971	0.00000
 0.00000 0.882812	-1.13281	0.00000
@@ -17,15 +10,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
 Refinement cycle 1
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 5.38429e-06
-DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Starting value 16.9566
-DEAL:SchurComplementOp:Pre::Convergence step 59 value 1.46447e-05
-DEAL:SchurComplementOp:Main::Starting value 5.38429e-06
-DEAL:SchurComplementOp:Main::Convergence step 11 value 7.25724e-10
-DEAL:SchurComplementOp:Post::Starting value 16.9566
-DEAL:SchurComplementOp:Post::Convergence step 105 value 1.46447e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000296712
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.566406	-1.76557	0.00000
 0.00000 0.628906	-1.59010	0.00000
 0.00000 0.691406	-1.44635	0.00000
@@ -37,15 +23,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000296712
 Refinement cycle 2
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 6.10267e-06
-DEAL:ManualSchur:cg::Convergence step 12 value 0
-DEAL:SchurComplementOp:Pre::Starting value 21.9643
-DEAL:SchurComplementOp:Pre::Convergence step 96 value 2.04878e-05
-DEAL:SchurComplementOp:Main::Starting value 6.10267e-06
-DEAL:SchurComplementOp:Main::Convergence step 12 value 6.88788e-10
-DEAL:SchurComplementOp:Post::Starting value 21.9643
-DEAL:SchurComplementOp:Post::Convergence step 187 value 2.04878e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000406470
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.533203	-1.87543	0.00000
 0.00000 0.564453	-1.77163	0.00000
 0.00000 0.595703	-1.67869	0.00000
@@ -57,8 +36,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000406470
 0.00000 0.783203	-1.27680	0.00000
 0.00000 0.814453	-1.22782	0.00000
 0.00000 0.845703	-1.18244	0.00000
-0.00000 0.876953	-1.14032	0.00000
-0.00000 0.908203	-1.10107	0.00000
-0.00000 0.939453	-1.06445	0.00000
-0.00000 0.970703	-1.03018	0.00000
+0.00000 0.876953	-1.14033	0.00000
+0.00000 0.908203	-1.10120	0.00000
+0.00000 0.939453	-1.06444	0.00000
+0.00000 0.970703	-1.03006	0.00000
 

--- a/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=3.output
+++ b/tests/lac/schur_complement_05.with_cxx11=on.with_trilinos=true.with_mpi=true.mpirun=3.output
@@ -1,15 +1,8 @@
 Refinement cycle 0
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 7.49608e-06
-DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Starting value 12.7149
-DEAL:SchurComplementOp:Pre::Convergence step 43 value 1.05660e-05
-DEAL:SchurComplementOp:Main::Starting value 7.49608e-06
-DEAL:SchurComplementOp:Main::Convergence step 12 value 4.00858e-10
-DEAL:SchurComplementOp:Post::Starting value 12.7149
-DEAL:SchurComplementOp:Post::Convergence step 74 value 1.05660e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.632812	-1.58049	0.00000
 0.00000 0.757812	-1.31971	0.00000
 0.00000 0.882812	-1.13281	0.00000
@@ -17,15 +10,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000618530
 Refinement cycle 1
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 5.38732e-06
-DEAL:ManualSchur:cg::Convergence step 11 value 0
-DEAL:SchurComplementOp:Pre::Starting value 16.9566
-DEAL:SchurComplementOp:Pre::Convergence step 59 value 1.30423e-05
-DEAL:SchurComplementOp:Main::Starting value 5.38732e-06
-DEAL:SchurComplementOp:Main::Convergence step 11 value 7.37537e-10
-DEAL:SchurComplementOp:Post::Starting value 16.9566
-DEAL:SchurComplementOp:Post::Convergence step 105 value 1.30423e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000296380
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.566406	-1.76557	0.00000
 0.00000 0.628906	-1.59010	0.00000
 0.00000 0.691406	-1.44635	0.00000
@@ -37,15 +23,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000296380
 Refinement cycle 2
    Assembling...
    Solving...
-DEAL:ManualSchur:cg::Starting value 6.10237e-06
-DEAL:ManualSchur:cg::Convergence step 12 value 0
-DEAL:SchurComplementOp:Pre::Starting value 21.9643
-DEAL:SchurComplementOp:Pre::Convergence step 96 value 2.07585e-05
-DEAL:SchurComplementOp:Main::Starting value 6.10237e-06
-DEAL:SchurComplementOp:Main::Convergence step 12 value 6.88676e-10
-DEAL:SchurComplementOp:Post::Starting value 21.9643
-DEAL:SchurComplementOp:Post::Convergence step 187 value 2.07585e-05
-DEAL::Rel. norm of error in SchurOperator solve: 0.000406467
+DEAL:ManualSchur::Solver stopped within 10 - 12 iterations
+DEAL::Relative difference of results less than 1.e-3
 0.00000 0.533203	-1.87543	0.00000
 0.00000 0.564453	-1.77163	0.00000
 0.00000 0.595703	-1.67869	0.00000
@@ -57,8 +36,8 @@ DEAL::Rel. norm of error in SchurOperator solve: 0.000406467
 0.00000 0.783203	-1.27680	0.00000
 0.00000 0.814453	-1.22782	0.00000
 0.00000 0.845703	-1.18244	0.00000
-0.00000 0.876953	-1.14032	0.00000
-0.00000 0.908203	-1.10107	0.00000
-0.00000 0.939453	-1.06445	0.00000
-0.00000 0.970703	-1.03018	0.00000
+0.00000 0.876953	-1.14033	0.00000
+0.00000 0.908203	-1.10120	0.00000
+0.00000 0.939453	-1.06444	0.00000
+0.00000 0.970703	-1.03006	0.00000
 


### PR DESCRIPTION
Subsequent to the implementation of Payloads for LinearOperators, it is
necessary that compound operations such as this one be expressed in
terms of overloaded operations (operator+,* etc.) instead of in a
low-level format, with the operator functions v_mult etc. expanded
manually. This is because the payload is not correctly configured in the
latter case, and the operations defined on the Payload-level would not
align with those being performed by the higher-level LinearOperator
interface. When operator+,* etc. are called, the equivalent operations
for the payload are automatically set up.

Fixes #3913