### PR TITLE
Use lambdas and tasks to parallelize construction of FESystem.

### DIFF
--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -973,23 +973,6 @@ private:
       base_elements;
 
   /**
-   * Initialize the @p unit_support_points field of the FiniteElement class.
-   * Called from the constructor.
-   */
-  void initialize_unit_support_points ();
-
-  /**
-   * Initialize the @p unit_face_support_points field of the FiniteElement
-   * class. Called from the constructor.
-   */
-  void initialize_unit_face_support_points ();
-
-  /**
-   * Initialize the @p adjust_quad_dof_index_for_face_orientation_table field
-   * of the FiniteElement class. Called from the constructor.
-   */
-  void initialize_quad_dof_index_permutation ();
-  /**
    * This function is simply singled out of the constructors since there are
    * several of them. It sets up the index table for the system as well as @p
    * restriction and @p prolongation matrices.


### PR DESCRIPTION
This is another step in trying out whether using lambdas and tasks together
are useful. It certainly reduces the complexity of the code base because it reduces the
number of functions we have to declare, and can instead inline thinks.

We've had problems in the past where some 'obvious' attempts at parallelizing
FESystem actually turned out slower than the code was before. The code I'm
parallelizing here is not large, and so it's questionable whether this here
is useful at all. At the same time, this is in the constructor, so I'm not
overly concerned about cases where we have too little work to do to make
it worth our while -- quick things done once might in the worst case
become slightly slower, but because they're only done once, I don't
care too much. On the other hand, if someone tries to construct an
expensive element with lots of bases and lots of dofs, the code here may
actually be useful.

Either way, I think of this mostly as a neutral, harmless experiment.