### PR TITLE
Add a couple of static asserts to SolutionTransfer.

### DIFF
--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -112,9 +112,15 @@ namespace parallel
      * @ingroup distributed
      * @author Timo Heister, 2009-2011
      */
-    template<int dim, typename VectorType, typename DoFHandlerType=DoFHandler<dim> >
+    template <int dim,
+              typename VectorType,
+              typename DoFHandlerType = DoFHandler<dim> >
     class SolutionTransfer
     {
+      static_assert (dim == DoFHandlerType::dimension,
+                     "The dimension explicitly provided as a template "
+                     "argument, and the dimension of the DoFHandlerType "
+                     "template argument must match.");
     public:
       /**
        * Constructor, takes the current DoFHandler as argument.

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -117,10 +117,12 @@ namespace parallel
               typename DoFHandlerType = DoFHandler<dim> >
     class SolutionTransfer
     {
+#ifndef DEAL_II_MSVC
       static_assert (dim == DoFHandlerType::dimension,
                      "The dimension explicitly provided as a template "
                      "argument, and the dimension of the DoFHandlerType "
                      "template argument must match.");
+#endif
     public:
       /**
        * Constructor, takes the current DoFHandler as argument.

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -293,10 +293,12 @@ template<int dim,
          typename DoFHandlerType = DoFHandler<dim> >
 class SolutionTransfer
 {
+#ifndef DEAL_II_MSVC
   static_assert (dim == DoFHandlerType::dimension,
                  "The dimension explicitly provided as a template "
                  "argument, and the dimension of the DoFHandlerType "
                  "template argument must match.");
+#endif
 public:
 
   /**

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -288,10 +288,15 @@ DEAL_II_NAMESPACE_OPEN
  * @author Ralf Hartmann, 1999, Oliver Kayser-Herold and Wolfgang Bangerth,
  * 2006, Wolfgang Bangerth 2014
  */
-template<int dim, typename VectorType=Vector<double>,
-         typename DoFHandlerType=DoFHandler<dim> >
+template<int dim,
+         typename VectorType = Vector<double>,
+         typename DoFHandlerType = DoFHandler<dim> >
 class SolutionTransfer
 {
+  static_assert (dim == DoFHandlerType::dimension,
+                 "The dimension explicitly provided as a template "
+                 "argument, and the dimension of the DoFHandlerType "
+                 "template argument must match.");
 public:
 
   /**


### PR DESCRIPTION
This class (in both of its incarnations) takes both a dimension and a DoFHandler
as template argument. The dimension of the DoFHandler better match the explicitly
given dimension. The added static_assert checks that and prevents instantiation
of the class if that is not the case.