### PR TITLE
Clean up task_09 a bit.

### DIFF
--- a/tests/base/task_09.cc
+++ b/tests/base/task_09.cc
@@ -22,9 +22,11 @@
 // this test verifies that we no longer deadlock
 
 #include "../tests.h"
-#include <iomanip>
+#include <chrono>
 #include <fstream>
-#include <unistd.h>
+#include <thread>
+
+#include <cstdlib>
 
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/multithread_info.h>
@@ -32,27 +34,19 @@
 
 void test ()
 {
-  sleep (1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 
 void outer ()
 {
-  // wait for some time to make sure
-  // that really all outer tasks have
-  // been started, then start a bunch
-  // of new tasks and wait for them
-  // to finish. it used to be that
-  // the join() function used a mutex
-  // which could only be acquired
-  // once the spawned task has
-  // finished, but since we already
-  // have so many tasks running at
-  // this point, the children never
-  // get to run and so never release
-  // the mutex that we try to acquire
-  // in join()
-  sleep (1);
+  // wait for some time to make sure that really all outer tasks have been
+  // started, then start a bunch of new tasks and wait for them to finish. it
+  // used to be that the join() function used a mutex which could only be
+  // acquired once the spawned task has finished, but since we already have so
+  // many tasks running at this point, the children never get to run and so
+  // never release the mutex that we try to acquire in join()
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   Threads::new_task (test).join();
 }
@@ -65,17 +59,25 @@ int main()
   deallog.attach(logfile);
   deallog.threshold_double(1.e-10);
 
-  const std::size_t n_tasks = MultithreadInfo::n_cores()*2;
-  // Since this test relies on providing more tasks than there are cores,
-  // reset the concurrency limit that exists in tests.h:
-  MultithreadInfo::set_thread_limit(n_tasks);
-  std::vector<Threads::Task<void>> tasks(n_tasks);
-  for (std::size_t task_n=0; task_n<n_tasks; ++task_n)
-    {
-      // We must save each task, otherwise it will join before the next loop
-      // iteration
-      tasks.emplace_back(Threads::new_task(outer));
-    }
+  {
+    const std::size_t n_tasks = MultithreadInfo::n_cores()*2;
+#ifdef _POSIX_C_SOURCE
+    // get rid of the environment variable if it exists (this may not be
+    // possible under MSVC, but the test will still pass; it just won't test
+    // what we want it to test)
+    unsetenv("DEAL_II_NUM_THREADS");
+#endif
+    // Since this test relies on providing more tasks than there are cores,
+    // reset the concurrency limit that exists in tests.h:
+    MultithreadInfo::set_thread_limit(n_tasks);
+    std::vector<Threads::Task<void>> tasks(n_tasks);
+    for (std::size_t task_n=0; task_n<n_tasks; ++task_n)
+      {
+        // We must save each task, otherwise it will join before the next loop
+        // iteration
+        tasks.emplace_back(Threads::new_task(outer));
+      }
+  }
 
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
This commit applies some small cleanups to this test (e.g., preferring C++11 functionality to POSIX) and, in addition, makes the following changes:
1. The OK message won't be set to deallog until after tasks is destroyed (i.e.,
   all threads must join).
2. If on a POSIX platform, unset the thread environment variable so that we
   really can run the 'right' number of threads.

This is a follow-up to #4429. Relates to #4427.