### PR TITLE
Forward declare two explicit specializations.

### DIFF
--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -339,8 +339,19 @@ namespace TrilinosWrappers
      * Store a copy of the flags for this particular solver.
      */
     const AdditionalData additional_data;
-
   };
+
+
+  // provide a declaration for two explicit specializations
+  template <>
+  void
+  SolverBase::set_preconditioner(AztecOO                &solver,
+                                 const PreconditionBase &preconditioner);
+
+  template <>
+  void
+  SolverBase::set_preconditioner(AztecOO               &solver,
+                                 const Epetra_Operator &preconditioner);
 
 
 


### PR DESCRIPTION
#4001 removed an attempt at explicitly instantiating functions that were
in fact explicitly specialized (so no longer templates). This made me wonder
whether we in fact *declare* these specializations, as is strictly speaking
required by the standard. It turns out that we do not. Do do.