### PR TITLE
Reduce size of Trilinos preconditioner test

### DIFF
--- a/tests/trilinos/precondition.cc
+++ b/tests/trilinos/precondition.cc
@@ -124,7 +124,7 @@ template <int dim>
 void Step4<dim>::make_grid ()
 {
   GridGenerator::hyper_cube (triangulation, -1, 1);
-  triangulation.refine_global (6);
+  triangulation.refine_global (5);
 }
 
 
@@ -248,7 +248,7 @@ void Step4<dim>::solve ()
     deallog.push("BlockJacobi");
     TrilinosWrappers::PreconditionBlockJacobi preconditioner;
     TrilinosWrappers::PreconditionBlockJacobi::AdditionalData data;
-    data.block_size = 4;
+    data.block_size = 16;
     solution = 0;
     SolverControl           solver_control (1000, 1e-10);
     SolverCG<>              solver (solver_control);
@@ -262,7 +262,7 @@ void Step4<dim>::solve ()
     deallog.push("BlockSSOR");
     TrilinosWrappers::PreconditionBlockSSOR preconditioner;
     TrilinosWrappers::PreconditionBlockSSOR::AdditionalData data;
-    data.block_size = 4;
+    data.block_size = 16;
     data.omega = 1.2;
     solution = 0;
     SolverControl           solver_control (1000, 1e-10);
@@ -277,7 +277,7 @@ void Step4<dim>::solve ()
     deallog.push("BlockSOR");
     TrilinosWrappers::PreconditionBlockSOR preconditioner;
     TrilinosWrappers::PreconditionBlockSOR::AdditionalData data;
-    data.block_size = 4;
+    data.block_size = 16;
     data.omega = 0.8;
     solution = 0;
     SolverControl           solver_control (1000, 1e-5);

--- a/tests/trilinos/precondition.output
+++ b/tests/trilinos/precondition.output
@@ -1,4 +1,26 @@
 
+DEAL:01089:Jacobi:cg::Starting value 15.4650
+DEAL:01089:Jacobi:cg::Convergence step 50 value 0
+DEAL:01089:SSOR:cg::Starting value 15.4650
+DEAL:01089:SSOR:cg::Convergence step 41 value 0
+DEAL:01089:SOR:Bicgstab::Starting value 15.4650
+DEAL:01089:SOR:Bicgstab::Convergence step 32 value 0
+DEAL:01089:BlockJacobi:cg::Starting value 15.4650
+DEAL:01089:BlockJacobi:cg::Convergence step 74 value 0
+DEAL:01089:BlockSSOR:cg::Starting value 15.4650
+DEAL:01089:BlockSSOR:cg::Convergence step 31 value 0
+DEAL:01089:BlockSOR:Bicgstab::Starting value 15.4650
+DEAL:01089:BlockSOR:Bicgstab::Convergence step 19 value 0
+DEAL:01089:IC:cg::Starting value 15.4650
+DEAL:01089:IC:cg::Convergence step 52 value 0
+DEAL:01089:ILU:cg::Starting value 15.4650
+DEAL:01089:ILU:cg::Convergence step 31 value 0
+DEAL:01089:ILUT:Bicgstab::Starting value 15.4650
+DEAL:01089:ILUT:Bicgstab::Convergence step 12 value 0
+DEAL:01089:Chebyshev:cg::Starting value 15.4650
+DEAL:01089:Chebyshev:cg::Convergence step 24 value 0
+DEAL:01089:Direct:cg::Starting value 15.4650
+DEAL:01089:Direct:cg::Convergence step 1 value 0
 DEAL:04225:Jacobi:cg::Starting value 21.8299
 DEAL:04225:Jacobi:cg::Convergence step 101 value 0
 DEAL:04225:SSOR:cg::Starting value 21.8299
@@ -6,11 +28,11 @@ DEAL:04225:SSOR:cg::Convergence step 78 value 0
 DEAL:04225:SOR:Bicgstab::Starting value 21.8299
 DEAL:04225:SOR:Bicgstab::Convergence step 63 value 0
 DEAL:04225:BlockJacobi:cg::Starting value 21.8299
-DEAL:04225:BlockJacobi:cg::Convergence step 163 value 0
+DEAL:04225:BlockJacobi:cg::Convergence step 146 value 0
 DEAL:04225:BlockSSOR:cg::Starting value 21.8299
 DEAL:04225:BlockSSOR:cg::Convergence step 60 value 0
 DEAL:04225:BlockSOR:Bicgstab::Starting value 21.8299
-DEAL:04225:BlockSOR:Bicgstab::Convergence step 54 value 0
+DEAL:04225:BlockSOR:Bicgstab::Convergence step 38 value 0
 DEAL:04225:IC:cg::Starting value 21.8299
 DEAL:04225:IC:cg::Convergence step 70 value 0
 DEAL:04225:ILU:cg::Starting value 21.8299
@@ -21,25 +43,3 @@ DEAL:04225:Chebyshev:cg::Starting value 21.8299
 DEAL:04225:Chebyshev:cg::Convergence step 47 value 0
 DEAL:04225:Direct:cg::Starting value 21.8299
 DEAL:04225:Direct:cg::Convergence step 1 value 0
-DEAL:16641:Jacobi:cg::Starting value 30.8770
-DEAL:16641:Jacobi:cg::Convergence step 201 value 0
-DEAL:16641:SSOR:cg::Starting value 30.8770
-DEAL:16641:SSOR:cg::Convergence step 141 value 0
-DEAL:16641:SOR:Bicgstab::Starting value 30.8770
-DEAL:16641:SOR:Bicgstab::Convergence step 140 value 0
-DEAL:16641:BlockJacobi:cg::Starting value 30.8770
-DEAL:16641:BlockJacobi:cg::Convergence step 321 value 0
-DEAL:16641:BlockSSOR:cg::Starting value 30.8770
-DEAL:16641:BlockSSOR:cg::Convergence step 117 value 0
-DEAL:16641:BlockSOR:Bicgstab::Starting value 30.8770
-DEAL:16641:BlockSOR:Bicgstab::Convergence step 104 value 0
-DEAL:16641:IC:cg::Starting value 30.8770
-DEAL:16641:IC:cg::Convergence step 134 value 0
-DEAL:16641:ILU:cg::Starting value 30.8770
-DEAL:16641:ILU:cg::Convergence step 110 value 0
-DEAL:16641:ILUT:Bicgstab::Starting value 30.8770
-DEAL:16641:ILUT:Bicgstab::Convergence step 36 value 0
-DEAL:16641:Chebyshev:cg::Starting value 30.8770
-DEAL:16641:Chebyshev:cg::Convergence step 94 value 0
-DEAL:16641:Direct:cg::Starting value 30.8770
-DEAL:16641:Direct:cg::Convergence step 1 value 0

--- a/tests/trilinos/precondition.output.2
+++ b/tests/trilinos/precondition.output.2
@@ -1,4 +1,26 @@
 
+DEAL:01089:Jacobi:cg::Starting value 15.4650
+DEAL:01089:Jacobi:cg::Convergence step 50 value 0
+DEAL:01089:SSOR:cg::Starting value 15.4650
+DEAL:01089:SSOR:cg::Convergence step 41 value 0
+DEAL:01089:SOR:Bicgstab::Starting value 15.4650
+DEAL:01089:SOR:Bicgstab::Convergence step 32 value 0
+DEAL:01089:BlockJacobi:cg::Starting value 15.4650
+DEAL:01089:BlockJacobi:cg::Convergence step 74 value 0
+DEAL:01089:BlockSSOR:cg::Starting value 15.4650
+DEAL:01089:BlockSSOR:cg::Convergence step 31 value 0
+DEAL:01089:BlockSOR:Bicgstab::Starting value 15.4650
+DEAL:01089:BlockSOR:Bicgstab::Convergence step 19 value 0
+DEAL:01089:IC:cg::Starting value 15.4650
+DEAL:01089:IC:cg::Convergence step 53 value 0
+DEAL:01089:ILU:cg::Starting value 15.4650
+DEAL:01089:ILU:cg::Convergence step 31 value 0
+DEAL:01089:ILUT:Bicgstab::Starting value 15.4650
+DEAL:01089:ILUT:Bicgstab::Convergence step 12 value 0
+DEAL:01089:Chebyshev:cg::Starting value 15.4650
+DEAL:01089:Chebyshev:cg::Convergence step 24 value 0
+DEAL:01089:Direct:cg::Starting value 15.4650
+DEAL:01089:Direct:cg::Convergence step 1 value 0
 DEAL:04225:Jacobi:cg::Starting value 21.8299
 DEAL:04225:Jacobi:cg::Convergence step 101 value 0
 DEAL:04225:SSOR:cg::Starting value 21.8299
@@ -6,11 +28,11 @@ DEAL:04225:SSOR:cg::Convergence step 78 value 0
 DEAL:04225:SOR:Bicgstab::Starting value 21.8299
 DEAL:04225:SOR:Bicgstab::Convergence step 63 value 0
 DEAL:04225:BlockJacobi:cg::Starting value 21.8299
-DEAL:04225:BlockJacobi:cg::Convergence step 163 value 0
+DEAL:04225:BlockJacobi:cg::Convergence step 146 value 0
 DEAL:04225:BlockSSOR:cg::Starting value 21.8299
 DEAL:04225:BlockSSOR:cg::Convergence step 60 value 0
 DEAL:04225:BlockSOR:Bicgstab::Starting value 21.8299
-DEAL:04225:BlockSOR:Bicgstab::Convergence step 54 value 0
+DEAL:04225:BlockSOR:Bicgstab::Convergence step 38 value 0
 DEAL:04225:IC:cg::Starting value 21.8299
 DEAL:04225:IC:cg::Convergence step 68 value 0
 DEAL:04225:ILU:cg::Starting value 21.8299
@@ -21,25 +43,3 @@ DEAL:04225:Chebyshev:cg::Starting value 21.8299
 DEAL:04225:Chebyshev:cg::Convergence step 47 value 0
 DEAL:04225:Direct:cg::Starting value 21.8299
 DEAL:04225:Direct:cg::Convergence step 1 value 0
-DEAL:16641:Jacobi:cg::Starting value 30.8770
-DEAL:16641:Jacobi:cg::Convergence step 201 value 0
-DEAL:16641:SSOR:cg::Starting value 30.8770
-DEAL:16641:SSOR:cg::Convergence step 141 value 0
-DEAL:16641:SOR:Bicgstab::Starting value 30.8770
-DEAL:16641:SOR:Bicgstab::Convergence step 140 value 0
-DEAL:16641:BlockJacobi:cg::Starting value 30.8770
-DEAL:16641:BlockJacobi:cg::Convergence step 321 value 0
-DEAL:16641:BlockSSOR:cg::Starting value 30.8770
-DEAL:16641:BlockSSOR:cg::Convergence step 117 value 0
-DEAL:16641:BlockSOR:Bicgstab::Starting value 30.8770
-DEAL:16641:BlockSOR:Bicgstab::Convergence step 104 value 0
-DEAL:16641:IC:cg::Starting value 30.8770
-DEAL:16641:IC:cg::Convergence step 120 value 0
-DEAL:16641:ILU:cg::Starting value 30.8770
-DEAL:16641:ILU:cg::Convergence step 110 value 0
-DEAL:16641:ILUT:Bicgstab::Starting value 30.8770
-DEAL:16641:ILUT:Bicgstab::Convergence step 36 value 0
-DEAL:16641:Chebyshev:cg::Starting value 30.8770
-DEAL:16641:Chebyshev:cg::Convergence step 94 value 0
-DEAL:16641:Direct:cg::Starting value 30.8770
-DEAL:16641:Direct:cg::Convergence step 1 value 0


### PR DESCRIPTION
Relates to #4427.

It is enough to test with a mesh one level coarser. Furthermore, increase the block size in the `PreconditionBlock{Jacobi,SSOR,SOR}` tests a bit because they call into the LU factorization of BLAS and that gets a bit faster for larger block sizes.