### PR TITLE
Bugfix: Make icc happy, do not use undefined macros in vecrotization check

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -39,6 +39,7 @@
 // 'check_01_cpu_features.cmake', ensures that these feature are not only
 // present in the compilation unit but also working properly.
 
+#ifndef __ICC
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && not defined(__SSE2__)
 #error "Mismatch in vectorization capabilities: SSE2 was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
 #endif
@@ -48,6 +49,7 @@
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && not defined(__AVX512F__)
 #error "Mismatch in vectorization capabilities: AVX-512F was detected during configuration of deal.II and switched on, but it is apparently not available for the file you are trying to compile at the moment. Check compilation flags controlling the instruction set, such as -march=native."
 #endif
+#endif __ICC
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 // AVX, AVX-512
 #include <immintrin.h>


### PR DESCRIPTION
This hopefully fixes
  https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=7569