### PR TITLE
Better document why we take a large argument by value.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -265,16 +265,22 @@ namespace deal_II_exceptions
      * This routine does the main work for the exception generation mechanism
      * used in the <tt>Assert</tt> macro.
      *
+     * The actual exception object (the last argument) is typically an unnamed
+     * object created in place; because we modify it, we can't take it by
+     * const reference, and temporaries don't bind to non-const references.
+     * So take it by value (=copy it) -- the performance implications are
+     * pretty minimal anyway.
+     *
      * @ref ExceptionBase
      */
-    template <class exc>
-    void issue_error (ExceptionHandling handling,
-                      const char *file,
-                      int         line,
-                      const char *function,
-                      const char *cond,
-                      const char *exc_name,
-                      exc         e)
+    template <class ExceptionType>
+    void issue_error (ExceptionHandling  handling,
+                      const char       *file,
+                      int               line,
+                      const char       *function,
+                      const char       *cond,
+                      const char       *exc_name,
+                      ExceptionType     e)
     {
       // Fill the fields of the exception object
       e.set_fields (file, line, function, cond, exc_name);


### PR DESCRIPTION
This addresses an issue found by Coverity. We copy the argument intentionally.
I had toyed with the idea of making the argument in question an rvalue
reference, but it turns out that we have a couple of places where we create
an exception object as a local variable and then pass that to Assert or
AssertThrow. Stealing the object via rvalue reference would work on those
cases, but maybe not if someone ever had the idea of throwing a member
variable -- it's not clear to me that moving it would be the right thing
in that circumstance.

In any case, the performance implications are minimal one way or the other.
So let's just punt on the Coverity issue and just document what we do
and why.