### PR TITLE
Always add the user version flag.

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -406,6 +406,13 @@ IF (DEAL_II_WITH_CXX14)
 ELSEIF(DEAL_II_WITH_CXX11)
   ADD_FLAGS(DEAL_II_CXX_FLAGS "${DEAL_II_CXX_VERSION_FLAG}")
   MESSAGE(STATUS "DEAL_II_WITH_CXX11 successfully set up")
+  #
+  # If the user specified a flag that does not imply C++11 or C++14 (e.g.,
+  # -std=c++03) then add it
+  #
+ELSEIF(_user_provided_cxx_version_flag)
+  MESSAGE(STATUS "Using C++ version flag \"${DEAL_II_CXX_VERSION_FLAG}\"")
+  ADD_FLAGS(DEAL_II_CXX_FLAGS "${DEAL_II_CXX_VERSION_FLAG}")
 ELSE()
   MESSAGE(STATUS "DEAL_II_WITH_CXX14 and DEAL_II_WITH_CXX11 are both disabled")
 ENDIF()


### PR DESCRIPTION
This gets around a bug where, if a user requests '-std=c++03' and is using a compiler which defaults to C++11 or newer (e.g., GCC 6) then the library is compiled with the default language flag (e.g., gnu++14) but
`DEAL_II_WITH_CXX11=OFF`: this causes compilation errors with `boost::optional`.

I must admit that I don't really understand the compilation error: if everything is compiled as C++14, and we disable C++11 and newer in the library, I expect things to be fine: boost is compiled under the same language standard both times but doesn't work only in the case where the only difference is `DEAL_II_WITH_CXX11=OFF`.