### PR TITLE
use jacobi preconditioner in fe_enriched test eigenproblems

### DIFF
--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -646,7 +646,7 @@ int main (int argc,char **argv)
         PETScWrappers::set_option_value("-eps_target","-1.0");
         PETScWrappers::set_option_value("-st_type","sinvert");
         PETScWrappers::set_option_value("-st_ksp_type","cg");
-        PETScWrappers::set_option_value("-st_pc_type", "gamg");
+        PETScWrappers::set_option_value("-st_pc_type", "jacobi");
         PETScWrappers::set_option_value("-st_ksp_tol", "1e-11");
         step36.run();
       }

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -870,7 +870,7 @@ int main (int argc,char **argv)
         dealii::PETScWrappers::set_option_value("-eps_target","-1.0");
         dealii::PETScWrappers::set_option_value("-st_type","sinvert");
         dealii::PETScWrappers::set_option_value("-st_ksp_type","cg");
-        dealii::PETScWrappers::set_option_value("-st_pc_type", "gamg");
+        dealii::PETScWrappers::set_option_value("-st_pc_type", "jacobi");
         dealii::PETScWrappers::set_option_value("-st_ksp_tol", "1e-11");
         step36.run();
       }


### PR DESCRIPTION
`gamg` (PETS'c AMG) stopped working for me with `petsc@3.7.5` and `slepc@3.7.3`. But this must not be deal.ii's fault.