### PR TITLE
Remove deprecated function FEValuesBase::get_normal_vectors().

### DIFF
--- a/doc/news/changes/incompatibilities/20170425Bangerth
+++ b/doc/news/changes/incompatibilities/20170425Bangerth
@@ -1,0 +1,9 @@
+Changed: The deprecated function FEValuesBase::get_normal_vectors()
+that returned a vector of Point objects has been removed. Its
+replacement, FEValuesBase::get_all_normal_vectors() has now itself
+been deprecated, and we have created a new function 
+FEValuesBase::get_normal_vectors() that returns a vector of
+Tensor<1,dim> objects. The net effect is that the function with the
+old name has simply gotten a new return type.
+<br>
+(Wolfgang Bangerth, 2017/04/25)

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2406,27 +2406,19 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_normal_vectors}
    *
-   * @note This function should really be named get_normal_vectors(), but this
-   * function already exists with a different return type that returns a
-   * vector of Point objects, rather than a vector of Tensor objects. This is
-   * a historical accident, but can not be fixed in a backward compatible
-   * style. That said, the get_normal_vectors() function is now deprecated,
-   * will be removed in the next version, and the current function will then
-   * be renamed.
+   * @deprecated Use get_normal_vectors() instead, which returns the exact
+   * same thing.
    */
-  const std::vector<Tensor<1,spacedim> > &get_all_normal_vectors () const;
+  const std::vector<Tensor<1,spacedim> > &get_all_normal_vectors () const DEAL_II_DEPRECATED;
 
   /**
-   * Return the normal vectors at the quadrature points as a vector of Point
-   * objects. This function is deprecated because normal vectors are correctly
-   * represented by rank-1 Tensor objects, not Point objects. Use
-   * get_all_normal_vectors() instead.
+   * Return the normal vectors at the quadrature points. For a face, these are
+   * the outward normal vectors to the cell. For a cell of codimension one,
+   * the orientation is given by the numbering of vertices.
    *
    * @dealiiRequiresUpdateFlags{update_normal_vectors}
-   *
-   * @deprecated
    */
-  std::vector<Point<spacedim> > get_normal_vectors () const DEAL_II_DEPRECATED;
+  const std::vector<Tensor<1,spacedim> > &get_normal_vectors () const;
 
   /**
    * Transform a set of vectors, one for each quadrature point. The

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -3375,24 +3375,19 @@ FEValuesBase<dim,spacedim>::get_all_normal_vectors () const
 {
   Assert (this->update_flags & update_normal_vectors,
           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_normal_vectors")));
-  return this->mapping_output.normal_vectors;
+  return get_normal_vectors();
 }
 
 
 
 template <int dim, int spacedim>
-std::vector<Point<spacedim> >
+const std::vector<Tensor<1,spacedim> > &
 FEValuesBase<dim,spacedim>::get_normal_vectors () const
 {
   Assert (this->update_flags & update_normal_vectors,
           (typename FEValuesBase<dim,spacedim>::ExcAccessToUninitializedField("update_normal_vectors")));
 
-  // copy things into a vector of Points, then return that
-  std::vector<Point<spacedim> > tmp (this->mapping_output.normal_vectors.size());
-  for (unsigned int q=0; q<this->mapping_output.normal_vectors.size(); ++q)
-    tmp[q] = Point<spacedim>(this->mapping_output.normal_vectors[q]);
-
-  return tmp;
+  return this->mapping_output.normal_vectors;
 }
 
 

--- a/tests/mappings/mapping_manifold_06.cc
+++ b/tests/mappings/mapping_manifold_06.cc
@@ -71,7 +71,7 @@ void test()
           {
             fe_v.reinit(cell, f);
             const std::vector<Point<spacedim> > &qps = fe_v.get_quadrature_points();
-            const std::vector<Point<spacedim> > &nps = fe_v.get_normal_vectors();
+            const std::vector<Tensor<1,spacedim> > &nps = fe_v.get_normal_vectors();
             for (unsigned int i=0; i<qps.size(); ++i)
               {
                 out << qps[i] << std::endl;
@@ -100,7 +100,7 @@ void test()
           {
             fe_v.reinit(cell, f);
             const std::vector<Point<spacedim> > &qps = fe_v.get_quadrature_points();
-            const std::vector<Point<spacedim> > &nps = fe_v.get_normal_vectors();
+            const std::vector<Tensor<1,spacedim> > &nps = fe_v.get_normal_vectors();
             for (unsigned int i=0; i<qps.size(); ++i)
               {
                 out << qps[i] << " " << nps[i] << std::endl;


### PR DESCRIPTION
The deprecated function FEValuesBase::get_normal_vectors()
that returned a vector of Point objects has been removed. Its
replacement, FEValuesBase::get_all_normal_vectors() has now itself
been deprecated, and we have created a new function 
FEValuesBase::get_normal_vectors() that returns a vector of
Tensor<1,dim> objects. The net effect is that the function with the
old name has simply gotten a new return type.