### PR TITLE
add extra output for parallel_block_vector_03

### DIFF
--- a/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.clang8-apple
+++ b/tests/mpi/parallel_block_vector_03.with_64bit_indices=off.mpirun=2.output.clang8-apple
@@ -1,0 +1,8 @@
+
+DEAL:0::numproc=2
+DEAL:0::727
+DEAL:0::1548
+
+DEAL:1::647
+DEAL:1::1326
+


### PR DESCRIPTION
given the fact that this tests has extra output for `gcc4` and `gcc6`, it's not surprising that we need another one 😢 

p.s. the test is recent (Nov2016)