### PR TITLE
Use std::unique_ptr instead of std::shared_ptr in FESystem.

### DIFF
--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -24,7 +24,9 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/fe/fe.h>
 #include <vector>
+#include <memory>
 #include <utility>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -968,7 +970,7 @@ private:
    * pointers to the underlying base finite elements. The last one of these
    * copies around will then delete the pointer to the base elements.
    */
-  std::vector<std::pair<std::shared_ptr<const FiniteElement<dim,spacedim> >,
+  std::vector<std::pair<std::unique_ptr<const FiniteElement<dim,spacedim> >,
       unsigned int> >
       base_elements;
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1478,7 +1478,7 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
           clone_base_elements += Threads::new_task ([ &,i,ind] ()
           {
             base_elements[ind]
-              = std::make_pair (std::shared_ptr<FiniteElement<dim,spacedim>>(fes[i]->clone()),
+              = std::make_pair (std::unique_ptr<FiniteElement<dim,spacedim>>(fes[i]->clone()),
                                 multiplicities[i]);
           });
           ++ind;


### PR DESCRIPTION
This is as discussed in #4209. It needs to wait for #4276, though, before it can be
committed.

Passes the testsuite when applied after #4276.