### PR TITLE
Replace FE::interpolate() by FE::convert_support_point_values_to_nodal_values().

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1941,11 +1941,13 @@ public:
    * element has support points. In this case, the resulting coefficients are
    * just the values in the support points. All other elements must
    * reimplement it.
+   *
+   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
    */
   virtual
   void
   interpolate(std::vector<double>       &local_dofs,
-              const std::vector<double> &values) const;
+              const std::vector<double> &values) const DEAL_II_DEPRECATED;
 
   /**
    * Interpolate a set of vector values, computed in the generalized support
@@ -1955,21 +1957,25 @@ public:
    * <tt>offset</tt> is used to determine the first component of the vector to
    * be interpolated. Maybe consider changing your data structures to use the
    * next function.
+   *
+   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
    */
   virtual
   void
   interpolate(std::vector<double>                &local_dofs,
               const std::vector<Vector<double> > &values,
-              const unsigned int                  offset = 0) const;
+              const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
 
   /**
    * Interpolate a set of vector values, computed in the generalized support
    * points.
+   *
+   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
    */
   virtual
   void
   interpolate(std::vector<double>                                         &local_dofs,
-              const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+              const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
   //@}
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1933,6 +1933,78 @@ public:
   GeometryPrimitive
   get_associated_geometry_primitive (const unsigned int cell_dof_index) const;
 
+
+  /**
+   * Given the values of a function $f(\mathbf x)$ at the (generalized) support
+   * points, this function then computes what the nodal values of the element
+   * are, i.e., $\Psi_i[f]$, where $\Psi_i$ are the node functionals of
+   * the element. The values $\Psi_i[f]$ are then the expansion coefficients
+   * for the shape functions of the finite element function that
+   * <i>interpolates</i> the given function $f(x)$, i.e.,
+   * $ f_h(\mathbf x) = \sum_i \Psi_i[f] \varphi_i(\mathbf x)
+   * $ is the finite element interpolant of $f$ with the current element.
+   * The operation described here is used, for example, in the
+   * FETools::compute_node_matrix() function.
+   *
+   * In more detail, let us assume that the generalized support points
+   * (see @ref GlossGeneralizedSupport "this glossary entry") of the current
+   * element are $\hat{\mathbf x}_i$ and that the node functionals associated
+   * with the current element are $\Psi_i[\cdot]$. Then, the fact that the
+   * element is based on generalized support points, implies that if we
+   * apply $\Psi_i$ to a (possibly vector-valued) finite element function
+   * $\varphi$, the result must have the form
+   * $\Psi_i[\varphi] = f_i(\varphi(\hat{\mathbf x}_i))$ -- in other words,
+   * the value of the node functional $\Psi_i$ applied to $\varphi$ <i>only</i>
+   * depends on the <i>values of $\varphi$ at $\hat{\mathbf x}_i$</i> and not
+   * on values anywhere else, or integrals of $\varphi$, or any other kind
+   * of information.
+   *
+   * The exact form of $f_i$ depends on the element. For example, for scalar
+   * @ref GlossLagrange "Lagrange elements", we have that in fact
+   * $\Psi_i[\varphi] = \varphi(\hat{\mathbf x}_i)$. If you combine multiple
+   * scalar Lagrange elements via an FESystem object, then
+   * $\Psi_i[\varphi] = \varphi(\hat{\mathbf x}_i)_{c(i)}$ where $c(i)$
+   * is the result of the FiniteElement::system_to_component_index()
+   * function's return value's first component. In these two cases,
+   * $f_i$ is therefore simply the identity (in the scalar case) or a
+   * function that selects a particular vector component of its argument.
+   * On the other hand, for Raviart-Thomas elements, one would have that
+   * $f_i(\mathbf y) = \mathbf y \cdot \mathbf n_i$ where $\mathbf n_i$
+   * is the normal vector of the face at which the shape function is
+   * defined.
+   *
+   * Given all of this, what this function does is the following: If you
+   * input a list of values of a function $\varphi$ at all generalized
+   * support points (where each value is in fact a vector of values with
+   * as many components as the element has), then this function returns
+   * a vector of values obtained by applying the node functionals to
+   * these values. In other words, if you pass in
+   * $\{\varphi(\hat{\mathbf x}_i)\}_{i=0}^{N-1}$ then you
+   * will get out a vector
+   * $\{\Psi[\varphi]\}_{i=0}^{N-1}$ where $N$ equals @p dofs_per_cell.
+   *
+   * @param[in] support_point_values An array of size @p dofs_per_cell
+   *   (which equals the number of points the get_generalized_support_points()
+   *   function will return) where each element is a vector with as many entries
+   *   as the element has vector components. This array should contain
+   *   the values of a function at the generalized support points of the
+   *   current element.
+   * @param[out] nodal_values An array of size @p dofs_per_cell that contains
+   *   the node functionals of the element applied to the given function.
+   *
+   * @note Given what the function is supposed to do, the function clearly
+   * can only work for elements that actually implement (generalized) support
+   * points. Elements that do not have generalized support points -- e.g.,
+   * elements whose nodal functionals evaluate integrals or moments of
+   * functions (such as FE_Q_Hierarchical) -- can in general not make
+   * sense of the operation that is required for this function. They
+   * consequently may not implement it.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   /**
    * Interpolate a set of scalar values, computed in the generalized support
    * points.
@@ -1942,7 +2014,7 @@ public:
    * just the values in the support points. All other elements must
    * reimplement it.
    *
-   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
+   * @deprecated Use convert_generalized_support_point_values_to_nodal_values() instead.
    */
   virtual
   void
@@ -1958,7 +2030,7 @@ public:
    * be interpolated. Maybe consider changing your data structures to use the
    * next function.
    *
-   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
+   * @deprecated Use convert_generalized_support_point_values_to_nodal_values() instead.
    */
   virtual
   void
@@ -1970,7 +2042,7 @@ public:
    * Interpolate a set of vector values, computed in the generalized support
    * points.
    *
-   * @deprecated Use convert_support_point_values_to_nodal_values() instead.
+   * @deprecated Use convert_generalized_support_point_values_to_nodal_values() instead.
    */
   virtual
   void

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -123,6 +123,12 @@ public:
   virtual bool has_support_on_face (const unsigned int shape_index,
                                     const unsigned int face_index) const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<double>          &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -124,13 +124,15 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double>          &values) const;
+                           const std::vector<double>          &values) const DEAL_II_DEPRECATED;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
+
   virtual std::size_t memory_consumption () const;
   virtual FiniteElement<dim> *clone() const;
 

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -72,6 +72,12 @@ public:
 
   virtual FiniteElement<dim> *clone () const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<double>          &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -73,13 +73,15 @@ public:
   virtual FiniteElement<dim> *clone () const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double>          &values) const;
+                           const std::vector<double>          &values) const DEAL_II_DEPRECATED;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
+
 private:
   /**
    * Only for internal use. Its full name is @p get_dofs_per_object_vector

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -81,13 +81,15 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double>          &values) const;
+                           const std::vector<double>          &values) const DEAL_II_DEPRECATED;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
+
   virtual std::size_t memory_consumption () const;
 
 private:

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -255,6 +255,12 @@ public:
   get_prolongation_matrix (const unsigned int child,
                            const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate (std::vector<double> &local_dofs,
                             const std::vector<double> &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -256,14 +256,14 @@ public:
                            const RefinementCase<dim> &refinement_case=RefinementCase<dim>::isotropic_refinement) const;
 
   virtual void interpolate (std::vector<double> &local_dofs,
-                            const std::vector<double> &values) const;
+                            const std::vector<double> &values) const DEAL_II_DEPRECATED;
 
   virtual void interpolate (std::vector<double> &local_dofs,
                             const std::vector<Vector<double> > &values,
-                            const unsigned int offset = 0) const;
+                            const unsigned int offset = 0) const DEAL_II_DEPRECATED;
+
   virtual void interpolate (std::vector<double> &local_dofs,
-                            const VectorSlice<const std::vector<std::vector<double> > > &values)
-  const;
+                            const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
   /**
    * Return a list of constant modes of the element.

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -104,33 +104,15 @@ public:
    */
   virtual std::string get_name () const;
 
-  /**
-   * Interpolate a set of scalar values, computed in the generalized support
-   * points.
-   */
   virtual void interpolate(std::vector<double>       &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double> &values) const DEAL_II_DEPRECATED;
 
-  /**
-   * Interpolate a set of vector values, computed in the generalized support
-   * points.
-   *
-   * Since a finite element often only interpolates part of a vector,
-   * <tt>offset</tt> is used to determine the first component of the vector to
-   * be interpolated. Maybe consider changing your data structures to use the
-   * next function.
-   */
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
 
-  /**
-   * Interpolate a set of vector values, computed in the generalized support
-   * points.
-   */
-  virtual void interpolate(
-    std::vector<double>          &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+  virtual void interpolate(std::vector<double>          &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
   /**
    * Return the matrix interpolating from the given finite element to the

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -104,6 +104,12 @@ public:
    */
   virtual std::string get_name () const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double>       &local_dofs,
                            const std::vector<double> &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -258,33 +258,15 @@ public:
    */
   virtual std::string get_name () const;
 
-  /**
-   * Interpolate a set of scalar values, computed in the generalized support
-   * points.
-   */
   virtual void interpolate(std::vector<double>       &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double> &values) const DEAL_II_DEPRECATED;
 
-  /**
-   * Interpolate a set of vector values, computed in the generalized support
-   * points.
-   *
-   * Since a finite element often only interpolates part of a vector,
-   * <tt>offset</tt> is used to determine the first component of the vector to
-   * be interpolated. Maybe consider changing your data structures to use the
-   * next function.
-   */
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
 
-  /**
-   * Interpolate a set of vector values, computed in the generalized support
-   * points.
-   */
-  virtual void interpolate(
-    std::vector<double>          &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+  virtual void interpolate(std::vector<double>          &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
   /**
    * Return the matrix interpolating from the given finite element to the

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -258,6 +258,12 @@ public:
    */
   virtual std::string get_name () const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double>       &local_dofs,
                            const std::vector<double> &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -692,7 +692,7 @@ public:
    */
   virtual
   void interpolate(std::vector<double>       &local_dofs,
-                   const std::vector<double> &values) const;
+                   const std::vector<double> &values) const DEAL_II_DEPRECATED;
 
   /**
    * This function is not implemented and throws an exception if called.
@@ -701,7 +701,7 @@ public:
   void
   interpolate(std::vector<double>                &local_dofs,
               const std::vector<Vector<double> > &values,
-              const unsigned int offset = 0) const;
+              const unsigned int offset = 0) const DEAL_II_DEPRECATED;
 
   /**
    * This function is not implemented and throws an exception if called.
@@ -709,7 +709,7 @@ public:
   virtual
   void
   interpolate(std::vector<double> &local_dofs,
-              const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+              const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
 
 protected:

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -67,16 +67,15 @@ public:
   virtual std::string get_name() const;
   virtual FiniteElement<dim> *clone() const;
 
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const std::vector<double> &values) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const std::vector<Vector<double> > &values,
-    const unsigned int offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const std::vector<double> &values) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const std::vector<Vector<double> > &values,
+                           const unsigned int offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 private:
   /**
    * Order of this element.

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -67,6 +67,12 @@ public:
   virtual std::string get_name() const;
   virtual FiniteElement<dim> *clone() const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double> &local_dofs,
                            const std::vector<double> &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -129,13 +129,14 @@ public:
                                     const unsigned int face_index) const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double>          &values) const;
+                           const std::vector<double>          &values) const DEAL_II_DEPRECATED;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
   /**
    * Return a list of constant modes of the element. This method is currently
@@ -260,13 +261,14 @@ public:
   virtual FiniteElement<dim> *clone () const;
 
   virtual void interpolate(std::vector<double>                &local_dofs,
-                           const std::vector<double> &values) const;
+                           const std::vector<double> &values) const DEAL_II_DEPRECATED;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<Vector<double> > &values,
-                           const unsigned int                  offset = 0) const;
-  virtual void interpolate(
-    std::vector<double> &local_dofs,
-    const VectorSlice<const std::vector<std::vector<double> > > &values) const;
+                           const unsigned int                  offset = 0) const DEAL_II_DEPRECATED;
+
+  virtual void interpolate(std::vector<double> &local_dofs,
+                           const VectorSlice<const std::vector<std::vector<double> > > &values) const DEAL_II_DEPRECATED;
 
 
   virtual void get_face_interpolation_matrix (const FiniteElement<dim> &source,

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -128,6 +128,12 @@ public:
   virtual bool has_support_on_face (const unsigned int shape_index,
                                     const unsigned int face_index) const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<double>          &values) const DEAL_II_DEPRECATED;
 
@@ -260,6 +266,11 @@ public:
 
   virtual FiniteElement<dim> *clone () const;
 
+  // documentation inherited from the base class
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
   virtual void interpolate(std::vector<double>                &local_dofs,
                            const std::vector<double> &values) const DEAL_II_DEPRECATED;
 

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -234,7 +234,7 @@ namespace FETools
   /**
    * This is a rather specialized function used during the construction of
    * finite element objects. It is used to build the basis of shape functions
-   * for an element given a set of polynomials and interpolation points. The
+   * for an element, given a set of polynomials and interpolation points. The
    * function is only implemented for finite elements with exactly @p dim
    * vector components. In particular, this applies to classes derived from
    * the FE_PolyTensor class.
@@ -291,7 +291,8 @@ namespace FETools
    *   that returns a scalar.
    * - That the finite element has exactly @p dim vector components.
    * - That the function $f_j$ is given by whatever the element implements
-   *   through the FiniteElement::interpolate() function.
+   *   through the FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+   *   function.
    *
    * @param fe The finite element for which the operations above are to be
    *        performed.

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1099,6 +1099,22 @@ FiniteElement<dim,spacedim>::get_constant_modes () const
 
 template <int dim, int spacedim>
 void
+FiniteElement<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &,
+                                                          std::vector<double> &) const
+{
+  Assert (has_generalized_support_points(),
+          ExcMessage ("The element for which you are calling the current "
+                      "function does not have generalized support points (see "
+                      "the glossary for a definition of generalized support "
+                      "points). Consequently, the current function can not "
+                      "be defined and is not implemented by the element."));
+  Assert (false, ExcNotImplemented());
+}
+
+
+template <int dim, int spacedim>
+void
 FiniteElement<dim,spacedim>::interpolate(
   std::vector<double>       &local_dofs,
   const std::vector<double> &values) const

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -330,6 +330,34 @@ FE_Q_Bubbles<dim,spacedim>::clone() const
 
 template <int dim, int spacedim>
 void
+FE_Q_Bubbles<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
+                                                         std::vector<double>    &nodal_values) const
+{
+  Assert (support_point_values.size() == this->unit_support_points.size(),
+          ExcDimensionMismatch(support_point_values.size(),
+                               this->unit_support_points.size()));
+  Assert (nodal_values.size() == this->dofs_per_cell,
+          ExcDimensionMismatch(nodal_values.size(),this->dofs_per_cell));
+  Assert (support_point_values[0].size() == this->n_components(),
+          ExcDimensionMismatch(support_point_values[0].size(),this->n_components()));
+
+  for (unsigned int i=0; i<this->dofs_per_cell-1; ++i)
+    {
+      const std::pair<unsigned int, unsigned int> index
+        = this->system_to_component_index(i);
+      nodal_values[i] = support_point_values[i](index.first);
+    }
+
+  // We don't use the bubble functions for local interpolation
+  for (unsigned int i = 0; i<n_bubbles; ++i)
+    nodal_values[nodal_values.size()-i-1] = 0.;
+}
+
+
+
+template <int dim, int spacedim>
+void
 FE_Q_Bubbles<dim,spacedim>::interpolate(std::vector<double>       &local_dofs,
                                         const std::vector<double> &values) const
 {

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -176,6 +176,33 @@ FE_Q_DG0<dim,spacedim>::clone() const
 
 template <int dim, int spacedim>
 void
+FE_Q_DG0<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
+                                                         std::vector<double>    &nodal_dofs) const
+{
+  Assert (support_point_values.size() == this->unit_support_points.size(),
+          ExcDimensionMismatch(support_point_values.size(),
+                               this->unit_support_points.size()));
+  Assert (nodal_dofs.size() == this->dofs_per_cell,
+          ExcDimensionMismatch(nodal_dofs.size(),this->dofs_per_cell));
+  Assert (support_point_values[0].size() == this->n_components(),
+          ExcDimensionMismatch(support_point_values[0].size(),this->n_components()));
+
+  for (unsigned int i=0; i<this->dofs_per_cell-1; ++i)
+    {
+      const std::pair<unsigned int, unsigned int> index
+        = this->system_to_component_index(i);
+      nodal_dofs[i] = support_point_values[i](index.first);
+    }
+
+  // We don't need the discontinuous function for local interpolation
+  nodal_dofs[nodal_dofs.size()-1] = 0.;
+}
+
+
+
+template <int dim, int spacedim>
+void
 FE_Q_DG0<dim,spacedim>::interpolate(std::vector<double>       &local_dofs,
                                     const std::vector<double> &values) const
 {

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -102,6 +102,26 @@ void FE_RannacherTurek<dim>::initialize_support_points()
 
 
 template <int dim>
+void
+FE_RannacherTurek<dim>::
+convert_generalized_support_point_values_to_nodal_values(const std::vector<Vector<double> > &support_point_values,
+                                                         std::vector<double> &nodal_dofs) const
+{
+  AssertDimension(support_point_values.size(), this->generalized_support_points.size());
+  AssertDimension(nodal_dofs.size(), this->dofs_per_cell);
+
+  // extract component and call scalar version of this function
+  std::vector<double> scalar_values(support_point_values.size());
+  for (unsigned int q = 0; q < support_point_values.size(); ++q)
+    {
+      scalar_values[q] = support_point_values[q][0];
+    }
+  this->interpolate(nodal_dofs, scalar_values);
+}
+
+
+
+template <int dim>
 void FE_RannacherTurek<dim>::interpolate(
   std::vector<double> &local_dofs,
   const std::vector<double> &values) const

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -1628,11 +1628,11 @@ namespace FETools
     // This function specifically works for the case where shape functions
     // have 'dim' vector components, so allocate that much space
     std::vector<Vector<double> >
-    values (points.size(), Vector<double>(dim));
+    support_point_values (points.size(), Vector<double>(dim));
 
     // In this vector, we store the
     // result of the interpolation
-    std::vector<double> local_dofs(n_dofs);
+    std::vector<double> nodal_values(n_dofs);
 
     // Get the values of each shape function in turn. Remember that these
     // are the 'raw' shape functions (i.e., where the element has not yet
@@ -1645,18 +1645,18 @@ namespace FETools
         for (unsigned int k=0; k<points.size(); ++k)
           for (unsigned int d=0; d<dim; ++d)
             {
-              values[k][d] = fe.shape_value_component(i, points[k], d);
-              Assert (numbers::is_finite(values[k][d]), ExcInternalError());
+              support_point_values[k][d] = fe.shape_value_component(i, points[k], d);
+              Assert (numbers::is_finite(support_point_values[k][d]), ExcInternalError());
             }
 
-        fe.convert_generalized_support_point_values_to_nodal_values(values,
-                                                                    local_dofs);
+        fe.convert_generalized_support_point_values_to_nodal_values(support_point_values,
+                                                                    nodal_values);
 
         // Enter the interpolated dofs into the matrix
         for (unsigned int j=0; j<n_dofs; ++j)
           {
-            N(j,i) = local_dofs[j];
-            Assert (numbers::is_finite(local_dofs[j]), ExcInternalError());
+            N(j,i) = nodal_values[j];
+            Assert (numbers::is_finite(nodal_values[j]), ExcInternalError());
           }
       }
 

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -1627,8 +1627,8 @@ namespace FETools
     // We need the values of the polynomials in all generalized support points.
     // This function specifically works for the case where shape functions
     // have 'dim' vector components, so allocate that much space
-    std::vector<std::vector<double> >
-    values (dim, std::vector<double>(points.size()));
+    std::vector<Vector<double> >
+    values (points.size(), Vector<double>(dim));
 
     // In this vector, we store the
     // result of the interpolation
@@ -1645,11 +1645,12 @@ namespace FETools
         for (unsigned int k=0; k<points.size(); ++k)
           for (unsigned int d=0; d<dim; ++d)
             {
-              values[d][k] = fe.shape_value_component(i, points[k], d);
-              Assert (numbers::is_finite(values[d][k]), ExcInternalError());
+              values[k][d] = fe.shape_value_component(i, points[k], d);
+              Assert (numbers::is_finite(values[k][d]), ExcInternalError());
             }
 
-        fe.interpolate(local_dofs, values);
+        fe.convert_generalized_support_point_values_to_nodal_values(values,
+                                                                    local_dofs);
 
         // Enter the interpolated dofs into the matrix
         for (unsigned int j=0; j<n_dofs; ++j)


### PR DESCRIPTION
This fixes #3810. In essence, we concluded there that the old function is
poorly named, has essentially no documentation, and the arguments are
unclear. This PR implements the replacement function in the base class
and documents it to the best of my abilities.

The PR has 5 commits that are logically separate:
* Patch 1 deprecates the old function and all implementations in 
  derived classes.
* Patch 2 provides the new function and documentation.
* Patch 3 implements this function in all derived classes. This patch
  has a lot of code, but nothing of it is new: the implementation is
  copied entirely from the existing implementations of the deprecated
  function, with necessary adjustments of function arguments,
  argument names, etc. This was pretty mechanical -- it is probably
  not worth trying to go through the actual code as none of it
  is new.
* Patch 4 replaces the call to FE::interpolate() by calling
  the new function in FETools::compute_node_matrix(). To the best
  of my knowledge, this is the only place where these functions
  are actually called.
* Patch 5 renames a few variables in FETools::compute_node_matrix()
  so that the variables at the calling site are named like the
  arguments of the function being called.

I've tested the patch with the test suite and see no new failures.
I'm not adding any new tests since these functions are already
quite well tested: They are called via the constructor of their
respective classes every time an element is created. I made a
little mistake in one implementation of the function and got
several dozen test failures.

I did think about shrinking the size of patch 3 above by letting
the old (now deprecated) functions call the new one, or the
other way around. But this is difficult because (i) the argument
lists don't match, and in at least one case the new function
no longer has an argument that the old one has; in any case
it would require awkward conversion of input and output
arguments. (ii) I will remove the deprecated functions after
the next release, as discussed in #3810, and so the code
duplication is only temporary and seemed acceptable.