### PR TITLE
Check array access in MatrixFree::cell_loop

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2529,9 +2529,11 @@ MatrixFree<dim, Number>::cell_loop
                       if (spawn_index_child == -1)
                         worker[spawn_index]->spawn(*blocked_worker[(part-1)/2]);
                       else
-                        worker[spawn_index]->spawn(*worker[spawn_index_child]);
+                        {
+                          Assert(spawn_index_child>=0, ExcInternalError());
+                          worker[spawn_index]->spawn(*worker[spawn_index_child]);
+                        }
                       spawn_index = spawn_index_new;
-                      spawn_index_child = -2;
                     }
                   else
                     {
@@ -2587,7 +2589,10 @@ MatrixFree<dim, Number>::cell_loop
                     }
                 }
               if (evens==odds)
-                worker[spawn_index]->spawn(*worker[spawn_index_child]);
+                {
+                  Assert(spawn_index_child>=0, ExcInternalError());
+                  worker[spawn_index]->spawn(*worker[spawn_index_child]);
+                }
               root->wait_for_all();
               root->destroy(*root);
             }


### PR DESCRIPTION
Coverity reports that the value assigned to `spawn_index_child`in line 2534 is never used since it is overwritten in line 2562, 2578 or 2586 and not used in between.

If we exit the for loop starting in line 2504 by the `continue` statement in line 2563, `spawn_index_child` is negative. In case `evens==odds`, we however access `worker[spawn_index_child]` in line 2590.
Let's at least check that everything is fine.

Passes `ctest -R "mf|matrix_free"`