### PR TITLE
CMake: Bugfix: Export DEAL_II_WITH_CXX11 in deal.IIConfig.cmake

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -173,6 +173,7 @@ SET(_files
   )
 FOREACH(_file ${_files})
   FILE(APPEND ${_file} "\n\n#\n# Feature configuration:\n#\n\n")
+  FILE(APPEND ${_file} "SET(DEAL_II_WITH_CXX11 ON)\n")
 ENDFOREACH()
 
 GET_CMAKE_PROPERTY(_res VARIABLES)


### PR DESCRIPTION
We might not use it internally any more but some user cmake scripts might still
depend on DEAL_II_WITH_CXX11 to be set.

So let's be generous and export it in deal.IIConfig.cmake as well.