### PR TITLE
fix c++11 detection under MSVC

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -177,8 +177,9 @@ CHECK_CXX_SOURCE_COMPILES(
   thread_local std::array<int,3> p;
   std::condition_variable c;
 
-  // check the version language macro
-  #if !(__cplusplus >= 201103L)
+  // Check the version language macro, but skip MSVC because
+  // MSVC reports 199711 even in MSVC 2017.
+  #if __cplusplus < 201103L && !defined(_MSC_VER)
   #  error \"insufficient support for C++11\"
   #endif
 


### PR DESCRIPTION
It turns out MSVC defines __cplusplus as 1997 even with MSVC 2017. Sigh.
Instead of trying to parse what support we have, just skip this macro
check and hope we catch all problems with the configuration tests
itself.