### PR TITLE
Remove dependence on FunctionParser in ARPACK test

### DIFF
--- a/tests/arpack/step-36_ar.cc
+++ b/tests/arpack/step-36_ar.cc
@@ -147,10 +147,7 @@ namespace Step36
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
 
-    FunctionParser<dim> potential;
-    potential.initialize (FunctionParser<dim>::default_variable_names (),
-                          "0",
-                          typename FunctionParser<dim>::ConstMap());
+    ZeroFunction<dim> potential;
 
     std::vector<double> potential_values (n_q_points);
 

--- a/tests/arpack/step-36_ar_shift.cc
+++ b/tests/arpack/step-36_ar_shift.cc
@@ -141,10 +141,7 @@ namespace Step36
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
 
-    FunctionParser<dim> potential;
-    potential.initialize (FunctionParser<dim>::default_variable_names (),
-                          "0",
-                          typename FunctionParser<dim>::ConstMap());
+    ZeroFunction<dim> potential;
 
     std::vector<double> potential_values (n_q_points);
 


### PR DESCRIPTION
Running the test suite with `DEAL_II_WITH_MUPARSER=OFF` revealed that `arpack/step-36_ar*` uses a  `FunctionParser` object. Since it only resembles a `ZeroFunction` it is easiest to just replace it.