### PR TITLE
Extend/grid tools/find active cell around point

### DIFF
--- a/doc/news/changes/minor/20170322VishalBoddu
+++ b/doc/news/changes/minor/20170322VishalBoddu
@@ -1,0 +1,4 @@
+Extend: The two overloaded functions GridTools::find_active_cell_around_point() now take an optional custom mask for vertices
+to narrow down the search for surrounding cells.
+<br>
+(Vishal Boddu, 2017/03/22)

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -24,7 +24,8 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
     template
     unsigned int
     find_closest_vertex (const X &,
-                         const Point<deal_II_space_dimension> &);
+                         const Point<deal_II_space_dimension> &,
+                         const std::vector<bool> &);
 
     template
     std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>
@@ -32,13 +33,14 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
 
     template
     dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type
-    find_active_cell_around_point (const X &, const Point<deal_II_space_dimension> &p);
+    find_active_cell_around_point (const X &, const Point<deal_II_space_dimension> &, const std::vector<bool> &);
 
     template
     std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type, Point<deal_II_dimension> >
     find_active_cell_around_point (const Mapping<deal_II_dimension, deal_II_space_dimension> &,
                                    const X &,
-                                   const Point<deal_II_space_dimension> &);
+                                   const Point<deal_II_space_dimension> &,
+                                   const std::vector<bool> &);
 
     template
     std::vector<dealii::internal::ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type>

--- a/tests/bits/find_cell_13.cc
+++ b/tests/bits/find_cell_13.cc
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// take a 2d mesh, provide a marked vertex such that the point is
+// outside of active cells adjacent to the marked vertex
+// and check that the function throws an exception
+// that it couldn't find an arbitrary point's cell
+
+// while not providing such marked vertex the function
+// executes normally as expected
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+
+#include <fstream>
+
+void check (Triangulation<2> &tria)
+{
+
+  // generate some random points bounded by [0., 0.2)^2 in R^2 space
+  // any point in this domain should be inside one of the cells
+  Point<2> p( static_cast<double>(Testing::rand())/static_cast<double>(RAND_MAX),
+              static_cast<double>(Testing::rand())/static_cast<double>(RAND_MAX)/8. );
+
+  try
+    {
+      // don't mark any vertex at first
+      std::vector<bool> marked_vertices (tria.n_vertices(), false);
+
+      // find the closes vertex to (1.,1.)
+      // (default call to find_closest_vertex() without passing marked_vertices)
+      unsigned int closest_vertex =
+        GridTools::find_closest_vertex(tria, Point<2>(1.,1.));
+
+      // mark the vertex closest to (1.,1.)
+      marked_vertices[closest_vertex] = true;
+
+      auto vertices = tria.get_vertices();
+      deallog << vertices[closest_vertex] << " is the closest vertex" << std::endl;
+
+      GridTools::find_active_cell_around_point(tria, p, marked_vertices);
+
+      // The test fails if the control reaches here.
+      deallog << "Garbage text to make the diff fail if the control "
+              << "reaches here:" << " Point: " << p;
+      deallog << std::endl; // Flush deallog buffer
+    }
+  catch ( GridTools::ExcPointNotFound<2>)
+    {
+      deallog << "The first call to the function find_closest_vertex() has thrown "
+              << "an exception. It is supposed to throw.";
+      deallog << std::endl;
+
+      // The default function call doesn't throw exceptions
+      // for this use case
+      Triangulation<2>::active_cell_iterator cell
+        = GridTools::find_active_cell_around_point (tria, p);
+
+      // check if the below function call actually finds appropriate cell
+      Assert (p.distance (cell->center()) < cell->diameter()/2,
+              ExcInternalError());
+      deallog << "Test passed!";
+      deallog << std::endl;
+
+    }
+  catch (...)
+    {
+      Assert (false,
+              ExcInternalError());
+    }
+
+}
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  {
+    Triangulation<2> coarse_grid;
+    GridGenerator::hyper_cube (coarse_grid);
+    coarse_grid.refine_global (2);
+    check (coarse_grid);
+  }
+
+  {
+
+    Triangulation<2> coarse_grid;
+    GridGenerator::hyper_ball (coarse_grid);
+    static const HyperBallBoundary<2> boundary;
+    coarse_grid.set_boundary (0, boundary);
+    coarse_grid.refine_global (2);
+    check (coarse_grid);
+
+  }
+}

--- a/tests/bits/find_cell_13.output
+++ b/tests/bits/find_cell_13.output
@@ -1,0 +1,7 @@
+
+DEAL::1.00000 1.00000 is the closest vertex
+DEAL::The first call to the function find_closest_vertex() has thrown an exception. It is supposed to throw.
+DEAL::Test passed!
+DEAL::0.707107 0.707107 is the closest vertex
+DEAL::The first call to the function find_closest_vertex() has thrown an exception. It is supposed to throw.
+DEAL::Test passed!


### PR DESCRIPTION
Currently the `find_active_cell_around_point()` is determined to find an active cell surrounding a point. It therefore loops through all the cells by calling an internal function `find_active_cell_around_point_internal()`. If one knows with absolute certainty that the point will lie in certain cells, there should be a mechanism to inform the function, for instance, by providing a custom mask for vertices (those vertices of potential cells). 

When custom mask for vertices is specified the function could be called inside a try block to catch the exception that the function might throw in the case it couldn't find an active cell surrounding the point.

The motivation of extending this function is to cut down the search space of vertices. For instance in the case when parallel::shared::Triangulation is employed, if one were to find a locally owned active cell surrounding the point, the vertices of locally owned active cells could be marked as relevant. If the function throws `GridTools::ExcPointNotFound`exception, it can be interpreted that the point lies outside locally owned active cells.