### PR TITLE
Make some documentation links relative.

### DIFF
--- a/examples/step-1/doc/intro.dox
+++ b/examples/step-1/doc/intro.dox
@@ -86,8 +86,8 @@ tutorial is that you're interested in) and type
 The first command sets up the files that describe which include files this
 tutorial program depends on, how to compile it and how to run it. This command
 should find the installed deal.II libraries as well that were generated when
-you compiled and installed everything as described in the <a
-href="http://www.dealii.org/readme.html">deal.II ReadMe file</a>.
+you compiled and installed everything as described in the
+<a href="../../readme.html" target="body">README</a> file.
 If this command should fail to find the deal.II library, then you need to
 provide the path to the installation using the command
 @code

--- a/examples/step-17/doc/intro.dox
+++ b/examples/step-17/doc/intro.dox
@@ -19,7 +19,7 @@ you want to run in %parallel on a cluster, you also need <a
 href="http://www-users.cs.umn.edu/~karypis/metis/index.html"
 target="_top">METIS</a> to partition meshes. The installation of deal.II
 together with these two additional libraries is described in the <a
-href="https://www.dealii.org/developer/readme.html" target="body">README</a> file.
+href="../../readme.html" target="body">README</a> file.
 
 Now, for the details: as mentioned, the program does not compute anything new,
 so the use of finite element classes, etc., is exactly the same as before. The

--- a/examples/step-36/doc/results.dox
+++ b/examples/step-36/doc/results.dox
@@ -170,12 +170,12 @@ procedure. A sketch of how this can be done can be found in @ref
 step_17 "step-17".
 
 <li> Finally, there are alternatives to using the SLEPc eigenvalue
-solvers. deal.II has interfaces to one of them, ARPACK (see
-http://www.dealii.org/developer/external-libs/arpack.html), implemented in the
-ArpackSolver class. Here is a short and quick overview of what one would need
-to change to use it, provided you have a working installation of ARPACK and
-deal.II has been configured properly for it (see the deal.II ReadMe file
-at http://www.dealii.org/readme.html):
+solvers. deal.II has interfaces to one of them, ARPACK (see <a
+href="../../external-libs/arpack.html">the ARPACK configuration page</a> for
+setup instructions), implemented in the ArpackSolver class. Here is a short and
+quick overview of what one would need to change to use it, provided you have a
+working installation of ARPACK and deal.II has been configured properly for it
+(see the deal.II <a href="../../readme.html" target="body">README</a> file):
 
 First, in order to use the ARPACK interfaces, we can go back to using standard
 deal.II matrices and vectors, so we start by replacing the PETSc and SLEPc


### PR DESCRIPTION
The other tutorial programs use relative links in these cases.

Fixes #4264.