### PR TITLE
Mark the vertex lookup functions as inline.

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -536,6 +536,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       line_index (const TriaAccessor<1, dim, spacedim> &,
@@ -550,6 +551,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       line_index (const TriaAccessor<2, dim, spacedim> &accessor,
@@ -560,6 +562,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       line_index (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -612,6 +615,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       unsigned int
       quad_index (const TriaAccessor<structdim, dim, spacedim> &,
@@ -626,6 +630,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       quad_index (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -643,6 +648,7 @@ namespace internal
        * Implementation of the function of some name in the mother class
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       bool
       face_orientation (const TriaAccessor<structdim, dim, spacedim> &,
@@ -659,6 +665,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       bool
       face_orientation (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -674,6 +681,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       bool
       face_flip (const TriaAccessor<structdim, dim, spacedim> &,
@@ -696,6 +704,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       bool
       face_flip (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -720,6 +729,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       bool
       face_rotation (const TriaAccessor<structdim, dim, spacedim> &,
@@ -736,6 +746,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       bool
       face_rotation (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -758,6 +769,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int dim, int spacedim>
+      inline
       static
       bool
       line_orientation (const TriaAccessor<1, dim, spacedim> &,
@@ -768,6 +780,7 @@ namespace internal
 
 
       template <int spacedim>
+      inline
       static
       bool
       line_orientation (const TriaAccessor<2, 2, spacedim> &,
@@ -779,6 +792,7 @@ namespace internal
 
 
       template <int spacedim>
+      inline
       static
       bool
       line_orientation (const TriaAccessor<2, 3, spacedim> &accessor,
@@ -792,6 +806,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       bool
       line_orientation (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -893,6 +908,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       void
       set_face_orientation (const TriaAccessor<structdim, dim, spacedim> &,
@@ -904,6 +920,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       void
       set_face_orientation (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -930,6 +947,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       void
       set_face_flip (const TriaAccessor<structdim, dim, spacedim> &,
@@ -941,6 +959,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       void
       set_face_flip (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -966,6 +985,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int structdim, int dim, int spacedim>
+      inline
       static
       void
       set_face_rotation (const TriaAccessor<structdim, dim, spacedim> &,
@@ -977,6 +997,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       void
       set_face_rotation (const TriaAccessor<3, dim, spacedim> &accessor,
@@ -1000,6 +1021,7 @@ namespace internal
        * Implementation of the function of some name in the mother class.
        */
       template <int dim, int spacedim>
+      inline
       static
       void
       set_line_orientation (const TriaAccessor<1, dim, spacedim> &,
@@ -1011,6 +1033,7 @@ namespace internal
 
 
       template <int spacedim>
+      inline
       static
       void
       set_line_orientation (const TriaAccessor<2, 2, spacedim> &,
@@ -1024,6 +1047,7 @@ namespace internal
 
 
       template <int spacedim>
+      inline
       static
       void
       set_line_orientation (const TriaAccessor<2, 3, spacedim> &accessor,
@@ -1047,6 +1071,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       void
       set_line_orientation (const TriaAccessor<3, dim, spacedim> &,
@@ -1063,6 +1088,7 @@ namespace internal
        * Implementation of the function of same name in the enclosing class.
        */
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       vertex_index (const TriaAccessor<1,dim,spacedim> &accessor,
@@ -1073,6 +1099,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       vertex_index (const TriaAccessor<2,dim,spacedim> &accessor,
@@ -1096,6 +1123,7 @@ namespace internal
 
 
       template <int dim, int spacedim>
+      inline
       static
       unsigned int
       vertex_index (const TriaAccessor<3,dim,spacedim> &accessor,
@@ -1162,6 +1190,7 @@ TriaAccessor<structdim,dim,spacedim>::vertex_iterator (const unsigned int i) con
 
 
 template <int structdim, int dim, int spacedim>
+inline
 unsigned int
 TriaAccessor<structdim, dim, spacedim>::
 vertex_index (const unsigned int corner) const
@@ -1175,6 +1204,7 @@ vertex_index (const unsigned int corner) const
 
 
 template <int structdim, int dim, int spacedim>
+inline
 Point<spacedim> &
 TriaAccessor<structdim, dim, spacedim>::vertex (const unsigned int i) const
 {


### PR DESCRIPTION
This lowers the number of calls to vertex() by a lot (down from 229 million to
46 million in a benchmark) and also provides about a 5% speed improvement.

For the sake of posterity, here is the benchmark used here and also in
b584c58d95 and cbb473c59d:

```cpp
#include <deal.II/base/geometry_info.h>

#include <deal.II/grid/grid_in.h>
#include <deal.II/grid/manifold_lib.h>
#include <deal.II/grid/tria.h>

#include <chrono>
#include <fstream>
#include <iostream>

using namespace dealii;

int main()
{
  constexpr int dim = 2;
  PolarManifold<dim> polar_manifold;
  TransfiniteInterpolationManifold<dim> inner_manifold;
  constexpr types::manifold_id polar_manifold_id = 1;
  constexpr types::manifold_id inner_manifold_id = 2;

  Triangulation<dim> triangulation;
  GridIn<dim> grid_in;
  std::ifstream input_grid("triangulation.msh");
  grid_in.attach_triangulation(triangulation);
  grid_in.read_msh(input_grid);
  triangulation.set_all_manifold_ids(inner_manifold_id);
  for (auto cell : triangulation.active_cell_iterators())
    {
      if (cell->at_boundary())
        {
          cell->set_all_manifold_ids(polar_manifold_id);
        }
    }
  triangulation.set_manifold(polar_manifold_id, polar_manifold);
  inner_manifold.initialize(triangulation);
  triangulation.set_manifold(inner_manifold_id, inner_manifold);

#ifdef DEBUG
  constexpr unsigned int n_refinements = 6;
#else
  constexpr unsigned int n_refinements = 8;
#endif

  for (unsigned int refinement_n = 0; refinement_n < n_refinements; ++refinement_n)
    {
      const auto t0 = std::chrono::high_resolution_clock::now();
      triangulation.refine_global(1);
      const auto t1 = std::chrono::high_resolution_clock::now();
      std::cout << "Number of active cells: "
                << triangulation.n_active_cells()
                << '\n';
      std::cout << "Refinement time: "
                << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count()
                << '\n';
    }
}
```

and here is triangulation.msh:

```
$NOD
25
1  1 0 0
2  0.70710678118654757274 0.70710678118654746172 0
3  6.1232339957367660359e-17 1 0
4  -0.70710678118654746172 0.70710678118654757274 0
5  -1 1.2246467991473532072e-16 0
6  -0.70710678118654768376 -0.70710678118654746172 0
7  -1.8369701987210296875e-16 -1 0
8  0.70710678118654735069 -0.70710678118654768376 0
9  0.5 0 0
10  0.35355339059327378637 0.35355339059327373086 0
11  3.0616169978683830179e-17 0.5 0
12  -0.35355339059327373086 0.35355339059327378637 0
13  -0.5 6.1232339957367660359e-17 0
14  -0.35355339059327384188 -0.35355339059327373086 0
15  -9.1848509936051484375e-17 -0.5 0
16  0.35355339059327367535 -0.35355339059327384188 0
17  -0.22097086912079610954 -0.22097086912079610954 0
18  0.22097086912079610954 -0.22097086912079610954 0
19  -0.22097086912079610954 0.22097086912079610954 0
20  0.22097086912079610954 0.22097086912079610954 0
21  0 -0.22097086912079610954 0
22  -0.22097086912079610954 0 0
23  0.22097086912079610954 0 0
24  0 0.22097086912079610954 0
25  0 0 0
$ENDNOD
$ELM
20
1 3 0 0 4 10 9 1 2
2 3 0 0 4 11 10 2 3
3 3 0 0 4 12 11 3 4
4 3 0 0 4 12 4 5 13
5 3 0 0 4 14 13 5 6
6 3 0 0 4 14 6 7 15
7 3 0 0 4 15 7 8 16
8 3 0 0 4 16 8 1 9
9 3 0 0 4 17 14 15 21
10 3 0 0 4 21 15 16 18
11 3 0 0 4 17 22 13 14
12 3 0 0 4 19 12 13 22
13 3 0 0 4 17 21 25 22
14 3 0 0 4 21 18 23 25
15 3 0 0 4 19 22 25 24
16 3 0 0 4 24 25 23 20
17 3 0 0 4 18 16 9 23
18 3 0 0 4 20 23 9 10
19 3 0 0 4 19 24 11 12
20 3 0 0 4 24 20 10 11
$ENDELM
```