### PR TITLE
replace call to md5sum in tests

### DIFF
--- a/tests/mpi/no_flux_constraints_02.cc
+++ b/tests/mpi/no_flux_constraints_02.cc
@@ -138,20 +138,15 @@ void test()
       //sort and merge the constraint matrices on proc 0, generate a checksum
       //and output that into the deallog
       system((std::string("cat ") + base+"cm_?.dot|sort -n|uniq >" + base+"cm").c_str());
-      system((std::string("md5sum ") + base + "cm >" + base + "cm.check").c_str());
       {
-        std::ifstream file((base+"cm.check").c_str());
-        std::string str;
-        while (!file.eof())
-          {
-            std::getline(file, str);
-            deallog << str << std::endl;
-          }
+        std::ifstream file((base+"cm").c_str());
+        std::stringstream ss;
+        ss << file.rdbuf();
+        std::string str = ss.str();
+        deallog << "checksum: " << checksum(str.begin(), str.end()) << std::endl;
       }
-      // delete the files created
-      // by processor 0
+      // delete the file created by processor 0
       std::remove ((base + "cm").c_str());
-      std::remove ((base + "cm.check").c_str());
     }
 
   // remove tmp files again. wait

--- a/tests/mpi/no_flux_constraints_02.with_trilinos=true.mpirun=1.output
+++ b/tests/mpi/no_flux_constraints_02.with_trilinos=true.mpirun=1.output
@@ -2,7 +2,6 @@
 DEAL:0:3d::# flagged cells = 224
 DEAL:0:3d::#cells = 7712
 DEAL:0:3d::#dofs = 27018
-DEAL:0:3d::9f3296fa8b319b40f49d8cc9de4efa48  cm
-DEAL:0:3d::
+DEAL:0:3d::checksum: 1517649227
 DEAL:0:3d::#constraints on 0: 2088
 DEAL:0:3d::OK

--- a/tests/mpi/no_flux_constraints_02.with_trilinos=true.mpirun=9.output
+++ b/tests/mpi/no_flux_constraints_02.with_trilinos=true.mpirun=9.output
@@ -2,8 +2,7 @@
 DEAL:0:3d::# flagged cells = 224
 DEAL:0:3d::#cells = 7712
 DEAL:0:3d::#dofs = 27018
-DEAL:0:3d::9f3296fa8b319b40f49d8cc9de4efa48  cm
-DEAL:0:3d::
+DEAL:0:3d::checksum: 1517649227
 DEAL:0:3d::#constraints on 0: 237
 DEAL:0:3d::#constraints on 1: 786
 DEAL:0:3d::#constraints on 2: 909

--- a/tests/mpi/no_flux_constraints_03.cc
+++ b/tests/mpi/no_flux_constraints_03.cc
@@ -108,24 +108,19 @@ void test()
   sleep(1);
   if (myid==0)
     {
+
       //sort and merge the constraint matrices on proc 0, generate a checksum
       //and output that into the deallog
       system((std::string("cat ") + base + "cm_*.dot | sort -n | uniq > " + base + "cm").c_str());
-      system((std::string("md5sum ") + base + "cm > " + base + "cm.check").c_str());
       {
-        std::ifstream file((base+"cm.check").c_str());
-        std::string str;
-        while (!file.eof())
-          {
-            std::getline(file, str);
-            deallog << str << std::endl;
-          }
+        std::ifstream file((base+"cm").c_str());
+        std::stringstream ss;
+        ss << file.rdbuf();
+        std::string str = ss.str();
+        deallog << "checksum: " << checksum(str.begin(), str.end()) << std::endl;
       }
-
-      // delete the files created
-      // by processor 0
+      // delete the file created by processor 0
       std::remove ((base + "cm").c_str());
-      std::remove ((base + "cm.check").c_str());
     }
 
   // remove tmp files again. wait

--- a/tests/mpi/no_flux_constraints_03.with_trilinos=true.mpirun=1.output
+++ b/tests/mpi/no_flux_constraints_03.with_trilinos=true.mpirun=1.output
@@ -1,7 +1,6 @@
 
 DEAL:0:3d::#cells = 568
 DEAL:0:3d::#dofs = 2481
-DEAL:0:3d::17a5cf8e1f66b693f8b54bf284cab4ac  cm
-DEAL:0:3d::
+DEAL:0:3d::checksum: 631047589
 DEAL:0:3d::#constraints on 0: 702
 DEAL:0:3d::OK

--- a/tests/mpi/no_flux_constraints_03.with_trilinos=true.mpirun=9.output
+++ b/tests/mpi/no_flux_constraints_03.with_trilinos=true.mpirun=9.output
@@ -1,8 +1,7 @@
 
 DEAL:0:3d::#cells = 568
 DEAL:0:3d::#dofs = 2481
-DEAL:0:3d::17a5cf8e1f66b693f8b54bf284cab4ac  cm
-DEAL:0:3d::
+DEAL:0:3d::checksum: 631047589
 DEAL:0:3d::#constraints on 0: 198
 DEAL:0:3d::#constraints on 1: 221
 DEAL:0:3d::#constraints on 2: 266

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -182,6 +182,30 @@ void sort_file_contents (const std::string &filename)
 }
 
 
+/*
+ * simple ADLER32 checksum for a range of chars
+ */
+template <class IT>
+unsigned int checksum(const IT &begin, const IT &end)
+{
+  AssertThrow(sizeof(unsigned int)==4, ExcInternalError());
+  AssertThrow(sizeof(*begin)==1, ExcInternalError());
+
+  unsigned int a = 1;
+  unsigned int b = 0;
+
+  IT it = begin;
+
+  while (it != end)
+    {
+      a = (a + (unsigned char)*it) % 65521;
+      b = (a + b) % 65521;
+      ++it;
+    }
+
+  return (b << 16) | a;
+}
+
 
 
 /*


### PR DESCRIPTION
I opted for a much simpler hashing function than md5.

fixes #3944, supersedes #3948