### PR TITLE
Fix two more tests

### DIFF
--- a/tests/base/memory_consumption_01.with_64bit_indices=on.output.2
+++ b/tests/base/memory_consumption_01.with_64bit_indices=on.output.2
@@ -1,0 +1,139 @@
+
+DEAL::1d
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       8
+DEAL::   Number of degrees of freedom: 17
+DEAL::Memory consumption -- Triangulation: 3090
+DEAL::Memory consumption -- DoFHandler:    1320
+DEAL::Memory consumption -- FE:            1480
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      792
+DEAL::Memory consumption -- Matrix:        632
+DEAL::Memory consumption -- Solution:      248
+DEAL::Memory consumption -- Rhs:           248
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       11
+DEAL::   Number of degrees of freedom: 23
+DEAL::Memory consumption -- Triangulation: 4026
+DEAL::Memory consumption -- DoFHandler:    1616
+DEAL::Memory consumption -- FE:            1480
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      1032
+DEAL::Memory consumption -- Matrix:        824
+DEAL::Memory consumption -- Solution:      296
+DEAL::Memory consumption -- Rhs:           296
+DEAL::Cycle 2:
+DEAL::   Number of active cells:       15
+DEAL::   Number of degrees of freedom: 31
+DEAL::Memory consumption -- Triangulation: 4946
+DEAL::Memory consumption -- DoFHandler:    1952
+DEAL::Memory consumption -- FE:            1480
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      1352
+DEAL::Memory consumption -- Matrix:        1080
+DEAL::Memory consumption -- Solution:      360
+DEAL::Memory consumption -- Rhs:           360
+DEAL::Cycle 3:
+DEAL::   Number of active cells:       20
+DEAL::   Number of degrees of freedom: 41
+DEAL::Memory consumption -- Triangulation: 6090
+DEAL::Memory consumption -- DoFHandler:    2360
+DEAL::Memory consumption -- FE:            1480
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      1752
+DEAL::Memory consumption -- Matrix:        1400
+DEAL::Memory consumption -- Solution:      440
+DEAL::Memory consumption -- Rhs:           440
+DEAL::Memory consumption -- DataOut:       3394
+DEAL::2d
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       20
+DEAL::   Number of degrees of freedom: 89
+DEAL::Memory consumption -- Triangulation: 5415
+DEAL::Memory consumption -- DoFHandler:    3328
+DEAL::Memory consumption -- FE:            3896
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      11352
+DEAL::Memory consumption -- Matrix:        10616
+DEAL::Memory consumption -- Solution:      824
+DEAL::Memory consumption -- Rhs:           824
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       44
+DEAL::   Number of degrees of freedom: 209
+DEAL::Memory consumption -- Triangulation: 11183
+DEAL::Memory consumption -- DoFHandler:    6848
+DEAL::Memory consumption -- FE:            3896
+DEAL::Memory consumption -- Constraints:   4634
+DEAL::Memory consumption -- Sparsity:      27864
+DEAL::Memory consumption -- Matrix:        26168
+DEAL::Memory consumption -- Solution:      1784
+DEAL::Memory consumption -- Rhs:           1784
+DEAL::Cycle 2:
+DEAL::   Number of active cells:       92
+DEAL::   Number of degrees of freedom: 449
+DEAL::Memory consumption -- Triangulation: 21895
+DEAL::Memory consumption -- DoFHandler:    13712
+DEAL::Memory consumption -- FE:            3896
+DEAL::Memory consumption -- Constraints:   15290
+DEAL::Memory consumption -- Sparsity:      62360
+DEAL::Memory consumption -- Matrix:        58744
+DEAL::Memory consumption -- Solution:      3704
+DEAL::Memory consumption -- Rhs:           3704
+DEAL::Cycle 3:
+DEAL::   Number of active cells:       200
+DEAL::   Number of degrees of freedom: 921
+DEAL::Memory consumption -- Triangulation: 44023
+DEAL::Memory consumption -- DoFHandler:    28688
+DEAL::Memory consumption -- FE:            3896
+DEAL::Memory consumption -- Constraints:   28122
+DEAL::Memory consumption -- Sparsity:      128216
+DEAL::Memory consumption -- Matrix:        120824
+DEAL::Memory consumption -- Solution:      7480
+DEAL::Memory consumption -- Rhs:           7480
+DEAL::Memory consumption -- DataOut:       42854
+DEAL::3d
+DEAL::Cycle 0:
+DEAL::   Number of active cells:       56
+DEAL::   Number of degrees of freedom: 517
+DEAL::Memory consumption -- Triangulation: 25011
+DEAL::Memory consumption -- DoFHandler:    18952
+DEAL::Memory consumption -- FE:            12272
+DEAL::Memory consumption -- Constraints:   122
+DEAL::Memory consumption -- Sparsity:      240440
+DEAL::Memory consumption -- Matrix:        236280
+DEAL::Memory consumption -- Solution:      4248
+DEAL::Memory consumption -- Rhs:           4248
+DEAL::Cycle 1:
+DEAL::   Number of active cells:       217
+DEAL::   Number of degrees of freedom: 2217
+DEAL::Memory consumption -- Triangulation: 98505
+DEAL::Memory consumption -- DoFHandler:    75360
+DEAL::Memory consumption -- FE:            12272
+DEAL::Memory consumption -- Constraints:   78490
+DEAL::Memory consumption -- Sparsity:      1134184
+DEAL::Memory consumption -- Matrix:        1116424
+DEAL::Memory consumption -- Solution:      17848
+DEAL::Memory consumption -- Rhs:           17848
+DEAL::Cycle 2:
+DEAL::   Number of active cells:       896
+DEAL::   Number of degrees of freedom: 9373
+DEAL::Memory consumption -- Triangulation: 395027
+DEAL::Memory consumption -- DoFHandler:    301880
+DEAL::Memory consumption -- FE:            12272
+DEAL::Memory consumption -- Constraints:   487354
+DEAL::Memory consumption -- Sparsity:      5034296
+DEAL::Memory consumption -- Matrix:        4959288
+DEAL::Memory consumption -- Solution:      75096
+DEAL::Memory consumption -- Rhs:           75096
+DEAL::Cycle 3:
+DEAL::   Number of active cells:       3248
+DEAL::   Number of degrees of freedom: 32433
+DEAL::Memory consumption -- Triangulation: 1390231
+DEAL::Memory consumption -- DoFHandler:    1083256
+DEAL::Memory consumption -- FE:            12272
+DEAL::Memory consumption -- Constraints:   1729818
+DEAL::Memory consumption -- Sparsity:      16643416
+DEAL::Memory consumption -- Matrix:        16383928
+DEAL::Memory consumption -- Solution:      259576
+DEAL::Memory consumption -- Rhs:           259576
+DEAL::Memory consumption -- DataOut:       1159790

--- a/tests/base/mpi_exceptions.mpirun=1.output.openmpi1-8
+++ b/tests/base/mpi_exceptions.mpirun=1.output.openmpi1-8
@@ -1,0 +1,61 @@
+
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_BUFFER: invalid buffer pointer".
+The numerical value of the original error code is 1.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_COUNT: invalid count argument".
+The numerical value of the original error code is 2.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TYPE: invalid datatype".
+The numerical value of the original error code is 3.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TAG: invalid tag".
+The numerical value of the original error code is 4.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_COMM: invalid communicator".
+The numerical value of the original error code is 5.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_RANK: invalid rank".
+The numerical value of the original error code is 6.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_REQUEST: invalid request".
+The numerical value of the original error code is 7.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_ROOT: invalid root".
+The numerical value of the original error code is 8.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_GROUP: invalid group".
+The numerical value of the original error code is 9.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_OP: invalid reduce operation".
+The numerical value of the original error code is 10.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_TOPOLOGY: invalid communicator topology".
+The numerical value of the original error code is 11.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_UNKNOWN: unknown error".
+The numerical value of the original error code is 14.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_OTHER: known error not in list".
+The numerical value of the original error code is 16.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+The description of the error provided by MPI is "MPI_ERR_INTERN: internal error".
+The numerical value of the original error code is 17.
+DEAL::
+deal.II encountered an error while calling an MPI function.
+This error code is not equal to any of the standard MPI error codes.
+The numerical value of the original error code is 71.


### PR DESCRIPTION
For the MPI exceptions, OpenMPI 1.8.x. uses a different error code for `MPI_ERR_LASTCODE` than previous versions, so we need an additional output file.