### PR TITLE
Fix multigrid/mpi tests

### DIFF
--- a/tests/multigrid/mg_coarse_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
+++ b/tests/multigrid/mg_coarse_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
@@ -1,69 +1,70 @@
-Cycle 0:
-   Number of active cells:       144
-   Number of degrees of freedom: 1369 (by level: 361, 1369)
-CG(ID):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 31
-CG(ILU):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 19
-CG(AMG):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 1
-AMG:
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-applications: 3
-Cycle 1:
-   Number of active cells:       484
-   Number of degrees of freedom: 4489 (by level: 1156, 4489)
-CG(ID):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 56
-CG(ILU):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 30
-CG(AMG):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 1
-AMG:
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-applications: 3
-Cycle 2:
-   Number of active cells:       1024
-   Number of degrees of freedom: 9409 (by level: 2401, 9409)
-CG(ID):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 80
-CG(ILU):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 38
-CG(AMG):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 22
-AMG:
-check residual:0.0114115
-check residual:0.0128114
-check residual:0.0135806
-applications: 3
+
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       144
+DEAL::   Number of degrees of freedom: 1369 (by level: 361, 1369)
+DEAL::CG(ID):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 31
+DEAL::CG(ILU):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 19
+DEAL::CG(AMG):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 1
+DEAL::AMG:
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::applications: 3
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       484
+DEAL::   Number of degrees of freedom: 4489 (by level: 1156, 4489)
+DEAL::CG(ID):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 56
+DEAL::CG(ILU):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 30
+DEAL::CG(AMG):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 1
+DEAL::AMG:
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::applications: 3
+DEAL::Cycle 2:
+DEAL::   Number of active cells:       1024
+DEAL::   Number of degrees of freedom: 9409 (by level: 2401, 9409)
+DEAL::CG(ID):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 80
+DEAL::CG(ILU):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 38
+DEAL::CG(AMG):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 22
+DEAL::AMG:
+DEAL::check residual: 0.0114120
+DEAL::check residual: 0.0128120
+DEAL::check residual: 0.0135811
+DEAL::applications: 3

--- a/tests/multigrid/mg_coarse_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/multigrid/mg_coarse_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -1,69 +1,70 @@
-Cycle 0:
-   Number of active cells:       144
-   Number of degrees of freedom: 1369 (by level: 361, 1369)
-CG(ID):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 31
-CG(ILU):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 30
-CG(AMG):
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-coarse iterations: 1
-AMG:
-check residual:0.0231622
-check residual:0.0192417
-check residual:0.0172953
-applications: 3
-Cycle 1:
-   Number of active cells:       484
-   Number of degrees of freedom: 4489 (by level: 1156, 4489)
-CG(ID):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 56
-CG(ILU):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 50
-CG(AMG):
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-coarse iterations: 1
-AMG:
-check residual:0.012677
-check residual:0.0105349
-check residual:0.00947063
-applications: 3
-Cycle 2:
-   Number of active cells:       1024
-   Number of degrees of freedom: 9409 (by level: 2401, 9409)
-CG(ID):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 80
-CG(ILU):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 67
-CG(AMG):
-check residual:0.00872685
-check residual:0.00725329
-check residual:0.00652099
-coarse iterations: 20
-AMG:
-check residual:0.0115343
-check residual:0.0130869
-check residual:0.0139613
-applications: 3
+
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       144
+DEAL::   Number of degrees of freedom: 1369 (by level: 361, 1369)
+DEAL::CG(ID):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 31
+DEAL::CG(ILU):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 30
+DEAL::CG(AMG):
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::coarse iterations: 1
+DEAL::AMG:
+DEAL::check residual: 0.0231622
+DEAL::check residual: 0.0192417
+DEAL::check residual: 0.0172953
+DEAL::applications: 3
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       484
+DEAL::   Number of degrees of freedom: 4489 (by level: 1156, 4489)
+DEAL::CG(ID):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 56
+DEAL::CG(ILU):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 50
+DEAL::CG(AMG):
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::coarse iterations: 1
+DEAL::AMG:
+DEAL::check residual: 0.0126770
+DEAL::check residual: 0.0105349
+DEAL::check residual: 0.00947063
+DEAL::applications: 3
+DEAL::Cycle 2:
+DEAL::   Number of active cells:       1024
+DEAL::   Number of degrees of freedom: 9409 (by level: 2401, 9409)
+DEAL::CG(ID):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 80
+DEAL::CG(ILU):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 67
+DEAL::CG(AMG):
+DEAL::check residual: 0.00872685
+DEAL::check residual: 0.00725329
+DEAL::check residual: 0.00652099
+DEAL::coarse iterations: 20
+DEAL::AMG:
+DEAL::check residual: 0.0115344
+DEAL::check residual: 0.0130870
+DEAL::check residual: 0.0139614
+DEAL::applications: 3

--- a/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
+++ b/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
@@ -1,38 +1,41 @@
-Cycle 0:
-   Number of active cells:       94
-   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 14.15
-mg_interface_mat3 1.66667
-mg_mat4 15.7198
-mg_interface_mat4 2.44949
-mg_mat5 12.4007
-mg_interface_mat5 2.86744
-check3 iteration: 2.0047e-07
-   CG converged in 8 iterations.
- sol: 0 - 0.0765196
-Cycle 1:
-   Number of active cells:       376
-   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 20.8487
-mg_interface_mat3 0
-mg_mat4 30.1146
-mg_interface_mat4 2.60342
-mg_mat5 33.546
-mg_interface_mat5 3.74166
-mg_mat6 28.2686
-mg_interface_mat6 4.78423
-check3 iteration: 4.0548e-08
-   CG converged in 7 iterations.
- sol: 0 - 0.0743542
+
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       94
+DEAL::   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 14.1500
+DEAL::mg_interface_mat3 1.66667
+DEAL::mg_mat4 15.7198
+DEAL::mg_interface_mat4 2.44949
+DEAL::mg_mat5 12.4007
+DEAL::mg_interface_mat5 2.86744
+DEAL::check3 iteration: 2.00470e-07
+DEAL:cg::Starting value 0.141831
+DEAL:cg::Convergence step 8 value 1.02533e-10
+DEAL:: sol: 0.00000 - 0.0765196
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       376
+DEAL::   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 20.8487
+DEAL::mg_interface_mat3 0.00000
+DEAL::mg_mat4 30.1146
+DEAL::mg_interface_mat4 2.60342
+DEAL::mg_mat5 33.5460
+DEAL::mg_interface_mat5 3.74166
+DEAL::mg_mat6 28.2686
+DEAL::mg_interface_mat6 4.78423
+DEAL::check3 iteration: 4.05480e-08
+DEAL:cg::Starting value 0.0832842
+DEAL:cg::Convergence step 7 value 5.24092e-10
+DEAL:: sol: 0.00000 - 0.0743542

--- a/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=5.output
+++ b/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=5.output
@@ -1,38 +1,41 @@
-Cycle 0:
-   Number of active cells:       94
-   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 14.15
-mg_interface_mat3 1.66667
-mg_mat4 15.7198
-mg_interface_mat4 2.44949
-mg_mat5 12.4007
-mg_interface_mat5 2.86744
-check3 iteration: 2.0047e-07
-   CG converged in 8 iterations.
- sol: 0 - 0.0765196
-Cycle 1:
-   Number of active cells:       376
-   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 20.8487
-mg_interface_mat3 0
-mg_mat4 30.1146
-mg_interface_mat4 2.60342
-mg_mat5 33.546
-mg_interface_mat5 3.74166
-mg_mat6 28.2686
-mg_interface_mat6 4.78423
-check3 iteration: 4.0548e-08
-   CG converged in 7 iterations.
- sol: 0 - 0.0743542
+
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       94
+DEAL::   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 14.1500
+DEAL::mg_interface_mat3 1.66667
+DEAL::mg_mat4 15.7198
+DEAL::mg_interface_mat4 2.44949
+DEAL::mg_mat5 12.4007
+DEAL::mg_interface_mat5 2.86744
+DEAL::check3 iteration: 2.00470e-07
+DEAL:cg::Starting value 0.141831
+DEAL:cg::Convergence step 8 value 1.02533e-10
+DEAL:: sol: 0.00000 - 0.0765196
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       376
+DEAL::   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 20.8487
+DEAL::mg_interface_mat3 0.00000
+DEAL::mg_mat4 30.1146
+DEAL::mg_interface_mat4 2.60342
+DEAL::mg_mat5 33.5460
+DEAL::mg_interface_mat5 3.74166
+DEAL::mg_mat6 28.2686
+DEAL::mg_interface_mat6 4.78423
+DEAL::check3 iteration: 4.05480e-08
+DEAL:cg::Starting value 0.0832842
+DEAL:cg::Convergence step 7 value 5.24092e-10
+DEAL:: sol: 0.00000 - 0.0743542

--- a/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=8.output
+++ b/tests/multigrid/step-50_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=8.output
@@ -1,38 +1,41 @@
-Cycle 0:
-   Number of active cells:       94
-   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 14.15
-mg_interface_mat3 1.66667
-mg_mat4 15.7198
-mg_interface_mat4 2.44949
-mg_mat5 12.4007
-mg_interface_mat5 2.86744
-check3 iteration: 2.0047e-07
-   CG converged in 8 iterations.
- sol: 0 - 0.0765196
-Cycle 1:
-   Number of active cells:       376
-   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
-mg_mat0 1.33333
-mg_interface_mat0 0
-mg_mat1 4
-mg_interface_mat1 0
-mg_mat2 9.56847
-mg_interface_mat2 0
-mg_mat3 20.8487
-mg_interface_mat3 0
-mg_mat4 30.1146
-mg_interface_mat4 2.60342
-mg_mat5 33.546
-mg_interface_mat5 3.74166
-mg_mat6 28.2686
-mg_interface_mat6 4.78423
-check3 iteration: 4.0548e-08
-   CG converged in 7 iterations.
- sol: 0 - 0.0743542
+
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       94
+DEAL::   Number of degrees of freedom: 129 (by level: 4, 9, 25, 45, 57, 57)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 14.1500
+DEAL::mg_interface_mat3 1.66667
+DEAL::mg_mat4 15.7198
+DEAL::mg_interface_mat4 2.44949
+DEAL::mg_mat5 12.4007
+DEAL::mg_interface_mat5 2.86744
+DEAL::check3 iteration: 2.00470e-07
+DEAL:cg::Starting value 0.141831
+DEAL:cg::Convergence step 8 value 1.02533e-10
+DEAL:: sol: 0.00000 - 0.0765196
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       376
+DEAL::   Number of degrees of freedom: 445 (by level: 4, 9, 25, 81, 153, 193, 177)
+DEAL::mg_mat0 1.33333
+DEAL::mg_interface_mat0 0.00000
+DEAL::mg_mat1 4.00000
+DEAL::mg_interface_mat1 0.00000
+DEAL::mg_mat2 9.56847
+DEAL::mg_interface_mat2 0.00000
+DEAL::mg_mat3 20.8487
+DEAL::mg_interface_mat3 0.00000
+DEAL::mg_mat4 30.1146
+DEAL::mg_interface_mat4 2.60342
+DEAL::mg_mat5 33.5460
+DEAL::mg_interface_mat5 3.74166
+DEAL::mg_mat6 28.2686
+DEAL::mg_interface_mat6 4.78423
+DEAL::check3 iteration: 4.05480e-08
+DEAL:cg::Starting value 0.0832842
+DEAL:cg::Convergence step 7 value 5.24092e-10
+DEAL:: sol: 0.00000 - 0.0743542


### PR DESCRIPTION
Change two tests that previously got their compare files through the standard outstream. Now, we get that info through the proper deallog stream. On some systems, including my own machine, there was a spurious error complaining about
```
[warn] Epoll ADD(4) on fd 1 failed.  Old events were 0; read change was 0 (none); write change was 1 (add): Operation not permitted
```
see here:
https://cdash.kyomu.43-1.org/testDetails.php?test=18175566&build=5499