### PR TITLE
Improve formatting of figures.

### DIFF
--- a/examples/step-28/doc/results.dox
+++ b/examples/step-28/doc/results.dox
@@ -70,20 +70,20 @@ The meanings of columns are: number of mesh iteration, numbers of degrees of
  freedom of fast energy group, numbers of DoFs of thermal group, converged 
 k-effective and the ratio between maximum of fast flux and maximum of thermal one.
 
-The grids of fast and thermal energy groups at mesh iteration #9 are shown 
-in following figure.
+The grids of fast and thermal energy groups at mesh iteration #9 look
+as follows:
 
-<img src="https://www.dealii.org/images/steps/developer/step-28.grid-0.9.order2.png" alt="">
-
-<img src="https://www.dealii.org/images/steps/developer/step-28.grid-1.9.order2.png" alt="">
+<img width="400" src="https://www.dealii.org/images/steps/developer/step-28.grid-0.9.order2.png" alt="">
+&nbsp;
+<img width="400" src="https://www.dealii.org/images/steps/developer/step-28.grid-1.9.order2.png" alt="">
 
 We see that the grid of thermal group is much finer than the one of fast group. 
 The solutions on these grids are, (Note: flux are normalized with total fission
 source equal to 1)
 
-<img src="https://www.dealii.org/images/steps/developer/step-28.solution-0.9.order2.png" alt="">
-
-<img src="https://www.dealii.org/images/steps/developer/step-28.solution-1.9.order2.png" alt="">
+<img width="400" src="https://www.dealii.org/images/steps/developer/step-28.solution-0.9.order2.png" alt="">
+&nbsp;
+<img width="400" src="https://www.dealii.org/images/steps/developer/step-28.solution-1.9.order2.png" alt="">
 
 Then we plot the convergence data with polynomial order being equal to 1,2 and 3.
 


### PR DESCRIPTION
The previous way had the top of the second picture run into the bottom
of the first one. Since both are meshes, it was hard to see what was
going on.