### PR TITLE
Catch exceptions in main() in later steps.

### DIFF
--- a/examples/step-49/step-49.cc
+++ b/examples/step-49/step-49.cc
@@ -350,11 +350,38 @@ void grid_7()
 // subfunctions.
 int main ()
 {
-  grid_1 ();
-  grid_2 ();
-  grid_3 ();
-  grid_4 ();
-  grid_5 ();
-  grid_6 ();
-  grid_7 ();
+  try
+    {
+      grid_1 ();
+      grid_2 ();
+      grid_3 ();
+      grid_4 ();
+      grid_5 ();
+      grid_6 ();
+      grid_7 ();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
 }

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -989,7 +989,6 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
-      throw;
     }
   catch (...)
     {


### PR DESCRIPTION
This was caught by Coverity.

We decided not to implement this in early steps to keep things simple: I marked those, in Coverity's GUI, as 'intentional' and 'ignore'.

Closes #4070.