### PR TITLE
Use only enum values, don't look at bits.

### DIFF
--- a/doc/news/changes/minor/20170609Bangerth-2
+++ b/doc/news/changes/minor/20170609Bangerth-2
@@ -1,0 +1,11 @@
+Changed: ParameterHandler::print_parameters() was at times looking at
+individual bits instead of just the declared values
+of ParameterHandler::OutputStyle. This presumably allowed for calling that
+function with a combination of the OutputStyle flags, for reasons that no
+longer seem particularly relevant nor obvious.
+<br>
+This possibility has now been removed from the current implementation of
+the function, but is for the moment retained for the (deprecated) function
+ParameterHandler::print_parameters_section().
+<br>
+(Wolfgang Bangerth, 2017/06/09)

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2386,7 +2386,7 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
             // the documentation, and then the actual entry; break the
             // documentation into readable chunks such that the whole
             // thing is at most 78 characters wide
-            if ((!(style & 128)) &&
+            if ((style == Text) &&
                 !p->second.get<std::string>("documentation").empty())
               {
                 if (first_entry == false)
@@ -2417,7 +2417,7 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
 
             // finally print the default value, but only if it differs
             // from the actual value
-            if ((!(style & 64)) && value != p->second.get<std::string>("default_value"))
+            if ((style == Text) && value != p->second.get<std::string>("default_value"))
               {
                 out << std::setw(longest_value-value.length()+1) << ' '
                     << "# ";
@@ -2612,7 +2612,7 @@ ParameterHandler::recursively_print_parameters (const std::vector<std::string> &
 
     if ((style != Description)
         &&
-        (!(style & 128))
+        (style != ShortText)
         &&
         (n_parameters != 0)
         &&


### PR DESCRIPTION
This fixes an (undocumented) oddity in ParameterHandler::print_parameters(): We
were at times looking at individual bits instead of just the declared values
of ParameterHandler::OutputStyle. This presumably allowed for calling that
function with a combination of the OutputStyle flags, for reasons that no
longer seem particularly relevant nor obvious. 

This patch removes this possibility from the current implementation of
the function, but retains it for the (deprecated) function
ParameterHandler::print_parameters_section().

Fixes #4500.