### PR TITLE
Compile TransfiniteInterpolationManifold<1> in the library.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -558,6 +558,11 @@ public:
    * has children.
    */
   bool has_children () const;
+
+  /**
+   * Dummy function that always returns numbers::invalid_manifold_id.
+   */
+  types::manifold_id manifold_id () const;
 };
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -511,6 +511,15 @@ InvalidAccessor<structdim, dim, spacedim>::operator -- () const
 
 
 
+template <int structdim, int dim, int spacedim>
+types::manifold_id
+InvalidAccessor<structdim, dim, spacedim>::manifold_id () const
+{
+  return numbers::invalid_manifold_id;
+}
+
+
+
 /*------------------------ Functions: TriaAccessor ---------------------------*/
 
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -630,7 +630,9 @@ TransfiniteInterpolationManifold<dim,spacedim>::TransfiniteInterpolationManifold
   :
   triangulation(nullptr),
   level_coarse (-1)
-{}
+{
+  AssertThrow(dim > 1, ExcNotImplemented());
+}
 
 
 
@@ -675,7 +677,7 @@ namespace
   Point<AccessorType::space_dimension>
   compute_transfinite_interpolation(const AccessorType &cell,
                                     const Point<1> &chart_point,
-                                    const bool      cell_is_flat)
+                                    const bool      /*cell_is_flat*/)
   {
     return cell.vertex(0) * (1.-chart_point[0]) + cell.vertex(1) * chart_point[0];
   }

--- a/source/grid/manifold_lib.inst.in
+++ b/source/grid/manifold_lib.inst.in
@@ -23,9 +23,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS
 #if deal_II_dimension <= deal_II_space_dimension
     template class PolarManifold<deal_II_dimension, deal_II_space_dimension>;
     template class SphericalManifold<deal_II_dimension, deal_II_space_dimension>;
-#if deal_II_dimension > 1
     template class TransfiniteInterpolationManifold<deal_II_dimension, deal_II_space_dimension>;
-#endif
 #endif
 #if deal_II_dimension == deal_II_space_dimension
     template class TorusManifold<deal_II_dimension>;


### PR DESCRIPTION
In addition, disable usage of the class in 1D by throwing an exception.

I have a solver which can run in 1D or 2D (this is the source of all of my recent 1D patches) and this enables me to use `TransfiniteInterpolationManifold` on some 2D grids and still compile the whole thing with `dim == 1`.