### PR TITLE
Remove AssertGlobalIndexRange.

### DIFF
--- a/doc/news/changes/incompatibilities/20170413DavidWells
+++ b/doc/news/changes/incompatibilities/20170413DavidWells
@@ -1,0 +1,3 @@
+Changed: The <code>AssertGlobalIndexRange</code> macro has been removed: the expansion of this macro involved an undeclared template and always generates compiler errors if used.
+<br>
+(David Wells, 2017/04/13)

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1171,21 +1171,6 @@ namespace StandardExceptions
                                              dealii::ExcIndexRange((index),0,(range)))
 
 /**
- * An assertion that tests that a given index is within the half-open
- * range <code>[0,range)</code>. It throws an exception object
- * <code>ExcIndexRange(index,0,range)</code> if the assertion
- * fails.
- *
- * This variation of the AssertIndexRange assertion is used for indices of type
- * types::global_dof_index for which we need to make special accommodations because
- * they may not fit into the regular 32-bit integer indices used in AssertIndexRange.
- *
- * @ingroup Exceptions
- */
-#define AssertGlobalIndexRange(index,range) Assert((index) < (range), \
-                                                   dealii::ExcIndexRange<types::global_dof_index>((index),0,(range)))
-
-/**
  * An assertion that checks whether a number is finite or not. We explicitly
  * cast the number to std::complex to match the signature of the exception
  * (see there for an explanation of why we use std::complex at all) and to


### PR DESCRIPTION
The expansion of this macro involves the nonexistent class template `ExcIndexRange<T>` and was never used inside the library, so we can just get rid of this altogether.

Closes #2372.