### PR TITLE
remove CXX14 requirement from FE_Enriched as we switched to C++11 of …

### DIFF
--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -18,11 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-// We require c++14 here even though we only need features that are part of
-// c++11, but it turns out that gcc 4.6.x and 4.7.x don't support c++11
-// features like delegating constructors.
-
-#ifdef DEAL_II_WITH_CXX14
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_nothing.h>
@@ -648,7 +643,5 @@ private:
 
 //}
 DEAL_II_NAMESPACE_CLOSE
-
-#endif // CXX14
 
 #endif // dealii__fe_enriched_h

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -16,8 +16,6 @@
 
 #include <deal.II/fe/fe_enriched.h>
 
-#ifdef DEAL_II_WITH_CXX14
-
 #include <deal.II/fe/fe_tools.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -942,5 +940,3 @@ InternalData::get_fe_output_object (const unsigned int base_no) const
 #include "fe_enriched.inst"
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif // CXX14


### PR DESCRIPTION
…gcc4.8 and alike

**UPDATE:**

this compiles with `4.8.5` on `Ubuntu`. Therefore i would say that this PR also fixes https://github.com/dealii/dealii/issues/3209