### PR TITLE
Add user-defined constructor for Point<dim> back in

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -93,7 +93,7 @@ public:
    * Standard constructor. Creates an object that corresponds to the origin,
    * i.e., all coordinates are set to zero.
    */
-  Point () = default;
+  Point ();
 
   /**
    * Convert a tensor to a point.
@@ -248,6 +248,15 @@ public:
 /*------------------------------- Inline functions: Point ---------------------------*/
 
 #ifndef DOXYGEN
+
+// At least clang-3.7 requires us to have a user-defined constructor
+// and we can't use 'Point<dim,Number>::Point () = default' here.
+template <int dim, typename Number>
+inline
+Point<dim,Number>::Point ()
+{}
+
+
 
 template <int dim, typename Number>
 inline


### PR DESCRIPTION
[CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=724ß6) shows that we need a user-defined constructor for `Point<dim>` at least when using `clang-3.7.0`.
See also 
http://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a and 
http://stackoverflow.com/questions/21900237/do-i-really-need-to-implement-user-provided-constructor-for-const-objects