### PR TITLE
Limit number of threads to 1 in some parallel tests.

### DIFF
--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -416,7 +416,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -236,7 +236,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -578,7 +578,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -305,7 +305,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -576,7 +576,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   mpi_initlog();
   deallog.threshold_double(1e-9);

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -305,7 +305,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -413,7 +413,7 @@ void test ()
 
 int main (int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
   mpi_initlog();
   deallog.threshold_double(1e-9);

--- a/tests/multigrid/dof_05.cc
+++ b/tests/multigrid/dof_05.cc
@@ -45,7 +45,7 @@ void check()
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
   check<2> ();
   check<3> ();

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -490,7 +490,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   try
     {

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -472,7 +472,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   try
     {

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -472,7 +472,7 @@ int main (int argc, char **argv)
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   try
     {

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -99,7 +99,7 @@ void check()
 
 int main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   mpi_initlog();
 
   check<2>();

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -157,7 +157,7 @@ private:
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   MPILogInitAll log;
 
   Test test1(false);

--- a/tests/trilinos/sparse_matrix_mmult_01.cc
+++ b/tests/trilinos/sparse_matrix_mmult_01.cc
@@ -36,7 +36,7 @@ void out_matrix_size(const MATRIX &M,
 
 int main(int argc, char *argv[])
 {
-  Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   initlog();
 


### PR DESCRIPTION
Some tests, in particular `matrix_free/parallel_multigrid_XXX`, take extremely long time to run on machines with many cores: 7 MPI tasks with 24 threads each are clearly too much... ;-)