### PR TITLE
Convert tests.

### DIFF
--- a/tests/fe/fe_rannacher_turek_01.cc
+++ b/tests/fe/fe_rannacher_turek_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 by the deal.II authors
+// Copyright (C) 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,14 +61,14 @@ void test_nodal_matrix()
   // simply assumes that there are dim components. Thus we do it ourselves.
   const unsigned int n_dofs = fe.dofs_per_cell;
   const std::vector<Point<2> > &points = fe.get_generalized_support_points();
-  std::vector<double> values(points.size());
+  std::vector<Vector<double> > values(points.size(), Vector<double>(1));
   std::vector<double> local_dofs(n_dofs);
 
   for (unsigned int i = 0; i < n_dofs; ++i)
     {
       for (unsigned int k = 0; k < values.size(); ++k)
-        values[k] = fe.shape_value(i, points[k]);
-      fe.interpolate(local_dofs, values);
+        values[k][0] = fe.shape_value(i, points[k]);
+      fe.convert_generalized_support_point_values_to_nodal_values(values, local_dofs);
 
       for (unsigned int j=0; j < n_dofs; ++j)
         N(j,i) = local_dofs[j];
@@ -121,11 +121,11 @@ void test_interpolation()
     {
       fev.reinit(cell);
 
-      std::vector<double> values(quadrature.size());
+      std::vector<Vector<double> > values(quadrature.size(), Vector<double>(1));
       fev.get_function_values(input_vector, values);
 
       std::vector<double> interpolated_local_dofs(n_dofs);
-      fe.interpolate(interpolated_local_dofs, values);
+      fe.convert_generalized_support_point_values_to_nodal_values(values, interpolated_local_dofs);
 
       Vector<double> local_dofs(n_dofs);
       cell->get_dof_values(input_vector, local_dofs);

--- a/tests/fe/interpolate_q1.cc
+++ b/tests/fe/interpolate_q1.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -35,19 +35,11 @@ void check(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
 template <int dim>
@@ -59,19 +51,11 @@ void check_dg(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
 template <int dim>
@@ -84,19 +68,11 @@ void check_dg_lobatto(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_q1.output
+++ b/tests/fe/interpolate_q1.output
@@ -1,22 +1,22 @@
 
-DEAL::FE_Q<1>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q<1>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q<1>(3)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<1>(1)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<1>(2)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<1>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_DGQ<3>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q<3>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q<3>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q<3>(3)  value 0 vector 0 Vector 0
+DEAL::FE_Q<1>(1)  vector 0
+DEAL::FE_Q<1>(2)  vector 0
+DEAL::FE_Q<1>(3)  vector 0
+DEAL::FE_DGQ<1>(1)  vector 0
+DEAL::FE_DGQ<1>(2)  vector 0
+DEAL::FE_DGQ<1>(3)  vector 0
+DEAL::FE_Q<2>(1)  vector 0
+DEAL::FE_Q<2>(2)  vector 0
+DEAL::FE_Q<2>(3)  vector 0
+DEAL::FE_DGQ<2>(2)  vector 0
+DEAL::FE_DGQ<2>(3)  vector 0
+DEAL::FE_Q<2>(2)  vector 0
+DEAL::FE_Q<2>(3)  vector 0
+DEAL::FE_DGQ<2>(2)  vector 0
+DEAL::FE_DGQ<2>(3)  vector 0
+DEAL::FE_DGQ<2>(3)  vector 0
+DEAL::FE_Q<2>(3)  vector 0
+DEAL::FE_DGQ<3>(1)  vector 0
+DEAL::FE_Q<3>(1)  vector 0
+DEAL::FE_Q<3>(2)  vector 0
+DEAL::FE_Q<3>(3)  vector 0

--- a/tests/fe/interpolate_q_bubbles.cc
+++ b/tests/fe/interpolate_q_bubbles.cc
@@ -31,19 +31,11 @@ void check_q_bubbles(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " value " << difference(fe,dofs,f) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_q_bubbles.output
+++ b/tests/fe/interpolate_q_bubbles.output
@@ -1,13 +1,13 @@
 
-DEAL::FE_Q_Bubbles<1>(QUnknownNodes(2))  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<1>(QUnknownNodes(3))  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<1>(QUnknownNodes(4))  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<3>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<3>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_Bubbles<3>(3)  value 0 vector 0 Vector 0
+DEAL::FE_Q_Bubbles<1>(QUnknownNodes(2))  value 0
+DEAL::FE_Q_Bubbles<1>(QUnknownNodes(3))  value 0
+DEAL::FE_Q_Bubbles<1>(QUnknownNodes(4))  value 0
+DEAL::FE_Q_Bubbles<2>(1)  value 0
+DEAL::FE_Q_Bubbles<2>(2)  value 0
+DEAL::FE_Q_Bubbles<2>(3)  value 0
+DEAL::FE_Q_Bubbles<2>(2)  value 0
+DEAL::FE_Q_Bubbles<2>(3)  value 0
+DEAL::FE_Q_Bubbles<2>(3)  value 0
+DEAL::FE_Q_Bubbles<3>(1)  value 0
+DEAL::FE_Q_Bubbles<3>(2)  value 0
+DEAL::FE_Q_Bubbles<3>(3)  value 0

--- a/tests/fe/interpolate_q_dg0.cc
+++ b/tests/fe/interpolate_q_dg0.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -31,19 +31,11 @@ void check_q_dg0(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_q_dg0.output
+++ b/tests/fe/interpolate_q_dg0.output
@@ -1,13 +1,13 @@
 
-DEAL::FE_Q_DG0<1>(QUnknownNodes(1))  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<1>(QUnknownNodes(2))  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<1>(QUnknownNodes(3))  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<3>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<3>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_DG0<3>(3)  value 0 vector 0 Vector 0
+DEAL::FE_Q_DG0<1>(QUnknownNodes(1))  vector 0
+DEAL::FE_Q_DG0<1>(QUnknownNodes(2))  vector 0
+DEAL::FE_Q_DG0<1>(QUnknownNodes(3))  vector 0
+DEAL::FE_Q_DG0<2>(1)  vector 0
+DEAL::FE_Q_DG0<2>(2)  vector 0
+DEAL::FE_Q_DG0<2>(3)  vector 0
+DEAL::FE_Q_DG0<2>(2)  vector 0
+DEAL::FE_Q_DG0<2>(3)  vector 0
+DEAL::FE_Q_DG0<2>(3)  vector 0
+DEAL::FE_Q_DG0<3>(1)  vector 0
+DEAL::FE_Q_DG0<3>(2)  vector 0
+DEAL::FE_Q_DG0<3>(3)  vector 0

--- a/tests/fe/interpolate_q_iso_q1.cc
+++ b/tests/fe/interpolate_q_iso_q1.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,19 +33,11 @@ void check(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(1, std::vector<double>(fe.get_unit_support_points().size()));
-  f.value_list(fe.get_unit_support_points(), values[0]);
-  fe.interpolate(dofs, values[0]);
-  deallog << " value " << difference(fe,dofs,f);
-  fe.interpolate(dofs, values);
-  deallog << " vector " << difference(fe,dofs,f);
-
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(), Vector<double>(1));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << difference(fe,dofs,f) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(1));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << difference(fe,dofs,f) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_q_iso_q1.output
+++ b/tests/fe/interpolate_q_iso_q1.output
@@ -1,10 +1,10 @@
 
-DEAL::FE_Q_iso_Q1<1>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<1>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<1>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<2>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<2>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<2>(3)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<3>(1)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<3>(2)  value 0 vector 0 Vector 0
-DEAL::FE_Q_iso_Q1<3>(3)  value 0 vector 0 Vector 0
+DEAL::FE_Q_iso_Q1<1>(1)  vector 0
+DEAL::FE_Q_iso_Q1<1>(2)  vector 0
+DEAL::FE_Q_iso_Q1<1>(3)  vector 0
+DEAL::FE_Q_iso_Q1<2>(1)  vector 0
+DEAL::FE_Q_iso_Q1<2>(2)  vector 0
+DEAL::FE_Q_iso_Q1<2>(3)  vector 0
+DEAL::FE_Q_iso_Q1<3>(1)  vector 0
+DEAL::FE_Q_iso_Q1<3>(2)  vector 0
+DEAL::FE_Q_iso_Q1<3>(3)  vector 0

--- a/tests/fe/interpolate_rt.cc
+++ b/tests/fe/interpolate_rt.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -34,22 +34,11 @@ void check1(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(dim, std::vector<double>(fe.get_generalized_support_points().size()));
-  std::vector<Vector<double> >
-  vectors(fe.get_generalized_support_points().size(),
-          Vector<double>(dim));
-  f.vector_value_list(fe.get_generalized_support_points(), vectors);
-
-  for (unsigned int c=0; c<values.size(); ++c)
-    for (unsigned int k=0; k<values[c].size(); ++k)
-      values[c][k] = vectors[k](c);
-
-  fe.interpolate(dofs, values);
-  deallog << " vector " << vector_difference(fe,dofs,f,0);
-
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << vector_difference(fe,dofs,f,0) << std::endl;
+  std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
+                                       Vector<double>(dim));
+  f.vector_value_list(fe.get_generalized_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_rt.output
+++ b/tests/fe/interpolate_rt.output
@@ -1,5 +1,5 @@
 
-DEAL::FE_RaviartThomas<2>(1) 12  vector 0 Vector 0
-DEAL::FE_RaviartThomas<2>(2) 21  vector 0 Vector 0
-DEAL::FE_RaviartThomas<2>(2) 21  vector 0 Vector 0
-DEAL::FE_RaviartThomas<2>(3) 32  vector 0 Vector 0
+DEAL::FE_RaviartThomas<2>(1) 12  vector 0
+DEAL::FE_RaviartThomas<2>(2) 21  vector 0
+DEAL::FE_RaviartThomas<2>(2) 21  vector 0
+DEAL::FE_RaviartThomas<2>(3) 32  vector 0

--- a/tests/fe/interpolate_rtn.cc
+++ b/tests/fe/interpolate_rtn.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -34,22 +34,11 @@ void check1(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(dim, std::vector<double>(fe.get_generalized_support_points().size()));
-  std::vector<Vector<double> >
-  vectors(fe.get_generalized_support_points().size(),
-          Vector<double>(dim));
-  f.vector_value_list(fe.get_generalized_support_points(), vectors);
-
-  for (unsigned int c=0; c<values.size(); ++c)
-    for (unsigned int k=0; k<values[c].size(); ++k)
-      values[c][k] = vectors[k](c);
-
-  fe.interpolate(dofs, values);
-  deallog << " vector " << vector_difference(fe,dofs,f,0);
-
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << vector_difference(fe,dofs,f,0) << std::endl;
+  std::vector<Vector<double> > values (fe.get_generalized_support_points().size(),
+                                       Vector<double>(dim));
+  f.vector_value_list(fe.get_generalized_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_rtn.output
+++ b/tests/fe/interpolate_rtn.output
@@ -1,7 +1,7 @@
 
-DEAL::FE_RaviartThomasNodal<2>(1) 12  vector 0 Vector 0
-DEAL::FE_RaviartThomasNodal<2>(2) 24  vector 0 Vector 0
-DEAL::FE_RaviartThomasNodal<2>(2) 24  vector 0 Vector 0
-DEAL::FE_RaviartThomasNodal<2>(3) 40  vector 0 Vector 0
-DEAL::FE_RaviartThomasNodal<3>(1) 36  vector 0 Vector 0
-DEAL::FE_RaviartThomasNodal<3>(2) 108  vector 0 Vector 0
+DEAL::FE_RaviartThomasNodal<2>(1) 12  vector 0
+DEAL::FE_RaviartThomasNodal<2>(2) 24  vector 0
+DEAL::FE_RaviartThomasNodal<2>(2) 24  vector 0
+DEAL::FE_RaviartThomasNodal<2>(3) 40  vector 0
+DEAL::FE_RaviartThomasNodal<3>(1) 36  vector 0
+DEAL::FE_RaviartThomasNodal<3>(2) 108  vector 0

--- a/tests/fe/interpolate_system.cc
+++ b/tests/fe/interpolate_system.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2005 - 2015 by the deal.II authors
+// Copyright (C) 2005 - 2015, 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -36,21 +36,11 @@ void check1(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(comp, std::vector<double>(fe.get_unit_support_points().size()));
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(),
-          Vector<double>(f.n_components));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  for (unsigned int c=0; c<values.size(); ++c)
-    for (unsigned int k=0; k<values[c].size(); ++k)
-      values[c][k] = vectors[k](c);
-
-  fe.interpolate(dofs, values);
-  deallog << " vector " << vector_difference(fe,dofs,f,0);
-
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << vector_difference(fe,dofs,f,0) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(comp));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 
 template <int dim>
@@ -68,22 +58,11 @@ void check3(const Function<dim> &f,
 
   std::vector<double> dofs(fe.dofs_per_cell);
 
-  std::vector<std::vector<double> >
-  values(f.n_components,
-         std::vector<double>(fe.get_unit_support_points().size()));
-  std::vector<Vector<double> >
-  vectors(fe.get_unit_support_points().size(),
-          Vector<double>(f.n_components));
-  f.vector_value_list(fe.get_unit_support_points(), vectors);
-  for (unsigned int c=0; c<values.size(); ++c)
-    for (unsigned int k=0; k<values[c].size(); ++k)
-      values[c][k] = vectors[k](c);
-
-  fe.interpolate(dofs, values);
-  deallog << " vector " << vector_difference(fe,dofs,f,0);
-
-  fe.interpolate(dofs, vectors, 0);
-  deallog << " Vector " << vector_difference(fe,dofs,f,0) << std::endl;
+  std::vector<Vector<double> > values (fe.get_unit_support_points().size(),
+                                       Vector<double>(f.n_components));
+  f.vector_value_list(fe.get_unit_support_points(), values);
+  fe.convert_generalized_support_point_values_to_nodal_values(values, dofs);
+  deallog << " vector " << vector_difference(fe,dofs,f,0) << std::endl;
 }
 
 int main()

--- a/tests/fe/interpolate_system.output
+++ b/tests/fe/interpolate_system.output
@@ -1,10 +1,10 @@
 
-DEAL::FESystem<1>[FE_Q<1>(1)^2]  vector 0 Vector 0
-DEAL::FESystem<1>[FE_Q<1>(2)^2]  vector 0 Vector 0
-DEAL::FESystem<1>[FE_Q<1>(3)^2]  vector 0 Vector 0
-DEAL::FESystem<2>[FE_Q<2>(2)^3]  vector 0 Vector 0
-DEAL::FESystem<2>[FE_Q<2>(3)^3]  vector 0 Vector 0
-DEAL::FESystem<3>[FE_Q<3>(1)^3]  vector 0 Vector 0
-DEAL::FESystem<3>[FE_Q<3>(2)^3]  vector 0 Vector 0
-DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(2)^3-FE_Q<2>(3)^4]  vector 0 Vector 0
-DEAL::FESystem<3>[FE_Q<3>(1)^2-FE_Q<3>(2)^3-FE_Q<3>(3)^4]  vector 0 Vector 0
+DEAL::FESystem<1>[FE_Q<1>(1)^2]  vector 0
+DEAL::FESystem<1>[FE_Q<1>(2)^2]  vector 0
+DEAL::FESystem<1>[FE_Q<1>(3)^2]  vector 0
+DEAL::FESystem<2>[FE_Q<2>(2)^3]  vector 0
+DEAL::FESystem<2>[FE_Q<2>(3)^3]  vector 0
+DEAL::FESystem<3>[FE_Q<3>(1)^3]  vector 0
+DEAL::FESystem<3>[FE_Q<3>(2)^3]  vector 0
+DEAL::FESystem<2>[FE_Q<2>(1)^2-FE_Q<2>(2)^3-FE_Q<2>(3)^4]  vector 0
+DEAL::FESystem<3>[FE_Q<3>(1)^2-FE_Q<3>(2)^3-FE_Q<3>(3)^4]  vector 0


### PR DESCRIPTION
Specifically, convert all tests from FE::interpolate to
FE::convert_generalized_support_point_values_to_nodal_values.

Since the former had three variants but that latter only one,
this also requires deleting some code and updating test results.

This is the last step before #4065 can happen. The patch is pretty boring
and repetitive. There is really nothing exciting to see here.