### PR TITLE
Fix uninitialized member variables in DoFInfo

### DIFF
--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -171,7 +171,7 @@ namespace MeshWorker
      * constructor is not recommended, but it is needed for the arrays in
      * DoFInfoBox.
      */
-    DoFInfo () = default;
+    DoFInfo ();
 
     /// Set up local block indices
     void set_block_indices ();
@@ -271,6 +271,16 @@ namespace MeshWorker
   };
 
 //----------------------------------------------------------------------//
+
+  template <int dim, int spacedim, typename number>
+  DoFInfo<dim, spacedim, number>::DoFInfo()
+    :
+    face_number(numbers::invalid_unsigned_int),
+    sub_number(numbers::invalid_unsigned_int),
+    level_cell(false)
+  {}
+
+
 
   template <int dim, int spacedim, typename number>
   DoFInfo<dim,spacedim,number>::DoFInfo(const DoFHandler<dim,spacedim> &dof_handler)


### PR DESCRIPTION
As reported by Coverity, the (private) default constructor of the `DoFInfo` class does not initialize all member variables leaving them in an undefined state.