### PR TITLE
Avoid using deprecated functions in the testsuite.

### DIFF
--- a/tests/bits/distorted_mapped_cells_01.cc
+++ b/tests/bits/distorted_mapped_cells_01.cc
@@ -63,7 +63,7 @@ void test()
 
   // this gives a Cartesian cell but in non-standard orientation (x-coordinate
   // is gone through backwards)
-  MappingQEulerian<dim> mapping(1,displacements, dof_h);
+  MappingQEulerian<dim> mapping(1, dof_h, displacements);
   QGauss<dim> quad(1);
   FEValues<dim> fe_val (mapping, fe, quad, update_JxW_values);
   double integral = 0.;

--- a/tests/codim_one/mapping_q_eulerian.cc
+++ b/tests/codim_one/mapping_q_eulerian.cc
@@ -64,7 +64,7 @@ void test(std::string filename, unsigned int degree)
   grid_out.write_ucd (tria, logfile);
 
   QTrapez<dim> quad;
-  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree, shift, shift_dh);
+  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree, shift_dh, shift);
 
   typename Triangulation<dim,spacedim>::active_cell_iterator cell=tria.begin_active(),
                                                              endc=tria.end() ;

--- a/tests/mappings/mapping_q_eulerian.cc
+++ b/tests/mappings/mapping_q_eulerian.cc
@@ -123,7 +123,7 @@ double MappingTest<dim>::compute_area ()
 {
   QGauss<dim>  quadrature_formula(degree+1);
 
-  MappingQEulerian<dim> mapping(degree,displacements,dof_handler);
+  MappingQEulerian<dim> mapping(degree, dof_handler, displacements);
 
   FEValues<dim> fe_values (mapping, fe, quadrature_formula,
                            update_JxW_values);

--- a/tests/mappings/mapping_q_eulerian_01.cc
+++ b/tests/mappings/mapping_q_eulerian_01.cc
@@ -99,7 +99,7 @@ void test ()
                             Displacement<dim>(),
                             displacements);
 
-  MappingQEulerian<dim> euler(2, displacements, dof_handler);
+  MappingQEulerian<dim> euler(2, dof_handler, displacements);
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);

--- a/tests/mappings/mapping_q_eulerian_02.cc
+++ b/tests/mappings/mapping_q_eulerian_02.cc
@@ -101,7 +101,7 @@ void test ()
                             Displacement<dim>(),
                             displacements);
 
-  MappingQEulerian<dim> euler(2, displacements, dof_handler);
+  MappingQEulerian<dim> euler(2, dof_handler, displacements);
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);

--- a/tests/mappings/mapping_q_eulerian_03.cc
+++ b/tests/mappings/mapping_q_eulerian_03.cc
@@ -102,7 +102,7 @@ void test ()
                             Displacement<dim>(),
                             displacements);
 
-  MappingQEulerian<dim> euler(2, displacements, dof_handler);
+  MappingQEulerian<dim> euler(2, dof_handler, displacements);
   // now the actual test
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);

--- a/tests/mappings/mapping_q_eulerian_05.cc
+++ b/tests/mappings/mapping_q_eulerian_05.cc
@@ -60,7 +60,7 @@ void test(unsigned int degree)
   grid_out.write_ucd (tria, logfile);
 
   QTrapez<dim> quad;
-  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree,shift, shift_dh);
+  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree, shift_dh, shift);
 
   typename Triangulation<dim,spacedim>::active_cell_iterator cell=tria.begin_active(),
                                                              endc=tria.end() ;

--- a/tests/mappings/mapping_q_eulerian_06.cc
+++ b/tests/mappings/mapping_q_eulerian_06.cc
@@ -56,7 +56,7 @@ void test(unsigned int degree)
     shift(i) = 0.1;
 
   QGauss<dim> quad(degree+1);
-  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree,shift, shift_dh);
+  MappingQEulerian<dim,Vector<double>,spacedim> mapping(degree, shift_dh, shift);
 
   Triangulation<dim,spacedim>::active_cell_iterator cell=tria.begin_active(),
                                                     endc=tria.end() ;

--- a/tests/matrix_free/update_mapping_only.cc
+++ b/tests/matrix_free/update_mapping_only.cc
@@ -76,7 +76,7 @@ void test ()
           shift(0) = 0.121;
           shift(1) = -0.005;
         }
-      MappingQEulerian<dim> mapping(2,shift,dofh_eulerian);
+      MappingQEulerian<dim> mapping(2, dofh_eulerian, shift);
 
       {
         const QGauss<1> quad (fe_degree+1);

--- a/tests/metis/metis_01a.cc
+++ b/tests/metis/metis_01a.cc
@@ -118,10 +118,12 @@ void test ()
   GridGenerator::hyper_cube (triangulation);
   triangulation.refine_global (2);
 
-  SparsityPattern cell_connectivity;
+  DynamicSparsityPattern cell_connectivity;
   GridTools::get_face_connectivity_of_cells (triangulation, cell_connectivity);
 
-  partition (cell_connectivity, 5);
+  SparsityPattern sp_cell_connectivity;
+  sp_cell_connectivity.copy_from (cell_connectivity);
+  partition (sp_cell_connectivity, 5);
 }
 
 

--- a/tests/mpi/fe_field_function_03.cc
+++ b/tests/mpi/fe_field_function_03.cc
@@ -186,7 +186,7 @@ void test()
           else
             break;
         }
-      catch (const typename Functions::FEFieldFunction<dim,DoFHandler<dim>,TrilinosWrappers::MPI::Vector>::ExcPointNotAvailableHere &)
+      catch (const VectorTools::ExcPointNotAvailableHere &)
         {
           deallog << "  ExcPointNotAvailableHere" << std::endl;
         }

--- a/tests/numerics/data_out_curved_cells.cc
+++ b/tests/numerics/data_out_curved_cells.cc
@@ -221,7 +221,7 @@ void curved_grid (std::ofstream &out)
       combined_cell->set_dof_values (dxy, displacements);
     }
   // and create the MappingQEulerian
-  MappingQEulerian<2> euler(2, displacements, cdh);
+  MappingQEulerian<2> euler(2, cdh, displacements);
   // now the actual test
   DataOut<2> data_out;
   data_out.attach_dof_handler(cdh);


### PR DESCRIPTION
I had pushed this patch to my github account before #4346, #4347, #4348, #4348,
but apparently forgotten to open a pull request :-( My apologies -- this patch
would have been necessary for the other pull requests to go through without
test failures :-((