### PR TITLE
Add get_manifold() to 1D vertex iterators.

### DIFF
--- a/doc/news/changes/minor/20170510DavidWells
+++ b/doc/news/changes/minor/20170510DavidWells
@@ -1,0 +1,3 @@
+New: The vertex (and face) iterator for dimension 1 triangulations now implements
+the get_manifold method.
+<br> (David Wells, 2017/05/10)

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -2110,6 +2110,11 @@ public:
   types::boundary_id boundary_id () const;
 
   /**
+   * Return a constant reference to the manifold object used for this object.
+   */
+  const Manifold<1,spacedim> &get_manifold () const;
+
+  /**
    * Return the manifold indicator of this object.
    *
    * @see

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2887,6 +2887,16 @@ TriaAccessor<0, 1, spacedim>::boundary_id () const
 
 template <int spacedim>
 inline
+const Manifold<1, spacedim> &
+TriaAccessor<0, 1, spacedim>::get_manifold () const
+{
+  return this->tria->get_manifold(this->manifold_id());
+}
+
+
+
+template <int spacedim>
+inline
 types::manifold_id
 TriaAccessor<0, 1, spacedim>::manifold_id () const
 {

--- a/tests/grid/oned_vertex_manifold.cc
+++ b/tests/grid/oned_vertex_manifold.cc
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// Test vertex manifold ids in 1D.
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/manifold_lib.h>
+
+int main()
+{
+  initlog(true);
+
+  SphericalManifold<1> spherical_manifold;
+
+
+  constexpr types::manifold_id spherical_manifold_id = 42;
+
+  Triangulation<1> triangulation;
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global(1);
+  triangulation.set_manifold(spherical_manifold_id, spherical_manifold);
+
+  triangulation.begin_active()->set_all_manifold_ids(spherical_manifold_id);
+
+  for (const auto cell : triangulation.active_cell_iterators())
+    {
+      deallog << "current cell manifold id: "
+              << cell->manifold_id()
+              << std::endl;
+
+      for (unsigned int vertex_n = 0; vertex_n < GeometryInfo<1>::vertices_per_cell;
+           ++vertex_n)
+        {
+          deallog << "current vertex: "
+                  << cell->vertex(vertex_n)
+                  << std::endl;
+          deallog << "current vertex manifold id: "
+                  << cell->face(vertex_n)->manifold_id()
+                  << std::endl;
+
+          if (cell->face(vertex_n)->manifold_id() == 42)
+            {
+              // since the reference is const, the pointer we compare it to
+              // must also be a to a const object
+              const auto &spherical_reference = spherical_manifold;
+              Assert(&spherical_reference == &cell->face(vertex_n)->get_manifold(),
+                     ExcMessage("manifolds should be the same."));
+            }
+        }
+    }
+}

--- a/tests/grid/oned_vertex_manifold.output
+++ b/tests/grid/oned_vertex_manifold.output
@@ -1,0 +1,11 @@
+
+DEAL::current cell manifold id: 42
+DEAL::current vertex: 0.00000
+DEAL::current vertex manifold id: 42
+DEAL::current vertex: 0.500000
+DEAL::current vertex manifold id: 42
+DEAL::current cell manifold id: 4294967295
+DEAL::current vertex: 0.500000
+DEAL::current vertex manifold id: 42
+DEAL::current vertex: 1.00000
+DEAL::current vertex manifold id: 4294967295


### PR DESCRIPTION
This little commit adds `get_manifold` to the 1D vertex iterator class, which makes it easier to write dimension-independent code for face iterators.