### PR TITLE
Remove unused helper function

### DIFF
--- a/source/lac/trilinos_vector_base.cc
+++ b/source/lac/trilinos_vector_base.cc
@@ -34,27 +34,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace TrilinosWrappers
 {
-  namespace
-  {
-#ifndef DEAL_II_WITH_64BIT_INDICES
-    // define a helper function that queries the global vector length of an
-    // Epetra_FEVector object  by calling either the 32- or 64-bit
-    // function necessary.
-    int global_length(const Epetra_FEVector &vector)
-    {
-      return vector.GlobalLength();
-    }
-#else
-    // define a helper function that queries the global vector length of an
-    // Epetra_FEVector object  by calling either the 32- or 64-bit
-    // function necessary.
-    long long int global_length(const Epetra_FEVector &vector)
-    {
-      return vector.GlobalLength64();
-    }
-#endif
-  }
-
   namespace internal
   {
     VectorReference::operator TrilinosScalar () const


### PR DESCRIPTION
As noticed by CDash for [32-bit](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=7273) and [64-bit](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=7270) indices the function `global_length(const Epetra_FEVector &vector)` is unused.