### PR TITLE
Remove usages of the deprecated PetscBooleanType.

### DIFF
--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -834,7 +834,7 @@ namespace PETScWrappers
      * Test whether a matrix is symmetric.  Default tolerance is
      * $1000\times32$-bit machine precision.
      */
-    PetscBooleanType
+    PetscBool
     is_symmetric (const double tolerance = 1.e-12);
 
     /**
@@ -842,7 +842,7 @@ namespace PETScWrappers
      * its transpose. Default tolerance is $1000\times32$-bit machine
      * precision.
      */
-    PetscBooleanType
+    PetscBool
     is_hermitian (const double tolerance = 1.e-12);
 
     /**

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -518,20 +518,20 @@ namespace PETScWrappers
     AssertThrow (ierr == 0, ExcPETScError(ierr));
   }
 
-  PetscBooleanType
+  PetscBool
   MatrixBase::is_symmetric (const double tolerance)
   {
-    PetscBooleanType truth;
+    PetscBool truth;
     assert_is_compressed ();
     const PetscErrorCode ierr = MatIsSymmetric (matrix, tolerance, &truth);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
     return truth;
   }
 
-  PetscBooleanType
+  PetscBool
   MatrixBase::is_hermitian (const double tolerance)
   {
-    PetscBooleanType truth;
+    PetscBool truth;
 
     assert_is_compressed ();
     const PetscErrorCode ierr = MatIsHermitian (matrix, tolerance, &truth);

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -222,7 +222,7 @@ namespace PETScWrappers
     Assert (size() == v.size(),
             ExcDimensionMismatch(size(), v.size()));
 
-    PetscBooleanType flag;
+    PetscBool flag;
     const PetscErrorCode ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 
@@ -237,7 +237,7 @@ namespace PETScWrappers
     Assert (size() == v.size(),
             ExcDimensionMismatch(size(), v.size()));
 
-    PetscBooleanType flag;
+    PetscBool flag;
     const PetscErrorCode ierr = VecEqual (vector, v.vector, &flag);
     AssertThrow (ierr == 0, ExcPETScError(ierr));
 


### PR DESCRIPTION
Followup to db66997e97 and #4481: we should avoid using deprecated types in the library and public headers.