### PR TITLE
CMake: Do not filter Scotch include directory in trilinos TPL includes

### DIFF
--- a/cmake/modules/FindTRILINOS.cmake
+++ b/cmake/modules/FindTRILINOS.cmake
@@ -190,16 +190,6 @@ STRING(REGEX REPLACE
 REMOVE_DUPLICATES(Trilinos_TPL_INCLUDE_DIRS)
 
 #
-# workaround: Do not pull in scotch include directory. It clashes with
-# our use of the metis headers...
-#
-FOREACH(_item ${Trilinos_TPL_INCLUDE_DIRS})
-  IF("${_item}" MATCHES "scotch$")
-    LIST(REMOVE_ITEM Trilinos_TPL_INCLUDE_DIRS ${_item})
-  ENDIF()
-ENDFOREACH()
-
-#
 # We'd like to have the full library names but the Trilinos package only
 # exports a list with short names...
 # So we check again for every lib and store the full path:


### PR DESCRIPTION
*ugh* This is messy.

Scotch happens to include a bundled metis version with headers. For example on my system:
```
$ qlist scotch | grep include
/usr/include/scotch/scotch.h
...
/usr/include/scotch/metis/parmetis.h
/usr/include/scotch/metis/metis.h
```
That's why I apparently removed `/usr/include/scotch` from `TRILINOS_TPL_INCLUDE_DIRS`.

But, for example Trilinos' Zoltan library happens to use `#include <scotch.h>` and populates`TRILINOS_TPL_INCLUDE_DIRS` with `/usr/include/scotch`. Removing thus leads to a build failure.

Unfortunately, we cannot work around this issue in a meaningful way. :-/

So what shall we do?