### PR TITLE
Make PETScWrappers::MPI::Vector always distributed.

### DIFF
--- a/doc/news/changes/minor/20170429DavidWells
+++ b/doc/news/changes/minor/20170429DavidWells
@@ -1,0 +1,3 @@
+Changed: The PETScWrappers::MPI::Vector class always corresponds to a PETSc
+vector with type <code>mpi</code>, even when empty.
+<br> (David Wells, 2017/03/29)

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -471,43 +471,6 @@ namespace PETScWrappers
 
 
 
-    inline
-    Vector &
-    Vector::operator= (const Vector &v)
-    {
-      // make sure left- and right-hand side of the assignment are compress()'ed:
-      Assert(v.last_action == VectorOperation::unknown,
-             internal::VectorReference::ExcWrongMode (VectorOperation::unknown,
-                                                      v.last_action));
-      Assert(last_action == VectorOperation::unknown,
-             internal::VectorReference::ExcWrongMode (VectorOperation::unknown,
-                                                      last_action));
-
-      // if the vectors have different sizes,
-      // then first resize the present one
-      if (size() != v.size())
-        {
-          if (v.has_ghost_elements())
-            reinit( v.locally_owned_elements(), v.ghost_indices, v.communicator);
-          else
-            reinit (v.communicator, v.size(), v.local_size(), true);
-        }
-
-      PetscErrorCode ierr = VecCopy (v.vector, vector);
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
-
-      if (has_ghost_elements())
-        {
-          ierr = VecGhostUpdateBegin(vector, INSERT_VALUES, SCATTER_FORWARD);
-          AssertThrow (ierr == 0, ExcPETScError(ierr));
-          ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);
-          AssertThrow (ierr == 0, ExcPETScError(ierr));
-        }
-      return *this;
-    }
-
-
-
     template <typename number>
     inline
     Vector &

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -483,30 +483,6 @@ namespace PETScWrappers
              internal::VectorReference::ExcWrongMode (VectorOperation::unknown,
                                                       last_action));
 
-
-      if (v.size()==0)
-        {
-          // this happens if v has not been initialized to something useful:
-          //   Vector x,v;
-          //   x=v;
-          // we skip the code below and create a simple serial vector of
-          // length 0
-
-#if DEAL_II_PETSC_VERSION_LT(3,2,0)
-          PetscErrorCode ierr = VecDestroy (vector);
-#else
-          PetscErrorCode ierr = VecDestroy (&vector);
-#endif
-          AssertThrow (ierr == 0, ExcPETScError(ierr));
-
-          const int n = 0;
-          ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
-          AssertThrow (ierr == 0, ExcPETScError(ierr));
-          ghosted = false;
-          ghost_indices.clear();
-          return *this;
-        }
-
       // if the vectors have different sizes,
       // then first resize the present one
       if (size() != v.size())

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -96,6 +96,42 @@ namespace PETScWrappers
 
 
 
+    Vector &
+    Vector::operator= (const Vector &v)
+    {
+      // make sure left- and right-hand side of the assignment are compress()'ed:
+      Assert(v.last_action == VectorOperation::unknown,
+             internal::VectorReference::ExcWrongMode (VectorOperation::unknown,
+                                                      v.last_action));
+      Assert(last_action == VectorOperation::unknown,
+             internal::VectorReference::ExcWrongMode (VectorOperation::unknown,
+                                                      last_action));
+
+      // if the vectors have different sizes,
+      // then first resize the present one
+      if (size() != v.size())
+        {
+          if (v.has_ghost_elements())
+            reinit( v.locally_owned_elements(), v.ghost_indices, v.communicator);
+          else
+            reinit (v.communicator, v.size(), v.local_size(), true);
+        }
+
+      PetscErrorCode ierr = VecCopy (v.vector, vector);
+      AssertThrow (ierr == 0, ExcPETScError(ierr));
+
+      if (has_ghost_elements())
+        {
+          ierr = VecGhostUpdateBegin(vector, INSERT_VALUES, SCATTER_FORWARD);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
+          ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);
+          AssertThrow (ierr == 0, ExcPETScError(ierr));
+        }
+      return *this;
+    }
+
+
+
     void
     Vector::clear ()
     {

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -32,12 +32,7 @@ namespace PETScWrappers
     Vector::Vector ()
       : communicator (MPI_COMM_SELF)
     {
-      // this is an invalid empty vector, so we can just as well create a
-      // sequential one to avoid all the overhead incurred by parallelism
-      const int n = 0;
-      const PetscErrorCode ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
-      ghosted = false;
+      create_vector(0, 0);
     }
 
 
@@ -104,15 +99,10 @@ namespace PETScWrappers
     void
     Vector::clear ()
     {
-      // destroy the PETSc Vec and create an invalid empty vector,
-      // so we can just as well create a sequential one to avoid
-      // all the overhead incurred by parallelism
       attained_ownership = true;
       VectorBase::clear ();
 
-      const int n = 0;
-      const PetscErrorCode ierr = VecCreateSeq (PETSC_COMM_SELF, n, &vector);
-      AssertThrow (ierr == 0, ExcPETScError(ierr));
+      create_vector(0, 0);
     }
 
 


### PR DESCRIPTION
While working on some of the other various PETSc things I have floating around I ended up with, for reasons I don't fully understand, a sequential vector in `PETScWrappers::MatrixFree::vmult` where I should have had an MPI vector. Previously, `PETScWrappers::MPI::Vector` would set itself up as a sequential vector if it is empty: I got rid of this optimization so that we always have a PETSc parallel vector type.