### PR TITLE
Deprecate SwappableVector.

### DIFF
--- a/include/deal.II/lac/swappable_vector.h
+++ b/include/deal.II/lac/swappable_vector.h
@@ -50,6 +50,8 @@ DEAL_II_NAMESPACE_OPEN
  * @ref Instantiations
  * in the manual).
  *
+ * @deprecated The usage of this class is deprecated.
+ *
  * @author Wolfgang Bangerth, 1999, 2000
  */
 template <typename number>
@@ -207,7 +209,7 @@ private:
    * to signal success itself if this is required.
    */
   void reload_vector (const bool set_flag);
-};
+} DEAL_II_DEPRECATED;
 
 /*@}*/
 /*----------------------------   swappable_vector.h     ---------------------------*/


### PR DESCRIPTION
This class is not used anywhere in the library nor are there any tests for it. Since more modern machines have tons of memory I think that the use case for this is not as strong as it used to be and we can retire this. Thoughts?

I noticed this while writing #4039: I had not seen this class before that.