### PR TITLE
update readme regarding MSVC

### DIFF
--- a/doc/news/changes/minor/20170420Heister
+++ b/doc/news/changes/minor/20170420Heister
@@ -1,0 +1,5 @@
+Changed: We no longer support Visual Studio 2013 because it
+lacks important c++11 features like constexpr. It is now possible
+to use MSVC 2017 in addition to MSVC 2015.
+<br>
+(Timo Heister, 2017/04/20)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -71,7 +71,7 @@
   <li>Mac OS X: GCC version 4.8 or later; Clang version 3.3 or later.
     Please see the <a href="https://github.com/dealii/dealii/wiki/MacOSX"
     target="_top">deal.II Wiki</a> for installation instructions.</li>
-  <li>Windows: experimental support for Visual Studio 2013 and 2015.
+  <li>Windows: experimental support for Visual Studio 2015 and 2017.
     Please have a look at the
     <a href="https://github.com/dealii/dealii/wiki/Frequently-Asked-Questions#can-i-use-dealii-on-a-windows-platform">
       FAQ</a> and at the <a href="https://github.com/dealii/dealii/wiki/Windows"


### PR DESCRIPTION
- We no longer support msvc 2013 (no constexpr support)
- MSVC 2015 and 2017 work correctly