### PR TITLE
Check whether a function call makes sense at the place where the function is called

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2277,8 +2277,7 @@ namespace internal
         // have any cells on that level or if the local part of the
         // Triangulation has fewer levels. we need to do this because
         // we need to communicate across all processors on all levels
-        const unsigned int n_levels = Utilities::MPI::max(dof_handler.get_triangulation().n_levels(),
-                                                          tr->get_communicator());
+        const unsigned int n_levels = tr->n_global_levels();
         for (unsigned int level = 0; level < n_levels; ++level)
           {
             NumberCache &number_cache = number_caches[level];


### PR DESCRIPTION
This is instead of returning early in the function. Check that the arguments are indeed
valid within the function.

I noticed this while working on #4526. In preparation for #3511.