### PR TITLE
Add make unique

### DIFF
--- a/include/deal.II/base/std_cxx14/memory.h
+++ b/include/deal.II/base/std_cxx14/memory.h
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+#ifndef dealii__cxx14_memory_h
+#define dealii__cxx14_memory_h
+
+#include <deal.II/base/config.h>
+
+#include <memory>
+
+#ifndef DEAL_II_WITH_CXX14
+// needed for array type check
+#  include <type_traits>
+#endif
+
+DEAL_II_NAMESPACE_OPEN
+namespace std_cxx14
+{
+#ifdef DEAL_II_WITH_CXX14
+  using std::make_unique;
+#else
+  template <typename T, typename... Args>
+  inline
+  std::unique_ptr<T>
+  make_unique(Args &&... constructor_arguments)
+  {
+    static_assert(!std::is_array<T>::value,
+                  "This function is not implemented for array types.");
+    return std::unique_ptr<T>(new T(std::forward<Args>(constructor_arguments)...));
+  }
+#endif
+}
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // dealii__cxx14_memory_h

--- a/source/numerics/data_out_dof_data.cc
+++ b/source/numerics/data_out_dof_data.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/work_stream.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_vector.h>
@@ -986,13 +987,13 @@ add_data_vector (const VectorType                         &vec,
       Assert (false, ExcInternalError());
     }
 
-  internal::DataOut::DataEntryBase<DoFHandlerType> *new_entry
-    = new internal::DataOut::DataEntry<DoFHandlerType,VectorType>(dofs, &vec, names,
-        data_component_interpretation);
+  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+                   (dofs, &vec, names, data_component_interpretation);
+
   if (actual_type == type_dof_data)
-    dof_data.push_back (std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> >(new_entry));
+    dof_data.emplace_back (std::move(new_entry));
   else
-    cell_data.push_back (std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> >(new_entry));
+    cell_data.emplace_back (std::move(new_entry));
 }
 
 
@@ -1018,9 +1019,9 @@ add_data_vector (const VectorType                       &vec,
                                                      dofs->n_dofs(),
                                                      dofs->get_triangulation().n_active_cells()));
 
-  internal::DataOut::DataEntryBase<DoFHandlerType> *new_entry
-    = new internal::DataOut::DataEntry<DoFHandlerType,VectorType>(dofs, &vec, &data_postprocessor);
-  dof_data.push_back (std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> >(new_entry));
+  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+                   (dofs, &vec, &data_postprocessor);
+  dof_data.emplace_back (std::move(new_entry));
 }
 
 
@@ -1041,9 +1042,9 @@ add_data_vector (const DoFHandlerType                   &dof_handler,
 
   AssertDimension (vec.size(), dof_handler.n_dofs());
 
-  internal::DataOut::DataEntryBase<DoFHandlerType> *new_entry
-    = new internal::DataOut::DataEntry<DoFHandlerType,VectorType>(&dof_handler, &vec, &data_postprocessor);
-  dof_data.push_back (std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> >(new_entry));
+  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+                   (&dof_handler, &vec, &data_postprocessor);
+  dof_data.emplace_back (std::move(new_entry));
 }
 
 
@@ -1118,10 +1119,9 @@ add_data_vector
        std::vector<DataComponentInterpretation::DataComponentInterpretation>
        (names.size(), DataComponentInterpretation::component_is_scalar));
 
-  internal::DataOut::DataEntryBase<DoFHandlerType> *new_entry
-    = new internal::DataOut::DataEntry<DoFHandlerType,VectorType>(&dof_handler, &data, names,
-        data_component_interpretation);
-  dof_data.push_back (std::shared_ptr<internal::DataOut::DataEntryBase<DoFHandlerType> >(new_entry));
+  auto new_entry = std_cxx14::make_unique<internal::DataOut::DataEntry<DoFHandlerType,VectorType>>
+                   (&dof_handler, &data, names, data_component_interpretation);
+  dof_data.emplace_back (std::move(new_entry));
 }
 
 


### PR DESCRIPTION
`std::make_unique` did not make its way into C++11, but it is easy enough to implement ourselves. I added the improvement that motivated me to write the wrapper too.