### PR TITLE
Make compile without C++11

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -779,7 +779,6 @@ namespace MatrixFreeOperators
   Base<dim,VectorType>::Base ()
     :
     Subscriptor(),
-    data(NULL),
     have_interface_matrices(false)
   {
   }


### PR DESCRIPTION
This fixes the build error
https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=5523