### PR TITLE
Old PETSc version fixes

### DIFF
--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -196,7 +196,6 @@ namespace PETScWrappers
       this->communicator = communicator;
 
       // get rid of old matrix and generate a new one
-      destroy_matrix (matrix);
       const PetscErrorCode ierr = destroy_matrix (matrix);
       AssertThrow (ierr == 0, ExcPETScError (ierr));
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -286,6 +286,7 @@ namespace
 {
   void check_petsc_allocations()
   {
+#if DEAL_II_PETSC_VERSION_GTE(3, 2, 0)
     PetscStageLog stageLog;
     PetscLogGetStageLog(&stageLog);
 
@@ -314,6 +315,7 @@ namespace
 
     if (errors)
       throw dealii::ExcMessage("PETSc memory leak");
+#endif
   }
 }
 #endif


### PR DESCRIPTION
This PR fixes some little things that were caught when running the test suite with PETSc 3.1 and PETSc 3.2. A few tests fail with PETSc 3.1 that do not with more modern versions, but the errors are segmentation faults within PETSc (after PETSc's own object sanity checks pass) so I think that this is nothing new and something we can ignore.