### PR TITLE
Remove deprecated SparsityTools::reorder_Cuthill_McKee

### DIFF
--- a/doc/news/changes/incompatibilities/20170515DanielArndt
+++ b/doc/news/changes/incompatibilities/20170515DanielArndt
@@ -1,0 +1,5 @@
+Changed: The deprecated function SparsityTools::reorder_Cuthill_McKee() 
+acting on a SparsityPattern object has been removed.
+Use the one acting on a DynamicSparsityPattern instead.
+<br>
+(Daniel Arndt, 2017/05/15)

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -136,16 +136,6 @@ namespace SparsityTools
                          const std::vector<DynamicSparsityPattern::size_type> &starting_indices = std::vector<DynamicSparsityPattern::size_type>());
 
   /**
-   * As above, but taking a SparsityPattern object instead.
-   *
-   * @deprecated
-   */
-  void
-  reorder_Cuthill_McKee (const SparsityPattern &sparsity,
-                         std::vector<SparsityPattern::size_type> &new_indices,
-                         const std::vector<SparsityPattern::size_type> &starting_indices = std::vector<SparsityPattern::size_type>()) DEAL_II_DEPRECATED;
-
-  /**
    * For a given sparsity pattern, compute a re-enumeration of row/column
    * indices in a hierarchical way, similar to what
    * DoFRenumbering::hierarchical does for degrees of freedom on

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -328,23 +328,6 @@ namespace SparsityTools
 
 
 
-  void
-  reorder_Cuthill_McKee (const SparsityPattern                   &sparsity,
-                         std::vector<SparsityPattern::size_type> &new_indices,
-                         const std::vector<SparsityPattern::size_type> &starting_indices)
-  {
-    DynamicSparsityPattern dsp(sparsity.n_rows(), sparsity.n_cols());
-    for (unsigned int row=0; row<sparsity.n_rows(); ++row)
-      {
-        for (SparsityPattern::iterator it=sparsity.begin(row); it!=sparsity.end(row)
-             && it->is_valid_entry() ; ++it)
-          dsp.add(row, it->column());
-      }
-    reorder_Cuthill_McKee(dsp, new_indices, starting_indices);
-  }
-
-
-
   namespace internal
   {
     void


### PR DESCRIPTION
Passes a full testsuite run.