### PR TITLE
Fix the check for compilers defaulting to C++11.

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -325,9 +325,14 @@ RESET_CMAKE_REQUIRED()
 CHECK_CXX_SOURCE_COMPILES(
   "
   #include <memory>
-  int main()
+
+  #if __cplusplus < 201103L
+  #  error \"The compiler does not default to C++11 or newer.\"
+  #endif
+
+  auto main() -> int
   {
-    std::unique_ptr<int> p0;
+    auto p0 = std::unique_ptr<int>();
     auto p1 = std::move(p0);
   }
   "


### PR DESCRIPTION
Some compilers (notably clang on macOS) enable C++11 features as extensions even when `__cplusplus == 199711` (i.e., compilation in C++98 mode). Mixing language versions in this way confuses some system headers (i..e., `override` versus `throw()`), so only treat the default compiler setting as C++11 if it sets the right value for `__cplusplus`.

Fixes #4186 

Ping @davydden would you please check this with your setup?