### PR TITLE
Refactor and fix IndexSet::is_ascending_and_one_to_one

### DIFF
--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -636,20 +636,23 @@ IndexSet::is_ascending_and_one_to_one (const MPI_Comm &communicator) const
   if (my_rank == 0)
     {
       // find out if the received std::vector is ascending
-      types::global_dof_index old_dof = global_dofs[0], new_dof = 0;
+      types::global_dof_index old_dof = global_dofs[0];
       types::global_dof_index index = 0;
       while (global_dofs[index] == numbers::invalid_dof_index)
         ++index;
       old_dof = global_dofs[index++];
       for (; index<global_dofs.size(); ++index)
         {
-          new_dof = global_dofs[index];
-          if (new_dof == numbers::invalid_dof_index)
-            new_dof = old_dof;
-          else if (new_dof<=old_dof)
+          const types::global_dof_index new_dof = global_dofs[index];
+          if (new_dof !=  numbers::invalid_dof_index)
             {
-              is_globally_ascending = false;
-              break;
+              if  (new_dof <= old_dof)
+                {
+                  is_globally_ascending = false;
+                  break;
+                }
+              else
+                old_dof = new_dof;
             }
         }
     }


### PR DESCRIPTION
The code fragment below checks if the values in the `std::vector` `global_dofs` are ascending ignoring all entries with value `types::global_dof_index`.

Coverity complained that the `new_value` was never used after the assignment `old_dof = new_dof`.
In fact, it seems that `old_dof`was never updated. This is now fixed.

`ctest -R "trilinos|petsc|index_set"` is passing.