### PR TITLE
Install examples if they are built.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -93,6 +93,9 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_EXECUTABLE_RELDIR}"
             )
           ADD_DEPENDENCIES(examples ${_name}.${_build_lowercase})
+          INSTALL(TARGETS ${_name}.${_build_lowercase}
+            DESTINATION ${DEAL_II_EXECUTABLE_RELDIR}
+            )
         ENDFOREACH()
 
       ELSE()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -94,7 +94,7 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
             )
           ADD_DEPENDENCIES(examples ${_name}.${_build_lowercase})
           INSTALL(TARGETS ${_name}.${_build_lowercase}
-            DESTINATION ${DEAL_II_EXECUTABLE_RELDIR}
+            DESTINATION ${DEAL_II_EXAMPLES_RELDIR}/${_name}
             )
         ENDFOREACH()
 


### PR DESCRIPTION
The cmake documentation states:

~~~
//If set to ON, all configurable example executables will be built
// and installed as well. If set to OFF, the examples component
// only installs the source code of example steps.
DEAL_II_COMPILE_EXAMPLES:BOOL=ON
~~~

however the examples were not installed. Only compiled. 