### PR TITLE
Address Assert in destructors

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -2973,8 +2973,8 @@ namespace Threads
       // of the arena". rather, let's explicitly destroy the empty
       // task object. before that, make sure that the task has been
       // shut down, expressed by a zero reference count
-      Assert (task != 0, ExcInternalError());
-      Assert (task->ref_count()==0, ExcInternalError());
+      AssertNothrow (task != 0, ExcInternalError());
+      AssertNothrow (task->ref_count()==0, ExcInternalError());
       task->destroy (*task);
     }
 

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -752,7 +752,12 @@ TimerOutput::Scope::Scope(dealii::TimerOutput &timer_, const std::string &sectio
 inline
 TimerOutput::Scope::~Scope()
 {
-  stop();
+  try
+    {
+      stop();
+    }
+  catch (...)
+    {}
 }
 
 inline

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2419,7 +2419,12 @@ FEEvaluationBase<dim,n_components_,Number>::~FEEvaluationBase ()
 {
   if (matrix_info != 0)
     {
-      matrix_info->release_scratch_data(scratch_data_array);
+      try
+        {
+          matrix_info->release_scratch_data(scratch_data_array);
+        }
+      catch (...)
+        {}
     }
   else
     {


### PR DESCRIPTION
In `TimerOutput::Scope::~Scope()`, `stop()` calls `timer.exit_section()` which after some more calls ends in checking 
```
  const int ierr = MPI_Initialized(&MPI_has_been_started);
  AssertThrowMPI(ierr);
```
in `mpi.cc:524`.

`FEEvaluationBase<dim,n_components_,Number>::~FEEvaluationBase ()` calls `MatrixFree<dim,Number>::release_scratch_data` which throws if the object to be freed cannot be found and may throw (`Assert`) if the object is unused.

