### PR TITLE
Fix the Trilinos quick test.

### DIFF
--- a/tests/quick_tests/step-trilinos.cc
+++ b/tests/quick_tests/step-trilinos.cc
@@ -85,8 +85,8 @@ void LaplaceProblem::setup_system ()
   DoFTools::make_sparsity_pattern (dof_handler, dsp, constraints, false);
 
   A.reinit (dsp);
-  b.reinit (dof_handler.n_dofs());
-  x.reinit (dof_handler.n_dofs());
+  b.reinit (complete_index_set(dof_handler.n_dofs()));
+  x.reinit (complete_index_set(dof_handler.n_dofs()));
 
   // some output
   output_table.add_value ("cells", triangulation.n_active_cells());


### PR DESCRIPTION
It looks like we did not update this constructor when we removed the serial vector (the parallel vector's constructor needs an `IndexSet`, not an integer).