### PR TITLE
Remove the deprecated member variables 'supports_distributed_data' of vector classes.

### DIFF
--- a/doc/news/changes/incompatibilities/20170430Bangerth
+++ b/doc/news/changes/incompatibilities/20170430Bangerth
@@ -1,0 +1,5 @@
+Changed: The deprecated member variables @p supports_distributed_data
+that was present in all vector classes has been removed. If you needed
+this functionality, use the type trait is_serial_vector instead.
+<br>
+(Wolfgang Bangerth, 2017/04/30)

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -562,20 +562,6 @@ public:
   typedef typename BlockType::real_type real_type;
 
   /**
-   * A variable that indicates whether this vector supports distributed data
-   * storage. If true, then this vector also needs an appropriate compress()
-   * function that allows communicating recent set or add operations to
-   * individual elements to be communicated to other processors.
-   *
-   * For the current class, the variable equals the value declared for the
-   * type of the individual blocks.
-   *
-   * @deprecated instead of using this variable, please use the type trait value
-   * <code>is_serial_vector< VectorType >::value</code>
-   */
-  static const bool supports_distributed_data DEAL_II_DEPRECATED = !is_serial_vector<BlockType>::value;
-
-  /**
    * Default constructor.
    */
   BlockVectorBase ();

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -188,21 +188,6 @@ namespace LinearAlgebra
       typedef typename numbers::NumberTraits<Number>::real_type real_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       *
-       * @deprecated instead of using this variable, please use the type trait
-       * value <code>is_serial_vector< VectorType >::value</code>
-       */
-      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
-
-      /**
        * @name 1: Basic Object-handling
        */
       //@{

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -163,21 +163,6 @@ namespace PETScWrappers
       typedef types::global_dof_index size_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       *
-       * @deprecated instead of using this variable, please use the type trait
-       * value <code>is_serial_vector< VectorType >::value</code>
-       */
-      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
-
-      /**
        * Default constructor. Initialize the vector as empty.
        */
       Vector ();

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -60,21 +60,6 @@ namespace PETScWrappers
     typedef types::global_dof_index size_type;
 
     /**
-     * A variable that indicates whether this vector supports distributed data
-     * storage. If true, then this vector also needs an appropriate compress()
-     * function that allows communicating recent set or add operations to
-     * individual elements to be communicated to other processors.
-     *
-     * For the current class, the variable equals false, since it does not
-     * support parallel data storage. If you do need parallel data storage,
-     * use PETScWrappers::MPI::Vector.
-     *
-     * @deprecated instead of using this variable, please use the type trait
-     * value <code>is_serial_vector< VectorType >::value</code>
-     */
-    static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
-
-    /**
      * Default constructor. Initialize the vector as empty.
      */
     Vector ();

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -261,21 +261,6 @@ namespace TrilinosWrappers
       typedef dealii::types::global_dof_index size_type;
 
       /**
-       * A variable that indicates whether this vector supports distributed
-       * data storage. If true, then this vector also needs an appropriate
-       * compress() function that allows communicating recent set or add
-       * operations to individual elements to be communicated to other
-       * processors.
-       *
-       * For the current class, the variable equals true, since it does
-       * support parallel data storage.
-       *
-       * @deprecated instead of using this variable, please use the type trait
-       * value <code>is_serial_vector< VectorType >::value</code>
-       */
-      static const bool supports_distributed_data DEAL_II_DEPRECATED = true;
-
-      /**
        * @name Basic constructors and initialization.
        */
       //@{
@@ -761,21 +746,6 @@ namespace TrilinosWrappers
      * Declare type for container size.
      */
     typedef dealii::types::global_dof_index size_type;
-
-    /**
-     * A variable that indicates whether this vector supports distributed data
-     * storage. If true, then this vector also needs an appropriate compress()
-     * function that allows communicating recent set or add operations to
-     * individual elements to be communicated to other processors.
-     *
-     * For the current class, the variable equals false, since it does not
-     * support parallel data storage.  If you do need parallel data storage,
-     * use TrilinosWrappers::MPI::Vector.
-     *
-     * @deprecated instead of using this variable, please use the type trait
-     * value <code>is_serial_vector< VectorType >::value</code>
-     */
-    static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
 
     /**
      * Default constructor that generates an empty (zero size) vector. The

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -162,20 +162,6 @@ public:
    */
   typedef typename numbers::NumberTraits<Number>::real_type real_type;
 
-  /**
-   * A variable that indicates whether this vector supports distributed data
-   * storage. If true, then this vector also needs an appropriate compress()
-   * function that allows communicating recent set or add operations to
-   * individual elements to be communicated to other processors.
-   *
-   * For the current class, the variable equals false, since it does not
-   * support parallel data storage.
-   *
-   * @deprecated instead of using this variable, please use the type trait value
-   * <code>is_serial_vector< VectorType >::value</code>
-   */
-  static const bool supports_distributed_data DEAL_II_DEPRECATED = false;
-
 public:
 
   /**


### PR DESCRIPTION
This should fix a lot of warnings one gets on some platforms when just using some of the
vector classes that have these variables, even if one doesn't actually use the deprecated
variable.

Passes the testsuite.