### PR TITLE
Remove the PETSc VectorBase copy operator.

### DIFF
--- a/doc/news/changes/incompatibilities/20170211DavidWells
+++ b/doc/news/changes/incompatibilities/20170211DavidWells
@@ -1,0 +1,10 @@
+Changed: PETScWrappers::VectorBase::operator= is now both private and
+undefined. This operator was formerly implicitly defined (i.e., it did a
+byte-for-byte copy of VectorBase's members), which provided, almost certainly,
+the wrong behavior since the underlying <code>Vec</code> (the managed PETSc
+object) would then be destroyed twice. Since both inheriting classes
+(PETScWrappers::Vector and PETScWrappers::MPI::Vector) define their own
+operator= overloads this operator is also not necessary.
+
+<br>
+(David Wells, 2017/02/11)

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -116,17 +116,16 @@ namespace PETScWrappers
      * @code
      *   PETScWrappers::MPI::Vector vector;
      *   ...
-     *                   // do some write operations on the vector
+     *   // do some write operations on the vector
      *   for (unsigned int i=0; i<vector.size(); ++i)
      *     vector(i) = i;
      *
-     *                   // do some additions to vector elements, but
-     *                   // only for some elements
+     *   // do some additions to vector elements, but only for some elements
      *   for (unsigned int i=0; i<vector.size(); ++i)
      *     if (some_condition(i) == true)
      *       vector(i) += 1;
      *
-     *                   // do another collective operation
+     *   // do another collective operation
      *   const double norm = vector.l2_norm();
      * @endcode
      *

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -227,10 +227,13 @@ namespace PETScWrappers
        *
        * @arg communicator denotes the MPI communicator over which the
        * different parts of the vector shall communicate
+       *
+       * @deprecated The use of objects that are explicitly of type VectorBase
+       * is deprecated: use PETScWrappers::MPI::Vector instead.
        */
       explicit Vector (const MPI_Comm     &communicator,
                        const VectorBase   &v,
-                       const size_type     local_size);
+                       const size_type     local_size) DEAL_II_DEPRECATED;
 
       /**
        * Construct a new parallel ghosted PETSc vector from an IndexSet.

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -801,7 +801,13 @@ namespace PETScWrappers
                                const PetscScalar  *values,
                                const bool         add_values);
 
-
+  private:
+    /**
+     * Assignment operator. This is currently not implemented, so it is
+     * deliberately left as private (and undefined) to prevent accidental
+     * usage.
+     */
+    VectorBase &operator=(const VectorBase &);
   };
 
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -56,11 +56,19 @@ namespace PETScWrappers
                     const VectorBase  &v,
                     const size_type   local_size)
       :
+      VectorBase (v),
       communicator (communicator)
     {
-      Vector::create_vector (v.size(), local_size);
-
-      VectorBase::operator = (v);
+      // In the past (before it was deprecated) this constructor did a
+      // byte-for-byte copy of v. This choice resulted in two problems:
+      // 1. The created vector will have the same size as v, not local size.
+      // 2. Since both the created vector and v maintain ownership of the same
+      // PETSc Vec, both will try to destroy it: this does not make sense.
+      //
+      // For the sake of backwards compatibility, preserve the behavior of the
+      // copy, but correct the ownership bug. Note that in both this (and the
+      // original) implementation local_size is ultimately unused.
+      (void)local_size;
     }
 
 


### PR DESCRIPTION
This PR makes `VectorBase::operator=` both private and undefined.

This operator was formerly implicitly defined, which provides, almost surely, the wrong behavior since the underlying `Vec` will be destroyed twice.

Since both inheriting classes (`PETScWrappers::Vector` and `PETScWrappers::MPI::Vector`) define their own `operator=` overloads this operator is also not necessary.

This is not backwards compatible, but given that any usage of this operator previously would result in double-destroy errors I think that it should just be removed.

Fixes #3538.
