### PR TITLE
Implement FE::convert_generalized_support_point_values_to_nodal_values() for FESystem.

### DIFF
--- a/doc/news/changes/minor/20170405Bangerth-2
+++ b/doc/news/changes/minor/20170405Bangerth-2
@@ -1,0 +1,6 @@
+New: The class FESystem now implements
+the
+FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+interface.
+<br>
+(Wolfgang Bangerth, 2017/04/05)

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -841,6 +841,18 @@ public:
   //@}
 
   /**
+   * Implementation of the
+   * FiniteElement::convert_generalized_support_point_values_to_nodal_values()
+   * function. The current function simply takes the input argument apart,
+   * passes the pieces to the base elements, and then re-assembles everything
+   * into the output argument.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
+
+  /**
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    *


### PR DESCRIPTION
This is a companion to #4185, in preparation for #4065. The code
is not completely trivial, but ultimately it is only about
unpacking an array in FESystem, passing things down to the
base elements, then packing up the results again.