### PR TITLE
Use Assert, not AssertThrow, with ExcInternalError.

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1909,7 +1909,7 @@ namespace internal
                   return dim+c;
 
             // should never get here:
-            AssertThrow(false, ExcInternalError());
+            Assert(false, ExcInternalError());
             return 0;
           }
           }
@@ -2011,7 +2011,7 @@ namespace internal
                   return TableIndices<2>(d,e);
 
             // should never get here:
-            AssertThrow(false, ExcInternalError());
+            Assert(false, ExcInternalError());
             return TableIndices<2>(0, 0);
           }
       }

--- a/include/deal.II/lac/swappable_vector.templates.h
+++ b/include/deal.II/lac/swappable_vector.templates.h
@@ -223,7 +223,8 @@ void SwappableVector<number>::kill_file ()
   if (filename != "")
     {
       int status = std::remove (filename.c_str());
-      AssertThrow (status == 0, ExcInternalError());
+      (void)status;
+      Assert (status == 0, ExcInternalError());
 
       filename = "";
     };

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -138,7 +138,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
       partition();
       this->update_number_cache ();

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -882,7 +882,7 @@ namespace
             break;
           }
           default:
-            AssertThrow (false, ExcInternalError());
+            Assert (false, ExcInternalError());
           }
       }
   }
@@ -1335,7 +1335,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       // note that now we have some content in the p4est objects and call the
@@ -1355,7 +1355,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       this->update_number_cache ();
@@ -1884,7 +1884,7 @@ namespace parallel
           // triangulation should not
           // be checking for
           // distorted cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       this->update_number_cache ();
@@ -2568,7 +2568,7 @@ namespace parallel
               {
                 // the underlying triangulation should not be checking for
                 // distorted cells
-                AssertThrow (false, ExcInternalError());
+                Assert (false, ExcInternalError());
               }
 
             refinement_in_progress = saved_refinement_in_progress;
@@ -2689,7 +2689,7 @@ namespace parallel
             {
               // the underlying triangulation should not be checking for
               // distorted cells
-              AssertThrow (false, ExcInternalError());
+              Assert (false, ExcInternalError());
             }
 
           refinement_in_progress = saved_refinement_in_progress;
@@ -2986,7 +2986,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
 #ifdef DEBUG
@@ -3102,7 +3102,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       refinement_in_progress = false;
@@ -3657,7 +3657,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       //finally call the base class for storing the periodicity information
@@ -3714,7 +3714,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       // note that now we have some content in the p4est objects and call the
@@ -3755,7 +3755,7 @@ namespace parallel
         {
           // the underlying triangulation should not be checking for distorted
           // cells
-          AssertThrow (false, ExcInternalError());
+          Assert (false, ExcInternalError());
         }
 
       this->update_number_cache ();

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -1039,7 +1039,7 @@ namespace DoFTools
       const dealii::hp::FECollection<dim,spacedim> *
       get_fe_collection (const dealii::DoFHandler<dim,spacedim> &)
       {
-        AssertThrow(false, ExcInternalError());
+        Assert(false, ExcInternalError());
         return NULL;
       }
     }

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -74,7 +74,7 @@ namespace FE_Q_Bubbles_Helper
           q_fine.reset(new QGauss<dim> (degree+1));
           break;
         default:
-          AssertThrow(false, ExcInternalError());
+          Assert(false, ExcInternalError());
         }
 
       Assert(q_fine.get() != NULL, ExcInternalError());

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -329,7 +329,7 @@ namespace GridGenerator
                       cell->face(f)->line(j)->set_boundary_id(1);
               }
             else
-              AssertThrow (false, ExcInternalError());
+              Assert (false, ExcInternalError());
           }
     }
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1777,7 +1777,7 @@ void GridIn<2>::read_netcdf (const std::string &filename)
   vertex_indices_var->get(&*vertex_indices.begin(), n_bquads, vertices_per_quad);
 
   for (unsigned int i=0; i<vertex_indices.size(); ++i)
-    AssertThrow(vertex_indices[i]>=0, ExcInternalError());
+    Assert(vertex_indices[i]>=0, ExcInternalError());
 
   if (output)
     {
@@ -1948,7 +1948,7 @@ void GridIn<3>::read_netcdf (const std::string &filename)
   vertex_indices_var->get(&*vertex_indices.begin(), n_cells, vertices_per_hex);
 
   for (unsigned int i=0; i<vertex_indices.size(); ++i)
-    AssertThrow(vertex_indices[i]>=0, ExcInternalError());
+    Assert(vertex_indices[i]>=0, ExcInternalError());
 
   if (output)
     {

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3530,7 +3530,7 @@ next_cell:
       if (matching == m_tff) return 1;           // [true ,false,false]
       static const MATCH_T m_ttf = {{ 1 , 0 }};
       if (matching == m_ttf) return 3;           // [true ,true ,false]
-      AssertThrow(false, ExcInternalError());
+      Assert(false, ExcInternalError());
       // what follows is dead code, but it avoids warnings about the lack
       // of a return value
       return 0;
@@ -3563,7 +3563,7 @@ next_cell:
       if (matching == m_ftf) return 2;                   // [false,true ,false]
       static const MATCH_T m_ftt = {{ 1 , 0 , 3 , 2 }};
       if (matching == m_ftt) return 6;                   // [false,true ,true ]
-      AssertThrow(false, ExcInternalError());
+      Assert(false, ExcInternalError());
       // what follows is dead code, but it avoids warnings about the lack
       // of a return value
       return 0;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1689,7 +1689,7 @@ namespace internal
               default:
                 // in 1d, a node must have one or two adjacent lines
                 if (spacedim==1)
-                  AssertThrow (false, ExcInternalError())
+                  Assert (false, ExcInternalError())
                   else
                     AssertThrow (false,
                                  ExcMessage ("You have a vertex in your triangulation "

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -468,7 +468,7 @@ LAPACKFullMatrix<number>::compute_lu_factorization()
   int info = 0;
   getrf(&mm, &nn, values, &mm, &ipiv[0], &info);
 
-  AssertThrow(info >= 0, ExcInternalError());
+  Assert(info >= 0, ExcInternalError());
   AssertThrow(info == 0, LACExceptions::ExcSingular());
 
   state = lu;
@@ -559,14 +559,14 @@ LAPACKFullMatrix<number>::invert()
     {
       getrf(&mm, &nn, values, &mm, &ipiv[0], &info);
 
-      AssertThrow(info >= 0, ExcInternalError());
+      Assert(info >= 0, ExcInternalError());
       AssertThrow(info == 0, LACExceptions::ExcSingular());
     }
 
   inv_work.resize (mm);
   getri(&mm, values, &mm, &ipiv[0], &inv_work[0], &mm, &info);
 
-  AssertThrow(info >= 0, ExcInternalError());
+  Assert(info >= 0, ExcInternalError());
   AssertThrow(info == 0, LACExceptions::ExcSingular());
 
   state = inverse_matrix;
@@ -591,7 +591,7 @@ LAPACKFullMatrix<number>::apply_lu_factorization(Vector<number> &v,
   getrs(trans, &nn, &one, values, &nn, &ipiv[0],
         v.begin(), &nn, &info);
 
-  AssertThrow(info == 0, ExcInternalError());
+  Assert(info == 0, ExcInternalError());
 }
 
 
@@ -613,7 +613,7 @@ LAPACKFullMatrix<number>::apply_lu_factorization(LAPACKFullMatrix<number> &B,
 
   getrs(trans, &nn, &kk, values, &nn, &ipiv[0], &B.values[0], &nn, &info);
 
-  AssertThrow(info == 0, ExcInternalError());
+  Assert(info == 0, ExcInternalError());
 }
 
 


### PR DESCRIPTION
I was curious, after seeing @tamiko's comment in #4034, whether or not we do this anywhere else and indeed we do (these were easy to find with grep).