### PR TITLE
Remove a pessimistic reserve() call.

### DIFF
--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -269,7 +269,6 @@ namespace Utilities
 
         // allocate memory for import data
         std::vector<std::pair<unsigned int,unsigned int> > import_targets_temp;
-        import_targets_temp.reserve(n_procs);
         n_import_indices_data = 0;
         for (unsigned int i=0; i<n_procs; i++)
           if (receive_buffer[i] > 0)


### PR DESCRIPTION
Many entries in receive_buffer are zero, so reallocation is not a substantial problem here.

Partially reverts eb5db19276b20829b1d74223a3435688b1e4a12f.

Fixes #4210.