### PR TITLE
Also clear triangulation signals on destruction

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2120,9 +2120,10 @@ public:
 
     /**
      * This signal is triggered whenever the Triangulation::clear() function
-     * is called. This signal is also triggered when loading a triangulation
-     * from an archive via Triangulation::load() as the previous content of
-     * the triangulation is first destroyed.
+     * is called and in the destructor of the triangulation. This signal is
+     * also triggered when loading a triangulation from an archive via
+     * Triangulation::load() as the previous content of the triangulation is
+     * first destroyed.
      *
      * The signal is triggered before the data structures of the
      * triangulation are destroyed. In other words, the functions

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9039,6 +9039,9 @@ Triangulation<dim, spacedim>::operator= (Triangulation<dim, spacedim> &&tria)
 template <int dim, int spacedim>
 Triangulation<dim, spacedim>::~Triangulation ()
 {
+  // notify listeners that the triangulation is going down...
+  signals.clear();
+
   levels.clear ();
 
   // the vertex_to_boundary_id_map_1d field should be unused except in


### PR DESCRIPTION
I see no reason why we should not clear the signals on the destructor call of `Triangulation` (at the least the `signals.clear` signals) as it is also done in `Triangulation::clear()`.

Noticed while working on #4404.