### PR TITLE
CMake: Compatibility with 2.8.8, do not build examples per default

### DIFF
--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -348,7 +348,7 @@ MARK_AS_ADVANCED(DEAL_II_DOXYGEN_USE_MATHJAX)
 
 OPTION(DEAL_II_COMPILE_EXAMPLES
   "If set to ON, all configurable example executables will be built and installed as well. If set to OFF, the examples component only installs the source code of example steps."
-  ON
+  OFF
   )
 MARK_AS_ADVANCED(DEAL_II_COMPILE_EXAMPLES)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,7 +53,11 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
     FILE(GLOB _steps ${CMAKE_CURRENT_SOURCE_DIR}/step-*/*.cc)
     FOREACH(_step ${_steps})
       GET_FILENAME_COMPONENT(_name ${_step} NAME_WE)
-      GET_FILENAME_COMPONENT(_directory ${_step} DIRECTORY)
+      #
+      # to ensure compatibility with 2.8.8 - 2.8.11 we use "PATH" instead
+      # of "DIRECTORY"
+      #
+      GET_FILENAME_COMPONENT(_directory ${_step} PATH)
 
       #
       # Extract dependency information from CMakeLists.txt file.


### PR DESCRIPTION
In reference to #4147 