### PR TITLE
Add a .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+#
+# An approximation of deal.II indent style as "defined" by
+#   ./contrib/styles/astyle.rc
+#
+
+BasedOnStyle: "LLVM"
+
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlwaysBreakTemplateDeclarations: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: true
+
+ColumnLimit:     80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+IndentWidth:     2
+NamespaceIndentation: All
+Standard:        Cpp11
+
+TabWidth:        4
+UseTab:          Never


### PR DESCRIPTION
This commit adds a .clang-format [1] file that approximates our indent
style as defined by
  ./contrib/styles/astyle.rc

The motivation behind this commit is the simple fact that clang-format
(utilizing the clang lexer and tokenizer) is a far superior indenter
than any of the alternatives (including astyle).

The format file tries to give a close approximation to the output of
astyle. Unfortunately astyle misinterprets heavily templated stuff
quite a bit, so that
  astyle after clang-format  =  clang-format
does not always hold.

[1] https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Todo:
 - [ ] do not wrap comments
 - [ ] try to unify indenting a bit more
 - [ ] align operators ?

A few random examples: