### PR TITLE
Shorten matrix-free multigrid tests

### DIFF
--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -15,8 +15,8 @@
 
 
 
-// same as parallel_multigrid.cc but using MatrixFreeOperators::LaplaceOperator
-// class.
+// similar to parallel_multigrid.cc but using MatrixFreeOperators::LaplaceOperator
+// class
 
 #include "../tests.h"
 
@@ -215,7 +215,7 @@ void do_test (const DoFHandler<dim>  &dof)
 template <int dim, int fe_degree>
 void test ()
 {
-  for (unsigned int i=5; i<8; ++i)
+  for (unsigned int i=5; i<7; ++i)
     {
       parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
                                                      Triangulation<dim>::limit_level_difference_at_vertices,

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -13,13 +13,6 @@ DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg::Convergence step 3 value 2.852e-08
-DEAL:2d::Testing FE_Q<2>(1)
-DEAL:2d::Number of degrees of freedom: 1089
-DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 1.188e-06
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
@@ -40,16 +33,6 @@ DEAL:2d:cg:cg::Convergence step 1 value 0
 DEAL:2d:cg:cg::Starting value 3.547e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
 DEAL:2d:cg::Convergence step 3 value 7.112e-07
-DEAL:2d::Testing FE_Q<2>(2)
-DEAL:2d::Number of degrees of freedom: 4225
-DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 10.69
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0006523
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 6.562e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 1.706e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
@@ -64,13 +47,6 @@ DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg::Convergence step 3 value 1.307e-07
-DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Number of degrees of freedom: 4913
-DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.389e-07
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
@@ -91,13 +67,3 @@ DEAL:3d:cg:cg::Convergence step 1 value 0
 DEAL:3d:cg:cg::Starting value 1.952e-06
 DEAL:3d:cg:cg::Convergence step 1 value 0
 DEAL:3d:cg::Convergence step 3 value 1.139e-06
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 35937
-DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 45.77
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.006203
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 8.376e-06
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 5.606e-06

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
@@ -13,13 +13,6 @@ DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg::Convergence step 3 value 2.901e-08
-DEAL:2d::Testing FE_Q<2>(1)
-DEAL:2d::Number of degrees of freedom: 1089
-DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 1.591e-06
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
@@ -40,16 +33,6 @@ DEAL:2d:cg:cg::Convergence step 1 value 0
 DEAL:2d:cg:cg::Starting value 3.494e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
 DEAL:2d:cg::Convergence step 3 value 7.111e-07
-DEAL:2d::Testing FE_Q<2>(2)
-DEAL:2d::Number of degrees of freedom: 4225
-DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 10.54
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0006433
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 6.472e-07
-DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 1.706e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
@@ -64,13 +47,6 @@ DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg::Convergence step 3 value 1.304e-07
-DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Number of degrees of freedom: 4913
-DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.365e-07
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
@@ -91,13 +67,3 @@ DEAL:3d:cg:cg::Convergence step 1 value 0
 DEAL:3d:cg:cg::Starting value 1.949e-06
 DEAL:3d:cg:cg::Convergence step 1 value 0
 DEAL:3d:cg::Convergence step 3 value 1.141e-06
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 35937
-DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 45.78
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.006202
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 8.370e-06
-DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 5.604e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -590,11 +590,9 @@ int main (int argc, char **argv)
     deallog.threshold_double(1.e-10);
     deallog.push("2d");
     test<2,1>();
-    test<2,3>();
     deallog.pop();
     deallog.push("3d");
     test<3,1>();
-    test<3,2>();
     deallog.pop();
   }
 }

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -2,48 +2,28 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.781e-07
+DEAL:2d:cg::Convergence step 5 value 7.800e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.215e-07
+DEAL:2d:cg::Convergence step 6 value 9.250e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.142e-06
+DEAL:2d:cg::Convergence step 6 value 1.135e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.563e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 4259
-DEAL:2d:cg::Starting value 64.26
-DEAL:2d:cg::Convergence step 5 value 1.632e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 7457
-DEAL:2d:cg::Starting value 83.11
-DEAL:2d:cg::Convergence step 5 value 7.695e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 18535
-DEAL:2d:cg::Starting value 131.0
-DEAL:2d:cg::Convergence step 5 value 6.059e-06
+DEAL:2d:cg::Convergence step 6 value 1.557e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.615e-08
+DEAL:3d:cg::Convergence step 6 value 3.602e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.941e-06
+DEAL:3d:cg::Convergence step 7 value 3.930e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.362e-06
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 7494
-DEAL:3d:cg::Starting value 82.90
-DEAL:3d:cg::Convergence step 7 value 8.682e-07
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 26548
-DEAL:3d:cg::Starting value 152.6
-DEAL:3d:cg::Convergence step 7 value 3.969e-06
+DEAL:3d:cg::Convergence step 8 value 5.370e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
@@ -2,48 +2,28 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 507
 DEAL:2d:cg::Starting value 21.93
-DEAL:2d:cg::Convergence step 5 value 7.781e-07
+DEAL:2d:cg::Convergence step 5 value 7.800e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 881
 DEAL:2d:cg::Starting value 27.77
-DEAL:2d:cg::Convergence step 6 value 9.215e-07
+DEAL:2d:cg::Convergence step 6 value 9.250e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d:cg::Starting value 43.26
-DEAL:2d:cg::Convergence step 6 value 1.142e-06
+DEAL:2d:cg::Convergence step 6 value 1.135e-06
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
 DEAL:2d:cg::Starting value 76.92
-DEAL:2d:cg::Convergence step 6 value 1.563e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 4259
-DEAL:2d:cg::Starting value 64.26
-DEAL:2d:cg::Convergence step 5 value 1.632e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 7457
-DEAL:2d:cg::Starting value 83.11
-DEAL:2d:cg::Convergence step 5 value 7.695e-06
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 18535
-DEAL:2d:cg::Starting value 131.0
-DEAL:2d:cg::Convergence step 5 value 6.059e-06
+DEAL:2d:cg::Convergence step 6 value 1.557e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 1103
 DEAL:3d:cg::Starting value 31.21
-DEAL:3d:cg::Convergence step 6 value 3.615e-08
+DEAL:3d:cg::Convergence step 6 value 3.602e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 3694
 DEAL:3d:cg::Starting value 55.00
-DEAL:3d:cg::Convergence step 7 value 3.941e-06
+DEAL:3d:cg::Convergence step 7 value 3.930e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 9566
 DEAL:3d:cg::Starting value 76.18
-DEAL:3d:cg::Convergence step 8 value 5.362e-06
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 7494
-DEAL:3d:cg::Starting value 82.90
-DEAL:3d:cg::Convergence step 7 value 8.682e-07
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 26548
-DEAL:3d:cg::Starting value 152.6
-DEAL:3d:cg::Convergence step 7 value 3.969e-06
+DEAL:3d:cg::Convergence step 8 value 5.370e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -583,7 +583,7 @@ int main (int argc, char **argv)
   deallog.threshold_double(1e-9);
 
   test<2,1,double>();
-  test<2,3,float>();
+  test<2,2,float>();
   test<3,1,double>();
-  test<3,2,float>();
+  test<3,1,float>();
 }

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -2,96 +2,104 @@
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 507
 DEAL:nothread:cg::Starting value 21.9317
-DEAL:nothread:cg::Convergence step 5 value 7.81205e-07
+DEAL:nothread:cg::Convergence step 5 value 7.78558e-07
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 507
 DEAL:threaded:cg::Starting value 21.9317
-DEAL:threaded:cg::Convergence step 5 value 7.81205e-07
+DEAL:threaded:cg::Convergence step 5 value 7.78558e-07
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 881
 DEAL:nothread:cg::Starting value 27.7669
-DEAL:nothread:cg::Convergence step 6 value 9.24482e-07
+DEAL:nothread:cg::Convergence step 6 value 9.22164e-07
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 881
 DEAL:threaded:cg::Starting value 27.7669
-DEAL:threaded:cg::Convergence step 6 value 9.24482e-07
+DEAL:threaded:cg::Convergence step 6 value 9.22164e-07
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 2147
 DEAL:nothread:cg::Starting value 43.2551
-DEAL:nothread:cg::Convergence step 6 value 1.14520e-06
+DEAL:nothread:cg::Convergence step 6 value 1.15108e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 2147
 DEAL:threaded:cg::Starting value 43.2551
-DEAL:threaded:cg::Convergence step 6 value 1.14520e-06
+DEAL:threaded:cg::Convergence step 6 value 1.15108e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 6517
 DEAL:nothread:cg::Starting value 76.9220
-DEAL:nothread:cg::Convergence step 6 value 1.55925e-06
+DEAL:nothread:cg::Convergence step 6 value 1.56831e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 6517
 DEAL:threaded:cg::Starting value 76.9220
-DEAL:threaded:cg::Convergence step 6 value 1.55925e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 4259
-DEAL:nothread:cg::Starting value 64.2573
-DEAL:nothread:cg::Convergence step 5 value 1.63125e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 4259
-DEAL:threaded:cg::Starting value 64.2573
-DEAL:threaded:cg::Convergence step 5 value 1.63120e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 7457
-DEAL:nothread:cg::Starting value 83.1084
-DEAL:nothread:cg::Convergence step 5 value 7.69258e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 7457
-DEAL:threaded:cg::Starting value 83.1084
-DEAL:threaded:cg::Convergence step 5 value 7.69315e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 18535
-DEAL:nothread:cg::Starting value 130.977
-DEAL:nothread:cg::Convergence step 5 value 6.04397e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 18535
-DEAL:threaded:cg::Starting value 130.977
-DEAL:threaded:cg::Convergence step 5 value 6.04357e-06
+DEAL:threaded:cg::Convergence step 6 value 1.56831e-06
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 1935
+DEAL:nothread:cg::Starting value 43.0929
+DEAL:nothread:cg::Convergence step 5 value 2.13384e-06
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 1935
+DEAL:threaded:cg::Starting value 43.0929
+DEAL:threaded:cg::Convergence step 5 value 2.13388e-06
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 3403
+DEAL:nothread:cg::Starting value 55.4346
+DEAL:nothread:cg::Convergence step 6 value 4.27828e-07
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 3403
+DEAL:threaded:cg::Starting value 55.4346
+DEAL:threaded:cg::Convergence step 6 value 4.27798e-07
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 8417
+DEAL:nothread:cg::Starting value 87.1149
+DEAL:nothread:cg::Convergence step 6 value 2.55138e-07
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 8417
+DEAL:threaded:cg::Starting value 87.1149
+DEAL:threaded:cg::Convergence step 6 value 2.55129e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 8.40297e-08
+DEAL:nothread:cg::Convergence step 3 value 2.26211e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 8.40297e-08
+DEAL:threaded:cg::Convergence step 3 value 2.26211e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.05183e-07
+DEAL:nothread:cg::Convergence step 6 value 1.11426e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.05183e-07
+DEAL:threaded:cg::Convergence step 6 value 1.11426e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.64836e-06
+DEAL:nothread:cg::Convergence step 7 value 1.63079e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.64836e-06
-DEAL:nothread::Testing FE_Q<3>(2)
-DEAL:nothread::Number of degrees of freedom: 1106
-DEAL:nothread:cg::Starting value 30.8707
-DEAL:nothread:cg::Convergence step 5 value 5.33407e-08
-DEAL:threaded::Testing FE_Q<3>(2)
-DEAL:threaded::Number of degrees of freedom: 1106
-DEAL:threaded:cg::Starting value 30.8707
-DEAL:threaded:cg::Convergence step 5 value 5.33448e-08
-DEAL:nothread::Testing FE_Q<3>(2)
-DEAL:nothread::Number of degrees of freedom: 4268
-DEAL:nothread:cg::Starting value 57.4891
-DEAL:nothread:cg::Convergence step 7 value 1.03521e-06
-DEAL:threaded::Testing FE_Q<3>(2)
-DEAL:threaded::Number of degrees of freedom: 4268
-DEAL:threaded:cg::Starting value 57.4891
-DEAL:threaded:cg::Convergence step 7 value 1.03521e-06
+DEAL:threaded:cg::Convergence step 7 value 1.63079e-06
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 186
+DEAL:nothread:cg::Starting value 12.3693
+DEAL:nothread:cg::Convergence step 3 value 2.24462e-07
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 186
+DEAL:threaded:cg::Starting value 12.3693
+DEAL:threaded:cg::Convergence step 3 value 2.24473e-07
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 648
+DEAL:nothread:cg::Starting value 21.1424
+DEAL:nothread:cg::Convergence step 6 value 1.06988e-07
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 648
+DEAL:threaded:cg::Starting value 21.1424
+DEAL:threaded:cg::Convergence step 6 value 1.06988e-07
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 2930
+DEAL:nothread:cg::Starting value 47.1699
+DEAL:nothread:cg::Convergence step 7 value 1.63550e-06
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 2930
+DEAL:threaded:cg::Starting value 47.1699
+DEAL:threaded:cg::Convergence step 7 value 1.63550e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -2,96 +2,104 @@
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 507
 DEAL:nothread:cg::Starting value 21.9317
-DEAL:nothread:cg::Convergence step 5 value 7.81205e-07
+DEAL:nothread:cg::Convergence step 5 value 7.76680e-07
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 507
 DEAL:threaded:cg::Starting value 21.9317
-DEAL:threaded:cg::Convergence step 5 value 7.81205e-07
+DEAL:threaded:cg::Convergence step 5 value 7.76680e-07
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 881
 DEAL:nothread:cg::Starting value 27.7669
-DEAL:nothread:cg::Convergence step 6 value 9.24482e-07
+DEAL:nothread:cg::Convergence step 6 value 9.25965e-07
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 881
 DEAL:threaded:cg::Starting value 27.7669
-DEAL:threaded:cg::Convergence step 6 value 9.24482e-07
+DEAL:threaded:cg::Convergence step 6 value 9.25965e-07
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 2147
 DEAL:nothread:cg::Starting value 43.2551
-DEAL:nothread:cg::Convergence step 6 value 1.14520e-06
+DEAL:nothread:cg::Convergence step 6 value 1.14972e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 2147
 DEAL:threaded:cg::Starting value 43.2551
-DEAL:threaded:cg::Convergence step 6 value 1.14520e-06
+DEAL:threaded:cg::Convergence step 6 value 1.14972e-06
 DEAL:nothread::Testing FE_Q<2>(1)
 DEAL:nothread::Number of degrees of freedom: 6517
 DEAL:nothread:cg::Starting value 76.9220
-DEAL:nothread:cg::Convergence step 6 value 1.55925e-06
+DEAL:nothread:cg::Convergence step 6 value 1.56712e-06
 DEAL:threaded::Testing FE_Q<2>(1)
 DEAL:threaded::Number of degrees of freedom: 6517
 DEAL:threaded:cg::Starting value 76.9220
-DEAL:threaded:cg::Convergence step 6 value 1.55925e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 4259
-DEAL:nothread:cg::Starting value 64.2573
-DEAL:nothread:cg::Convergence step 5 value 1.63125e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 4259
-DEAL:threaded:cg::Starting value 64.2573
-DEAL:threaded:cg::Convergence step 5 value 1.63120e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 7457
-DEAL:nothread:cg::Starting value 83.1084
-DEAL:nothread:cg::Convergence step 5 value 7.69258e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 7457
-DEAL:threaded:cg::Starting value 83.1084
-DEAL:threaded:cg::Convergence step 5 value 7.69315e-06
-DEAL:nothread::Testing FE_Q<2>(3)
-DEAL:nothread::Number of degrees of freedom: 18535
-DEAL:nothread:cg::Starting value 130.977
-DEAL:nothread:cg::Convergence step 5 value 6.04397e-06
-DEAL:threaded::Testing FE_Q<2>(3)
-DEAL:threaded::Number of degrees of freedom: 18535
-DEAL:threaded:cg::Starting value 130.977
-DEAL:threaded:cg::Convergence step 5 value 6.04357e-06
+DEAL:threaded:cg::Convergence step 6 value 1.56712e-06
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 1935
+DEAL:nothread:cg::Starting value 43.0929
+DEAL:nothread:cg::Convergence step 5 value 2.13377e-06
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 1935
+DEAL:threaded:cg::Starting value 43.0929
+DEAL:threaded:cg::Convergence step 5 value 2.13371e-06
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 3403
+DEAL:nothread:cg::Starting value 55.4346
+DEAL:nothread:cg::Convergence step 6 value 4.27767e-07
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 3403
+DEAL:threaded:cg::Starting value 55.4346
+DEAL:threaded:cg::Convergence step 6 value 4.27807e-07
+DEAL:nothread::Testing FE_Q<2>(2)
+DEAL:nothread::Number of degrees of freedom: 8417
+DEAL:nothread:cg::Starting value 87.1149
+DEAL:nothread:cg::Convergence step 6 value 2.55168e-07
+DEAL:threaded::Testing FE_Q<2>(2)
+DEAL:threaded::Number of degrees of freedom: 8417
+DEAL:threaded:cg::Starting value 87.1149
+DEAL:threaded:cg::Convergence step 6 value 2.55163e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 186
 DEAL:nothread:cg::Starting value 12.3693
-DEAL:nothread:cg::Convergence step 3 value 8.40297e-08
+DEAL:nothread:cg::Convergence step 3 value 2.28324e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 186
 DEAL:threaded:cg::Starting value 12.3693
-DEAL:threaded:cg::Convergence step 3 value 8.40297e-08
+DEAL:threaded:cg::Convergence step 3 value 2.28324e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 648
 DEAL:nothread:cg::Starting value 21.1424
-DEAL:nothread:cg::Convergence step 6 value 1.05183e-07
+DEAL:nothread:cg::Convergence step 6 value 1.11195e-07
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 648
 DEAL:threaded:cg::Starting value 21.1424
-DEAL:threaded:cg::Convergence step 6 value 1.05183e-07
+DEAL:threaded:cg::Convergence step 6 value 1.11195e-07
 DEAL:nothread::Testing FE_Q<3>(1)
 DEAL:nothread::Number of degrees of freedom: 2930
 DEAL:nothread:cg::Starting value 47.1699
-DEAL:nothread:cg::Convergence step 7 value 1.64836e-06
+DEAL:nothread:cg::Convergence step 7 value 1.63163e-06
 DEAL:threaded::Testing FE_Q<3>(1)
 DEAL:threaded::Number of degrees of freedom: 2930
 DEAL:threaded:cg::Starting value 47.1699
-DEAL:threaded:cg::Convergence step 7 value 1.64836e-06
-DEAL:nothread::Testing FE_Q<3>(2)
-DEAL:nothread::Number of degrees of freedom: 1106
-DEAL:nothread:cg::Starting value 30.8707
-DEAL:nothread:cg::Convergence step 5 value 5.33407e-08
-DEAL:threaded::Testing FE_Q<3>(2)
-DEAL:threaded::Number of degrees of freedom: 1106
-DEAL:threaded:cg::Starting value 30.8707
-DEAL:threaded:cg::Convergence step 5 value 5.33448e-08
-DEAL:nothread::Testing FE_Q<3>(2)
-DEAL:nothread::Number of degrees of freedom: 4268
-DEAL:nothread:cg::Starting value 57.4891
-DEAL:nothread:cg::Convergence step 7 value 1.03521e-06
-DEAL:threaded::Testing FE_Q<3>(2)
-DEAL:threaded::Number of degrees of freedom: 4268
-DEAL:threaded:cg::Starting value 57.4891
-DEAL:threaded:cg::Convergence step 7 value 1.03521e-06
+DEAL:threaded:cg::Convergence step 7 value 1.63163e-06
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 186
+DEAL:nothread:cg::Starting value 12.3693
+DEAL:nothread:cg::Convergence step 3 value 1.58643e-07
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 186
+DEAL:threaded:cg::Starting value 12.3693
+DEAL:threaded:cg::Convergence step 3 value 1.58660e-07
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 648
+DEAL:nothread:cg::Starting value 21.1424
+DEAL:nothread:cg::Convergence step 6 value 1.06758e-07
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 648
+DEAL:threaded:cg::Starting value 21.1424
+DEAL:threaded:cg::Convergence step 6 value 1.06760e-07
+DEAL:nothread::Testing FE_Q<3>(1)
+DEAL:nothread::Number of degrees of freedom: 2930
+DEAL:nothread:cg::Starting value 47.1699
+DEAL:nothread:cg::Convergence step 7 value 1.63203e-06
+DEAL:threaded::Testing FE_Q<3>(1)
+DEAL:threaded::Number of degrees of freedom: 2930
+DEAL:threaded:cg::Starting value 47.1699
+DEAL:threaded:cg::Convergence step 7 value 1.63203e-06

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -279,7 +279,7 @@ void test ()
                                                  Triangulation<dim>::limit_level_difference_at_vertices,
                                                  parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
   GridGenerator::hyper_cube (tria);
-  tria.refine_global(6-dim);
+  tria.refine_global(8-2*dim);
   const unsigned int n_runs = fe_degree == 1 ? 6-dim : 5-dim;
   for (unsigned int i=0; i<n_runs; ++i)
     {
@@ -317,11 +317,9 @@ int main (int argc, char **argv)
     deallog.threshold_double(1.e-10);
     deallog.push("2d");
     test<2,1>();
-    test<2,3>();
     deallog.pop();
     deallog.push("3d");
     test<3,1>();
-    test<3,2>();
     deallog.pop();
   }
 }

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -7,19 +7,9 @@ DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 2147
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 6517
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 4259
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 7457
-DEAL:2d::Testing FE_Q<2>(3)
-DEAL:2d::Number of degrees of freedom: 18535
 DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Number of degrees of freedom: 1103
+DEAL:3d::Number of degrees of freedom: 186
 DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Number of degrees of freedom: 3694
+DEAL:3d::Number of degrees of freedom: 648
 DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Number of degrees of freedom: 9566
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 7494
-DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Number of degrees of freedom: 26548
+DEAL:3d::Number of degrees of freedom: 2930

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -392,7 +392,7 @@ void do_test (const DoFHandler<dim>  &dof)
 template <int dim, int fe_degree, typename number>
 void test ()
 {
-  for (unsigned int i=5; i<8; ++i)
+  for (unsigned int i=5; i<7; ++i)
     {
       parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD,
                                                      Triangulation<dim>::limit_level_difference_at_vertices,

--- a/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_mf.with_mpi=true.with_p4est=true.mpirun=7.output
@@ -2,27 +2,19 @@
 DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 81
 DEAL:cg::Starting value 9.00000
-DEAL:cg::Convergence step 3 value 3.51892e-08
+DEAL:cg::Convergence step 3 value 3.51890e-08
 DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 289
 DEAL:cg::Starting value 17.0000
-DEAL:cg::Convergence step 3 value 3.00255e-08
-DEAL::Testing FE_Q<2>(1)
-DEAL::Number of degrees of freedom: 1089
-DEAL:cg::Starting value 33.0000
-DEAL:cg::Convergence step 3 value 1.23434e-06
+DEAL:cg::Convergence step 3 value 2.90115e-08
 DEAL::Testing FE_Q<2>(2)
 DEAL::Number of degrees of freedom: 289
 DEAL:cg::Starting value 17.0000
-DEAL:cg::Convergence step 3 value 2.83605e-07
+DEAL:cg::Convergence step 3 value 2.86879e-07
 DEAL::Testing FE_Q<2>(2)
 DEAL::Number of degrees of freedom: 1089
 DEAL:cg::Starting value 33.0000
-DEAL:cg::Convergence step 3 value 7.10480e-07
-DEAL::Testing FE_Q<2>(2)
-DEAL::Number of degrees of freedom: 4225
-DEAL:cg::Starting value 65.0000
-DEAL:cg::Convergence step 3 value 1.70919e-06
+DEAL:cg::Convergence step 3 value 7.11331e-07
 DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 125
 DEAL:cg::Starting value 11.1803
@@ -30,20 +22,12 @@ DEAL:cg::Convergence step 3 value 0
 DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 27.0000
-DEAL:cg::Convergence step 3 value 1.30226e-07
-DEAL::Testing FE_Q<3>(1)
-DEAL::Number of degrees of freedom: 4913
-DEAL:cg::Starting value 70.0928
-DEAL:cg::Convergence step 3 value 1.26015e-07
+DEAL:cg::Convergence step 3 value 1.30374e-07
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 27.0000
-DEAL:cg::Convergence step 3 value 2.86664e-08
+DEAL:cg::Convergence step 3 value 2.75558e-08
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 4913
 DEAL:cg::Starting value 70.0928
-DEAL:cg::Convergence step 3 value 1.13131e-06
-DEAL::Testing FE_Q<3>(2)
-DEAL::Number of degrees of freedom: 35937
-DEAL:cg::Starting value 189.571
-DEAL:cg::Convergence step 3 value 5.57593e-06
+DEAL:cg::Convergence step 3 value 1.14078e-06


### PR DESCRIPTION
In reference to #4427.

While not taking more than 45 seconds, most of the multigrid tests are still running for quite a while. Since testing the variants of the multigrid scheme does not need to be done with two polynomial degrees in 2D and 3D for every case, we can safely reduce the amount of tests a bit here.