### PR TITLE
Remove hp::DoFHandler::MGVertexDoFs.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -687,6 +687,58 @@ namespace internal
       }
 
 
+      template<int dim, int spacedim>
+      static
+      types::global_dof_index
+      mg_vertex_dof_index (const dealii::DoFHandler<dim,spacedim> &dof_handler,
+                           const int                       level,
+                           const unsigned int              vertex_index,
+                           const unsigned int              i)
+      {
+        return dof_handler.mg_vertex_dofs[vertex_index].get_index (level, i);
+      }
+
+
+      template<int dim, int spacedim>
+      static
+      types::global_dof_index
+      mg_vertex_dof_index (const dealii::hp::DoFHandler<dim,spacedim> &,
+                           const int,
+                           const unsigned int,
+                           const unsigned int)
+      {
+        Assert (false, ExcMessage ("hp::DoFHandler does not implement multilevel DoFs."));
+        return numbers::invalid_dof_index;
+      }
+
+
+      template<int dim, int spacedim>
+      static
+      void
+      set_mg_vertex_dof_index (dealii::DoFHandler<dim,spacedim> &dof_handler,
+                               const int                       level,
+                               const unsigned int              vertex_index,
+                               const unsigned int              i,
+                               types::global_dof_index         index)
+      {
+        return dof_handler.mg_vertex_dofs[vertex_index].set_index (level, i, index);
+      }
+
+
+      template<int dim, int spacedim>
+      static
+      void
+      set_mg_vertex_dof_index (dealii::hp::DoFHandler<dim,spacedim> &,
+                               const int,
+                               const unsigned int,
+                               const unsigned int,
+                               types::global_dof_index)
+      {
+        Assert (false, ExcMessage ("hp::DoFHandler does not implement multilevel DoFs."));
+      }
+
+
+
       template <int structdim, int dim, int spacedim>
       static
       bool
@@ -1668,9 +1720,17 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::mg_vertex_dof_index (co
 {
   (void)fe_index;
   Assert (this->dof_handler != nullptr, ExcInvalidObject ());
-  Assert (vertex < GeometryInfo<structdim>::vertices_per_cell, ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex, ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
-  return this->dof_handler->mg_vertex_dofs[this->vertex_index (vertex)].get_index (level, i);
+  Assert (vertex < GeometryInfo<structdim>::vertices_per_cell,
+          ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
+  Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex,
+          ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
+
+  return
+    dealii::internal::DoFAccessor::Implementation::mg_vertex_dof_index
+    (*this->dof_handler,
+     level,
+     this->vertex_index(vertex),
+     i);
 }
 
 
@@ -1703,9 +1763,18 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_vertex_dof_index
 {
   (void)fe_index;
   Assert (this->dof_handler != nullptr, ExcInvalidObject ());
-  Assert (vertex < GeometryInfo<structdim>::vertices_per_cell, ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex, ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
-  this->dof_handler->mg_vertex_dofs[this->vertex_index (vertex)].set_index (level, i, index);
+  Assert (vertex < GeometryInfo<structdim>::vertices_per_cell,
+          ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
+  Assert (i < this->dof_handler->get_fe ()[fe_index].dofs_per_vertex,
+          ExcIndexRange (i, 0, this->dof_handler->get_fe ()[fe_index].dofs_per_vertex));
+
+  return
+    dealii::internal::DoFAccessor::Implementation::set_mg_vertex_dof_index
+    (*this->dof_handler,
+     level,
+     this->vertex_index(vertex),
+     i,
+     index);
 }
 
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -734,15 +734,6 @@ namespace hp
      */
     DoFHandler &operator = (const DoFHandler &);
 
-    class MGVertexDoFs
-    {
-    public:
-      MGVertexDoFs ();
-      ~MGVertexDoFs ();
-      types::global_dof_index get_index (const unsigned int level, const unsigned int dof_number) const;
-      void set_index (const unsigned int level, const unsigned int dof_number, const types::global_dof_index index);
-    };
-
     /**
      * Free all used memory.
      */
@@ -865,8 +856,6 @@ namespace hp
      * class.
      */
     std::vector<types::global_dof_index>      vertex_dofs_offsets;
-
-    std::vector<MGVertexDoFs> mg_vertex_dofs;  // we should really remove this field!
 
     /**
      * Array to store the information if a cell on some level has children or
@@ -1049,41 +1038,6 @@ namespace hp
   {
     return *tria;
   }
-
-
-
-  template<int dim, int spacedim>
-  inline
-  DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs()
-  {
-    Assert (false, ExcNotImplemented ());
-  }
-
-  template<int dim, int spacedim>
-  inline
-  DoFHandler<dim, spacedim>::MGVertexDoFs::~MGVertexDoFs()
-  {
-    Assert (false, ExcNotImplemented ());
-  }
-
-  template<int dim, int spacedim>
-  inline
-  types::global_dof_index DoFHandler<dim, spacedim>::MGVertexDoFs::get_index (const unsigned int,
-      const unsigned int) const
-  {
-    Assert (false, ExcNotImplemented ());
-    return invalid_dof_index;
-  }
-
-  template<int dim, int spacedim>
-  inline
-  void DoFHandler<dim, spacedim>::MGVertexDoFs::set_index (const unsigned int,
-                                                           const unsigned int,
-                                                           types::global_dof_index)
-  {
-    Assert (false, ExcNotImplemented ());
-  }
-
 
 #endif
 


### PR DESCRIPTION
The hp::DoFHandler class does not support multilevel DoFs, and so having a
remnant part of the infrastructure for them makes no sense. Removing this
part from the class, however, requires a couple of specializations of
functions in the DoFAccessor class that may have previously compiled,
but would likely have led to segmentation faults if anyone tried to use them.

I noticed this while working on #4526. In preparation for #3511.