### PR TITLE
Fix PETScWrappers::MatrixBase::set for 64bit and complex scalars

### DIFF
--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1208,26 +1208,32 @@ namespace PETScWrappers
                    const PetscScalar  *values,
                    const bool         elide_zero_values)
   {
-    (void)elide_zero_values;
-
     prepare_action(VectorOperation::insert);
 
     const PetscInt petsc_i = row;
-    PetscInt *col_index_ptr;
+    PetscInt const *col_index_ptr;
 
     PetscScalar const *col_value_ptr;
     int n_columns;
 
     // If we don't elide zeros, the pointers are already available...
-#ifndef PETSC_USE_64BIT_INDICES
     if (elide_zero_values == false)
       {
-        col_index_ptr = (int *)col_indices;
+#ifndef PETSC_USE_64BIT_INDICES
+        col_index_ptr = reinterpret_cast<const PetscInt *>(col_indices);
+#else
+        if (column_indices.size() < n_cols)
+          column_indices.resize(n_cols);
+
+        for (size_type j=0; j<n_cols; ++j)
+          column_indices[j] = col_indices[j];
+
+        col_index_ptr = &column_indices[0];
+#endif
         col_value_ptr = values;
         n_columns = n_cols;
       }
     else
-#endif
       {
         // Otherwise, extract nonzero values in each row and get the
         // respective index.
@@ -1355,21 +1361,29 @@ namespace PETScWrappers
     prepare_action(VectorOperation::add);
 
     const PetscInt petsc_i = row;
-    PetscInt *col_index_ptr;
+    PetscInt const *col_index_ptr;
 
     PetscScalar const *col_value_ptr;
     int n_columns;
 
     // If we don't elide zeros, the pointers are already available...
-#ifndef PETSC_USE_64BIT_INDICES
     if (elide_zero_values == false)
       {
-        col_index_ptr = (int *)col_indices;
+#ifndef PETSC_USE_64BIT_INDICES
+        col_index_ptr = reinterpret_cast<const PetscInt *>(col_indices);
+#else
+        if (column_indices.size() < n_cols)
+          column_indices.resize(n_cols);
+
+        for (size_type j=0; j<n_cols; ++j)
+          column_indices[j] = col_indices[j];
+
+        col_index_ptr = &column_indices[0];
+#endif
         col_value_ptr = values;
         n_columns = n_cols;
       }
     else
-#endif
       {
         // Otherwise, extract nonzero values in each row and get the
         // respective index.

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1219,17 +1219,7 @@ namespace PETScWrappers
     // If we don't elide zeros, the pointers are already available...
     if (elide_zero_values == false)
       {
-#ifndef PETSC_USE_64BIT_INDICES
         col_index_ptr = reinterpret_cast<const PetscInt *>(col_indices);
-#else
-        if (column_indices.size() < n_cols)
-          column_indices.resize(n_cols);
-
-        for (size_type j=0; j<n_cols; ++j)
-          column_indices[j] = col_indices[j];
-
-        col_index_ptr = &column_indices[0];
-#endif
         col_value_ptr = values;
         n_columns = n_cols;
       }
@@ -1369,17 +1359,7 @@ namespace PETScWrappers
     // If we don't elide zeros, the pointers are already available...
     if (elide_zero_values == false)
       {
-#ifndef PETSC_USE_64BIT_INDICES
         col_index_ptr = reinterpret_cast<const PetscInt *>(col_indices);
-#else
-        if (column_indices.size() < n_cols)
-          column_indices.resize(n_cols);
-
-        for (size_type j=0; j<n_cols; ++j)
-          column_indices[j] = col_indices[j];
-
-        col_index_ptr = &column_indices[0];
-#endif
         col_value_ptr = values;
         n_columns = n_cols;
       }


### PR DESCRIPTION
Running the test suite with complex scalar type and 64bit indices `petsc_complex/element_access_01` and `petsc_complex/element_access_03` failed since `elide_zero_values==true` was implicitly assumed in `PETScWrappers::MatrixBase::set`.