### PR TITLE
Be more specific which files we feed to doxygen.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -129,11 +129,15 @@ SET(_doxygen_input
   ${CMAKE_CURRENT_SOURCE_DIR}/headers/
 )
 
+file(GLOB _changelog_files
+  ${CMAKE_SOURCE_DIR}/doc/news/*.h
+  )
+
 LIST(APPEND _doxygen_input
   ${CMAKE_SOURCE_DIR}/include/
   ${CMAKE_SOURCE_DIR}/source/
   ${CMAKE_BINARY_DIR}/include/
-  ${CMAKE_SOURCE_DIR}/doc/news/
+  ${_changelog_files}
   ${CMAKE_BINARY_DIR}/doc/news/
   ${CMAKE_CURRENT_BINARY_DIR}/tutorial/tutorial.h
   )


### PR DESCRIPTION
Specifically, make sure that we exclude the doc/news/changes/README.md file.

Fixes #4104.