### PR TITLE
Improve serialization interface

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -23,6 +23,7 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/serialization/split_member.hpp>
+#include <boost/property_tree/ptree_serialization.hpp>
 
 #include <map>
 #include <vector>

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -23,7 +23,7 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/serialization/split_member.hpp>
-#include <boost/archive/basic_archive.hpp> 
+#include <boost/archive/basic_archive.hpp>
 #include <boost/property_tree/ptree_serialization.hpp>
 
 #include <map>

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -23,6 +23,7 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/serialization/split_member.hpp>
+#include <boost/archive/basic_archive.hpp> 
 #include <boost/property_tree/ptree_serialization.hpp>
 
 #include <map>

--- a/tests/serialization/parameter_handler.cc
+++ b/tests/serialization/parameter_handler.cc
@@ -19,7 +19,6 @@
 
 #include "serialization.h"
 #include <deal.II/base/parameter_handler.h>
-#include <boost/property_tree/ptree_serialization.hpp>
 #include <boost/serialization/vector.hpp>
 
 


### PR DESCRIPTION
Included ptree_serialization.hpp in parameter_handler.h, for the reason discussed in #4243.