### PR TITLE
Restrict LAPACKFullMatrix::print_formatted to matrix states

### DIFF
--- a/doc/news/changes/incompatibilities/20170318DanielArndt
+++ b/doc/news/changes/incompatibilities/20170318DanielArndt
@@ -1,0 +1,4 @@
+Changed: LAPACKFullMatrix::print_formatted is only allowed
+if the state is 'matrix' or 'inverse_matrix'.
+<br>
+(Daniel Arndt, 2017/03/18)

--- a/include/deal.II/lac/exceptions.h
+++ b/include/deal.II/lac/exceptions.h
@@ -30,7 +30,8 @@ namespace LACExceptions
   /**
    * This function only works for quadratic matrices.
    */
-  DeclException0 (ExcNotQuadratic);
+  DeclExceptionMsg (ExcNotQuadratic,
+                    "This function only works for quadratic objects!");
 
   /**
    * The operation cannot be finished since the matrix is singular.

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -592,6 +592,10 @@ public:
    *
    * @arg <tt>threshold</tt>: all entries with absolute value smaller than
    * this are considered zero.
+   *
+   * @note The entries stored resemble a matrix only if the state is either
+   * LAPACKSupport::matrix or LAPACK::inverse_matrix. Otherwise, calling this
+   * function is not allowed.
    */
   void print_formatted (std::ostream       &out,
                         const unsigned int  precision   = 3,

--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -26,9 +26,12 @@ DEAL_II_NAMESPACE_OPEN
 namespace LAPACKSupport
 {
   /**
-   * Most LAPACK functions change the contents of the matrix applied to to
-   * something which is not a matrix anymore. Therefore, LAPACK matrix classes
-   * in <tt>deal.II</tt> have a state flag indicating what happened to them.
+   * Most of the LAPACK functions one can apply to a matrix (e.g., by calling
+   * the member functions of this class) change its content in some ways. For
+   * example, they may invert the matrix, or may replace it by a matrix whose
+   * columns represent the eigenvectors of the original content of the matrix.
+   * The elements of this enumeration are therefore used to track what is
+   * currently being stored by this object.
    *
    * @author Guido Kanschat, 2005
    */

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -985,6 +985,9 @@ LAPACKFullMatrix<number>::print_formatted (
 
   Assert ((!this->empty()) || (this->n_cols()+this->n_rows()==0),
           ExcInternalError());
+  Assert (state == LAPACKSupport::matrix ||
+          state == LAPACKSupport::inverse_matrix,
+          ExcState(state));
 
   // set output format, but store old
   // state


### PR DESCRIPTION
Currently, it is possible to call `LAPACKFullMatrix::print_formatted` also in case, e.g. `compute_svd()`, `compute_inverse_svd()` or `compute_lu_factorization()` is called. It is not immediately obvious that the stored (and thus printed) indices don't resemble the matrix or its inverse anymore.
Although this change is strictly speaking not backwards compatible, I doubt that anyone can use the output if the state is neither `matrix` nor `inverse_matrix` as the stored entries are just internal data otherwise.