### PR TITLE
Fix occurrences of std_cxx11.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -748,9 +748,9 @@ namespace GridTools
   template <class MeshType>
   std::vector<typename MeshType::cell_iterator>
   compute_cell_halo_layer_on_level
-  (const MeshType                                                             &mesh,
-   const std_cxx11::function<bool (const typename MeshType::cell_iterator &)> &predicate,
-   const unsigned int                                                         level);
+  (const MeshType                                                       &mesh,
+   const std::function<bool (const typename MeshType::cell_iterator &)> &predicate,
+   const unsigned int                                                    level);
 
 
   /**

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -111,7 +111,7 @@ namespace parallel
           // loop over all cells in multigrid hierarchy and mark artificial:
           if (settings & construct_multigrid_hierarchy)
             {
-              std_cxx11::function<bool (const typename parallel::shared::Triangulation<dim,spacedim>::cell_iterator &)> predicate
+              std::function<bool (const typename parallel::shared::Triangulation<dim,spacedim>::cell_iterator &)> predicate
                 = IteratorFilters::LocallyOwnedLevelCell();
               for (unsigned int lvl=0; lvl<this->n_levels(); ++lvl)
                 {

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1619,9 +1619,9 @@ next_cell:
   template <class MeshType>
   std::vector<typename MeshType::cell_iterator>
   compute_cell_halo_layer_on_level
-  (const MeshType                                                             &mesh,
-   const std_cxx11::function<bool (const typename MeshType::cell_iterator &)> &predicate,
-   const unsigned int                                                         level)
+  (const MeshType                                                       &mesh,
+   const std::function<bool (const typename MeshType::cell_iterator &)> &predicate,
+   const unsigned int                                                    level)
   {
     std::vector<typename MeshType::cell_iterator> level_halo_layer;
     std::vector<bool> locally_active_vertices_on_level_subdomain (mesh.get_triangulation().n_vertices(),

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -48,7 +48,7 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS ; deal_II
     template
     std::vector<X::cell_iterator>
     compute_cell_halo_layer_on_level (const X &,
-                                      const std_cxx11::function<bool (const X::cell_iterator&)> &,
+                                      const std::function<bool (const X::cell_iterator&)> &,
                                       const unsigned int);
 
     template


### PR DESCRIPTION
This fixes a couple of places where we used namespace std_cxx11 after #4128 was
written. This now causes build failures.

Fixes #4197