### PR TITLE
Actions for parameter handler

### DIFF
--- a/doc/news/changes/minor/20170417Bangerth
+++ b/doc/news/changes/minor/20170417Bangerth
@@ -1,0 +1,8 @@
+New: The new function ParameterHandler::add_action() allows to
+register actions that should be performed when a parameter
+is read from somewhere. This allows, in particular, initializing
+member variables that store parameter values without having to
+explicitly call ParameterHandler::get(),
+ParameterHandler::get_integer(), or similar functions.
+<br>
+(Wolfgang Bangerth, 2017/04/16)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2016 by the deal.II authors
+// Copyright (C) 1998 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -1156,6 +1156,110 @@ namespace Patterns
  * know the values of parameters not specified in the input file.
  *
  *
+ *
+ * <h3>Adding Actions to Parameters</h3>
+ *
+ * It is often convenient to have something happen as soon as a parameter
+ * value is read. This could be a check that it is valid -- say, that a
+ * file that is listed in the parameter file exists -- or to initiate
+ * something else in response, such as setting a variable outside the
+ * ParameterHandler (as in the example shown below). In almost all cases,
+ * this "action" could also be initiated once all parameters are read
+ * via parse_input(), but it is sometimes <i>convenient</i> to do it
+ * right away.
+ *
+ * This is facilitated by the add_action() function that can be called
+ * after declaring a parameter via declare_entry(). "Actions" are in essence
+ * pointers to functions that will be called for parameters that have
+ * associated actions. These functions take the value of a parameter as
+ * argument, and can then do whatever they want with it -- e.g., save it
+ * somewhere outside the ParameterHandler object. (Exactly when the
+ * action is called is described in the documentation of the
+ * add_action() function.) Of course, in C++ one doesn't usually pass
+ * around the address of a function, but an action can be a function-like
+ * object (taking a string as argument) that results from calling
+ * @p std::bind, or more conveniently, it can be a
+ * <a href="http://en.cppreference.com/w/cpp/language/lambda">lambda
+ * function</a> that has the form
+ * @code
+ *   [] (const std::string &value) { ... do something with the value ... }
+ * @endcode
+ * and that is attached to a specific parameter.
+ *
+ * A typical example of such an action would be as follows: let's assume
+ * that you have a program that declares a parameter for the number
+ * of iterations it is going to run, say
+ * @code
+ *   class MyAlgorithm
+ *   {
+ *      public:
+ *        void run ();
+ *      private:
+ *        unsigned int n_iterations;
+ *   };
+ * @endcode
+ * then one could obtain this parameter from a parameter file using a
+ * code snippet in @p run() as follows:
+ * @code
+ *   void MyAlgorithm::run ()
+ *   {
+ *     ParameterHandler prm;
+ *     prm.declare_entry ("Number of iterations",  // name of parameter
+ *                        "10",                    // default value
+ *                        Patterns::Integer(1,100),// allowed values: 1...100
+ *                        "The number of ...");    // some documentation, to be completed
+ *
+ *     // next read the parameter from an input file...
+ *     prm.parse_input ("my_algorithm.prm");
+ *
+ *     // ...and finally get the value for use in the program:
+ *     n_iterations = prm.get_integer ("Number of iterations");
+ *
+ *     ... actual code doing something useful follows here...
+ * @endcode
+ *
+ * This two-step process -- first declaring the parameter, and later reading
+ * it -- is a bit cumbersome because one has to first declare <i>all</i>
+ * parameters and at a later time retrieve them from the ParameterHandler
+ * object. In large programs, these two things also often happen in
+ * different functions.
+ *
+ * To avoid this, it would be nice if we could put both the declaration
+ * and the retrieval into the same place. This can be done via actions,
+ * and the function would then look like this:
+ * @code
+ *   void MyAlgorithm::run ()
+ *   {
+ *     ParameterHandler prm;
+ *     prm.declare_entry ("Number of iterations",  // name of parameter
+ *                        "10",                    // default value
+ *                        Patterns::Integer(1,100),// allowed values: 1...100
+ *                        "The number of ...");    // some documentation, to be completed
+ *     prm.add_action ("Number of iterations",
+ *                     [&](const std::string &value) {
+ *                       this->n_iterations = Utilities::string_to_int(value);
+ *                     });
+ *
+ *     // next read the parameter from an input file...
+ *     prm.parse_input ("my_algorithm.prm");
+ *
+ *     ... actual code doing something useful follows here...
+ * @endcode
+ * Here, the action consists of a lambda function that takes the value
+ * for this parameter as a string, and then converts it to an integer
+ * to store in the variable where it belongs. This action is
+ * executed inside the call to <code>prm.parse_input()</code>, and so
+ * there is now no longer a need to extract the parameter's value
+ * at a later time. Furthermore, the code that sets the member variable
+ * is located right next to the place where the parameter is actually
+ * declared, so we no longer need to have two separate parts of the code
+ * base that deal with input parameters.
+ *
+ * Of course, it is possible to execute far more involved actions than
+ * just setting a member variable as shown above, even though that is
+ * a typical case.
+ *
+ *
  * <h3>Style guide for data retrieval</h3>
  *
  * We propose that every class which gets data out of a ParameterHandler
@@ -1470,7 +1574,8 @@ namespace Patterns
  * We can think of the parameters so arranged as a file system in which every
  * parameter is a directory. The name of this directory is the name of the
  * parameter, and in this directory lie files that describe the parameter.
- * These files are:
+ * These files are at the time of writing this documentation (other fields,
+ * such as those indicating "actions" may also exist in each directory):
  *
  * - <code>value</code>: The content of this file is the current value of this
  * parameter; initially, the content of the file equals the default value of
@@ -1551,7 +1656,7 @@ namespace Patterns
  *
  *
  * @ingroup input
- * @author Wolfgang Bangerth, October 1997, revised February 1998, 2010, 2011
+ * @author Wolfgang Bangerth, October 1997, revised February 1998, 2010, 2011, 2017
  * @author Alberto Sartori, 2015
  * @author David Wells, 2016
  */
@@ -1774,6 +1879,43 @@ public:
                       const std::string           &default_value,
                       const Patterns::PatternBase &pattern = Patterns::Anything(),
                       const std::string           &documentation = std::string());
+
+  /**
+   * Attach an action to the parameter with name @p entry in the current
+   * section. The action needs to be a function-like object that takes the
+   * value of the parameter as a (string) argument. See the general documentation
+   * of this class for a longer description of actions, as well as examples.
+   *
+   * The action is executed in three different circumstances:
+   * - With the default value of the parameter with name @p name, at
+   *   the end of the current function. This is useful because it allows
+   *   for the action to execute whatever it needs to do at least once
+   *   for each parameter, even those that are not actually specified in
+   *   the input file (and thus remain at their default values).
+   * - Within the ParameterHandler::set() functions that explicitly
+   *   set a value for a parameter.
+   * - Within the parse_input() function and similar functions such
+   *   as parse_input_from_string(). Here, the action is executed
+   *   whenever the parameter with which it is associated is read
+   *   from the input, after it has been established that the value
+   *   so read matches the pattern that corresponds to this parameter,
+   *   and before the value is actually saved.
+   *
+   * It is valid to add multiple actions to the same parameter. They will
+   * in that case be executed in the same order in which they were added.
+   *
+   * @note Actions may modify all sorts of variables in their scope. The
+   *  only thing an action should not modify is the ParameterHandler object
+   *  it is attached to. In other words, it is not allowed to enter or
+   *  leave sections of the current ParameterHandler object. It is, in
+   *  principle, acceptable to call ParameterHandler::get() and related
+   *  functions on other parameters in the current section, but since
+   *  there is no guarantee about the order in which they will be read
+   *  from an input file, you will not want to rely on the values these
+   *  functions would return.
+   */
+  void add_action (const std::string &entry,
+                   const std::function<void (const std::string &value)> &action);
 
   /**
    * Create an alias for an existing entry. This provides a way to refer to a
@@ -2161,9 +2303,18 @@ private:
 
   /**
    * A list of patterns that are used to describe the parameters of this
-   * object. The are indexed by nodes in the property tree.
+   * object. Every nodes in the property tree corresponding to a parameter
+   * stores an index into this array.
    */
   std::vector<std::shared_ptr<const Patterns::PatternBase> > patterns;
+
+  /**
+   * A list of actions that are associated with parameters. These
+   * are added by the add_action() function. Nodes in the property
+   * tree corresponding to individual parameters
+   * store indices into this array in order to reference specific actions.
+   */
+  std::vector<std::function<void (const std::string &)> > actions;
 
   /**
    * Mangle a string so that it doesn't contain any special characters or

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2024,6 +2024,43 @@ ParameterHandler::declare_entry (const std::string           &entry,
 
 
 
+
+void ParameterHandler::add_action(const std::string &entry,
+                                  const std::function<void (const std::string &)> &action)
+{
+  actions.push_back (action);
+
+  // get the current list of actions, if any
+  boost::optional<std::string>
+  current_actions
+    =
+      entries->get_optional<std::string> (get_current_full_path(entry) + path_separator + "actions");
+
+  // if there were actions already associated with this parameter, add
+  // the current one to it; otherwise, create a one-item list and use
+  // that
+  if (current_actions)
+    {
+      const std::string all_actions = current_actions.get() +
+                                      "," +
+                                      Utilities::int_to_string (actions.size()-1);
+      entries->put (get_current_full_path(entry) + path_separator + "actions",
+                    all_actions);
+    }
+  else
+    entries->put (get_current_full_path(entry) + path_separator + "actions",
+                  Utilities::int_to_string(actions.size()-1));
+
+
+  // as documented, run the action on the default value at the very end
+  const std::string default_value = entries->get<std::string>(get_current_full_path(entry) +
+                                                              path_separator +
+                                                              "default_value");
+  action (default_value);
+}
+
+
+
 void
 ParameterHandler::declare_alias(const std::string &existing_entry_name,
                                 const std::string &alias_name,
@@ -2193,9 +2230,12 @@ ParameterHandler::set (const std::string &entry_string,
   if (entries->get_optional<std::string>(path + path_separator + "alias"))
     path = get_current_full_path(entries->get<std::string>(path + path_separator + "alias"));
 
-  // assert that the entry is indeed declared
+  // get the node for the entry. if it doesn't exist, then we end up
+  // in the else-branch below, which asserts that the entry is indeed
+  // declared
   if (entries->get_optional<std::string>(path + path_separator + "value"))
     {
+      // verify that the new value satisfies the provided pattern
       const unsigned int pattern_index
         = entries->get<unsigned int> (path + path_separator + "pattern");
       AssertThrow (patterns[pattern_index]->match(new_value),
@@ -2205,6 +2245,20 @@ ParameterHandler::set (const std::string &entry_string,
                                                  path_separator +
                                                  "pattern_description")));
 
+      // then also execute the actions associated with this
+      // parameter (if any have been provided)
+      const boost::optional<std::string> action_indices_as_string
+        = entries->get_optional<std::string> (path + path_separator + "actions");
+      if (action_indices_as_string)
+        {
+          std::vector<int> action_indices
+            = Utilities::string_to_int (Utilities::split_string_list (action_indices_as_string.get()));
+          for (unsigned int index : action_indices)
+            if (actions.size() >= index+1)
+              actions[index](new_value);
+        }
+
+      // finally write the new value into the database
       entries->put (path + path_separator + "value",
                     new_value);
     }
@@ -2998,7 +3052,9 @@ ParameterHandler::scan_line (std::string         line,
           path = get_current_full_path(entries->get<std::string>(path + path_separator + "alias"));
         }
 
-      // assert that the entry is indeed declared
+      // get the node for the entry. if it doesn't exist, then we end up
+      // in the else-branch below, which asserts that the entry is indeed
+      // declared
       if (entries->get_optional<std::string> (path + path_separator + "value"))
         {
           // if entry was declared:
@@ -3009,6 +3065,7 @@ ParameterHandler::scan_line (std::string         line,
           // entry, then ignore content
           if (entry_value.find ('{') == std::string::npos)
             {
+              // verify that the new value satisfies the provided pattern
               const unsigned int pattern_index
                 = entries->get<unsigned int> (path + path_separator + "pattern");
               AssertThrow (patterns[pattern_index]->match (entry_value),
@@ -3017,8 +3074,22 @@ ParameterHandler::scan_line (std::string         line,
                                                       entry_value,
                                                       entry_name,
                                                       patterns[pattern_index]->description()));
+
+              // then also execute the actions associated with this
+              // parameter (if any have been provided)
+              const boost::optional<std::string> action_indices_as_string
+                = entries->get_optional<std::string> (path + path_separator + "actions");
+              if (action_indices_as_string)
+                {
+                  std::vector<int> action_indices
+                    = Utilities::string_to_int (Utilities::split_string_list (action_indices_as_string.get()));
+                  for (unsigned int index : action_indices)
+                    if (actions.size() >= index+1)
+                      actions[index](entry_value);
+                }
             }
 
+          // finally write the new value into the database
           entries->put (path + path_separator + "value",
                         entry_value);
         }

--- a/tests/parameter_handler/parameter_handler_action_01.cc
+++ b/tests/parameter_handler/parameter_handler_action_01.cc
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2002 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the ParameterHandler::add_action() function
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+
+
+void check (const char *p)
+{
+  std::string parameter_set_by_action;
+
+  ParameterHandler prm;
+  prm.declare_entry ("test_1", "-1,0",
+                     Patterns::List(Patterns::Integer(-1,1),2,3));
+  prm.add_action ("test_1",
+                  [&](const std::string &s)
+  {
+    deallog << "In action:" << s << std::endl;
+    parameter_set_by_action = s;
+    return true;
+  });
+
+
+  std::ifstream in(p);
+
+  deallog << "Reading parameters" << std::endl;
+  prm.read_input (in);
+
+  deallog << "test_1=" << prm.get ("test_1") << std::endl;
+  deallog << "Saved parameter: " << parameter_set_by_action << std::endl;
+}
+
+
+
+int main ()
+{
+  initlog();
+
+  check (SOURCE_DIR "/prm/parameter_handler_1.prm");
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_action_01.output
+++ b/tests/parameter_handler/parameter_handler_action_01.output
@@ -1,0 +1,6 @@
+
+DEAL::In action:-1,0
+DEAL::Reading parameters
+DEAL::In action:1,0,1
+DEAL::test_1=1,0,1
+DEAL::Saved parameter: 1,0,1

--- a/tests/parameter_handler/parameter_handler_action_02.cc
+++ b/tests/parameter_handler/parameter_handler_action_02.cc
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2002 - 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check the ParameterHandler::add_action() function. like _01, but
+// attach a second action
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+
+
+void check (const char *p)
+{
+  std::string parameter_set_by_action;
+
+  ParameterHandler prm;
+  prm.declare_entry ("test_1", "-1,0",
+                     Patterns::List(Patterns::Integer(-1,1),2,3));
+  prm.add_action ("test_1",
+                  [&](const std::string &s)
+  {
+    deallog << "In action 1:" << s << std::endl;
+    parameter_set_by_action = s;
+    return true;
+  });
+  prm.add_action ("test_1",
+                  [&](const std::string &s)
+  {
+    deallog << "In action 2:" << s << std::endl;
+    parameter_set_by_action = s + " some modification";
+    return true;
+  });
+
+
+  std::ifstream in(p);
+
+  deallog << "Reading parameters" << std::endl;
+  prm.read_input (in);
+
+  deallog << "test_1=" << prm.get ("test_1") << std::endl;
+  deallog << "Saved parameter: " << parameter_set_by_action << std::endl;
+}
+
+
+
+int main ()
+{
+  initlog();
+
+  check (SOURCE_DIR "/prm/parameter_handler_1.prm");
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_action_02.output
+++ b/tests/parameter_handler/parameter_handler_action_02.output
@@ -1,0 +1,8 @@
+
+DEAL::In action 1:-1,0
+DEAL::In action 2:-1,0
+DEAL::Reading parameters
+DEAL::In action 1:1,0,1
+DEAL::In action 2:1,0,1
+DEAL::test_1=1,0,1
+DEAL::Saved parameter: 1,0,1 some modification


### PR DESCRIPTION
This is a proposal to address #2268. It allows attaching one or more "actions" to parameters, for example for setting a member variable. #2268 asks for more than just this, but everything that's discussed in #2268 can in principle be implemented with only minor effort based on what I propose here.

@luca-heltai -- does this go in the right direction?

There is one design decision that one could discuss for my patch: The action I am allowing here takes the value of the parameter as argument, but it does not evaluate the return value of the action. I had toyed with the idea of making the return type a `bool`, and using the value returned by the action to indicate whether the action is happy with the value or not -- the latter being similar to a value not satisfying the "pattern" that is attached to every parameter. This would, in principle, allow more complicated patterns. In practice, however, I see little reason why this would be preferable to do through an "action", as opposed to just doing it once all parameters are read. In particular, my experience is that the more complicated tests one may want to run depend on multiple parameters that need to be compatible with each other, but we cannot rely on other parameters already having certain values at the point where we execute the action. Furthermore, requiring a `bool` return type on actions requires *every action* to have a return statement, even though in almost all cases it would simply be `true`.

I have a couple of follow-up things that I need to address later (e.g., defining what happens in cases of exceptions). I'll open github issues for these at a later time. This must suffice for now.