### PR TITLE
Replace push_back by emplace_back

### DIFF
--- a/source/base/event.cc
+++ b/source/base/event.cc
@@ -28,7 +28,7 @@ namespace Algorithms
   Event::assign(const char *name)
   {
     unsigned int index = names.size();
-    names.push_back(name);
+    names.emplace_back(name);
 
     Event result;
     // The constructor generated an

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -131,14 +131,14 @@ namespace Polynomials
     std::vector<PiecewisePolynomial<double> > p;
     p.reserve (n_subdivisions * base_degree + 1);
 
-    p.push_back (PiecewisePolynomial<double> (p_base[0], n_subdivisions, 0,
-                                              false));
+    p.emplace_back(p_base[0], n_subdivisions, 0,
+                   false);
     for (unsigned int s=0; s<n_subdivisions; ++s)
       for (unsigned int i=0; i<base_degree; ++i)
-        p.push_back (PiecewisePolynomial<double> (p_base[i+1], n_subdivisions,
-                                                  s,
-                                                  i==(base_degree-1) &&
-                                                  s<n_subdivisions-1));
+        p.emplace_back(p_base[i+1], n_subdivisions,
+                       s,
+                       i==(base_degree-1) &&
+                       s<n_subdivisions-1);
     return p;
   }
 

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -215,7 +215,7 @@ void TableHandler::start_new_row ()
   for (std::map<std::string,Column>::iterator col=columns.begin(); col!=columns.end(); ++col)
     while (col->second.entries.size() < max_col_length)
       {
-        col->second.entries.push_back (internal::TableEntry(""));
+        col->second.entries.emplace_back("");
         internal::TableEntry &entry = col->second.entries.back();
         entry.cache_string(col->second.scientific, col->second.precision);
         col->second.max_length = std::max(col->second.max_length,

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -177,7 +177,7 @@ struct FE_Q_Base<PolynomialType,xdim,xspacedim>::Implementation
     // 0 and on subface 1
     std::vector<Point<dim-1> > constraint_points;
     // Add midpoint
-    constraint_points.push_back (Point<dim-1> (0.5));
+    constraint_points.emplace_back(0.5);
 
     if (q_deg>1)
       {
@@ -256,13 +256,13 @@ struct FE_Q_Base<PolynomialType,xdim,xspacedim>::Implementation
     std::vector<Point<dim-1> > constraint_points;
 
     // Add midpoint
-    constraint_points.push_back (Point<dim-1> (0.5, 0.5));
+    constraint_points.emplace_back(0.5, 0.5);
 
     // Add midpoints of lines of "mother-face"
-    constraint_points.push_back (Point<dim-1> (0, 0.5));
-    constraint_points.push_back (Point<dim-1> (1, 0.5));
-    constraint_points.push_back (Point<dim-1> (0.5, 0));
-    constraint_points.push_back (Point<dim-1> (0.5, 1));
+    constraint_points.emplace_back(0, 0.5);
+    constraint_points.emplace_back(1, 0.5);
+    constraint_points.emplace_back(0.5, 0);
+    constraint_points.emplace_back(0.5, 1);
 
     if (q_deg>1)
       {

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1524,7 +1524,7 @@ namespace GridGenerator
     double ax = p[0];
     for (unsigned int x=0; x<=n_cells; ++x)
       {
-        points.push_back (Point<1> (ax));
+        points.emplace_back(ax);
         if (x<n_cells)
           ax += spacing[0][x];
       }
@@ -1591,7 +1591,7 @@ namespace GridGenerator
         double ax = p[0];
         for (unsigned int x=0; x<=repetitions[0]; ++x)
           {
-            points.push_back (Point<2> (ax,ay));
+            points.emplace_back(ax,ay);
             if (x<repetitions[0])
               ax += spacing[0][x];
           }
@@ -1693,7 +1693,7 @@ namespace GridGenerator
             double ax = p[0];
             for (unsigned int x=0; x<=repetitions[0]; ++x)
               {
-                points.push_back (Point<dim> (ax,ay,az));
+                points.emplace_back(ax,ay,az);
                 if (x<repetitions[0])
                   ax += spacing[0][x];
               }

--- a/tests/numerics/point_value_history_02.cc
+++ b/tests/numerics/point_value_history_02.cc
@@ -275,9 +275,9 @@ void TestPointValueHistory<dim>::run()
   {
     node_monitor.add_field_name("Solution");
     std::vector <std::string> solution_names;
-    solution_names.push_back("X velocity");
-    solution_names.push_back("Y velocity");
-    solution_names.push_back("Z velocity");
+    solution_names.emplace_back("X velocity");
+    solution_names.emplace_back("Y velocity");
+    solution_names.emplace_back("Z velocity");
     node_monitor.add_component_names ("Solution", solution_names);
     node_monitor.add_field_name("Post Processed Vector"); // not sensitive to spaces
     std::vector <bool> component_mask (3, false);
@@ -294,7 +294,7 @@ void TestPointValueHistory<dim>::run()
     node_monitor.add_field_name("Scalar_out", component_mask);
 
     std::vector <std::string> indep_names;
-    indep_names.push_back ("Input");
+    indep_names.emplace_back("Input");
     node_monitor.add_independent_names(indep_names);
 
     // two alternatives here, adding a point at a time or a vector of points
@@ -342,8 +342,8 @@ void TestPointValueHistory<dim>::run()
       Postprocess<dim> postprocessor;
       QGauss<dim> postprocess_quadrature (2);
       std::vector<std::string> names;
-      names.push_back ("Vector_out");
-      names.push_back ("Scalar_out");
+      names.emplace_back("Vector_out");
+      names.emplace_back("Scalar_out");
       node_monitor.evaluate_field(names, solution, postprocessor, postprocess_quadrature);
 //         output_results (step, solution);
       step++;
@@ -401,7 +401,7 @@ template <int dim>
 void TestPointValueHistory<dim>::output_results (unsigned int step, Vector <double> solution)  const
 {
   std::vector<std::string> solution_names (dim, "velocity");
-  solution_names.push_back ("pressure");
+  solution_names.emplace_back("pressure");
 
   std::vector<DataComponentInterpretation::DataComponentInterpretation>
   data_component_interpretation


### PR DESCRIPTION
`clang-tidy` found some more places in `include` and `source` where we can replace `push_back` by `emplace_back`.