### PR TITLE
Add forward declaration of vectorized array

### DIFF
--- a/doc/news/changes/minor/20170312MartinKronbichler
+++ b/doc/news/changes/minor/20170312MartinKronbichler
@@ -1,0 +1,6 @@
+Fixed: By moving a forward declaration of VectorizedArray to a more central
+place, it is now possible to use the norm() methods of Tensor, Point or
+SymmetricTensor objects of VectorizedArray classes without particular order of
+include files.
+<br>
+(Martin Kronbichler, 2017/03/12)

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -26,6 +26,26 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// forward declarations to support abs or sqrt operations on VectorizedArray
+template <typename Number> class VectorizedArray;
+template <typename T> struct EnableIfScalar;
+
+DEAL_II_NAMESPACE_CLOSE
+
+namespace std
+{
+  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
+  sqrt(const ::dealii::VectorizedArray<Number> &);
+  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
+  abs(const ::dealii::VectorizedArray<Number> &);
+  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
+  max(const ::dealii::VectorizedArray<Number> &, const ::dealii::VectorizedArray<Number> &);
+  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
+  min (const ::dealii::VectorizedArray<Number> &, const ::dealii::VectorizedArray<Number> &);
+}
+
+DEAL_II_NAMESPACE_OPEN
+
 /**
  * Namespace for the declaration of universal constants. Since the
  * availability in <tt>math.h</tt> is not always guaranteed, we put them here.

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -46,26 +46,6 @@
 #endif
 
 
-// forward declarations
-DEAL_II_NAMESPACE_OPEN
-template <typename Number> class VectorizedArray;
-template <typename T> struct EnableIfScalar;
-DEAL_II_NAMESPACE_CLOSE
-
-
-namespace std
-{
-  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
-  sqrt(const ::dealii::VectorizedArray<Number> &);
-  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
-  abs(const ::dealii::VectorizedArray<Number> &);
-  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
-  max(const ::dealii::VectorizedArray<Number> &, const ::dealii::VectorizedArray<Number> &);
-  template <typename Number> DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number>
-  min (const ::dealii::VectorizedArray<Number> &, const ::dealii::VectorizedArray<Number> &);
-}
-
-
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/tests/base/vectorization_08.cc
+++ b/tests/base/vectorization_08.cc
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// check that operations on tensors of vectorized arrays are properly
+// supported
+
+#include "../tests.h"
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/vectorization.h>
+
+int main()
+{
+  initlog();
+
+  Tensor<1,2,VectorizedArray<double> > t;
+  deallog << "Tensor norm: " << t.norm()[0] << std::endl;
+  Point<3,VectorizedArray<float> > p;
+  deallog << "Point norm: " << p.norm()[0] << std::endl;
+  SymmetricTensor<2,3,VectorizedArray<double> > st2;
+  SymmetricTensor<4,2,VectorizedArray<double> > st4;
+  deallog << "Symmetric tensor norm: " << st2.norm()[0]
+          << " " << st4.norm()[0] << std::endl;
+}

--- a/tests/base/vectorization_08.output
+++ b/tests/base/vectorization_08.output
@@ -1,0 +1,4 @@
+
+DEAL::Tensor norm: 0.00000
+DEAL::Point norm: 0
+DEAL::Symmetric tensor norm: 0.00000 0.00000


### PR DESCRIPTION
Previously, invoking `Tensor<1,dim,VectorizedArray<double> >::norm()` would yield a compile error unless `vectorization.h` was included before `tensor.h`. To fix this, we need to forward declare `VectorizedArray` in a central place in `numbers.h` before the `NumberTraits` are defined. Since `numbers.h` is included in `config.h` and thus in `tensor.h`, the compiler now knows that there might be a `VectorizedArray` class around with a definition of `std::sqrt` and `std::abs` on it, thus compiling.

I realized this while looking at #4058 and simplifying code a bit: The commit to `symmetric_tensor.h` simplifies multiplication by two a little bit by writing `sum += sum;` rather than `sum *= 2.0`. I realized that by looking at the assembler output of clang. This is a typical strength reduction optimization (additions are cheaper than multiplications) but I think in this particular case it is actually also cleaner to read because we add the contributions from both sides of the diagonal. (If there is big objections against this commit, I can remove it again.)