### PR TITLE
Fix tests after removal of deprecated functions in TrilinosWrappers vectors

### DIFF
--- a/doc/news/changes/minor/20170509DanielArndt
+++ b/doc/news/changes/minor/20170509DanielArndt
@@ -1,0 +1,7 @@
+New: TrilinosWrappers::MPI::BlockMatrix can now return its MPI_Comm via
+get_mpi_communicator() and its range and domain indices via
+locally_owned_range_indices() and locally_owned_domain_indices()
+relying on the information of the TrilinosWrappers::MPI::Matrix
+object it is based on.
+<br>
+(Daniel Arndt, 2017/05/09)

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -456,7 +456,8 @@ namespace internal
                                 TrilinosWrappers::MPI::BlockVector &v,
                                 bool omit_zeroing_entries)
       {
-        v.reinit(matrix.range_partitioner(), omit_zeroing_entries);
+        v.reinit(matrix.locally_owned_range_indices(),
+                 matrix.get_mpi_communicator(), omit_zeroing_entries);
       }
 
       template <typename Matrix>
@@ -465,7 +466,8 @@ namespace internal
                                 TrilinosWrappers::MPI::BlockVector &v,
                                 bool omit_zeroing_entries)
       {
-        v.reinit(matrix.domain_partitioner(), omit_zeroing_entries);
+        v.reinit(matrix.locally_owned_domain_indices(),
+                 matrix.get_mpi_communicator(), omit_zeroing_entries);
       }
     };
 

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -416,7 +416,13 @@ namespace TrilinosWrappers
 
 
 
-
+  MPI_Comm
+  BlockSparseMatrix::get_mpi_communicator () const
+  {
+    Assert (this->n_block_cols() != 0, ExcNotInitialized());
+    Assert (this->n_block_rows() != 0, ExcNotInitialized());
+    return this->sub_objects[0][0]->get_mpi_communicator();
+  }
 
 
 

--- a/tests/gla/extract_subvector_to.cc
+++ b/tests/gla/extract_subvector_to.cc
@@ -85,7 +85,8 @@ int main (int argc, char **argv)
 
     {
       deallog.push("Trilinos");
-      TrilinosWrappers::Vector v(17);
+      TrilinosWrappers::Vector v;
+      v.reinit(17);
       test (v);
       deallog.pop();
     }
@@ -115,7 +116,8 @@ int main (int argc, char **argv)
 
     {
       deallog.push("Trilinos");
-      TrilinosWrappers::BlockVector v(3);
+      TrilinosWrappers::BlockVector v;
+      v.reinit(3);
       v.block(0).reinit(7);
       v.block(1).reinit(5);
       v.block(2).reinit(3);

--- a/tests/lac/linear_operator_10.cc
+++ b/tests/lac/linear_operator_10.cc
@@ -224,8 +224,10 @@ int main(int argc, char *argv[])
     sparsity_pattern.compress();
 
     TrilinosWrappers::SparseMatrix A (sparsity_pattern);
-    TrilinosWrappers::Vector b (A.domain_partitioner());
-    TrilinosWrappers::MPI::Vector c (A.domain_partitioner());
+    TrilinosWrappers::Vector b;
+    b.reinit(A.locally_owned_domain_indices());
+    TrilinosWrappers::MPI::Vector c;
+    c.reinit(A.locally_owned_domain_indices());
     for (unsigned int i=0; i < rc; ++i)
       {
         A.set(i,i,2.0);

--- a/tests/lac/linear_operator_10a.cc
+++ b/tests/lac/linear_operator_10a.cc
@@ -230,8 +230,10 @@ int main(int argc, char *argv[])
     sparsity_pattern.compress();
 
     TrilinosWrappers::SparseMatrix A (sparsity_pattern);
-    TrilinosWrappers::Vector b (A.domain_partitioner());
-    TrilinosWrappers::MPI::Vector c (A.domain_partitioner());
+    TrilinosWrappers::Vector b;
+    b.reinit(A.domain_partitioner());
+    TrilinosWrappers::MPI::Vector c;
+    c.reinit(A.locally_owned_domain_indices());
     for (unsigned int i=0; i < rc; ++i)
       {
         A.set(i,i,2.0);

--- a/tests/lac/linear_operator_15.cc
+++ b/tests/lac/linear_operator_15.cc
@@ -69,8 +69,10 @@ int main (int argc, char *argv[])
     A.reinit(csp);
     testproblem.five_point(A);
 
-    TrilinosWrappers::Vector  f(dim);
-    TrilinosWrappers::Vector  u(dim);
+    TrilinosWrappers::Vector  f;
+    f.reinit(dim);
+    TrilinosWrappers::Vector  u;
+    u.reinit(dim);
 
     A.compress (VectorOperation::insert);
     f.compress (VectorOperation::insert);

--- a/tests/lac/linear_operator_16.cc
+++ b/tests/lac/linear_operator_16.cc
@@ -69,8 +69,10 @@ int main (int argc, char *argv[])
     A.reinit(csp);
     testproblem.five_point(A);
 
-    TrilinosWrappers::Vector  f(dim);
-    TrilinosWrappers::Vector  u(dim);
+    TrilinosWrappers::Vector  f;
+    f.reinit(dim);
+    TrilinosWrappers::Vector  u;
+    u.reinit(dim);
 
     A.compress (VectorOperation::insert);
     f.compress (VectorOperation::insert);

--- a/tests/lac/schur_complement_04.cc
+++ b/tests/lac/schur_complement_04.cc
@@ -102,8 +102,10 @@ int main(int argc,char **argv)
       TrilinosWrappers::SparseMatrix C (rc,rc,rc);
       TrilinosWrappers::SparseMatrix D (rc,rc,rc);
 
-      VectorType y (rc);
-      VectorType g (rc);
+      VectorType y;
+      y.reinit(rc);
+      VectorType g;
+      g.reinit(rc);
       for (unsigned int i=0; i < rc; ++i)
         {
           A.set(i,i, 1.0*(i+1));


### PR DESCRIPTION
It seems I missed some tests in #4345. This PR fixes all (newly) failing tests reported by [CDash](https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=7155).
In particular, the accidentally deleted definition of 
`TrilinosWrappers::MPI::Vector::reinit (const BlockVector &v, const bool import_data)`
is restored.

Fixing the tests required to get information on the locally owned range and domain indices of a `TrilinosWrappers::MPI::BlockMatrix`object as well as its  `MPI_Comm`.