### PR TITLE
Use C++11 instead of boost in base/symmetric_tensor_36

### DIFF
--- a/tests/base/symmetric_tensor_36.cc
+++ b/tests/base/symmetric_tensor_36.cc
@@ -21,8 +21,7 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/logstream.h>
 
-// These boost functions are bundled with deal.II
-#include <boost/type_traits.hpp>
+#include <type_traits>
 
 #include <complex>
 #include <fstream>
@@ -36,7 +35,7 @@ template<int rank, int dim,
          template<int,int,typename> class TensorType,
          typename NumberType1,
          typename NumberType2>
-typename boost::disable_if<boost::is_constructible<NumberType1,NumberType2>,void>::type
+typename std::enable_if<!std::is_constructible<NumberType1,NumberType2>::value,void>::type
 test_tensor_constructor (const std::string &, const std::string &)
 {}
 
@@ -44,7 +43,7 @@ template<int rank, int dim,
          template<int,int,typename> class TensorType,
          typename NumberType1,
          typename NumberType2>
-typename boost::enable_if<boost::is_constructible<NumberType1,NumberType2>,void>::type
+typename std::enable_if<std::is_constructible<NumberType1,NumberType2>::value,void>::type
 test_tensor_constructor (const std::string &type1, const std::string &type2)
 {
   deallog


### PR DESCRIPTION
`base/symmetric_tensor_36` uses `boost::is_constructible` which seems not to be available for all [boost versions](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=base%2Fsymmetric_tensor_36.release&date=2017-02-15). Since we already require C++11 for this test, we can also just switch to the corresponding C++11 statements.