### PR TITLE
Reduce computation time of step-18 based tests

### DIFF
--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -304,7 +304,7 @@ namespace Step18
   {
     present_time = 0;
     present_timestep = 1;
-    end_time = 10;
+    end_time = 5;
     timestep_no = 0;
     do_initial_timestep ();
     while (present_time < end_time)
@@ -581,7 +581,7 @@ namespace Step18
     ++timestep_no;
     pcout << "Timestep " << timestep_no << " at time " << present_time
           << std::endl;
-    for (unsigned int cycle=0; cycle<2; ++cycle)
+    for (unsigned int cycle=0; cycle<1; ++cycle)
       {
         pcout << "  Cycle " << cycle << ':' << std::endl;
         if (cycle == 0)

--- a/tests/physics/step-18-rotation_matrix.with_petsc=true.with_petsc_with_complex=false.output
+++ b/tests/physics/step-18-rotation_matrix.with_petsc=true.with_petsc_with_complex=false.output
@@ -1,10 +1,5 @@
 
-DEAL::Timestep 2: 0.00982 -1.35e-06 -0.100
-DEAL::Timestep 3: 0.0201 -3.32e-06 -0.200
-DEAL::Timestep 4: 0.0308 -5.19e-06 -0.300
-DEAL::Timestep 5: 0.0424 -5.68e-06 -0.400
-DEAL::Timestep 6: 0.0554 7.87e-07 -0.500
-DEAL::Timestep 7: 0.0720 3.84e-05 -0.600
-DEAL::Timestep 8: 0.0979 0.000188 -0.700
-DEAL::Timestep 9: 0.139 0.000618 -0.800
-DEAL::Timestep 10: 0.178 0.00126 -0.900
+DEAL::Timestep 2: 0.00982 -7.31e-08 -0.100
+DEAL::Timestep 3: 0.0201 6.50e-08 -0.200
+DEAL::Timestep 4: 0.0308 2.51e-07 -0.300
+DEAL::Timestep 5: 0.0424 9.18e-07 -0.400

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -331,7 +331,7 @@ namespace Step18
   {
     present_time = 0;
     present_timestep = 1;
-    end_time = 10;
+    end_time = 5;
     timestep_no = 0;
     do_initial_timestep ();
     while (present_time < end_time)
@@ -608,7 +608,7 @@ namespace Step18
     ++timestep_no;
     pcout << "Timestep " << timestep_no << " at time " << present_time
           << std::endl;
-    for (unsigned int cycle=0; cycle<2; ++cycle)
+    for (unsigned int cycle=0; cycle<1; ++cycle)
       {
         pcout << "  Cycle " << cycle << ':' << std::endl;
         if (cycle == 0)

--- a/tests/physics/step-18.with_petsc=true.with_petsc_with_complex=false.output
+++ b/tests/physics/step-18.with_petsc=true.with_petsc_with_complex=false.output
@@ -1,10 +1,5 @@
 
-DEAL::Timestep 2: 0.00982 -1.35e-06 -0.100
-DEAL::Timestep 3: 0.0201 -3.32e-06 -0.200
-DEAL::Timestep 4: 0.0308 -5.19e-06 -0.300
-DEAL::Timestep 5: 0.0424 -5.68e-06 -0.400
-DEAL::Timestep 6: 0.0554 7.87e-07 -0.500
-DEAL::Timestep 7: 0.0720 3.84e-05 -0.600
-DEAL::Timestep 8: 0.0979 0.000188 -0.700
-DEAL::Timestep 9: 0.139 0.000618 -0.800
-DEAL::Timestep 10: 0.178 0.00126 -0.900
+DEAL::Timestep 2: 0.00982 -7.31e-08 -0.100
+DEAL::Timestep 3: 0.0201 6.50e-08 -0.200
+DEAL::Timestep 4: 0.0308 2.51e-07 -0.300
+DEAL::Timestep 5: 0.0424 9.18e-07 -0.400


### PR DESCRIPTION
Partially addresses #4427 

Previous runtime (including build) on my laptop 
```
$ ctest -R "physics/step-18" -j1
    Start  7: physics/step-18-rotation_matrix.debug
1/4 Test  #7: physics/step-18-rotation_matrix.debug .....   Passed  204.90 sec
    Start  8: physics/step-18-rotation_matrix.release
2/4 Test  #8: physics/step-18-rotation_matrix.release ...   Passed   15.49 sec
    Start  9: physics/step-18.debug
3/4 Test  #9: physics/step-18.debug .....................   Passed  209.54 sec
    Start 10: physics/step-18.release
4/4 Test #10: physics/step-18.release ...................   Passed   16.38 sec
```

After this patch (build + run)
```
$ ctest -R "physics/step-18" -j1
    Start  7: physics/step-18-rotation_matrix.debug
1/4 Test  #7: physics/step-18-rotation_matrix.debug .....   Passed   42.53 sec
    Start  8: physics/step-18-rotation_matrix.release
2/4 Test  #8: physics/step-18-rotation_matrix.release ...   Passed    8.69 sec
    Start  9: physics/step-18.debug
3/4 Test  #9: physics/step-18.debug .....................   Passed   43.90 sec
    Start 10: physics/step-18.release
4/4 Test #10: physics/step-18.release ...................   Passed    9.07 sec
```