### PR TITLE
Use '= default' for some constructors.

### DIFF
--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -37,7 +37,7 @@ class AnyData :
 {
 public:
   /// Default constructor for empty object
-  AnyData();
+  AnyData() = default;
 
   /// Number of stored data objects.
   unsigned int size() const;
@@ -192,11 +192,6 @@ private:
   /// The names of the stored data
   std::vector<std::string> names;
 };
-
-
-inline
-AnyData::AnyData()
-{}
 
 
 unsigned int
@@ -470,13 +465,3 @@ void AnyData::list(StreamType &os) const
 DEAL_II_NAMESPACE_CLOSE
 
 #endif
-
-
-
-
-
-
-
-
-
-

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -93,7 +93,7 @@ public:
    * Standard constructor. Creates an object that corresponds to the origin,
    * i.e., all coordinates are set to zero.
    */
-  Point ();
+  Point () = default;
 
   /**
    * Convert a tensor to a point.
@@ -248,13 +248,6 @@ public:
 /*------------------------------- Inline functions: Point ---------------------------*/
 
 #ifndef DOXYGEN
-
-template <int dim, typename Number>
-inline
-Point<dim,Number>::Point ()
-{}
-
-
 
 template <int dim, typename Number>
 inline

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -529,7 +529,7 @@ public:
   /**
    * Default constructor. Creates a tensor with all entries equal to zero.
    */
-  SymmetricTensor ();
+  SymmetricTensor () = default;
 
   /**
    * Constructor. Generate a symmetric tensor from a general one. Assumes that
@@ -919,13 +919,6 @@ namespace internal
     }
   }
 }
-
-
-
-template <int rank, int dim, typename Number>
-inline
-SymmetricTensor<rank,dim,Number>::SymmetricTensor ()
-{}
 
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -414,7 +414,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  TableBase ();
+  TableBase () = default;
 
   /**
    * Constructor. Initialize the array with the given dimensions in each index
@@ -700,7 +700,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimension to the base class.
@@ -819,7 +819,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1004,7 +1004,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1138,7 +1138,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1231,7 +1231,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1325,7 +1325,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1421,7 +1421,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  Table ();
+  Table () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1524,7 +1524,7 @@ public:
   /**
    * Default constructor. Set all dimensions to zero.
    */
-  TransposeTable ();
+  TransposeTable () = default;
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
@@ -1609,12 +1609,6 @@ protected:
 /* --------------------- Template and inline functions ---------------- */
 
 #ifndef DOXYGEN
-
-template <int N, typename T>
-TableBase<N,T>::TableBase ()
-{}
-
-
 
 template <int N, typename T>
 TableBase<N,T>::TableBase (const TableIndices<N> &sizes)
@@ -2174,13 +2168,6 @@ TableBase<N,T>::el (const TableIndices<N> &indices)
 
 template <typename T>
 inline
-Table<1,T>::Table ()
-{}
-
-
-
-template <typename T>
-inline
 Table<1,T>::Table (const unsigned int size)
   :
   TableBase<1,T> (TableIndices<1> (size))
@@ -2270,11 +2257,6 @@ Table<1,T>::operator () (const TableIndices<1> &indices)
 
 
 //---------------------------------------------------------------------------
-
-template <typename T>
-inline
-Table<2,T>::Table ()
-{}
 
 
 
@@ -2434,14 +2416,6 @@ Table<2,T>::n_cols () const
 
 
 //---------------------------------------------------------------------------
-
-template <typename T>
-inline
-TransposeTable<T>::TransposeTable ()
-{}
-
-
-
 template <typename T>
 inline
 TransposeTable<T>::TransposeTable (const unsigned int size1,
@@ -2537,12 +2511,6 @@ TransposeTable<T>::n_cols () const
 
 
 //---------------------------------------------------------------------------
-
-
-template <typename T>
-inline
-Table<3,T>::Table ()
-{}
 
 
 
@@ -2665,13 +2633,6 @@ Table<3,T>::operator () (const TableIndices<3> &indices)
 
 template <typename T>
 inline
-Table<4,T>::Table ()
-{}
-
-
-
-template <typename T>
-inline
 Table<4,T>::Table (const unsigned int size1,
                    const unsigned int size2,
                    const unsigned int size3,
@@ -2779,13 +2740,6 @@ Table<4,T>::operator () (const TableIndices<4> &indices)
 {
   return TableBase<4,T>::operator () (indices);
 }
-
-
-
-template <typename T>
-inline
-Table<5,T>::Table ()
-{}
 
 
 
@@ -2909,13 +2863,6 @@ Table<5,T>::operator () (const TableIndices<5> &indices)
 {
   return TableBase<5,T>::operator () (indices);
 }
-
-
-
-template <typename T>
-inline
-Table<6,T>::Table ()
-{}
 
 
 
@@ -3050,13 +2997,6 @@ Table<6,T>::operator () (const TableIndices<6> &indices)
 {
   return TableBase<6,T>::operator () (indices);
 }
-
-
-
-template <typename T>
-inline
-Table<7,T>::Table ()
-{}
 
 
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -291,8 +291,7 @@ namespace Threads
     /**
      * Default constructor.
      */
-    Mutex ()
-    {}
+    Mutex () = default;
 
     /**
      * Copy constructor. As discussed in this class's documentation, no state
@@ -1223,7 +1222,7 @@ namespace Threads
      * this way, except for assigning it a thread object that holds data
      * created by the new_thread() functions.
      */
-    Thread () {}
+    Thread () = default;
 
     /**
      * Copy constructor.
@@ -3103,7 +3102,7 @@ namespace Threads
      * @post Using this constructor leaves the object in an unjoinable state,
      * i.e., joinable() will return false.
      */
-    Task () {}
+    Task () = default;
 
     /**
      * Join the task represented by this object, i.e. wait for it to finish.

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -77,7 +77,7 @@ public:
    * constructor results in a block mask that always returns <code>true</code>
    * whenever asked whether a block is selected.
    */
-  BlockMask ();
+  BlockMask () = default;
 
   /**
    * Initialize an object of this type with a set of selected blocks specified
@@ -229,11 +229,6 @@ std::ostream &operator << (std::ostream &out,
 
 
 // -------------------- inline functions ---------------------
-
-inline
-BlockMask::BlockMask()
-{}
-
 
 inline
 BlockMask::BlockMask(const std::vector<bool> &block_mask)

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -73,7 +73,7 @@ public:
    * calling this constructor results in a component mask that always returns
    * <code>true</code> whenever asked whether a component is selected.
    */
-  ComponentMask ();
+  ComponentMask () = default;
 
   /**
    * Initialize an object of this type with a set of selected components
@@ -237,11 +237,6 @@ std::ostream &operator << (std::ostream &out,
 
 
 // -------------------- inline functions ---------------------
-
-inline
-ComponentMask::ComponentMask()
-{}
-
 
 inline
 ComponentMask::ComponentMask(const std::vector<bool> &component_mask)

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -64,8 +64,7 @@ namespace internal
         /**
          * Default constructor.
          */
-        type ()
-        {}
+        type () = default;
 
         /**
          * Dummy constructor. Only level zero is allowed.

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -50,7 +50,7 @@ namespace hp
      * Default constructor. Leads to an empty collection that can later be
      * filled using push_back().
      */
-    QCollection ();
+    QCollection () = default;
 
     /**
      * Conversion constructor. This constructor creates a QCollection from a
@@ -173,13 +173,6 @@ namespace hp
             ExcIndexRange (index, 0, quadratures.size ()));
     return *quadratures[index];
   }
-
-
-
-  template <int dim>
-  inline
-  QCollection<dim>::QCollection ()
-  {}
 
 
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -369,7 +369,7 @@ public:
   /**
    * Default constructor.
    */
-  BlockMatrixBase ();
+  BlockMatrixBase () = default;
 
   /**
    * Destructor.
@@ -1484,12 +1484,6 @@ namespace BlockMatrixIterators
 
 
 //---------------------------------------------------------------------------
-
-
-template <typename MatrixType>
-inline
-BlockMatrixBase<MatrixType>::BlockMatrixBase ()
-{}
 
 template <typename MatrixType>
 inline

--- a/include/deal.II/lac/block_sparse_matrix.h
+++ b/include/deal.II/lac/block_sparse_matrix.h
@@ -87,7 +87,7 @@ public:
    * reinit(BlockSparsityPattern). The number of blocks per row and column are
    * then determined by that function.
    */
-  BlockSparseMatrix ();
+  BlockSparseMatrix () = default;
 
   /**
    * Constructor. Takes the given matrix sparsity structure to represent the

--- a/include/deal.II/lac/block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/block_sparse_matrix.templates.h
@@ -23,13 +23,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-template <typename number>
-BlockSparseMatrix<number>::BlockSparseMatrix ()
-{}
-
-
-
 template <typename number>
 BlockSparseMatrix<number>::
 BlockSparseMatrix (const BlockSparsityPattern &sparsity)

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -60,7 +60,7 @@ public:
   /**
    * Default constructor. The result is an empty object with zero dimensions.
    */
-  BlockSparseMatrixEZ ();
+  BlockSparseMatrixEZ () = default;
 
   /**
    * Constructor setting up an object with given number of block rows and

--- a/include/deal.II/lac/block_sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.templates.h
@@ -23,13 +23,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-template <typename number>
-BlockSparseMatrixEZ<number>::BlockSparseMatrixEZ ()
-{}
-
-
-
 template <typename number>
 BlockSparseMatrixEZ<number>::
 BlockSparseMatrixEZ (const unsigned int rows,

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -551,7 +551,7 @@ public:
   /**
    * Default constructor.
    */
-  BlockVectorBase ();
+  BlockVectorBase () = default;
 
   /**
    * Copy constructor.
@@ -1450,13 +1450,6 @@ namespace internal
   } // namespace BlockVectorIterators
 
 } //namespace internal
-
-
-
-template <class VectorType>
-inline
-BlockVectorBase<VectorType>::BlockVectorBase ()
-{}
 
 
 

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -52,7 +52,7 @@ public:
   /**
    * Constructor.
    */
-  DiagonalMatrix();
+  DiagonalMatrix() = default;
 
   /**
    * Initialize with a given vector by copying the content of the vector
@@ -193,14 +193,6 @@ private:
 /* ---------------------------------- Inline functions ------------------- */
 
 #ifndef DOXYGEN
-
-template <typename VectorType>
-DiagonalMatrix<VectorType>::DiagonalMatrix()
-  :
-  Subscriptor()
-{}
-
-
 
 template <typename VectorType>
 void

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -599,11 +599,6 @@ private:
     std::vector<size_type> entries;
 
     /**
-     * Constructor.
-     */
-    Line ();
-
-    /**
      * Add the given column number to this line.
      */
     void add (const size_type col_num);
@@ -983,12 +978,6 @@ DynamicSparsityPattern::add_entries (const size_type row,
     rowset.size()==0 ? row : rowset.index_within_set(row);
   lines[rowindex].add_entries (begin, end, indices_are_sorted);
 }
-
-
-
-inline
-DynamicSparsityPattern::Line::Line ()
-{}
 
 
 

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -68,7 +68,7 @@ namespace LinearAlgebra
     /**
      * Constructor. Create a vector of dimension zero.
      */
-    Vector();
+    Vector() = default;
 
     /**
      * Copy constructor. Sets the dimension to that of the given vector and
@@ -338,12 +338,6 @@ namespace LinearAlgebra
 
   /*@}*/
   /*----------------------- Inline functions ----------------------------------*/
-
-  template <typename Number>
-  inline
-  Vector<Number>::Vector() {}
-
-
 
   template <typename Number>
   inline

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -87,7 +87,7 @@ namespace PETScWrappers
       /**
        * Default constructor. Generate an empty vector without any blocks.
        */
-      BlockVector ();
+      BlockVector () = default;
 
       /**
        * Constructor. Generate a block vector with @p n_blocks blocks, each of
@@ -280,13 +280,6 @@ namespace PETScWrappers
     /*@}*/
 
     /*----------------------- Inline functions ----------------------------------*/
-
-
-    inline
-    BlockVector::BlockVector ()
-    {}
-
-
 
     inline
     BlockVector::BlockVector (const unsigned int  n_blocks,

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -106,7 +106,7 @@ public:
   /**
    * Constructor, filling in default values
    */
-  SolverSelector ();
+  SolverSelector () = default;
 
   /**
    * Destructor
@@ -240,11 +240,6 @@ private:
 
 /*@}*/
 /* --------------------- Inline and template functions ------------------- */
-
-
-template <typename VectorType>
-SolverSelector<VectorType>::SolverSelector()
-{}
 
 
 template <typename VectorType>

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -96,7 +96,7 @@ namespace TrilinosWrappers
       /**
        * Default constructor. Generate an empty vector without any blocks.
        */
-      BlockVector ();
+      BlockVector () = default;
 
       /**
        * Constructor. Generate a block vector with as many blocks as there are
@@ -306,14 +306,6 @@ namespace TrilinosWrappers
 
 
     /*----------------------- Inline functions ----------------------------------*/
-
-
-    inline
-    BlockVector::BlockVector ()
-    {}
-
-
-
     inline
     BlockVector::BlockVector (const std::vector<IndexSet> &parallel_partitioning,
                               const MPI_Comm              &communicator)

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -1863,12 +1863,7 @@ namespace TrilinosWrappers
      * preconditioner to be handed to a smoother.  This does nothing.
      */
     struct AdditionalData
-    {
-      /**
-       * Constructor.
-       */
-      AdditionalData () {}
-    };
+    {};
 
     /**
      * The matrix argument is ignored and here just for compatibility with more

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -176,7 +176,7 @@ public:
   /**
    * Constructor.
    */
-  PrimitiveVectorMemory () {}
+  PrimitiveVectorMemory () = default;
 
   /**
    * Return a pointer to a new vector. The number of elements or their

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -171,7 +171,7 @@ namespace MeshWorker
      * constructor is not recommended, but it is needed for the arrays in
      * DoFInfoBox.
      */
-    DoFInfo ();
+    DoFInfo () = default;
 
     /// Set up local block indices
     void set_block_indices ();

--- a/include/deal.II/meshworker/dof_info.templates.h
+++ b/include/deal.II/meshworker/dof_info.templates.h
@@ -39,10 +39,6 @@ namespace MeshWorker
   }
 
 
-  template <int dim, int spacedim, typename number>
-  DoFInfo<dim,spacedim,number>::DoFInfo()
-  {}
-
 
   template <int dim, int spacedim, typename number>
   void

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -293,7 +293,8 @@ namespace MeshWorker
     /**
      * Constructor.
      */
-    VectorData();
+    VectorData() = default;
+
     /**
      * Constructor using a prefilled VectorSelector
      */
@@ -359,7 +360,7 @@ namespace MeshWorker
     /**
      * Constructor.
      */
-    MGVectorData();
+    MGVectorData() = default;
 
     /**
      * Constructor using a prefilled VectorSelector

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -89,11 +89,6 @@ namespace MeshWorker
 //----------------------------------------------------------------------//
 
   template <typename VectorType, int dim, int spacedim>
-  VectorData<VectorType, dim, spacedim>::VectorData()
-  {}
-
-
-  template <typename VectorType, int dim, int spacedim>
   VectorData<VectorType, dim, spacedim>::VectorData(const VectorSelector &s)
     :
     VectorDataBase<dim, spacedim, typename VectorType::value_type>(s)
@@ -170,11 +165,6 @@ namespace MeshWorker
   }
 
 //----------------------------------------------------------------------//
-
-  template <typename VectorType, int dim, int spacedim>
-  MGVectorData<VectorType, dim, spacedim>::MGVectorData()
-  {}
-
 
   template <typename VectorType, int dim, int spacedim>
   MGVectorData<VectorType, dim, spacedim>::MGVectorData(const VectorSelector &s)

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -278,7 +278,7 @@ public:
   /**
    * Constructor leaving an uninitialized object.
    */
-  MGCoarseGridSVD ();
+  MGCoarseGridSVD () = default;
 
   /**
    * Initialize for a new matrix. This resets the dimensions to the
@@ -548,11 +548,6 @@ MGCoarseGridHouseholder<number, VectorType>::operator() (const unsigned int /*le
 }
 
 //---------------------------------------------------------------------------
-
-template<typename number, class VectorType>
-inline
-MGCoarseGridSVD<number, VectorType>::MGCoarseGridSVD()
-{}
 
 
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -47,7 +47,7 @@ namespace mg
     /**
      * Default constructor for an empty object.
      */
-    Matrix();
+    Matrix() = default;
 
     /**
      * Constructor setting up pointers to the matrices in <tt>M</tt> by
@@ -192,13 +192,6 @@ namespace mg
   {
     initialize(p);
   }
-
-
-
-  template <typename VectorType>
-  inline
-  Matrix<VectorType>::Matrix ()
-  {}
 
 
 


### PR DESCRIPTION
This commit marks a bunch of our constructors as `= default` instead of providing our own empty block for a constructor. I opted to completely remove the default constructor in two cases where the `stuct` in question had no other constructors (this was for an `AdditionalData` `struct` and the private `Line` class).