### PR TITLE
Remove Utilities::System::job_supports_mpi()

### DIFF
--- a/doc/news/changes/incompatibilities/20170514DanielArndt
+++ b/doc/news/changes/incompatibilities/20170514DanielArndt
@@ -1,0 +1,4 @@
+Changed: The deprecated function Utilities::System::job_supports_mpi()
+has been removed. Use Utilities::MPI::job_supports_mpi() instead. 
+<br>
+(Daniel Arndt, 2017/05/14)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -450,11 +450,6 @@ namespace Utilities
      * leaving this task to the calling site.
      */
     void posix_memalign (void **memptr, size_t alignment, size_t size);
-
-    /**
-     * @deprecated Use Utilities::MPI::job_supports_mpi() instead.
-     */
-    bool job_supports_mpi () DEAL_II_DEPRECATED;
   }
 
 

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -105,7 +105,7 @@ namespace Utilities
     void
     Partitioner::set_owned_indices (const IndexSet &locally_owned_indices)
     {
-      if (Utilities::System::job_supports_mpi() == true)
+      if (Utilities::MPI::job_supports_mpi() == true)
         {
           my_pid = Utilities::MPI::this_mpi_process(communicator);
           n_procs = Utilities::MPI::n_mpi_processes(communicator);


### PR DESCRIPTION
This function was deprecated on 2015-01-13.