### PR TITLE
Add test where inversion in real_to_unit_cell fails

### DIFF
--- a/tests/mappings/mapping_real_to_unit_q1_singular.cc
+++ b/tests/mappings/mapping_real_to_unit_q1_singular.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that MappingQ1::transform_real_to_unit_cell can handle the case of a
+// singular discriminant. Previously we used to have a division by zero
+
+#include "../tests.h"
+
+#include <deal.II/base/utilities.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/fe/mapping_q1.h>
+
+
+template<int dim>
+void test_real_to_unit_cell()
+{
+  deallog << "dim=" << dim << std::endl;
+
+  Triangulation<dim>   triangulation;
+  GridGenerator::hyper_ball (triangulation);
+
+  Point<dim> point;
+  MappingQGeneric<dim> mapping(1);
+
+  point[1] = -1./(1+std::sqrt(2.0))/std::sqrt(2);
+
+  // check on cell 2
+  typename Triangulation<dim>::cell_iterator cell = triangulation.begin();
+  ++cell;
+  try
+    {
+      mapping.transform_real_to_unit_cell(cell, point);
+    }
+  catch (typename Mapping<dim>::ExcTransformationFailed)
+    {
+      deallog << "Transformation for point " << point << " on cell with "
+              << "center " << cell->center() << " is not invertible" << std::endl;
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  std::ofstream logfile ("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  test_real_to_unit_cell<2>();
+
+  return 0;
+}

--- a/tests/mappings/mapping_real_to_unit_q1_singular.output
+++ b/tests/mappings/mapping_real_to_unit_q1_singular.output
@@ -1,0 +1,4 @@
+
+DEAL::dim=2
+DEAL::Transformation for point 0.00000 -0.292893 on cell with center -0.500000 -1.38778e-17 is not invertible
+DEAL::OK


### PR DESCRIPTION
I managed to find a case where the discriminant in #4404 regarding the 2D `internal::MappingQ1::transform_real_to_unit_cell` is exactly zero and where `a` and `b` are zero. This test makes sure that we keep the code right in the future (at least in debug mode, release can optimize differently and then the error does not appear).