### PR TITLE
Let FE::clone() return a std::unique_ptr.

### DIFF
--- a/doc/news/changes/incompatibilities/20170601Bangerth
+++ b/doc/news/changes/incompatibilities/20170601Bangerth
@@ -1,0 +1,6 @@
+Changed: The FiniteElement::clone() function and all of its
+implementations in derived classes now return a std::unique_ptr rather
+than a plain pointer to a finite element object. User-implemented
+finite element classes need to be adjusted accordingly.
+<br>
+(Wolfgang Bangerth, 2017/06/01)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -24,6 +24,9 @@
 #include <deal.II/fe/block_mask.h>
 #include <deal.II/fe/mapping.h>
 
+#include <memory>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim> class FEValuesBase;
@@ -697,12 +700,19 @@ public:
   virtual ~FiniteElement ();
 
   /**
-   * A sort of virtual copy constructor. Some places in the library, for
+   * A sort of virtual copy constructor, this function returns a copy of
+   * the finite element object. Derived classes need to override the function
+   * here in this base class and return an object of the same type as the
+   * derived class.
+   *
+   * Some places in the library, for
    * example the constructors of FESystem as well as the hp::FECollection
    * class, need to make copies of finite elements without knowing their exact
    * type. They do so through this function.
    */
-  virtual FiniteElement<dim,spacedim> *clone() const = 0;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim>>
+                                            clone() const = 0;
 
   /**
    * Return a string that uniquely identifies a finite element. The general

--- a/include/deal.II/fe/fe_abf.h
+++ b/include/deal.II/fe/fe_abf.h
@@ -130,7 +130,10 @@ public:
                                                             std::vector<double>                &nodal_values) const;
 
   virtual std::size_t memory_consumption () const;
-  virtual FiniteElement<dim> *clone() const;
+
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
 private:
   /**

--- a/include/deal.II/fe/fe_bdm.h
+++ b/include/deal.II/fe/fe_bdm.h
@@ -70,7 +70,9 @@ public:
    */
   virtual std::string get_name () const;
 
-  virtual FiniteElement<dim> *clone () const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
   // documentation inherited from the base class
   virtual

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -192,14 +192,11 @@ public:
    */
   virtual std::string get_name () const;
 
-protected:
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+protected:
 
   /**
    * Only for internal use. Its full name is @p get_dofs_per_object_vector

--- a/include/deal.II/fe/fe_dg_vector.h
+++ b/include/deal.II/fe/fe_dg_vector.h
@@ -59,9 +59,6 @@ public:
    * Constructor for the vector element of degree @p p.
    */
   FE_DGVector (const unsigned int p, MappingType m);
-public:
-
-  FiniteElement<dim, spacedim> *clone() const;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
@@ -70,6 +67,9 @@ public:
    */
   virtual std::string get_name () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -21,6 +21,9 @@
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/base/std_cxx14/memory.h>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -51,10 +54,10 @@ FE_DGVector<PolynomialType,dim,spacedim>::FE_DGVector (
 
 
 template <class PolynomialType, int dim, int spacedim>
-FiniteElement<dim, spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGVector<PolynomialType,dim,spacedim>::clone() const
 {
-  return new FE_DGVector<PolynomialType, dim, spacedim>(*this);
+  return std_cxx14::make_unique<FE_DGVector<PolynomialType, dim, spacedim>>(*this);
 }
 
 

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -472,14 +472,9 @@ public:
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
   get_constant_modes () const;
 
-protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
 private:
 

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -433,14 +433,9 @@ public:
    */
   virtual std::size_t memory_consumption () const;
 
-protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
 private:
 

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -281,6 +281,10 @@ public:
    */
   virtual std::string get_name () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
+
   // for documentation, see the FiniteElement base class
   virtual
   UpdateFlags
@@ -532,13 +536,6 @@ private:
   };
 
 protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
 
   /**
    * Prepare internal data structures and fill in values independent of the

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -322,6 +322,9 @@ public:
    */
   virtual std::size_t memory_consumption () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
 protected:
   /**
@@ -333,13 +336,6 @@ protected:
    * The degree of these polynomials is <tt>polynomials.size()-1</tt>.
    */
   FE_DGQ (const std::vector<Polynomials::Polynomial<double> > &polynomials);
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim, spacedim> *clone() const;
 
 private:
   /**
@@ -432,14 +428,9 @@ public:
   void
   convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
                                                             std::vector<double>                &nodal_values) const;
-
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 };
 
 
@@ -480,13 +471,9 @@ public:
    */
   virtual std::string get_name () const;
 
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 };
 
 
@@ -531,13 +518,9 @@ public:
    */
   virtual std::string get_name () const;
 
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 };
 
 

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -273,12 +273,9 @@ private:
                const std::vector<std::vector<std::function<const Function<spacedim> *(const typename Triangulation<dim, spacedim>::cell_iterator &) > > > &functions);
 public:
 
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
   virtual
   UpdateFlags

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -59,7 +59,9 @@ public:
    */
   FE_FaceQ (const unsigned int p);
 
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
@@ -156,10 +158,9 @@ public:
    */
   FE_FaceQ (const unsigned int p);
 
-  /**
-   * Clone method.
-   */
-  virtual FiniteElement<1,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<1,spacedim>>
+                                          clone() const;
 
   /**
    * Return a string that uniquely identifies a finite element. This class
@@ -358,10 +359,9 @@ public:
    */
   FE_FaceP(unsigned int p);
 
-  /**
-   * Clone method.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
   /**
    * Return a string that uniquely identifies a finite element. This class

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -268,7 +268,10 @@ public:
   get_constant_modes () const;
 
   virtual std::size_t memory_consumption () const;
-  virtual FiniteElement<dim> *clone() const;
+
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
 private:
   /**

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -95,14 +95,8 @@ public:
   FE_Nothing (const unsigned int n_components = 1,
               const bool dominate = false);
 
-  /**
-   * A sort of virtual copy constructor. Some places in the library, for
-   * example the constructors of FESystem as well as the hp::FECollection
-   * class, need to make copied of finite elements without knowing their exact
-   * type. They do so through this function.
-   */
   virtual
-  FiniteElement<dim,spacedim> *
+  std::unique_ptr<FiniteElement<dim,spacedim> >
   clone() const;
 
   /**

--- a/include/deal.II/fe/fe_p1nc.h
+++ b/include/deal.II/fe/fe_p1nc.h
@@ -265,7 +265,9 @@ public:
 
   virtual UpdateFlags requires_update_flags (const UpdateFlags flags) const;
 
-  virtual FiniteElement<2,2> *clone () const;
+  virtual
+  std::unique_ptr<FiniteElement<2,2>>
+                                   clone() const;
 
   /**
    * Destructor.

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -586,6 +586,10 @@ public:
    */
   virtual std::string get_name () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
+
   /**
    * Implementation of the corresponding function in the FiniteElement
    * class.  Since the current element is interpolatory, the nodal
@@ -597,15 +601,6 @@ public:
   void
   convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,
                                                             std::vector<double>                &nodal_values) const;
-
-protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
 };
 
 

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -142,13 +142,9 @@ public:
   virtual bool has_support_on_face (const unsigned int shape_index,
                                     const unsigned int face_index) const;
 
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
 private:
 

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -294,13 +294,9 @@ public:
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
   get_constant_modes () const;
 
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
 private:
 

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -553,6 +553,10 @@ public:
    */
   virtual std::string get_name () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
+
   /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
@@ -687,14 +691,6 @@ public:
    */
   virtual std::pair<Table<2,bool>, std::vector<unsigned int> >
   get_constant_modes () const;
-
-protected:
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim> *clone() const;
 
 private:
 

--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -125,6 +125,10 @@ public:
    */
   virtual std::string get_name () const;
 
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
+
   /**
    * Implementation of the corresponding function in the FiniteElement
    * class.  Since the current element is interpolatory, the nodal
@@ -155,15 +159,6 @@ public:
   FiniteElementDomination::Domination
   compare_for_face_domination (const FiniteElement<dim,spacedim> &fe_other) const;
   //@}
-
-protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
 };
 
 

--- a/include/deal.II/fe/fe_rannacher_turek.h
+++ b/include/deal.II/fe/fe_rannacher_turek.h
@@ -65,7 +65,10 @@ public:
                     const unsigned int n_face_support_points = 2);
 
   virtual std::string get_name() const;
-  virtual FiniteElement<dim> *clone() const;
+
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
   // documentation inherited from the base class
   virtual

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -117,6 +117,10 @@ public:
    */
   virtual std::string get_name () const;
 
+  // documentation inherited from the base class
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
@@ -142,7 +146,6 @@ public:
   get_constant_modes () const;
 
   virtual std::size_t memory_consumption () const;
-  virtual FiniteElement<dim> *clone() const;
 
 private:
   /**
@@ -254,9 +257,11 @@ public:
    */
   virtual std::string get_name () const;
 
-  virtual FiniteElement<dim> *clone () const;
-
   // documentation inherited from the base class
+  virtual
+  std::unique_ptr<FiniteElement<dim,dim> >
+  clone() const;
+
   virtual
   void
   convert_generalized_support_point_values_to_nodal_values (const std::vector<Vector<double> > &support_point_values,

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -444,6 +444,10 @@ public:
 
   // for documentation, see the FiniteElement base class
   virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
+
+  virtual
   UpdateFlags
   requires_update_flags (const UpdateFlags update_flags) const;
 
@@ -870,14 +874,6 @@ public:
   virtual std::size_t memory_consumption () const;
 
 protected:
-
-  /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
-
 
   virtual typename FiniteElement<dim,spacedim>::InternalDataBase *
   get_data (const UpdateFlags                                                    update_flags,

--- a/include/deal.II/fe/fe_trace.h
+++ b/include/deal.II/fe/fe_trace.h
@@ -52,18 +52,15 @@ public:
   FE_TraceQ(unsigned int p);
 
   /**
-   * @p clone function instead of a copy constructor.
-   *
-   * This function is needed by the constructors of @p FESystem.
-   */
-  virtual FiniteElement<dim,spacedim> *clone() const;
-
-  /**
    * Return a string that uniquely identifies a finite element. This class
    * returns <tt>FE_DGQ<dim>(degree)</tt>, with <tt>dim</tt> and
    * <tt>degree</tt> replaced by appropriate values.
    */
   virtual std::string get_name () const;
+
+  virtual
+  std::unique_ptr<FiniteElement<dim,spacedim> >
+  clone() const;
 
   /**
    * This function returns @p true, if the shape function @p shape_index has

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -30,6 +30,8 @@
 
 #include <sstream>
 #include <iostream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 //TODO: implement the adjust_quad_dof_index_for_face_orientation_table and
 //adjust_line_dof_index_for_line_orientation_table fields, and write tests
@@ -126,10 +128,10 @@ FE_ABF<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_ABF<dim>::clone() const
 {
-  return new FE_ABF<dim>(rt_order);
+  return std_cxx14::make_unique<FE_ABF<dim>>(rt_order);
 }
 
 

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -114,10 +115,10 @@ FE_BDM<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_BDM<dim>::clone() const
 {
-  return new FE_BDM<dim>(*this);
+  return std_cxx14::make_unique<FE_BDM<dim>>(*this);
 }
 
 

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -26,6 +26,8 @@
 
 #include <vector>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -315,10 +317,10 @@ FE_Bernstein<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Bernstein<dim,spacedim>::clone() const
 {
-  return new FE_Bernstein<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Bernstein<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_dg_vector.cc
+++ b/source/fe/fe_dg_vector.cc
@@ -20,6 +20,9 @@
 #include <deal.II/base/polynomials_nedelec.h>
 #include <deal.II/base/polynomials_raviart_thomas.h>
 
+#include <deal.II/base/std_cxx14/memory.h>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>

--- a/source/fe/fe_dgp.cc
+++ b/source/fe/fe_dgp.cc
@@ -18,6 +18,8 @@
 #include <deal.II/fe/fe_tools.h>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -63,10 +65,10 @@ FE_DGP<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGP<dim,spacedim>::clone() const
 {
-  return new FE_DGP<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_DGP<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -18,6 +18,8 @@
 #include <deal.II/fe/fe_tools.h>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -156,10 +158,10 @@ FE_DGPMonomial<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_DGPMonomial<dim>::clone() const
 {
-  return new FE_DGPMonomial<dim>(*this);
+  return std_cxx14::make_unique<FE_DGPMonomial<dim>>(*this);
 }
 
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -24,6 +24,8 @@
 #include <deal.II/fe/fe_values.h>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -114,10 +116,10 @@ FE_DGPNonparametric<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGPNonparametric<dim,spacedim>::clone() const
 {
-  return new FE_DGPNonparametric<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_DGPNonparametric<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -24,6 +24,8 @@
 
 #include <iostream>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -127,10 +129,10 @@ convert_generalized_support_point_values_to_nodal_values (const std::vector<Vect
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGQ<dim, spacedim>::clone() const
 {
-  return new FE_DGQ<dim, spacedim>(*this);
+  return std_cxx14::make_unique<FE_DGQ<dim, spacedim>>(*this);
 }
 
 
@@ -808,7 +810,7 @@ convert_generalized_support_point_values_to_nodal_values (const std::vector<Vect
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGQArbitraryNodes<dim,spacedim>::clone() const
 {
   // Construct a dummy quadrature formula containing the FE's nodes:
@@ -818,7 +820,7 @@ FE_DGQArbitraryNodes<dim,spacedim>::clone() const
     qpoints[i] = Point<1>(this->unit_support_points[lexicographic[i]][0]);
   Quadrature<1> pquadrature(qpoints);
 
-  return new FE_DGQArbitraryNodes<dim,spacedim>(pquadrature);
+  return std_cxx14::make_unique<FE_DGQArbitraryNodes<dim,spacedim>>(pquadrature);
 }
 
 
@@ -857,10 +859,10 @@ FE_DGQLegendre<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGQLegendre<dim,spacedim>::clone() const
 {
-  return new FE_DGQLegendre<dim,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_DGQLegendre<dim,spacedim>>(this->degree);
 }
 
 
@@ -912,10 +914,10 @@ FE_DGQHermite<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_DGQHermite<dim,spacedim>::clone() const
 {
-  return new FE_DGQHermite<dim,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_DGQHermite<dim,spacedim>>(this->degree);
 }
 
 

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -15,8 +15,10 @@
 
 
 #include <deal.II/fe/fe_enriched.h>
-
 #include <deal.II/fe/fe_tools.h>
+
+#include <deal.II/base/std_cxx14/memory.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -236,7 +238,7 @@ FE_Enriched<dim,spacedim>::shape_value(const unsigned int   i,
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Enriched<dim,spacedim>::clone() const
 {
   std::vector< const FiniteElement< dim, spacedim > * > fes;
@@ -248,7 +250,9 @@ FE_Enriched<dim,spacedim>::clone() const
       multiplicities.push_back(this->element_multiplicity(i) );
     }
 
-  return new FE_Enriched<dim,spacedim>(fes, multiplicities, get_enrichments());
+  return std::unique_ptr<FE_Enriched<dim,spacedim>>(new FE_Enriched<dim,spacedim>(fes,
+                                                    multiplicities,
+                                                    get_enrichments()));
 }
 
 

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -20,7 +20,9 @@
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/householder.h>
+
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -102,10 +104,10 @@ FE_FaceQ<dim,spacedim>::FE_FaceQ (const unsigned int degree)
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_FaceQ<dim,spacedim>::clone() const
 {
-  return new FE_FaceQ<dim,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_FaceQ<dim,spacedim>>(this->degree);
 }
 
 
@@ -329,10 +331,10 @@ FE_FaceQ<1,spacedim>::FE_FaceQ (const unsigned int degree)
 
 
 template <int spacedim>
-FiniteElement<1,spacedim> *
-FE_FaceQ<1,spacedim>::clone() const
+std::unique_ptr<FiniteElement<1,spacedim>>
+                                        FE_FaceQ<1,spacedim>::clone() const
 {
-  return new FE_FaceQ<1,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_FaceQ<1,spacedim>>(this->degree);
 }
 
 
@@ -527,10 +529,10 @@ FE_FaceP<dim,spacedim>::FE_FaceP (const unsigned int degree)
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_FaceP<dim,spacedim>::clone() const
 {
-  return new FE_FaceP<dim,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_FaceP<dim,spacedim>>(this->degree);
 }
 
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -28,8 +28,10 @@
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/vector.h>
+
 #include <sstream>
 #include <iostream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 //TODO: implement the adjust_quad_dof_index_for_face_orientation_table and
 //adjust_line_dof_index_for_line_orientation_table fields, and write tests
@@ -207,10 +209,10 @@ FE_Nedelec<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim>
-*FE_Nedelec<dim>::clone () const
+std::unique_ptr<FiniteElement<dim,dim> >
+FE_Nedelec<dim>::clone () const
 {
-  return new FE_Nedelec<dim> (*this);
+  return std_cxx14::make_unique<FE_Nedelec<dim> >(*this);
 }
 
 //---------------------------------------------------------------------------

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/fe/fe_nothing.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -48,10 +49,10 @@ FE_Nothing<dim,spacedim>::FE_Nothing (const unsigned int n_components,
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Nothing<dim,spacedim>::clone() const
 {
-  return new FE_Nothing<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Nothing<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -15,6 +15,7 @@
 
 
 #include <deal.II/fe/fe_p1nc.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -64,9 +65,10 @@ UpdateFlags FE_P1NC::requires_update_flags (const UpdateFlags flags) const
 
 
 
-FiniteElement<2,2> *FE_P1NC::clone () const
+std::unique_ptr<FiniteElement<2,2>>
+                                 FE_P1NC::clone () const
 {
-  return new FE_P1NC(*this);
+  return std_cxx14::make_unique<FE_P1NC>(*this);
 }
 
 

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -157,10 +158,10 @@ convert_generalized_support_point_values_to_nodal_values (const std::vector<Vect
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Q<dim,spacedim>::clone() const
 {
-  return new FE_Q<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Q<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -33,6 +33,7 @@
 #include <vector>
 #include <sstream>
 #include <memory>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -320,10 +321,10 @@ FE_Q_Bubbles<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Q_Bubbles<dim,spacedim>::clone() const
 {
-  return new FE_Q_Bubbles<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Q_Bubbles<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -166,10 +167,10 @@ FE_Q_DG0<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Q_DG0<dim,spacedim>::clone() const
 {
-  return new FE_Q_DG0<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Q_DG0<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 //TODO: implement the adjust_quad_dof_index_for_face_orientation_table and
 //adjust_line_dof_index_for_line_orientation_table fields, and write tests
@@ -125,10 +126,10 @@ FE_Q_Hierarchical<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_Q_Hierarchical<dim>::clone() const
 {
-  return new FE_Q_Hierarchical<dim>(*this);
+  return std_cxx14::make_unique<FE_Q_Hierarchical<dim>>(*this);
 }
 
 

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -92,10 +93,10 @@ convert_generalized_support_point_values_to_nodal_values (const std::vector<Vect
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_Q_iso_Q1<dim,spacedim>::clone() const
 {
-  return new FE_Q_iso_Q1<dim,spacedim>(*this);
+  return std_cxx14::make_unique<FE_Q_iso_Q1<dim,spacedim>>(*this);
 }
 
 

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -70,9 +71,10 @@ std::string FE_RannacherTurek<dim>::get_name() const
 
 
 template <int dim>
-FiniteElement<dim> *FE_RannacherTurek<dim>::clone() const
+std::unique_ptr<FiniteElement<dim,dim> >
+FE_RannacherTurek<dim>::clone() const
 {
-  return new FE_RannacherTurek<dim>(this->order, this->n_face_support_points);
+  return std_cxx14::make_unique<FE_RannacherTurek<dim>>(this->order, this->n_face_support_points);
 }
 
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -30,6 +30,7 @@
 
 #include <sstream>
 #include <iostream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 //TODO: implement the adjust_quad_dof_index_for_face_orientation_table and
 //adjust_line_dof_index_for_line_orientation_table fields, and write tests
@@ -122,10 +123,10 @@ FE_RaviartThomas<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_RaviartThomas<dim>::clone() const
 {
-  return new FE_RaviartThomas<dim>(*this);
+  return std_cxx14::make_unique<FE_RaviartThomas<dim>>(*this);
 }
 
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -27,6 +27,7 @@
 #include <deal.II/fe/fe_tools.h>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -119,10 +120,10 @@ FE_RaviartThomasNodal<dim>::get_name () const
 
 
 template <int dim>
-FiniteElement<dim> *
+std::unique_ptr<FiniteElement<dim,dim> >
 FE_RaviartThomasNodal<dim>::clone() const
 {
-  return new FE_RaviartThomasNodal<dim>(*this);
+  return std_cxx14::make_unique<FE_RaviartThomasNodal<dim>>(*this);
 }
 
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_tools.h>
 
 #include <sstream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -319,7 +320,7 @@ FESystem<dim,spacedim>::get_name () const
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FESystem<dim,spacedim>::clone() const
 {
   std::vector< const FiniteElement<dim,spacedim>* >  fes;
@@ -330,7 +331,7 @@ FESystem<dim,spacedim>::clone() const
       fes.push_back( & base_element(i) );
       multiplicities.push_back(this->element_multiplicity(i) );
     }
-  return new FESystem<dim,spacedim>(fes, multiplicities);
+  return std_cxx14::make_unique<FESystem<dim,spacedim>>(fes, multiplicities);
 }
 
 
@@ -1477,9 +1478,7 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
         {
           clone_base_elements += Threads::new_task ([ &,i,ind] ()
           {
-            base_elements[ind]
-              = std::make_pair (std::unique_ptr<FiniteElement<dim,spacedim>>(fes[i]->clone()),
-                                multiplicities[i]);
+            base_elements[ind] = { fes[i]->clone(), multiplicities[i] };
           });
           ++ind;
         }

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <fstream>
 #include <iostream>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -64,10 +65,10 @@ FE_TraceQ<dim,spacedim>::FE_TraceQ (const unsigned int degree)
 
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr<FiniteElement<dim,spacedim> >
 FE_TraceQ<dim,spacedim>::clone() const
 {
-  return new FE_TraceQ<dim,spacedim>(this->degree);
+  return std_cxx14::make_unique<FE_TraceQ<dim,spacedim>>(this->degree);
 }
 
 


### PR DESCRIPTION
This fixes #4209. The only interesting part is the fact that I can't use
std_cxx14::make_unique() for FE_Enriched because it wants to call a
constructor that is not public. So I have to make the cast from a
pointer to the std::unique_ptr by hand. The rest is boring and
mechanical.

The patch by itself fails a lot of tests because the current master
branch is broken. But when tested together with #4464, I have only
3 failing tests that are all unrelated to the best of my knowledge.