### PR TITLE
Fix some issues reported by Coverity

### DIFF
--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -327,6 +327,9 @@ SolverCG<VectorType>::SolverCG (SolverControl        &cn,
                                 const AdditionalData     &data)
   :
   Solver<VectorType>(cn,mem),
+  Vr(NULL),
+  Vp(NULL),
+  Vz(NULL),
   additional_data(data)
 {}
 

--- a/include/deal.II/lac/trilinos_vector_base.h
+++ b/include/deal.II/lac/trilinos_vector_base.h
@@ -1225,12 +1225,14 @@ namespace TrilinosWrappers
   {
     AssertIsFinite(s);
 
-    const int ierr = vector->PutScalar(s);
-
+    int ierr = vector->PutScalar(s);
     AssertThrow (ierr == 0, ExcTrilinosError(ierr));
 
     if (nonlocal_vector.get() != 0)
-      nonlocal_vector->PutScalar(0.);
+      {
+        ierr = nonlocal_vector->PutScalar(0.);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
+      }
 
     return *this;
   }
@@ -1282,7 +1284,10 @@ namespace TrilinosWrappers
     Assert (!has_ghost_elements(), ExcGhostsPresent());
 
     if (last_action == Add)
-      vector->GlobalAssemble(Add);
+      {
+        const int ierr = vector->GlobalAssemble(Add);
+        AssertThrow (ierr == 0, ExcTrilinosError(ierr));
+      }
 
     if (last_action != Insert)
       last_action = Insert;

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -60,8 +60,7 @@ void ConvergenceTable::evaluate_convergence_rates(const std::string &data_column
 
   switch (rate_mode)
     {
-    case none:
-      break;
+    // case none: already considered above
     case reduction_rate:
       rate_key += "red.rate";
       no_rate_entries = columns[rate_key].entries.size();

--- a/source/base/path_search.cc
+++ b/source/base/path_search.cc
@@ -187,7 +187,7 @@ PathSearch::find (const std::string &filename,
         {
           return find(filename, *suffix, open_mode);
         }
-      catch (ExcFileNotFound)
+      catch (ExcFileNotFound &)
         {
           continue;
         }

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -31,6 +31,7 @@ namespace PETScWrappers
   namespace MPI
   {
     SparseMatrix::SparseMatrix ()
+      : communicator(MPI_COMM_SELF)
     {
       // just like for vectors: since we
       // create an empty matrix, we can as

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -30,6 +30,7 @@ namespace PETScWrappers
   {
 
     Vector::Vector ()
+      : communicator (MPI_COMM_SELF)
     {
       // this is an invalid empty vector, so we can just as well create a
       // sequential one to avoid all the overhead incurred by parallelism

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -170,7 +170,11 @@ namespace LinearAlgebra
       const Vector &down_V = dynamic_cast<const Vector &>(V);
       // If the maps are the same we can Update right away.
       if (vector->Map().SameAs(down_V.trilinos_vector().Map()))
-        vector->Update(1., down_V.trilinos_vector(), 1.);
+        {
+          const int ierr = vector->Update(1., down_V.trilinos_vector(), 1.);
+          Assert(ierr==0, ExcTrilinosError(ierr));
+          (void) ierr;
+        }
       else
         {
           Assert(this->size()==down_V.size(),
@@ -178,7 +182,8 @@ namespace LinearAlgebra
 
 #if DEAL_II_TRILINOS_VERSION_GTE(11,11,0)
           Epetra_Import data_exchange (vector->Map(), down_V.trilinos_vector().Map());
-          int ierr = vector->Import(down_V.trilinos_vector(), data_exchange, Epetra_AddLocalAlso);
+          const int ierr = vector->Import(down_V.trilinos_vector(),
+                                          data_exchange, Epetra_AddLocalAlso);
           Assert(ierr==0, ExcTrilinosError(ierr));
           (void) ierr;
 #else
@@ -190,7 +195,6 @@ namespace LinearAlgebra
 
           int ierr = dummy.Import(down_V.trilinos_vector(), data_exchange, Insert);
           Assert(ierr==0, ExcTrilinosError(ierr));
-          (void) ierr;
 
           ierr = vector->Update(1.0, dummy, 1.0);
           Assert(ierr==0, ExcTrilinosError(ierr));
@@ -427,6 +431,7 @@ namespace LinearAlgebra
     {
       const Epetra_MpiComm *epetra_comm
         = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()));
+      Assert (epetra_comm != 0, ExcInternalError());
       return epetra_comm->GetMpiComm();
     }
 

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -313,7 +313,7 @@ namespace TrilinosWrappers
   PreconditionAMG::size_type
   PreconditionAMG::memory_consumption() const
   {
-    unsigned int memory = sizeof(this);
+    unsigned int memory = sizeof(*this);
 
     // todo: find a way to read out ML's data
     // sizes

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -313,7 +313,7 @@ namespace TrilinosWrappers
   PreconditionAMGMueLu::size_type
   PreconditionAMGMueLu::memory_consumption() const
   {
-    unsigned int memory = sizeof(this);
+    unsigned int memory = sizeof(*this);
 
     // todo: find a way to read out ML's data
     // sizes

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2386,7 +2386,7 @@ namespace TrilinosWrappers
   SparseMatrix::size_type
   SparseMatrix::memory_consumption () const
   {
-    size_type static_memory = sizeof(this) + sizeof (*matrix)
+    size_type static_memory = sizeof(*this) + sizeof (*matrix)
                               + sizeof(*matrix->Graph().DataPtr());
     return ((sizeof(TrilinosScalar)+sizeof(TrilinosWrappers::types::int_type))*
             matrix->NumMyNonzeros() + sizeof(int)*local_size() + static_memory);
@@ -2433,6 +2433,7 @@ namespace TrilinosWrappers
 
     const Epetra_MpiComm *mpi_comm
       = dynamic_cast<const Epetra_MpiComm *>(&matrix->RangeMap().Comm());
+    Assert(mpi_comm != 0, ExcInternalError());
     return mpi_comm->Comm();
 #else
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -1051,6 +1051,7 @@ namespace TrilinosWrappers
 
     const Epetra_MpiComm *mpi_comm
       = dynamic_cast<const Epetra_MpiComm *>(&graph->RangeMap().Comm());
+    Assert (mpi_comm != 0, ExcInternalError());
     return mpi_comm->Comm();
 #else
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -238,10 +238,11 @@ namespace TrilinosWrappers
             }
         }
 #if defined(DEBUG) && defined(DEAL_II_WITH_MPI)
-      const MPI_Comm mpi_communicator
-        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()))->Comm();
+      const Epetra_MpiComm *comm_ptr
+        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()));
+      Assert (comm_ptr != 0, ExcInternalError());
       const size_type n_elements_global
-        = Utilities::MPI::sum (owned_elements.n_elements(), mpi_communicator);
+        = Utilities::MPI::sum (owned_elements.n_elements(), comm_ptr->Comm());
 
       Assert (has_ghosts || n_elements_global == size(), ExcInternalError());
 #endif
@@ -358,10 +359,11 @@ namespace TrilinosWrappers
           last_action = Insert;
         }
 #if defined(DEBUG) && defined(DEAL_II_WITH_MPI)
-      const MPI_Comm mpi_communicator
-        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()))->Comm();
+      const Epetra_MpiComm *comm_ptr
+        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()));
+      Assert (comm_ptr != 0, ExcInternalError());
       const size_type n_elements_global
-        = Utilities::MPI::sum (owned_elements.n_elements(), mpi_communicator);
+        = Utilities::MPI::sum (owned_elements.n_elements(), comm_ptr->Comm());
 
       Assert (has_ghosts || n_elements_global == size(), ExcInternalError());
 #endif
@@ -436,10 +438,11 @@ namespace TrilinosWrappers
           last_action = Insert;
         }
 #if defined(DEBUG) && defined(DEAL_II_WITH_MPI)
-      const MPI_Comm mpi_communicator
-        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()))->Comm();
+      const Epetra_MpiComm *comm_ptr
+        = dynamic_cast<const Epetra_MpiComm *>(&(vector->Comm()));
+      Assert (comm_ptr != 0, ExcInternalError());
       const size_type n_elements_global
-        = Utilities::MPI::sum (owned_elements.n_elements(), mpi_communicator);
+        = Utilities::MPI::sum (owned_elements.n_elements(), comm_ptr->Comm());
 
       Assert (has_ghosts || n_elements_global == size(), ExcInternalError());
 #endif


### PR DESCRIPTION
This adresses
- variables not initialized in the constructor
- checking the return value for Trilinos and PETSc function calls
- checking pointers after `dynamic_cast`
- catching by reference

in the considered files.