### PR TITLE
Implement FE::convert_generalized_support_point_values_to_nodal_values() for FE_Q_iso_Q1.

### DIFF
--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2000 - 2016 by the deal.II authors
+// Copyright (C) 2000 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -120,6 +120,18 @@ public:
    * equivalent_degree replaced by appropriate values.
    */
   virtual std::string get_name () const;
+
+  /**
+   * Implementation of the corresponding function in the FiniteElement
+   * class.  Since the current element is interpolatory, the nodal
+   * values are exactly the support point values. Furthermore, since
+   * the current element is scalar, the support point values need to
+   * be vectors of length 1.
+   */
+  virtual
+  void
+  convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                            std::vector<double>                &nodal_values) const;
 
   /**
    * @name Functions to support hp

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/lac/vector.h>
 #include <deal.II/fe/fe_q_iso_q1.h>
 #include <deal.II/fe/fe_nothing.h>
 
@@ -63,6 +64,29 @@ FE_Q_iso_Q1<dim,spacedim>::get_name () const
           << Utilities::dim_string(dim,spacedim)
           << ">(" << this->degree << ")";
   return namebuf.str();
+}
+
+
+
+template <int dim, int spacedim>
+void
+FE_Q_iso_Q1<dim,spacedim>::
+convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
+                                                          std::vector<double>                &nodal_values) const
+{
+  AssertDimension (support_point_values.size(),
+                   this->get_unit_support_points().size());
+  AssertDimension (support_point_values.size(),
+                   nodal_values.size());
+  AssertDimension (this->dofs_per_cell,
+                   nodal_values.size());
+
+  for (unsigned int i=0; i<this->dofs_per_cell; ++i)
+    {
+      AssertDimension (support_point_values[i].size(), 1);
+
+      nodal_values[i] = support_point_values[i](0);
+    }
 }
 
 


### PR DESCRIPTION
I forgot to commit this patch yesterday. This complements #4185 and #4187.
In relation to #4065. Fixes the fe/interpolate_q_iso_q1 test that currently fails.