### PR TITLE
Prefer std::atomic to volatile for thread data.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -156,6 +156,9 @@
  * Depending on the use of threads, we will have to make some variables
  * volatile. We do this here in a very old-fashioned C-style, but still
  * convenient way.
+ *
+ * @deprecated This macro is deprecated in favor of using the
+ * <code>std::atomic</code> template class.
  */
 #ifdef DEAL_II_WITH_THREADS
 #  define DEAL_VOLATILE volatile

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -42,14 +42,17 @@ DEAL_II_NAMESPACE_OPEN
  * The utility of this class is even enhanced by providing identifying strings
  * to the functions subscribe() and unsubscribe(). In case of a hanging
  * subscription during destruction, this string will be listed in the
- * exception's message. For reasons of efficiency, these strings are handled
- * as <tt>const char*</tt>. Therefore, the pointers provided to subscribe()
- * and to unsubscribe() must be the same. Strings with equal contents will not
- * be recognized to be the same. The handling in SmartPointer will take care
- * of this.
+ * exception's message. These strings are represented as <code>const char
+ * *</code> pointers since the underlying buffer comes from (and is managed
+ * by) the run-time type information system: more exactly, these pointers are
+ * the result the function call <code>typeid(x).name()<code> where
+ * <code>x</code> is some object. Therefore, the pointers provided to
+ * subscribe() and to unsubscribe() must be the same. Strings with equal
+ * contents will not be recognized to be the same. The handling in
+ * SmartPointer will take care of this.
  *
- * @note Due to a problem with <tt>volatile</tt> declarations, this additional
- * feature is switched off if multithreading is used.
+ * @note This feature is switched off if multithreading is used (i.e., if
+ * <code>DEAL_II_WITH_THREADS</code> is on).
  *
  * @ingroup memory
  * @author Guido Kanschat, 1998 - 2005

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -20,9 +20,10 @@
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
 
-#include <typeinfo>
+#include <atomic>
 #include <map>
 #include <string>
+#include <typeinfo>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -191,12 +192,12 @@ private:
    * We use the <tt>mutable</tt> keyword in order to allow subscription to
    * constant objects also.
    *
-   * In multithreaded mode, this counter may be modified by different threads.
-   * We thus have to mark it <tt>volatile</tt>. However, this is counter-
-   * productive in non-MT mode since it may pessimize code. So use the macro
-   * defined in <tt>deal.II/base/config.h</tt> to selectively add volatility.
+   * This counter may be read from and written to concurrently in
+   * multithreaded code: hence we use the <code>std::atomic</code> class
+   * template.
+   *
    */
-  mutable DEAL_VOLATILE unsigned int counter;
+  mutable std::atomic<unsigned int> counter;
 
   /**
    * In this map, we count subscriptions for each different identification

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -152,6 +152,8 @@ Subscriptor::subscribe(const char *id) const
     object_info = &typeid(*this);
   ++counter;
 
+  // This feature is disabled when we compile with threads: see the
+  // documentation of this class.
 #  ifndef DEAL_II_WITH_THREADS
   const char *const name = (id != 0) ? id : unknown_subscriber;
 
@@ -183,6 +185,8 @@ Subscriptor::unsubscribe(const char *id) const
 
   --counter;
 
+  // This feature is disabled when we compile with threads: see the
+  // documentation of this class.
 #  ifndef DEAL_II_WITH_THREADS
   map_iterator it = counter_map.find(name);
   AssertNothrow (it != counter_map.end(), ExcNoSubscriber(object_info->name(), name));

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -24,23 +24,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-#ifdef DEBUG
-namespace
-{
-// create a lock that might be used to control subscription to and
-// unsubscription from objects, as that might happen in parallel.
-// since it should happen rather seldom that several threads try to
-// operate on different objects at the same time (the usual case is
-// that they subscribe to the same object right after thread
-// creation), a global lock should be sufficient, rather than one that
-// operates on a per-object base (in which case we would have to
-// include the huge <thread_management.h> file into the
-// <subscriptor.h> file).
-  Threads::Mutex subscription_lock;
-}
-#endif
-
-
 static const char *unknown_subscriber = "unknown subscriber";
 
 
@@ -167,7 +150,6 @@ Subscriptor::subscribe(const char *id) const
 #ifdef DEBUG
   if (object_info == nullptr)
     object_info = &typeid(*this);
-  Threads::Mutex::ScopedLock lock (subscription_lock);
   ++counter;
 
 #  ifndef DEAL_II_WITH_THREADS
@@ -199,7 +181,6 @@ Subscriptor::unsubscribe(const char *id) const
   if (counter == 0)
     return;
 
-  Threads::Mutex::ScopedLock lock (subscription_lock);
   --counter;
 
 #  ifndef DEAL_II_WITH_THREADS

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -15,10 +15,9 @@
 
 #include <deal.II/base/thread_management.h>
 
-#include <cerrno>
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
-#include <list>
 
 #ifdef DEAL_II_HAVE_UNISTD_H
 #  include <unistd.h>
@@ -32,15 +31,11 @@ namespace Threads
 {
   namespace internal
   {
-    // counter and access mutex for the
-    // number of threads
-    volatile unsigned int n_existing_threads_counter = 1;
-    Mutex  n_existing_threads_mutex;
+    static std::atomic<unsigned int> n_existing_threads_counter(1);
 
 
     void register_thread ()
     {
-      Mutex::ScopedLock lock (n_existing_threads_mutex);
       ++n_existing_threads_counter;
     }
 
@@ -48,7 +43,6 @@ namespace Threads
 
     void deregister_thread ()
     {
-      Mutex::ScopedLock lock (n_existing_threads_mutex);
       --n_existing_threads_counter;
       Assert (n_existing_threads_counter >= 1,
               ExcInternalError());
@@ -128,7 +122,6 @@ namespace Threads
 
   unsigned int n_existing_threads ()
   {
-    Mutex::ScopedLock lock (internal::n_existing_threads_mutex);
     return internal::n_existing_threads_counter;
   }
 

--- a/tests/base/thread_local_storage_01.cc
+++ b/tests/base/thread_local_storage_01.cc
@@ -17,6 +17,7 @@
 // verify that thread local storage works as advertised
 
 #include "../tests.h"
+#include <atomic>
 #include <iomanip>
 #include <fstream>
 
@@ -39,7 +40,7 @@ struct X
 
 Threads::ThreadLocalStorage<X> *tls_data;
 
-volatile int counter = 0;
+static std::atomic<int> counter(0);
 
 void execute (int i)
 {

--- a/tests/base/thread_local_storage_02.cc
+++ b/tests/base/thread_local_storage_02.cc
@@ -18,6 +18,7 @@
 // the initialization with an exemplar
 
 #include "../tests.h"
+#include <atomic>
 #include <iomanip>
 #include <fstream>
 
@@ -49,7 +50,7 @@ struct X
 
 Threads::ThreadLocalStorage<X> *tls_data;
 
-volatile int counter = 0;
+static std::atomic<int> counter(0);
 
 void execute (int i)
 {

--- a/tests/base/thread_validity_08.cc
+++ b/tests/base/thread_validity_08.cc
@@ -17,6 +17,7 @@
 // see if we can detach from threads
 
 #include "../tests.h"
+#include <atomic>
 #include <iomanip>
 #include <fstream>
 #include <unistd.h>
@@ -25,7 +26,7 @@
 
 
 Threads::Mutex mutex;
-volatile int spin_lock = 0;
+static std::atomic<int> spin_lock(0);
 
 
 void worker ()

--- a/tests/base/thread_validity_09.cc
+++ b/tests/base/thread_validity_09.cc
@@ -20,6 +20,7 @@
 // and makes sure nobody writes into it at undue times
 
 #include "../tests.h"
+#include <atomic>
 #include <iomanip>
 #include <fstream>
 #include <unistd.h>
@@ -28,7 +29,7 @@
 
 
 Threads::Mutex mutex;
-volatile int spin_lock = 0;
+static std::atomic<int> spin_lock(0);
 
 
 int worker ()


### PR DESCRIPTION
This commit gets rid of our usage of `volatile` for data shared between threads in favor of the new `std::atomic` class template. 

In case you are not familiar with this class, here is a brief description from Scott Meyers' Effective Modern C++:

Once a `std::atomic` object has been constructed, operations on it behave as if they were inside a mutex-protected critical section, but the operations are generally implemented using special machine instructions that are more efficient than would be the case if a mutex were deployed.