### PR TITLE
Initialize all member variables in TrilinosWrappers::MPI::Vector

### DIFF
--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -798,8 +798,10 @@ namespace TrilinosWrappers
     {
       std::swap(last_action, v.last_action);
       std::swap(compressed, v.compressed);
-      std::swap(vector, v.vector);
       std::swap(has_ghosts, v.has_ghosts);
+      std::swap(vector, v.vector);
+      std::swap(nonlocal_vector, v.nonlocal_vector);
+      std::swap(owned_elements, v.owned_elements);
     }
 
 

--- a/tests/trilinos/vector_swap_02.cc
+++ b/tests/trilinos/vector_swap_02.cc
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+/*
+  test that swapping two TrilinosWrapper::MPI::Vector objects
+  also swaps has_ghosts and locally_owned_elements.
+ */
+
+
+#include "../tests.h"
+#include <deal.II/base/utilities.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+void print(TrilinosWrappers::MPI::Vector &v, unsigned int first_element)
+{
+  deallog << "size= " << v.size()
+          << " el(" << first_element << ")= " << v(first_element)
+          << " has_ghost_elements: " << v.has_ghost_elements()
+          << std::endl
+          << " locally_owned_elements: " << std::endl;
+  v.locally_owned_elements().print(deallog);
+}
+
+
+void test ()
+{
+  unsigned int my_id = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  TrilinosWrappers::MPI::Vector v;
+  IndexSet owned_indices_1(6);
+  IndexSet ghosted_indices_1(6);
+  owned_indices_1.add_range(my_id*3,(my_id+1)*3);
+  ghosted_indices_1.add_range((1-my_id)*3,(2-my_id)*3);
+  v.reinit(owned_indices_1, ghosted_indices_1, MPI_COMM_WORLD);
+
+  TrilinosWrappers::MPI::Vector w;
+  IndexSet owned_indices_2(10);
+  owned_indices_2.add_range(my_id*5, (my_id+1)*5);
+  w.reinit(owned_indices_2, MPI_COMM_WORLD);
+  for (unsigned int i=my_id*5; i<(my_id+1)*5; ++i)
+    w(i) = 2;
+
+
+  deallog << "v: ";
+  print(v, my_id*3);
+  deallog << "w: ";
+  print(w, my_id*5);
+
+  deallog << "**swap**" << std::endl;
+
+  swap(v,w);
+
+  deallog << "v: ";
+  print(v, my_id*5);
+  deallog << "w: ";
+  print(w, my_id*3);
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll mpi_log;
+
+  try
+    {
+      test ();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+}

--- a/tests/trilinos/vector_swap_02.mpirun=2.output
+++ b/tests/trilinos/vector_swap_02.mpirun=2.output
@@ -1,0 +1,31 @@
+
+DEAL:0::v: size= 6 el(0)= 0.00000 has_ghost_elements: 1
+DEAL:0:: locally_owned_elements: 
+DEAL:0::{[0,2]}
+DEAL:0::w: size= 10 el(0)= 2.00000 has_ghost_elements: 0
+DEAL:0:: locally_owned_elements: 
+DEAL:0::{[0,4]}
+DEAL:0::**swap**
+DEAL:0::v: size= 10 el(0)= 2.00000 has_ghost_elements: 0
+DEAL:0:: locally_owned_elements: 
+DEAL:0::{[0,4]}
+DEAL:0::w: size= 6 el(0)= 0.00000 has_ghost_elements: 1
+DEAL:0:: locally_owned_elements: 
+DEAL:0::{[0,2]}
+DEAL:0::OK
+
+DEAL:1::v: size= 6 el(3)= 0.00000 has_ghost_elements: 1
+DEAL:1:: locally_owned_elements: 
+DEAL:1::{[3,5]}
+DEAL:1::w: size= 10 el(5)= 2.00000 has_ghost_elements: 0
+DEAL:1:: locally_owned_elements: 
+DEAL:1::{[5,9]}
+DEAL:1::**swap**
+DEAL:1::v: size= 10 el(5)= 2.00000 has_ghost_elements: 0
+DEAL:1:: locally_owned_elements: 
+DEAL:1::{[5,9]}
+DEAL:1::w: size= 6 el(3)= 0.00000 has_ghost_elements: 1
+DEAL:1:: locally_owned_elements: 
+DEAL:1::{[3,5]}
+DEAL:1::OK
+


### PR DESCRIPTION
After merging `TrilinosWrappers::Base` into `TrilinosWrappers::MPI::Vector` in #4454, Coverity reports some uninitialized variables. Since we are requiring C++11 now, we might as well use default member initializer.