### PR TITLE
Add missing include file when compiling without threads.

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/vectorization.h>
 
+#include <cstring>
 #include <cstdio>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Fixes this error:
https://cdash.kyomu.43-1.org/testDetails.php?test=18027941&build=5456