### PR TITLE
Deprecate (hp::)DoFHandler::invalid_dof_index.

### DIFF
--- a/doc/news/changes/minor/20170620Bangerth
+++ b/doc/news/changes/minor/20170620Bangerth
@@ -1,0 +1,5 @@
+Deprecated: The static member variables DoFHandler::invalid_dof_index
+and hp::DoFHandler::invalid_dof_index are now deprecated. Use
+numbers::invalid_dof_index instead.
+<br>
+(Wolfgang Bangerth, 2017/06/20)

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -283,8 +283,10 @@ public:
    *
    * Please note that you should not rely on it having a certain value, but
    * rather take its symbolic name.
+   *
+   * @deprecated Use numbers::invalid_dof_index instead.
    */
-  static const types::global_dof_index invalid_dof_index = numbers::invalid_dof_index;
+  static const types::global_dof_index invalid_dof_index DEAL_II_DEPRECATED = numbers::invalid_dof_index;
 
   /**
    * The default index of the finite element to be used on a given cell. Since

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -92,12 +92,12 @@ namespace GridTools
  * freedom. The map_dof_to_boundary_indices() function does exactly this: it
  * provides a vector with as many entries as there are degrees of freedom on
  * the whole domain, with each entry being the number in the numbering of the
- * boundary or DoFHandler::invalid_dof_index if the dof is not on the
+ * boundary or numbers::invalid_dof_index if the dof is not on the
  * boundary.
  *
  * With this vector, one can get, for any given degree of freedom, a unique
  * number among those DoFs that sit on the boundary; or, if your DoF was
- * interior to the domain, the result would be DoFHandler::invalid_dof_index.
+ * interior to the domain, the result would be numbers::invalid_dof_index.
  * We need this mapping, for example, to build the mass matrix on the boundary
  * (for this, see make_boundary_sparsity_pattern() function, the corresponding
  * section below, as well as the MatrixCreator namespace documentation).
@@ -116,10 +116,10 @@ namespace GridTools
  * intermixed.
  *
  * Degrees of freedom on the boundary but not on one of the specified boundary
- * parts are given the index DoFHandler::invalid_dof_index, as if they were in
+ * parts are given the index numbers::invalid_dof_index, as if they were in
  * the interior. If no boundary indicator was given or if no face of a cell
  * has a boundary indicator contained in the given list, the vector of new
- * indices consists solely of DoFHandler::invalid_dof_index.
+ * indices consists solely of numbers::invalid_dof_index.
  *
  * (As a side note, for corner cases: The question what a degree of freedom on
  * the boundary is, is not so easy.  It should really be a degree of freedom
@@ -2128,7 +2128,7 @@ namespace DoFTools
    * <tt>mapping[dof]</tt> gives the index of the degree of freedom with
    * global number @p dof in the list of degrees of freedom on the boundary.
    * If the degree of freedom requested is not on the boundary, the value of
-   * <tt>mapping[dof]</tt> is @p invalid_dof_index. This function is mainly
+   * <tt>mapping[dof]</tt> is numbers::invalid_dof_index. This function is mainly
    * used when setting up matrices and vectors on the boundary from the trial
    * functions, which have global numbers, while the matrices and vectors use
    * numbers of the trial functions local to the boundary.

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -226,8 +226,10 @@ namespace hp
      *
      * Please note that you should not rely on it having a certain value, but
      * rather take its symbolic name.
+     *
+     * @deprecated Use numbers::invalid_dof_index instead.
      */
-    static const types::global_dof_index invalid_dof_index = numbers::invalid_dof_index;
+    static const types::global_dof_index invalid_dof_index DEAL_II_DEPRECATED = numbers::invalid_dof_index;
 
     /**
      * The default index of the finite element to be used on a given cell. For

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -1538,7 +1538,7 @@ namespace MatrixCreator
               types::global_dof_index max_element = static_cast<types::global_dof_index>(0);
               for (std::vector<types::global_dof_index>::const_iterator i=dof_to_boundary_mapping.begin();
                    i!=dof_to_boundary_mapping.end(); ++i)
-                if ((*i != hp::DoFHandler<dim,spacedim>::invalid_dof_index) &&
+                if ((*i != numbers::invalid_dof_index) &&
                     (*i > max_element))
                   max_element = *i;
               Assert (max_element  == matrix.n()-1, ExcInternalError());

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2961,7 +2961,7 @@ namespace VectorTools
         }
       // fill in boundary values
       for (unsigned int i=0; i<dof_to_boundary_mapping.size(); ++i)
-        if (dof_to_boundary_mapping[i] != DoFHandler<dim,spacedim>::invalid_dof_index
+        if (dof_to_boundary_mapping[i] != numbers::invalid_dof_index
             && ! excluded_dofs[dof_to_boundary_mapping[i]])
           {
             AssertIsFinite(boundary_projection(dof_to_boundary_mapping[i]));

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -54,7 +54,7 @@ namespace internal
   template <int dim, int spacedim>
   const types::global_dof_index *dummy ()
   {
-    return &dealii::DoFHandler<dim,spacedim>::invalid_dof_index;
+    return &dealii::numbers::invalid_dof_index;
   }
 }
 
@@ -272,7 +272,7 @@ namespace internal
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
                 dof_handler.selected_fe->dofs_per_vertex,
-                DoFHandler<1,spacedim>::invalid_dof_index);
+                numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
@@ -281,12 +281,12 @@ namespace internal
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_line,
-                     DoFHandler<1,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_cell,
-                     DoFHandler<1,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
           }
       }
 
@@ -298,7 +298,7 @@ namespace internal
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
                 dof_handler.selected_fe->dofs_per_vertex,
-                DoFHandler<2,spacedim>::invalid_dof_index);
+                numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
@@ -307,12 +307,12 @@ namespace internal
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_quad,
-                     DoFHandler<2,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_cell,
-                     DoFHandler<2,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
           }
 
         dof_handler.faces.reset (new internal::DoFHandler::DoFFaces<2>);
@@ -322,7 +322,7 @@ namespace internal
             dof_handler.faces->lines.dofs
             .resize (dof_handler.tria->n_raw_lines() *
                      dof_handler.selected_fe->dofs_per_line,
-                     DoFHandler<2,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
           }
       }
 
@@ -334,7 +334,7 @@ namespace internal
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
                 dof_handler.selected_fe->dofs_per_vertex,
-                DoFHandler<3,spacedim>::invalid_dof_index);
+                numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
           {
@@ -343,12 +343,12 @@ namespace internal
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_hex,
-                     DoFHandler<3,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
                      dof_handler.selected_fe->dofs_per_cell,
-                     DoFHandler<3,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
           }
         dof_handler.faces.reset (new internal::DoFHandler::DoFFaces<3>);
 
@@ -358,11 +358,11 @@ namespace internal
             dof_handler.faces->lines.dofs
             .resize (dof_handler.tria->n_raw_lines() *
                      dof_handler.selected_fe->dofs_per_line,
-                     DoFHandler<3,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
             dof_handler.faces->quads.dofs
             .resize (dof_handler.tria->n_raw_quads() *
                      dof_handler.selected_fe->dofs_per_quad,
-                     DoFHandler<3,spacedim>::invalid_dof_index);
+                     numbers::invalid_dof_index);
           }
       }
 
@@ -380,7 +380,7 @@ namespace internal
         for (unsigned int i = 0; i < n_levels; ++i)
           {
             dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<1>);
-            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines (i) * dofs_per_line, DoFHandler<1>::invalid_dof_index);
+            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines (i) * dofs_per_line, numbers::invalid_dof_index);
           }
 
         const unsigned int &n_vertices = tria.n_vertices ();
@@ -436,11 +436,11 @@ namespace internal
         for (unsigned int i = 0; i < n_levels; ++i)
           {
             dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<2>);
-            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads (i) * fe.dofs_per_quad, DoFHandler<2>::invalid_dof_index);
+            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads (i) * fe.dofs_per_quad, numbers::invalid_dof_index);
           }
 
         dof_handler.mg_faces.reset (new internal::DoFHandler::DoFFaces<2>);
-        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, DoFHandler<2>::invalid_dof_index);
+        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
 
         const unsigned int &n_vertices = tria.n_vertices ();
 
@@ -495,12 +495,12 @@ namespace internal
         for (unsigned int i = 0; i < n_levels; ++i)
           {
             dof_handler.mg_levels.emplace_back (new internal::DoFHandler::DoFLevel<3>);
-            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_hexs (i) * fe.dofs_per_hex, DoFHandler<3>::invalid_dof_index);
+            dof_handler.mg_levels.back ()->dof_object.dofs = std::vector<types::global_dof_index> (tria.n_raw_hexs (i) * fe.dofs_per_hex, numbers::invalid_dof_index);
           }
 
         dof_handler.mg_faces.reset (new internal::DoFHandler::DoFFaces<3>);
-        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, DoFHandler<3>::invalid_dof_index);
-        dof_handler.mg_faces->quads.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads () * fe.dofs_per_quad, DoFHandler<3>::invalid_dof_index);
+        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index> (tria.n_raw_lines () * fe.dofs_per_line, numbers::invalid_dof_index);
+        dof_handler.mg_faces->quads.dofs = std::vector<types::global_dof_index> (tria.n_raw_quads () * fe.dofs_per_quad, numbers::invalid_dof_index);
 
         const unsigned int &n_vertices = tria.n_vertices ();
 
@@ -1255,7 +1255,7 @@ void DoFHandler<1>::renumber_dofs (const unsigned int level,
   for (std::vector<types::global_dof_index>::iterator i=mg_levels[level]->dof_object.dofs.begin();
        i!=mg_levels[level]->dof_object.dofs.end(); ++i)
     {
-      if (*i != DoFHandler<1>::invalid_dof_index)
+      if (*i != numbers::invalid_dof_index)
         {
           Assert(*i<new_numbers.size(), ExcInternalError());
           *i = new_numbers[*i];
@@ -1315,7 +1315,7 @@ void DoFHandler<2>::renumber_dofs (const unsigned int  level,
   for (std::vector<types::global_dof_index>::iterator i=mg_levels[level]->dof_object.dofs.begin();
        i!=mg_levels[level]->dof_object.dofs.end(); ++i)
     {
-      if (*i != DoFHandler<2>::invalid_dof_index)
+      if (*i != numbers::invalid_dof_index)
         {
           Assert(*i<new_numbers.size(), ExcInternalError());
           *i = new_numbers[*i];
@@ -1408,7 +1408,7 @@ void DoFHandler<3>::renumber_dofs (const unsigned int  level,
   for (std::vector<types::global_dof_index>::iterator i=mg_levels[level]->dof_object.dofs.begin();
        i!=mg_levels[level]->dof_object.dofs.end(); ++i)
     {
-      if (*i != DoFHandler<3>::invalid_dof_index)
+      if (*i != numbers::invalid_dof_index)
         {
           Assert(*i<new_numbers.size(), ExcInternalError());
           *i = new_numbers[*i];
@@ -1563,7 +1563,7 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
       const unsigned int n_indices = n_levels * dofs_per_vertex;
 
       indices = new types::global_dof_index[n_indices];
-      std::fill (indices, indices+n_indices, DoFHandler<dim,spacedim>::invalid_dof_index);
+      std::fill (indices, indices+n_indices, numbers::invalid_dof_index);
 
       indices_offset = new types::global_dof_index[n_levels];
       for (unsigned int i = 0; i < n_levels; ++i)

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -79,18 +79,18 @@ namespace internal
           if (dof_handler.get_fe().dofs_per_vertex > 0)
             for (unsigned int v=0; v<GeometryInfo<1>::vertices_per_cell; ++v)
               {
-                if (cell->vertex_dof_index (v,0) == DoFHandler<1,spacedim>::invalid_dof_index)
+                if (cell->vertex_dof_index (v,0) == numbers::invalid_dof_index)
                   for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                     {
                       Assert ((cell->vertex_dof_index (v,d) ==
-                               DoFHandler<1,spacedim>::invalid_dof_index),
+                               numbers::invalid_dof_index),
                               ExcInternalError());
                       cell->set_vertex_dof_index (v, d, next_free_dof++);
                     }
                 else
                   for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                     Assert ((cell->vertex_dof_index (v,d) !=
-                             DoFHandler<1,spacedim>::invalid_dof_index),
+                             numbers::invalid_dof_index),
                             ExcInternalError());
               }
 
@@ -115,7 +115,7 @@ namespace internal
             for (unsigned int vertex=0; vertex<GeometryInfo<2>::vertices_per_cell; ++vertex)
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
-              if (cell->vertex_dof_index(vertex, 0) == DoFHandler<2,spacedim>::invalid_dof_index)
+              if (cell->vertex_dof_index(vertex, 0) == numbers::invalid_dof_index)
                 for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof++);
 
@@ -128,7 +128,7 @@ namespace internal
 
                 // distribute dofs if necessary: check whether line dof is already
                 // numbered (checking the first dof should be good enough)
-                if (line->dof_index(0) == DoFHandler<2,spacedim>::invalid_dof_index)
+                if (line->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                     line->set_dof_index (d, next_free_dof++);
@@ -157,7 +157,7 @@ namespace internal
             for (unsigned int vertex=0; vertex<GeometryInfo<3>::vertices_per_cell; ++vertex)
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
-              if (cell->vertex_dof_index(vertex, 0) == DoFHandler<3,spacedim>::invalid_dof_index)
+              if (cell->vertex_dof_index(vertex, 0) == numbers::invalid_dof_index)
                 for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof++);
 
@@ -170,7 +170,7 @@ namespace internal
 
                 // distribute dofs if necessary: check whether line dof is already
                 // numbered (checking the first dof should be good enough)
-                if (line->dof_index(0) == DoFHandler<3,spacedim>::invalid_dof_index)
+                if (line->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                     line->set_dof_index (d, next_free_dof++);
@@ -185,7 +185,7 @@ namespace internal
 
                 // distribute dofs if necessary: check whether line dof is already
                 // numbered (checking the first dof should be good enough)
-                if (quad->dof_index(0) == DoFHandler<3,spacedim>::invalid_dof_index)
+                if (quad->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_quad; ++d)
                     quad->set_dof_index (d, next_free_dof++);
@@ -335,7 +335,7 @@ namespace internal
               // check whether dofs for this
               // vertex have been distributed
               // (only check the first dof)
-              if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == DoFHandler<2>::invalid_dof_index)
+              if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == numbers::invalid_dof_index)
                 for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
                   cell->set_mg_vertex_dof_index (cell->level(), vertex, d, next_free_dof++);
 
@@ -348,7 +348,7 @@ namespace internal
                 // distribute dofs if necessary:
                 // check whether line dof is already
                 // numbered (check only first dof)
-                if (line->mg_dof_index(cell->level(), 0) == DoFHandler<2>::invalid_dof_index)
+                if (line->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<cell->get_fe().dofs_per_line; ++d)
                     line->set_mg_dof_index (cell->level(), d, next_free_dof++);
@@ -382,7 +382,7 @@ namespace internal
               // check whether dofs for this
               // vertex have been distributed
               // (only check the first dof)
-              if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == DoFHandler<3>::invalid_dof_index)
+              if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == numbers::invalid_dof_index)
                 for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
                   cell->set_mg_vertex_dof_index (cell->level(), vertex, d, next_free_dof++);
 
@@ -395,7 +395,7 @@ namespace internal
                 // distribute dofs if necessary:
                 // check whether line dof is already
                 // numbered (check only first dof)
-                if (line->mg_dof_index(cell->level(), 0) == DoFHandler<3>::invalid_dof_index)
+                if (line->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<cell->get_fe().dofs_per_line; ++d)
                     line->set_mg_dof_index (cell->level(), d, next_free_dof++);
@@ -410,7 +410,7 @@ namespace internal
                 // distribute dofs if necessary:
                 // check whether line dof is already
                 // numbered (check only first dof)
-                if (quad->mg_dof_index(cell->level(), 0) == DoFHandler<3>::invalid_dof_index)
+                if (quad->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
                   for (unsigned int d=0; d<cell->get_fe().dofs_per_quad; ++d)
                     quad->set_mg_dof_index (cell->level(), d, next_free_dof++);
@@ -510,7 +510,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.vertex_dofs.begin();
                i!=dof_handler.vertex_dofs.end(); ++i)
-            if (*i != DoFHandler<1,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = new_numbers[*i];
             else if (check_validity)
               // if index is invalid_dof_index: check if this one
@@ -525,7 +525,7 @@ namespace internal
             for (std::vector<types::global_dof_index>::iterator
                  i=dof_handler.levels[level]->dof_object.dofs.begin();
                  i!=dof_handler.levels[level]->dof_object.dofs.end(); ++i)
-              if (*i != DoFHandler<1,spacedim>::invalid_dof_index)
+              if (*i != numbers::invalid_dof_index)
                 *i = new_numbers[*i];
 
           // update the cache used for cell dof indices
@@ -560,9 +560,9 @@ namespace internal
                 {
                   const dealii::types::global_dof_index idx = i->get_index (level, d);
                   if (check_validity)
-                    Assert(idx != DoFHandler<1>::invalid_dof_index, ExcInternalError ());
+                    Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                  if (idx != DoFHandler<1>::invalid_dof_index)
+                  if (idx != numbers::invalid_dof_index)
                     i->set_index (level, d,
                                   (indices.n_elements() == 0)?
                                   (new_numbers[idx]) :
@@ -575,7 +575,7 @@ namespace internal
                i!=dof_handler.mg_levels[level]->dof_object.dofs.end();
                ++i)
             {
-              if (*i != DoFHandler<1>::invalid_dof_index)
+              if (*i != numbers::invalid_dof_index)
                 {
                   Assert(*i<new_numbers.size(), ExcInternalError());
                   *i = (indices.n_elements() == 0)?
@@ -604,7 +604,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.vertex_dofs.begin();
                i!=dof_handler.vertex_dofs.end(); ++i)
-            if (*i != DoFHandler<2,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = (indices.n_elements() == 0)?
                    (new_numbers[*i]) :
                    (new_numbers[indices.index_within_set(*i)]);
@@ -620,7 +620,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.faces->lines.dofs.begin();
                i!=dof_handler.faces->lines.dofs.end(); ++i)
-            if (*i != DoFHandler<2,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = ((indices.n_elements() == 0) ?
                     new_numbers[*i] :
                     new_numbers[indices.index_within_set(*i)]);
@@ -630,7 +630,7 @@ namespace internal
               for (std::vector<types::global_dof_index>::iterator
                    i=dof_handler.levels[level]->dof_object.dofs.begin();
                    i!=dof_handler.levels[level]->dof_object.dofs.end(); ++i)
-                if (*i != DoFHandler<2,spacedim>::invalid_dof_index)
+                if (*i != numbers::invalid_dof_index)
                   *i = ((indices.n_elements() == 0) ?
                         new_numbers[*i] :
                         new_numbers[indices.index_within_set(*i)]);
@@ -666,9 +666,9 @@ namespace internal
                 {
                   const dealii::types::global_dof_index idx = i->get_index (level, d);
                   if (check_validity)
-                    Assert(idx != DoFHandler<2>::invalid_dof_index, ExcInternalError ());
+                    Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                  if (idx != DoFHandler<1>::invalid_dof_index)
+                  if (idx != numbers::invalid_dof_index)
                     i->set_index (level, d/*, dof_handler.get_fe().dofs_per_vertex*/,
                                   ((indices.n_elements() == 0) ?
                                    new_numbers[idx] :
@@ -701,9 +701,9 @@ namespace internal
                         {
                           const dealii::types::global_dof_index idx = cell->line(l)->mg_dof_index(level, d);
                           if (check_validity)
-                            Assert(idx != DoFHandler<2>::invalid_dof_index, ExcInternalError ());
+                            Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                          if (idx != DoFHandler<1>::invalid_dof_index)
+                          if (idx != numbers::invalid_dof_index)
                             cell->line(l)->set_mg_dof_index (level, d, ((indices.n_elements() == 0) ?
                                                                         new_numbers[idx] :
                                                                         new_numbers[indices.index_within_set(idx)]));
@@ -717,7 +717,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator i=dof_handler.mg_levels[level]->dof_object.dofs.begin();
                i!=dof_handler.mg_levels[level]->dof_object.dofs.end(); ++i)
             {
-              if (*i != DoFHandler<2>::invalid_dof_index)
+              if (*i != numbers::invalid_dof_index)
                 {
                   Assert(*i<new_numbers.size(), ExcInternalError());
                   *i = ((indices.n_elements() == 0) ?
@@ -746,7 +746,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.vertex_dofs.begin();
                i!=dof_handler.vertex_dofs.end(); ++i)
-            if (*i != DoFHandler<3,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = ((indices.n_elements() == 0) ?
                     new_numbers[*i] :
                     new_numbers[indices.index_within_set(*i)]);
@@ -762,14 +762,14 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.faces->lines.dofs.begin();
                i!=dof_handler.faces->lines.dofs.end(); ++i)
-            if (*i != DoFHandler<3,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = ((indices.n_elements() == 0) ?
                     new_numbers[*i] :
                     new_numbers[indices.index_within_set(*i)]);
           for (std::vector<types::global_dof_index>::iterator
                i=dof_handler.faces->quads.dofs.begin();
                i!=dof_handler.faces->quads.dofs.end(); ++i)
-            if (*i != DoFHandler<3,spacedim>::invalid_dof_index)
+            if (*i != numbers::invalid_dof_index)
               *i = ((indices.n_elements() == 0) ?
                     new_numbers[*i] :
                     new_numbers[indices.index_within_set(*i)]);
@@ -779,7 +779,7 @@ namespace internal
               for (std::vector<types::global_dof_index>::iterator
                    i=dof_handler.levels[level]->dof_object.dofs.begin();
                    i!=dof_handler.levels[level]->dof_object.dofs.end(); ++i)
-                if (*i != DoFHandler<3,spacedim>::invalid_dof_index)
+                if (*i != numbers::invalid_dof_index)
                   *i = ((indices.n_elements() == 0) ?
                         new_numbers[*i] :
                         new_numbers[indices.index_within_set(*i)]);
@@ -815,9 +815,9 @@ namespace internal
                 {
                   const dealii::types::global_dof_index idx = i->get_index (level, d);
                   if (check_validity)
-                    Assert(idx != DoFHandler<3>::invalid_dof_index, ExcInternalError ());
+                    Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                  if (idx != DoFHandler<3>::invalid_dof_index)
+                  if (idx != numbers::invalid_dof_index)
                     i->set_index (level, d,
                                   ((indices.n_elements() == 0) ?
                                    new_numbers[idx] :
@@ -850,9 +850,9 @@ namespace internal
                         {
                           const dealii::types::global_dof_index idx = cell->line(l)->mg_dof_index(level, d);
                           if (check_validity)
-                            Assert(idx != DoFHandler<3>::invalid_dof_index, ExcInternalError ());
+                            Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                          if (idx != DoFHandler<3>::invalid_dof_index)
+                          if (idx != numbers::invalid_dof_index)
                             cell->line(l)->set_mg_dof_index (level, d, ((indices.n_elements() == 0) ?
                                                                         new_numbers[idx] :
                                                                         new_numbers[indices.index_within_set(idx)]));
@@ -876,9 +876,9 @@ namespace internal
                         {
                           const dealii::types::global_dof_index idx = cell->quad(l)->mg_dof_index(level, d);
                           if (check_validity)
-                            Assert(idx != DoFHandler<3>::invalid_dof_index, ExcInternalError ());
+                            Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
-                          if (idx != DoFHandler<1>::invalid_dof_index)
+                          if (idx != numbers::invalid_dof_index)
                             cell->quad(l)->set_mg_dof_index (level, d, ((indices.n_elements() == 0) ?
                                                                         new_numbers[idx] :
                                                                         new_numbers[indices.index_within_set(idx)]));
@@ -893,7 +893,7 @@ namespace internal
           for (std::vector<types::global_dof_index>::iterator i=dof_handler.mg_levels[level]->dof_object.dofs.begin();
                i!=dof_handler.mg_levels[level]->dof_object.dofs.end(); ++i)
             {
-              if (*i != DoFHandler<3>::invalid_dof_index)
+              if (*i != numbers::invalid_dof_index)
                 {
                   Assert(*i<new_numbers.size(), ExcInternalError());
                   *i = ((indices.n_elements() == 0) ?
@@ -1551,10 +1551,10 @@ namespace internal
 
               bool complete = true;
               for (unsigned int i=0; i<dof_indices.size(); ++i)
-                if (dofs[i] != DoFHandler<dim,spacedim>::invalid_dof_index)
+                if (dofs[i] != numbers::invalid_dof_index)
                   {
                     Assert((dof_indices[i] ==
-                            (DoFHandler<dim,spacedim>::invalid_dof_index))
+                            (numbers::invalid_dof_index))
                            ||
                            (dof_indices[i]==dofs[i]),
                            ExcInternalError());
@@ -1797,10 +1797,10 @@ namespace internal
 
               bool complete = true;
               for (unsigned int i=0; i<dof_indices.size(); ++i)
-                if (dofs[i] != DoFHandler<dim,spacedim>::invalid_dof_index)
+                if (dofs[i] != numbers::invalid_dof_index)
                   {
                     Assert((dof_indices[i] ==
-                            (DoFHandler<dim,spacedim>::invalid_dof_index))
+                            (numbers::invalid_dof_index))
                            ||
                            (dof_indices[i]==dofs[i]),
                            ExcInternalError());
@@ -1949,7 +1949,7 @@ namespace internal
                       if (local_dof_indices.end() !=
                           std::find (local_dof_indices.begin(),
                                      local_dof_indices.end(),
-                                     DoFHandler<dim,spacedim>::invalid_dof_index))
+                                     numbers::invalid_dof_index))
                         cell->set_user_flag();
                       else
                         cell->clear_user_flag();
@@ -2119,9 +2119,9 @@ namespace internal
                 local_dof_indices.resize (cell->get_fe().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
                 for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
-                  if (local_dof_indices[i] != DoFHandler<dim,spacedim>::invalid_dof_index)
+                  if (local_dof_indices[i] != numbers::invalid_dof_index)
                     renumbering[local_dof_indices[i]]
-                      = DoFHandler<dim,spacedim>::invalid_dof_index;
+                      = numbers::invalid_dof_index;
               }
         }
 
@@ -2130,7 +2130,7 @@ namespace internal
         number_cache.n_locally_owned_dofs = 0;
         for (std::vector<dealii::types::global_dof_index>::iterator it=renumbering.begin();
              it!=renumbering.end(); ++it)
-          if (*it != DoFHandler<dim,spacedim>::invalid_dof_index)
+          if (*it != numbers::invalid_dof_index)
             *it = number_cache.n_locally_owned_dofs++;
 
         //* 3. communicate local dofcount and shift ids to make them
@@ -2153,7 +2153,7 @@ namespace internal
                                  static_cast<dealii::types::global_dof_index>(0));
         for (std::vector<dealii::types::global_dof_index>::iterator it=renumbering.begin();
              it!=renumbering.end(); ++it)
-          if (*it != DoFHandler<dim,spacedim>::invalid_dof_index)
+          if (*it != numbers::invalid_dof_index)
             (*it) += shift;
 
         // now re-enumerate all dofs to this shifted and condensed
@@ -2254,7 +2254,7 @@ namespace internal
                 if (local_dof_indices.end() !=
                     std::find (local_dof_indices.begin(),
                                local_dof_indices.end(),
-                               DoFHandler<dim,spacedim>::invalid_dof_index))
+                               numbers::invalid_dof_index))
                   {
                     if (cell->is_ghost())
                       {
@@ -2348,9 +2348,9 @@ namespace internal
                       local_dof_indices.resize (cell->get_fe().dofs_per_cell);
                       cell->get_mg_dof_indices (local_dof_indices);
                       for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
-                        if (local_dof_indices[i] != DoFHandler<dim,spacedim>::invalid_dof_index)
+                        if (local_dof_indices[i] != numbers::invalid_dof_index)
                           renumbering[local_dof_indices[i]]
-                            = DoFHandler<dim,spacedim>::invalid_dof_index;
+                            = numbers::invalid_dof_index;
                     }
               }
 
@@ -2359,7 +2359,7 @@ namespace internal
             level_number_cache.n_locally_owned_dofs = 0;
             for (std::vector<dealii::types::global_dof_index>::iterator it=renumbering.begin();
                  it!=renumbering.end(); ++it)
-              if (*it != DoFHandler<dim,spacedim>::invalid_dof_index)
+              if (*it != numbers::invalid_dof_index)
                 *it = level_number_cache.n_locally_owned_dofs++;
 
             //* 3. communicate local dofcount and shift ids to make
@@ -2382,7 +2382,7 @@ namespace internal
                                      static_cast<dealii::types::global_dof_index>(0));
             for (std::vector<dealii::types::global_dof_index>::iterator it=renumbering.begin();
                  it!=renumbering.end(); ++it)
-              if (*it != DoFHandler<dim,spacedim>::invalid_dof_index)
+              if (*it != numbers::invalid_dof_index)
                 (*it) += shift;
 
             // now re-enumerate all dofs to this shifted and condensed
@@ -2515,7 +2515,7 @@ namespace internal
                 if (local_dof_indices.end() !=
                     std::find (local_dof_indices.begin(),
                                local_dof_indices.end(),
-                               DoFHandler<dim,spacedim>::invalid_dof_index))
+                               numbers::invalid_dof_index))
                   {
                     Assert(false, ExcMessage ("not all DoFs got distributed!"));
                   }
@@ -2648,14 +2648,14 @@ namespace internal
                 cell->get_dof_indices (local_dof_indices);
                 for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
                   {
-                    if (local_dof_indices[i] == DoFHandler<dim,spacedim>::invalid_dof_index)
+                    if (local_dof_indices[i] == numbers::invalid_dof_index)
                       continue;
 
                     if (!dof_handler.locally_owned_dofs().is_element(local_dof_indices[i]))
                       {
                         //this DoF is not owned by us, so set it to invalid.
                         local_dof_indices[i]
-                          = DoFHandler<dim,spacedim>::invalid_dof_index;
+                          = numbers::invalid_dof_index;
                       }
                   }
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -124,7 +124,7 @@ namespace DoFRenumbering
                    const bool       use_constraints)
     {
       std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                       DoFHandlerType::invalid_dof_index);
+                                                       numbers::invalid_dof_index);
       compute_Cuthill_McKee(renumbering, dof_handler, reversed_numbering,
                             use_constraints);
 
@@ -168,7 +168,7 @@ namespace DoFRenumbering
         new_dof_indices[index_map[inv_perm[c]]] = c;
 
       Assert (std::find (new_dof_indices.begin(), new_dof_indices.end(),
-                         DoFHandlerType::invalid_dof_index) == new_dof_indices.end(),
+                         numbers::invalid_dof_index) == new_dof_indices.end(),
               ExcInternalError());
     }
 
@@ -181,7 +181,7 @@ namespace DoFRenumbering
                    const bool       use_constraints)
     {
       std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                       DoFHandlerType::invalid_dof_index);
+                                                       numbers::invalid_dof_index);
       compute_king_ordering(renumbering, dof_handler, reversed_numbering,
                             use_constraints);
 
@@ -221,7 +221,7 @@ namespace DoFRenumbering
         new_dof_indices[index_map[inv_perm[c]]] = c;
 
       Assert (std::find (new_dof_indices.begin(), new_dof_indices.end(),
-                         DoFHandlerType::invalid_dof_index) == new_dof_indices.end(),
+                         numbers::invalid_dof_index) == new_dof_indices.end(),
               ExcInternalError());
     }
 
@@ -234,7 +234,7 @@ namespace DoFRenumbering
                     const bool       use_constraints)
     {
       std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                       DoFHandlerType::invalid_dof_index);
+                                                       numbers::invalid_dof_index);
       compute_minimum_degree(renumbering, dof_handler, reversed_numbering,
                              use_constraints);
 
@@ -353,7 +353,7 @@ namespace DoFRenumbering
                  const std::vector<types::global_dof_index> &starting_indices)
   {
     std::vector<types::global_dof_index> renumbering(dof_handler.locally_owned_dofs().n_elements(),
-                                                     DoFHandlerType::invalid_dof_index);
+                                                     numbers::invalid_dof_index);
     compute_Cuthill_McKee(renumbering, dof_handler, reversed_numbering,
                           use_constraints, starting_indices);
 
@@ -502,7 +502,7 @@ namespace DoFRenumbering
                   const std::vector<unsigned int> &component_order_arg)
   {
     std::vector<types::global_dof_index> renumbering (dof_handler.n_locally_owned_dofs(),
-                                                      DoFHandler<dim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator
     start = dof_handler.begin_active();
@@ -547,7 +547,7 @@ namespace DoFRenumbering
   {
 //TODO: Merge with previous function
     std::vector<types::global_dof_index> renumbering (dof_handler.n_dofs(),
-                                                      hp::DoFHandler<dim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename hp::DoFHandler<dim>::active_cell_iterator
     start = dof_handler.begin_active();
@@ -580,7 +580,7 @@ namespace DoFRenumbering
            ExcNotInitialized());
 
     std::vector<types::global_dof_index> renumbering (dof_handler.n_dofs(level),
-                                                      DoFHandlerType::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename DoFHandlerType::level_cell_iterator start =dof_handler.begin(level);
     typename DoFHandlerType::level_cell_iterator end = dof_handler.end(level);
@@ -845,7 +845,7 @@ namespace DoFRenumbering
   block_wise (DoFHandler<dim,spacedim> &dof_handler)
   {
     std::vector<types::global_dof_index> renumbering (dof_handler.n_locally_owned_dofs(),
-                                                      DoFHandler<dim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator
     start = dof_handler.begin_active();
@@ -883,7 +883,7 @@ namespace DoFRenumbering
   block_wise (hp::DoFHandler<dim,spacedim> &dof_handler)
   {
     std::vector<types::global_dof_index> renumbering (dof_handler.n_dofs(),
-                                                      hp::DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename hp::DoFHandler<dim,spacedim>::active_cell_iterator
     start = dof_handler.begin_active();
@@ -914,7 +914,7 @@ namespace DoFRenumbering
            ExcNotInitialized());
 
     std::vector<types::global_dof_index> renumbering (dof_handler.n_dofs(level),
-                                                      DoFHandler<dim, spacedim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename DoFHandler<dim, spacedim>::level_cell_iterator
     start =dof_handler.begin(level);
@@ -1165,7 +1165,7 @@ namespace DoFRenumbering
                     {
                       // this is a locally owned DoF, assign new number if not assigned a number yet
                       unsigned int idx = locally_owned.index_within_set (local_dof_indices[i]);
-                      if (new_indices[idx] == DoFHandler<dim>::invalid_dof_index)
+                      if (new_indices[idx] == numbers::invalid_dof_index)
                         {
                           new_indices[idx] = locally_owned.nth_index_in_set (next_free);
                           next_free++;
@@ -1185,7 +1185,7 @@ namespace DoFRenumbering
   hierarchical (DoFHandler<dim> &dof_handler)
   {
     std::vector<types::global_dof_index> renumbering (dof_handler.n_locally_owned_dofs(),
-                                                      DoFHandler<dim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
     typename DoFHandler<dim>::level_cell_iterator cell;
 
@@ -1260,7 +1260,7 @@ namespace DoFRenumbering
                            const std::vector<bool> &selected_dofs)
   {
     std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                     DoFHandlerType::invalid_dof_index);
+                                                     numbers::invalid_dof_index);
     compute_sort_selected_dofs_back(renumbering, dof_handler, selected_dofs);
 
     dof_handler.renumber_dofs(renumbering);
@@ -1278,7 +1278,7 @@ namespace DoFRenumbering
            ExcNotInitialized());
 
     std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(level),
-                                                     DoFHandlerType::invalid_dof_index);
+                                                     numbers::invalid_dof_index);
     compute_sort_selected_dofs_back(renumbering, dof_handler, selected_dofs, level);
 
     dof_handler.renumber_dofs(level, renumbering);
@@ -1849,7 +1849,7 @@ namespace DoFRenumbering
   random (DoFHandlerType &dof_handler)
   {
     std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                     DoFHandlerType::invalid_dof_index);
+                                                     numbers::invalid_dof_index);
     compute_random(renumbering, dof_handler);
 
     dof_handler.renumber_dofs(renumbering);
@@ -1892,7 +1892,7 @@ namespace DoFRenumbering
   subdomain_wise (DoFHandlerType &dof_handler)
   {
     std::vector<types::global_dof_index> renumbering(dof_handler.n_dofs(),
-                                                     DoFHandlerType::invalid_dof_index);
+                                                     numbers::invalid_dof_index);
     compute_subdomain_wise(renumbering, dof_handler);
 
     dof_handler.renumber_dofs(renumbering);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1901,7 +1901,7 @@ namespace DoFTools
   {
     mapping.clear ();
     mapping.insert (mapping.end(), dof_handler.n_dofs(),
-                    DoFHandlerType::invalid_dof_index);
+                    numbers::invalid_dof_index);
 
     std::vector<types::global_dof_index> dofs_on_face;
     dofs_on_face.reserve (max_dofs_per_face(dof_handler));
@@ -1924,7 +1924,7 @@ namespace DoFTools
             cell->face(f)->get_dof_indices (dofs_on_face,
                                             cell->active_fe_index());
             for (unsigned int i=0; i<dofs_per_face; ++i)
-              if (mapping[dofs_on_face[i]] == DoFHandlerType::invalid_dof_index)
+              if (mapping[dofs_on_face[i]] == numbers::invalid_dof_index)
                 mapping[dofs_on_face[i]] = next_boundary_index++;
           }
 
@@ -1944,7 +1944,7 @@ namespace DoFTools
 
     mapping.clear ();
     mapping.insert (mapping.end(), dof_handler.n_dofs(),
-                    DoFHandlerType::invalid_dof_index);
+                    numbers::invalid_dof_index);
 
     // return if there is nothing to do
     if (boundary_ids.size() == 0)
@@ -1965,7 +1965,7 @@ namespace DoFTools
             dofs_on_face.resize (dofs_per_face);
             cell->face(f)->get_dof_indices (dofs_on_face, cell->active_fe_index());
             for (unsigned int i=0; i<dofs_per_face; ++i)
-              if (mapping[dofs_on_face[i]] == DoFHandlerType::invalid_dof_index)
+              if (mapping[dofs_on_face[i]] == numbers::invalid_dof_index)
                 mapping[dofs_on_face[i]] = next_boundary_index++;
           }
 

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3202,7 +3202,7 @@ namespace DoFTools
 
     // first construct the inverse mapping of weight_mapping
     std::vector<types::global_dof_index> inverse_weight_mapping (n_global_parm_dofs,
-        DoFHandler<dim,spacedim>::invalid_dof_index);
+        numbers::invalid_dof_index);
     for (types::global_dof_index i=0; i<weight_mapping.size(); ++i)
       {
         const types::global_dof_index parameter_dof = weight_mapping[i];
@@ -3210,7 +3210,7 @@ namespace DoFTools
         if (parameter_dof != numbers::invalid_dof_index)
           {
             Assert (parameter_dof < n_global_parm_dofs, ExcInternalError());
-            Assert ((inverse_weight_mapping[parameter_dof] == DoFHandler<dim,spacedim>::invalid_dof_index),
+            Assert ((inverse_weight_mapping[parameter_dof] == numbers::invalid_dof_index),
                     ExcInternalError());
 
             inverse_weight_mapping[parameter_dof] = i;

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -332,7 +332,7 @@ namespace DoFTools
         types::global_dof_index max_element = 0;
         for (std::vector<types::global_dof_index>::const_iterator i=dof_to_boundary_mapping.begin();
              i!=dof_to_boundary_mapping.end(); ++i)
-          if ((*i != DoFHandlerType::invalid_dof_index) &&
+          if ((*i != numbers::invalid_dof_index) &&
               (*i > max_element))
             max_element = *i;
         AssertDimension (max_element, sparsity.n_rows()-1);
@@ -425,7 +425,7 @@ namespace DoFTools
         types::global_dof_index max_element = 0;
         for (std::vector<types::global_dof_index>::const_iterator i=dof_to_boundary_mapping.begin();
              i!=dof_to_boundary_mapping.end(); ++i)
-          if ((*i != DoFHandlerType::invalid_dof_index) &&
+          if ((*i != numbers::invalid_dof_index) &&
               (*i > max_element))
             max_element = *i;
         AssertDimension (max_element, sparsity.n_rows()-1);

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -302,7 +302,7 @@ namespace internal
           // set up the linked lists for
           // each of the vertices
           dof_handler.vertex_dofs.resize (vertex_slots_needed,
-                                          DoFHandler<dim,spacedim>::invalid_dof_index);
+                                          numbers::invalid_dof_index);
           for (unsigned int v=0; v<dof_handler.tria->n_vertices(); ++v)
             if (dof_handler.tria->vertex_used(v) == true)
               {
@@ -363,7 +363,7 @@ namespace internal
           if (fe.dofs_per_vertex > 0)
             for (unsigned int vertex=0; vertex<GeometryInfo<1>::vertices_per_cell; ++vertex)
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
-                  DoFHandler<dim,spacedim>::invalid_dof_index)
+                  numbers::invalid_dof_index)
                 for (unsigned int d=0; d<fe.dofs_per_vertex; ++d, ++next_free_dof)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof, fe_index);
 
@@ -372,7 +372,7 @@ namespace internal
           if (fe.dofs_per_line > 0)
             {
               Assert ((cell->dof_index(0, fe_index) ==
-                       DoFHandler<dim,spacedim>::invalid_dof_index),
+                       numbers::invalid_dof_index),
                       ExcInternalError());
 
               for (unsigned int d=0; d<fe.dofs_per_line; ++d, ++next_free_dof)
@@ -408,7 +408,7 @@ namespace internal
           if (fe.dofs_per_vertex > 0)
             for (unsigned int vertex=0; vertex<GeometryInfo<2>::vertices_per_cell; ++vertex)
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
-                  DoFHandler<dim,spacedim>::invalid_dof_index)
+                  numbers::invalid_dof_index)
                 for (unsigned int d=0; d<fe.dofs_per_vertex; ++d, ++next_free_dof)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof, fe_index);
 
@@ -424,7 +424,7 @@ namespace internal
                 line = cell->line(l);
 
                 if (line->dof_index(0,fe_index) ==
-                    DoFHandler<dim,spacedim>::invalid_dof_index)
+                    numbers::invalid_dof_index)
                   for (unsigned int d=0; d<fe.dofs_per_line; ++d, ++next_free_dof)
                     line->set_dof_index (d, next_free_dof, fe_index);
               }
@@ -435,7 +435,7 @@ namespace internal
           if (fe.dofs_per_quad > 0)
             {
               Assert ((cell->dof_index(0, fe_index) ==
-                       DoFHandler<dim,spacedim>::invalid_dof_index),
+                       numbers::invalid_dof_index),
                       ExcInternalError());
 
               for (unsigned int d=0; d<fe.dofs_per_quad; ++d, ++next_free_dof)
@@ -471,7 +471,7 @@ namespace internal
           if (fe.dofs_per_vertex > 0)
             for (unsigned int vertex=0; vertex<GeometryInfo<3>::vertices_per_cell; ++vertex)
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
-                  DoFHandler<dim,spacedim>::invalid_dof_index)
+                  numbers::invalid_dof_index)
                 for (unsigned int d=0; d<fe.dofs_per_vertex; ++d, ++next_free_dof)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof, fe_index);
 
@@ -487,7 +487,7 @@ namespace internal
                 line = cell->line(l);
 
                 if (line->dof_index(0,fe_index) ==
-                    DoFHandler<dim,spacedim>::invalid_dof_index)
+                    numbers::invalid_dof_index)
                   for (unsigned int d=0; d<fe.dofs_per_line; ++d, ++next_free_dof)
                     line->set_dof_index (d, next_free_dof, fe_index);
               }
@@ -500,7 +500,7 @@ namespace internal
                 quad = cell->quad(q);
 
                 if (quad->dof_index(0,fe_index) ==
-                    DoFHandler<dim,spacedim>::invalid_dof_index)
+                    numbers::invalid_dof_index)
                   for (unsigned int d=0; d<fe.dofs_per_quad; ++d, ++next_free_dof)
                     quad->set_dof_index (d, next_free_dof, fe_index);
               }
@@ -511,7 +511,7 @@ namespace internal
           if (fe.dofs_per_hex > 0)
             {
               Assert ((cell->dof_index(0, fe_index) ==
-                       DoFHandler<dim,spacedim>::invalid_dof_index),
+                       numbers::invalid_dof_index),
                       ExcInternalError());
 
               for (unsigned int d=0; d<fe.dofs_per_hex; ++d, ++next_free_dof)
@@ -621,10 +621,10 @@ namespace internal
 
               dof_handler.levels[level]->dof_indices
                 = std::vector<types::global_dof_index> (next_free_dof,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
               dof_handler.levels[level]->cell_dof_indices_cache
                 = std::vector<types::global_dof_index> (cache_size,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
             }
 
           // safety check: make sure that
@@ -750,10 +750,10 @@ namespace internal
 
               dof_handler.levels[level]->dof_indices
                 = std::vector<types::global_dof_index> (next_free_dof,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
               dof_handler.levels[level]->cell_dof_indices_cache
                 = std::vector<types::global_dof_index> (cache_size,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
             }
 
           // safety check: make sure that
@@ -894,7 +894,7 @@ namespace internal
                                            (unsigned int)(-1));
             dof_handler.faces->lines.dofs
               = std::vector<types::global_dof_index> (n_line_slots,
-                                                      DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                      numbers::invalid_dof_index);
 
             // with the memory now
             // allocated, loop over the
@@ -1127,10 +1127,10 @@ namespace internal
 
               dof_handler.levels[level]->dof_indices
                 = std::vector<types::global_dof_index> (next_free_dof,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
               dof_handler.levels[level]->cell_dof_indices_cache
                 = std::vector<types::global_dof_index> (cache_size,
-                                                        DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                        numbers::invalid_dof_index);
             }
 
           // safety check: make sure that
@@ -1276,7 +1276,7 @@ namespace internal
                      (unsigned int)(-1));
                 dof_handler.faces->quads.dofs
                   = std::vector<types::global_dof_index> (n_quad_slots,
-                                                          DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                          numbers::invalid_dof_index);
               }
 
             // with the memory now
@@ -1500,7 +1500,7 @@ namespace internal
               // set up the linked lists for
               // each of the lines
               dof_handler.faces->lines.dofs.resize (line_slots_needed,
-                                                    DoFHandler<dim,spacedim>::invalid_dof_index);
+                                                    numbers::invalid_dof_index);
               for (unsigned int line=0; line<dof_handler.tria->n_raw_lines(); ++line)
                 if (line_is_used[line] == true)
                   {

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1239,7 +1239,7 @@ namespace MGTools
     local_dofs.reserve (DoFTools::max_dofs_per_face(dof));
     std::fill (local_dofs.begin (),
                local_dofs.end (),
-               DoFHandler<dim,spacedim>::invalid_dof_index);
+               numbers::invalid_dof_index);
 
     // First, deal with the simpler case when we have to identify all boundary dofs
     if (component_mask.n_selected_components(n_components) == n_components)

--- a/tests/bits/get_dof_indices_01.cc
+++ b/tests/bits/get_dof_indices_01.cc
@@ -75,7 +75,7 @@ void test ()
               << ", DoFs=";
       for (unsigned int i=0; i<fe.dofs_per_cell; ++i)
         {
-          Assert (local_dof_indices[i] != DoFHandler<dim>::invalid_dof_index,
+          Assert (local_dof_indices[i] != numbers::invalid_dof_index,
                   ExcInternalError());
           deallog << local_dof_indices[i] << ' ';
         }

--- a/tests/dofs/dof_tools_09.cc
+++ b/tests/dofs/dof_tools_09.cc
@@ -36,7 +36,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   boundary_ids.insert (0);
   DoFTools::map_dof_to_boundary_indices (dof_handler, map);
   for (unsigned int i=0; i<map.size(); ++i)
-    deallog << (map[i] == DoFHandler<dim>::invalid_dof_index ?
+    deallog << (map[i] == numbers::invalid_dof_index ?
                 -1 : static_cast<signed int>(map[i]))
             << " ";
   deallog << std::endl;
@@ -45,7 +45,7 @@ check_this (const DoFHandler<dim> &dof_handler)
   boundary_ids.insert (1);
   DoFTools::map_dof_to_boundary_indices (dof_handler, map);
   for (unsigned int i=0; i<map.size(); ++i)
-    deallog << (map[i] == DoFHandler<dim>::invalid_dof_index ?
+    deallog << (map[i] == numbers::invalid_dof_index ?
                 -1 : static_cast<signed int>(map[i]))
             << " ";
   deallog << std::endl;

--- a/tests/mpi/mg_04.cc
+++ b/tests/mpi/mg_04.cc
@@ -20,7 +20,7 @@
 An error occurred in line <1344> of file </scratch/deal-trunk/deal.II/source/dofs/dof_handler_policy.cc> in function
     void dealii::internal::DoFHandler::Policy::{anonymous}::set_mg_dofindices_recursively(const dealii::parallel::distributed::Triangulation<dim, spacedim>&, const typename dealii::internal::p4est::types<dim>::quadrant&, const typename dealii::DoFHandler<dim, spacedim>::level_cell_iterator&, const typename dealii::internal::p4est::types<dim>::quadrant&, unsigned int*, unsigned int) [with int dim = 2; int spacedim = 2; typename dealii::internal::p4est::types<dim>::quadrant = p4est_quadrant; typename dealii::DoFHandler<dim, spacedim>::level_cell_iterator = dealii::TriaIterator<dealii::DoFCellAccessor<dealii::DoFHandler<2>, true> >]
 The violated condition was:
-    (dof_indices[i] == (DoFHandler<dim,spacedim>::invalid_dof_index)) || (dof_indices[i]==dofs[i])
+    (dof_indices[i] == (numbers::invalid_dof_index)) || (dof_indices[i]==dofs[i])
 The name and call sequence of the exception was:
     ExcInternalError()
 Additional Information:

--- a/tests/mpi/p4est_2d_dofhandler_03.cc
+++ b/tests/mpi/p4est_2d_dofhandler_03.cc
@@ -105,7 +105,7 @@ void test()
             std::sort(local_dof_indices.begin(), local_dof_indices.end());
 
             //macros are evil...
-            types::global_dof_index invalid_dofindex = DoFHandler<dim,dim>::invalid_dof_index;
+            types::global_dof_index invalid_dofindex = numbers::invalid_dof_index;
             Assert((*local_dof_indices.rbegin())!=invalid_dofindex, ExcInternalError());
 
           }

--- a/tests/mpi/p4est_2d_dofhandler_04.cc
+++ b/tests/mpi/p4est_2d_dofhandler_04.cc
@@ -108,7 +108,7 @@ void test()
             cell->get_dof_indices (local_dof_indices);
             for (std::vector<types::global_dof_index>::iterator it=local_dof_indices.begin(); it!= local_dof_indices.end(); ++it)
               {
-                types::global_dof_index invalid_dofindex = DoFHandler<dim,dim>::invalid_dof_index;
+                types::global_dof_index invalid_dofindex = numbers::invalid_dof_index;
                 Assert(*it!=invalid_dofindex, ExcInternalError());
                 control_dof_set.insert(*it);
               }


### PR DESCRIPTION
Also replace all uses by numbers::invalid_dof_index. I can't see a reason to
have both of these numbers, in particular because the only logical choice is
to have them have the same value.

This is a follow-up to #4526 and should be merged after that. Only the last of the commits here is actually new, compared to #4526. In preparation for #3511.