### PR TITLE
Implement vmult() method in RelaxationBlock{Jacobi,SOR,SSOR}

### DIFF
--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -227,9 +227,9 @@ protected:
    * Perform one block relaxation step.
    *
    * Depending on the arguments @p dst and @p pref, this performs an SOR step
-   * (both reference the same vector) of a Jacobi step (both are different
+   * (both reference the same vector) or a Jacobi step (both are different
    * vectors). For the Jacobi step, the calling function must copy @p dst to
-   * @p pref after this.
+   * @p prev after this.
    */
   void do_step (
     VectorType       &dst,
@@ -340,6 +340,18 @@ public:
   void Tstep (VectorType &dst, const VectorType &rhs) const;
 
   /**
+   * Implements a vmult() operation, which for this class first sets the dst()
+   * vector to zero before calling the step() method.
+   */
+  void vmult (VectorType &dst, const VectorType &rhs) const;
+
+  /**
+   * Implements a transpose vmult operation, which for this class first sets
+   * the dst() vector to zero before calling the Tstep() method.
+   */
+  void Tvmult (VectorType &dst, const VectorType &rhs) const;
+
+  /**
    * Return the memory allocated in this object.
    */
   std::size_t memory_consumption() const;
@@ -426,6 +438,18 @@ public:
    * Perform one step of the transposed SOR iteration.
    */
   void Tstep (VectorType &dst, const VectorType &rhs) const;
+
+  /**
+   * Implements a vmult() operation, which for this class first sets the dst()
+   * vector to zero before calling the step() method.
+   */
+  void vmult (VectorType &dst, const VectorType &rhs) const;
+
+  /**
+   * Implements a transpose vmult operation, which for this class first sets
+   * the dst() vector to zero before calling the Tstep() method.
+   */
+  void Tvmult (VectorType &dst, const VectorType &rhs) const;
 };
 
 
@@ -505,6 +529,18 @@ public:
    * Perform one step of the transposed SSOR iteration.
    */
   void Tstep (VectorType &dst, const VectorType &rhs) const;
+
+  /**
+   * Implements a vmult() operation, which for this class first sets the dst()
+   * vector to zero before calling the step() method.
+   */
+  void vmult (VectorType &dst, const VectorType &rhs) const;
+
+  /**
+   * Implements a transpose vmult operation, which for this class first sets
+   * the dst() vector to zero before calling the Tstep() method.
+   */
+  void Tvmult (VectorType &dst, const VectorType &rhs) const;
 };
 
 

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -299,6 +299,32 @@ void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::Tstep
 }
 
 
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::vmult
+(VectorType       &dst,
+ const VectorType &src) const
+{
+  GrowingVectorMemory<VectorType> mem;
+  typename VectorMemory<VectorType>::Pointer aux = mem;
+  dst = 0;
+  aux->reinit(dst);
+  this->do_step(dst, *aux, src, false);
+}
+
+
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::Tvmult
+(VectorType       &dst,
+ const VectorType &src) const
+{
+  GrowingVectorMemory<VectorType> mem;
+  typename VectorMemory<VectorType>::Pointer aux = mem;
+  dst = 0;
+  aux->reinit(dst);
+  this->do_step(dst, *aux, src, true);
+}
+
+
 //----------------------------------------------------------------------//
 
 template <typename MatrixType, typename InverseNumberType, typename VectorType>
@@ -315,6 +341,26 @@ void RelaxationBlockSOR<MatrixType, InverseNumberType, VectorType>::Tstep
 (VectorType       &dst,
  const VectorType &src) const
 {
+  this->do_step(dst, dst, src, true);
+}
+
+
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockSOR<MatrixType, InverseNumberType, VectorType>::vmult
+(VectorType &dst,
+ const VectorType &src) const
+{
+  dst = 0;
+  this->do_step(dst, dst, src, false);
+}
+
+
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockSOR<MatrixType, InverseNumberType, VectorType>::Tvmult
+(VectorType       &dst,
+ const VectorType &src) const
+{
+  dst = 0;
   this->do_step(dst, dst, src, true);
 }
 
@@ -336,6 +382,28 @@ void RelaxationBlockSSOR<MatrixType, InverseNumberType, VectorType>::Tstep
 (VectorType       &dst,
  const VectorType &src) const
 {
+  this->do_step(dst, dst, src, true);
+  this->do_step(dst, dst, src, false);
+}
+
+
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockSSOR<MatrixType, InverseNumberType, VectorType>::vmult
+(VectorType       &dst,
+ const VectorType &src) const
+{
+  dst = 0;
+  this->do_step(dst, dst, src, false);
+  this->do_step(dst, dst, src, true);
+}
+
+
+template <typename MatrixType, typename InverseNumberType, typename VectorType>
+void RelaxationBlockSSOR<MatrixType, InverseNumberType, VectorType>::Tvmult
+(VectorType       &dst,
+ const VectorType &src) const
+{
+  dst = 0;
   this->do_step(dst, dst, src, true);
   this->do_step(dst, dst, src, false);
 }


### PR DESCRIPTION
Fixes issue for the test `step-39-block` introduced by new interfaces in #4494: We now need to provide a `vmult()` operation.