### PR TITLE
Fix two test outputs.

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -602,7 +602,7 @@ namespace Patterns
 
   bool List::match (const std::string &test_string_list) const
   {
-    std::vector<std::string> split_list =
+    const std::vector<std::string> split_list =
       Utilities::split_string_list(test_string_list, separator);
 
     if ((split_list.size() < min_elements) ||
@@ -610,7 +610,7 @@ namespace Patterns
       return false;
 
     // check the different possibilities
-    for (auto &string : split_list)
+    for (const std::string &string : split_list)
       if (pattern->match (string) == false)
         return false;
 

--- a/tests/parameter_handler/parameter_handler_backslash_03.output
+++ b/tests/parameter_handler/parameter_handler_backslash_03.output
@@ -1,17 +1,17 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <prm/parameter_handler_backslash_03.prm>:
-    The entry value 
+    The entry value
         a,\
     for the entry named
         Function
     does not match the given pattern:
-        [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <input file>:
-    The entry value 
+    The entry value
         a,\
     for the entry named
         Function
     does not match the given pattern:
-        [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_04.output
+++ b/tests/parameter_handler/parameter_handler_backslash_04.output
@@ -1,17 +1,17 @@
 
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <prm/parameter_handler_backslash_04.prm>:
-    The entry value 
+    The entry value
         a,\ b,
     for the entry named
         Function
     does not match the given pattern:
-        [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
 DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
 Line <4> of file <input file>:
-    The entry value 
+    The entry value
         a,\ b,
     for the entry named
         Function
     does not match the given pattern:
-        [List list of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]


### PR DESCRIPTION
Commit 852db02 removed the redundant "list" (i.e., previously we printed "List list of ...") from `List::description`. This commit updates the output files in the corresponding tests.

I also marked a few things as `const` that were new in 852db02.