### PR TITLE
CMake: Bugfix: run get_latest_tag only if git is recent enough

### DIFF
--- a/cmake/scripts/get_closest_tag.sh
+++ b/cmake/scripts/get_closest_tag.sh
@@ -5,6 +5,11 @@
 #   - with shortest (positive) distance of the common ancestor to HEAD
 #
 
+if ! git --version | grep -q "git version 2"; then
+  # This script requires version 2 or newer
+  exit 1
+fi
+
 head="$(git rev-parse HEAD)"
 
 tags="$(git tag --sort=-creatordate)"

--- a/cmake/scripts/get_latest_tag.sh
+++ b/cmake/scripts/get_latest_tag.sh
@@ -4,6 +4,11 @@
 # current HEAD
 #
 
+if ! git --version | grep -q "git version 2"; then
+  # This script requires version 2 or newer
+  exit 1
+fi
+
 head="$(git rev-parse HEAD)"
 
 tags="$(git tag --sort=-creatordate)"


### PR DESCRIPTION
Fixes #4420