### PR TITLE
Fix tests by performing an explicit cast.

### DIFF
--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
@@ -79,7 +79,9 @@ void test (const unsigned int flag)
   ConstraintMatrix cm;
   DoFTools::make_hanging_node_constraints(dh,cm);
 
-  IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh, pred_d<dim>, cm);
+  IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh,
+                     std::function<bool (const typename DoFHandler<dim>::active_cell_iterator &)>(&pred_d<dim>),
+                     cm);
   support.print(deallog);
 
   // print grid and DoFs for visual inspection

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
@@ -102,7 +102,9 @@ void test (const unsigned int flag)
   DoFTools::make_hanging_node_constraints(dh,cm);
   cm.close ();
 
-  const IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh, pred_d<dim>, cm);
+  const IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh,
+                           std::function<bool (const typename DoFHandler<dim>::active_cell_iterator &)>(&pred_d<dim>),
+                           cm);
   const IndexSet support_local = support & dh.locally_owned_dofs();
 
   deallog << support.n_elements() << std::endl;

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
@@ -96,8 +96,12 @@ void test (const bool left = true)
   DoFTools::make_hanging_node_constraints(dh,cm);
 
   IndexSet support = left ?
-                     DoFTools::extract_dofs_with_support_contained_within(dh, pred_left<dim>, cm) :
-                     DoFTools::extract_dofs_with_support_contained_within(dh, pred_right<dim>, cm);
+                     DoFTools::extract_dofs_with_support_contained_within(dh,
+                         std::function<bool (const typename DoFHandler<dim>::active_cell_iterator &)>(&pred_left<dim>),
+                         cm) :
+                     DoFTools::extract_dofs_with_support_contained_within(dh,
+                         std::function<bool (const typename DoFHandler<dim>::active_cell_iterator &)>(&pred_right<dim>),
+                         cm);
   support.print(deallog);
 
   // print grid and DoFs for visual inspection

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -111,7 +111,9 @@ void test ()
   std::vector<types::global_dof_index> local_dof_indices(fe.dofs_per_cell);
 
   // get support on the predicate
-  IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh, pred_d<dim>, cm);
+  IndexSet support = DoFTools::extract_dofs_with_support_contained_within(dh,
+                     std::function<bool (const typename DoFHandler<dim>::active_cell_iterator &)>(&pred_d<dim>),
+                     cm);
   IndexSet local_support = support & locally_owned_set;
 
   // rhs vectors:


### PR DESCRIPTION
#4287 did not really fix the issue for me -- what is necessary to make it
work on my platform is to perform an explicit cast to a std::function object.