### PR TITLE
Prefer emplace_back to push_back.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1805,7 +1805,7 @@ namespace DataOutBase
    *    std::ofstream output (filename.c_str());
    *    data_out.write_vtu (output);
    *
-   *    times_and_names.push_back (std::pair<double,std::string> (time, filename));
+   *    times_and_names.emplace_back (time, filename);
    *    std::ofstream pvd_output ("solution.pvd");
    *    DataOutBase::write_pvd_record (pvd_output, times_and_names);
    *  }
@@ -1848,14 +1848,14 @@ namespace DataOutBase
    *  const unsigned int number_of_time_steps = 3;
    *  std::vector<std::vector<std::string > > piece_names(number_of_time_steps);
    *
-   *  piece_names[0].push_back("subdomain_01.time_step_0.vtk");
-   *  piece_names[0].push_back("subdomain_02.time_step_0.vtk");
+   *  piece_names[0].emplace_back("subdomain_01.time_step_0.vtk");
+   *  piece_names[0].emplace_back("subdomain_02.time_step_0.vtk");
    *
-   *  piece_names[1].push_back("subdomain_01.time_step_1.vtk");
-   *  piece_names[1].push_back("subdomain_02.time_step_1.vtk");
+   *  piece_names[1].emplace_back("subdomain_01.time_step_1.vtk");
+   *  piece_names[1].emplace_back("subdomain_02.time_step_1.vtk");
    *
-   *  piece_names[2].push_back("subdomain_01.time_step_2.vtk");
-   *  piece_names[2].push_back("subdomain_02.time_step_2.vtk");
+   *  piece_names[2].emplace_back("subdomain_01.time_step_2.vtk");
+   *  piece_names[2].emplace_back("subdomain_02.time_step_2.vtk");
    *
    *  std::ofstream visit_output ("master_file.visit");
    *
@@ -1880,16 +1880,16 @@ namespace DataOutBase
    *  std::vector<std::pair<double,std::vector<std::string > > > times_and_piece_names(number_of_time_steps);
    *
    *  times_and_piece_names[0].first = 0.0;
-   *  times_and_piece_names[0].second.push_back("subdomain_01.time_step_0.vtk");
-   *  times_and_piece_names[0].second.push_back("subdomain_02.time_step_0.vtk");
+   *  times_and_piece_names[0].second.emplace_back("subdomain_01.time_step_0.vtk");
+   *  times_and_piece_names[0].second.emplace_back("subdomain_02.time_step_0.vtk");
    *
    *  times_and_piece_names[1].first = 0.5;
-   *  times_and_piece_names[1].second.push_back("subdomain_01.time_step_1.vtk");
-   *  times_and_piece_names[1].second.push_back("subdomain_02.time_step_1.vtk");
+   *  times_and_piece_names[1].second.emplace_back("subdomain_01.time_step_1.vtk");
+   *  times_and_piece_names[1].second.emplace_back("subdomain_02.time_step_1.vtk");
    *
    *  times_and_piece_names[2].first = 1.0;
-   *  times_and_piece_names[2].second.push_back("subdomain_01.time_step_2.vtk");
-   *  times_and_piece_names[2].second.push_back("subdomain_02.time_step_2.vtk");
+   *  times_and_piece_names[2].second.emplace_back("subdomain_01.time_step_2.vtk");
+   *  times_and_piece_names[2].second.emplace_back("subdomain_02.time_step_2.vtk");
    *
    *  std::ofstream visit_output ("master_file.visit");
    *

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -815,9 +815,7 @@ namespace WorkStream
                 scratch_data = new ScratchData(sample_scratch_data);
                 copy_data    = new CopyData(sample_copy_data);
 
-                typename ScratchAndCopyDataList::value_type
-                new_scratch_object (scratch_data, copy_data, true);
-                scratch_and_copy_data_list.push_back (new_scratch_object);
+                scratch_and_copy_data_list.emplace_back (scratch_data, copy_data, true);
               }
           }
 

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -1451,7 +1451,7 @@ ConstraintMatrix::add_line (const size_type line)
                         numbers::invalid_size_type);
 
   // push a new line to the end of the list
-  lines.push_back (ConstraintLine());
+  lines.emplace_back ();
   lines.back().line = line;
   lines.back().inhomogeneity = 0.;
   lines_cache[line_index] = lines.size()-1;
@@ -1497,7 +1497,7 @@ ConstraintMatrix::add_entry (const size_type line,
         return;
       }
 
-  line_ptr->entries.push_back (std::make_pair(column,value));
+  line_ptr->entries.emplace_back (column, value);
 }
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -703,8 +703,7 @@ no_constraint:
                 else
                   {
                     const unsigned short constraint_loc = constr_ind[j]->second;
-                    new_constraint_indicator.push_back
-                    (std::pair<unsigned short,unsigned short> (m_index, constraint_loc));
+                    new_constraint_indicator.emplace_back (m_index, constraint_loc);
                     for (unsigned int k=constraint_pool_row_index[constraint_loc];
                          k<constraint_pool_row_index[constraint_loc+1];
                          ++k, ++glob_indices[j])

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1613,7 +1613,7 @@ reinit(const DoFHandlerType                                  &dof_handler,
     (dof_handlers, additional_data.level_mg_handler);
 
   std::vector<hp::QCollection<1> > quad_hp;
-  quad_hp.push_back (hp::QCollection<1>(quad));
+  quad_hp.emplace_back (quad);
 
   internal_reinit(StaticMappingQ1<dim>::mapping, dof_handlers,constraints,
                   locally_owned_sets, quad_hp, additional_data);
@@ -1641,7 +1641,7 @@ reinit(const Mapping<dim>                                    &mapping,
     (dof_handlers, additional_data.level_mg_handler);
 
   std::vector<hp::QCollection<1> > quad_hp;
-  quad_hp.push_back (hp::QCollection<1>(quad));
+  quad_hp.emplace_back (quad);
 
   internal_reinit(mapping, dof_handlers,constraints,locally_owned_sets,
                   quad_hp,  additional_data);
@@ -1662,7 +1662,7 @@ reinit(const std::vector<const DoFHandlerType *>   &dof_handler,
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   for (unsigned int q=0; q<quad.size(); ++q)
-    quad_hp.push_back (hp::QCollection<1>(quad[q]));
+    quad_hp.emplace_back (quad[q]);
   internal_reinit(StaticMappingQ1<dim>::mapping, dof_handler,constraint,
                   locally_owned_set, quad_hp, additional_data);
 }
@@ -1681,7 +1681,7 @@ reinit(const std::vector<const DoFHandlerType *>             &dof_handler,
     internal::MatrixFree::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
-  quad_hp.push_back (hp::QCollection<1>(quad));
+  quad_hp.emplace_back (quad);
   internal_reinit(StaticMappingQ1<dim>::mapping, dof_handler,constraint,
                   locally_owned_set, quad_hp, additional_data);
 }
@@ -1701,7 +1701,7 @@ reinit(const Mapping<dim>                                    &mapping,
     internal::MatrixFree::extract_locally_owned_index_sets
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
-  quad_hp.push_back (hp::QCollection<1>(quad));
+  quad_hp.emplace_back (quad);
   internal_reinit(mapping, dof_handler,constraint,
                   locally_owned_set, quad_hp, additional_data);
 }
@@ -1722,7 +1722,7 @@ reinit(const Mapping<dim>                                   &mapping,
     (dof_handler, additional_data.level_mg_handler);
   std::vector<hp::QCollection<1> > quad_hp;
   for (unsigned int q=0; q<quad.size(); ++q)
-    quad_hp.push_back (hp::QCollection<1>(quad[q]));
+    quad_hp.emplace_back (quad[q]);
   internal_reinit(mapping, dof_handler,constraint,locally_owned_set,
                   quad_hp, additional_data);
 }
@@ -1742,7 +1742,7 @@ reinit(const Mapping<dim>                                    &mapping,
   // find out whether we use a hp Quadrature or a standard quadrature
   std::vector<hp::QCollection<1> > quad_hp;
   for (unsigned int q=0; q<quad.size(); ++q)
-    quad_hp.push_back (hp::QCollection<1>(quad[q]));
+    quad_hp.emplace_back (quad[q]);
   internal_reinit (mapping,
                    dof_handler,
                    constraint, locally_owned_set, quad_hp, additional_data);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -392,8 +392,7 @@ namespace internal
              || cell->subdomain_id() == subdomain_id)
       {
         Assert (cell->active(), ExcInternalError());
-        cell_its.push_back (std::pair<unsigned int,unsigned int>
-                            (cell->level(), cell->index()));
+        cell_its.emplace_back (cell->level(), cell->index());
       }
   }
 }
@@ -448,8 +447,7 @@ initialize_dof_handlers (const std::vector<const DoFHandler<dim>*> &dof_handler,
                                                      end_cell = tria.end(level);
           for ( ; cell != end_cell; ++cell)
             if (cell->level_subdomain_id() == my_pid)
-              cell_level_index.push_back (std::pair<unsigned int,unsigned int>
-                                          (cell->level(), cell->index()));
+              cell_level_index.emplace_back (cell->level(), cell->index());
         }
     }
 }

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -388,8 +388,8 @@ namespace internal
  *   ...   // compute error_estimator, which contains one value per cell
  *
  *   std::vector<std::string> solution_names;
- *   solution_names.push_back ("x-displacement");
- *   solution_names.push_back ("y-displacement");
+ *   solution_names.emplace_back ("x-displacement");
+ *   solution_names.emplace_back ("y-displacement");
  *
  *   DataOut<dim> data_out;
  *   data_out.attach_dof_handler (dof_handler);

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -78,8 +78,8 @@ template <int dim, int spacedim> class DoFHandler;
  *                                  // first declare the vectors
  *                                  // to be used later
  *   std::vector<std::string> solution_names;
- *   solution_names.push_back ("u");
- *   solution_names.push_back ("v");
+ *   solution_names.emplace_back ("u");
+ *   solution_names.emplace_back ("v");
  *   data_out_stack.declare_data_vector (solution_names,
  *                                       DataOutStack<dim>::dof_vector);
  *   data_out_stack.declare_data_vector ("error",

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -498,8 +498,8 @@ namespace Functions
 
       // Put in the first point.
       cells.push_back(cell);
-      qpoints.push_back(std::vector<Point<dim> >(1, qp.get()));
-      maps.push_back(std::vector<unsigned int> (1, 0));
+      qpoints.emplace_back(1, qp.get());
+      maps.emplace_back(1, 0);
     }
 
 
@@ -556,8 +556,8 @@ namespace Functions
                          VectorTools::ExcPointNotAvailableHere());
 
             cells.push_back(my_pair.first);
-            qpoints.push_back(std::vector<Point<dim> >(1, my_pair.second));
-            maps.push_back(std::vector<unsigned int>(1, first_outside));
+            qpoints.emplace_back(1, my_pair.second);
+            maps.emplace_back(1, first_outside);
             c++;
             point_flags[first_outside] = true;
             // And check if we can exit the loop now

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -938,7 +938,7 @@ namespace MatrixCreator
 
       std::vector<types::global_dof_index> dofs_on_face_vector (dofs_per_face);
 
-      // Because CopyData objects are reused and that push_back is
+      // Because CopyData objects are reused and emplace_back is
       // used, dof_is_on_face, cell_matrix, and cell_vector must be
       // cleared before they are reused
       copy_data.dof_is_on_face.clear();
@@ -951,9 +951,9 @@ namespace MatrixCreator
         if (boundary_functions.find(cell->face(face)->boundary_id()) !=
             boundary_functions.end())
           {
-            copy_data.cell_matrix.push_back(FullMatrix<number> (copy_data.dofs_per_cell,
-                                                                copy_data.dofs_per_cell));
-            copy_data.cell_vector.push_back(Vector<number> (copy_data.dofs_per_cell));
+            copy_data.cell_matrix.emplace_back(copy_data.dofs_per_cell,
+                                               copy_data.dofs_per_cell);
+            copy_data.cell_vector.emplace_back(copy_data.dofs_per_cell);
             fe_values.reinit (cell, face);
 
             if (fe_is_system)
@@ -1069,7 +1069,7 @@ namespace MatrixCreator
             cell->face(face)->get_dof_indices (dofs_on_face_vector);
             // for each dof on the cell, have a flag whether it is on
             // the face
-            copy_data.dof_is_on_face.push_back(std::vector<bool> (copy_data.dofs_per_cell));
+            copy_data.dof_is_on_face.emplace_back(copy_data.dofs_per_cell);
             // check for each of the dofs on this cell whether it is
             // on the face
             for (unsigned int i=0; i<copy_data.dofs_per_cell; ++i)
@@ -1325,9 +1325,9 @@ namespace MatrixCreator
 
             const FEFaceValues<dim,spacedim> &fe_values = x_fe_values.get_present_fe_values ();
 
-            copy_data.cell_matrix.push_back(FullMatrix<number> (copy_data.dofs_per_cell,
-                                                                copy_data.dofs_per_cell));
-            copy_data.cell_vector.push_back(Vector<number> (copy_data.dofs_per_cell));
+            copy_data.cell_matrix.emplace_back(copy_data.dofs_per_cell,
+                                               copy_data.dofs_per_cell);
+            copy_data.cell_vector.emplace_back(copy_data.dofs_per_cell);
 
             if (fe_is_system)
               // FE has several components
@@ -1466,7 +1466,7 @@ namespace MatrixCreator
                                                cell->active_fe_index());
             // for each dof on the cell, have a
             // flag whether it is on the face
-            copy_data.dof_is_on_face.push_back(std::vector<bool> (copy_data.dofs_per_cell));
+            copy_data.dof_is_on_face.emplace_back(copy_data.dofs_per_cell);
             // check for each of the dofs on this cell
             // whether it is on the face
             for (unsigned int i=0; i<copy_data.dofs_per_cell; ++i)

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -550,7 +550,7 @@ void DataOutBase::DataOutFilter::write_data_set(const std::string &name, const u
   // Record the data set name, dimension, and allocate space for it
   data_set_names.push_back(name);
   data_set_dims.push_back(new_dim);
-  data_sets.push_back(std::vector<double>(new_dim*num_verts));
+  data_sets.emplace_back(new_dim*num_verts);
 
   // TODO: averaging, min/max, etc for merged vertices
   for (i=0; i<filtered_points.size(); ++i)
@@ -1613,9 +1613,9 @@ namespace DataOutBase
 
   GnuplotFlags::GnuplotFlags ()
   {
-    space_dimension_labels.push_back("x");
-    space_dimension_labels.push_back("y");
-    space_dimension_labels.push_back("z");
+    space_dimension_labels.emplace_back("x");
+    space_dimension_labels.emplace_back("y");
+    space_dimension_labels.emplace_back("z");
   }
 
 

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -419,7 +419,7 @@ IndexSet::add_indices(const IndexSet &other,
         }
       else if (r1 == ranges.end() || (r2->end+offset) < r1->begin)
         {
-          new_ranges.push_back(Range(r2->begin+offset,r2->end+offset));
+          new_ranges.emplace_back(r2->begin+offset, r2->end+offset);
           ++r2;
         }
       else

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1998,10 +1998,8 @@ ParameterHandler::declare_entry (const std::string           &entry,
   entries->put (get_current_full_path(entry) + path_separator + "documentation",
                 documentation);
 
-  // clone the pattern and store its
-  // index in the node
-  patterns.push_back (std::shared_ptr<const Patterns::PatternBase>
-                      (pattern.clone()));
+  patterns.reserve (patterns.size() + 1);
+  patterns.emplace_back (pattern.clone());
   entries->put (get_current_full_path(entry) + path_separator + "pattern",
                 static_cast<unsigned int>(patterns.size()-1));
   // also store the description of
@@ -3239,9 +3237,9 @@ void MultipleParameterLoop::init_branches_current_section ()
       {
         const std::string value = p->second.get<std::string>("value");
         if (value.find('{') != std::string::npos)
-          multiple_choices.push_back (Entry(subsection_path,
-                                            demangle(p->first),
-                                            value));
+          multiple_choices.emplace_back (subsection_path,
+                                         demangle(p->first),
+                                         value);
       }
 
   // then loop over all subsections

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -227,7 +227,7 @@ namespace Utilities
           // indices and then push back new values. When we are done, copy the
           // data to that field of the partitioner. This way, the variable
           // ghost_targets will have exactly the size we need, whereas the
-          // vector filled with push_back might actually be too long.
+          // vector filled with emplace_back might actually be too long.
           unsigned int current_proc = 0;
           ghost_indices_data.fill_index_vector (expanded_ghost_indices);
           types::global_dof_index current_index = expanded_ghost_indices[0];
@@ -247,8 +247,7 @@ namespace Utilities
                 {
                   ghost_targets_temp[n_ghost_targets-1].second =
                     iterator - ghost_targets_temp[n_ghost_targets-1].second;
-                  ghost_targets_temp.push_back(std::pair<unsigned int,
-                                               unsigned int>(current_proc,iterator));
+                  ghost_targets_temp.emplace_back (current_proc, iterator);
                   n_ghost_targets++;
                 }
             }
@@ -274,8 +273,7 @@ namespace Utilities
           if (receive_buffer[i] > 0)
             {
               n_import_indices_data += receive_buffer[i];
-              import_targets_temp.push_back(std::pair<unsigned int,
-                                            unsigned int> (i, receive_buffer[i]));
+              import_targets_temp.emplace_back(i, receive_buffer[i]);
             }
         // copy, don't move, to get deterministic memory usage.
         import_targets_data = import_targets_temp;
@@ -340,8 +338,7 @@ namespace Utilities
                 compressed_import_indices.back().second++;
               else
                 {
-                  compressed_import_indices.push_back
-                  (std::pair<unsigned int,unsigned int>(new_index,new_index+1));
+                  compressed_import_indices.emplace_back (new_index,new_index+1);
                 }
               last_index = new_index;
             }

--- a/source/base/path_search.cc
+++ b/source/base/path_search.cc
@@ -33,7 +33,7 @@ void
 PathSearch::initialize_classes()
 {
   std::vector<std::string> v;
-  v.push_back(empty);
+  v.emplace_back();
   path_lists.insert(map_type(std::string("PARAMETER"), v));
 
   /*
@@ -42,8 +42,8 @@ PathSearch::initialize_classes()
   path_lists.insert(map_type(std::string("MESH"), v));
 
   v.clear();
-  v.push_back(empty);
-  v.push_back(std::string(".prm"));
+  v.emplace_back();
+  v.emplace_back(".prm");
   suffix_lists.insert(map_type(std::string("PARAMETER"), v));
 
   /*
@@ -55,14 +55,14 @@ PathSearch::initialize_classes()
   // would require linking with the
   // deal.II libraries.
   v.clear();
-  v.push_back(empty);
-  v.push_back(std::string(".inp"));
-  v.push_back(std::string(".xda"));
-  v.push_back(std::string(".dbmesh"));
-  v.push_back(std::string(".dat"));
-  v.push_back(std::string(".plt"));
-  v.push_back(std::string(".nc"));
-  v.push_back(std::string(".msh"));
+  v.emplace_back();
+  v.emplace_back(".inp");
+  v.emplace_back(".xda");
+  v.emplace_back(".dbmesh");
+  v.emplace_back(".dat");
+  v.emplace_back(".plt");
+  v.emplace_back(".nc");
+  v.emplace_back(".msh");
   suffix_lists.insert(map_type(std::string("MESH"), v));
 }
 
@@ -208,7 +208,7 @@ PathSearch::add_class (const std::string &cls)
   // Add empty path and empty suffix
   // for new class
   std::vector<std::string> v;
-  v.push_back(empty);
+  v.emplace_back();
   path_lists.insert(map_type(cls, v));
   suffix_lists.insert(map_type(cls, v));
 }

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -832,7 +832,7 @@ namespace Polynomials
     p.reserve (points.size());
 
     for (unsigned int i=0; i<points.size(); ++i)
-      p.push_back (Polynomial<double> (points, i));
+      p.emplace_back (points, i);
     return p;
   }
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -800,14 +800,14 @@ QGaussOneOverR<2>::QGaussOneOverR(const unsigned int n,
   std::vector<Point<2> > origins;
   // Id of the corner with a
   // singularity
-  quads.push_back(QGaussOneOverR(n, 3, factor_out_singularity));
-  quads.push_back(QGaussOneOverR(n, 2, factor_out_singularity));
-  quads.push_back(QGaussOneOverR(n, 1, factor_out_singularity));
-  quads.push_back(QGaussOneOverR(n, 0, factor_out_singularity));
+  quads.emplace_back(n, 3, factor_out_singularity);
+  quads.emplace_back(n, 2, factor_out_singularity);
+  quads.emplace_back(n, 1, factor_out_singularity);
+  quads.emplace_back(n, 0, factor_out_singularity);
 
-  origins.push_back(Point<2>(0.,0.));
-  origins.push_back(Point<2>(singularity[0],0.));
-  origins.push_back(Point<2>(0.,singularity[1]));
+  origins.emplace_back(0., 0.);
+  origins.emplace_back(singularity[0], 0.);
+  origins.emplace_back(0., singularity[1]);
   origins.push_back(singularity);
 
   // Lexicographical ordering.

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -142,13 +142,13 @@ compute (const Point<dim>            &p,
   if (do_values)
     values.push_back(1.);
   if (do_grads)
-    grads.push_back(Tensor<1,dim>());
+    grads.emplace_back();
   if (do_grad_grads)
-    grad_grads.push_back(Tensor<2,dim>());
+    grad_grads.emplace_back();
   if (do_3rd_derivatives)
-    third_derivatives.push_back(Tensor<3,dim>());
+    third_derivatives.emplace_back();
   if (do_4th_derivatives)
-    fourth_derivatives.push_back(Tensor<4,dim>());
+    fourth_derivatives.emplace_back();
 }
 
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -56,8 +56,7 @@ namespace
       for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
         {
           ++vertex_touch_count[cell->vertex_index(v)];
-          vertex_to_cell[cell->vertex_index(v)]
-          .push_back (std::make_pair (cell, v));
+          vertex_to_cell[cell->vertex_index(v)].emplace_back (cell, v);
         }
   }
 
@@ -82,8 +81,7 @@ namespace
       for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_cell; ++l)
         {
           ++edge_touch_count[cell->line(l)->index()];
-          edge_to_cell[cell->line(l)->index()]
-          .push_back (std::make_pair (cell, l));
+          edge_to_cell[cell->line(l)->index()].emplace_back (cell, l);
         }
   }
 
@@ -3286,9 +3284,7 @@ namespace parallel
       unsigned int offset = attached_data_size+sizeof(CellStatus);
       ++n_attached_datas;
       attached_data_size+=size;
-      attached_data_pack_callbacks.push_back(
-        std::pair<unsigned int, pack_callback_t> (offset, pack_callback)
-      );
+      attached_data_pack_callbacks.emplace_back(offset, pack_callback);
       return offset;
     }
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1108,7 +1108,7 @@ namespace DoFTools
           for (unsigned int i=0; i<data.second.size(); ++i)
             if (component_mask[data.second[i]])
               constant_mode_to_component_translation[data.second[i]].
-              push_back(std::make_pair(n_constant_modes++,i));
+              emplace_back(n_constant_modes++, i);
         AssertDimension(element_constant_modes.back().n_rows(),
                         element_constant_modes[0].n_rows());
       }

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3142,8 +3142,7 @@ namespace DoFTools
               const std::map<types::global_dof_index,float>::const_iterator
               j = weights[row].find(col);
               if ((j != weights[row].end()) && (j->second != 0))
-                constraint_line.push_back (std::pair<types::global_dof_index,double>(representants[row],
-                                           j->second));
+                constraint_line.emplace_back (representants[row], j->second);
             };
 
           constraints.add_entries (global_dof, constraint_line);

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2382,7 +2382,7 @@ const
 
       for (unsigned int i = 0;
            i < std::min (fe_nedelec_other->degree, this->degree); ++i)
-        identities.push_back (std::make_pair (i, i));
+        identities.emplace_back (i, i);
 
       return identities;
     }
@@ -2427,10 +2427,8 @@ const
       for (unsigned int i = 0; i < p_min; ++i)
         for (unsigned int j = 0; j < p_min - 1; ++j)
           {
-            identities.push_back (std::make_pair (i * (q - 1) + j,
-                                                  i * (p - 1) + j));
-            identities.push_back (std::make_pair (i + (j + q - 1) * q,
-                                                  i + (j + p - 1) * p));
+            identities.emplace_back (i * (q - 1) + j, i * (p - 1) + j);
+            identities.emplace_back (i + (j + q - 1) * q, i + (j + p - 1) * p);
           }
 
       return identities;

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -752,7 +752,7 @@ hp_line_dof_identities (const FiniteElement<dim,spacedim> &fe_other) const
           if (std::fabs(this->unit_support_points[index_map_inverse[i+1]][0]-
                         fe_q_other->unit_support_points[index_map_inverse_other[j+1]][0])
               < 1e-14)
-            identities.push_back (std::make_pair(i,j));
+            identities.emplace_back (i, j);
 
       return identities;
     }
@@ -818,8 +818,7 @@ hp_quad_dof_identities (const FiniteElement<dim,spacedim>        &fe_other) cons
                   (std::fabs(this->unit_support_points[index_map_inverse[i2+1]][0]-
                              fe_q_other->unit_support_points[index_map_inverse_other[j2+1]][0])
                    < 1e-14))
-                identities.push_back (std::make_pair(i1*(p-1)+i2,
-                                                     j1*(q-1)+j2));
+                identities.emplace_back (i1*(p-1)+i2, j1*(q-1)+j2);
 
       return identities;
     }

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -258,7 +258,7 @@ hp_line_dof_identities (const FiniteElement<dim> &fe_other) const
       // dofs_per_line for each FE_Q_Hierarchical.
       std::vector<std::pair<unsigned int, unsigned int> > res;
       for (unsigned int i = 0; i < std::min(this_dpl,other_dpl); i++)
-        res.push_back(std::make_pair (i, i));
+        res.emplace_back(i, i);
 
       return res;
     }
@@ -297,7 +297,7 @@ hp_quad_dof_identities (const FiniteElement<dim> &fe_other) const
       // dofs_per_line for each FE_Q_Hierarchical.
       std::vector<std::pair<unsigned int, unsigned int> > res;
       for (unsigned int i = 0; i < std::min(this_dpq,other_dpq); i++)
-        res.push_back(std::make_pair (i, i));
+        res.emplace_back(i, i);
 
       return res;
     }

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -402,10 +402,10 @@ hp_line_dof_identities (const FiniteElement<dim> &fe_other) const
 
       if (p==q)
         for (unsigned int i=0; i<p+1; ++i)
-          identities.push_back (std::make_pair(i,i));
+          identities.emplace_back (i, i);
 
       else if (p%2==0 && q%2==0)
-        identities.push_back(std::make_pair(p/2,q/2));
+        identities.emplace_back(p/2, q/2);
 
       return identities;
     }
@@ -442,10 +442,10 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities (
 
       if (p==q)
         for (unsigned int i=0; i<p; ++i)
-          identities.push_back (std::make_pair(i,i));
+          identities.emplace_back (i, i);
 
       else if (p%2!=0 && q%2!=0)
-        identities.push_back(std::make_pair(p/2, q/2));
+        identities.emplace_back (p/2, q/2);
 
       return identities;
     }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1937,9 +1937,8 @@ FESystem<dim,spacedim>::hp_object_dof_identities (const FiniteElement<dim,spaced
             }
 
           for (unsigned int i=0; i<base_identities.size(); ++i)
-            identities.push_back
-            (std::make_pair (base_identities[i].first + dof_offset,
-                             base_identities[i].second + dof_offset_other));
+            identities.emplace_back (base_identities[i].first + dof_offset,
+                                     base_identities[i].second + dof_offset_other);
 
           // record the dofs treated above as already taken care of
           dof_offset       += base.template n_dofs_per_object<structdim>();

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -146,7 +146,7 @@ void GridIn<dim, spacedim>::read_vtk(std::istream &in)
           Point<3> x;
           in >> x(0) >> x(1) >> x(2);
 
-          vertices.push_back(Point<spacedim>());
+          vertices.emplace_back();
           for (unsigned int d=0; d<spacedim; ++d)
             vertices.back()(d) = x(d);
         }
@@ -194,7 +194,7 @@ void GridIn<dim, spacedim>::read_vtk(std::istream &in)
                                subcelldata.boundary_lines.size() == 0,
                                ExcNotImplemented());
 
-                  cells.push_back(CellData<dim>());
+                  cells.emplace_back();
 
                   for (unsigned int j = 0; j < type; j++) //loop to feed data
                     in >> cells.back().vertices[j];
@@ -204,7 +204,7 @@ void GridIn<dim, spacedim>::read_vtk(std::istream &in)
 
               else if ( type == 4)
                 {
-                  subcelldata.boundary_quads.push_back(CellData<2>());
+                  subcelldata.boundary_quads.emplace_back();
 
                   for (unsigned int j = 0; j < type; j++) //loop to feed the data to the boundary
                     in >> subcelldata.boundary_quads.back().vertices[j];
@@ -232,7 +232,7 @@ void GridIn<dim, spacedim>::read_vtk(std::istream &in)
                   AssertThrow (subcelldata.boundary_lines.size() == 0,
                                ExcNotImplemented());
 
-                  cells.push_back(CellData<dim>());
+                  cells.emplace_back();
 
                   for (unsigned int j = 0; j < type; j++) //loop to feed data
                     in >> cells.back().vertices[j];
@@ -244,7 +244,7 @@ void GridIn<dim, spacedim>::read_vtk(std::istream &in)
                 {
                   //If this is encountered, the pointer comes out of the loop
                   //and starts processing boundaries.
-                  subcelldata.boundary_lines.push_back(CellData<1>());
+                  subcelldata.boundary_lines.emplace_back();
 
                   for (unsigned int j = 0; j < type; j++) //loop to feed the data to the boundary
                     {
@@ -424,7 +424,7 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
       AssertThrow(in, ExcIO());
       in >> x[0] >> x[1] >> x[2];
 
-      vertices.push_back(Point<spacedim>());
+      vertices.emplace_back();
 
       for (unsigned int d = 0; d < spacedim; d++)
         vertices.back()(d) = x[d];
@@ -473,7 +473,7 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
 
       if ( (((type == 44)||(type == 94))&&(dim == 2)) || ((type == 115)&&(dim == 3)) ) // cell
         {
-          cells.push_back(CellData<dim>());
+          cells.emplace_back();
 
           AssertThrow(in, ExcIO());
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; v++)
@@ -493,7 +493,7 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
           AssertThrow(in, ExcIO());
           in >> dummy >> dummy >> dummy;
 
-          subcelldata.boundary_lines.push_back(CellData<1>());
+          subcelldata.boundary_lines.emplace_back();
 
           AssertThrow(in, ExcIO());
           for (unsigned int v = 0; v < 2; v++)
@@ -510,7 +510,7 @@ void GridIn<dim, spacedim>::read_unv(std::istream &in)
         }
       else if ( ((type == 44)||(type == 94)) && (dim == 3) ) // boundary quad
         {
-          subcelldata.boundary_quads.push_back(CellData<2>());
+          subcelldata.boundary_quads.emplace_back();
 
           AssertThrow(in, ExcIO());
           for (unsigned int v = 0; v < 4; v++)
@@ -694,7 +694,7 @@ void GridIn<dim, spacedim>::read_ucd (std::istream                            &i
         // found a cell
         {
           // allocate and read indices
-          cells.push_back (CellData<dim>());
+          cells.emplace_back ();
           for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_cell; ++i)
             in >> cells.back().vertices[i];
 
@@ -725,7 +725,7 @@ void GridIn<dim, spacedim>::read_ucd (std::istream                            &i
       else if ((cell_type == "line") && ((dim == 2) || (dim == 3)))
         // boundary info
         {
-          subcelldata.boundary_lines.push_back (CellData<1>());
+          subcelldata.boundary_lines.emplace_back ();
           in >> subcelldata.boundary_lines.back().vertices[0]
              >> subcelldata.boundary_lines.back().vertices[1];
 
@@ -764,7 +764,7 @@ void GridIn<dim, spacedim>::read_ucd (std::istream                            &i
       else if ((cell_type == "quad") && (dim == 3))
         // boundary info
         {
-          subcelldata.boundary_quads.push_back (CellData<2>());
+          subcelldata.boundary_quads.emplace_back ();
           in >> subcelldata.boundary_quads.back().vertices[0]
              >> subcelldata.boundary_quads.back().vertices[1]
              >> subcelldata.boundary_quads.back().vertices[2]
@@ -1015,7 +1015,7 @@ void GridIn<dim, spacedim>::read_dbmesh (std::istream &in)
     {
       // read in vertex numbers. they
       // are 1-based, so subtract one
-      cells.push_back (CellData<dim>());
+      cells.emplace_back ();
       for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_cell; ++i)
         {
           in >> cells.back().vertices[i];
@@ -1420,7 +1420,7 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
                                    "number required for this object"));
 
           // allocate and read indices
-          cells.push_back (CellData<dim>());
+          cells.emplace_back ();
           for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_cell; ++i)
             in >> cells.back().vertices[i];
 
@@ -1449,7 +1449,7 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
       else if ((cell_type == 1) && ((dim == 2) || (dim == 3)))
         // boundary info
         {
-          subcelldata.boundary_lines.push_back (CellData<1>());
+          subcelldata.boundary_lines.emplace_back ();
           in >> subcelldata.boundary_lines.back().vertices[0]
              >> subcelldata.boundary_lines.back().vertices[1];
 
@@ -1484,7 +1484,7 @@ void GridIn<dim, spacedim>::read_msh (std::istream &in)
       else if ((cell_type == 3) && (dim == 3))
         // boundary info
         {
-          subcelldata.boundary_quads.push_back (CellData<2>());
+          subcelldata.boundary_quads.emplace_back ();
           in >> subcelldata.boundary_quads.back().vertices[0]
              >> subcelldata.boundary_quads.back().vertices[1]
              >> subcelldata.boundary_quads.back().vertices[2]

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -2537,10 +2537,10 @@ void GridOut::write_mesh_per_processor_as_vtu (const Triangulation<dim,spacedim>
   std::vector<DataOutBase::Patch<dim,spacedim> > patches;
   const unsigned int n_datasets=4;
   std::vector<std::string> data_names;
-  data_names.push_back("level");
-  data_names.push_back("subdomain");
-  data_names.push_back("level_subdomain");
-  data_names.push_back("proc_writing");
+  data_names.emplace_back("level");
+  data_names.emplace_back("subdomain");
+  data_names.emplace_back("level_subdomain");
+  data_names.emplace_back("proc_writing");
 
   const unsigned int n_q_points = GeometryInfo<dim>::vertices_per_cell;
 
@@ -3642,12 +3642,12 @@ namespace internal
                   // the compiler will
                   // optimize away this
                   // little kludge
-                  line_list.push_back (LineEntry(Point<2>(line->vertex(0)(0),
-                                                          line->vertex(0)(1)),
-                                                 Point<2>(line->vertex(1)(0),
-                                                          line->vertex(1)(1)),
-                                                 line->user_flag_set(),
-                                                 cell->level()));
+                  line_list.emplace_back(Point<2>(line->vertex(0)(0),
+                                                  line->vertex(0)(1)),
+                                         Point<2>(line->vertex(1)(0),
+                                                  line->vertex(1)(1)),
+                                         line->user_flag_set(),
+                                         cell->level());
               }
 
           // next if we are to treat
@@ -3700,18 +3700,20 @@ namespace internal
                                                      (cell, q_projector.point(offset+i)));
                             const Point<2>   p1     (p1_dim(0), p1_dim(1));
 
-                            line_list.push_back (LineEntry(p0, p1,
-                                                           face->user_flag_set(),
-                                                           cell->level() ));
+                            line_list.emplace_back (p0,
+                                                    p1,
+                                                    face->user_flag_set(),
+                                                    cell->level() );
                             p0=p1;
                           }
 
                         // generate last piece
                         const Point<dim> p1_dim (face->vertex(1));
                         const Point<2>   p1     (p1_dim(0), p1_dim(1));
-                        line_list.push_back (LineEntry(p0, p1,
-                                                       face->user_flag_set(),
-                                                       cell->level()));
+                        line_list.emplace_back (p0,
+                                                p1,
+                                                face->user_flag_set(),
+                                                cell->level());
                       }
                   }
             }
@@ -3778,12 +3780,12 @@ namespace internal
               {
                 typename dealii::Triangulation<dim, spacedim>::line_iterator
                 line=cell->line(line_no);
-                line_list.push_back (LineEntry(Point<2>(line->vertex(0) * unit_vector2,
-                                                        line->vertex(0) * unit_vector1),
-                                               Point<2>(line->vertex(1) * unit_vector2,
-                                                        line->vertex(1) * unit_vector1),
-                                               line->user_flag_set(),
-                                               cell->level()));
+                line_list.emplace_back (Point<2>(line->vertex(0) * unit_vector2,
+                                                 line->vertex(0) * unit_vector1),
+                                        Point<2>(line->vertex(1) * unit_vector2,
+                                                 line->vertex(1) * unit_vector1),
+                                        line->user_flag_set(),
+                                        cell->level());
               }
 
           break;

--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -549,7 +549,7 @@ namespace
     edge_list.reserve(cells.size()*GeometryInfo<dim>::lines_per_cell);
     for (unsigned int i=0; i<cells.size(); ++i)
       for (unsigned int l=0; l<GeometryInfo<dim>::lines_per_cell; ++l)
-        edge_list.push_back (Edge<dim>(cells[i], l));
+        edge_list.emplace_back (cells[i], l);
 
     // next sort the edge list and then remove duplicates
     std::sort (edge_list.begin(), edge_list.end());
@@ -576,7 +576,7 @@ namespace
       {
         // create our own data structure for the cells and let it
         // connect to the edges array
-        cell_list.push_back (Cell<dim>(cells[i], edges));
+        cell_list.emplace_back (cells[i], edges);
 
         // then also inform the edges that they are adjacent
         // to the current cell, and where within this cell
@@ -1269,4 +1269,3 @@ template class GridReordering<2,3>;
 template class GridReordering<3,3>;
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1790,10 +1790,8 @@ next_cell:
                               tmp((*adjacent_cell)->subdomain_id(), cell->vertex_index(i));
                               if (vertices_added.find(tmp)==vertices_added.end())
                                 {
-                                  vertices_to_send[(*adjacent_cell)->subdomain_id()].push_back(
-                                    std::tuple<types::global_vertex_index,types::global_vertex_index,
-                                    std::string> (i,cell->vertex_index(i),
-                                                  cell->id().to_string()));
+                                  vertices_to_send[(*adjacent_cell)->subdomain_id()].emplace_back
+                                  (i, cell->vertex_index(i), cell->id().to_string());
                                   if (cell->id().to_string().size() > max_cellid_size)
                                     max_cellid_size = cell->id().to_string().size();
                                   vertices_added.insert(tmp);
@@ -2453,7 +2451,7 @@ next_cell:
     cell_1 = mesh_1.begin(0),
     cell_2 = mesh_2.begin(0);
     for (; cell_1 != mesh_1.end(0); ++cell_1, ++cell_2)
-      cell_list.push_back (std::make_pair (cell_1, cell_2));
+      cell_list.emplace_back (cell_1, cell_2);
 
     // then traverse list as described
     // above
@@ -2471,8 +2469,8 @@ next_cell:
             Assert(cell_pair->first->refinement_case()==
                    cell_pair->second->refinement_case(), ExcNotImplemented());
             for (unsigned int c=0; c<cell_pair->first->n_children(); ++c)
-              cell_list.push_back (std::make_pair (cell_pair->first->child(c),
-                                                   cell_pair->second->child(c)));
+              cell_list.emplace_back (cell_pair->first->child(c),
+                                      cell_pair->second->child(c));
 
             // erasing an iterator
             // keeps other iterators

--- a/source/grid/persistent_tria.cc
+++ b/source/grid/persistent_tria.cc
@@ -67,8 +67,8 @@ void
 PersistentTriangulation<dim,spacedim>::execute_coarsening_and_refinement ()
 {
   // first save flags
-  refine_flags.push_back (std::vector<bool>());
-  coarsen_flags.push_back (std::vector<bool>());
+  refine_flags.emplace_back ();
+  coarsen_flags.emplace_back ();
   this->save_refine_flags (refine_flags.back());
   this->save_coarsen_flags (coarsen_flags.back());
 
@@ -206,8 +206,8 @@ PersistentTriangulation<dim,spacedim>::read_flags(std::istream &in)
   in >> n_flag_levels;
   for (unsigned int i=0; i<n_flag_levels; ++i)
     {
-      refine_flags.push_back (std::vector<bool>());
-      coarsen_flags.push_back (std::vector<bool>());
+      refine_flags.emplace_back ();
+      coarsen_flags.emplace_back ();
       this->read_bool_vector (mn_tria_refine_flags_begin, refine_flags.back(),
                               mn_tria_refine_flags_end, in);
       this->read_bool_vector (mn_tria_coarsen_flags_begin, coarsen_flags.back(),
@@ -252,4 +252,3 @@ template class PersistentTriangulation<1,2>;
 template class PersistentTriangulation<2,3>;
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -317,10 +317,9 @@ void ConstraintMatrix::close ()
                                       weight);
 
                     for (size_type i=1; i<constrained_line->entries.size(); ++i)
-                      line->entries
-                      .push_back (std::make_pair (constrained_line->entries[i].first,
-                                                  constrained_line->entries[i].second *
-                                                  weight));
+                      line->entries.emplace_back (constrained_line->entries[i].first,
+                                                  constrained_line->entries[i].second
+                                                  * weight);
 
 #ifdef DEBUG
                     // keep track of how many entries we replace in this
@@ -528,8 +527,7 @@ ConstraintMatrix::merge (const ConstraintMatrix &other_constraints,
 
               for (ConstraintLine::Entries::const_iterator j=other_line->begin();
                    j!=other_line->end(); ++j)
-                tmp.push_back (std::pair<size_type,double>(j->first,
-                                                           j->second*weight));
+                tmp.emplace_back(j->first, j->second*weight);
 
               line->inhomogeneity
               += other_constraints.get_inhomogeneity(line->entries[i].first) *

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -431,7 +431,7 @@ namespace SparsityTools
 
               // Add the pivot and all direct neighbors of the pivot node not
               // yet touched to the list of new entries.
-              groups.push_back(std::vector<types::global_dof_index>());
+              groups.emplace_back();
               std::vector<types::global_dof_index> &next_group = groups.back();
 
               next_group.push_back(min_neighbors.first);

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -157,10 +157,10 @@ namespace TrilinosWrappers
   {
     std::vector<Epetra_Map> parallel_partitioning;
     for (size_type i=0; i<block_sparsity_pattern.n_block_rows(); ++i)
-      parallel_partitioning.push_back
-      (Epetra_Map(static_cast<TrilinosWrappers::types::int_type>(block_sparsity_pattern.block(i,0).n_rows()),
-                  0,
-                  Utilities::Trilinos::comm_self()));
+      parallel_partitioning.emplace_back
+      (static_cast<TrilinosWrappers::types::int_type>(block_sparsity_pattern.block(i,0).n_rows()),
+       0,
+       Utilities::Trilinos::comm_self());
 
     reinit (parallel_partitioning, block_sparsity_pattern);
   }
@@ -250,9 +250,10 @@ namespace TrilinosWrappers
 
     std::vector<Epetra_Map> parallel_partitioning;
     for (size_type i=0; i<dealii_block_sparse_matrix.n_block_rows(); ++i)
-      parallel_partitioning.push_back (Epetra_Map(static_cast<TrilinosWrappers::types::int_type>(dealii_block_sparse_matrix.block(i,0).m()),
-                                                  0,
-                                                  trilinos_communicator));
+      parallel_partitioning.emplace_back
+      (static_cast<TrilinosWrappers::types::int_type>(dealii_block_sparse_matrix.block(i,0).m()),
+       0,
+       trilinos_communicator);
 
     reinit (parallel_partitioning, dealii_block_sparse_matrix, drop_tolerance);
   }

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -273,13 +273,13 @@ void MGTransferBlockBase::build_matrices (
   // by itself
   prolongation_matrices.resize (0);
   prolongation_sparsities.resize (0);
+  prolongation_matrices.reserve (n_levels - 1);
+  prolongation_sparsities.reserve (n_levels - 1);
 
   for (unsigned int i=0; i<n_levels-1; ++i)
     {
-      prolongation_sparsities
-      .push_back (std::shared_ptr<BlockSparsityPattern> (new BlockSparsityPattern));
-      prolongation_matrices
-      .push_back (std::shared_ptr<BlockSparseMatrix<double> > (new BlockSparseMatrix<double>));
+      prolongation_sparsities.emplace_back (new BlockSparsityPattern);
+      prolongation_matrices.emplace_back (new BlockSparseMatrix<double>);
     }
 
   // two fields which will store the

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -372,13 +372,13 @@ void MGTransferComponentBase::build_matrices (
   // by itself
   prolongation_matrices.resize (0);
   prolongation_sparsities.resize (0);
+  prolongation_matrices.reserve (n_levels - 1);
+  prolongation_sparsities.reserve (n_levels - 1);
 
   for (unsigned int i=0; i<n_levels-1; ++i)
     {
-      prolongation_sparsities
-      .push_back (std::shared_ptr<BlockSparsityPattern> (new BlockSparsityPattern));
-      prolongation_matrices
-      .push_back (std::shared_ptr<BlockSparseMatrix<double> > (new BlockSparseMatrix<double>));
+      prolongation_sparsities.emplace_back (new BlockSparsityPattern);
+      prolongation_matrices.emplace_back (new BlockSparseMatrix<double>);
     }
 
   // two fields which will store the

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -127,16 +127,18 @@ namespace internal
 
                   if (global_mine && level_mine)
                     {
-                      copy_indices[level].push_back(
-                        std::make_pair (global_dof_indices[i], level_dof_indices[i]));
+                      copy_indices[level].emplace_back(global_dof_indices[i],
+                                                       level_dof_indices[i]);
                     }
                   else if (global_mine)
                     {
-                      copy_indices_global_mine[level].push_back(
-                        std::make_pair (global_dof_indices[i], level_dof_indices[i]));
+                      copy_indices_global_mine[level].emplace_back(global_dof_indices[i],
+                                                                   level_dof_indices[i]);
 
                       //send this to the owner of the level_dof:
-                      send_data_temp.push_back(DoFPair(level, global_dof_indices[i], level_dof_indices[i]));
+                      send_data_temp.emplace_back(level,
+                                                  global_dof_indices[i],
+                                                  level_dof_indices[i]);
                     }
                   else
                     {
@@ -631,7 +633,7 @@ namespace internal
                                          local_dof_indices,
                                          &global_level_dof_indices_l0[start_index]);
 
-                  dirichlet_indices[0].push_back(std::vector<unsigned short>());
+                  dirichlet_indices[0].emplace_back();
                   if (mg_constrained_dofs != nullptr)
                     for (unsigned int i=0; i<mg_dof.get_fe().dofs_per_cell; ++i)
                       if (mg_constrained_dofs->is_boundary_index(0, local_dof_indices[elem_info.lexicographic_numbering[i]]))

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -149,13 +149,15 @@ void MGTransferPrebuilt<VectorType>::build_matrices
   // by itself
   prolongation_matrices.resize (0);
   prolongation_sparsities.resize (0);
+  prolongation_matrices.reserve (n_levels - 1);
+  prolongation_sparsities.reserve (n_levels - 1);
 
   for (unsigned int i=0; i<n_levels-1; ++i)
     {
-      prolongation_sparsities.push_back
-      (std::shared_ptr<typename internal::MatrixSelector<VectorType>::Sparsity> (new typename internal::MatrixSelector<VectorType>::Sparsity));
-      prolongation_matrices.push_back
-      (std::shared_ptr<typename internal::MatrixSelector<VectorType>::Matrix> (new typename internal::MatrixSelector<VectorType>::Matrix));
+      prolongation_sparsities.emplace_back
+      (new typename internal::MatrixSelector<VectorType>::Sparsity);
+      prolongation_matrices.emplace_back
+      (new typename internal::MatrixSelector<VectorType>::Matrix);
     }
 
   // two fields which will store the

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -406,7 +406,7 @@ void DataOut<dim,DoFHandlerType>::build_patches
                 ExcInternalError());
         cell_to_patch_index_map[cell->level()][cell->index()] = all_cells.size();
 
-        all_cells.push_back (std::make_pair(cell, active_index));
+        all_cells.emplace_back (cell, active_index);
       }
   }
 

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -118,12 +118,12 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::declare_data_vector (const std::
   switch (vector_type)
     {
     case dof_vector:
-      dof_data.push_back (DataVector());
+      dof_data.emplace_back ();
       dof_data.back().names = names;
       break;
 
     case cell_vector:
-      cell_data.push_back (DataVector());
+      cell_data.emplace_back ();
       cell_data.back().names = names;
       break;
     };

--- a/source/numerics/histogram.cc
+++ b/source/numerics/histogram.cc
@@ -146,7 +146,7 @@ void Histogram::evaluate (const std::vector<Vector<number> > &values,
   // then produce all the other lists
   // for the other data vectors by
   // copying
-  intervals.push_back (std::vector<Interval>());
+  intervals.emplace_back ();
 
   switch (interval_spacing)
     {
@@ -155,8 +155,7 @@ void Histogram::evaluate (const std::vector<Vector<number> > &values,
       const float delta = (max_value-min_value)/n_intervals;
 
       for (unsigned int n=0; n<n_intervals; ++n)
-        intervals[0].push_back (Interval(min_value+n*delta,
-                                         min_value+(n+1)*delta));
+        intervals[0].emplace_back (min_value+n*delta, min_value+(n+1)*delta);
 
       break;
     };
@@ -166,8 +165,8 @@ void Histogram::evaluate (const std::vector<Vector<number> > &values,
       const float delta = (std::log(max_value)-std::log(min_value))/n_intervals;
 
       for (unsigned int n=0; n<n_intervals; ++n)
-        intervals[0].push_back (Interval(std::exp(std::log(min_value)+n*delta),
-                                         std::exp(std::log(min_value)+(n+1)*delta)));
+        intervals[0].emplace_back (std::exp(std::log(min_value)+n*delta),
+                                   std::exp(std::log(min_value)+(n+1)*delta));
 
       break;
     };

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -491,8 +491,8 @@ void TimeStepBase_Tria<dim>::save_refine_flags ()
 {
   // for any of the non-initial grids
   // store the refinement flags
-  refine_flags.push_back (std::vector<bool>());
-  coarsen_flags.push_back (std::vector<bool>());
+  refine_flags.emplace_back ();
+  coarsen_flags.emplace_back ();
   tria->save_refine_flags (refine_flags.back());
   tria->save_coarsen_flags (coarsen_flags.back());
 }


### PR DESCRIPTION
This PR uses the new `emplace_back` function to simplify a lot of code, usually something like

```cpp
std::vector<std::pair<types::global_dof_index, double>> vec;
[...]
vec.push_back(std::pair<types::global_dof_index, double>());
vec.push_back(std::pair<types::global_dof_index, double>(dof, var));
```

to
```cpp
std::vector<std::pair<types::global_dof_index, double>> vec;
[...]
vec.emplace_back();
vec.emplace_back(dof, var);
```