### PR TITLE
Update error message.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -8982,7 +8982,8 @@ Triangulation (const Triangulation<dim, spacedim> &other)
 {
   Assert (false, ExcMessage ("You are not allowed to call this constructor "
                              "because copying Triangulation objects is not "
-                             "allowed. Use Triangulation::copy_from() instead."));
+                             "allowed. Use Triangulation::copy_triangulation() "
+                             "instead."));
 }
 
 


### PR DESCRIPTION
`Triangulation::copy_from()` does not exist (anymore?). Redirect to `Triangulation::copy_triangulation()` instead.