### PR TITLE
Add an error message for vectorization capability mismatch

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -39,6 +39,16 @@
 // 'check_01_cpu_features.cmake', ensures that these feature are not only
 // present in the compilation unit but also working properly.
 
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && not defined(__SSE2__)
+#error "Mismatch in vectorization capabilities: SSE2 was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
+#endif
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && not defined(__AVX__)
+#error "Mismatch in vectorization capabilities: AVX was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
+#endif
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && not defined(__AVX512F__)
+#error "Mismatch in vectorization capabilities: AVX-512F was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
+#endif
+
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 // AVX, AVX-512
 #include <immintrin.h>
 #elif DEAL_II_COMPILER_VECTORIZATION_LEVEL == 1 // SSE2


### PR DESCRIPTION
When deal.II is included in user projects and the CXX flags are not imported from deal.II, it could happen that deal.II was compiled with AVX enabled (4-wide vectorization) but an application might use deal.II headers with only SSE2 (2-wide vectorization) enabled. This lead to hard-to-understand memory faults. We cannot fix that but we can issue a suitable error message so a user can check the compiler flags.