### PR TITLE
Fix uninitialized memory in ghost range of distributed vector

### DIFF
--- a/doc/news/changes/minor/20170412MartinKronbichler
+++ b/doc/news/changes/minor/20170412MartinKronbichler
@@ -1,0 +1,6 @@
+Fixed: When initializing a LinearAlgebra::distributed::Vector and omitting
+zeroing the entries, ghost entries were left undefined, leading to use of
+invalid memory when calling compress() without a previous zero_out_ghosts()
+also when the local range was completely valid. This is now fixed.
+<br>
+(Martin Kronbichler, 2017/04/12)

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -104,8 +104,8 @@ namespace LinearAlgebra
       // set entries to zero if so requested
       if (omit_zeroing_entries == false)
         this->operator = (Number());
-
-      vector_is_ghosted = false;
+      else
+        zero_out_ghosts();
     }
 
 
@@ -133,6 +133,8 @@ namespace LinearAlgebra
 
       if (omit_zeroing_entries == false)
         this->operator= (Number());
+      else
+        zero_out_ghosts();
 
       if (import_data != nullptr)
         {
@@ -144,8 +146,6 @@ namespace LinearAlgebra
           // call these methods and hence do not need to have the storage.
           import_data = nullptr;
         }
-
-      vector_is_ghosted = false;
 
       thread_loop_partitioner = v.thread_loop_partitioner;
     }
@@ -240,8 +240,6 @@ namespace LinearAlgebra
       dealii::internal::VectorOperations::Vector_copy<Number,Number> copier(v.val, val);
       internal::VectorOperations::parallel_for(copier, 0, partitioner->local_size(),
                                                thread_loop_partitioner);
-
-      zero_out_ghosts();
     }
 
 

--- a/tests/mpi/parallel_vector_21.cc
+++ b/tests/mpi/parallel_vector_21.cc
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Check that the data range representing ghosts is really initialized to zero
+// when doing reinit() from another vector and manually setting the local
+// range
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+void test()
+{
+  unsigned int my_id = Utilities::MPI::this_mpi_process (MPI_COMM_WORLD);
+  unsigned int n_procs = Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD);
+
+  IndexSet locally_owned(n_procs*2);
+  locally_owned.add_range(my_id*2, my_id*2+2);
+  IndexSet ghost_set(n_procs*2);
+  ghost_set.add_index(0);
+  ghost_set.add_index(2);
+
+  LinearAlgebra::distributed::Vector<double> v(locally_owned, ghost_set, MPI_COMM_WORLD);
+
+  // create vector without actually setting the entries since they will be
+  // overwritten soon anyway
+  LinearAlgebra::distributed::Vector<double> v2;
+  v2.reinit(v, true);
+
+  // set locally owned range of v2 manually
+  for (unsigned int i=0; i<v2.local_size(); ++i)
+    v2.local_element(i) = 1.;
+
+  // add entries to ghost values
+  v2(0) += 1.;
+  v2(2) += 1.;
+  v2.compress(VectorOperation::add);
+
+  // now we should have the correct data, not some uninitialized trash that
+  // resided in the ghost range
+  v2.print(deallog.get_file_stream());
+
+  v2.update_ghost_values();
+  v2.print(deallog.get_file_stream());
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  MPILogInitAll log;
+  test();
+}

--- a/tests/mpi/parallel_vector_21.mpirun=3.output
+++ b/tests/mpi/parallel_vector_21.mpirun=3.output
@@ -1,0 +1,35 @@
+
+Process #0
+Local range: [0, 2), global size: 6
+Vector data:
+4.000e+00 1.000e+00 
+Process #0
+Local range: [0, 2), global size: 6
+Vector data:
+4.000e+00 1.000e+00 
+Ghost entries (global index / value):
+(2/4.000e+00) 
+
+Process #1
+Local range: [2, 4), global size: 6
+Vector data:
+4.000e+00 1.000e+00 
+Process #1
+Local range: [2, 4), global size: 6
+Vector data:
+4.000e+00 1.000e+00 
+Ghost entries (global index / value):
+(0/4.000e+00) 
+
+
+Process #2
+Local range: [4, 6), global size: 6
+Vector data:
+1.000e+00 1.000e+00 
+Process #2
+Local range: [4, 6), global size: 6
+Vector data:
+1.000e+00 1.000e+00 
+Ghost entries (global index / value):
+(0/4.000e+00) (2/4.000e+00) 
+


### PR DESCRIPTION
In case a distributed vector is initialized from another vector with `omit_zeroing_entries==true`, the ghost range needs still be initialized with zero to not give uninitialized memory.

The test I added relies on the correct behavior, but one would need to run it in valgrind to really see it on all machines, showing an error message of the form
```
==25518== Uninitialised byte(s) found during client check request
==25518==    at 0x2A85A8D1: ??? (in /usr/lib64/openmpi/lib/libopen-pal.so.6.2.2)
==25518==    by 0x29482705: PMPI_Isend (in /usr/lib64/openmpi/lib/libmpi.so.1.6.2)
==25518==    by 0xB396053: dealii::LinearAlgebra::distributed::Vector<double>::compress_start(unsigned int, dealii::VectorOperation::values) (la_parallel_vector.templates.h:605)
==25518==    by 0xB396FB4: dealii::LinearAlgebra::distributed::Vector<double>::compress(dealii::VectorOperation::values) (la_parallel_vector.templates.h:493)
```
Many times the undefined memory is still `0` and thus ok for the test. But I do not know of a better way to test for uninitialized memory.