### PR TITLE
Revert eb5db19276 to get consistent memory usage.

### DIFF
--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -269,7 +269,6 @@ namespace Utilities
 
         // allocate memory for import data
         std::vector<std::pair<unsigned int,unsigned int> > import_targets_temp;
-        import_targets_temp.reserve(n_procs);
         n_import_indices_data = 0;
         for (unsigned int i=0; i<n_procs; i++)
           if (receive_buffer[i] > 0)
@@ -278,8 +277,8 @@ namespace Utilities
               import_targets_temp.push_back(std::pair<unsigned int,
                                             unsigned int> (i, receive_buffer[i]));
             }
-
-        import_targets_data = std::move(import_targets_temp);
+        // copy, don't move, to get deterministic memory usage.
+        import_targets_data = import_targets_temp;
       }
 
       // send and receive indices for import data. non-blocking receives and


### PR DESCRIPTION
Rather than rely on details of std::vector's reallocation scheme, just copy the vector.

Supercedes #4233. Fixes #4210.