### PR TITLE
Remove redundant explicit instantiation

### DIFF
--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -934,14 +934,6 @@ namespace TrilinosWrappers
 
   template void
   SolverBase::do_solve(const Epetra_Operator &preconditioner);
-
-  template void
-  SolverBase::set_preconditioner(AztecOO                &solver,
-                                 const PreconditionBase &preconditioner);
-
-  template void
-  SolverBase::set_preconditioner(AztecOO               &solver,
-                                 const Epetra_Operator &preconditioner);
 }
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This PR addresses clang's warnings
>source/lac/trilinos_solver.cc:939:15: warning: explicit instantiation of 'set_preconditioner<dealii::TrilinosWrappers::PreconditionBase>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
  SolverBase::set_preconditioner(AztecOO                &solver,
              ^
source/lac/trilinos_solver.cc:565:15: note: previous template specialization is here
  SolverBase::set_preconditioner(AztecOO                &solver,
              ^
source/lac/trilinos_solver.cc:943:15: warning: explicit instantiation of 'set_preconditioner<Epetra_Operator>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
  SolverBase::set_preconditioner(AztecOO               &solver,
              ^
source/lac/trilinos_solver.cc:583:15: note: previous template specialization is here SolverBase::set_preconditioner(AztecOO               &solver,
              ^