### PR TITLE
CMake: Add support for cotire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+code-gallery
+cotire

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -37,6 +37,9 @@ MACRO(DEAL_II_ADD_LIBRARY _library)
       ${ARGN}
       )
 
+    IF(DEAL_II_USE_COTIRE)
+      cotire(${_library}_${_build_lowercase})
+    ENDIF()
 
     #
     # Work around a problem in CUDA_WARP_SRCS that doesn't take empty list

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -38,6 +38,11 @@ MACRO(DEAL_II_ADD_LIBRARY _library)
       )
 
     IF(DEAL_II_USE_COTIRE)
+      IF(${_disable_unity_build_${_library}})
+        SET_TARGET_PROPERTIES(${_library}_${_build_lowercase}
+          PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE
+          )
+      ENDIF()
       cotire(${_library}_${_build_lowercase})
     ENDIF()
 

--- a/cmake/macros/macro_deal_ii_insource_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_insource_setup_target.cmake
@@ -41,6 +41,10 @@ MACRO(DEAL_II_INSOURCE_SETUP_TARGET _target _build)
       ${DEAL_II_INCLUDE_DIRS}
     )
 
+  IF(DEAL_II_USE_COTIRE)
+    cotire(${_target})
+  ENDIF()
+
 GET_PROPERTY(_type TARGET ${_target} PROPERTY TYPE)
 IF(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
   TARGET_LINK_LIBRARIES(${_target}

--- a/cmake/macros/macro_expand_instantiations.cmake
+++ b/cmake/macros/macro_expand_instantiations.cmake
@@ -81,6 +81,12 @@ MACRO(EXPAND_INSTANTIATIONS _target _inst_in_files)
 
     ADD_DEPENDENCIES(${_target}_${_build_lowercase} ${_target}_inst)
 
+    IF(TARGET ${_target}_${_build_lowercase}_pch)
+      ADD_DEPENDENCIES(${_target}_${_build_lowercase}_pch ${_target}_inst)
+    ENDIF()
+    IF(TARGET ${_target}_${_build_lowercase}_unity)
+      ADD_DEPENDENCIES(${_target}_${_build_lowercase}_unity ${_target}_inst)
+    ENDIF()
     IF(TARGET ${_target}_${_build_lowercase}_cuda)
       ADD_DEPENDENCIES(${_target}_${_build_lowercase}_cuda ${_target}_inst)
     ENDIF()

--- a/cmake/setup_external_macros.cmake
+++ b/cmake/setup_external_macros.cmake
@@ -25,3 +25,10 @@ INCLUDE(CheckIncludeFileCXX)
 
 INCLUDE(CheckCSourceCompiles)
 INCLUDE(CheckFunctionExists)
+
+IF(EXISTS ${CMAKE_SOURCE_DIR}/cotire/CMake/cotire.cmake)
+  INCLUDE(${CMAKE_SOURCE_DIR}/cotire/CMake/cotire.cmake)
+  IF("${DEAL_II_USE_COTIRE}" STREQUAL "")
+    SET(DEAL_II_USE_COTIRE TRUE)
+  ENDIF()
+ENDIF()

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -116,5 +116,6 @@ FILE(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/fe/*.h
   )
 
+SET(_disable_unity_build_obj_fe TRUE)
 DEAL_II_ADD_LIBRARY(obj_fe OBJECT ${_src} ${_header} ${_inst})
 EXPAND_INSTANTIATIONS(obj_fe "${_inst}")

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -57,5 +57,6 @@ FILE(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/grid/*.h
   )
 
+SET(_disable_unity_build_obj_grid TRUE)
 DEAL_II_ADD_LIBRARY(obj_grid OBJECT ${_src} ${_header} ${_inst})
 EXPAND_INSTANTIATIONS(obj_grid "${_inst}")

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -145,5 +145,6 @@ FILE(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/lac/*.h
   )
 
+SET(_disable_unity_build_obj_lac TRUE)
 DEAL_II_ADD_LIBRARY(obj_lac OBJECT ${_src} ${_header} ${_inst})
 EXPAND_INSTANTIATIONS(obj_lac "${_inst}")

--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -93,5 +93,6 @@ FILE(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/numerics/*.h
   )
 
+SET(_disable_unity_build_obj_numerics TRUE)
 DEAL_II_ADD_LIBRARY(obj_numerics OBJECT ${_src} ${_header} ${_inst})
 EXPAND_INSTANTIATIONS(obj_numerics "${_inst}")


### PR DESCRIPTION
Simply check out

  https://github.com/sakra/cotire

into ${CMAKE_SOURCE_DIR}/cotire

Closes #4392

TODO
 - [ ] create top level dependency for all `_inst` targets.
 - [x] selectively enable unity builds for individual object targets