### PR TITLE
Restore stream flags after use.

### DIFF
--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -16,6 +16,8 @@
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/table.h>
 
+#include <boost/io/ios_state.hpp>
+
 #include <sstream>
 #include <iostream>
 #include <iomanip>
@@ -322,6 +324,7 @@ void TableHandler::write_text(std::ostream &out,
                               const TextOutputFormat format) const
 {
   AssertThrow (out, ExcIO());
+  boost::io::ios_flags_saver restore_flags(out);
 
   // first pad the table from below if necessary
   if (auto_fill_mode == true)

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -20,6 +20,9 @@
 #ifdef DEAL_II_WITH_MPI
 
 #include <deal.II/base/index_set.h>
+
+#include <boost/io/ios_state.hpp>
+
 #include "Epetra_Import.h"
 #include "Epetra_Map.h"
 #include "Epetra_MpiComm.h"
@@ -482,6 +485,7 @@ namespace LinearAlgebra
                        const bool across) const
     {
       AssertThrow(out, ExcIO());
+      boost::io::ios_flags_saver restore_flags(out);
 
       // Get a representation of the vector and loop over all
       // the elements

--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -25,6 +25,8 @@
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Import.h>
 #  include <Epetra_Export.h>
+
+#  include <boost/io/ios_state.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
@@ -487,6 +489,7 @@ namespace TrilinosWrappers
                      const bool         across) const
   {
     AssertThrow (out, ExcIO());
+    boost::io::ios_flags_saver restore_flags(out);
 
     // get a representation of the
     // vector and loop over all


### PR DESCRIPTION
This was caught by Coverity. Boost has a nice little class that restores flags when its destructor is called so this should be exception safe.

This is not technically backwards compatible if users are relying on widths set inside the library, but that is an obscure enough problem that I very much doubt this will cause any harm.