### PR TITLE
Add a pragma for ignoring nonvirtual destructors.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -302,6 +302,7 @@ _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")     \
 _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")       \
 _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")   \
 _Pragma("GCC diagnostic ignored \"-Wundef\"")                    \
+_Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")         \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \


### PR DESCRIPTION
An OpenCascade header triggers this warning, so lets ignore it in external libraries.