### PR TITLE
Implement FE::convert_generalized_support_point_values_to_nodal_values() for FE_Q, FE_DGQ, FE_DGQArbitraryNodes.

### DIFF
--- a/doc/news/changes/minor/20170405Bangerth
+++ b/doc/news/changes/minor/20170405Bangerth
@@ -1,0 +1,6 @@
+New: The classes FE_Q, FE_DGQ, and FE_DGQArbitraryNodes now implement
+the
+FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+interface.
+<br>
+(Wolfgang Bangerth, 2017/04/05)

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -301,6 +301,18 @@ public:
   get_constant_modes () const;
 
   /**
+   * Implementation of the corresponding function in the FiniteElement
+   * class.  Since the current element is interpolatory, the nodal
+   * values are exactly the support point values. Furthermore, since
+   * the current element is scalar, the support point values need to
+   * be vectors of length 1.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
+  /**
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    *
@@ -408,6 +420,18 @@ public:
    * <tt>degree</tt> replaced by appropriate values.
    */
   virtual std::string get_name () const;
+
+  /**
+   * Implementation of the corresponding function in the FiniteElement
+   * class.  Since the current element is interpolatory, the nodal
+   * values are exactly the support point values. Furthermore, since
+   * the current element is scalar, the support point values need to
+   * be vectors of length 1.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
 
 protected:
   /**

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2016 by the deal.II authors
+// Copyright (C) 2000 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -585,6 +585,18 @@ public:
    * appropriate values.
    */
   virtual std::string get_name () const;
+
+  /**
+   * Implementation of the corresponding function in the FiniteElement
+   * class.  Since the current element is interpolatory, the nodal
+   * values are exactly the support point values. Furthermore, since
+   * the current element is scalar, the support point values need to
+   * be vectors of length 1.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
 
 protected:
 

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2016 by the deal.II authors
+// Copyright (C) 2000 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_tools.h>
@@ -98,6 +99,29 @@ FE_DGQ<dim, spacedim>::get_name () const
           << Utilities::dim_string(dim,spacedim)
           << ">(" << this->degree << ")";
   return namebuf.str();
+}
+
+
+
+template <int dim, int spacedim>
+void
+FE_DGQ<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const
+{
+  AssertDimension (support_point_values.size(),
+                   this->get_unit_support_points().size());
+  AssertDimension (support_point_values.size(),
+                   nodal_values.size());
+  AssertDimension (this->dofs_per_cell,
+                   nodal_values.size());
+
+  for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+    {
+      AssertDimension (support_point_values[i].size(), 1);
+
+      nodal_values[i] = support_point_values[i](0);
+    }
 }
 
 
@@ -756,6 +780,30 @@ FE_DGQArbitraryNodes<dim,spacedim>::get_name () const
   namebuf << "FE_DGQArbitraryNodes<" << Utilities::dim_string(dim,spacedim) << ">(QUnknownNodes(" << this->degree+1 << "))";
   return namebuf.str();
 }
+
+
+
+template <int dim, int spacedim>
+void
+FE_DGQArbitraryNodes<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const
+{
+  AssertDimension (support_point_values.size(),
+                   this->get_unit_support_points().size());
+  AssertDimension (support_point_values.size(),
+                   nodal_values.size());
+  AssertDimension (this->dofs_per_cell,
+                   nodal_values.size());
+
+  for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+    {
+      AssertDimension (support_point_values[i].size(), 1);
+
+      nodal_values[i] = support_point_values[i](0);
+    }
+}
+
 
 
 

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2016 by the deal.II authors
+// Copyright (C) 2000 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/fe/fe_q.h>
 
 #include <vector>
@@ -128,6 +129,29 @@ FE_Q<dim,spacedim>::get_name () const
                 << ">(QUnknownNodes(" << this->degree << "))";
     }
   return namebuf.str();
+}
+
+
+
+template <int dim, int spacedim>
+void
+FE_Q<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const
+{
+  AssertDimension (support_point_values.size(),
+                   this->get_unit_support_points().size());
+  AssertDimension (support_point_values.size(),
+                   nodal_values.size());
+  AssertDimension (this->dofs_per_cell,
+                   nodal_values.size());
+
+  for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+    {
+      AssertDimension (support_point_values[i].size(), 1);
+
+      nodal_values[i] = support_point_values[i](0);
+    }
 }
 
 


### PR DESCRIPTION
I need this as a prerequisite for #4065.

All three classes that I implemented this function for are derived
from FE_Q_Base, which is itself derived from FE_Poly. It would have
been possible to put the function into one of these base classes,
only once, rather than into the derived classes. However, I could
not convince myself that either FE_Q_Base or FE_Poly has as a strict
requirement that the element implemented this way is in fact
interpolatory (i.e., a Lagrange-type element). The documentation
of both classes doesn't actually say anything about this, and
the way I read it is that these classes really only get a polynomial
space/basis as argument, but they don't make assumptions about
the nodal functionals from which this polynomial basis has been
generated.

So I opted to put these functions into the derived classes where
I know this to be true.