### PR TITLE
add mg::Matrix::reset() and MGCoarseGridApplySmoother::clear()

### DIFF
--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -48,6 +48,11 @@ public:
   MGCoarseGridApplySmoother (const MGSmootherBase<VectorType> &coarse_smooth);
 
   /**
+   * Clear the pointer.
+   */
+  void clear ();
+
+  /**
    * Initialize new data.
    */
   void initialize (const MGSmootherBase<VectorType> &coarse_smooth);
@@ -328,6 +333,15 @@ MGCoarseGridApplySmoother<VectorType>::initialize (const MGSmootherBase<VectorTy
     SmartPointer<const MGSmootherBase<VectorType>, MGCoarseGridApplySmoother<VectorType> >
     (&coarse_smooth_,typeid(*this).name());
 }
+
+
+template<class VectorType>
+void
+MGCoarseGridApplySmoother<VectorType>::clear()
+{
+  coarse_smooth = nullptr;
+}
+
 
 template<class VectorType>
 void

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -65,6 +65,11 @@ namespace mg
     initialize(const MGLevelObject<MatrixType> &M);
 
     /**
+     * Reset the object.
+     */
+    void reset();
+
+    /**
      * Access matrix on a level.
      */
     const PointerMatrixBase<VectorType> &operator[] (unsigned int level) const;
@@ -181,6 +186,16 @@ namespace mg
     for (unsigned int level=p.min_level(); level <= p.max_level(); ++level)
       matrices[level] = std::shared_ptr<PointerMatrixBase<VectorType> >
                         (new_pointer_matrix_base(p[level], VectorType()));
+  }
+
+
+
+  template <typename VectorType>
+  inline
+  void
+  Matrix<VectorType>::reset ()
+  {
+    matrices.resize(0,0);
   }
 
 


### PR DESCRIPTION
this is a must to use those classes as member variables with adaptive refinement.