### PR TITLE
Avoid a warning about an unused constructor argument.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -556,7 +556,7 @@ public:
   /**
    * Copy constructor.
    */
-  BlockVectorBase (const BlockVectorBase &V) = default;
+  BlockVectorBase (const BlockVectorBase &/*V*/) = default;
 
   /**
    * Move constructor. Each block of the argument vector is moved into the current


### PR DESCRIPTION
Annoyingly, my compiler warns about =default constructors whenever we name constructor
arguments. It says they are unused -- which is patently wrong: the argument is used
just fine, we just never explicitly reference the *name* of the argument. Either way,
work around this.