### PR TITLE
Check that numdiff and diff can run with very simple input.

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -114,6 +114,26 @@ MACRO(DEAL_II_PICKUP_TESTS)
   ENDIF()
 
   #
+  # Check that the diff programs can run and terminate successfully:
+  #
+  FOREACH(_diff_program ${NUMDIFF_EXECUTABLE} ${DIFF_EXECUTABLE})
+    EXECUTE_PROCESS(COMMAND ${_diff_program} "-v"
+      TIMEOUT 4 # seconds
+      OUTPUT_QUIET
+      ERROR_QUIET
+      RESULT_VARIABLE _diff_program_status
+      )
+
+    IF(NOT "${_diff_program_status}" STREQUAL "0")
+      MESSAGE(FATAL_ERROR
+        "\nThe command \"${_diff_program} -v\" did not run correctly: it either "
+        "failed to exit after a few seconds or returned a nonzero exit code. "
+        "The test suite cannot be set up without this program, so please "
+        "reinstall it and then run the test suite setup command again.\n")
+    ENDIF()
+  ENDFOREACH()
+
+  #
   # Set time limit:
   #
 


### PR DESCRIPTION
I think that it is reasonable to add a sanity check here to make sure that the executables we pick up work. If people symlink diff to numdiff then there is not much we can do (what would they expect to happen if we feed the executable numdiff-only flags?) so I think this limited test suffices.

I tested this by replacing numdiff with a shell script:
```bash
#!/bin/bash
sleep 10
```
and things failed correctly.

Closes #3661.