### PR TITLE
Make ParameterHandler::print_parameters() const.

### DIFF
--- a/doc/news/changes/incompatibilities/20170607Bangerth
+++ b/doc/news/changes/incompatibilities/20170607Bangerth
@@ -1,0 +1,4 @@
+Deprecated: The ParameterHandler::print_parameters_section() function
+has been deprecated.
+<br>
+(Wolfgang Bangerth, 2017/06/07)

--- a/doc/news/changes/minor/20170607Bangerth
+++ b/doc/news/changes/minor/20170607Bangerth
@@ -1,0 +1,4 @@
+Changed: The ParameterHandler::print_parameters() function is now 
+@p const, as one would expect it to be.
+<br>
+(Wolfgang Bangerth, 2017/06/07)

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2060,8 +2060,9 @@ public:
    * \printindex[prmindexfull]
    * @endcode
    */
-  std::ostream &print_parameters (std::ostream      &out,
-                                  const OutputStyle  style);
+  std::ostream &
+  print_parameters (std::ostream      &out,
+                    const OutputStyle  style) const;
 
   /**
    * Print out the parameters of the present subsection as given by the
@@ -2246,6 +2247,11 @@ private:
   static const char path_separator = '.';
 
   /**
+   * Path of presently selected subsections; empty list means top level
+   */
+  std::vector<std::string> subsection_path;
+
+  /**
    * The complete tree of sections and entries. See the general documentation
    * of this class for a description how data is stored in this variable.
    *
@@ -2282,14 +2288,22 @@ private:
   static std::string demangle (const std::string &s);
 
   /**
-   * Path of presently selected subsections; empty list means top level
+   * Given a list of directories and subdirectories that identify
+   * a particular place in the tree, return the string that identifies
+   * this place in the way the BOOST property tree libraries likes
+   * to identify things.
    */
-  std::vector<std::string> subsection_path;
+  static
+  std::string
+  collate_path_string (const std::vector<std::string> &subsection_path);
 
   /**
    * Return the string that identifies the current path into the property
    * tree. This is only a path, i.e. it is not terminated by the
    * path_separator character.
+   *
+   * This function simply calls collate_path_string() with
+   * @p subsection_path as argument
    */
   std::string get_current_path () const;
 
@@ -2314,6 +2328,22 @@ private:
   void scan_line (std::string         line,
                   const std::string  &input_filename,
                   const unsigned int  current_line_n);
+
+  /**
+   * Print out the parameters of the subsection given by the
+   * @p target_subsection_path argument, as well as all subsections
+   * within it recursively. This function is called from the
+   * print_parameters() function, and is implemented for all @p style
+   * arguments other than XML and JSON (where we can output the
+   * entire set of parameters via BOOST functions). The @p indent_level
+   * argument indicates how many spaces the output should be indented,
+   * so that subsections properly nest inside the output of higher
+   * sections.
+   */
+  void recursively_print_parameters (const std::vector<std::string> &target_subsection_path,
+                                     const OutputStyle               style,
+                                     const unsigned int              indent_level,
+                                     std::ostream                   &out) const;
 
   friend class MultipleParameterLoop;
 };


### PR DESCRIPTION
This is done by introducing a new, private function, that duplicates most
of what the now deprecated function ParameterHandler::print_parameters_section()
does, but without changing the state of the object.

The duplication of code will be removed once the deprecated function is removed.

This fixes #3989. It passes the testsuite, which calls print_parameters()
and now the newly added function many many times.