### PR TITLE
Fix compilation for complex-valued PETSc

### DIFF
--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -235,8 +235,9 @@ namespace FETools
                  ExcInternalError());
 
 
-          const double val = ::dealii::internal::ElementAccess<OutVector>::get(
-                               u2, i);
+          const typename OutVector::value_type val
+            = ::dealii::internal::ElementAccess<OutVector>::get(
+                u2, i);
           ::dealii::internal::ElementAccess<OutVector>::set(
             val/::dealii::internal::ElementAccess<OutVector>::get(touch_count,i), i, u2);
         }

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -358,12 +358,12 @@ namespace VectorTools
       {
         Assert (touch_count[i] != 0,
                 ExcInternalError());
-
-        const double val = ::dealii::internal::ElementAccess<OutVector>::get(
-                             data_2, i);
+        typedef typename OutVector::value_type value_type;
+        const value_type val
+          = ::dealii::internal::ElementAccess<OutVector>::get(data_2, i);
 
         ::dealii::internal::ElementAccess<OutVector>::set(
-          val/touch_count[i], i, data_2);
+          val/static_cast<value_type>(touch_count[i]), i, data_2);
       }
   }
 


### PR DESCRIPTION
According reports that the building with complex scalar-type starts to fail between `e61ce25` and `c2df311`. This PR fixes this.