### PR TITLE
removed requirement of MPI support to compile with SLEPC

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -43,9 +43,7 @@
 #endif
 
 #ifdef DEAL_II_WITH_SLEPC
-#  ifdef DEAL_II_WITH_MPI
 #    include <slepcsys.h>
-#  endif
 #  include <deal.II/lac/slepc_solver.h>
 #endif
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -44,7 +44,7 @@
 
 #ifdef DEAL_II_WITH_SLEPC
 #    include <slepcsys.h>
-#  include <deal.II/lac/slepc_solver.h>
+#    include <deal.II/lac/slepc_solver.h>
 #endif
 
 #ifdef DEAL_II_WITH_P4EST


### PR DESCRIPTION
SLEPC actually does not require DEAL_II_WITH_MPI to be difined. SLEPC can be compiled with -with-mpi=0 PETSC flag as well.