### PR TITLE
Use C++17's [[fallthrough]]

### DIFF
--- a/examples/step-19/step-19.cc
+++ b/examples/step-19/step-19.cc
@@ -456,6 +456,7 @@ namespace Step19
             return;
           }
         AssertThrow (false, ExcNotImplemented());
+        break;
 
       case 2:
         switch (dimensions.second)
@@ -469,6 +470,7 @@ namespace Step19
             return;
           }
         AssertThrow (false, ExcNotImplemented());
+        break;
 
       case 3:
         switch (dimensions.second)

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -140,22 +140,30 @@ TableIndices<N>::TableIndices(const unsigned int index0,
 
   switch (N)
     {
-    case 1: // fallthrough
+    case 1:
       Assert (index1 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 2: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 2:
       Assert (index2 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 3: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 3:
       Assert (index3 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 4: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 4:
       Assert (index4 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 5: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 5:
       Assert (index5 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 6: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 6:
       Assert (index6 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 7: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 7:
       Assert (index7 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
-    case 8: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 8:
       Assert (index8 == numbers::invalid_unsigned_int, ExcMessage("more than N index values provided"));
+      break;
     default:
       ;
     }
@@ -169,23 +177,32 @@ TableIndices<N>::TableIndices(const unsigned int index0,
       // remaining indices to numbers::invalid_unsigned_int:
       for (unsigned int i=0; i<N; ++i)
         indices[i] = numbers::invalid_unsigned_int;
-    case 9: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 9:
       indices[8 % N] = index8;
-    case 8: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 8:
       indices[7 % N] = index7;
-    case 7: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 7:
       indices[6 % N] = index6;
-    case 6: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 6:
       indices[5 % N] = index5;
-    case 5: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 5:
       indices[4 % N] = index4;
-    case 4: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 4:
       indices[3 % N] = index3;
-    case 3: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 3:
       indices[2 % N] = index2;
-    case 2: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 2:
       indices[1 % N] = index1;
-    case 1: // fallthrough
+      DEAL_II_FALLTHROUGH;
+    case 1:
       indices[0 % N] = index0;
     }
 

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -659,26 +659,32 @@ namespace Utilities
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 6:
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 5:
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 4:
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 3:
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 2:
                 if (!comp(*first, val))
                   return first;
                 ++first;
+                DEAL_II_FALLTHROUGH;
               case 1:
                 if (!comp(*first, val))
                   return first;

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -124,9 +124,8 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                 for (unsigned int k=0; k<this->dofs_per_quad; ++k)
                   output_data.shape_values(foffset+k,i) = fe_data.shape_values[k+this->first_face_quad_index][i];
               }
-
-            // fall through...
           }
+          DEAL_II_FALLTHROUGH;
 
           case 2:
           {
@@ -141,9 +140,8 @@ fill_fe_face_values (const typename Triangulation<dim,spacedim>::cell_iterator &
                         = fe_data.shape_values[k+(line*this->dofs_per_line)+this->first_face_line_index][i];
                   }
               }
-
-            // fall through...
           }
+          DEAL_II_FALLTHROUGH;
 
           case 1:
           {

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1404,6 +1404,7 @@ isotropic_child_index (const unsigned int i) const
       else
         Assert(false,
                ExcMessage("This cell has no grandchildren equivalent to isotropic refinement"));
+      break;
     }
 
     case 3:
@@ -1510,6 +1511,7 @@ isotropic_child (const unsigned int i) const
       else
         Assert(false,
                ExcMessage("This cell has no grandchildren equivalent to isotropic refinement"));
+      break;
     }
 
     default:

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -965,18 +965,18 @@ namespace internal
                   r2 = op(index++);
                   for (size_type j=1; j<8; ++j)
                     r2 += op(index++);
-                // no break
+                  DEAL_II_FALLTHROUGH;
                 case 2:
                   r1 = op(index++);
                   for (size_type j=1; j<8; ++j)
                     r1 += op(index++);
                   r1 += r2;
-                // no break
+                  DEAL_II_FALLTHROUGH;
                 case 1:
                   r2 = op(index++);
                   for (size_type j=1; j<8; ++j)
                     r2 += op(index++);
-                // no break
+                  DEAL_II_FALLTHROUGH;
                 default:
                   for (size_type j=0; j<remainder_inner; ++j)
                     r0 += op(index++);

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -7112,7 +7112,7 @@ namespace VectorTools
           update_flags |= UpdateFlags (update_gradients);
           if (spacedim == dim+1)
             update_flags |= UpdateFlags (update_normal_vectors);
-        // no break!
+          DEAL_II_FALLTHROUGH;
 
         default:
           update_flags |= UpdateFlags (update_values);

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -128,6 +128,7 @@ namespace
         {
           while (1)
             {
+              DEAL_II_FALLTHROUGH;
             case step_A:
             {
               if (plainchar == plaintextend)
@@ -140,6 +141,7 @@ namespace
               result = (fragment & 0x0fc) >> 2;
               *codechar++ = base64_encode_value(result);
               result = (fragment & 0x003) << 4;
+              DEAL_II_FALLTHROUGH;
             }
             case step_B:
             {
@@ -153,6 +155,7 @@ namespace
               result |= (fragment & 0x0f0) >> 4;
               *codechar++ = base64_encode_value(result);
               result = (fragment & 0x00f) << 2;
+              DEAL_II_FALLTHROUGH;
             }
             case step_C:
             {
@@ -626,15 +629,16 @@ namespace
     if (patch->points_are_available)
       {
         unsigned int point_no=0;
-        // note: switch without break !
         switch (dim)
           {
           case 3:
             Assert (zstep<n_subdivisions+1, ExcIndexRange(zstep,0,n_subdivisions+1));
             point_no+=(n_subdivisions+1)*(n_subdivisions+1)*zstep;
+            DEAL_II_FALLTHROUGH;
           case 2:
             Assert (ystep<n_subdivisions+1, ExcIndexRange(ystep,0,n_subdivisions+1));
             point_no+=(n_subdivisions+1)*ystep;
+            DEAL_II_FALLTHROUGH;
           case 1:
             Assert (xstep<n_subdivisions+1, ExcIndexRange(xstep,0,n_subdivisions+1));
             point_no+=xstep;
@@ -1887,6 +1891,7 @@ namespace DataOutBase
             rgb_values.red   = 1;
             rgb_values.green = (4*x-xmin-3*xmax)*rezdif;
             rgb_values.blue  = (4.*x-sum13)*rezdif;
+            break;
           default:
             break;
           }

--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -1608,6 +1608,7 @@ d_linear_shape_function (const Point<dim> &xi,
         case 1:
           return x;
         }
+      break;
     }
 
     case 2:
@@ -1625,6 +1626,7 @@ d_linear_shape_function (const Point<dim> &xi,
         case 3:
           return x*y;
         }
+      break;
     }
 
     case 3:
@@ -1651,6 +1653,7 @@ d_linear_shape_function (const Point<dim> &xi,
         case 7:
           return x*y*z;
         }
+      break;
     }
 
     default:

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -1743,7 +1743,9 @@ FE_PolyTensor<PolynomialType,dim,spacedim>::requires_update_flags(const UpdateFl
         out |= update_hessians |  update_values | update_gradients |
                update_jacobian_pushed_forward_grads |
                update_jacobian_pushed_forward_2nd_derivatives;
+      break;
     }
+
     case mapping_raviart_thomas:
     case mapping_piola:
     {

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1061,11 +1061,12 @@ face_to_cell_index (const unsigned int face_index,
 
       // we now also need to adjust the line index for the case of
       // face orientation, face flips, etc
-      unsigned int adjusted_dof_index_on_line;
+      unsigned int adjusted_dof_index_on_line = 0;
       switch (dim)
         {
         case 1:
           Assert (false, ExcInternalError());
+          break;
 
         case 2:
           // in 2d, only face_flip has a meaning. if it is set, consider
@@ -1091,6 +1092,9 @@ face_to_cell_index (const unsigned int face_index,
                   ExcNotImplemented());
           adjusted_dof_index_on_line = dof_index_on_line;
           break;
+
+        default:
+          Assert (false, ExcInternalError());
         }
 
       return (this->first_line_index

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4211,6 +4211,7 @@ namespace GridGenerator
                           break;
                         case 7:
                           cell->face(f)->vertex(v) = center+Point<dim>(outer_radius,-outer_radius);
+                          break;
                         default:
                           break;
                         }

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2119,8 +2119,10 @@ void GridIn<dim, spacedim>::parse_tecplot_header(std::string &header,
     {
     case 3:
       IJK[2]=0;
+      DEAL_II_FALLTHROUGH;
     case 2:
       IJK[1]=0;
+      DEAL_II_FALLTHROUGH;
     case 1:
       IJK[0]=0;
     }

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -508,15 +508,19 @@ namespace TrilinosWrappers
       case -1:
         AssertThrow (false, ExcMessage("AztecOO::Iterate error code -1: "
                                        "option not implemented"));
+        break;
       case -2:
         AssertThrow (false, ExcMessage("AztecOO::Iterate error code -2: "
                                        "numerical breakdown"));
+        break;
       case -3:
         AssertThrow (false, ExcMessage("AztecOO::Iterate error code -3: "
                                        "loss of precision"));
+        break;
       case -4:
         AssertThrow (false, ExcMessage("AztecOO::Iterate error code -4: "
                                        "GMRES Hessenberg ill-conditioned"));
+        break;
       default:
         AssertThrow (ierr >= 0, ExcTrilinosError(ierr));
       }


### PR DESCRIPTION
Based on #4232.

Currently, `gcc-7` (`-Wimplicit-fallthrough`) produces tons of warnings because of not handling these fallthrough/break issues. Although there are also warnings from other libraries during build, this PR silences the warnings appearing when compiling user applications.

In the end, we probably need to handle the warnings from other libraries (set a proper `Wimplicit-fallthrough=n` level)