### PR TITLE
Fix clang compilation

### DIFF
--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -164,7 +164,7 @@ namespace OpenCASCADE
     /**
      * Direction used to project new points on the shape.
      */
-    const Point<3> direction;
+    const Tensor<1, spacedim> direction;
 
     /**
      * Relative tolerance used by this class to compute distances.

--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -249,11 +249,6 @@ namespace OpenCASCADE
     const TopoDS_Shape sh;
 
     /**
-     * Direction used to project new points on the shape.
-     */
-    const Point<3> direction;
-
-    /**
      * Relative tolerance used by this class to compute distances.
      */
     const double tolerance;


### PR DESCRIPTION
It looks like the recent change in default constructors confuses older versions of clang. Fortunately, we never use this variable anyway, so we can get rid of it.

I also converted a `Point` to a `Tensor`.