### PR TITLE
Fix disconnect of listener in FEValues

### DIFF
--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2628,12 +2628,21 @@ protected:
 
   /**
    * A signal connection we use to ensure we get informed whenever the
-   * triangulation changes. We need to know about that because it invalidates
-   * all cell iterators and, as part of that, the 'present_cell' iterator we
-   * keep around between subsequent calls to reinit() in order to compute the
-   * cell similarity.
+   * triangulation changes by refinement. We need to know about that because
+   * it invalidates all cell iterators and, as part of that, the
+   * 'present_cell' iterator we keep around between subsequent calls to
+   * reinit() in order to compute the cell similarity.
    */
-  boost::signals2::connection tria_listener;
+  boost::signals2::connection tria_listener_refinement;
+
+  /**
+   * A signal connection we use to ensure we get informed whenever the
+   * triangulation changes by mesh transformations. We need to know about that
+   * because it invalidates all cell iterators and, as part of that, the
+   * 'present_cell' iterator we keep around between subsequent calls to
+   * reinit() in order to compute the cell similarity.
+   */
+  boost::signals2::connection tria_listener_mesh_transform;
 
   /**
    * A function that is connected to the triangulation in order to reset the


### PR DESCRIPTION
This fixes a bug introduced by #4050 where we did not disconnect the mesh movement listener. I must admit that I do not fully understand the signal details and whether I made my life unnecessarily complicated. I would appreciate if you could have a look @bangerth.