### PR TITLE
Use override consistently

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -172,7 +172,7 @@ namespace LinearAlgebra
        * Copy operator: fill all components of the vector with the given
        * scalar value.
        */
-      BlockVector &operator = (const value_type s);
+      virtual BlockVector &operator = (const value_type s) override;
 
       /**
        * Copy operator for arguments of the same type. Resize the present
@@ -301,7 +301,7 @@ namespace LinearAlgebra
        * elements do not agree.
        *
        */
-      void compress (::dealii::VectorOperation::values operation);
+      virtual void compress (::dealii::VectorOperation::values operation) override;
 
       /**
        * Fills the data field for ghost indices with the values stored in the
@@ -372,7 +372,7 @@ namespace LinearAlgebra
       /**
        * Compute the mean value of all the entries in the vector.
        */
-      Number mean_value () const;
+      virtual Number mean_value () const override;
 
       /**
        * $l_p$-norm of the vector. The pth root of the sum of the pth powers
@@ -410,27 +410,27 @@ namespace LinearAlgebra
        * copied.
        */
       virtual void reinit(const VectorSpaceVector<Number> &V,
-                          const bool omit_zeroing_entries = false);
+                          const bool omit_zeroing_entries = false) override;
 
       /**
        * Multiply the entire vector by a fixed factor.
        */
-      virtual BlockVector<Number> &operator*= (const Number factor);
+      virtual BlockVector<Number> &operator*= (const Number factor) override;
 
       /**
        * Divide the entire vector by a fixed factor.
        */
-      virtual BlockVector<Number> &operator/= (const Number factor);
+      virtual BlockVector<Number> &operator/= (const Number factor) override;
 
       /**
        * Add the vector @p V to the present one.
        */
-      virtual BlockVector<Number> &operator+= (const VectorSpaceVector<Number> &V);
+      virtual BlockVector<Number> &operator+= (const VectorSpaceVector<Number> &V) override;
 
       /**
        * Subtract the vector @p V from the present one.
        */
-      virtual BlockVector<Number> &operator-= (const VectorSpaceVector<Number> &V);
+      virtual BlockVector<Number> &operator-= (const VectorSpaceVector<Number> &V) override;
 
       /**
        * Import all the elements present in the vector's IndexSet from the input
@@ -443,28 +443,28 @@ namespace LinearAlgebra
       virtual void import(const LinearAlgebra::ReadWriteVector<Number> &V,
                           VectorOperation::values operation,
                           std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-                            std::shared_ptr<const CommunicationPatternBase> ());
+                            std::shared_ptr<const CommunicationPatternBase> ()) override;
 
       /**
        * Return the scalar product of two vectors.
        */
-      virtual Number operator* (const VectorSpaceVector<Number> &V) const;
+      virtual Number operator* (const VectorSpaceVector<Number> &V) const override;
 
       /**
        * Add @p a to all components. Note that @p a is a scalar not a vector.
        */
-      virtual void add(const Number a);
+      virtual void add(const Number a) override;
 
       /**
        * Simple addition of a multiple of a vector, i.e. <tt>*this += a*V</tt>.
        */
-      virtual void add(const Number a, const VectorSpaceVector<Number> &V);
+      virtual void add(const Number a, const VectorSpaceVector<Number> &V) override;
 
       /**
        * Multiple addition of scaled vectors, i.e. <tt>*this += a*V+b*W</tt>.
        */
       virtual void add(const Number a, const VectorSpaceVector<Number> &V,
-                       const Number b, const VectorSpaceVector<Number> &W);
+                       const Number b, const VectorSpaceVector<Number> &W) override;
 
       /**
        * A collective add operation: This function adds a whole set of values
@@ -478,37 +478,37 @@ namespace LinearAlgebra
        * s*(*this)+a*V</tt>.
        */
       virtual void sadd(const Number s, const Number a,
-                        const VectorSpaceVector<Number> &V);
+                        const VectorSpaceVector<Number> &V) override;
 
       /**
        * Scale each element of this vector by the corresponding element in the
        * argument. This function is mostly meant to simulate multiplication (and
        * immediate re-assignment) by a diagonal scaling matrix.
        */
-      virtual void scale(const VectorSpaceVector<Number> &scaling_factors);
+      virtual void scale(const VectorSpaceVector<Number> &scaling_factors) override;
 
       /**
        * Assignment <tt>*this = a*V</tt>.
        */
-      virtual void equ(const Number a, const VectorSpaceVector<Number> &V);
+      virtual void equ(const Number a, const VectorSpaceVector<Number> &V) override;
 
       /**
        * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the
        * absolute values of all entries among all processors).
        */
-      virtual real_type l1_norm() const;
+      virtual real_type l1_norm() const override;
 
       /**
        * Return the l<sub>2</sub> norm of the vector (i.e., the square root of
        * the sum of the square of all entries among all processors).
        */
-      virtual real_type l2_norm() const;
+      virtual real_type l2_norm() const override;
 
       /**
        * Return the maximum norm of the vector (i.e., the maximum absolute value
        * among all entries and among all processors).
        */
-      virtual real_type linfty_norm() const;
+      virtual real_type linfty_norm() const override;
 
       /**
        * Perform a combined operation of a vector addition and a subsequent
@@ -528,13 +528,13 @@ namespace LinearAlgebra
        */
       virtual Number add_and_dot(const Number a,
                                  const VectorSpaceVector<Number> &V,
-                                 const VectorSpaceVector<Number> &W);
+                                 const VectorSpaceVector<Number> &W) override;
 
       /**
        * Return the global size of the vector, equal to the sum of the number of
        * locally owned indices among all processors.
        */
-      virtual size_type size() const;
+      virtual size_type size() const override;
 
       /**
        * Return an index set that describes which elements of this vector are
@@ -547,7 +547,7 @@ namespace LinearAlgebra
        *  vec.locally_owned_elements() == complete_index_set(vec.size())
        * @endcode
        */
-      virtual dealii::IndexSet locally_owned_elements() const;
+      virtual dealii::IndexSet locally_owned_elements() const override;
 
       /**
        * Print the vector to the output stream @p out.
@@ -555,12 +555,12 @@ namespace LinearAlgebra
       virtual void print(std::ostream &out,
                          const unsigned int precision=3,
                          const bool scientific=true,
-                         const bool across=true) const;
+                         const bool across=true) const override;
 
       /**
        * Return the memory consumption of this class in bytes.
        */
-      virtual std::size_t memory_consumption() const;
+      virtual std::size_t memory_consumption() const override;
       //@}
 
       /**

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -244,7 +244,7 @@ namespace LinearAlgebra
       /**
        * Destructor.
        */
-      virtual ~Vector ();
+      virtual ~Vector () override;
 
       /**
        * Set the global size of the vector to @p size without any actual
@@ -405,7 +405,7 @@ namespace LinearAlgebra
        * ghost element is found, it is compared to the value on the owning
        * processor and an exception is thrown if these elements do not agree.
        */
-      void compress (::dealii::VectorOperation::values operation);
+      virtual void compress (::dealii::VectorOperation::values operation) override;
 
       /**
        * Fills the data field for ghost indices with the values stored in the
@@ -524,27 +524,27 @@ namespace LinearAlgebra
        * copied.
        */
       virtual void reinit(const VectorSpaceVector<Number> &V,
-                          const bool omit_zeroing_entries = false);
+                          const bool omit_zeroing_entries = false) override;
 
       /**
        * Multiply the entire vector by a fixed factor.
        */
-      virtual Vector<Number> &operator*= (const Number factor);
+      virtual Vector<Number> &operator*= (const Number factor) override;
 
       /**
        * Divide the entire vector by a fixed factor.
        */
-      virtual Vector<Number> &operator/= (const Number factor);
+      virtual Vector<Number> &operator/= (const Number factor) override;
 
       /**
        * Add the vector @p V to the present one.
        */
-      virtual Vector<Number> &operator+= (const VectorSpaceVector<Number> &V);
+      virtual Vector<Number> &operator+= (const VectorSpaceVector<Number> &V) override;
 
       /**
        * Subtract the vector @p V from the present one.
        */
-      virtual Vector<Number> &operator-= (const VectorSpaceVector<Number> &V);
+      virtual Vector<Number> &operator-= (const VectorSpaceVector<Number> &V) override;
 
       /**
        * Import all the elements present in the vector's IndexSet from the input
@@ -557,28 +557,28 @@ namespace LinearAlgebra
       virtual void import(const LinearAlgebra::ReadWriteVector<Number> &V,
                           VectorOperation::values operation,
                           std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-                            std::shared_ptr<const CommunicationPatternBase> ());
+                            std::shared_ptr<const CommunicationPatternBase> ()) override;
 
       /**
        * Return the scalar product of two vectors.
        */
-      virtual Number operator* (const VectorSpaceVector<Number> &V) const;
+      virtual Number operator* (const VectorSpaceVector<Number> &V) const override;
 
       /**
        * Add @p a to all components. Note that @p a is a scalar not a vector.
        */
-      virtual void add(const Number a);
+      virtual void add(const Number a) override;
 
       /**
        * Simple addition of a multiple of a vector, i.e. <tt>*this += a*V</tt>.
        */
-      virtual void add(const Number a, const VectorSpaceVector<Number> &V);
+      virtual void add(const Number a, const VectorSpaceVector<Number> &V) override;
 
       /**
        * Multiple addition of scaled vectors, i.e. <tt>*this += a*V+b*W</tt>.
        */
       virtual void add(const Number a, const VectorSpaceVector<Number> &V,
-                       const Number b, const VectorSpaceVector<Number> &W);
+                       const Number b, const VectorSpaceVector<Number> &W) override;
 
       /**
        * A collective add operation: This function adds a whole set of values
@@ -592,37 +592,37 @@ namespace LinearAlgebra
        * s*(*this)+a*V</tt>.
        */
       virtual void sadd(const Number s, const Number a,
-                        const VectorSpaceVector<Number> &V);
+                        const VectorSpaceVector<Number> &V) override;
 
       /**
        * Scale each element of this vector by the corresponding element in the
        * argument. This function is mostly meant to simulate multiplication (and
        * immediate re-assignment) by a diagonal scaling matrix.
        */
-      virtual void scale(const VectorSpaceVector<Number> &scaling_factors);
+      virtual void scale(const VectorSpaceVector<Number> &scaling_factors) override;
 
       /**
        * Assignment <tt>*this = a*V</tt>.
        */
-      virtual void equ(const Number a, const VectorSpaceVector<Number> &V);
+      virtual void equ(const Number a, const VectorSpaceVector<Number> &V) override;
 
       /**
        * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the
        * absolute values of all entries among all processors).
        */
-      virtual real_type l1_norm() const;
+      virtual real_type l1_norm() const override;
 
       /**
        * Return the l<sub>2</sub> norm of the vector (i.e., the square root of
        * the sum of the square of all entries among all processors).
        */
-      virtual real_type l2_norm() const;
+      virtual real_type l2_norm() const override;
 
       /**
        * Return the maximum norm of the vector (i.e., the maximum absolute value
        * among all entries and among all processors).
        */
-      virtual real_type linfty_norm() const;
+      virtual real_type linfty_norm() const override;
 
       /**
        * Perform a combined operation of a vector addition and a subsequent
@@ -642,13 +642,13 @@ namespace LinearAlgebra
        */
       virtual Number add_and_dot(const Number a,
                                  const VectorSpaceVector<Number> &V,
-                                 const VectorSpaceVector<Number> &W);
+                                 const VectorSpaceVector<Number> &W) override;
 
       /**
        * Return the global size of the vector, equal to the sum of the number of
        * locally owned indices among all processors.
        */
-      virtual size_type size() const;
+      virtual size_type size() const override;
 
       /**
        * Return an index set that describes which elements of this vector are
@@ -661,7 +661,7 @@ namespace LinearAlgebra
        *  vec.locally_owned_elements() == complete_index_set(vec.size())
        * @endcode
        */
-      virtual dealii::IndexSet locally_owned_elements() const;
+      virtual dealii::IndexSet locally_owned_elements() const override;
 
       /**
        * Print the vector to the output stream @p out.
@@ -669,12 +669,12 @@ namespace LinearAlgebra
       virtual void print(std::ostream &out,
                          const unsigned int precision=3,
                          const bool scientific=true,
-                         const bool across=true) const;
+                         const bool across=true) const override;
 
       /**
        * Return the memory consumption of this class in bytes.
        */
-      virtual std::size_t memory_consumption() const;
+      virtual std::size_t memory_consumption() const override;
       //@}
 
       /**
@@ -687,7 +687,7 @@ namespace LinearAlgebra
        * zero, also ghost elements are set to zero, otherwise they remain
        * unchanged.
        */
-      Vector<Number> &operator = (const Number s);
+      virtual Vector<Number> &operator = (const Number s) override;
 
       /**
        * This is a collective add operation that adds a whole set of values
@@ -902,7 +902,7 @@ namespace LinearAlgebra
       /**
        * Compute the mean value of all the entries in the vector.
        */
-      virtual Number mean_value () const;
+      virtual Number mean_value () const override;
 
       /**
        * $l_p$-norm of the vector. The pth root of the sum of the pth powers

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -104,7 +104,7 @@ namespace LinearAlgebra
      * user must make sure to fill it with reasonable data before using it).
      */
     virtual void reinit(const size_type size,
-                        const bool      omit_zeroing_entries = false);
+                        const bool      omit_zeroing_entries = false) override;
 
     /**
      * Uses the same IndexSet as the one of the input vector @p in_vector and
@@ -128,7 +128,7 @@ namespace LinearAlgebra
      * locally_stored_indices.
      */
     virtual void reinit(const IndexSet &locally_stored_indices,
-                        const bool      omit_zeroing_entries = false);
+                        const bool      omit_zeroing_entries = false) override;
 
 
     /**
@@ -136,7 +136,7 @@ namespace LinearAlgebra
      * copied.
      */
     virtual void reinit(const VectorSpaceVector<Number> &V,
-                        const bool omit_zeroing_entries = false);
+                        const bool omit_zeroing_entries = false) override;
 
     /**
      * Copies the data of the input vector @p in_vector.
@@ -153,32 +153,32 @@ namespace LinearAlgebra
      * Sets all elements of the vector to the scalar @p s. This operation is
      * only allowed if @p s is equal to zero.
      */
-    Vector<Number> &operator= (const Number s);
+    virtual Vector<Number> &operator= (const Number s) override;
 
     /**
      * Multiply the entire vector by a fixed factor.
      */
-    virtual Vector<Number> &operator*= (const Number factor);
+    virtual Vector<Number> &operator*= (const Number factor) override;
 
     /**
      * Divide the entire vector by a fixed factor.
      */
-    virtual Vector<Number> &operator/= (const Number factor);
+    virtual Vector<Number> &operator/= (const Number factor) override;
 
     /**
      * Add the vector @p V to the present one.
      */
-    virtual Vector<Number> &operator+= (const VectorSpaceVector<Number> &V);
+    virtual Vector<Number> &operator+= (const VectorSpaceVector<Number> &V) override;
 
     /**
      * Subtract the vector @p V from the present one.
      */
-    virtual Vector<Number> &operator-= (const VectorSpaceVector<Number> &V);
+    virtual Vector<Number> &operator-= (const VectorSpaceVector<Number> &V) override;
 
     /**
      * Return the scalar product of two vectors.
      */
-    virtual Number operator* (const VectorSpaceVector<Number> &V) const;
+    virtual Number operator* (const VectorSpaceVector<Number> &V) const override;
 
     /**
      * This function is not implemented and will throw an exception.
@@ -187,43 +187,43 @@ namespace LinearAlgebra
                         VectorOperation::values operation,
                         std::shared_ptr<const CommunicationPatternBase>
                         communication_pattern =
-                          std::shared_ptr<const CommunicationPatternBase>());
+                          std::shared_ptr<const CommunicationPatternBase>()) override;
 
     /**
      * Add @p a to all components. Note that @p a is a scalar not a vector.
      */
-    virtual void add(const Number a);
+    virtual void add(const Number a) override;
 
     /**
      * Simple addition of a multiple of a vector, i.e. <tt>*this += a*V</tt>.
      */
-    virtual void add(const Number a, const VectorSpaceVector<Number> &V);
+    virtual void add(const Number a, const VectorSpaceVector<Number> &V) override;
 
     /**
      * Multiple addition of a multiple of a vector, i.e. <tt>*this +=
      * a*V+b*W</tt>.
      */
     virtual void add(const Number a, const VectorSpaceVector<Number> &V,
-                     const Number b, const VectorSpaceVector<Number> &W);
+                     const Number b, const VectorSpaceVector<Number> &W) override;
 
     /**
      * Scaling and simple addition of a multiple of a vector, i.e. <tt>*this =
      * s*(*this)+a*V</tt>.
      */
     virtual void sadd(const Number s, const Number a,
-                      const VectorSpaceVector<Number> &V);
+                      const VectorSpaceVector<Number> &V) override;
 
     /**
      * Scale each element of this vector by the corresponding element in the
      * argument. This function is mostly meant to simulate multiplication (and
      * immediate re-assignment) by a diagonal scaling matrix.
      */
-    virtual void scale(const VectorSpaceVector<Number> &scaling_factors);
+    virtual void scale(const VectorSpaceVector<Number> &scaling_factors) override;
 
     /**
      * Assignment <tt>*this = a*V</tt>.
      */
-    virtual void equ(const Number a, const VectorSpaceVector<Number> &V);
+    virtual void equ(const Number a, const VectorSpaceVector<Number> &V) override;
 
     /**
      * Return wether the vector contains only elements with value zero.
@@ -233,25 +233,25 @@ namespace LinearAlgebra
     /**
      * Return the mean value of all the entries of this vector.
      */
-    virtual value_type mean_value() const;
+    virtual value_type mean_value() const override;
 
     /**
      * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the
      * absolute values of all entries).
      */
-    virtual typename VectorSpaceVector<Number>::real_type l1_norm() const;
+    virtual typename VectorSpaceVector<Number>::real_type l1_norm() const override;
 
     /**
      * Return the l<sub>2</sub> norm of the vector (i.e., the square root of
      * the sum of the square of all entries among all processors).
      */
-    virtual typename VectorSpaceVector<Number>::real_type l2_norm() const;
+    virtual typename VectorSpaceVector<Number>::real_type l2_norm() const override;
 
     /**
      * Return the maximum norm of the vector (i.e., the maximum absolute value
      * among all entries and among all processors).
      */
-    virtual typename VectorSpaceVector<Number>::real_type linfty_norm() const;
+    virtual typename VectorSpaceVector<Number>::real_type linfty_norm() const override;
 
     /**
      * Perform a combined operation of a vector addition and a subsequent
@@ -264,13 +264,13 @@ namespace LinearAlgebra
      */
     virtual Number add_and_dot(const Number a,
                                const VectorSpaceVector<Number> &V,
-                               const VectorSpaceVector<Number> &W);
+                               const VectorSpaceVector<Number> &W) override;
 
     /**
      * Return the global size of the vector, equal to the sum of the number of
      * locally owned indices among all processors.
      */
-    virtual size_type size() const;
+    virtual size_type size() const override;
 
     /**
      * Return an index set that describes which elements of this vector are
@@ -283,7 +283,7 @@ namespace LinearAlgebra
      *  vec.locally_owned_elements() == complete_index_set(vec.size())
      * @endcode
      */
-    virtual dealii::IndexSet locally_owned_elements() const;
+    virtual dealii::IndexSet locally_owned_elements() const override;
 
     /**
      * Prints the vector to the output stream @p out.
@@ -291,7 +291,8 @@ namespace LinearAlgebra
     virtual void print(std::ostream &out,
                        const unsigned int precision=3,
                        const bool scientific=true,
-                       const bool across=true) const;
+                       const bool across=true) const override;
+
     /**
      * Write the vector en bloc to a file. This is done in a binary mode, so
      * the output is neither readable by humans nor (probably) by other
@@ -315,7 +316,7 @@ namespace LinearAlgebra
     /**
      * Return the memory consumption of this class in bytes.
      */
-    virtual std::size_t memory_consumption() const;
+    virtual std::size_t memory_consumption() const override;
 
     /**
      * Attempt to perform an operation between two incompatible vector types.

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -87,7 +87,7 @@ namespace LinearAlgebra
        * copied.
        */
       virtual void reinit(const VectorSpaceVector<double> &V,
-                          const bool omit_zeroing_entries = false);
+                          const bool omit_zeroing_entries = false) override;
 
       /**
        * Copy function. This function takes a Vector and copies all the
@@ -100,7 +100,7 @@ namespace LinearAlgebra
        * Sets all elements of the vector to the scalar @p s. This operation is
        * only allowed if @p s is equal to zero.
        */
-      Vector &operator= (const double s);
+      virtual Vector &operator= (const double s) override;
 
       /**
        * Imports all the elements present in the vector's IndexSet from the input
@@ -113,58 +113,58 @@ namespace LinearAlgebra
       virtual void import(const ReadWriteVector<double>  &V,
                           VectorOperation::values         operation,
                           std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-                            std::shared_ptr<const CommunicationPatternBase> ());
+                            std::shared_ptr<const CommunicationPatternBase> ()) override;
 
       /**
        * Multiply the entire vector by a fixed factor.
        */
-      virtual Vector &operator*= (const double factor);
+      virtual Vector &operator*= (const double factor) override;
 
       /**
        * Divide the entire vector by a fixed factor.
        */
-      virtual Vector &operator/= (const double factor);
+      virtual Vector &operator/= (const double factor) override;
 
       /**
        * Add the vector @p V to the present one.
        */
-      virtual Vector &operator+= (const VectorSpaceVector<double> &V);
+      virtual Vector &operator+= (const VectorSpaceVector<double> &V) override;
 
       /**
        * Substract the vector @p V from the present one.
        */
-      virtual Vector &operator-= (const VectorSpaceVector<double> &V);
+      virtual Vector &operator-= (const VectorSpaceVector<double> &V) override;
 
       /**
        * Return the scalar product of two vectors. The vectors need to have the
        * same layout.
        */
-      virtual double operator* (const VectorSpaceVector<double> &V) const;
+      virtual double operator* (const VectorSpaceVector<double> &V) const override;
 
       /**
        * Add @p a to all components. Note that @p is a scalar not a vector.
        */
-      virtual void add(const double a);
+      virtual void add(const double a) override;
 
       /**
        * Simple addition of a multiple of a vector, i.e. <tt>*this +=
        * a*V</tt>. The vectors need to have the same layout.
        */
-      virtual void add(const double a, const VectorSpaceVector<double> &V);
+      virtual void add(const double a, const VectorSpaceVector<double> &V) override;
 
       /**
        * Multiple addition of multiple of a vector, i.e. <tt>*this> +=
        * a*V+b*W</tt>. The vectors need to have the same layout.
        */
       virtual void add(const double a, const VectorSpaceVector<double> &V,
-                       const double b, const VectorSpaceVector<double> &W);
+                       const double b, const VectorSpaceVector<double> &W) override;
 
       /**
        * Scaling and simple addition of a multiple of a vector, i.e. <tt>*this
        * = s*(*this)+a*V</tt>.
        */
       virtual void sadd(const double s, const double a,
-                        const VectorSpaceVector<double> &V);
+                        const VectorSpaceVector<double> &V) override;
 
       /**
        * Scale each element of this vector by the corresponding element in the
@@ -172,12 +172,12 @@ namespace LinearAlgebra
        * (and immediate re-assignement) by a diagonal scaling matrix. The
        * vectors need to have the same layout.
        */
-      virtual void scale(const VectorSpaceVector<double> &scaling_factors);
+      virtual void scale(const VectorSpaceVector<double> &scaling_factors) override;
 
       /**
        * Assignement <tt>*this = a*V</tt>.
        */
-      virtual void equ(const double a, const VectorSpaceVector<double> &V);
+      virtual void equ(const double a, const VectorSpaceVector<double> &V) override;
 
       /**
        * Return wether the vector contains only elements with value zero.
@@ -187,25 +187,25 @@ namespace LinearAlgebra
       /**
        * Return the mean value of the element of this vector.
        */
-      virtual double mean_value() const;
+      virtual double mean_value() const override;
 
       /**
        * Return the l<sub>1</sub> norm of the vector (i.e., the sum of the
        * absolute values of all entries among all processors).
        */
-      virtual double l1_norm() const;
+      virtual double l1_norm() const override;
 
       /**
        * Return the l<sub>2</sub> norm of the vector (i.e., the square root of
        * the sum of the square of all entries among all processors).
        */
-      virtual double l2_norm() const;
+      virtual double l2_norm() const override;
 
       /**
        * Return the maximum norm of the vector (i.e., the maximum absolute value
        * among all entries and among all processors).
        */
-      virtual double linfty_norm() const;
+      virtual double linfty_norm() const override;
 
       /**
        * Performs a combined operation of a vector addition and a subsequent
@@ -227,7 +227,7 @@ namespace LinearAlgebra
        */
       virtual double add_and_dot(const double a,
                                  const VectorSpaceVector<double> &V,
-                                 const VectorSpaceVector<double> &W);
+                                 const VectorSpaceVector<double> &W) override;
       /**
        * This function always returns false and is present only for backward
        * compatibility.
@@ -238,7 +238,7 @@ namespace LinearAlgebra
        * Return the global size of the vector, equal to the sum of the number of
        * locally owned indices among all processors.
        */
-      virtual size_type size() const;
+      virtual size_type size() const override;
 
       /**
        * Return the MPI communicator object in use with this object.
@@ -255,7 +255,7 @@ namespace LinearAlgebra
        *  vec.locally_owned_elements() == complete_index_set(vec.size())
        * @endcode
        */
-      virtual ::dealii::IndexSet locally_owned_elements() const;
+      virtual ::dealii::IndexSet locally_owned_elements() const override;
 
       /**
        * Return a const reference to the underlying Trilinos
@@ -275,12 +275,12 @@ namespace LinearAlgebra
       virtual void print(std::ostream &out,
                          const unsigned int precision=3,
                          const bool scientific=true,
-                         const bool across=true) const;
+                         const bool across=true) const override;
 
       /**
        * Return the memory consumption of this class in bytes.
        */
-      virtual std::size_t memory_consumption() const;
+      virtual std::size_t memory_consumption() const override;
 
       /**
        * The vectors have different partitioning, i.e. they have use different


### PR DESCRIPTION
Fixes #4372.
`clang` complained that we use `override` in the changed files, but not consistently.
It's probably a good idea to do these substitutions throughout the whole library but `clang-tidy` introduces a lot off indentation issues... So let's do this part by part.