### PR TITLE
Save the state of the stream we're going to write into.

### DIFF
--- a/doc/news/changes/minor/20170609Bangerth
+++ b/doc/news/changes/minor/20170609Bangerth
@@ -1,0 +1,5 @@
+Fixed: The ParameterHandler::print_parameters() function
+used the previously set fill character of the output stream, but it
+should have filled with spaces instead. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2017/06/07)

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -24,6 +24,8 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+#include <boost/io/ios_state.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <fstream>
@@ -2264,6 +2266,14 @@ ParameterHandler::print_parameters (std::ostream     &out,
                                     const OutputStyle style) const
 {
   AssertThrow (out, ExcIO());
+
+  // we'll have to print some text that is padded with spaces;
+  // set the appropriate fill character, but also make sure that
+  // we will restore the previous setting (and all other stream
+  // flags) when we exit this function
+  boost::io::ios_flags_saver restore_flags(out);
+  boost::io::basic_ios_fill_saver<char> restore_fill_state(out);
+  out.fill(' ');
 
   // we treat XML and JSON is one step via BOOST, whereas all of the others are
   // done recursively in our own code. take care of the two special formats

--- a/tests/parameter_handler/save_flags.cc
+++ b/tests/parameter_handler/save_flags.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2002 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that ParameterHandler::print_parameters() saves and resets
+// the iostream flags of the stream it writes to
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <fstream>
+#include <iomanip>
+
+
+int main ()
+{
+  std::ofstream logfile("output");
+  deallog.attach(logfile);
+  deallog.threshold_double(1.e-10);
+
+  ParameterHandler prm;
+  prm.declare_entry ("int1",
+                     "1",
+                     Patterns::Integer(),
+                     "doc 1");
+  prm.declare_entry ("int2",
+                     "2",
+                     Patterns::Integer(),
+                     "doc 2");
+  prm.enter_subsection ("ss1");
+  {
+    prm.declare_entry ("double 1",
+                       "1.234",
+                       Patterns::Double(),
+                       "doc 3");
+
+    prm.enter_subsection ("ss2");
+    {
+      prm.declare_entry ("double 2",
+                         "4.321",
+                         Patterns::Double(),
+                         "doc 4");
+    }
+    prm.leave_subsection ();
+  }
+  prm.leave_subsection ();
+
+  // things with strange characters
+  prm.enter_subsection ("Testing%testing");
+  {
+    prm.declare_entry ("string&list",
+                       "< & > ; /",
+                       Patterns::Anything(),
+                       "docs 1");
+    prm.declare_entry ("int*int",
+                       "2",
+                       Patterns::Integer());
+    prm.declare_entry ("double+double",
+                       "6.1415926",
+                       Patterns::Double(),
+                       "docs 3");
+  }
+  prm.leave_subsection ();
+
+  // set a special fill char and verify that it is being used
+  logfile.fill('x');
+  logfile.width(15);
+  logfile << std::left << 42 << std::endl;
+
+  // now let ParameterHandler output its state
+  prm.print_parameters (logfile, ParameterHandler::Description);
+
+  // verify that the special fill char is still available (i.e., that
+  // print_parameters() has saved and restored the stream flags)
+  logfile.width(15);
+  logfile << std::left << 42 << std::endl;
+
+  return 0;
+}

--- a/tests/parameter_handler/save_flags.output
+++ b/tests/parameter_handler/save_flags.output
@@ -1,0 +1,21 @@
+
+42xxxxxxxxxxxxx
+Listing of Parameters:
+
+set int1  =   An integer n such that -2147483648 <= n <= 2147483647
+              (doc 1)
+set int2  =   An integer n such that -2147483648 <= n <= 2147483647
+              (doc 2)
+subsection Testing%testing
+  set double+double  =   A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE
+                         (docs 3)
+  set int*int        =   An integer n such that -2147483648 <= n <= 2147483647
+  set string&list    =   Any string
+                         (docs 1)
+subsection ss1
+  set double 1  =   A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE
+                    (doc 3)
+  subsection ss2
+    set double 2  =   A floating point number v such that -MAX_DOUBLE <= v <= MAX_DOUBLE
+                      (doc 4)
+42xxxxxxxxxxxxx


### PR DESCRIPTION
This fixes #4503. I couldn't find a test where the flags make a difference (because
we're not setting any flags other than the fill width that only affects the very
next read), but I realized that we need to use a space for filling and that a user
may have set a different fill character -- so set that, and restore the previous
value at a later time. There is also a test that checks that.