### PR TITLE
Disable -Winstantiation-after-specialization

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -103,6 +103,14 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-undefined-var-template")
 
   #
+  # Disable warnings about template instantiations for template arguments
+  # for which there is already a specialization. Our setup with the
+  # *.inst.in files makes it hard to selectively exclude these. There
+  # is no harm in still using the instantiation, it just has no effect.
+  #
+  ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-instantiation-after-specialization")
+
+  #
   # Clang versions prior to 3.6 emit a lot of false positives wrt
   # "-Wunused-function". Also suppress warnings for Xcode older than 6.3
   # (which is equivalent to clang < 3.6).


### PR DESCRIPTION
Currently, we get warnings like
> source/numerics/vector_tools_mean_value.inst:3194:7: warning: explicit instantiation of 'subtract_mean_value<dealii::LinearAlgebra::EpetraWrappers::Vector>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
 void subtract_mean_value( LinearAlgebra::EpetraWrappers::Vector  &, const std::vector<bool> &);
      ^
../source/numerics/vector_tools_mean_value.cc:26:3: note: previous template specialization is here
  subtract_mean_value(LinearAlgebra::EpetraWrappers::Vector &,


when compiling with clang-4. Due to our setup using the loops in the `*.inst.in` files it is not really feasible to selectively remove the explicit instantiations of the specializations. In the end there, is no harm in just keeping them, it's the other way round that would cause trouble (and normally results in a compiler error).