### PR TITLE
Initialization of Chebyshev smoother

### DIFF
--- a/doc/news/changes/minor/20170607NFehn
+++ b/doc/news/changes/minor/20170607NFehn
@@ -1,0 +1,6 @@
+Initialization of Chebyshev smoother: project vector onto space of vectors 
+with zero mean which is necessary in some cases where the matrix is singular.
+Rename variable is_initialized -> eigenvalues_are_initialized 
+in order to improve code readability.
+<br>
+(Niklas Fehn, 2017/06/07)

--- a/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -2,130 +2,130 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Starting value 0.009192
+DEAL:2d:cg:cg::Starting value 0.009297
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 7.683e-06
+DEAL:2d:cg:cg::Starting value 6.865e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 7.681e-08
+DEAL:2d:cg:cg::Starting value 7.160e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 4.627e-07
+DEAL:2d:cg::Convergence step 3 value 4.624e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.02924
+DEAL:2d:cg:cg::Starting value 0.02741
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 5.528e-06
+DEAL:2d:cg:cg::Starting value 5.357e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.143e-09
+DEAL:2d:cg:cg::Starting value 1.614e-09
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 3.949e-07
+DEAL:2d:cg::Convergence step 3 value 3.874e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 0.1049
+DEAL:2d:cg:cg::Starting value 0.09872
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.095e-06
+DEAL:2d:cg:cg::Starting value 3.026e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.204e-07
+DEAL:2d:cg:cg::Starting value 1.139e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.752e-10
+DEAL:2d:cg:cg::Starting value 1.716e-10
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 4 value 1.436e-08
+DEAL:2d:cg::Convergence step 4 value 1.475e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.7350
+DEAL:2d:cg:cg::Starting value 0.7288
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0001136
+DEAL:2d:cg:cg::Starting value 0.0001125
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 6.839e-07
+DEAL:2d:cg:cg::Starting value 5.547e-07
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.680e-09
+DEAL:2d:cg:cg::Starting value 1.651e-09
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.403e-08
+DEAL:2d:cg::Convergence step 4 value 1.217e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 2.771
+DEAL:2d:cg:cg::Starting value 2.750
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0001123
+DEAL:2d:cg:cg::Starting value 0.0001016
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.360e-06
+DEAL:2d:cg:cg::Starting value 1.332e-06
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 2.849e-09
+DEAL:2d:cg:cg::Starting value 3.295e-09
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.621e-08
+DEAL:2d:cg::Convergence step 4 value 1.552e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 10.93
+DEAL:2d:cg:cg::Starting value 10.87
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0006025
+DEAL:2d:cg:cg::Starting value 0.0005755
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 7.933e-07
+DEAL:2d:cg:cg::Starting value 8.458e-07
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.160e-08
+DEAL:2d:cg:cg::Starting value 1.274e-08
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 3.006e-08
+DEAL:2d:cg::Convergence step 4 value 3.067e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Starting value 0.1413
+DEAL:3d:cg:cg::Starting value 0.1418
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.091e-05
+DEAL:3d:cg:cg::Starting value 7.294e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.800e-09
+DEAL:3d:cg:cg::Starting value 4.688e-09
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 9.079e-09
+DEAL:3d:cg::Convergence step 3 value 9.196e-09
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.03499
+DEAL:3d:cg:cg::Starting value 0.03518
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0002863
+DEAL:3d:cg:cg::Starting value 0.0002887
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.469e-07
+DEAL:3d:cg:cg::Starting value 1.492e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.323e-06
+DEAL:3d:cg::Convergence step 3 value 1.324e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 0.06182
+DEAL:3d:cg:cg::Starting value 0.06164
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.408e-05
+DEAL:3d:cg:cg::Starting value 6.844e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 9.192e-07
+DEAL:3d:cg:cg::Starting value 7.352e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.274e-09
+DEAL:3d:cg:cg::Starting value 1.067e-09
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 4 value 6.463e-08
+DEAL:3d:cg::Convergence step 4 value 6.582e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.154
+DEAL:3d:cg:cg::Starting value 1.136
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0001372
+DEAL:3d:cg:cg::Starting value 0.0001381
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 1.430e-07
+DEAL:3d:cg:cg::Starting value 7.483e-08
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 4.895e-08
+DEAL:3d:cg::Convergence step 3 value 4.444e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.457
+DEAL:3d:cg:cg::Starting value 6.333
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0005811
+DEAL:3d:cg:cg::Starting value 0.0005547
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 2.200e-06
+DEAL:3d:cg:cg::Starting value 2.051e-06
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 2.510e-06
+DEAL:3d:cg::Convergence step 3 value 2.121e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 47.58
+DEAL:3d:cg:cg::Starting value 46.10
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.006336
+DEAL:3d:cg:cg::Starting value 0.006090
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.287e-06
+DEAL:3d:cg:cg::Starting value 8.064e-06
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 9.888e-06
+DEAL:3d:cg::Convergence step 3 value 9.434e-06

--- a/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
@@ -2,130 +2,130 @@
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
-DEAL:2d:cg:cg::Starting value 0.009346
+DEAL:2d:cg:cg::Starting value 0.009339
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 6.496e-06
+DEAL:2d:cg:cg::Starting value 6.557e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 6.938e-08
+DEAL:2d:cg:cg::Starting value 6.976e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
 DEAL:2d:cg::Convergence step 3 value 4.626e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.02705
+DEAL:2d:cg:cg::Starting value 0.02740
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 5.317e-06
+DEAL:2d:cg:cg::Starting value 5.355e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.194e-09
+DEAL:2d:cg:cg::Starting value 1.596e-09
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 3.838e-07
+DEAL:2d:cg::Convergence step 3 value 3.872e-07
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 0.09791
+DEAL:2d:cg:cg::Starting value 0.09908
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 2.929e-06
+DEAL:2d:cg:cg::Starting value 2.974e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.185e-07
+DEAL:2d:cg:cg::Starting value 1.212e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 1.692e-10
+DEAL:2d:cg:cg::Starting value 1.678e-10
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 4 value 1.780e-08
+DEAL:2d:cg::Convergence step 4 value 1.837e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.7249
+DEAL:2d:cg:cg::Starting value 0.7166
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0001120
+DEAL:2d:cg:cg::Starting value 0.0001109
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 6.729e-07
+DEAL:2d:cg:cg::Starting value 5.827e-07
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.656e-09
+DEAL:2d:cg:cg::Starting value 1.608e-09
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.401e-08
+DEAL:2d:cg::Convergence step 4 value 1.277e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 2.734
+DEAL:2d:cg:cg::Starting value 2.695
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0001108
+DEAL:2d:cg:cg::Starting value 9.568e-05
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.342e-06
+DEAL:2d:cg:cg::Starting value 1.282e-06
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 2.808e-09
+DEAL:2d:cg:cg::Starting value 3.283e-09
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 1.621e-08
+DEAL:2d:cg::Convergence step 4 value 1.559e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
-DEAL:2d:cg:cg::Starting value 10.78
+DEAL:2d:cg:cg::Starting value 10.65
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 0.0005940
+DEAL:2d:cg:cg::Starting value 0.0005552
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 7.817e-07
+DEAL:2d:cg:cg::Starting value 8.195e-07
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg:cg::Starting value 1.143e-08
+DEAL:2d:cg:cg::Starting value 1.269e-08
 DEAL:2d:cg:cg::Convergence step 2 value 0
-DEAL:2d:cg::Convergence step 4 value 3.006e-08
+DEAL:2d:cg::Convergence step 4 value 3.101e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
-DEAL:3d:cg:cg::Starting value 0.1412
+DEAL:3d:cg:cg::Starting value 0.1413
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.069e-05
+DEAL:3d:cg:cg::Starting value 7.120e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.813e-09
+DEAL:3d:cg:cg::Starting value 4.784e-09
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 9.066e-09
+DEAL:3d:cg::Convergence step 3 value 9.096e-09
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.03502
+DEAL:3d:cg:cg::Starting value 0.03518
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0002871
+DEAL:3d:cg:cg::Starting value 0.0002883
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.475e-07
+DEAL:3d:cg:cg::Starting value 1.489e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.325e-06
+DEAL:3d:cg::Convergence step 3 value 1.321e-06
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 0.06183
+DEAL:3d:cg:cg::Starting value 0.06170
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 7.450e-05
+DEAL:3d:cg:cg::Starting value 6.304e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 9.333e-07
+DEAL:3d:cg:cg::Starting value 5.815e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.291e-09
+DEAL:3d:cg:cg::Starting value 8.967e-10
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 4 value 6.450e-08
+DEAL:3d:cg::Convergence step 4 value 6.469e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.154
+DEAL:3d:cg:cg::Starting value 1.126
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0001378
+DEAL:3d:cg:cg::Starting value 0.0001398
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 1.421e-07
+DEAL:3d:cg:cg::Starting value 2.278e-08
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 4.863e-08
+DEAL:3d:cg::Convergence step 3 value 5.638e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.449
+DEAL:3d:cg:cg::Starting value 6.331
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.0005799
+DEAL:3d:cg:cg::Starting value 0.0005469
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 2.195e-06
+DEAL:3d:cg:cg::Starting value 2.015e-06
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 2.497e-06
+DEAL:3d:cg::Convergence step 3 value 2.003e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 47.58
+DEAL:3d:cg:cg::Starting value 47.14
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 0.006336
+DEAL:3d:cg:cg::Starting value 0.006202
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg:cg::Starting value 8.282e-06
+DEAL:3d:cg:cg::Starting value 8.144e-06
 DEAL:3d:cg:cg::Convergence step 2 value 0
-DEAL:3d:cg::Convergence step 3 value 9.898e-06
+DEAL:3d:cg::Convergence step 3 value 9.599e-06

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=3.output
@@ -5,65 +5,65 @@ DEAL:2d:cg::Starting value 9.000
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 3.519e-08
+DEAL:2d:cg::Convergence step 3 value 3.525e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 2.852e-08
+DEAL:2d:cg::Convergence step 3 value 2.883e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.7172
+DEAL:2d:cg:cg::Starting value 0.7112
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0001433
+DEAL:2d:cg:cg::Starting value 0.0001324
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.394e-07
+DEAL:2d:cg:cg::Starting value 2.886e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 2.855e-07
+DEAL:2d:cg::Convergence step 3 value 4.342e-07
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 2.710
+DEAL:2d:cg:cg::Starting value 2.690
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0002209
+DEAL:2d:cg:cg::Starting value 0.0002067
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.547e-08
+DEAL:2d:cg:cg::Starting value 4.530e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 7.112e-07
+DEAL:2d:cg::Convergence step 3 value 7.932e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 9.648e-10
+DEAL:3d:cg::Convergence step 3 value 9.765e-10
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.307e-07
+DEAL:3d:cg::Convergence step 3 value 1.305e-07
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.110
+DEAL:3d:cg:cg::Starting value 1.088
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.566e-05
+DEAL:3d:cg:cg::Starting value 3.828e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.159e-07
+DEAL:3d:cg:cg::Starting value 1.155e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 2.775e-08
+DEAL:3d:cg::Convergence step 3 value 2.674e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.209
+DEAL:3d:cg:cg::Starting value 6.089
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0006089
+DEAL:3d:cg:cg::Starting value 0.0005714
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.952e-06
+DEAL:3d:cg:cg::Starting value 1.861e-06
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.139e-06
+DEAL:3d:cg::Convergence step 3 value 1.215e-06

--- a/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
@@ -12,58 +12,58 @@ DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
 DEAL:2d:cg:cg::Convergence step 0 value 0
-DEAL:2d:cg::Convergence step 3 value 2.901e-08
+DEAL:2d:cg::Convergence step 3 value 2.884e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
-DEAL:2d:cg:cg::Starting value 0.7073
+DEAL:2d:cg:cg::Starting value 0.6993
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0001412
+DEAL:2d:cg:cg::Starting value 0.0001337
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.343e-07
+DEAL:2d:cg:cg::Starting value 2.994e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 2.869e-07
+DEAL:2d:cg::Convergence step 3 value 3.919e-07
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
-DEAL:2d:cg:cg::Starting value 2.673
+DEAL:2d:cg:cg::Starting value 2.636
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 0.0002179
+DEAL:2d:cg:cg::Starting value 0.0001975
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg:cg::Starting value 3.494e-08
+DEAL:2d:cg:cg::Starting value 4.406e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0
-DEAL:2d:cg::Convergence step 3 value 7.111e-07
+DEAL:2d:cg::Convergence step 3 value 8.342e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 9.634e-10
+DEAL:3d:cg::Convergence step 3 value 9.666e-10
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
 DEAL:3d:cg:cg::Convergence step 0 value 0
-DEAL:3d:cg::Convergence step 3 value 1.304e-07
+DEAL:3d:cg::Convergence step 3 value 1.308e-07
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 1.110
+DEAL:3d:cg:cg::Starting value 1.076
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 4.552e-05
+DEAL:3d:cg:cg::Starting value 3.521e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.159e-07
+DEAL:3d:cg:cg::Starting value 1.182e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 2.755e-08
+DEAL:3d:cg::Convergence step 3 value 3.247e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 6.201
+DEAL:3d:cg:cg::Starting value 6.088
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 0.0006074
+DEAL:3d:cg:cg::Starting value 0.0005598
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg:cg::Starting value 1.949e-06
+DEAL:3d:cg:cg::Starting value 1.843e-06
 DEAL:3d:cg:cg::Convergence step 1 value 0
-DEAL:3d:cg::Convergence step 3 value 1.141e-06
+DEAL:3d:cg::Convergence step 3 value 1.246e-06


### PR DESCRIPTION
project vector onto space of vectors with zero mean which is necessary in some cases where the matrix is singular
rename variable is_initialized -> eigenvalues_are_initialized in order to improve code readability