### PR TITLE
Align function argument names.

### DIFF
--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -1243,7 +1243,7 @@ namespace Functions
      */
     InterpolatedUniformGridData (const std::array<std::pair<double,double>,dim> &interval_endpoints,
                                  const std::array<unsigned int,dim>             &n_subintervals,
-                                 const Table<dim,double>                              &data_values);
+                                 const Table<dim,double>                        &data_values);
 
     /**
      * Compute the value of the function set by bilinear interpolation of the


### PR DESCRIPTION
This addresses the only comment in #4128 that had not been addressed
before the merge.