### PR TITLE
matrix-free: remove deprecated mpi_communicator

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -166,9 +166,6 @@ public:
       color
     };
 
-    // avoid warning about use of deprecated variables
-    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-
     /**
      * Constructor for AdditionalData.
      */
@@ -280,8 +277,6 @@ public:
      */
     bool                initialize_mapping;
   };
-
-  DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
   /**
    * @name 1: Construction and initialization

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -180,7 +180,6 @@ public:
                     const bool                initialize_indices = true,
                     const bool                initialize_mapping = true)
       :
-      mpi_communicator      (MPI_COMM_SELF),
       tasks_parallel_scheme (tasks_parallel_scheme),
       tasks_block_size      (tasks_block_size),
       mapping_update_flags  (mapping_update_flags),
@@ -190,41 +189,6 @@ public:
       initialize_mapping    (initialize_mapping)
     {};
 
-    /**
-     * Constructor for AdditionalData.
-     *
-     * @deprecated @p mpi_communicator should not be specified here
-     * since it is not used in the MatrixFree class.
-     */
-    AdditionalData (const MPI_Comm            mpi_communicator,
-                    const TasksParallelScheme tasks_parallel_scheme = partition_partition,
-                    const unsigned int        tasks_block_size   = 0,
-                    const UpdateFlags         mapping_update_flags  = update_gradients | update_JxW_values,
-                    const unsigned int level_mg_handler = numbers::invalid_unsigned_int,
-                    const bool                store_plain_indices = true,
-                    const bool                initialize_indices = true,
-                    const bool                initialize_mapping = true)
-      :
-      mpi_communicator      (mpi_communicator),
-      tasks_parallel_scheme (tasks_parallel_scheme),
-      tasks_block_size      (tasks_block_size),
-      mapping_update_flags  (mapping_update_flags),
-      level_mg_handler      (level_mg_handler),
-      store_plain_indices   (store_plain_indices),
-      initialize_indices    (initialize_indices),
-      initialize_mapping    (initialize_mapping)
-    {} DEAL_II_DEPRECATED
-
-    /**
-     * Set the MPI communicator that the parallel layout of the operator
-     * should be based upon. Defaults to MPI_COMM_SELF, but should be set to a
-     * communicator similar to the one used for a distributed triangulation in
-     * order to inform this class over all cells that are present.
-     *
-     * @deprecated This variable is not used anymore. The @p mpi_communicator
-     * is automatically set to the one used by the triangulation.
-     */
-    MPI_Comm            mpi_communicator DEAL_II_DEPRECATED;
 
     /**
      * Set the scheme for task parallelism. There are four options available.

--- a/tests/matrix_free/copy.cc
+++ b/tests/matrix_free/copy.cc
@@ -80,7 +80,7 @@ void sub_test()
       {
         const QGauss<1> quad (fe_degree+1);
         mf_data.reinit (dof, constraints, quad,
-                        typename MatrixFree<dim,number>::AdditionalData(MPI_COMM_SELF,MatrixFree<dim,number>::AdditionalData::none));
+                        typename MatrixFree<dim,number>::AdditionalData(MatrixFree<dim,number>::AdditionalData::none));
       }
 
       MatrixFreeTest<dim,fe_degree,number> mf_ref (mf_data);

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -313,8 +313,7 @@ void test ()
     // no parallelism
     mf_data.reinit (mapping, dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -262,8 +262,7 @@ void test ()
       quad.push_back(QGauss<1>(fe_degree+1+no));
     mf_data.reinit (dof, constraints, quad,
                     typename MatrixFree<dim,number>::AdditionalData
-                    (MPI_COMM_SELF,
-                     MatrixFree<dim,number>::AdditionalData::none));
+                    (MatrixFree<dim,number>::AdditionalData::none));
   }
 
   MatrixFreeTest<dim,fe_degree,fe_degree+1,number> mf (mf_data);
@@ -295,4 +294,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -314,8 +314,7 @@ void test ()
     quad.push_back (QGauss<1>(fe_degree+1));
     mf_data.reinit (dof, constraints, quad,
                     typename MatrixFree<dim,number>::AdditionalData
-                    (MPI_COMM_SELF,
-                     MatrixFree<dim,number>::AdditionalData::none));
+                    (MatrixFree<dim,number>::AdditionalData::none));
   }
 
   MatrixFreeTest<dim,fe_degree,fe_degree+1,number> mf (mf_data);
@@ -347,4 +346,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -198,7 +198,7 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     mf_data.reinit (dof, constraints, quad,
-                    typename MatrixFree<dim,number>::AdditionalData(MPI_COMM_SELF,MatrixFree<dim,number>::AdditionalData::none));
+                    typename MatrixFree<dim,number>::AdditionalData(MatrixFree<dim,number>::AdditionalData::none));
   }
 
   MatrixFreeTest<dim,fe_degree,number> mf (mf_data);

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -307,7 +307,7 @@ void test ()
     for (unsigned int no=0; no<2; ++no)
       quad.push_back(QGauss<1>(fe_degree+1+no));
     mf_data.reinit (dof, constraints, quad,
-                    typename MatrixFree<dim,number>::AdditionalData(MPI_COMM_SELF,MatrixFree<dim,number>::AdditionalData::none));
+                    typename MatrixFree<dim,number>::AdditionalData(MatrixFree<dim,number>::AdditionalData::none));
   }
 
   MatrixFreeTest<dim,fe_degree,number> mf (mf_data);

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -298,7 +298,7 @@ void test ()
     quad.push_back (QGauss<1>(1));
     quad.push_back (QGauss<1>(fe_degree+1));
     mf_data.reinit (dof, constraints, quad,
-                    typename MatrixFree<dim,number>::AdditionalData(MPI_COMM_SELF,MatrixFree<dim,number>::AdditionalData::none));
+                    typename MatrixFree<dim,number>::AdditionalData(MatrixFree<dim,number>::AdditionalData::none));
   }
 
   MatrixFreeTest<dim,fe_degree,number> mf (mf_data);
@@ -351,4 +351,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_20.cc
+++ b/tests/matrix_free/matrix_vector_20.cc
@@ -168,7 +168,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::partition_color;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_21.cc
+++ b/tests/matrix_free/matrix_vector_21.cc
@@ -159,7 +159,6 @@ void test ()
   {
     const QGauss<1> quad (fe_degree+1);
     typename MatrixFree<dim,number>::AdditionalData data;
-    data.mpi_communicator = MPI_COMM_WORLD;
     data.tasks_parallel_scheme =
       MatrixFree<dim,number>::AdditionalData::partition_color;
     data.tasks_block_size = 7;

--- a/tests/matrix_free/matrix_vector_curl.cc
+++ b/tests/matrix_free/matrix_vector_curl.cc
@@ -255,8 +255,7 @@ void test ()
     QGauss<1> quad(fe_degree+1);
     mf_data.reinit (dof_handler_sca, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);

--- a/tests/matrix_free/matrix_vector_div.cc
+++ b/tests/matrix_free/matrix_vector_div.cc
@@ -254,8 +254,7 @@ void test ()
     QGauss<1> quad(fe_degree+1);
     mf_data.reinit (dof_handler_sca, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);
@@ -295,4 +294,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_stokes.cc
+++ b/tests/matrix_free/matrix_vector_stokes.cc
@@ -284,8 +284,7 @@ void test ()
     QGauss<1> quad(fe_degree+2);
     mf_data.reinit (dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);
@@ -327,4 +326,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_stokes_base.cc
+++ b/tests/matrix_free/matrix_vector_stokes_base.cc
@@ -255,8 +255,7 @@ test()
     // no parallelism
     mf_data->reinit (dofs, constraints, quad,
                      typename MatrixFree<dim>::AdditionalData
-                     (MPI_COMM_WORLD,
-                      MatrixFree<dim>::AdditionalData::none));
+                     (MatrixFree<dim>::AdditionalData::none));
   }
   system_matrix.vmult (solution, system_rhs);
 

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -310,8 +310,7 @@ void test ()
     // no parallelism
     mf_data.reinit (mapping, dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);

--- a/tests/matrix_free/matrix_vector_stokes_notempl.cc
+++ b/tests/matrix_free/matrix_vector_stokes_notempl.cc
@@ -307,8 +307,7 @@ void test (const unsigned int fe_degree)
     // no parallelism
     mf_data.reinit (mapping, dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);

--- a/tests/matrix_free/matrix_vector_stokes_qdg0.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0.cc
@@ -286,8 +286,7 @@ void test ()
     QGauss<1> quad(fe_degree+2);
     mf_data.reinit (dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);
@@ -328,4 +327,3 @@ int main ()
     deallog.pop();
   }
 }
-

--- a/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
@@ -287,8 +287,7 @@ void test (const unsigned int fe_degree)
     QGauss<1> quad(fe_degree+2);
     mf_data.reinit (dofs, constraints, quad,
                     typename MatrixFree<dim>::AdditionalData
-                    (MPI_COMM_WORLD,
-                     MatrixFree<dim>::AdditionalData::none));
+                    (MatrixFree<dim>::AdditionalData::none));
   }
 
   system_matrix.vmult (solution, system_rhs);

--- a/tests/matrix_free/thread_correctness.cc
+++ b/tests/matrix_free/thread_correctness.cc
@@ -83,20 +83,18 @@ void sub_test()
       {
         const QGauss<1> quad (fe_degree+1);
         mf_data.reinit (dof, constraints, quad,
-                        typename MatrixFree<dim,number>::AdditionalData(MPI_COMM_SELF,MatrixFree<dim,number>::AdditionalData::none));
+                        typename MatrixFree<dim,number>::AdditionalData(MatrixFree<dim,number>::AdditionalData::none));
 
         // choose block size of 3 which introduces
         // some irregularity to the blocks (stress the
         // non-overlapping computation harder)
         mf_data_color.reinit (dof, constraints, quad,
                               typename MatrixFree<dim,number>::AdditionalData
-                              (MPI_COMM_SELF,
-                               MatrixFree<dim,number>::AdditionalData::partition_color,
+                              (MatrixFree<dim,number>::AdditionalData::partition_color,
                                3));
         mf_data_partition.reinit (dof, constraints, quad,
                                   typename MatrixFree<dim,number>::AdditionalData
-                                  (MPI_COMM_SELF,
-                                   MatrixFree<dim,number>::AdditionalData::partition_partition,
+                                  (MatrixFree<dim,number>::AdditionalData::partition_partition,
                                    3));
       }
 


### PR DESCRIPTION
since we already have 8.5 branch, i think we can remove depricated mpi communicator.

~~running `$ ctest -R "matrix_free"` now...~~

all `$ ctest -R "matrix_free"` pass.

fixes https://github.com/dealii/dealii/issues/4123