### PR TITLE
Fix typo in MatrixFreeOperators::Base

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -997,7 +997,7 @@ namespace MatrixFreeOperators
         for (unsigned int i=0; i<given_column_selection.size(); ++i)
           {
             AssertIndexRange(given_column_selection[i], data_->n_components());
-            for (unsigned int j=0; j<given_row_selection.size(); ++j)
+            for (unsigned int j=0; j<given_column_selection.size(); ++j)
               if (j!=i)
                 Assert(given_column_selection[j] != given_column_selection[i],
                        ExcMessage("Given column indices must be unique"));


### PR DESCRIPTION
It seems that we missed this in #4052.