### PR TITLE
parallel::split::Triangulation

### DIFF
--- a/include/deal.II/distributed/split_tria.h
+++ b/include/deal.II/distributed/split_tria.h
@@ -41,6 +41,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+class IndexSet;
+
 namespace parallel
 {
 
@@ -129,6 +131,17 @@ namespace parallel
       void load (Archive &ar, const unsigned int version);
 
 
+      /**
+        */
+      virtual types::global_dof_index coarse_cell_index_to_global_index (const int index) const;
+
+      /**
+        */
+      virtual int global_coarse_index_to_cell_index (const types::global_dof_index index) const;
+
+      /**
+        */
+      virtual types::global_dof_index n_global_coarse_cells () const;
 
     private:
       /**
@@ -138,17 +151,16 @@ namespace parallel
       void partition();
 
       /**
-       * A vector containing subdomain IDs of cells obtained by partitioning
-       * using METIS. In case allow_artificial_cells is false, this vector is
-       * consistent with IDs stored in cell->subdomain_id() of the
-       * triangulation class. When allow_artificial_cells is true, cells which
-       * are artificial will have cell->subdomain_id() == numbers::artificial;
-       *
-       * The original parition information is stored to allow using sequential
-       * DoF distribution and partitioning functions with semi-artificial
-       * cells.
+       * map local cell->index() on level 0 to globally consistent cell
+       * index
        */
-      std::vector<types::subdomain_id> true_subdomain_ids_of_cells;
+      std::vector<types::global_dof_index> local_to_global_coarse_cell_index;
+
+      /**
+        * This IndexSet has the size n_global_coarse_cells() and contains
+        * all cell indices that are available locally;
+        */
+      IndexSet available_coarse_cells;
     };
 
     template <int dim, int spacedim>

--- a/include/deal.II/distributed/split_tria.h
+++ b/include/deal.II/distributed/split_tria.h
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------
+// $Id: tria.h 32739 2014-04-08 16:39:47Z denis.davydov $
+//
+// Copyright (C) 2008 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii__distributed__split_tria_h
+#define dealii__distributed__split_tria_h
+
+
+#include <deal.II/base/config.h>
+#include <deal.II/base/subscriptor.h>
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/template_constraints.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/distributed/tria_base.h>
+
+#include <deal.II/base/std_cxx1x/function.h>
+#include <deal.II/base/std_cxx1x/tuple.h>
+
+#include <set>
+#include <vector>
+#include <list>
+#include <utility>
+
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace parallel
+{
+
+#ifdef DEAL_II_WITH_MPI
+
+
+  namespace split
+  {
+
+    /**
+     * Split triangulation for parallel computations where the coarse mesh
+     * is distributed. Work in progress.
+     * @ingroup distributed
+     *
+     */
+    template <int dim, int spacedim = dim>
+    class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
+    {
+    public:
+      typedef typename dealii::Triangulation<dim,spacedim>::active_cell_iterator active_cell_iterator;
+      typedef typename dealii::Triangulation<dim,spacedim>::cell_iterator        cell_iterator;
+
+      /**
+       * Constructor.
+       *
+       * If @p allow_aritifical_cells is true, this class will behave similar
+       * to parallel::distributed::Triangulation in that there will be locally
+       * owned, ghost and artificial cells.
+       *
+       * Otherwise all non-locally owned cells are considered ghost.
+       */
+      Triangulation (MPI_Comm mpi_communicator,
+                     const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing =
+                       (dealii::Triangulation<dim,spacedim>::none));
+
+      /**
+       * Destructor.
+       */
+      virtual ~Triangulation ();
+
+      /**
+       * Coarsen and refine the mesh according to refinement and coarsening
+       * flags set.
+       *
+       * This step is equivalent to the dealii::Triangulation class with an
+       * addition of calling dealii::GridTools::partition_triangulation() at
+       * the end.
+       */
+      virtual void execute_coarsening_and_refinement ();
+
+//      /**
+//       * Create a triangulation.
+//       *
+//       * This function also partitions triangulation based on the MPI
+//       * communicator provided to the constructor.
+//       */
+//      virtual void create_triangulation (const std::vector< Point< spacedim > > &vertices,
+//                                         const std::vector< CellData< dim > > &cells,
+//                                         const SubCellData &subcelldata);
+
+      /**
+       * Copy @p other_tria to this triangulation.
+       *
+       * This function also partitions triangulation based on the MPI
+       * communicator provided to the constructor.
+       *
+       * @note This function can not be used with parallel::distributed::Triangulation,
+       * since it only stores those cells that it owns, one layer of ghost cells around
+       * the ones it locally owns, and a number of artificial cells.
+       */
+      virtual void copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria);
+
+      /**
+       * Read the data of this object from a stream for the purpose of
+       * serialization. Throw away the previous content.
+       *
+       * This function first does the same work as in dealii::Triangulation::load,
+       * then partitions the triangulation based on the MPI communicator
+       * provided to the constructor.
+       */
+      template <class Archive>
+      void load (Archive &ar, const unsigned int version);
+
+
+
+    private:
+      /**
+       * This function calls GridTools::partition_triangulation () and if
+       * requested in the constructor of the class marks artificial cells.
+       */
+      void partition();
+
+      /**
+       * A vector containing subdomain IDs of cells obtained by partitioning
+       * using METIS. In case allow_artificial_cells is false, this vector is
+       * consistent with IDs stored in cell->subdomain_id() of the
+       * triangulation class. When allow_artificial_cells is true, cells which
+       * are artificial will have cell->subdomain_id() == numbers::artificial;
+       *
+       * The original parition information is stored to allow using sequential
+       * DoF distribution and partitioning functions with semi-artificial
+       * cells.
+       */
+      std::vector<types::subdomain_id> true_subdomain_ids_of_cells;
+    };
+
+    template <int dim, int spacedim>
+    template <class Archive>
+    void
+    Triangulation<dim,spacedim>::load (Archive &ar,
+                                       const unsigned int version)
+    {
+      dealii::Triangulation<dim,spacedim>::load (ar, version);
+      partition();
+      this->update_number_cache ();
+    }
+  }
+#else
+
+  TODO
+  namespace shared
+  {
+
+    /**
+     * Dummy class the compiler chooses for parallel shared triangulations if
+     * we didn't actually configure deal.II with the MPI library. The
+     * existence of this class allows us to refer to
+     * parallel::shared::Triangulation objects throughout the library even if
+     * it is disabled.
+     *
+     * Since the constructor of this class is private, no such objects can
+     * actually be created if MPI is not available.
+     */
+    template <int dim, int spacedim = dim>
+    class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
+    {
+    public:
+
+      /**
+       * A dummy function to return empty vector.
+       */
+      const std::vector<types::subdomain_id> &get_true_subdomain_ids_of_cells() const;
+
+      /**
+       * A dummy function which always returns true.
+       */
+      bool with_artificial_cells() const;
+    private:
+      /**
+       * Constructor.
+       */
+      Triangulation ();
+
+      /**
+       * A dummy vector.
+       */
+      std::vector<types::subdomain_id> true_subdomain_ids_of_cells;
+    };
+  }
+
+
+#endif
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/distributed/split_tria.h
+++ b/include/deal.II/distributed/split_tria.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/index_set.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/distributed/tria_base.h>

--- a/include/deal.II/distributed/split_tria.h
+++ b/include/deal.II/distributed/split_tria.h
@@ -144,6 +144,10 @@ namespace parallel
         */
       virtual types::global_dof_index n_global_coarse_cells () const;
 
+      /**
+        */
+      virtual const IndexSet &available_coarse_cells () const;
+
     private:
       /**
        * This function calls GridTools::partition_triangulation () and if
@@ -152,16 +156,10 @@ namespace parallel
       void partition();
 
       /**
-       * map local cell->index() on level 0 to globally consistent cell
-       * index
-       */
-      std::vector<types::global_dof_index> local_to_global_coarse_cell_index;
-
-      /**
         * This IndexSet has the size n_global_coarse_cells() and contains
-        * all cell indices that are available locally;
+        * all cell indices that are available locally
         */
-      IndexSet available_coarse_cells;
+      IndexSet available_coarse_cell_set;
     };
 
     template <int dim, int spacedim>

--- a/include/deal.II/distributed/split_tria.h
+++ b/include/deal.II/distributed/split_tria.h
@@ -101,6 +101,10 @@ namespace parallel
 //                                         const std::vector< CellData< dim > > &cells,
 //                                         const SubCellData &subcelldata);
 
+      virtual void
+      update_number_cache ();
+
+
       /**
        * Copy @p other_tria to this triangulation.
        *

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -863,6 +863,7 @@ namespace parallel
        * subdomains are adjacent to that vertex. Used by
        * DoFHandler::Policy::ParallelDistributed.
        */
+      virtual
       void
       fill_vertices_with_ghost_neighbors
       (std::map<unsigned int, std::set<dealii::types::subdomain_id> >

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -152,6 +152,16 @@ namespace parallel
     const std::set<types::subdomain_id> &
     level_ghost_owners () const;
 
+    /**
+     * Fills a map that, for each vertex, lists all the processors whose
+     * subdomains are adjacent to that vertex.
+     */
+    virtual
+    void
+    fill_vertices_with_ghost_neighbors
+    (std::map<unsigned int, std::set<dealii::types::subdomain_id> >
+     &vertices_with_ghost_neighbors);
+
   protected:
     /**
      * MPI communicator to be used for the triangulation. We create a unique

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -180,13 +180,63 @@ namespace internal
 
       };
 
+      /**
+       * Base policy for parallel policies
+       */
+      template <int dim, int spacedim>
+      class ParallelBase : public PolicyBase<dim,spacedim>
+      {
+      public:
+        virtual
+        void
+        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
+                         NumberCache &number_cache) const;
+
+        virtual
+        void
+        verify_dof_distribution(const dealii::DoFHandler<dim,spacedim> &dof_handler) const;
+      };
 
       /**
        * This class implements the policy for operations when we use a
        * parallel::distributed::Triangulation object.
        */
       template <int dim, int spacedim>
-      class ParallelDistributed : public PolicyBase<dim,spacedim>
+      class ParallelDistributed : public ParallelBase<dim,spacedim>
+      {
+      public:
+        /**
+         * Distribute degrees of freedom on the object given as last argument.
+         */
+        virtual
+        void
+        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
+                         NumberCache &number_cache) const;
+
+        /**
+         * Distribute multigrid DoFs.
+         */
+        virtual
+        void
+        distribute_mg_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
+                            std::vector<NumberCache> &number_caches) const;
+
+        /**
+         * Renumber degrees of freedom as specified by the first argument.
+         */
+        virtual
+        void
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
+                       dealii::DoFHandler<dim,spacedim> &dof_handler,
+                       NumberCache &number_cache) const;
+      };
+
+      /**
+       * This class implements the policy for operations when we use a
+       * parallel::distributed::Triangulation object.
+       */
+      template <int dim, int spacedim>
+      class ParallelSplit : public ParallelBase<dim,spacedim>
       {
       public:
         /**

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -919,6 +919,17 @@ namespace GridGenerator
   ///@{
 
   /**
+    * Create a new Triangulation (in @p dest) that contains all cells from
+    * @p other_tria that have a user flag set or that are a parent or sibling
+    * of a cell that is flagged.
+    */
+  template <int dim, int spacedim>
+  void create_mesh_from_marked_cells (Triangulation<dim, spacedim> &dest,
+                                      Triangulation<dim, spacedim> &other_tria);
+
+
+
+  /**
    * Given the two triangulations specified as the first two arguments, create
    * the triangulation that contains the cells of both triangulation and store
    * it in the third parameter. Previous content of @p result will be deleted.

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -28,6 +28,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+class IndexSet;
+
+
 /**
  * This namespace provides a collection of functions for generating
  * triangulations for some basic geometries.
@@ -925,7 +929,8 @@ namespace GridGenerator
     */
   template <int dim, int spacedim>
   void create_mesh_from_marked_cells (Triangulation<dim, spacedim> &dest,
-                                      Triangulation<dim, spacedim> &other_tria);
+                                      Triangulation<dim, spacedim> &other_tria,
+                                      IndexSet &coarse_cell_indices);
 
 
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2908,6 +2908,19 @@ public:
   virtual types::subdomain_id locally_owned_subdomain () const;
 
   /**
+    */
+  virtual types::global_dof_index coarse_cell_index_to_global_index (const int index) const;
+
+  /**
+    */
+  virtual int global_coarse_index_to_cell_index (const types::global_dof_index index) const;
+
+  /**
+    */
+  virtual types::global_dof_index n_global_coarse_cells () const;
+
+
+  /**
    * Return a reference to the current object.
    *
    * This doesn't seem to be very useful but allows to write code that can

--- a/source/distributed/CMakeLists.txt
+++ b/source/distributed/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(_src
   tria.cc
   tria_base.cc
   shared_tria.cc
+  split_tria.cc
   p4est_wrappers.cc
   )
 
@@ -29,6 +30,7 @@ SET(_inst
   solution_transfer.inst.in
   tria.inst.in
   shared_tria.inst.in
+  split_tria.inst.in
   tria_base.inst.in
   p4est_wrappers.inst.in
   )

--- a/source/distributed/split_tria.cc
+++ b/source/distributed/split_tria.cc
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------
+// $Id: tria.cc 32807 2014-04-22 15:01:57Z heister $
+//
+// Copyright (C) 2015 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/distributed/split_tria.h>
+#include <deal.II/distributed/tria.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_MPI
+namespace parallel
+{
+  namespace split
+  {
+
+    template <int dim, int spacedim>
+    Triangulation<dim,spacedim>::Triangulation (MPI_Comm mpi_communicator,
+                                                const typename dealii::Triangulation<dim,spacedim>::MeshSmoothing smooth_grid):
+      dealii::parallel::Triangulation<dim,spacedim>(mpi_communicator,smooth_grid,false)
+    {}
+
+
+
+    template <int dim, int spacedim>
+    void Triangulation<dim,spacedim>::partition()
+    {
+      //dealii::GridTools::partition_triangulation (this->n_subdomains, *this);
+
+      true_subdomain_ids_of_cells.resize(this->n_active_cells());
+
+      // mark artificial cells
+      typename parallel::Triangulation<dim,spacedim>::active_cell_iterator
+      cell = this->begin_active(),
+      endc = this->end();
+      {
+        // get halo layer of (ghost) cells
+        // parallel::shared::Triangulation<dim>::
+        std_cxx11::function<bool (const typename Triangulation<dim,spacedim>::active_cell_iterator &)> predicate
+          = IteratorFilters::SubdomainEqualTo(this->my_subdomain);
+
+        const std::vector<typename dealii::Triangulation<dim,spacedim>::active_cell_iterator>
+        active_halo_layer_vector = GridTools::compute_active_cell_halo_layer<dealii::Triangulation<dim,spacedim> > (*this, predicate);
+        std::set<typename Triangulation<dim,spacedim>::active_cell_iterator>
+        active_halo_layer(active_halo_layer_vector.begin(), active_halo_layer_vector.end());
+
+        for (unsigned int index=0; cell != endc; cell++, index++)
+          {
+            if (cell->is_locally_owned() == false &&
+                active_halo_layer.find(cell) == active_halo_layer.end())
+              cell->set_subdomain_id(numbers::artificial_subdomain_id);
+          }
+      }
+
+
+#ifdef DEBUG
+      {
+        // TODO: check that we have exactly one ghost layer
+
+      }
+#endif
+    }
+
+
+
+
+
+//    template <int dim, int spacedim>
+//    const std::vector<types::subdomain_id> &
+//    Triangulation<dim,spacedim>::get_true_subdomain_ids_of_cells() const
+//    {
+//      return true_subdomain_ids_of_cells;
+//    }
+
+
+
+    template <int dim, int spacedim>
+    Triangulation<dim,spacedim>::~Triangulation ()
+    {}
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim,spacedim>::execute_coarsening_and_refinement ()
+    {
+      // TODO: okay if called through copy_triangulation, not implemented if not
+
+      dealii::Triangulation<dim,spacedim>::execute_coarsening_and_refinement ();
+      //partition();
+      //this->update_number_cache ();
+    }
+
+
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::
+    copy_triangulation (const dealii::Triangulation<dim, spacedim> &other_tria)
+    {
+      Assert ((dynamic_cast<const dealii::parallel::distributed::Triangulation<dim,spacedim> *>(&other_tria) == NULL),
+              ExcMessage("Cannot use this function on parallel::distributed::Triangulation."));
+
+
+      //mark_cells
+      std::vector<bool> user_flags;
+      other_tria.save_user_flags(user_flags);
+
+      // TODO: maybe using the flags is not a great idea after all...
+      dealii::Triangulation<dim, spacedim> &other_not_const
+        =  const_cast<dealii::Triangulation<dim, spacedim> &>(other_tria);
+      other_not_const.clear_user_flags ();
+
+
+      // mark our cells
+      typename Triangulation<dim, spacedim>::active_cell_iterator it = other_not_const.begin_active(),
+                                                                  endc = other_not_const.end();
+      for (; it != endc; ++it)
+        {
+          if (it->subdomain_id() == this->locally_owned_subdomain())
+            it->set_user_flag();
+        }
+
+      // mark ghost cells
+      std_cxx11::function<bool (const typename Triangulation<dim,spacedim>::active_cell_iterator &)> predicate
+        = IteratorFilters::SubdomainEqualTo(this->locally_owned_subdomain());
+      std::vector<typename Triangulation<dim,spacedim>::active_cell_iterator>
+      active_halo_layer_vector = GridTools::compute_active_cell_halo_layer (other_not_const, predicate);
+      for (typename std::vector<Triangulation<dim,spacedim>::active_cell_iterator>::iterator
+           it = active_halo_layer_vector.begin(); it != active_halo_layer_vector.end(); ++it)
+        (*it)->set_user_flag();
+
+      GridGenerator::create_mesh_from_marked_cells(*this, other_not_const);
+
+      other_not_const.load_user_flags(user_flags);
+
+      partition();
+      //this->update_number_cache ();
+    }
+
+  }
+}
+
+#else
+
+namespace parallel
+{
+  namespace shared
+  {
+    template <int dim, int spacedim>
+    Triangulation<dim,spacedim>::Triangulation ()
+      :
+      dealii::parallel::Triangulation<dim,spacedim>(MPI_COMM_SELF)
+    {
+      Assert (false, ExcNotImplemented());
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    Triangulation<dim,spacedim>::with_artificial_cells() const
+    {
+      Assert (false, ExcNotImplemented());
+      return true;
+    }
+
+
+
+    template <int dim, int spacedim>
+    const std::vector<unsigned int> &
+    Triangulation<dim,spacedim>::get_true_subdomain_ids_of_cells() const
+    {
+      Assert (false, ExcNotImplemented());
+      return true_subdomain_ids_of_cells;
+    }
+
+  }
+}
+
+
+#endif
+
+
+/*-------------- Explicit Instantiations -------------------------------*/
+#include "split_tria.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/distributed/split_tria.inst.in
+++ b/source/distributed/split_tria.inst.in
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------
+// $Id: tria.inst.in 32674 2014-03-20 16:57:24Z denis.davydov $
+//
+// Copyright (C) 2010 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+{
+    namespace parallel
+    \{
+    namespace split
+    \{
+    template class Triangulation<deal_II_dimension>;
+#       if deal_II_dimension < 3
+    template class Triangulation<deal_II_dimension, deal_II_dimension+1>;
+#       endif
+#       if deal_II_dimension < 2
+    template class Triangulation<deal_II_dimension, deal_II_dimension+2>;
+#       endif
+    \}
+    \}
+
+}
+

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -246,6 +246,25 @@ namespace parallel
     return number_cache.level_ghost_owners;
   }
 
+  template <int dim, int spacedim>
+  void
+  Triangulation<dim,spacedim>::
+  fill_vertices_with_ghost_neighbors
+  (std::map<unsigned int, std::set<dealii::types::subdomain_id> >
+   &vertices_with_ghost_neighbors)
+  {
+    // TODO: periodicity?!
+    for (typename Triangulation<dim,spacedim>::active_cell_iterator
+         cell = this->begin_active();
+         cell != this->end(); ++cell)
+      if (cell->is_ghost())
+        {
+          for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+            vertices_with_ghost_neighbors[cell->vertex_index(v)].insert(cell->subdomain_id());
+        }
+
+  }
+
 } // end namespace parallel
 
 

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -26,6 +26,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/fe/fe.h>
 #include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/split_tria.h>
 #include <deal.II/distributed/tria.h>
 
 #include <set>
@@ -78,6 +79,8 @@ namespace internal
       policy_name = "Policy::ParallelShared<";
     else
       AssertThrow(false, ExcNotImplemented());
+
+
     policy_name += Utilities::int_to_string(dim)+
                    ","+Utilities::int_to_string(spacedim)+">";
     return policy_name;
@@ -667,10 +670,14 @@ DoFHandler<dim,spacedim>::DoFHandler (const Triangulation<dim,spacedim> &tria)
     policy.reset (new internal::DoFHandler::Policy::ParallelShared<dim,spacedim>());
   else if (dynamic_cast<const parallel::distributed::Triangulation< dim, spacedim >*>
            (&tria)
-           == 0)
-    policy.reset (new internal::DoFHandler::Policy::Sequential<dim,spacedim>());
-  else
+           != 0)
     policy.reset (new internal::DoFHandler::Policy::ParallelDistributed<dim,spacedim>());
+  else if (dynamic_cast<const parallel::split::Triangulation< dim, spacedim >*>
+           (&tria)
+           != 0)
+    policy.reset (new internal::DoFHandler::Policy::ParallelSplit<dim,spacedim>());
+  else
+    policy.reset (new internal::DoFHandler::Policy::Sequential<dim,spacedim>());
 }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3008,17 +3008,6 @@ namespace internal
                           {
                             const dealii::types::subdomain_id subdomain = *it;
 
-                            std::cout << "sending cell " << cell->id()
-                                      << " from " << (int)tr->locally_owned_subdomain()
-                                      << " to " << (int)subdomain
-                                      << " with ";
-                            for (auto i: local_dof_indices)
-                              std::cout << i << " ";
-
-                            std::cout << std::endl;
-
-
-
                             // get an iterator
                             // to what needs to
                             // be sent to that
@@ -3058,11 +3047,6 @@ namespace internal
                    ++it, ++idx)
                 {
                   celldofinfo<dim> &cdi = destination_to_dof_info[*it];
-
-                  std::cout << " SEND " << cdi.cell_ids.size()
-                            << " cells from " << tr->locally_owned_subdomain()
-                            << " to " << *it
-                            << std::endl;
 
                   // pack all the data into
                   // the buffer for this
@@ -3105,8 +3089,6 @@ namespace internal
                   dealii::types::global_dof_index *dofs = cellinfo.dofs.data();
                   for (unsigned int c=0; c<cellinfo.cell_ids.size(); ++c, dofs+=1+dofs[0])
                     {
-                      std::cout << "unpacking cell id " << cellinfo.cell_ids[c]
-                                << std::endl;
                       typename parallel::split::Triangulation<dim,spacedim>::cell_iterator
                       tria_cell = cellinfo.cell_ids[c].to_cell(*tr);
                       typename DoFHandler<dim,spacedim>::active_cell_iterator
@@ -3121,11 +3103,6 @@ namespace internal
                       cell->update_cell_dof_indices_cache();
                       cell->get_dof_indices(dof_indices);
 
-                      std::cout << "setting " << cell->id() << " from ";
-                      for (auto i: dof_indices)
-                        std::cout << i << " ";
-                      std::cout << " to ";
-
                       Assert(cell->get_fe().dofs_per_cell == *dofs,
                              ExcInternalError());
                       const dealii::types::global_dof_index *new_dofs = dofs+1;
@@ -3134,24 +3111,15 @@ namespace internal
                       for (unsigned int i=0; i<dof_indices.size(); ++i)
                         if (new_dofs[i] != DoFHandler<dim,spacedim>::invalid_dof_index)
                           {
-                            if ((dof_indices[i] !=
-                                 (DoFHandler<dim,spacedim>::invalid_dof_index))
-                                &&
-                                (dof_indices[i]!=new_dofs[i]))
-                              std::cout << "oh no! " << dof_indices[i] << " " << new_dofs[i] << std::endl;
-//                            Assert((dof_indices[i] ==
-//                                    (DoFHandler<dim,spacedim>::invalid_dof_index))
-//                                   ||
-//                                   (dof_indices[i]==dofs[i]),
-//                                   ExcInternalError());
+                            Assert((dof_indices[i] ==
+                                    (DoFHandler<dim,spacedim>::invalid_dof_index))
+                                   ||
+                                   (dof_indices[i]==new_dofs[i]),
+                                   ExcInternalError());
                             dof_indices[i]=new_dofs[i];
                           }
                         else if (dof_indices[i] == DoFHandler<dim,spacedim>::invalid_dof_index)
                           complete=false;
-
-                      for (auto i: dof_indices)
-                        std::cout << i << " ";
-                      std::cout << std::endl;
 
                       if (complete)
                         cell->clear_user_flag();

--- a/source/dofs/dof_handler_policy.inst.in
+++ b/source/dofs/dof_handler_policy.inst.in
@@ -26,12 +26,14 @@ for (deal_II_dimension : DIMENSIONS)
     template class Sequential<deal_II_dimension,deal_II_dimension>;
     template class ParallelShared<deal_II_dimension,deal_II_dimension>;
     template class ParallelDistributed<deal_II_dimension,deal_II_dimension>;
+    template class ParallelSplit<deal_II_dimension,deal_II_dimension>;
 
 #if deal_II_dimension==1 || deal_II_dimension==2
     template class PolicyBase<deal_II_dimension,deal_II_dimension+1>;
     template class Sequential<deal_II_dimension,deal_II_dimension+1>;
     template class ParallelShared<deal_II_dimension,deal_II_dimension+1>;
     template class ParallelDistributed<deal_II_dimension,deal_II_dimension+1>;
+    template class ParallelSplit<deal_II_dimension,deal_II_dimension+1>;
 #endif
 
 #if deal_II_dimension==3
@@ -39,6 +41,7 @@ for (deal_II_dimension : DIMENSIONS)
     template class Sequential<1,3>;
     template class ParallelShared<1,3>;
     template class ParallelDistributed<1,3>;
+    template class ParallelSplit<1,3>;
 #endif
     \}
     \}

--- a/source/grid/cell_id.cc
+++ b/source/grid/cell_id.cc
@@ -162,7 +162,8 @@ template <int dim, int spacedim>
 typename Triangulation<dim,spacedim>::cell_iterator
 CellId::to_cell(const Triangulation<dim,spacedim> &tria) const
 {
-  typename Triangulation<dim,spacedim>::cell_iterator cell (&tria,0,coarse_cell_id);
+  const int coarse_index = tria.global_coarse_index_to_cell_index(coarse_cell_id);
+  typename Triangulation<dim,spacedim>::cell_iterator cell (&tria,0,coarse_index);
 
   for (unsigned int i = 0; i < n_child_indices; ++i)
     cell = cell->child(static_cast<unsigned int> (child_indices[i]));

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -13,6 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/index_set.h>
+
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_reordering.h>
 #include <deal.II/grid/grid_tools.h>
@@ -3926,7 +3929,8 @@ namespace GridGenerator
   template <int dim, int spacedim>
   void
   create_mesh_from_marked_cells (Triangulation<dim, spacedim> &dest,
-                                 Triangulation<dim, spacedim> &other_tria)
+                                 Triangulation<dim, spacedim> &other_tria,
+                                 IndexSet &coarse_cell_indices)
   {
 
     Assert (other_tria.n_cells() > 0,
@@ -3972,6 +3976,8 @@ namespace GridGenerator
 
 
     // create coarse mesh
+    coarse_cell_indices.clear();
+    coarse_cell_indices.set_size(other_tria.n_cells(0));
     std::vector<unsigned int> map_new_to_old_coarse_cell;
     std::vector<unsigned int> map_old_to_new_vertex(other_tria.n_vertices(),
                                                     numbers::invalid_unsigned_int);
@@ -4006,8 +4012,8 @@ namespace GridGenerator
                 data.vertices[vidx] = new_idx;
               }
             cells.push_back(data);
+            coarse_cell_indices.add_index(map_new_to_old_coarse_cell.size());
             map_new_to_old_coarse_cell.push_back(it->index());
-
           }
 
       // TODO subcelldata
@@ -4022,6 +4028,7 @@ namespace GridGenerator
 
       dest.create_triangulation (vertices, cells, subcelldata);
     }
+    coarse_cell_indices.compress();
 
 
     // now refine:

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4006,7 +4006,7 @@ namespace GridGenerator
                 data.vertices[vidx] = new_idx;
               }
             cells.push_back(data);
-            coarse_cell_indices.add_index(map_new_to_old_coarse_cell.size());
+            coarse_cell_indices.add_index(it->index());
             map_new_to_old_coarse_cell.push_back(it->index());
           }
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3936,8 +3936,8 @@ namespace GridGenerator
     unsigned int n_levels = 0;
     unsigned int n_total = 0;
 
-    // mark parents and find out max level
-    for (unsigned int level=0; level<other_tria.n_levels(); ++level)
+    // mark parents of all cells recursively and find out max level
+    for (int level=other_tria.n_levels()-1; level>=0; --level)
       {
         typename Triangulation<dim, spacedim>::cell_iterator it = other_tria.begin(level),
                                                              endc = other_tria.end(level);
@@ -4017,6 +4017,8 @@ namespace GridGenerator
 
 
 
+      if (cells.size()==0)
+        return; // mesh is empty, but that is okay
 
       dest.create_triangulation (vertices, cells, subcelldata);
     }

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3969,12 +3969,6 @@ namespace GridGenerator
 
       }
 
-    std::cout << "copy_marked_cells: "
-              << " levels=" << n_levels
-              << " cells=" << n_total << std::endl;
-
-
-
     // create coarse mesh
     coarse_cell_indices.clear();
     coarse_cell_indices.set_size(other_tria.n_cells(0));

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3873,6 +3873,7 @@ namespace GridGenerator
         {
           it_dst->set_material_id(it_src->material_id());
           it_dst->set_manifold_id(it_src->manifold_id());
+
           it_dst->set_subdomain_id(it_src->subdomain_id());
           it_dst->set_level_subdomain_id(it_src->level_subdomain_id());
 
@@ -3894,7 +3895,10 @@ namespace GridGenerator
         }
 
       if (!it_src->user_flag_set())
-        return false;
+        {
+          it_dst->set_subdomain_id(numbers::artificial_subdomain_id);
+          return false;
+        }
 
       if (it_src->n_children()>0 && it_dst->n_children()==0)
         {
@@ -3913,8 +3917,7 @@ namespace GridGenerator
 
       bool change = false;
       for (unsigned int i=0; i<it_src->n_children(); ++i)
-        if (it_src->child(i)->user_flag_set())
-          change |= recurse_for_marked_cells<dim,spacedim>(it_dst->child(i), it_src->child(i));
+        change |= recurse_for_marked_cells<dim,spacedim>(it_dst->child(i), it_src->child(i));
 
       return change;
     }

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -64,7 +64,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
     template
     void
     create_mesh_from_marked_cells (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-                                   Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+                                   Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+                                   IndexSet &);
     template
     void
     merge_triangulations

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -63,6 +63,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 
     template
     void
+    create_mesh_from_marked_cells (Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+                                   Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+    template
+    void
     merge_triangulations
     (const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation_1,
      const Triangulation<deal_II_dimension,deal_II_space_dimension> &triangulation_2,

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11854,6 +11854,37 @@ Triangulation<dim,spacedim>::locally_owned_subdomain () const
 
 
 template <int dim, int spacedim>
+types::global_dof_index
+Triangulation<dim,spacedim>::
+coarse_cell_index_to_global_index (const int index) const
+{
+  Assert(index>=0 && index<n_cells(0),
+         dealii::ExcIndexRange(index,0,n_cells(0)));
+  return index;
+}
+
+
+template <int dim, int spacedim>
+int
+Triangulation<dim,spacedim>::
+global_coarse_index_to_cell_index (const types::global_dof_index index) const
+{
+  Assert(index>=0 && index<n_global_coarse_cells(),
+         dealii::ExcIndexRange(index,0,n_global_coarse_cells()));
+  return index;
+}
+
+
+template <int dim, int spacedim>
+types::global_dof_index
+Triangulation<dim,spacedim>::
+n_global_coarse_cells () const
+{
+  return n_cells(0);
+}
+
+
+template <int dim, int spacedim>
 Triangulation<dim,spacedim> &
 Triangulation<dim,spacedim>::get_triangulation ()
 {

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1668,7 +1668,8 @@ CellAccessor<dim,spacedim>::id() const
     }
 
   Assert(ptr.level()==0, ExcInternalError());
-  const unsigned int coarse_index = ptr.index();
+  // TODO: coarse_index can be more than 32bits?
+  const unsigned int coarse_index = this->tria->coarse_cell_index_to_global_index(ptr.index());
 
   return CellId(coarse_index, n_child_indices, &(id[0]));
 }

--- a/tests/grid_gen/CMakeLists.txt
+++ b/tests/grid_gen/CMakeLists.txt
@@ -1,0 +1,4 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+INCLUDE(../setup_testsubproject.cmake)
+PROJECT(testsuite CXX)
+DEAL_II_PICKUP_TESTS()

--- a/tests/grid_gen/tria_copy_marked_cells_01.cc
+++ b/tests/grid_gen/tria_copy_marked_cells_01.cc
@@ -92,7 +92,8 @@ void test ()
   }
 
   Triangulation<dim, spacedim> tria2;
-  GridGenerator::create_mesh_from_marked_cells(tria2, tria);
+  IndexSet coarse_cell_indices;
+  GridGenerator::create_mesh_from_marked_cells(tria2, tria, coarse_cell_indices);
 
   {
     std::ofstream f("out.svg");
@@ -102,9 +103,12 @@ void test ()
 
 
   deallog << dim
-          << tria2.n_levels()
-          << tria2.n_active_cells()
+          << " n_levels: " << tria2.n_levels()
+          << " n_active_cells: " << tria2.n_active_cells()
           << std::endl;
+  deallog << "coarse_cell_indices size=" << coarse_cell_indices.size() << ":" << std::endl;
+  coarse_cell_indices.print(deallog);
+
 }
 
 

--- a/tests/grid_gen/tria_copy_marked_cells_01.cc
+++ b/tests/grid_gen/tria_copy_marked_cells_01.cc
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test copy_marked_cells
+
+#include "../tests.h"
+#include <deal.II/grid/tria_boundary.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/base/logstream.h>
+#include <cmath>
+#include <cstdlib>
+
+#include <fstream>
+#include <iomanip>
+#include <cstdio>
+
+std::ofstream logfile("output");
+
+
+
+template <int dim, int spacedim>
+void test ()
+{
+  Triangulation<dim, spacedim> tria;
+  std::vector<unsigned int> reps(dim, 1);
+  reps[0]=3;
+  Point<dim> p1;
+  Point<dim> p2;
+  for (unsigned int d=0; d<dim; ++d)
+    p2[d] = 1.0;
+  p2[0] = 3.0;
+
+  GridGenerator::subdivided_hyper_rectangle (tria, reps,
+                                             p1, p2, true);
+  tria.begin_active()->set_refine_flag();
+  (++tria.begin_active())->set_refine_flag();
+  tria.execute_coarsening_and_refinement ();
+
+  typename Triangulation<dim>::active_cell_iterator
+  cell = tria.begin_active();
+
+  for (unsigned int i=0; i < tria.n_active_cells(); ++i)
+    {
+      if (i < tria.n_active_cells()/2-1)
+        {
+          cell->set_material_id(1+i);
+          cell->set_user_flag();
+        }
+      else
+        cell->set_material_id(0);
+
+      if (i==0)
+        cell->set_all_manifold_ids(17);
+
+      cell->set_subdomain_id(i%2);
+      cell->set_level_subdomain_id(i%2);
+      ++cell;
+    }
+  GridOut gout;
+  GridOutFlags::Svg svg_flags;
+
+  svg_flags.coloring = GridOutFlags::Svg::level_number;
+  svg_flags.label_cell_index = false;
+  svg_flags.label_level_number = false;
+  svg_flags.label_material_id = true;
+  svg_flags.label_subdomain_id = true;
+  svg_flags.label_level_subdomain_id = true;
+
+  gout.set_flags(svg_flags);
+
+  {
+    std::ofstream f("in.svg");
+    gout.write_svg(tria, f);
+    gout.write_svg(tria, deallog.get_file_stream());
+  }
+
+  Triangulation<dim, spacedim> tria2;
+  GridGenerator::create_mesh_from_marked_cells(tria2, tria);
+
+  {
+    std::ofstream f("out.svg");
+    gout.write_svg(tria2, f);
+    gout.write_svg(tria2, deallog.get_file_stream());
+  }
+
+
+  deallog << dim
+          << tria2.n_levels()
+          << tria2.n_active_cells()
+          << std::endl;
+}
+
+
+int main ()
+{
+  initlog();
+
+  //test<1>();
+  test<2,2>();
+  //test<3>();
+
+  return 0;
+}

--- a/tests/grid_gen/tria_copy_marked_cells_01.output
+++ b/tests/grid_gen/tria_copy_marked_cells_01.output
@@ -103,11 +103,11 @@
   <line x1="1080" y1="920" x2="1080" y2="500"/>
   <line x1="660" y1="920" x2="1080" y2="920"/>
   <path class="p1" d="M 240 500 L 660 500 L 660 80 L 240 80 L 240 500"/>
-  <text x="450" y="340" style="font-size:100px">3,0,0</text>
+  <text x="450" y="340" style="font-size:100px">0,-2,1</text>
   <line x1="240" y1="500" x2="240" y2="80"/>
   <line x1="240" y1="80" x2="660" y2="80"/>
   <path class="p1" d="M 660 500 L 1080 500 L 1080 80 L 660 80 L 660 500"/>
-  <text x="870" y="342" style="font-size:104px">3,0,0</text>
+  <text x="870" y="342" style="font-size:104px">0,-2,0</text>
   <line x1="1080" y1="500" x2="1080" y2="80"/>
   <line x1="660" y1="80" x2="1080" y2="80"/>
 

--- a/tests/grid_gen/tria_copy_marked_cells_01.output
+++ b/tests/grid_gen/tria_copy_marked_cells_01.output
@@ -1,0 +1,129 @@
+
+<svg width="3400" height="1000" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+
+<!-- internal style sheet -->
+<style type="text/css"><![CDATA[
+ rect.background{fill:white}
+ rect{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ text{font-family:Helvetica; text-anchor:middle; fill:rgb(25,25,25)}
+ line{stroke:rgb(25,25,25); stroke-width:4}
+ path{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+
+ path.p0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps0{fill:rgb(0,77,191); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.p1{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps1{fill:rgb(191,0,0); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r1{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+]]></style>
+
+ <rect class="background" width="3000" height="1000"/>
+  <!-- cells -->
+  <path class="p0" d="M 1920 920 L 2760 920 L 2760 80 L 1920 80 L 1920 920"/>
+  <text x="2340" y="603" style="font-size:205px">1,0,0</text>
+  <line x1="2760" y1="920" x2="2760" y2="80"/>
+  <line x1="1920" y1="920" x2="2760" y2="920"/>
+  <line x1="1920" y1="80" x2="2760" y2="80"/>
+  <path class="p1" d="M 240 920 L 660 920 L 660 500 L 240 500 L 240 920"/>
+  <text x="450" y="760" style="font-size:100px">2,1,1</text>
+  <line x1="240" y1="920" x2="240" y2="500"/>
+  <line x1="240" y1="920" x2="660" y2="920"/>
+  <path class="p1" d="M 660 920 L 1080 920 L 1080 500 L 660 500 L 660 920"/>
+  <text x="870" y="762" style="font-size:104px">3,0,0</text>
+  <line x1="660" y1="920" x2="1080" y2="920"/>
+  <path class="p1" d="M 240 500 L 660 500 L 660 80 L 240 80 L 240 500"/>
+  <text x="450" y="340" style="font-size:100px">0,1,1</text>
+  <line x1="240" y1="500" x2="240" y2="80"/>
+  <line x1="240" y1="80" x2="660" y2="80"/>
+  <path class="p1" d="M 660 500 L 1080 500 L 1080 80 L 660 80 L 660 500"/>
+  <text x="870" y="342" style="font-size:104px">0,0,0</text>
+  <line x1="660" y1="80" x2="1080" y2="80"/>
+  <path class="p1" d="M 1080 920 L 1500 920 L 1500 500 L 1080 500 L 1080 920"/>
+  <text x="1290" y="763" style="font-size:106px">0,1,1</text>
+  <line x1="1080" y1="920" x2="1500" y2="920"/>
+  <path class="p1" d="M 1500 920 L 1920 920 L 1920 500 L 1500 500 L 1500 920"/>
+  <text x="1710" y="763" style="font-size:106px">0,0,0</text>
+  <line x1="1500" y1="920" x2="1920" y2="920"/>
+  <path class="p1" d="M 1080 500 L 1500 500 L 1500 80 L 1080 80 L 1080 500"/>
+  <text x="1290" y="343" style="font-size:106px">0,1,1</text>
+  <line x1="1080" y1="80" x2="1500" y2="80"/>
+  <path class="p1" d="M 1500 500 L 1920 500 L 1920 80 L 1500 80 L 1500 500"/>
+  <text x="1710" y="343" style="font-size:106px">0,0,0</text>
+  <line x1="1500" y1="80" x2="1920" y2="80"/>
+
+ <!-- legend -->
+ <rect x="3000" y="80" width="320" height="165"/>
+ <text x="3013" y="107" style="text-anchor:start; font-weight:bold; font-size:18px">cell label</text>
+  <text x="3020" y="134" style="text-anchor:start; font-style:oblique; font-size:18px">material_id,</text>
+  <text x= "3020" y="161" style="text-anchor:start; font-style:oblique; font-size:18px">subdomain_id,</text>
+  <text x= "3020" y="188" style="text-anchor:start; font-style:oblique; font-size:18px">level_subdomain_id</text>
+  <text x="3000" y="274" style="text-anchor:start; font-size:18px">azimuth: 0°, polar: 0°</text>
+
+ <!-- colorbar -->
+ <text x="3000" y="356" style="text-anchor:start; font-weight:bold; font-size:18px">level_number</text>
+  <rect class="r0" x="3000" y="645" width="25" height="275"/>
+  <text x="3037.50" y="788.500" style="text-anchor:start; font-size:18px; font-weight:bold">0 min</text>
+  <rect class="r1" x="3000" y="370" width="25" height="275"/>
+  <text x="3037.50" y="513.500" style="text-anchor:start; font-size:18px; font-weight:bold">1 max</text>
+
+</svg><svg width="3400" height="1000" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+
+<!-- internal style sheet -->
+<style type="text/css"><![CDATA[
+ rect.background{fill:white}
+ rect{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ text{font-family:Helvetica; text-anchor:middle; fill:rgb(25,25,25)}
+ line{stroke:rgb(25,25,25); stroke-width:4}
+ path{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+
+ path.p0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps0{fill:rgb(0,77,191); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.p1{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps1{fill:rgb(191,0,0); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r1{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+]]></style>
+
+ <rect class="background" width="3000" height="1000"/>
+  <!-- cells -->
+  <path class="p0" d="M 1920 920 L 2760 920 L 2760 80 L 1920 80 L 1920 920"/>
+  <text x="2340" y="603" style="font-size:205px">1,0,0</text>
+  <line x1="1920" y1="920" x2="1920" y2="80"/>
+  <line x1="2760" y1="920" x2="2760" y2="80"/>
+  <line x1="1920" y1="920" x2="2760" y2="920"/>
+  <line x1="1920" y1="80" x2="2760" y2="80"/>
+  <path class="p1" d="M 240 920 L 660 920 L 660 500 L 240 500 L 240 920"/>
+  <text x="450" y="760" style="font-size:100px">2,1,1</text>
+  <line x1="240" y1="920" x2="240" y2="500"/>
+  <line x1="240" y1="920" x2="660" y2="920"/>
+  <path class="p1" d="M 660 920 L 1080 920 L 1080 500 L 660 500 L 660 920"/>
+  <text x="870" y="762" style="font-size:104px">3,0,0</text>
+  <line x1="1080" y1="920" x2="1080" y2="500"/>
+  <line x1="660" y1="920" x2="1080" y2="920"/>
+  <path class="p1" d="M 240 500 L 660 500 L 660 80 L 240 80 L 240 500"/>
+  <text x="450" y="340" style="font-size:100px">3,0,0</text>
+  <line x1="240" y1="500" x2="240" y2="80"/>
+  <line x1="240" y1="80" x2="660" y2="80"/>
+  <path class="p1" d="M 660 500 L 1080 500 L 1080 80 L 660 80 L 660 500"/>
+  <text x="870" y="342" style="font-size:104px">3,0,0</text>
+  <line x1="1080" y1="500" x2="1080" y2="80"/>
+  <line x1="660" y1="80" x2="1080" y2="80"/>
+
+ <!-- legend -->
+ <rect x="3000" y="80" width="320" height="165"/>
+ <text x="3013" y="107" style="text-anchor:start; font-weight:bold; font-size:18px">cell label</text>
+  <text x="3020" y="134" style="text-anchor:start; font-style:oblique; font-size:18px">material_id,</text>
+  <text x= "3020" y="161" style="text-anchor:start; font-style:oblique; font-size:18px">subdomain_id,</text>
+  <text x= "3020" y="188" style="text-anchor:start; font-style:oblique; font-size:18px">level_subdomain_id</text>
+  <text x="3000" y="274" style="text-anchor:start; font-size:18px">azimuth: 0°, polar: 0°</text>
+
+ <!-- colorbar -->
+ <text x="3000" y="356" style="text-anchor:start; font-weight:bold; font-size:18px">level_number</text>
+  <rect class="r0" x="3000" y="645" width="25" height="275"/>
+  <text x="3037.50" y="788.500" style="text-anchor:start; font-size:18px; font-weight:bold">0 min</text>
+  <rect class="r1" x="3000" y="370" width="25" height="275"/>
+  <text x="3037.50" y="513.500" style="text-anchor:start; font-size:18px; font-weight:bold">1 max</text>
+
+</svg>DEAL::225

--- a/tests/grid_gen/tria_copy_marked_cells_01.output
+++ b/tests/grid_gen/tria_copy_marked_cells_01.output
@@ -126,4 +126,6 @@
   <rect class="r1" x="3000" y="370" width="25" height="275"/>
   <text x="3037.50" y="513.500" style="text-anchor:start; font-size:18px; font-weight:bold">1 max</text>
 
-</svg>DEAL::225
+</svg>DEAL::2 n_levels: 2 n_active_cells: 5
+DEAL::coarse_cell_indices size=3:
+DEAL::{[0,1]}

--- a/tests/sharedtria/split_dof_01.cc
+++ b/tests/sharedtria/split_dof_01.cc
@@ -1,0 +1,200 @@
+// ---------------------------------------------------------------------
+// $Id: dof_handler_number_cache.cc 31761 2013-11-22 14:42:37Z heister $
+//
+// Copyright (C) 2008 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check number cache for split_tria
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/distributed/split_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/mapping_q1.h>
+#include <deal.II/grid/grid_out.h>
+
+#include <fstream>
+#include <cstdlib>
+#include <numeric>
+
+
+template<int dim>
+void test()
+{
+  const unsigned int nproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  Triangulation<dim> basetria;
+  {
+    GridGenerator::hyper_L(basetria);
+    basetria.refine_global (1);
+    typename Triangulation<dim>::active_cell_iterator
+    cell = basetria.begin_active();
+
+    for (unsigned int i=0; i < basetria.n_active_cells(); ++i)
+      {
+        cell->set_subdomain_id((i*nproc/basetria.n_active_cells()) % nproc);
+        ++cell;
+      }
+  }
+
+
+  /*
+  const unsigned int n_refinements[] = { 0, 4, 3, 2 };
+  for (unsigned int i=0; i<n_refinements[dim]; ++i)
+  {
+    // refine one-fifth of cells randomly
+    std::vector<bool> flags (triangulation.n_active_cells(), false);
+    for (unsigned int k=0; k<flags.size()/5 + 1; ++k)
+      flags[Testing::rand() % flags.size()] = true;
+    // make sure there's at least one that
+    // will be refined
+    flags[0] = true;
+
+    // refine triangulation
+    unsigned int index=0;
+    for (typename Triangulation<dim>::active_cell_iterator
+         cell = triangulation.begin_active();
+         cell != triangulation.end(); ++cell)
+      {
+        if (flags[index])
+          cell->set_refine_flag();
+        ++index;
+      }
+
+    Assert (index <= triangulation.n_active_cells(), ExcInternalError());
+
+    // flag all other cells for coarsening
+    // (this should ensure that at least
+    // some of them will actually be
+    // coarsened)
+    index=0;
+    for (typename Triangulation<dim>::active_cell_iterator
+         cell = triangulation.begin_active();
+         cell != triangulation.end(); ++cell)
+      {
+        if (!flags[index])
+          cell->set_coarsen_flag();
+        ++index;
+      }
+
+    triangulation.execute_coarsening_and_refinement ();*/
+
+  parallel::split::Triangulation<dim> tr(MPI_COMM_WORLD);
+  tr.copy_triangulation(basetria);
+
+  GridOut go;
+  go.write_mesh_per_processor_as_vtu (tr, "mesh", false, true);
+
+
+  FE_Q<dim> fe(1);
+  DoFHandler<dim> dof_handler (tr);
+
+  dof_handler.distribute_dofs (fe);
+
+  int n_coarse = tr.n_active_cells()>0 ? tr.n_cells(0) : 0;
+  deallog
+      << " locally_owned_subdomain(): " << tr.locally_owned_subdomain() << "\n"
+      << " n_active_cells: " << tr.n_active_cells() << "\n"
+      << " n_levels: " << tr.n_levels() << "\n"
+      << " n_global_levels: " << tr.n_global_levels()  << "\n"
+      << " n_locally_owned_active_cells: " << tr.n_locally_owned_active_cells() << "\n"
+      << " n_global_active_cells: " << tr.n_global_active_cells() << "\n"
+      << " n_coarse_cells: " << n_coarse << "\n"
+      << " n_global_coarse_cells: " << tr.n_global_coarse_cells()
+      << std::endl;
+
+  deallog << "available_coarse_cells: ";
+  tr.available_coarse_cells().print(deallog);
+
+  deallog
+      << "n_dofs: " << dof_handler.n_dofs() << std::endl
+      << "n_locally_owned_dofs: " << dof_handler.n_locally_owned_dofs() << std::endl;
+
+  deallog << "n_locally_owned_dofs_per_processor: ";
+  std::vector<types::global_dof_index> v = dof_handler.n_locally_owned_dofs_per_processor();
+  unsigned int sum = 0;
+  for (unsigned int i=0; i<v.size(); ++i)
+    {
+      deallog << v[i] << " ";
+      sum += v[i];
+    }
+  deallog << " sum: " << sum << std::endl;
+
+  //  Assert(dof_handler.n_locally_owned_dofs() == dof_handler.n_locally_owned_dofs_per_processor()[tr.locally_owned_subdomain()], ExcInternalError());
+  //  Assert( dof_handler.n_locally_owned_dofs() == dof_handler.locally_owned_dofs().n_elements(), ExcInternalError());
+
+  const unsigned int N = dof_handler.n_dofs();
+
+  Assert (dof_handler.n_locally_owned_dofs() <= N,
+          ExcInternalError());
+  /*Assert (std::accumulate (dof_handler.n_locally_owned_dofs_per_processor().begin(),
+                           dof_handler.n_locally_owned_dofs_per_processor().end(),
+                           0U) == N,
+          ExcInternalError());
+  */
+  IndexSet all (N);
+  for (unsigned int i=0;
+       i<dof_handler.locally_owned_dofs_per_processor().size(); ++i)
+    {
+      IndexSet intersect = all & dof_handler.locally_owned_dofs_per_processor()[i];
+      //  Assert(intersect.n_elements()==0, ExcInternalError());
+      all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+    }
+
+  //Assert(all == complete_index_set(N), ExcInternalError());
+
+  std::ofstream out(Utilities::int_to_string(tr.locally_owned_subdomain())
+                    + ".gpl");
+
+  out << "plot '-' using 1:2 with lines, '-' with labels point pt 2 offset 1,1" << std::endl;
+  GridOut().write_gnuplot (tr, out);
+
+  out << "e" << std::endl;
+
+  std::map<types::global_dof_index, Point<dim> > support_points;
+  DoFTools::map_dofs_to_support_points (MappingQ1<dim>(),
+                                        dof_handler,
+                                        support_points);
+  DoFTools::write_gnuplot_dof_support_point_info(out,
+                                                 support_points);
+
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  //test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/split_dof_01.mpirun=2.output
+++ b/tests/sharedtria/split_dof_01.mpirun=2.output
@@ -1,0 +1,27 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 6
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:0:2d::available_coarse_cells: {[0,2]}
+DEAL:0:2d::n_dofs: 21
+DEAL:0:2d::n_locally_owned_dofs: 13
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 13 8  sum: 21
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 6
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:1:2d::available_coarse_cells: {[0,2]}
+DEAL:1:2d::n_dofs: 21
+DEAL:1:2d::n_locally_owned_dofs: 8
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 13 8  sum: 21
+

--- a/tests/sharedtria/split_dof_01.mpirun=5.output
+++ b/tests/sharedtria/split_dof_01.mpirun=5.output
@@ -1,0 +1,69 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 3
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:0:2d::available_coarse_cells: {[0,2]}
+DEAL:0:2d::n_dofs: 21
+DEAL:0:2d::n_locally_owned_dofs: 8
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 8 3 4 3 3  sum: 21
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 2
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:1:2d::available_coarse_cells: {[0,2]}
+DEAL:1:2d::n_dofs: 21
+DEAL:1:2d::n_locally_owned_dofs: 3
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 8 3 4 3 3  sum: 21
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 3
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:2:2d::available_coarse_cells: {[0,2]}
+DEAL:2:2d::n_dofs: 21
+DEAL:2:2d::n_locally_owned_dofs: 4
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 8 3 4 3 3  sum: 21
+
+
+DEAL:3:2d:: locally_owned_subdomain(): 3
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 2
+ n_global_active_cells: 12
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:3:2d::available_coarse_cells: {[0,2]}
+DEAL:3:2d::n_dofs: 21
+DEAL:3:2d::n_locally_owned_dofs: 3
+DEAL:3:2d::n_locally_owned_dofs_per_processor: 8 3 4 3 3  sum: 21
+
+
+DEAL:4:2d:: locally_owned_subdomain(): 4
+ n_active_cells: 4
+ n_levels: 2
+ n_global_levels: 2
+ n_locally_owned_active_cells: 2
+ n_global_active_cells: 12
+ n_coarse_cells: 1
+ n_global_coarse_cells: 3
+DEAL:4:2d::available_coarse_cells: {2}
+DEAL:4:2d::n_dofs: 21
+DEAL:4:2d::n_locally_owned_dofs: 3
+DEAL:4:2d::n_locally_owned_dofs_per_processor: 8 3 4 3 3  sum: 21
+

--- a/tests/sharedtria/split_dof_02.cc
+++ b/tests/sharedtria/split_dof_02.cc
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------
+// $Id: dof_handler_number_cache.cc 31761 2013-11-22 14:42:37Z heister $
+//
+// Copyright (C) 2008 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check number cache for split_tria
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/distributed/split_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+
+#include <fstream>
+#include <cstdlib>
+#include <numeric>
+
+
+template<int dim>
+void test()
+{
+  const unsigned int nproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  Triangulation<dim> basetria;
+  {
+    GridGenerator::hyper_L(basetria);
+    basetria.refine_global (2);
+    typename Triangulation<dim>::active_cell_iterator
+    cell = basetria.begin_active();
+
+    for (unsigned int i=0; i < basetria.n_active_cells(); ++i)
+      {
+        cell->set_subdomain_id((i*nproc/basetria.n_active_cells()) % nproc);
+        ++cell;
+      }
+  }
+
+
+  /*
+  const unsigned int n_refinements[] = { 0, 4, 3, 2 };
+  for (unsigned int i=0; i<n_refinements[dim]; ++i)
+  {
+    // refine one-fifth of cells randomly
+    std::vector<bool> flags (triangulation.n_active_cells(), false);
+    for (unsigned int k=0; k<flags.size()/5 + 1; ++k)
+      flags[Testing::rand() % flags.size()] = true;
+    // make sure there's at least one that
+    // will be refined
+    flags[0] = true;
+
+    // refine triangulation
+    unsigned int index=0;
+    for (typename Triangulation<dim>::active_cell_iterator
+         cell = triangulation.begin_active();
+         cell != triangulation.end(); ++cell)
+      {
+        if (flags[index])
+          cell->set_refine_flag();
+        ++index;
+      }
+
+    Assert (index <= triangulation.n_active_cells(), ExcInternalError());
+
+    // flag all other cells for coarsening
+    // (this should ensure that at least
+    // some of them will actually be
+    // coarsened)
+    index=0;
+    for (typename Triangulation<dim>::active_cell_iterator
+         cell = triangulation.begin_active();
+         cell != triangulation.end(); ++cell)
+      {
+        if (!flags[index])
+          cell->set_coarsen_flag();
+        ++index;
+      }
+
+    triangulation.execute_coarsening_and_refinement ();*/
+
+  parallel::split::Triangulation<dim> tr(MPI_COMM_WORLD);
+  tr.copy_triangulation(basetria);
+
+  FESystem<dim> fe (FE_Q<dim>(3),2,
+                    FE_DGQ<dim>(1),1);
+
+  DoFHandler<dim> dof_handler (tr);
+
+  dof_handler.distribute_dofs (fe);
+
+  int n_coarse = tr.n_active_cells()>0 ? tr.n_cells(0) : 0;
+  deallog
+      << " locally_owned_subdomain(): " << tr.locally_owned_subdomain() << "\n"
+      << " n_active_cells: " << tr.n_active_cells() << "\n"
+      << " n_levels: " << tr.n_levels() << "\n"
+      << " n_global_levels: " << tr.n_global_levels()  << "\n"
+      << " n_locally_owned_active_cells: " << tr.n_locally_owned_active_cells() << "\n"
+      << " n_global_active_cells: " << tr.n_global_active_cells() << "\n"
+      << " n_coarse_cells: " << n_coarse << "\n"
+      << " n_global_coarse_cells: " << tr.n_global_coarse_cells()
+      << std::endl;
+
+  deallog << "available_coarse_cells: ";
+  tr.available_coarse_cells().print(deallog);
+
+  deallog
+      << "n_dofs: " << dof_handler.n_dofs() << std::endl
+      << "n_locally_owned_dofs: " << dof_handler.n_locally_owned_dofs() << std::endl;
+
+  deallog << "n_locally_owned_dofs_per_processor: ";
+  std::vector<types::global_dof_index> v = dof_handler.n_locally_owned_dofs_per_processor();
+  unsigned int sum = 0;
+  for (unsigned int i=0; i<v.size(); ++i)
+    {
+      deallog << v[i] << " ";
+      sum += v[i];
+    }
+  deallog << " sum: " << sum << std::endl;
+
+  //  Assert(dof_handler.n_locally_owned_dofs() == dof_handler.n_locally_owned_dofs_per_processor()[tr.locally_owned_subdomain()], ExcInternalError());
+  //  Assert( dof_handler.n_locally_owned_dofs() == dof_handler.locally_owned_dofs().n_elements(), ExcInternalError());
+
+  const unsigned int N = dof_handler.n_dofs();
+
+  Assert (dof_handler.n_locally_owned_dofs() <= N,
+          ExcInternalError());
+  /*Assert (std::accumulate (dof_handler.n_locally_owned_dofs_per_processor().begin(),
+                           dof_handler.n_locally_owned_dofs_per_processor().end(),
+                           0U) == N,
+          ExcInternalError());
+  */
+  IndexSet all (N);
+  for (unsigned int i=0;
+       i<dof_handler.locally_owned_dofs_per_processor().size(); ++i)
+    {
+      IndexSet intersect = all & dof_handler.locally_owned_dofs_per_processor()[i];
+      //  Assert(intersect.n_elements()==0, ExcInternalError());
+      all.add_indices(dof_handler.locally_owned_dofs_per_processor()[i]);
+    }
+
+  //Assert(all == complete_index_set(N), ExcInternalError());
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  //test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/split_dof_02.mpirun=2.output
+++ b/tests/sharedtria/split_dof_02.mpirun=2.output
@@ -1,0 +1,27 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 42
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 24
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:0:2d::available_coarse_cells: {[0,2]}
+DEAL:0:2d::n_dofs: 1154
+DEAL:0:2d::n_locally_owned_dofs: 602
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 602 552  sum: 1154
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 45
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 24
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:1:2d::available_coarse_cells: {[0,2]}
+DEAL:1:2d::n_dofs: 1154
+DEAL:1:2d::n_locally_owned_dofs: 552
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 602 552  sum: 1154
+

--- a/tests/sharedtria/split_dof_02.mpirun=5.output
+++ b/tests/sharedtria/split_dof_02.mpirun=5.output
@@ -1,0 +1,69 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 26
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 10
+ n_global_active_cells: 48
+ n_coarse_cells: 2
+ n_global_coarse_cells: 3
+DEAL:0:2d::available_coarse_cells: {[0,1]}
+DEAL:0:2d::n_dofs: 1154
+DEAL:0:2d::n_locally_owned_dofs: 264
+DEAL:0:2d::n_locally_owned_dofs_per_processor: 264 238 210 232 210  sum: 1154
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 42
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 10
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:1:2d::available_coarse_cells: {[0,2]}
+DEAL:1:2d::n_dofs: 1154
+DEAL:1:2d::n_locally_owned_dofs: 238
+DEAL:1:2d::n_locally_owned_dofs_per_processor: 264 238 210 232 210  sum: 1154
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 33
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 9
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:2:2d::available_coarse_cells: {[0,2]}
+DEAL:2:2d::n_dofs: 1154
+DEAL:2:2d::n_locally_owned_dofs: 210
+DEAL:2:2d::n_locally_owned_dofs_per_processor: 264 238 210 232 210  sum: 1154
+
+
+DEAL:3:2d:: locally_owned_subdomain(): 3
+ n_active_cells: 39
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 10
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:3:2d::available_coarse_cells: {[0,2]}
+DEAL:3:2d::n_dofs: 1154
+DEAL:3:2d::n_locally_owned_dofs: 232
+DEAL:3:2d::n_locally_owned_dofs_per_processor: 264 238 210 232 210  sum: 1154
+
+
+DEAL:4:2d:: locally_owned_subdomain(): 4
+ n_active_cells: 16
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 9
+ n_global_active_cells: 48
+ n_coarse_cells: 1
+ n_global_coarse_cells: 3
+DEAL:4:2d::available_coarse_cells: {2}
+DEAL:4:2d::n_dofs: 1154
+DEAL:4:2d::n_locally_owned_dofs: 210
+DEAL:4:2d::n_locally_owned_dofs_per_processor: 264 238 210 232 210  sum: 1154
+

--- a/tests/sharedtria/split_tria_01.cc
+++ b/tests/sharedtria/split_tria_01.cc
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------
+// $Id: 3d_refinement_01.cc 31349 2013-10-20 19:07:06Z maier $
+//
+// Copyright (C) 2008 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// create a split tria mesh
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/distributed/split_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/numerics/data_out.h>
+
+#include <fstream>
+
+template <int dim, int spacedim>
+void write_mesh (const Triangulation<dim,spacedim> &tria,
+                 const char                                *filename_)
+{
+  DataOut<dim> data_out;
+  data_out.attach_triangulation (tria);
+  Vector<float> subdomain (tria.n_active_cells());
+  for (unsigned int i=0; i<subdomain.size(); ++i)
+    subdomain(i) = tria.locally_owned_subdomain();
+  data_out.add_data_vector (subdomain, "subdomain");
+
+  data_out.build_patches ();
+  const std::string filename = (filename_ +
+                                Utilities::int_to_string
+                                (tria.locally_owned_subdomain(), 4));
+  {
+    std::ofstream output ((filename + ".vtu").c_str());
+    data_out.write_vtu (output);
+  }
+}
+
+
+
+template<int dim>
+void test()
+{
+  Triangulation<dim> basetria;
+  GridGenerator::hyper_L(basetria);
+  basetria.refine_global();
+
+  typename Triangulation<dim>::active_cell_iterator it = basetria.begin_active();
+  it->set_refine_flag();
+  //  ++it;
+  it->set_refine_flag();
+  basetria.execute_coarsening_and_refinement ();
+
+  typename Triangulation<dim>::active_cell_iterator
+  cell = basetria.begin_active();
+
+  for (unsigned int i=0; i < basetria.n_active_cells(); ++i)
+    {
+      cell->set_subdomain_id((i*3/basetria.n_active_cells()) % 3);
+      ++cell;
+    }
+
+
+
+  parallel::split::Triangulation<dim> tr(MPI_COMM_WORLD);
+  tr.copy_triangulation(basetria);
+
+  deallog
+      << " locally_owned_subdomain(): " << tr.locally_owned_subdomain() << "\n"
+      << " n_active_cells: " << tr.n_active_cells() << "\n"
+      << " n_levels: " << tr.n_levels() << "\n"
+      << " n_global_levels: " << tr.n_global_levels()  << "\n"
+      << " n_locally_owned_active_cells: " << tr.n_locally_owned_active_cells() << "\n"
+      << " n_global_active_cells: " << tr.n_global_active_cells() << "\n"
+      << std::endl;
+
+  /*deallog << "n_locally_owned_active_cells_per_processor: ";
+  std::vector<unsigned int> v = tr.n_locally_owned_active_cells_per_processor();
+  for (unsigned int i=0;i<v.size();++i)
+    deallog << v[i] << " ";
+    deallog << std::endl;*/
+
+  {
+    deallog << "subdomains: ";
+    typename  Triangulation<dim>::active_cell_iterator it=tr.begin_active();
+    for (unsigned int index=0; it!=tr.end(); ++it,++index)
+      {
+        deallog << it->subdomain_id() << " ";
+      }
+    deallog << std::endl;
+  }
+
+  GridOut go;
+  go.write_mesh_per_processor_as_vtu (tr, "mesh", false, true);
+
+  //write_mesh(tr, "mesh");
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  //  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/split_tria_01.mpirun=3.output
+++ b/tests/sharedtria/split_tria_01.mpirun=3.output
@@ -2,18 +2,18 @@
 DEAL:0:2d:: locally_owned_subdomain(): 0
  n_active_cells: 15
  n_levels: 3
- n_global_levels: 0
- n_locally_owned_active_cells: 0
- n_global_active_cells: 0
+ n_global_levels: 3
+ n_locally_owned_active_cells: 5
+ n_global_active_cells: 15
 
 DEAL:0:2d::subdomains: 0 0 0 0 0 1 1 1 1 4294967294 4294967294 4294967294 2 2 2 
 
 DEAL:1:2d:: locally_owned_subdomain(): 1
  n_active_cells: 12
  n_levels: 2
- n_global_levels: 0
- n_locally_owned_active_cells: 0
- n_global_active_cells: 0
+ n_global_levels: 3
+ n_locally_owned_active_cells: 5
+ n_global_active_cells: 15
 
 DEAL:1:2d::subdomains: 4294967294 0 0 0 0 0 1 1 1 1 1 2 
 
@@ -21,9 +21,9 @@ DEAL:1:2d::subdomains: 4294967294 0 0 0 0 0 1 1 1 1 1 2
 DEAL:2:2d:: locally_owned_subdomain(): 2
  n_active_cells: 11
  n_levels: 3
- n_global_levels: 0
- n_locally_owned_active_cells: 0
- n_global_active_cells: 0
+ n_global_levels: 3
+ n_locally_owned_active_cells: 5
+ n_global_active_cells: 15
 
 DEAL:2:2d::subdomains: 0 0 0 1 1 1 2 2 2 2 2 
 

--- a/tests/sharedtria/split_tria_01.mpirun=3.output
+++ b/tests/sharedtria/split_tria_01.mpirun=3.output
@@ -1,0 +1,29 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 15
+ n_levels: 3
+ n_global_levels: 0
+ n_locally_owned_active_cells: 0
+ n_global_active_cells: 0
+
+DEAL:0:2d::subdomains: 0 0 0 0 0 1 1 1 1 4294967294 4294967294 4294967294 2 2 2 
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 12
+ n_levels: 2
+ n_global_levels: 0
+ n_locally_owned_active_cells: 0
+ n_global_active_cells: 0
+
+DEAL:1:2d::subdomains: 4294967294 0 0 0 0 0 1 1 1 1 1 2 
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 11
+ n_levels: 3
+ n_global_levels: 0
+ n_locally_owned_active_cells: 0
+ n_global_active_cells: 0
+
+DEAL:2:2d::subdomains: 0 0 0 1 1 1 2 2 2 2 2 
+

--- a/tests/sharedtria/split_tria_02.cc
+++ b/tests/sharedtria/split_tria_02.cc
@@ -61,20 +61,20 @@ void test()
 
   Triangulation<dim> basetria;
   GridGenerator::hyper_L(basetria);
-  basetria.refine_global();
-
-  typename Triangulation<dim>::active_cell_iterator it = basetria.begin_active();
-  it->set_refine_flag();
-  //  ++it;
-  it->set_refine_flag();
-  basetria.execute_coarsening_and_refinement ();
+  basetria.refine_global(2);
 
   typename Triangulation<dim>::active_cell_iterator
   cell = basetria.begin_active();
 
   for (unsigned int i=0; i < basetria.n_active_cells(); ++i)
     {
-      cell->set_subdomain_id((i*3/basetria.n_active_cells()) % nproc);
+      unsigned int j=0;
+      if (i<4)
+        j=1;
+      else if (i<8)
+        j=2;
+
+      cell->set_subdomain_id(j % nproc);
       ++cell;
     }
 
@@ -98,15 +98,16 @@ void test()
     deallog << v[i] << " ";
     deallog << std::endl;*/
 
-  {
-    deallog << "subdomains: ";
-    typename  Triangulation<dim>::active_cell_iterator it=tr.begin_active();
-    for (unsigned int index=0; it!=tr.end(); ++it,++index)
-      {
-        deallog << it->subdomain_id() << " ";
-      }
-    deallog << std::endl;
-  }
+  if (tr.n_active_cells()>0)
+    {
+      deallog << "subdomains: ";
+      typename  Triangulation<dim>::active_cell_iterator it=tr.begin_active();
+      for (unsigned int index=0; it!=tr.end(); ++it,++index)
+        {
+          deallog << it->subdomain_id() << " ";
+        }
+      deallog << std::endl;
+    }
 
   GridOut go;
   go.write_mesh_per_processor_as_vtu (tr, "mesh", false, true);

--- a/tests/sharedtria/split_tria_02.mpirun=3.output
+++ b/tests/sharedtria/split_tria_02.mpirun=3.output
@@ -1,0 +1,29 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 48
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 40
+ n_global_active_cells: 48
+
+DEAL:0:2d::subdomains: 4294967294 4294967294 1 1 4294967294 2 2 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 16
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+
+DEAL:1:2d::subdomains: 1 1 1 1 2 4294967294 2 4294967294 0 0 4294967294 4294967294 0 4294967294 4294967294 4294967294 
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 26
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+
+DEAL:2:2d::subdomains: 4294967294 4294967294 4294967294 1 4294967294 1 2 2 2 2 4294967294 0 4294967294 4294967294 0 0 4294967294 4294967294 0 4294967294 0 4294967294 0 4294967294 4294967294 4294967294 
+

--- a/tests/sharedtria/split_tria_02.mpirun=4.output
+++ b/tests/sharedtria/split_tria_02.mpirun=4.output
@@ -1,0 +1,38 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 48
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 40
+ n_global_active_cells: 48
+
+DEAL:0:2d::subdomains: 4294967294 4294967294 1 1 4294967294 2 2 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 16
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+
+DEAL:1:2d::subdomains: 1 1 1 1 2 4294967294 2 4294967294 0 0 4294967294 4294967294 0 4294967294 4294967294 4294967294 
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 26
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+
+DEAL:2:2d::subdomains: 4294967294 4294967294 4294967294 1 4294967294 1 2 2 2 2 4294967294 0 4294967294 4294967294 0 0 4294967294 4294967294 0 4294967294 0 4294967294 0 4294967294 4294967294 4294967294 
+
+
+DEAL:3:2d:: locally_owned_subdomain(): 3
+ n_active_cells: 0
+ n_levels: 0
+ n_global_levels: 3
+ n_locally_owned_active_cells: 0
+ n_global_active_cells: 48
+
+

--- a/tests/sharedtria/split_tria_03.cc
+++ b/tests/sharedtria/split_tria_03.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+// $Id: 3d_refinement_01.cc 31349 2013-10-20 19:07:06Z maier $
+//
+// Copyright (C) 2008 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check cellids for a split tria mesh
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/distributed/split_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/numerics/data_out.h>
+
+#include <fstream>
+
+template <int dim, int spacedim>
+void write_mesh (const Triangulation<dim,spacedim> &tria,
+                 const char                                *filename_)
+{
+  DataOut<dim> data_out;
+  data_out.attach_triangulation (tria);
+  Vector<float> subdomain (tria.n_active_cells());
+  for (unsigned int i=0; i<subdomain.size(); ++i)
+    subdomain(i) = tria.locally_owned_subdomain();
+  data_out.add_data_vector (subdomain, "subdomain");
+
+  data_out.build_patches ();
+  const std::string filename = (filename_ +
+                                Utilities::int_to_string
+                                (tria.locally_owned_subdomain(), 4));
+  {
+    std::ofstream output ((filename + ".vtu").c_str());
+    data_out.write_vtu (output);
+  }
+}
+
+
+
+template<int dim>
+void test()
+{
+  const unsigned int nproc = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  Triangulation<dim> basetria;
+  GridGenerator::hyper_L(basetria);
+  basetria.refine_global(2);
+
+  typename Triangulation<dim>::active_cell_iterator
+  cell = basetria.begin_active();
+
+  for (unsigned int i=0; i < basetria.n_active_cells(); ++i)
+    {
+      unsigned int j=0;
+      if (i<4)
+        j=1;
+      else if (i<8)
+        j=2;
+
+      cell->set_subdomain_id(j % nproc);
+      ++cell;
+    }
+
+
+
+  parallel::split::Triangulation<dim> tr(MPI_COMM_WORLD);
+  tr.copy_triangulation(basetria);
+
+  int n_coarse = tr.n_active_cells()>0 ? tr.n_cells(0) : 0;
+  deallog
+      << " locally_owned_subdomain(): " << tr.locally_owned_subdomain() << "\n"
+      << " n_active_cells: " << tr.n_active_cells() << "\n"
+      << " n_levels: " << tr.n_levels() << "\n"
+      << " n_global_levels: " << tr.n_global_levels()  << "\n"
+      << " n_locally_owned_active_cells: " << tr.n_locally_owned_active_cells() << "\n"
+      << " n_global_active_cells: " << tr.n_global_active_cells() << "\n"
+      << " n_coarse_cells: " << n_coarse << "\n"
+      << " n_global_coarse_cells: " << tr.n_global_coarse_cells()
+      << std::endl;
+
+
+  /*deallog << "n_locally_owned_active_cells_per_processor: ";
+  std::vector<unsigned int> v = tr.n_locally_owned_active_cells_per_processor();
+  for (unsigned int i=0;i<v.size();++i)
+    deallog << v[i] << " ";
+    deallog << std::endl;*/
+
+  if (tr.n_active_cells()>0)
+    {
+      typename Triangulation<dim>::cell_iterator it=tr.begin();
+      for (unsigned int index=0; it!=tr.end(); ++it,++index)
+        {
+          deallog << "cell at " << it->center()
+                  << " has id "
+                  << it->id() << std::endl;
+
+          // check that we get the same cell back:
+          typename Triangulation<dim>::cell_iterator it2
+            = it->id().to_cell(tr);
+          Assert(it2->index()==it->index(), ExcInternalError());
+          Assert(it2->level()==it->level(), ExcInternalError());
+        }
+    }
+
+  GridOut go;
+  go.write_mesh_per_processor_as_vtu (tr, "mesh", false, true);
+
+  //write_mesh(tr, "mesh");
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  //  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/split_tria_03.cc
+++ b/tests/sharedtria/split_tria_03.cc
@@ -95,6 +95,10 @@ void test()
       << " n_global_coarse_cells: " << tr.n_global_coarse_cells()
       << std::endl;
 
+  deallog << "available_coarse_cells: ";
+  tr.available_coarse_cells().print(deallog);
+
+
 
   /*deallog << "n_locally_owned_active_cells_per_processor: ";
   std::vector<unsigned int> v = tr.n_locally_owned_active_cells_per_processor();
@@ -108,7 +112,8 @@ void test()
       for (unsigned int index=0; it!=tr.end(); ++it,++index)
         {
           deallog << "cell at " << it->center()
-                  << " has id "
+                  << " has owner " << (int)(it->active() ? it->subdomain_id() : -1)
+                  << " id "
                   << it->id() << std::endl;
 
           // check that we get the same cell back:

--- a/tests/sharedtria/split_tria_03.mpirun=3.output
+++ b/tests/sharedtria/split_tria_03.mpirun=3.output
@@ -1,0 +1,147 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 48
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 40
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:0:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:0:2d::cell at 0.500000 -0.500000 has id 1_0:
+DEAL:0:2d::cell at -0.500000 0.500000 has id 2_0:
+DEAL:0:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:0:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:0:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:0:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:0:2d::cell at 0.250000 -0.750000 has id 1_1:0
+DEAL:0:2d::cell at 0.750000 -0.750000 has id 1_1:1
+DEAL:0:2d::cell at 0.250000 -0.250000 has id 1_1:2
+DEAL:0:2d::cell at 0.750000 -0.250000 has id 1_1:3
+DEAL:0:2d::cell at -0.750000 0.250000 has id 2_1:0
+DEAL:0:2d::cell at -0.250000 0.250000 has id 2_1:1
+DEAL:0:2d::cell at -0.750000 0.750000 has id 2_1:2
+DEAL:0:2d::cell at -0.250000 0.750000 has id 2_1:3
+DEAL:0:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:0:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:0:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:0:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:0:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:0:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:0:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:0:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:0:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:0:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:0:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:0:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:0:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:0:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:0:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:0:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:0:2d::cell at 0.125000 -0.875000 has id 1_2:00
+DEAL:0:2d::cell at 0.375000 -0.875000 has id 1_2:01
+DEAL:0:2d::cell at 0.125000 -0.625000 has id 1_2:02
+DEAL:0:2d::cell at 0.375000 -0.625000 has id 1_2:03
+DEAL:0:2d::cell at 0.625000 -0.875000 has id 1_2:10
+DEAL:0:2d::cell at 0.875000 -0.875000 has id 1_2:11
+DEAL:0:2d::cell at 0.625000 -0.625000 has id 1_2:12
+DEAL:0:2d::cell at 0.875000 -0.625000 has id 1_2:13
+DEAL:0:2d::cell at 0.125000 -0.375000 has id 1_2:20
+DEAL:0:2d::cell at 0.375000 -0.375000 has id 1_2:21
+DEAL:0:2d::cell at 0.125000 -0.125000 has id 1_2:22
+DEAL:0:2d::cell at 0.375000 -0.125000 has id 1_2:23
+DEAL:0:2d::cell at 0.625000 -0.375000 has id 1_2:30
+DEAL:0:2d::cell at 0.875000 -0.375000 has id 1_2:31
+DEAL:0:2d::cell at 0.625000 -0.125000 has id 1_2:32
+DEAL:0:2d::cell at 0.875000 -0.125000 has id 1_2:33
+DEAL:0:2d::cell at -0.875000 0.125000 has id 2_2:00
+DEAL:0:2d::cell at -0.625000 0.125000 has id 2_2:01
+DEAL:0:2d::cell at -0.875000 0.375000 has id 2_2:02
+DEAL:0:2d::cell at -0.625000 0.375000 has id 2_2:03
+DEAL:0:2d::cell at -0.375000 0.125000 has id 2_2:10
+DEAL:0:2d::cell at -0.125000 0.125000 has id 2_2:11
+DEAL:0:2d::cell at -0.375000 0.375000 has id 2_2:12
+DEAL:0:2d::cell at -0.125000 0.375000 has id 2_2:13
+DEAL:0:2d::cell at -0.875000 0.625000 has id 2_2:20
+DEAL:0:2d::cell at -0.625000 0.625000 has id 2_2:21
+DEAL:0:2d::cell at -0.875000 0.875000 has id 2_2:22
+DEAL:0:2d::cell at -0.625000 0.875000 has id 2_2:23
+DEAL:0:2d::cell at -0.375000 0.625000 has id 2_2:30
+DEAL:0:2d::cell at -0.125000 0.625000 has id 2_2:31
+DEAL:0:2d::cell at -0.375000 0.875000 has id 2_2:32
+DEAL:0:2d::cell at -0.125000 0.875000 has id 2_2:33
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 16
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+ n_coarse_cells: 1
+ n_global_coarse_cells: 3
+DEAL:1:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:1:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:1:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:1:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:1:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:1:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:1:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:1:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:1:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:1:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:1:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:1:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:1:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:1:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:1:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:1:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:1:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:1:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:1:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:1:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:1:2d::cell at -0.125000 -0.125000 has id 0_2:33
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 26
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+ n_coarse_cells: 2
+ n_global_coarse_cells: 3
+DEAL:2:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:2:2d::cell at 0.500000 -0.500000 has id 1_0:
+DEAL:2:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:2:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:2:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:2:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:2:2d::cell at 0.250000 -0.750000 has id 1_1:0
+DEAL:2:2d::cell at 0.750000 -0.750000 has id 1_1:1
+DEAL:2:2d::cell at 0.250000 -0.250000 has id 1_1:2
+DEAL:2:2d::cell at 0.750000 -0.250000 has id 1_1:3
+DEAL:2:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:2:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:2:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:2:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:2:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:2:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:2:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:2:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:2:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:2:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:2:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:2:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:2:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:2:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:2:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:2:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:2:2d::cell at 0.125000 -0.875000 has id 1_2:00
+DEAL:2:2d::cell at 0.375000 -0.875000 has id 1_2:01
+DEAL:2:2d::cell at 0.125000 -0.625000 has id 1_2:02
+DEAL:2:2d::cell at 0.375000 -0.625000 has id 1_2:03
+DEAL:2:2d::cell at 0.125000 -0.375000 has id 1_2:20
+DEAL:2:2d::cell at 0.375000 -0.375000 has id 1_2:21
+DEAL:2:2d::cell at 0.125000 -0.125000 has id 1_2:22
+DEAL:2:2d::cell at 0.375000 -0.125000 has id 1_2:23
+

--- a/tests/sharedtria/split_tria_03.mpirun=3.output
+++ b/tests/sharedtria/split_tria_03.mpirun=3.output
@@ -7,69 +7,70 @@ DEAL:0:2d:: locally_owned_subdomain(): 0
  n_global_active_cells: 48
  n_coarse_cells: 3
  n_global_coarse_cells: 3
-DEAL:0:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:0:2d::cell at 0.500000 -0.500000 has id 1_0:
-DEAL:0:2d::cell at -0.500000 0.500000 has id 2_0:
-DEAL:0:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:0:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:0:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:0:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:0:2d::cell at 0.250000 -0.750000 has id 1_1:0
-DEAL:0:2d::cell at 0.750000 -0.750000 has id 1_1:1
-DEAL:0:2d::cell at 0.250000 -0.250000 has id 1_1:2
-DEAL:0:2d::cell at 0.750000 -0.250000 has id 1_1:3
-DEAL:0:2d::cell at -0.750000 0.250000 has id 2_1:0
-DEAL:0:2d::cell at -0.250000 0.250000 has id 2_1:1
-DEAL:0:2d::cell at -0.750000 0.750000 has id 2_1:2
-DEAL:0:2d::cell at -0.250000 0.750000 has id 2_1:3
-DEAL:0:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:0:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:0:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:0:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:0:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:0:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:0:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:0:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:0:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:0:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:0:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:0:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:0:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:0:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:0:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:0:2d::cell at -0.125000 -0.125000 has id 0_2:33
-DEAL:0:2d::cell at 0.125000 -0.875000 has id 1_2:00
-DEAL:0:2d::cell at 0.375000 -0.875000 has id 1_2:01
-DEAL:0:2d::cell at 0.125000 -0.625000 has id 1_2:02
-DEAL:0:2d::cell at 0.375000 -0.625000 has id 1_2:03
-DEAL:0:2d::cell at 0.625000 -0.875000 has id 1_2:10
-DEAL:0:2d::cell at 0.875000 -0.875000 has id 1_2:11
-DEAL:0:2d::cell at 0.625000 -0.625000 has id 1_2:12
-DEAL:0:2d::cell at 0.875000 -0.625000 has id 1_2:13
-DEAL:0:2d::cell at 0.125000 -0.375000 has id 1_2:20
-DEAL:0:2d::cell at 0.375000 -0.375000 has id 1_2:21
-DEAL:0:2d::cell at 0.125000 -0.125000 has id 1_2:22
-DEAL:0:2d::cell at 0.375000 -0.125000 has id 1_2:23
-DEAL:0:2d::cell at 0.625000 -0.375000 has id 1_2:30
-DEAL:0:2d::cell at 0.875000 -0.375000 has id 1_2:31
-DEAL:0:2d::cell at 0.625000 -0.125000 has id 1_2:32
-DEAL:0:2d::cell at 0.875000 -0.125000 has id 1_2:33
-DEAL:0:2d::cell at -0.875000 0.125000 has id 2_2:00
-DEAL:0:2d::cell at -0.625000 0.125000 has id 2_2:01
-DEAL:0:2d::cell at -0.875000 0.375000 has id 2_2:02
-DEAL:0:2d::cell at -0.625000 0.375000 has id 2_2:03
-DEAL:0:2d::cell at -0.375000 0.125000 has id 2_2:10
-DEAL:0:2d::cell at -0.125000 0.125000 has id 2_2:11
-DEAL:0:2d::cell at -0.375000 0.375000 has id 2_2:12
-DEAL:0:2d::cell at -0.125000 0.375000 has id 2_2:13
-DEAL:0:2d::cell at -0.875000 0.625000 has id 2_2:20
-DEAL:0:2d::cell at -0.625000 0.625000 has id 2_2:21
-DEAL:0:2d::cell at -0.875000 0.875000 has id 2_2:22
-DEAL:0:2d::cell at -0.625000 0.875000 has id 2_2:23
-DEAL:0:2d::cell at -0.375000 0.625000 has id 2_2:30
-DEAL:0:2d::cell at -0.125000 0.625000 has id 2_2:31
-DEAL:0:2d::cell at -0.375000 0.875000 has id 2_2:32
-DEAL:0:2d::cell at -0.125000 0.875000 has id 2_2:33
+DEAL:0:2d::available_coarse_cells: {[0,2]}
+DEAL:0:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:0:2d::cell at 0.500000 -0.500000 has owner -1 id 1_0:
+DEAL:0:2d::cell at -0.500000 0.500000 has owner -1 id 2_0:
+DEAL:0:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:0:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:0:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:0:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:0:2d::cell at 0.250000 -0.750000 has owner -1 id 1_1:0
+DEAL:0:2d::cell at 0.750000 -0.750000 has owner -1 id 1_1:1
+DEAL:0:2d::cell at 0.250000 -0.250000 has owner -1 id 1_1:2
+DEAL:0:2d::cell at 0.750000 -0.250000 has owner -1 id 1_1:3
+DEAL:0:2d::cell at -0.750000 0.250000 has owner -1 id 2_1:0
+DEAL:0:2d::cell at -0.250000 0.250000 has owner -1 id 2_1:1
+DEAL:0:2d::cell at -0.750000 0.750000 has owner -1 id 2_1:2
+DEAL:0:2d::cell at -0.250000 0.750000 has owner -1 id 2_1:3
+DEAL:0:2d::cell at -0.875000 -0.875000 has owner -2 id 0_2:00
+DEAL:0:2d::cell at -0.625000 -0.875000 has owner -2 id 0_2:01
+DEAL:0:2d::cell at -0.875000 -0.625000 has owner 1 id 0_2:02
+DEAL:0:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:0:2d::cell at -0.375000 -0.875000 has owner -2 id 0_2:10
+DEAL:0:2d::cell at -0.125000 -0.875000 has owner 2 id 0_2:11
+DEAL:0:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:0:2d::cell at -0.125000 -0.625000 has owner 2 id 0_2:13
+DEAL:0:2d::cell at -0.875000 -0.375000 has owner 0 id 0_2:20
+DEAL:0:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:0:2d::cell at -0.875000 -0.125000 has owner 0 id 0_2:22
+DEAL:0:2d::cell at -0.625000 -0.125000 has owner 0 id 0_2:23
+DEAL:0:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:0:2d::cell at -0.125000 -0.375000 has owner 0 id 0_2:31
+DEAL:0:2d::cell at -0.375000 -0.125000 has owner 0 id 0_2:32
+DEAL:0:2d::cell at -0.125000 -0.125000 has owner 0 id 0_2:33
+DEAL:0:2d::cell at 0.125000 -0.875000 has owner 0 id 1_2:00
+DEAL:0:2d::cell at 0.375000 -0.875000 has owner 0 id 1_2:01
+DEAL:0:2d::cell at 0.125000 -0.625000 has owner 0 id 1_2:02
+DEAL:0:2d::cell at 0.375000 -0.625000 has owner 0 id 1_2:03
+DEAL:0:2d::cell at 0.625000 -0.875000 has owner 0 id 1_2:10
+DEAL:0:2d::cell at 0.875000 -0.875000 has owner 0 id 1_2:11
+DEAL:0:2d::cell at 0.625000 -0.625000 has owner 0 id 1_2:12
+DEAL:0:2d::cell at 0.875000 -0.625000 has owner 0 id 1_2:13
+DEAL:0:2d::cell at 0.125000 -0.375000 has owner 0 id 1_2:20
+DEAL:0:2d::cell at 0.375000 -0.375000 has owner 0 id 1_2:21
+DEAL:0:2d::cell at 0.125000 -0.125000 has owner 0 id 1_2:22
+DEAL:0:2d::cell at 0.375000 -0.125000 has owner 0 id 1_2:23
+DEAL:0:2d::cell at 0.625000 -0.375000 has owner 0 id 1_2:30
+DEAL:0:2d::cell at 0.875000 -0.375000 has owner 0 id 1_2:31
+DEAL:0:2d::cell at 0.625000 -0.125000 has owner 0 id 1_2:32
+DEAL:0:2d::cell at 0.875000 -0.125000 has owner 0 id 1_2:33
+DEAL:0:2d::cell at -0.875000 0.125000 has owner 0 id 2_2:00
+DEAL:0:2d::cell at -0.625000 0.125000 has owner 0 id 2_2:01
+DEAL:0:2d::cell at -0.875000 0.375000 has owner 0 id 2_2:02
+DEAL:0:2d::cell at -0.625000 0.375000 has owner 0 id 2_2:03
+DEAL:0:2d::cell at -0.375000 0.125000 has owner 0 id 2_2:10
+DEAL:0:2d::cell at -0.125000 0.125000 has owner 0 id 2_2:11
+DEAL:0:2d::cell at -0.375000 0.375000 has owner 0 id 2_2:12
+DEAL:0:2d::cell at -0.125000 0.375000 has owner 0 id 2_2:13
+DEAL:0:2d::cell at -0.875000 0.625000 has owner 0 id 2_2:20
+DEAL:0:2d::cell at -0.625000 0.625000 has owner 0 id 2_2:21
+DEAL:0:2d::cell at -0.875000 0.875000 has owner 0 id 2_2:22
+DEAL:0:2d::cell at -0.625000 0.875000 has owner 0 id 2_2:23
+DEAL:0:2d::cell at -0.375000 0.625000 has owner 0 id 2_2:30
+DEAL:0:2d::cell at -0.125000 0.625000 has owner 0 id 2_2:31
+DEAL:0:2d::cell at -0.375000 0.875000 has owner 0 id 2_2:32
+DEAL:0:2d::cell at -0.125000 0.875000 has owner 0 id 2_2:33
 
 DEAL:1:2d:: locally_owned_subdomain(): 1
  n_active_cells: 16
@@ -79,27 +80,28 @@ DEAL:1:2d:: locally_owned_subdomain(): 1
  n_global_active_cells: 48
  n_coarse_cells: 1
  n_global_coarse_cells: 3
-DEAL:1:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:1:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:1:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:1:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:1:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:1:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:1:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:1:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:1:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:1:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:1:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:1:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:1:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:1:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:1:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:1:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:1:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:1:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:1:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:1:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:1:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:1:2d::available_coarse_cells: {0}
+DEAL:1:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:1:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:1:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:1:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:1:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:1:2d::cell at -0.875000 -0.875000 has owner 1 id 0_2:00
+DEAL:1:2d::cell at -0.625000 -0.875000 has owner 1 id 0_2:01
+DEAL:1:2d::cell at -0.875000 -0.625000 has owner 1 id 0_2:02
+DEAL:1:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:1:2d::cell at -0.375000 -0.875000 has owner 2 id 0_2:10
+DEAL:1:2d::cell at -0.125000 -0.875000 has owner -2 id 0_2:11
+DEAL:1:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:1:2d::cell at -0.125000 -0.625000 has owner -2 id 0_2:13
+DEAL:1:2d::cell at -0.875000 -0.375000 has owner 0 id 0_2:20
+DEAL:1:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:1:2d::cell at -0.875000 -0.125000 has owner -2 id 0_2:22
+DEAL:1:2d::cell at -0.625000 -0.125000 has owner -2 id 0_2:23
+DEAL:1:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:1:2d::cell at -0.125000 -0.375000 has owner -2 id 0_2:31
+DEAL:1:2d::cell at -0.375000 -0.125000 has owner -2 id 0_2:32
+DEAL:1:2d::cell at -0.125000 -0.125000 has owner -2 id 0_2:33
 
 
 DEAL:2:2d:: locally_owned_subdomain(): 2
@@ -110,38 +112,39 @@ DEAL:2:2d:: locally_owned_subdomain(): 2
  n_global_active_cells: 48
  n_coarse_cells: 2
  n_global_coarse_cells: 3
-DEAL:2:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:2:2d::cell at 0.500000 -0.500000 has id 1_0:
-DEAL:2:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:2:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:2:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:2:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:2:2d::cell at 0.250000 -0.750000 has id 1_1:0
-DEAL:2:2d::cell at 0.750000 -0.750000 has id 1_1:1
-DEAL:2:2d::cell at 0.250000 -0.250000 has id 1_1:2
-DEAL:2:2d::cell at 0.750000 -0.250000 has id 1_1:3
-DEAL:2:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:2:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:2:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:2:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:2:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:2:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:2:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:2:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:2:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:2:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:2:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:2:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:2:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:2:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:2:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:2:2d::cell at -0.125000 -0.125000 has id 0_2:33
-DEAL:2:2d::cell at 0.125000 -0.875000 has id 1_2:00
-DEAL:2:2d::cell at 0.375000 -0.875000 has id 1_2:01
-DEAL:2:2d::cell at 0.125000 -0.625000 has id 1_2:02
-DEAL:2:2d::cell at 0.375000 -0.625000 has id 1_2:03
-DEAL:2:2d::cell at 0.125000 -0.375000 has id 1_2:20
-DEAL:2:2d::cell at 0.375000 -0.375000 has id 1_2:21
-DEAL:2:2d::cell at 0.125000 -0.125000 has id 1_2:22
-DEAL:2:2d::cell at 0.375000 -0.125000 has id 1_2:23
+DEAL:2:2d::available_coarse_cells: {[0,1]}
+DEAL:2:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:2:2d::cell at 0.500000 -0.500000 has owner -1 id 1_0:
+DEAL:2:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:2:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:2:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:2:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:2:2d::cell at 0.250000 -0.750000 has owner -1 id 1_1:0
+DEAL:2:2d::cell at 0.750000 -0.750000 has owner -2 id 1_1:1
+DEAL:2:2d::cell at 0.250000 -0.250000 has owner -1 id 1_1:2
+DEAL:2:2d::cell at 0.750000 -0.250000 has owner -2 id 1_1:3
+DEAL:2:2d::cell at -0.875000 -0.875000 has owner -2 id 0_2:00
+DEAL:2:2d::cell at -0.625000 -0.875000 has owner 1 id 0_2:01
+DEAL:2:2d::cell at -0.875000 -0.625000 has owner -2 id 0_2:02
+DEAL:2:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:2:2d::cell at -0.375000 -0.875000 has owner 2 id 0_2:10
+DEAL:2:2d::cell at -0.125000 -0.875000 has owner 2 id 0_2:11
+DEAL:2:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:2:2d::cell at -0.125000 -0.625000 has owner 2 id 0_2:13
+DEAL:2:2d::cell at -0.875000 -0.375000 has owner -2 id 0_2:20
+DEAL:2:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:2:2d::cell at -0.875000 -0.125000 has owner -2 id 0_2:22
+DEAL:2:2d::cell at -0.625000 -0.125000 has owner -2 id 0_2:23
+DEAL:2:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:2:2d::cell at -0.125000 -0.375000 has owner 0 id 0_2:31
+DEAL:2:2d::cell at -0.375000 -0.125000 has owner -2 id 0_2:32
+DEAL:2:2d::cell at -0.125000 -0.125000 has owner -2 id 0_2:33
+DEAL:2:2d::cell at 0.125000 -0.875000 has owner 0 id 1_2:00
+DEAL:2:2d::cell at 0.375000 -0.875000 has owner -2 id 1_2:01
+DEAL:2:2d::cell at 0.125000 -0.625000 has owner 0 id 1_2:02
+DEAL:2:2d::cell at 0.375000 -0.625000 has owner -2 id 1_2:03
+DEAL:2:2d::cell at 0.125000 -0.375000 has owner 0 id 1_2:20
+DEAL:2:2d::cell at 0.375000 -0.375000 has owner -2 id 1_2:21
+DEAL:2:2d::cell at 0.125000 -0.125000 has owner -2 id 1_2:22
+DEAL:2:2d::cell at 0.375000 -0.125000 has owner -2 id 1_2:23
 

--- a/tests/sharedtria/split_tria_03.mpirun=4.output
+++ b/tests/sharedtria/split_tria_03.mpirun=4.output
@@ -7,69 +7,70 @@ DEAL:0:2d:: locally_owned_subdomain(): 0
  n_global_active_cells: 48
  n_coarse_cells: 3
  n_global_coarse_cells: 3
-DEAL:0:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:0:2d::cell at 0.500000 -0.500000 has id 1_0:
-DEAL:0:2d::cell at -0.500000 0.500000 has id 2_0:
-DEAL:0:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:0:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:0:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:0:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:0:2d::cell at 0.250000 -0.750000 has id 1_1:0
-DEAL:0:2d::cell at 0.750000 -0.750000 has id 1_1:1
-DEAL:0:2d::cell at 0.250000 -0.250000 has id 1_1:2
-DEAL:0:2d::cell at 0.750000 -0.250000 has id 1_1:3
-DEAL:0:2d::cell at -0.750000 0.250000 has id 2_1:0
-DEAL:0:2d::cell at -0.250000 0.250000 has id 2_1:1
-DEAL:0:2d::cell at -0.750000 0.750000 has id 2_1:2
-DEAL:0:2d::cell at -0.250000 0.750000 has id 2_1:3
-DEAL:0:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:0:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:0:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:0:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:0:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:0:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:0:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:0:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:0:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:0:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:0:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:0:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:0:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:0:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:0:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:0:2d::cell at -0.125000 -0.125000 has id 0_2:33
-DEAL:0:2d::cell at 0.125000 -0.875000 has id 1_2:00
-DEAL:0:2d::cell at 0.375000 -0.875000 has id 1_2:01
-DEAL:0:2d::cell at 0.125000 -0.625000 has id 1_2:02
-DEAL:0:2d::cell at 0.375000 -0.625000 has id 1_2:03
-DEAL:0:2d::cell at 0.625000 -0.875000 has id 1_2:10
-DEAL:0:2d::cell at 0.875000 -0.875000 has id 1_2:11
-DEAL:0:2d::cell at 0.625000 -0.625000 has id 1_2:12
-DEAL:0:2d::cell at 0.875000 -0.625000 has id 1_2:13
-DEAL:0:2d::cell at 0.125000 -0.375000 has id 1_2:20
-DEAL:0:2d::cell at 0.375000 -0.375000 has id 1_2:21
-DEAL:0:2d::cell at 0.125000 -0.125000 has id 1_2:22
-DEAL:0:2d::cell at 0.375000 -0.125000 has id 1_2:23
-DEAL:0:2d::cell at 0.625000 -0.375000 has id 1_2:30
-DEAL:0:2d::cell at 0.875000 -0.375000 has id 1_2:31
-DEAL:0:2d::cell at 0.625000 -0.125000 has id 1_2:32
-DEAL:0:2d::cell at 0.875000 -0.125000 has id 1_2:33
-DEAL:0:2d::cell at -0.875000 0.125000 has id 2_2:00
-DEAL:0:2d::cell at -0.625000 0.125000 has id 2_2:01
-DEAL:0:2d::cell at -0.875000 0.375000 has id 2_2:02
-DEAL:0:2d::cell at -0.625000 0.375000 has id 2_2:03
-DEAL:0:2d::cell at -0.375000 0.125000 has id 2_2:10
-DEAL:0:2d::cell at -0.125000 0.125000 has id 2_2:11
-DEAL:0:2d::cell at -0.375000 0.375000 has id 2_2:12
-DEAL:0:2d::cell at -0.125000 0.375000 has id 2_2:13
-DEAL:0:2d::cell at -0.875000 0.625000 has id 2_2:20
-DEAL:0:2d::cell at -0.625000 0.625000 has id 2_2:21
-DEAL:0:2d::cell at -0.875000 0.875000 has id 2_2:22
-DEAL:0:2d::cell at -0.625000 0.875000 has id 2_2:23
-DEAL:0:2d::cell at -0.375000 0.625000 has id 2_2:30
-DEAL:0:2d::cell at -0.125000 0.625000 has id 2_2:31
-DEAL:0:2d::cell at -0.375000 0.875000 has id 2_2:32
-DEAL:0:2d::cell at -0.125000 0.875000 has id 2_2:33
+DEAL:0:2d::available_coarse_cells: {[0,2]}
+DEAL:0:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:0:2d::cell at 0.500000 -0.500000 has owner -1 id 1_0:
+DEAL:0:2d::cell at -0.500000 0.500000 has owner -1 id 2_0:
+DEAL:0:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:0:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:0:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:0:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:0:2d::cell at 0.250000 -0.750000 has owner -1 id 1_1:0
+DEAL:0:2d::cell at 0.750000 -0.750000 has owner -1 id 1_1:1
+DEAL:0:2d::cell at 0.250000 -0.250000 has owner -1 id 1_1:2
+DEAL:0:2d::cell at 0.750000 -0.250000 has owner -1 id 1_1:3
+DEAL:0:2d::cell at -0.750000 0.250000 has owner -1 id 2_1:0
+DEAL:0:2d::cell at -0.250000 0.250000 has owner -1 id 2_1:1
+DEAL:0:2d::cell at -0.750000 0.750000 has owner -1 id 2_1:2
+DEAL:0:2d::cell at -0.250000 0.750000 has owner -1 id 2_1:3
+DEAL:0:2d::cell at -0.875000 -0.875000 has owner -2 id 0_2:00
+DEAL:0:2d::cell at -0.625000 -0.875000 has owner -2 id 0_2:01
+DEAL:0:2d::cell at -0.875000 -0.625000 has owner 1 id 0_2:02
+DEAL:0:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:0:2d::cell at -0.375000 -0.875000 has owner -2 id 0_2:10
+DEAL:0:2d::cell at -0.125000 -0.875000 has owner 2 id 0_2:11
+DEAL:0:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:0:2d::cell at -0.125000 -0.625000 has owner 2 id 0_2:13
+DEAL:0:2d::cell at -0.875000 -0.375000 has owner 0 id 0_2:20
+DEAL:0:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:0:2d::cell at -0.875000 -0.125000 has owner 0 id 0_2:22
+DEAL:0:2d::cell at -0.625000 -0.125000 has owner 0 id 0_2:23
+DEAL:0:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:0:2d::cell at -0.125000 -0.375000 has owner 0 id 0_2:31
+DEAL:0:2d::cell at -0.375000 -0.125000 has owner 0 id 0_2:32
+DEAL:0:2d::cell at -0.125000 -0.125000 has owner 0 id 0_2:33
+DEAL:0:2d::cell at 0.125000 -0.875000 has owner 0 id 1_2:00
+DEAL:0:2d::cell at 0.375000 -0.875000 has owner 0 id 1_2:01
+DEAL:0:2d::cell at 0.125000 -0.625000 has owner 0 id 1_2:02
+DEAL:0:2d::cell at 0.375000 -0.625000 has owner 0 id 1_2:03
+DEAL:0:2d::cell at 0.625000 -0.875000 has owner 0 id 1_2:10
+DEAL:0:2d::cell at 0.875000 -0.875000 has owner 0 id 1_2:11
+DEAL:0:2d::cell at 0.625000 -0.625000 has owner 0 id 1_2:12
+DEAL:0:2d::cell at 0.875000 -0.625000 has owner 0 id 1_2:13
+DEAL:0:2d::cell at 0.125000 -0.375000 has owner 0 id 1_2:20
+DEAL:0:2d::cell at 0.375000 -0.375000 has owner 0 id 1_2:21
+DEAL:0:2d::cell at 0.125000 -0.125000 has owner 0 id 1_2:22
+DEAL:0:2d::cell at 0.375000 -0.125000 has owner 0 id 1_2:23
+DEAL:0:2d::cell at 0.625000 -0.375000 has owner 0 id 1_2:30
+DEAL:0:2d::cell at 0.875000 -0.375000 has owner 0 id 1_2:31
+DEAL:0:2d::cell at 0.625000 -0.125000 has owner 0 id 1_2:32
+DEAL:0:2d::cell at 0.875000 -0.125000 has owner 0 id 1_2:33
+DEAL:0:2d::cell at -0.875000 0.125000 has owner 0 id 2_2:00
+DEAL:0:2d::cell at -0.625000 0.125000 has owner 0 id 2_2:01
+DEAL:0:2d::cell at -0.875000 0.375000 has owner 0 id 2_2:02
+DEAL:0:2d::cell at -0.625000 0.375000 has owner 0 id 2_2:03
+DEAL:0:2d::cell at -0.375000 0.125000 has owner 0 id 2_2:10
+DEAL:0:2d::cell at -0.125000 0.125000 has owner 0 id 2_2:11
+DEAL:0:2d::cell at -0.375000 0.375000 has owner 0 id 2_2:12
+DEAL:0:2d::cell at -0.125000 0.375000 has owner 0 id 2_2:13
+DEAL:0:2d::cell at -0.875000 0.625000 has owner 0 id 2_2:20
+DEAL:0:2d::cell at -0.625000 0.625000 has owner 0 id 2_2:21
+DEAL:0:2d::cell at -0.875000 0.875000 has owner 0 id 2_2:22
+DEAL:0:2d::cell at -0.625000 0.875000 has owner 0 id 2_2:23
+DEAL:0:2d::cell at -0.375000 0.625000 has owner 0 id 2_2:30
+DEAL:0:2d::cell at -0.125000 0.625000 has owner 0 id 2_2:31
+DEAL:0:2d::cell at -0.375000 0.875000 has owner 0 id 2_2:32
+DEAL:0:2d::cell at -0.125000 0.875000 has owner 0 id 2_2:33
 
 DEAL:1:2d:: locally_owned_subdomain(): 1
  n_active_cells: 16
@@ -79,27 +80,28 @@ DEAL:1:2d:: locally_owned_subdomain(): 1
  n_global_active_cells: 48
  n_coarse_cells: 1
  n_global_coarse_cells: 3
-DEAL:1:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:1:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:1:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:1:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:1:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:1:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:1:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:1:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:1:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:1:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:1:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:1:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:1:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:1:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:1:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:1:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:1:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:1:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:1:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:1:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:1:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:1:2d::available_coarse_cells: {0}
+DEAL:1:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:1:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:1:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:1:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:1:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:1:2d::cell at -0.875000 -0.875000 has owner 1 id 0_2:00
+DEAL:1:2d::cell at -0.625000 -0.875000 has owner 1 id 0_2:01
+DEAL:1:2d::cell at -0.875000 -0.625000 has owner 1 id 0_2:02
+DEAL:1:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:1:2d::cell at -0.375000 -0.875000 has owner 2 id 0_2:10
+DEAL:1:2d::cell at -0.125000 -0.875000 has owner -2 id 0_2:11
+DEAL:1:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:1:2d::cell at -0.125000 -0.625000 has owner -2 id 0_2:13
+DEAL:1:2d::cell at -0.875000 -0.375000 has owner 0 id 0_2:20
+DEAL:1:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:1:2d::cell at -0.875000 -0.125000 has owner -2 id 0_2:22
+DEAL:1:2d::cell at -0.625000 -0.125000 has owner -2 id 0_2:23
+DEAL:1:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:1:2d::cell at -0.125000 -0.375000 has owner -2 id 0_2:31
+DEAL:1:2d::cell at -0.375000 -0.125000 has owner -2 id 0_2:32
+DEAL:1:2d::cell at -0.125000 -0.125000 has owner -2 id 0_2:33
 
 
 DEAL:2:2d:: locally_owned_subdomain(): 2
@@ -110,40 +112,41 @@ DEAL:2:2d:: locally_owned_subdomain(): 2
  n_global_active_cells: 48
  n_coarse_cells: 2
  n_global_coarse_cells: 3
-DEAL:2:2d::cell at -0.500000 -0.500000 has id 0_0:
-DEAL:2:2d::cell at 0.500000 -0.500000 has id 1_0:
-DEAL:2:2d::cell at -0.750000 -0.750000 has id 0_1:0
-DEAL:2:2d::cell at -0.250000 -0.750000 has id 0_1:1
-DEAL:2:2d::cell at -0.750000 -0.250000 has id 0_1:2
-DEAL:2:2d::cell at -0.250000 -0.250000 has id 0_1:3
-DEAL:2:2d::cell at 0.250000 -0.750000 has id 1_1:0
-DEAL:2:2d::cell at 0.750000 -0.750000 has id 1_1:1
-DEAL:2:2d::cell at 0.250000 -0.250000 has id 1_1:2
-DEAL:2:2d::cell at 0.750000 -0.250000 has id 1_1:3
-DEAL:2:2d::cell at -0.875000 -0.875000 has id 0_2:00
-DEAL:2:2d::cell at -0.625000 -0.875000 has id 0_2:01
-DEAL:2:2d::cell at -0.875000 -0.625000 has id 0_2:02
-DEAL:2:2d::cell at -0.625000 -0.625000 has id 0_2:03
-DEAL:2:2d::cell at -0.375000 -0.875000 has id 0_2:10
-DEAL:2:2d::cell at -0.125000 -0.875000 has id 0_2:11
-DEAL:2:2d::cell at -0.375000 -0.625000 has id 0_2:12
-DEAL:2:2d::cell at -0.125000 -0.625000 has id 0_2:13
-DEAL:2:2d::cell at -0.875000 -0.375000 has id 0_2:20
-DEAL:2:2d::cell at -0.625000 -0.375000 has id 0_2:21
-DEAL:2:2d::cell at -0.875000 -0.125000 has id 0_2:22
-DEAL:2:2d::cell at -0.625000 -0.125000 has id 0_2:23
-DEAL:2:2d::cell at -0.375000 -0.375000 has id 0_2:30
-DEAL:2:2d::cell at -0.125000 -0.375000 has id 0_2:31
-DEAL:2:2d::cell at -0.375000 -0.125000 has id 0_2:32
-DEAL:2:2d::cell at -0.125000 -0.125000 has id 0_2:33
-DEAL:2:2d::cell at 0.125000 -0.875000 has id 1_2:00
-DEAL:2:2d::cell at 0.375000 -0.875000 has id 1_2:01
-DEAL:2:2d::cell at 0.125000 -0.625000 has id 1_2:02
-DEAL:2:2d::cell at 0.375000 -0.625000 has id 1_2:03
-DEAL:2:2d::cell at 0.125000 -0.375000 has id 1_2:20
-DEAL:2:2d::cell at 0.375000 -0.375000 has id 1_2:21
-DEAL:2:2d::cell at 0.125000 -0.125000 has id 1_2:22
-DEAL:2:2d::cell at 0.375000 -0.125000 has id 1_2:23
+DEAL:2:2d::available_coarse_cells: {[0,1]}
+DEAL:2:2d::cell at -0.500000 -0.500000 has owner -1 id 0_0:
+DEAL:2:2d::cell at 0.500000 -0.500000 has owner -1 id 1_0:
+DEAL:2:2d::cell at -0.750000 -0.750000 has owner -1 id 0_1:0
+DEAL:2:2d::cell at -0.250000 -0.750000 has owner -1 id 0_1:1
+DEAL:2:2d::cell at -0.750000 -0.250000 has owner -1 id 0_1:2
+DEAL:2:2d::cell at -0.250000 -0.250000 has owner -1 id 0_1:3
+DEAL:2:2d::cell at 0.250000 -0.750000 has owner -1 id 1_1:0
+DEAL:2:2d::cell at 0.750000 -0.750000 has owner -2 id 1_1:1
+DEAL:2:2d::cell at 0.250000 -0.250000 has owner -1 id 1_1:2
+DEAL:2:2d::cell at 0.750000 -0.250000 has owner -2 id 1_1:3
+DEAL:2:2d::cell at -0.875000 -0.875000 has owner -2 id 0_2:00
+DEAL:2:2d::cell at -0.625000 -0.875000 has owner 1 id 0_2:01
+DEAL:2:2d::cell at -0.875000 -0.625000 has owner -2 id 0_2:02
+DEAL:2:2d::cell at -0.625000 -0.625000 has owner 1 id 0_2:03
+DEAL:2:2d::cell at -0.375000 -0.875000 has owner 2 id 0_2:10
+DEAL:2:2d::cell at -0.125000 -0.875000 has owner 2 id 0_2:11
+DEAL:2:2d::cell at -0.375000 -0.625000 has owner 2 id 0_2:12
+DEAL:2:2d::cell at -0.125000 -0.625000 has owner 2 id 0_2:13
+DEAL:2:2d::cell at -0.875000 -0.375000 has owner -2 id 0_2:20
+DEAL:2:2d::cell at -0.625000 -0.375000 has owner 0 id 0_2:21
+DEAL:2:2d::cell at -0.875000 -0.125000 has owner -2 id 0_2:22
+DEAL:2:2d::cell at -0.625000 -0.125000 has owner -2 id 0_2:23
+DEAL:2:2d::cell at -0.375000 -0.375000 has owner 0 id 0_2:30
+DEAL:2:2d::cell at -0.125000 -0.375000 has owner 0 id 0_2:31
+DEAL:2:2d::cell at -0.375000 -0.125000 has owner -2 id 0_2:32
+DEAL:2:2d::cell at -0.125000 -0.125000 has owner -2 id 0_2:33
+DEAL:2:2d::cell at 0.125000 -0.875000 has owner 0 id 1_2:00
+DEAL:2:2d::cell at 0.375000 -0.875000 has owner -2 id 1_2:01
+DEAL:2:2d::cell at 0.125000 -0.625000 has owner 0 id 1_2:02
+DEAL:2:2d::cell at 0.375000 -0.625000 has owner -2 id 1_2:03
+DEAL:2:2d::cell at 0.125000 -0.375000 has owner 0 id 1_2:20
+DEAL:2:2d::cell at 0.375000 -0.375000 has owner -2 id 1_2:21
+DEAL:2:2d::cell at 0.125000 -0.125000 has owner -2 id 1_2:22
+DEAL:2:2d::cell at 0.375000 -0.125000 has owner -2 id 1_2:23
 
 
 DEAL:3:2d:: locally_owned_subdomain(): 3
@@ -154,4 +157,5 @@ DEAL:3:2d:: locally_owned_subdomain(): 3
  n_global_active_cells: 48
  n_coarse_cells: 0
  n_global_coarse_cells: 3
+DEAL:3:2d::available_coarse_cells: {}
 

--- a/tests/sharedtria/split_tria_03.mpirun=4.output
+++ b/tests/sharedtria/split_tria_03.mpirun=4.output
@@ -1,0 +1,157 @@
+
+DEAL:0:2d:: locally_owned_subdomain(): 0
+ n_active_cells: 48
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 40
+ n_global_active_cells: 48
+ n_coarse_cells: 3
+ n_global_coarse_cells: 3
+DEAL:0:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:0:2d::cell at 0.500000 -0.500000 has id 1_0:
+DEAL:0:2d::cell at -0.500000 0.500000 has id 2_0:
+DEAL:0:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:0:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:0:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:0:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:0:2d::cell at 0.250000 -0.750000 has id 1_1:0
+DEAL:0:2d::cell at 0.750000 -0.750000 has id 1_1:1
+DEAL:0:2d::cell at 0.250000 -0.250000 has id 1_1:2
+DEAL:0:2d::cell at 0.750000 -0.250000 has id 1_1:3
+DEAL:0:2d::cell at -0.750000 0.250000 has id 2_1:0
+DEAL:0:2d::cell at -0.250000 0.250000 has id 2_1:1
+DEAL:0:2d::cell at -0.750000 0.750000 has id 2_1:2
+DEAL:0:2d::cell at -0.250000 0.750000 has id 2_1:3
+DEAL:0:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:0:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:0:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:0:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:0:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:0:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:0:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:0:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:0:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:0:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:0:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:0:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:0:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:0:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:0:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:0:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:0:2d::cell at 0.125000 -0.875000 has id 1_2:00
+DEAL:0:2d::cell at 0.375000 -0.875000 has id 1_2:01
+DEAL:0:2d::cell at 0.125000 -0.625000 has id 1_2:02
+DEAL:0:2d::cell at 0.375000 -0.625000 has id 1_2:03
+DEAL:0:2d::cell at 0.625000 -0.875000 has id 1_2:10
+DEAL:0:2d::cell at 0.875000 -0.875000 has id 1_2:11
+DEAL:0:2d::cell at 0.625000 -0.625000 has id 1_2:12
+DEAL:0:2d::cell at 0.875000 -0.625000 has id 1_2:13
+DEAL:0:2d::cell at 0.125000 -0.375000 has id 1_2:20
+DEAL:0:2d::cell at 0.375000 -0.375000 has id 1_2:21
+DEAL:0:2d::cell at 0.125000 -0.125000 has id 1_2:22
+DEAL:0:2d::cell at 0.375000 -0.125000 has id 1_2:23
+DEAL:0:2d::cell at 0.625000 -0.375000 has id 1_2:30
+DEAL:0:2d::cell at 0.875000 -0.375000 has id 1_2:31
+DEAL:0:2d::cell at 0.625000 -0.125000 has id 1_2:32
+DEAL:0:2d::cell at 0.875000 -0.125000 has id 1_2:33
+DEAL:0:2d::cell at -0.875000 0.125000 has id 2_2:00
+DEAL:0:2d::cell at -0.625000 0.125000 has id 2_2:01
+DEAL:0:2d::cell at -0.875000 0.375000 has id 2_2:02
+DEAL:0:2d::cell at -0.625000 0.375000 has id 2_2:03
+DEAL:0:2d::cell at -0.375000 0.125000 has id 2_2:10
+DEAL:0:2d::cell at -0.125000 0.125000 has id 2_2:11
+DEAL:0:2d::cell at -0.375000 0.375000 has id 2_2:12
+DEAL:0:2d::cell at -0.125000 0.375000 has id 2_2:13
+DEAL:0:2d::cell at -0.875000 0.625000 has id 2_2:20
+DEAL:0:2d::cell at -0.625000 0.625000 has id 2_2:21
+DEAL:0:2d::cell at -0.875000 0.875000 has id 2_2:22
+DEAL:0:2d::cell at -0.625000 0.875000 has id 2_2:23
+DEAL:0:2d::cell at -0.375000 0.625000 has id 2_2:30
+DEAL:0:2d::cell at -0.125000 0.625000 has id 2_2:31
+DEAL:0:2d::cell at -0.375000 0.875000 has id 2_2:32
+DEAL:0:2d::cell at -0.125000 0.875000 has id 2_2:33
+
+DEAL:1:2d:: locally_owned_subdomain(): 1
+ n_active_cells: 16
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+ n_coarse_cells: 1
+ n_global_coarse_cells: 3
+DEAL:1:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:1:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:1:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:1:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:1:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:1:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:1:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:1:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:1:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:1:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:1:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:1:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:1:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:1:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:1:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:1:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:1:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:1:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:1:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:1:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:1:2d::cell at -0.125000 -0.125000 has id 0_2:33
+
+
+DEAL:2:2d:: locally_owned_subdomain(): 2
+ n_active_cells: 26
+ n_levels: 3
+ n_global_levels: 3
+ n_locally_owned_active_cells: 4
+ n_global_active_cells: 48
+ n_coarse_cells: 2
+ n_global_coarse_cells: 3
+DEAL:2:2d::cell at -0.500000 -0.500000 has id 0_0:
+DEAL:2:2d::cell at 0.500000 -0.500000 has id 1_0:
+DEAL:2:2d::cell at -0.750000 -0.750000 has id 0_1:0
+DEAL:2:2d::cell at -0.250000 -0.750000 has id 0_1:1
+DEAL:2:2d::cell at -0.750000 -0.250000 has id 0_1:2
+DEAL:2:2d::cell at -0.250000 -0.250000 has id 0_1:3
+DEAL:2:2d::cell at 0.250000 -0.750000 has id 1_1:0
+DEAL:2:2d::cell at 0.750000 -0.750000 has id 1_1:1
+DEAL:2:2d::cell at 0.250000 -0.250000 has id 1_1:2
+DEAL:2:2d::cell at 0.750000 -0.250000 has id 1_1:3
+DEAL:2:2d::cell at -0.875000 -0.875000 has id 0_2:00
+DEAL:2:2d::cell at -0.625000 -0.875000 has id 0_2:01
+DEAL:2:2d::cell at -0.875000 -0.625000 has id 0_2:02
+DEAL:2:2d::cell at -0.625000 -0.625000 has id 0_2:03
+DEAL:2:2d::cell at -0.375000 -0.875000 has id 0_2:10
+DEAL:2:2d::cell at -0.125000 -0.875000 has id 0_2:11
+DEAL:2:2d::cell at -0.375000 -0.625000 has id 0_2:12
+DEAL:2:2d::cell at -0.125000 -0.625000 has id 0_2:13
+DEAL:2:2d::cell at -0.875000 -0.375000 has id 0_2:20
+DEAL:2:2d::cell at -0.625000 -0.375000 has id 0_2:21
+DEAL:2:2d::cell at -0.875000 -0.125000 has id 0_2:22
+DEAL:2:2d::cell at -0.625000 -0.125000 has id 0_2:23
+DEAL:2:2d::cell at -0.375000 -0.375000 has id 0_2:30
+DEAL:2:2d::cell at -0.125000 -0.375000 has id 0_2:31
+DEAL:2:2d::cell at -0.375000 -0.125000 has id 0_2:32
+DEAL:2:2d::cell at -0.125000 -0.125000 has id 0_2:33
+DEAL:2:2d::cell at 0.125000 -0.875000 has id 1_2:00
+DEAL:2:2d::cell at 0.375000 -0.875000 has id 1_2:01
+DEAL:2:2d::cell at 0.125000 -0.625000 has id 1_2:02
+DEAL:2:2d::cell at 0.375000 -0.625000 has id 1_2:03
+DEAL:2:2d::cell at 0.125000 -0.375000 has id 1_2:20
+DEAL:2:2d::cell at 0.375000 -0.375000 has id 1_2:21
+DEAL:2:2d::cell at 0.125000 -0.125000 has id 1_2:22
+DEAL:2:2d::cell at 0.375000 -0.125000 has id 1_2:23
+
+
+DEAL:3:2d:: locally_owned_subdomain(): 3
+ n_active_cells: 0
+ n_levels: 0
+ n_global_levels: 3
+ n_locally_owned_active_cells: 0
+ n_global_active_cells: 48
+ n_coarse_cells: 0
+ n_global_coarse_cells: 3
+


### PR DESCRIPTION
The goal is to have a new parallel (and for now static) Triangulation that only contains the coarse cells that are needed on the local machine.

TODO list:
- [x] extract from Triangulation
- [x] cell ids
- [x] distribute dofs
- [ ] renumbering
- [ ] GMG
- [ ] periodicity

Totally work in progress but I can already generate a mesh:
![split-tria-02](https://cloud.githubusercontent.com/assets/1531285/22803668/e20e69b8-eee3-11e6-9c4b-1c756a53b89c.png)

