### PR TITLE
Remove deprecated BlockSparseMatrixEZ<Number>::n_rows/n_cols

### DIFF
--- a/doc/news/changes/incompatibilities/20170514DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20170514DanielArndt-1
@@ -1,0 +1,5 @@
+Changed: The deprecated functions BlockSparseMatrixEZ::n_rows()
+and BlockSparseMatrixEZ::n_cols() have been removed.
+Use BlockSparseMatrixEZ::m() and BlockSparseMatrixEZ::n() instead.
+<br>
+(Daniel Arndt, 2017/05/14)

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -152,24 +152,6 @@ public:
   /**
    * Return number of rows of this matrix, which equals the dimension of the
    * codomain (or range) space. It is the sum of the number of rows over the
-   * sub-matrix blocks of this matrix.
-   *
-   * @deprecated Use m() instead.
-   */
-  size_type n_rows () const DEAL_II_DEPRECATED;
-
-  /**
-   * Return number of columns of this matrix, which equals the dimension of
-   * the domain space. It is the sum of the number of columns over the sub-
-   * matrix blocks of this matrix.
-   *
-   * @deprecated Use n() instead.
-   */
-  size_type n_cols () const DEAL_II_DEPRECATED;
-
-  /**
-   * Return number of rows of this matrix, which equals the dimension of the
-   * codomain (or range) space. It is the sum of the number of rows over the
    * sub-matrix blocks of this matrix. Recall that the matrix is of size m()
    * times n().
    */
@@ -279,30 +261,10 @@ BlockSparseMatrixEZ<Number>::n_block_rows () const
 
 template <typename Number>
 inline
-typename BlockSparseMatrixEZ<Number>::size_type
-BlockSparseMatrixEZ<Number>::n_rows () const
-{
-  return row_indices.total_size();
-}
-
-
-
-template <typename Number>
-inline
 unsigned int
 BlockSparseMatrixEZ<Number>::n_block_cols () const
 {
   return column_indices.size();
-}
-
-
-
-template <typename Number>
-inline
-typename BlockSparseMatrixEZ<Number>::size_type
-BlockSparseMatrixEZ<Number>::n_cols () const
-{
-  return column_indices.total_size();
 }
 
 


### PR DESCRIPTION
These two member functions were deprecated on 2015-04-08. There are no tests attached to them.