### PR TITLE
Remove tests.h dependency from the quick tests.

### DIFF
--- a/tests/quick_tests/arpack.cc
+++ b/tests/quick_tests/arpack.cc
@@ -16,13 +16,9 @@
 
 // test Arpack by calculating eigenvalues of Laplace matrix.
 
-#include "../tests.h"
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-
-#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
@@ -43,7 +39,12 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>
 
+#include <complex>
+#include <fstream>
+#include <iostream>
+#include <vector>
 
+using namespace dealii;
 
 template <int dim>
 void test ()

--- a/tests/quick_tests/gsl.cc
+++ b/tests/quick_tests/gsl.cc
@@ -17,9 +17,15 @@
 // Test GSL by running CSpline. Copy-paste of /base/functions_cspline
 // take example from https://www.gnu.org/software/gsl/manual/html_node/Interpolation-Example-programs.html
 
-#include "../tests.h"
-#include <cmath>
 #include <deal.II/base/function_cspline.h>
+#include <deal.II/base/logstream.h>
+
+#include <cmath>
+#include <string>
+#include <fstream>
+#include <vector>
+
+using namespace dealii;
 
 template <int dim>
 void check()
@@ -52,4 +58,3 @@ int main()
 
   check<1>();
 }
-

--- a/tests/quick_tests/lapack.cc
+++ b/tests/quick_tests/lapack.cc
@@ -17,7 +17,6 @@
 // Tests vector multiplication and eigenvalues of LAPACKFullMatrix
 // copy-paste of lapack/full_matrix_01
 
-#include "../tests.h"
 #include <deal.II/base/logstream.h>
 #include <deal.II/lac/lapack_full_matrix.h>
 #include <deal.II/lac/full_matrix.h>
@@ -48,6 +47,7 @@ const double rect[] =
   11., 13., -4., -5
 };
 
+using namespace dealii;
 
 void test_rect(unsigned int m, unsigned int n, const double *values)
 {

--- a/tests/quick_tests/umfpack.cc
+++ b/tests/quick_tests/umfpack.cc
@@ -18,13 +18,13 @@
 // test the umfpack sparse direct solver on a mass matrix.
 // test of the transpose as well
 
-#include "../tests.h"
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
 
-#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
@@ -42,6 +42,7 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <deal.II/numerics/matrix_tools.h>
 
+using namespace dealii;
 
 template <int dim>
 void test (bool transpose = false)


### PR DESCRIPTION
The release candidates ship without this file, so these tests won't work.

We should also apply this patch to 8.5