### PR TITLE
Fix a deprecation warning in user codes.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -573,7 +573,7 @@ public:
    * @deprecated instead of using this variable, please use the type trait value
    * <code>is_serial_vector< VectorType >::value</code>
    */
-  static const bool supports_distributed_data DEAL_II_DEPRECATED = BlockType::supports_distributed_data;
+  static const bool supports_distributed_data DEAL_II_DEPRECATED = !is_serial_vector<BlockType>::value;
 
   /**
    * Default constructor.


### PR DESCRIPTION
Since supports_distributed_data is deprecated, instantiating a BlockVector raises a deprecation warning in user codes. Fix this by simply using the type trait replacement.

Fixes #3933.