### PR TITLE
Add missing FEValues IndexSet instantiations.

### DIFF
--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -240,133 +240,63 @@ for (VEC : SERIAL_VECTORS; deal_II_dimension : DIMENSIONS; deal_II_space_dimensi
 
 // instantiations for VEC=IndexSet
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
+#if deal_II_dimension <= deal_II_space_dimension
     template
-    void FEValuesViews::Scalar<deal_II_dimension>::get_function_values<dealii::IndexSet>
+    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
     (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type> &) const;
     template
-    void FEValuesViews::Scalar<deal_II_dimension>::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Scalar<deal_II_dimension>::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Scalar<deal_II_dimension>::get_function_laplacians<dealii::IndexSet>
+    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<dealii::IndexSet>
     (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type>&) const;
     template
-    void FEValuesViews::Scalar<deal_II_dimension>::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Scalar<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
 
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_symmetric_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_symmetric_gradients<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_curls<dealii::IndexSet>
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_curls<dealii::IndexSet>
     (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,curl_type>::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_divergences<dealii::IndexSet>
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
     (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,divergence_type>::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_laplacians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Vector<deal_II_dimension>::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<4,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Vector<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<4,deal_II_space_dimension> >::type>&) const;
 
     template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_dimension>::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::SymmetricTensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
 
     template
-    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_dimension>::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension> >::type>&) const;
+    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_values<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_space_dimension> >::type>&) const;
     template
-    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_dimension>::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension> >::type>&) const;
-
-
-#if deal_II_dimension != 3
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,value_type>::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_laplacians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type>&) const;
-    template
-    void FEValuesViews::Scalar<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension+1> >::type>&) const;
-
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_symmetric_gradients<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,double>::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_hessians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<3,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_laplacians<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Vector<deal_II_dimension, deal_II_dimension+1>
-    ::get_function_third_derivatives<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<4,deal_II_dimension+1> >::type>&) const;
-
-    template
-    void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_dimension+1>
-    ::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::SymmetricTensor<2,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::SymmetricTensor<2, deal_II_dimension, deal_II_dimension+1>
-    ::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
-
-    template
-    void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_dimension+1>
-    ::get_function_values<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<2,deal_II_dimension+1> >::type>&) const;
-    template
-    void FEValuesViews::Tensor<2, deal_II_dimension, deal_II_dimension+1>
-    ::get_function_divergences<dealii::IndexSet>
-    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_dimension+1> >::type>&) const;
-
+    void FEValuesViews::Tensor<2,deal_II_dimension,deal_II_space_dimension>::get_function_divergences<dealii::IndexSet>
+    (const dealii::IndexSet&, std::vector<ProductType<IndexSet::value_type,dealii::Tensor<1,deal_II_space_dimension> >::type>&) const;
 #endif
 }
 
@@ -374,190 +304,97 @@ for (deal_II_dimension : DIMENSIONS)
 
 // Instantiations of functions in FEValuesBase and IndexSet=IndexSet
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 {
+#if deal_II_dimension <= deal_II_space_dimension
     template
-    void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
     (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
     (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
      std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_values<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_values<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
      VectorSlice<std::vector<std::vector<IndexSet::value_type> > >, bool) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > &) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
+    (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > &) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > &) const;
+     std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > > &) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
+    (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > > &) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_gradients<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_gradients<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension,IndexSet::value_type> > > >, bool) const;
+     VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > &) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
+    (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > &) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > &) const;
+     std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > > &, bool) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
+    (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > > &, bool) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_hessians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_hessians<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension,IndexSet::value_type> > > >, bool) const;
+     VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
     (const IndexSet&, std::vector<IndexSet::value_type>&) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
     (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
      std::vector<Vector<IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_laplacians<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_laplacians<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
      std::vector<std::vector<IndexSet::value_type> > &, bool) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<3,deal_II_dimension,IndexSet::value_type> > &) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
+    (const IndexSet&, std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > &) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_third_derivatives<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<3,deal_II_dimension,IndexSet::value_type> > &) const;
+     std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > &) const;
 
     template
-    void FEValuesBase<deal_II_dimension>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<3,deal_II_dimension,IndexSet::value_type> > > &, bool) const;
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
+    (const IndexSet&, std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > > &, bool) const;
     template
-    void FEValuesBase<deal_II_dimension>::get_function_third_derivatives<IndexSet>
+    void FEValuesBase<deal_II_dimension,deal_II_space_dimension>::get_function_third_derivatives<IndexSet>
     (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<3,deal_II_dimension,IndexSet::value_type> > > >, bool) const;
-
-
-#if deal_II_dimension != 3
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-    (const IndexSet&, std::vector<IndexSet::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-    (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_values<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<IndexSet::value_type> > >, bool) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_gradients<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<1,deal_II_dimension+1,IndexSet::value_type> > > >, bool) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_hessians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<2,deal_II_dimension+1,IndexSet::value_type> > > >, bool) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-    (const IndexSet&, std::vector<IndexSet::value_type>&) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&, std::vector<IndexSet::value_type>&) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-    (const IndexSet&, std::vector<Vector<IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<Vector<IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_laplacians<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<std::vector<IndexSet::value_type> > &, bool) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<dealii::Tensor<3,deal_II_dimension+1,IndexSet::value_type> > &) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     std::vector<dealii::Tensor<3,deal_II_dimension+1,IndexSet::value_type> > &) const;
-
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, std::vector<std::vector<dealii::Tensor<3,deal_II_dimension+1,IndexSet::value_type> > > &, bool) const;
-    template
-    void FEValuesBase<deal_II_dimension,deal_II_dimension+1>::get_function_third_derivatives<IndexSet>
-    (const IndexSet&, const VectorSlice<const std::vector<types::global_dof_index> >&,
-     VectorSlice<std::vector<std::vector<dealii::Tensor<3,deal_II_dimension+1,IndexSet::value_type> > > >, bool) const;
-
+     VectorSlice<std::vector<std::vector<dealii::Tensor<3,deal_II_space_dimension,IndexSet::value_type> > > >, bool) const;
 #endif
 }


### PR DESCRIPTION
It turns out that we support using `IndexSet` as a vector class in a few different places: this PR adds some missing codimension != 0 instantiations.

On a related note: this functionality seems very obscure. Would anyone oppose deprecating these and adding a new `Vector<double>(const IndexSet &)` constructor to recover equivalent functionality? AFAIK these are only used in step-41 ~~and I don't think this functionality is documented in any other place~~.