### PR TITLE
Allow using cxx17's [[fallthrough]]

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -2,7 +2,7 @@ This folder contains the deal.II CMake build system
 ===================================================
 
 Extensive documentation can be found at
-`/doc/development/cmake-internals.html`
+`/doc/developers/cmake-internals.html`
 
 It is structured as follows:
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -117,6 +117,7 @@
 #cmakedefine DEAL_II_HAVE_ISFINITE
 #cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 #cmakedefine DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
+#cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
 
 
 /***********************************************************************


### PR DESCRIPTION
C++17 finally allows to unify all the fallthrough comments/statements by the [[fallthrough]] attribute.

Precedes #4230.