### PR TITLE
Remove references to the old read_input function.

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2586,15 +2586,14 @@ public:
    * will stop parsing lines after encountering @p last_line .
    * This is handy when adding extra data that shall be parsed manually.
    *
-   * @note Of the three <tt>parse_input</tt> functions implemented by
-   * ParameterHandler, this method and the deprecated method
-   * MultipleParameterLoop::read_input are the only ones overridden with new
-   * behavior by this class. This is because the other two <tt>parse_input</tt>
-   * functions just reformat their inputs and then call this version.
+   * @note This is the only overload of the three <tt>parse_input</tt>
+   * functions implemented by ParameterHandler overridden with new behavior by
+   * this class. This is because the other two <tt>parse_input</tt> functions
+   * just reformat their inputs and then call this version.
    */
   virtual void parse_input (std::istream &input,
                             const std::string &filename = "input file",
-                            const std::string &last_line = "");
+                            const std::string &last_line = "") override;
 
   /**
    * Overriding virtual functions which are overloaded (like

--- a/tests/parameter_handler/parameter_handler_exceptions_01.cc
+++ b/tests/parameter_handler/parameter_handler_exceptions_01.cc
@@ -54,7 +54,7 @@ void check (const char *p)
 
 
   // make sure the prm object was reset to a state where we are in the
-  // subsection we were in before attempting the `read_input` call
+  // subsection we were in before attempting the `parse_input` call
   // (namely, in the top-level section of the prm tree)
   deallog << "test_1="
           << prm.get ("test_1")  // should =1, because we read that value

--- a/tests/parameter_handler/parameter_handler_exceptions_02.cc
+++ b/tests/parameter_handler/parameter_handler_exceptions_02.cc
@@ -63,7 +63,7 @@ void check (const char *p)
 
 
   // make sure the prm object was reset to a state where we are in the
-  // subsection we were in before attempting the `read_input` call
+  // subsection we were in before attempting the `parse_input` call
   // (namely, in the top-level section of the prm tree)
   deallog << "test_1="
           << prm.get ("test_1")  // should =1, because we read that value


### PR DESCRIPTION
I noticed these while doing some research for #4408.