### PR TITLE
Fix base/symmetric_tensor_39 for clang

### DIFF
--- a/tests/base/symmetric_tensor_39.cc
+++ b/tests/base/symmetric_tensor_39.cc
@@ -13,10 +13,29 @@
 //
 // ---------------------------------------------------------------------
 
+// test that multiplying a rank-4 (identity) symmetric tensor and
+// a rank-2 symmetric tensor works correctly for VectorizedArray<double>
+
 #include "../tests.h"
 
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/vectorization.h>
+
+
+// Trying to fill the rank-2 ensor in the main function triggers a compiler bug
+// in clang-3.7.0 and clang-3.9.1 in release mode. Hence, use a separate function.
+template <int dim, typename Number>
+void fill_tensor(dealii::SymmetricTensor<2,dim,dealii::VectorizedArray<Number> > &A)
+{
+  Number counter = 0.0;
+  for (unsigned int i = 0; i < dim; ++i)
+    for (unsigned int j = 0; j < dim; ++j)
+      for (unsigned int v = 0; v < dealii::VectorizedArray<Number>::n_array_elements; v++)
+        {
+          A[i][j][v] = counter;
+          counter += 1.0;
+        }
+}
 
 int main()
 {
@@ -35,14 +54,7 @@ int main()
         for (unsigned int l = 0; l < dim; l++)
           I[i][j][k][l] = ( (i == k && j== l && i == l && j == k) ? make_vectorized_array(1.0) : ( (i == k && j== l) || (i == l && j == k) ? make_vectorized_array(0.5) : make_vectorized_array(0.0)));
 
-  double counter = 0.0;
-  for (unsigned int i = 0; i < dim; ++i)
-    for (unsigned int j = 0; j < dim; ++j)
-      for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; v++)
-        {
-          A[i][j][v] = counter;
-          counter += 1.0;
-        }
+  fill_tensor(A);
 
   B = I*A;
   B -= A;


### PR DESCRIPTION
`base/symmetric_tensor_39` fails for all clang versions I tried and also on the [tester](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=base%2Fsymmetric_tensor_39.release&date=2017-03-09) in release mode.
The problem appears when changing from `O1`to `O2`. Interestingly printing anything to `std::cout` just before  
``` 
B = I*A;
```
fixes this and this is the only fix I found so far. Without this, the result of `B=I*A` is zero for all components. Any hints on what could possibly be going on?