### PR TITLE
Use manifold instead of boundary for VectorTools::compute_nonzero_normal_flux_constraints

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -6063,7 +6063,7 @@ namespace VectorTools
                     // if they should point in different directions. this is the
                     // case in tests/deal.II/no_flux_11.
                     Tensor<1,dim> normal_vector
-                      = (cell->face(face_no)->get_boundary().normal_vector
+                      = (cell->face(face_no)->get_manifold().normal_vector
                          (cell->face(face_no),
                           fe_values.quadrature_point(i)));
                     if (normal_vector * fe_values.normal_vector(i) < 0)


### PR DESCRIPTION
I have not much experience with the transition from boundary objects to manifolds, but my impression was that it should be possible to define a geometry with a manifold without needing any boundary objects. However, `VectorTools::compute_nonzero_normal_flux_constraints` currently expects a boundary object to provide a normal vector. Internally, the boundary object just forwards the manifolds normal vector anyway, and since there is a default implementation for `normal_vector` within `Manifold` we do not need to require a boundary object at the boundary. Is that correct?
All tests that use this function remain unchanged (we just circumvent one Assert by this change).