### PR TITLE
Add secondary output for one test.

### DIFF
--- a/tests/trilinos/precondition.output.2
+++ b/tests/trilinos/precondition.output.2
@@ -34,7 +34,7 @@ DEAL:04225:BlockSSOR:cg::Convergence step 60 value 0
 DEAL:04225:BlockSOR:Bicgstab::Starting value 21.8299
 DEAL:04225:BlockSOR:Bicgstab::Convergence step 38 value 0
 DEAL:04225:IC:cg::Starting value 21.8299
-DEAL:04225:IC:cg::Convergence step 68 value 0
+DEAL:04225:IC:cg::Convergence step 70 value 0
 DEAL:04225:ILU:cg::Starting value 21.8299
 DEAL:04225:ILU:cg::Convergence step 57 value 0
 DEAL:04225:ILUT:Bicgstab::Starting value 21.8299


### PR DESCRIPTION
The test takes one more or less iteration, depending on the system.
So add a secondary output. This gets me down to zero failing
tests again on my system.