### PR TITLE
Fix asserts in destructors

### DIFF
--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1495,7 +1495,12 @@ template <typename MatrixType>
 inline
 BlockMatrixBase<MatrixType>::~BlockMatrixBase ()
 {
-  clear ();
+  try
+    {
+      clear ();
+    }
+  catch (...)
+    {}
 }
 
 

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -368,7 +368,12 @@ template <typename VectorType>
 inline
 VectorMemory<VectorType>::Pointer::~Pointer()
 {
-  pool->free(v);
+  try
+    {
+      pool->free(v);
+    }
+  catch (...)
+    {}
 }
 
 

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -353,8 +353,13 @@ TimerOutput::TimerOutput (MPI_Comm      mpi_communicator,
 
 TimerOutput::~TimerOutput()
 {
-  while (active_sections.size() > 0)
-    leave_subsection();
+  try
+    {
+      while (active_sections.size() > 0)
+        leave_subsection();
+    }
+  catch (...)
+    {}
 
   if ( (output_frequency == summary || output_frequency == every_call_and_summary)
        && output_is_enabled == true)

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -64,7 +64,12 @@ template <class SparsityPatternBase>
 BlockSparsityPatternBase<SparsityPatternBase>::~BlockSparsityPatternBase ()
 {
   // clear all memory
-  reinit (0,0);
+  try
+    {
+      reinit (0,0);
+    }
+  catch (...)
+    {}
 }
 
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -37,7 +37,12 @@ namespace PETScWrappers
 
   PreconditionerBase::~PreconditionerBase ()
   {
-    clear();
+    try
+      {
+        clear();
+      }
+    catch (...)
+      {}
   }
 
   void

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -206,7 +206,8 @@ namespace PETScWrappers
 #else
         const PetscErrorCode ierr = VecDestroy (&vector);
 #endif
-        AssertThrow (ierr == 0, ExcPETScError(ierr));
+        AssertNothrow (ierr == 0, ExcPETScError(ierr));
+        (void) ierr;
       }
   }
 

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -33,7 +33,12 @@ namespace TrilinosWrappers
   {
     // delete previous content of
     // the subobjects array
-    clear ();
+    try
+      {
+        clear ();
+      }
+    catch (...)
+      {}
   }
 
 

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -51,8 +51,13 @@ TimeDependent::TimeDependent (const TimeSteppingData &data_primal,
 
 TimeDependent::~TimeDependent ()
 {
-  while (timesteps.size() != 0)
-    delete_timestep (0);
+  try
+    {
+      while (timesteps.size() != 0)
+        delete_timestep (0);
+    }
+  catch (...)
+    {}
 }
 
 


### PR DESCRIPTION
This is again resulting from the Coverty scan.
Calling `Assert` or `AssertNothrow` is uncritical as long as `disable_abort_on_exception` was not called. By wrapping possibly offending functions in a `try-catch-block`, we avoid double-exception situations and hiding exceptions also in the latter case.

Even if we only call `AssertNothrow`, Coverty still thinks that we might `throw`. Hence, there are also some false-positives in the report of the scan.