### PR TITLE
Clean base/ directory

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -91,15 +91,11 @@ public:
    */
   AlignedVector (const AlignedVector<T> &vec);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. Create a new aligned vector by stealing the contents of
    * @p vec.
-   *
-   * @note This constructor is only available if deal.II is built with C++11.
    */
   AlignedVector (AlignedVector<T> &&vec);
-#endif
 
   /**
    * Assignment to the input vector @p vec.
@@ -109,15 +105,11 @@ public:
   AlignedVector &
   operator = (const AlignedVector<T> &vec);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move assignment operator.
-   *
-   * @note This operator is only available if deal.II is built with C++11.
    */
   AlignedVector &
   operator = (AlignedVector<T> &&vec);
-#endif
 
   /**
    * Change the size of the vector. It keeps old elements previously available
@@ -525,7 +517,6 @@ AlignedVector<T>::AlignedVector (const AlignedVector<T> &vec)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
 template < class T >
 inline
 AlignedVector<T>::AlignedVector (AlignedVector<T> &&vec)
@@ -538,7 +529,6 @@ AlignedVector<T>::AlignedVector (AlignedVector<T> &&vec)
   vec._end_data = nullptr;
   vec._end_allocated = nullptr;
 }
-#endif
 
 
 
@@ -555,7 +545,6 @@ AlignedVector<T>::operator = (const AlignedVector<T> &vec)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
 template < class T >
 inline
 AlignedVector<T> &
@@ -573,7 +562,6 @@ AlignedVector<T>::operator = (AlignedVector<T> &&vec)
 
   return *this;
 }
-#endif
 
 
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -311,16 +311,6 @@ _Pragma("GCC diagnostic pop")
 #endif
 
 
-/**
- * BOOST can falsely detect cxx11 support and will try to use
- * variadic templates even when we disable cxx11. This would create
- * a ton of warnings, so we tell boost to not use them in this case.
- */
-#ifndef DEAL_II_WITH_CXX11
-#define BOOST_NO_CXX11_VARIADIC_TEMPLATES
-#endif
-
-
 /***********************************************************************
  * Final inclusions:
  */

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -108,7 +108,6 @@ public:
    */
   explicit IndexSet (const size_type size);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Copy constructor.
    */
@@ -130,7 +129,6 @@ public:
    * the current one.
    */
   IndexSet &operator= (IndexSet &&is);
-#endif
 
 #ifdef DEAL_II_WITH_TRILINOS
   /**
@@ -1348,8 +1346,6 @@ IndexSet::IndexSet (const size_type size)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
-
 inline
 IndexSet::IndexSet (IndexSet &&is)
   :
@@ -1365,6 +1361,7 @@ IndexSet::IndexSet (IndexSet &&is)
 
   compress ();
 }
+
 
 
 inline
@@ -1385,7 +1382,6 @@ IndexSet &IndexSet::operator= (IndexSet &&is)
   return *this;
 }
 
-#endif
 
 
 inline

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -125,16 +125,11 @@ public:
    */
   Quadrature (const Quadrature<dim> &q);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. Construct a new quadrature object by transferring the
    * internal data of another quadrature object.
-   *
-   * @note this constructor is only available if deal.II is configured with
-   * C++11 support.
    */
   Quadrature (Quadrature<dim> &&) = default;
-#endif
 
   /**
    * Construct a quadrature formula from given vectors of quadrature points

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -295,13 +295,11 @@ public:
              const double alpha = 1,
              const bool factor_out_singular_weight=false);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. We cannot rely on the move constructor for `Quadrature`,
    * since it does not know about the additional member `fraction` of this class.
    */
   QGaussLogR(QGaussLogR<dim> &&) = default;
-#endif
 
 protected:
   /**
@@ -600,13 +598,11 @@ public:
   QGaussRadauChebyshev(const unsigned int n,
                        EndPoint ep=QGaussRadauChebyshev::left);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. We cannot rely on the move constructor for `Quadrature`,
    * since it does not know about the additional member `ep` of this class.
    */
   QGaussRadauChebyshev(QGaussRadauChebyshev<dim> &&) = default;
-#endif
 
 private:
   const EndPoint ep;

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -16,10 +16,7 @@
 #ifndef dealii__quadrature_point_data_h
 #define dealii__quadrature_point_data_h
 
-// must include config before checking for DEAL_II_WITH_CXX11
 #include <deal.II/base/config.h>
-
-#ifdef DEAL_II_WITH_CXX11
 
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/subscriptor.h>
@@ -51,8 +48,6 @@ DEAL_II_NAMESPACE_OPEN
  * However, within the cell this class stores a vector of objects of a single data type.
  * For this reason, this class may not be sufficiently flexible when, for example,
  * adopting a level-set approach to describe material behavior.
- *
- * @note This class is only available if deal.II is configured with C++11 support.
  *
  * @author Denis Davydov, Jean-Paul Pelteret, 2016
  */
@@ -857,7 +852,5 @@ namespace parallel
 
 #endif // DOXYGEN
 DEAL_II_NAMESPACE_CLOSE
-
-#endif // CXX11
 
 #endif

--- a/include/deal.II/base/std_cxx11/bind.h
+++ b/include/deal.II/base/std_cxx11/bind.h
@@ -25,7 +25,7 @@
 DEAL_II_NAMESPACE_OPEN
 // In boost, the placeholders _1, _2, ... are in the global namespace. In
 // C++11, they are in namespace std::placeholders, which makes them awkward to
-// use. Import them into the dealii::std_cxx11 namespace instead and do them
+// use. Import them into the dealii::std_cxx11 namespace instead and do the
 // same below if we use boost instead. Namespace 'placeholders' is also defined
 // in dealii::std_cxx11 namespace to make code C++ standard compatible.
 // That is to say, if std::something works with C++11 standard,

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -69,7 +69,6 @@ public:
    */
   Subscriptor(const Subscriptor &);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor.
    *
@@ -77,7 +76,6 @@ public:
    * objects are subscribing to it.
    */
   Subscriptor(Subscriptor &&);
-#endif
 
   /**
    * Destructor, asserting that the counter is zero.
@@ -92,14 +90,12 @@ public:
    */
   Subscriptor &operator = (const Subscriptor &);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move assignment operator.
    *
    * Asserts that the counter for the moved object is zero.
    */
   Subscriptor &operator = (Subscriptor &&);
-#endif
 
   /**
    * Subscribes a user of the object. The subscriber may be identified by text

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2872,23 +2872,6 @@ operator * (const Number                            factor,
 }
 
 
-#ifndef DEAL_II_WITH_CXX11
-
-template <typename T, typename U, int rank, int dim>
-struct ProductType<T,SymmetricTensor<rank,dim,U> >
-{
-  typedef SymmetricTensor<rank,dim,typename ProductType<T,U>::type> type;
-};
-
-template <typename T, typename U, int rank, int dim>
-struct ProductType<SymmetricTensor<rank,dim,T>,U>
-{
-  typedef SymmetricTensor<rank,dim,typename ProductType<T,U>::type> type;
-};
-
-#endif
-
-
 
 /**
  * Multiplication of a symmetric tensor with a scalar number from the right.

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -444,14 +444,10 @@ public:
   template <typename T2>
   TableBase (const TableBase<N,T2> &src);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move constructor. Transfers the contents of another Table.
-   *
-   * @note This constructor is only available if deal.II is built with C++11.
    */
   TableBase (TableBase<N,T> &&src);
-#endif
 
   /**
    * Destructor. Free allocated memory.
@@ -478,15 +474,11 @@ public:
   template<typename T2>
   TableBase<N,T> &operator = (const TableBase<N,T2> &src);
 
-#ifdef DEAL_II_WITH_CXX11
   /**
    * Move assignment operator. Transfer all elements of <tt>src</tt> into the
    * table.
-   *
-   * @note This operator is only available if deal.II is built with C++11.
    */
   TableBase<N,T> &operator = (TableBase<N,T> &&src);
-#endif
 
   /**
    * Test for equality of two tables.
@@ -1668,8 +1660,6 @@ TableBase<N,T>::TableBase (const TableBase<N,T2> &src)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
-
 template <int N, typename T>
 TableBase<N,T>::TableBase (TableBase<N,T> &&src)
   :
@@ -1679,8 +1669,6 @@ TableBase<N,T>::TableBase (TableBase<N,T> &&src)
 {
   src.table_size = TableIndices<N>();
 }
-
-#endif
 
 
 
@@ -1882,8 +1870,6 @@ TableBase<N,T>::operator = (const TableBase<N,T2> &m)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
-
 template <int N, typename T>
 inline
 TableBase<N,T> &
@@ -1896,8 +1882,6 @@ TableBase<N,T>::operator = (TableBase<N,T> &&m)
 
   return *this;
 }
-
-#endif
 
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1146,22 +1146,6 @@ std::ostream &operator << (std::ostream &out, const Tensor<0,dim,Number> &p)
 //@{
 
 
-#ifndef DEAL_II_WITH_CXX11
-template <typename T, typename U, int rank, int dim>
-struct ProductType<T,Tensor<rank,dim,U> >
-{
-  typedef Tensor<rank,dim,typename ProductType<T,U>::type> type;
-};
-
-template <typename T, typename U, int rank, int dim>
-struct ProductType<Tensor<rank,dim,T>,U>
-{
-  typedef Tensor<rank,dim,typename ProductType<T,U>::type> type;
-};
-#endif
-
-
-
 /**
  * Scalar multiplication of a tensor of rank 0 with an object from the left.
  *
@@ -1178,6 +1162,7 @@ operator * (const Other                 object,
 {
   return object * static_cast<const Number &>(t);
 }
+
 
 
 /**

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -185,10 +185,8 @@ namespace TensorAccessors
   internal::ReorderedIndexView<index, rank, T>
   reordered_index_view(T &t)
   {
-#ifdef DEAL_II_WITH_CXX11
     static_assert(0 <= index && index < rank,
                   "The specified index must lie within the range [0,rank)");
-#endif
 
     return internal::ReorderedIndexView<index, rank, T>(t);
   }
@@ -266,14 +264,12 @@ namespace TensorAccessors
   inline DEAL_II_ALWAYS_INLINE
   void contract(T1 &result, const T2 &left, const T3 &right)
   {
-#ifdef DEAL_II_WITH_CXX11
     static_assert(rank_1 >= no_contr, "The rank of the left tensor must be "
                   "equal or greater than the number of "
                   "contractions");
     static_assert(rank_2 >= no_contr, "The rank of the right tensor must be "
                   "equal or greater than the number of "
                   "contractions");
-#endif
 
     internal::Contract<no_contr, rank_1, rank_2, dim>::template contract<T1, T2, T3>
     (result, left, right);

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1746,7 +1746,6 @@ namespace Threads
   }
 
 
-#ifdef DEAL_II_WITH_CXX11
 
   /**
    * Overload of the new_thread() function for objects that can be called like a
@@ -1821,7 +1820,6 @@ namespace Threads
     return Thread<return_type>(std::function<return_type ()>(function_object));
   }
 
-#endif
 
 
   /**
@@ -3212,7 +3210,6 @@ namespace Threads
   }
 
 
-#ifdef DEAL_II_WITH_CXX11
 
   /**
    * Overload of the new_task function for objects that can be called like a
@@ -3287,7 +3284,7 @@ namespace Threads
     return Task<return_type>(std::function<return_type ()>(function_object));
   }
 
-#endif
+
 
   /**
    * Overload of the new_task function for non-member or static member

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -85,41 +85,6 @@ struct EnableIfScalar<VectorizedArray<Number> >
 
 
 
-#ifndef DEAL_II_WITH_CXX11
-// Specify the types for the implemented multiplications explicitly
-
-template <typename Number>
-struct ProductType<Number, VectorizedArray<Number> >
-{
-  typedef VectorizedArray<Number> type;
-};
-
-template <typename Number>
-struct ProductType<VectorizedArray<Number>, Number>
-{
-  typedef VectorizedArray<Number> type;
-};
-
-// In contrast to scalar types for which the product of a float and a double
-// variable would be a double variable, the implemented type here really is
-// VectorizedArray<float>. Since VectorizedArray<double> is only half as
-// wide as VectorizedArray<float>, we would have to throw away half of the
-// vector otherwise.
-template<>
-struct ProductType<double, VectorizedArray<float> >
-{
-  typedef VectorizedArray<float> type;
-};
-
-template<>
-struct ProductType<VectorizedArray<float>, double>
-{
-  typedef VectorizedArray<float> type;
-};
-#endif
-
-
-
 /**
  * This generic class defines a unified interface to a vectorized data type.
  * For general template arguments, this class simply corresponds to the

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1433,12 +1433,10 @@ namespace MatrixFreeOperators
   MGInterfaceOperator<OperatorType>::vmult (VectorType &dst,
                                             const VectorType &src) const
   {
-#ifdef DEAL_II_WITH_CXX11
 #ifndef DEAL_II_MSVC
     static_assert (std::is_same<typename VectorType::value_type,value_type>::value,
                    "The vector type must be based on the same value type as this"
                    "operator");
-#endif
 #endif
 
     Assert(mf_base_operator != NULL,
@@ -1455,12 +1453,10 @@ namespace MatrixFreeOperators
   MGInterfaceOperator<OperatorType>::Tvmult (VectorType &dst,
                                              const VectorType &src) const
   {
-#ifdef DEAL_II_WITH_CXX11
 #ifndef DEAL_II_MSVC
     static_assert (std::is_same<typename VectorType::value_type,value_type>::value,
                    "The vector type must be based on the same value type as this"
                    "operator");
-#endif
 #endif
 
     Assert(mf_base_operator != NULL,

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -63,7 +63,6 @@ Subscriptor::Subscriptor (const Subscriptor &)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
 Subscriptor::Subscriptor (Subscriptor &&subscriptor)
   :
   counter(0),
@@ -71,19 +70,13 @@ Subscriptor::Subscriptor (Subscriptor &&subscriptor)
 {
   subscriptor.check_no_subscribers();
 }
-#endif
 
 
 
 Subscriptor::~Subscriptor ()
 {
   check_no_subscribers();
-
-#ifdef DEAL_II_WITH_CXX11
   object_info = nullptr;
-#else
-  object_info = 0;
-#endif
 }
 
 
@@ -159,14 +152,13 @@ Subscriptor &Subscriptor::operator = (const Subscriptor &s)
 
 
 
-#ifdef DEAL_II_WITH_CXX11
 Subscriptor &Subscriptor::operator = (Subscriptor &&s)
 {
   s.check_no_subscribers();
   object_info = s.object_info;
   return *this;
 }
-#endif
+
 
 
 void


### PR DESCRIPTION
Remove uses of `DEAL_II_WITH_CXX11`
- enable move constructors and move assignments operators
- further clean-up of `ProductType`
- enable `static_asserts`
- enable `TransferableQuadraturePointData`