### PR TITLE
Add missing instantiations for DoFAccessor<0 ...>.

### DIFF
--- a/doc/news/changes/minor/20170219DavidWells
+++ b/doc/news/changes/minor/20170219DavidWells
@@ -1,0 +1,5 @@
+Fixed: The DoFAccessor specialization for <code>structdim == 0</code> and
+<code>dimension == 1</code> was missing several definitions, which were
+required for use of hp::DoFHandler in 1D. These have now been added.
+<br>
+(David Wells, 2017/02/19)

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -844,17 +844,19 @@ public:
   child (const unsigned int c) const;
 
   /**
-   * Pointer to the @p ith line bounding this object. If the current object is
-   * a line itself, then the only valid index is @p i equals to zero, and the
-   * function returns an iterator to itself.
+   * Pointer to the @p ith line bounding this object.
+   *
+   * Since meshes with dimension 1 do not have quads this method just throws
+   * an exception.
    */
   typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
   line (const unsigned int i) const;
 
   /**
-   * Pointer to the @p ith quad bounding this object. If the current object is
-   * a quad itself, then the only valid index is @p i equals to zero, and the
-   * function returns an iterator to itself.
+   * Pointer to the @p ith quad bounding this object.
+   *
+   * Since meshes with dimension 1 do not have quads this method just throws
+   * an exception.
    */
   typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
   quad (const unsigned int i) const;
@@ -872,14 +874,12 @@ public:
 
   /**
    * Return the <i>global</i> indices of the degrees of freedom located on
-   * this object in the standard ordering defined by the finite element (i.e.,
-   * dofs on vertex 0, dofs on vertex 1, etc, dofs on line 0, dofs on line 1,
-   * etc, dofs on quad 0, etc.) This function is only available on
-   * <i>active</i> objects (see
-   * @ref GlossActive "this glossary entry").
+   * this object in the standard ordering defined by the finite element. This
+   * function is only available on <i>active</i> objects (see @ref GlossActive
+   * "this glossary entry").
    *
-   * The cells needs to be an active cell (and not artificial in a parallel
-   * distributed computation).
+   * The present vertex must belong to an active cell (and not artificial in a
+   * parallel distributed computation).
    *
    * The vector has to have the right size before being passed to this
    * function.
@@ -905,7 +905,6 @@ public:
    */
   void get_dof_indices (std::vector<types::global_dof_index> &dof_indices,
                         const unsigned int fe_index = AccessorData::default_fe_index) const;
-
 
   /**
    * Return the global multilevel indices of the degrees of freedom that live
@@ -950,20 +949,7 @@ public:
    * cells, as well as vertices, there may therefore be two sets of degrees of
    * freedom, one for each of the finite elements used on the adjacent cells.
    * In order to specify which set of degrees of freedom to work on, the last
-   * argument is used to disambiguate. Finally, if this function is called for
-   * a cell object, there can only be a single set of degrees of freedom, and
-   * fe_index has to match the result of active_fe_index().
-   *
-   * @note While the get_dof_indices() function returns an array that contains
-   * the indices of all degrees of freedom that somehow live on this object
-   * (i.e. on the vertices, edges or interior of this object), the current
-   * dof_index() function only considers the DoFs that really belong to this
-   * particular object's interior. In other words, as an example, if the
-   * current object refers to a quad (a cell in 2d, a face in 3d) and the
-   * finite element associated with it is a bilinear one, then the
-   * get_dof_indices() will return an array of size 4 while dof_index() will
-   * produce an exception because no degrees are defined in the interior of
-   * the face.
+   * argument is used to disambiguate.
    */
   types::global_dof_index dof_index (const unsigned int i,
                                      const unsigned int fe_index = AccessorData::default_fe_index) const;
@@ -982,33 +968,30 @@ public:
   /**
    * Return the number of finite elements that are active on a given object.
    *
-   * For non-hp DoFHandler objects, the answer is of course always one.
-   * However, for hp::DoFHandler objects, this isn't the case: If this is a
-   * cell, the answer is of course one. If it is a face, the answer may be one
-   * or two, depending on whether the two adjacent cells use the same finite
-   * element or not. If it is an edge in 3d, the possible return value may be
-   * one or any other value larger than that.
+   * Since vertices do not store the information necessary for this to be
+   * calculated, this method just raises an exception and only exists to
+   * enable dimension-independent programming.
    */
   unsigned int
   n_active_fe_indices () const;
 
   /**
-   * Return the @p n-th active fe index on this object. For cells and all non-
-   * hp objects, there is only a single active fe index, so the argument must
-   * be equal to zero. For lower-dimensional hp objects, there are
-   * n_active_fe_indices() active finite elements, and this function can be
-   * queried for their indices.
+   * Return the @p n-th active fe index on this object.
+   *
+   * Since vertices do not store the information necessary for this to be
+   * calculated, this method just raises an exception and only exists to
+   * enable dimension-independent programming.
    */
   unsigned int
   nth_active_fe_index (const unsigned int n) const;
 
   /**
    * Return true if the finite element with given index is active on the
-   * present object. For non-hp DoF accessors, this is of course the case only
-   * if @p fe_index equals zero. For cells, it is the case if @p fe_index
-   * equals active_fe_index() of this cell. For faces and other lower-
-   * dimensional objects, there may be more than one @p fe_index that are
-   * active on any given object (see n_active_fe_indices()).
+   * present object.
+   *
+   * Since vertices do not store the information necessary for this to be
+   * calculated, this method just raises an exception and only exists to
+   * enable dimension-independent programming.
    */
   bool
   fe_index_is_active (const unsigned int fe_index) const;
@@ -1302,8 +1285,8 @@ public:
   /**
    * Return an iterator to the @p ith face of this cell.
    *
-   * This function is not implemented in 1D, and returns DoFAccessor::line in
-   * 2D and DoFAccessor::quad in 3d.
+   * This function returns a DoFAccessor with <code>structdim == 0</code> in
+   * 1D, a DoFAccessor::line in 2D, and a DoFAccessor::quad in 3d.
    */
   face_iterator
   face (const unsigned int i) const;

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2287,6 +2287,33 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::set_dof_handler
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 inline
+void
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::set_dof_index
+(const unsigned int /*i*/,
+ const types::global_dof_index /*index*/,
+ const unsigned int /*fe_index*/) const
+{
+  Assert (false, ExcNotImplemented());
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+void
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::set_vertex_dof_index
+(const unsigned int /*vertex*/,
+ const unsigned int /*i*/,
+ const types::global_dof_index /*index*/,
+ const unsigned int /*fe_index*/) const
+{
+  Assert (false, ExcNotImplemented());
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
 const DoFHandlerType<1,spacedim> &
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::get_dof_handler () const
 {
@@ -2354,6 +2381,70 @@ vertex_dof_index (const unsigned int vertex,
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 inline
+types::global_dof_index
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+dof_index (const unsigned int i,
+           const unsigned int fe_index) const
+{
+  return dealii::internal::DoFAccessor::Implementation::get_vertex_dof_index
+         (*this->dof_handler,
+          this->vertex_index(0),
+          fe_index,
+          i);
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+unsigned int
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+n_active_fe_indices() const
+{
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+unsigned int
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+nth_active_fe_index(const unsigned int /*n*/) const
+{
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+bool
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+fe_index_is_active (const unsigned int fe_index) const
+{
+  Assert(false, ExcNotImplemented());
+  return false;
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+const FiniteElement<DoFHandlerType<1,spacedim>::dimension,DoFHandlerType<1,spacedim>::space_dimension> &
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+get_fe (const unsigned int fe_index) const
+{
+  Assert (this->dof_handler != 0, ExcInvalidObject());
+  return dof_handler->get_fe()[fe_index];
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
 void
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::copy_from
 (const TriaAccessorBase<0,1,spacedim> &da)
@@ -2383,6 +2474,32 @@ TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::child (const unsigned int /*i*/) const
 {
   return TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >();
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::line
+(const unsigned int /*c*/) const
+{
+  Assert(false, ExcNotImplemented());
+  return typename dealii::internal::
+         DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::line_iterator();
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+typename dealii::internal::DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::quad
+(const unsigned int /*c*/) const
+{
+  Assert(false, ExcNotImplemented());
+  return typename dealii::internal::
+         DoFHandler::Iterators<DoFHandlerType<1,spacedim>, level_dof_access>::quad_iterator();
 }
 
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2378,6 +2378,16 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::copy_from
 
 
 template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::child (const unsigned int /*i*/) const
+{
+  return TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >();
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
 template <int dim2, class DoFHandlerType2, bool level_dof_access2>
 inline
 bool
@@ -2402,18 +2412,6 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::operator !=
   Assert (this->dof_handler == a.dof_handler, ExcCantCompareIterators());
   return (BaseClass::operator != (a));
 }
-
-
-
-template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
-inline
-TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >
-DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::child (const unsigned int /*i*/) const
-{
-  return TriaIterator<DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access > >();
-}
-
-
 
 
 

--- a/tests/hp/accessor_0.cc
+++ b/tests/hp/accessor_0.cc
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Ensure that the newly added instantiations for DoFAccessor<0, ...>
+// (dof_index and get_fe) work correctly for an hp::DoFHandler.
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+int main()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog << std::boolalpha;
+
+  using namespace dealii;
+
+  Triangulation<1> triangulation;
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global(2);
+
+  hp::FECollection<1> fe_collection;
+  hp::DoFHandler<1> dof_handler(triangulation);
+  fe_collection.push_back(FE_Q<1>(2));
+  fe_collection.push_back(FE_Q<1>(4));
+  fe_collection.push_back(FE_Q<1>(6));
+
+  const unsigned int n_fe_indices = 3;
+  {
+    typename hp::DoFHandler<1>::active_cell_iterator
+    cell = dof_handler.begin_active();
+    dof_handler.begin_active()->set_active_fe_index(1);
+    ++cell; // go to cell 1
+    ++cell; // go to cell 2
+    ++cell; // go to cell 3
+    cell->set_active_fe_index(2);
+  }
+  dof_handler.distribute_dofs(fe_collection);
+
+  // dof_index
+  // get_fe
+
+  std::vector<types::global_dof_index> dof_indices;
+
+  typename hp::DoFHandler<1>::active_cell_iterator
+  cell = dof_handler.begin_active(),
+  endc = dof_handler.end();
+  for (; cell != endc; ++cell)
+    {
+      deallog << "==================================="
+              << std::endl;
+      deallog << "cell center: "
+              << cell->center()
+              << std::endl;
+
+      dof_indices.resize(fe_collection[cell->active_fe_index()].dofs_per_cell);
+      cell->get_dof_indices(dof_indices);
+      deallog << "cell dofs: ";
+      for (unsigned int dof_n = 0; dof_n < dof_indices.size(); ++dof_n)
+        {
+          deallog << dof_indices[dof_n];
+          if (dof_n != dof_indices.size() - 1)
+            {
+              deallog << ", ";
+            }
+        }
+      deallog << std::endl;
+
+      // see if we have a neighbor on the right. If so, the common vertex
+      // should be associated with two FE indices.
+      const typename hp::DoFHandler<1>::active_cell_iterator neighbor = cell->neighbor(1);
+      if (neighbor != dof_handler.end())
+        {
+          const unsigned int current_index = cell->active_fe_index();
+          const unsigned int neighbor_index = neighbor->active_fe_index();
+          deallog << "dof index (current cell, current index): "
+                  << cell->face(1)->dof_index(0, current_index)
+                  << " (neighbor cell, current index): "
+                  << neighbor->face(0)->dof_index(0, current_index)
+                  << std::endl
+                  << "dof index (current cell, neighbor index): "
+                  << cell->face(1)->dof_index(0, neighbor_index)
+                  << " (neighbor cell, neighbor index): "
+                  << neighbor->face(0)->dof_index(0, neighbor_index)
+                  << std::endl;
+        }
+
+      for (unsigned int fe_index = 0; fe_index < n_fe_indices; ++fe_index)
+        {
+          const bool index_is_active = cell->fe_index_is_active(fe_index);
+          deallog << "cell uses fe index " << fe_index << ": "
+                  << index_is_active
+                  << std::endl;
+
+          for (unsigned int face_n = 0; face_n < GeometryInfo<1>::faces_per_cell;
+               ++face_n)
+            {
+              AssertThrow (&cell->face(face_n)->get_fe(fe_index) == &fe_collection[fe_index],
+                           ExcMessage("The result of get_fe should always return"
+                                      " a known finite element."));
+
+              if (index_is_active)
+                {
+                  deallog << "vertex dof index: "
+                          << cell->face(face_n)->dof_index(0, fe_index)
+                          << std::endl;
+                }
+            }
+        }
+    }
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/hp/accessor_0.output
+++ b/tests/hp/accessor_0.output
@@ -1,0 +1,40 @@
+
+DEAL::===================================
+DEAL::cell center: 0.125000
+DEAL::cell dofs: 0, 4, 1, 2, 3
+DEAL::dof index (current cell, current index): 4 (neighbor cell, current index): 4
+DEAL::dof index (current cell, neighbor index): 4 (neighbor cell, neighbor index): 4
+DEAL::cell uses fe index 0: false
+DEAL::cell uses fe index 1: true
+DEAL::vertex dof index: 0
+DEAL::vertex dof index: 4
+DEAL::cell uses fe index 2: false
+DEAL::===================================
+DEAL::cell center: 0.375000
+DEAL::cell dofs: 4, 5, 6
+DEAL::dof index (current cell, current index): 5 (neighbor cell, current index): 5
+DEAL::dof index (current cell, neighbor index): 5 (neighbor cell, neighbor index): 5
+DEAL::cell uses fe index 0: true
+DEAL::vertex dof index: 4
+DEAL::vertex dof index: 5
+DEAL::cell uses fe index 1: false
+DEAL::cell uses fe index 2: false
+DEAL::===================================
+DEAL::cell center: 0.625000
+DEAL::cell dofs: 5, 7, 8
+DEAL::dof index (current cell, current index): 7 (neighbor cell, current index): 7
+DEAL::dof index (current cell, neighbor index): 7 (neighbor cell, neighbor index): 7
+DEAL::cell uses fe index 0: true
+DEAL::vertex dof index: 5
+DEAL::vertex dof index: 7
+DEAL::cell uses fe index 1: false
+DEAL::cell uses fe index 2: false
+DEAL::===================================
+DEAL::cell center: 0.875000
+DEAL::cell dofs: 7, 9, 10, 11, 12, 13, 14
+DEAL::cell uses fe index 0: false
+DEAL::cell uses fe index 1: false
+DEAL::cell uses fe index 2: true
+DEAL::vertex dof index: 7
+DEAL::vertex dof index: 9
+DEAL::OK


### PR DESCRIPTION
I added stubs that just throw exceptions: this was enough to get around some linker errors and run a 1D application I am working on.

I marked this as WIP since I would like to finish the definitions in time for 8.5.