### PR TITLE
Further DoFHandlerPolicy cleanups.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1950,8 +1950,6 @@ namespace internal
      const unsigned int                                             fe_index)
     {
       const DoFHandlerType &handler = accessor.get_dof_handler();
-      Assert(handler.n_dofs(level) != numbers::invalid_dof_index,
-             ExcNotInitialized());
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
         = handler.get_fe ()[fe_index];
@@ -1976,8 +1974,6 @@ namespace internal
                              const unsigned int fe_index)
     {
       const DoFHandlerType &handler = accessor.get_dof_handler();
-      Assert(handler.n_dofs(level) != numbers::invalid_dof_index,
-             ExcNotInitialized());
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
         = handler.get_fe ()[fe_index];
@@ -2007,8 +2003,6 @@ namespace internal
      const unsigned int                                             fe_index)
     {
       const DoFHandlerType &handler = accessor.get_dof_handler();
-      Assert(handler.n_dofs(level) != numbers::invalid_dof_index,
-             ExcNotInitialized());
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
         = handler.get_fe ()[fe_index];

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -62,25 +62,24 @@ namespace internal
         virtual ~PolicyBase () = default;
 
         /**
-         * Distribute degrees of freedom on the object given as first
-         * argument. The reference to the NumberCache of the DoFHandler object
-         * has to be passed in a second argument. It could then be modified to
+         * Distribute degrees of freedom on the DoFHandler object associated
+         * with this policy object. The argument is a reference to the NumberCache
+         * of the DoFHandler object. The function may modify it to
          * make DoFHandler related functions work properly when called within
          * the policies classes. The updated NumberCache is written to that
          * argument.
          */
         virtual
         void
-        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                         NumberCache &number_cache) const = 0;
+        distribute_dofs (NumberCache &number_cache) const = 0;
 
         /**
-         * Distribute the multigrid dofs on each level
+         * Distribute the multigrid dofs on each level of the DoFHandler
+         * associated with this policy object.
          */
         virtual
         void
-        distribute_mg_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                            std::vector<NumberCache> &number_caches) const = 0;
+        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const = 0;
 
         /**
          * Renumber degrees of freedom as specified by the first argument. The
@@ -93,7 +92,6 @@ namespace internal
         virtual
         void
         renumber_dofs (const std::vector<types::global_dof_index> &new_numbers,
-                       dealii::DoFHandler<dim,spacedim> &dof_handler,
                        NumberCache &number_cache) const = 0;
       };
 
@@ -107,29 +105,33 @@ namespace internal
       {
       public:
         /**
-         * Distribute degrees of freedom on the object given as last argument.
+         * Constructor.
+         * @param dof_handler The DoFHandler object upon which this
+         *   policy class is supposed to work.
          */
+        Sequential (dealii::DoFHandler<dim,spacedim> &dof_handler);
+
+        // documentation is inherited
         virtual
         void
-        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                         NumberCache &number_cache) const;
+        distribute_dofs (NumberCache &number_cache) const;
 
-        /**
-         * Distribute multigrid DoFs.
-         */
+        // documentation is inherited
         virtual
         void
-        distribute_mg_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                            std::vector<NumberCache> &number_caches) const;
+        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
 
-        /**
-         * Renumber degrees of freedom as specified by the first argument.
-         */
+        // documentation is inherited
         virtual
         void
         renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       dealii::DoFHandler<dim,spacedim> &dof_handler,
                        NumberCache &number_cache) const;
+
+      protected:
+        /**
+         * The DoFHandler object on which this policy object works.
+         */
+        dealii::DoFHandler<dim,spacedim> &dof_handler;
       };
 
       /**
@@ -140,6 +142,12 @@ namespace internal
       class ParallelShared : public Sequential<dim,spacedim>
       {
       public:
+        /**
+         * Constructor.
+         * @param dof_handler The DoFHandler object upon which this
+         *   policy class is supposed to work.
+         */
+        ParallelShared (dealii::DoFHandler<dim,spacedim> &dof_handler);
 
         /**
          * Distribute degrees of freedom on the object given as first
@@ -151,16 +159,14 @@ namespace internal
          */
         virtual
         void
-        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                         NumberCache &number_cache) const;
+        distribute_dofs (NumberCache &number_cache) const;
 
         /**
          * This function is not yet implemented.
          */
         virtual
         void
-        distribute_mg_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                            std::vector<NumberCache> &number_caches) const;
+        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
 
         /**
          * Renumber degrees of freedom as specified by the first argument.
@@ -174,7 +180,6 @@ namespace internal
         virtual
         void
         renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       dealii::DoFHandler<dim,spacedim> &dof_handler,
                        NumberCache &number_cache) const;
       };
 
@@ -188,29 +193,33 @@ namespace internal
       {
       public:
         /**
-         * Distribute degrees of freedom on the object given as last argument.
+         * Constructor.
+         * @param dof_handler The DoFHandler object upon which this
+         *   policy class is supposed to work.
          */
+        ParallelDistributed (dealii::DoFHandler<dim,spacedim> &dof_handler);
+
+        // documentation is inherited
         virtual
         void
-        distribute_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                         NumberCache &number_cache) const;
+        distribute_dofs (NumberCache &number_cache) const;
 
-        /**
-         * Distribute multigrid DoFs.
-         */
+        // documentation is inherited
         virtual
         void
-        distribute_mg_dofs (dealii::DoFHandler<dim,spacedim> &dof_handler,
-                            std::vector<NumberCache> &number_caches) const;
+        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
 
-        /**
-         * Renumber degrees of freedom as specified by the first argument.
-         */
+        // documentation is inherited
         virtual
         void
         renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       dealii::DoFHandler<dim,spacedim> &dof_handler,
                        NumberCache &number_cache) const;
+
+      private:
+        /**
+         * The DoFHandler object on which this policy object works.
+         */
+        dealii::DoFHandler<dim,spacedim> &dof_handler;
       };
     }
   }

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -59,7 +59,7 @@ namespace internal
         /**
          * Destructor.
          */
-        virtual ~PolicyBase ();
+        virtual ~PolicyBase () = default;
 
         /**
          * Distribute degrees of freedom on the object given as first

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -70,8 +70,8 @@ namespace internal
          * argument.
          */
         virtual
-        void
-        distribute_dofs (NumberCache &number_cache) const = 0;
+        NumberCache
+        distribute_dofs () const = 0;
 
         /**
          * Distribute the multigrid dofs on each level of the DoFHandler
@@ -113,8 +113,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        distribute_dofs (NumberCache &number_cache) const;
+        NumberCache
+        distribute_dofs () const;
 
         // documentation is inherited
         virtual
@@ -158,8 +158,8 @@ namespace internal
          * number_cache.locally_owned_dofs are updated consistently.
          */
         virtual
-        void
-        distribute_dofs (NumberCache &number_cache) const;
+        NumberCache
+        distribute_dofs () const;
 
         /**
          * This function is not yet implemented.
@@ -201,8 +201,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        distribute_dofs (NumberCache &number_cache) const;
+        NumberCache
+        distribute_dofs () const;
 
         // documentation is inherited
         virtual

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -75,11 +75,12 @@ namespace internal
 
         /**
          * Distribute the multigrid dofs on each level of the DoFHandler
-         * associated with this policy object.
+         * associated with this policy object. Return a vector of number
+         * caches for all of the levels.
          */
         virtual
-        void
-        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const = 0;
+        std::vector<NumberCache>
+        distribute_mg_dofs () const = 0;
 
         /**
          * Renumber degrees of freedom as specified by the first argument. The
@@ -118,8 +119,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
+        std::vector<NumberCache>
+        distribute_mg_dofs () const;
 
         // documentation is inherited
         virtual
@@ -165,8 +166,8 @@ namespace internal
          * This function is not yet implemented.
          */
         virtual
-        void
-        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
+        std::vector<NumberCache>
+        distribute_mg_dofs () const;
 
         /**
          * Renumber degrees of freedom as specified by the first argument.
@@ -206,8 +207,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        distribute_mg_dofs (std::vector<NumberCache> &number_caches) const;
+        std::vector<NumberCache>
+        distribute_mg_dofs () const;
 
         // documentation is inherited
         virtual

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -131,7 +131,7 @@ namespace internal
         /**
          * The DoFHandler object on which this policy object works.
          */
-        dealii::DoFHandler<dim,spacedim> &dof_handler;
+        SmartPointer<dealii::DoFHandler<dim,spacedim> > dof_handler;
       };
 
       /**
@@ -219,7 +219,7 @@ namespace internal
         /**
          * The DoFHandler object on which this policy object works.
          */
-        dealii::DoFHandler<dim,spacedim> &dof_handler;
+        SmartPointer<dealii::DoFHandler<dim,spacedim> > dof_handler;
       };
     }
   }

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -83,17 +83,13 @@ namespace internal
         distribute_mg_dofs () const = 0;
 
         /**
-         * Renumber degrees of freedom as specified by the first argument. The
-         * reference to the NumberCache of the DoFHandler object has to be
-         * passed in a second argument. It could then be modified to make
-         * DoFHandler related functions work properly when called within the
-         * policies classes. The updated NumberCache is written to that
-         * argument.
+         * Renumber degrees of freedom as specified by the first argument.
+         *
+         * Return an updated NumberCache for the DoFHandler after renumbering.
          */
         virtual
-        void
-        renumber_dofs (const std::vector<types::global_dof_index> &new_numbers,
-                       NumberCache &number_cache) const = 0;
+        NumberCache
+        renumber_dofs (const std::vector<types::global_dof_index> &new_numbers) const = 0;
       };
 
 
@@ -124,9 +120,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       NumberCache &number_cache) const;
+        NumberCache
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
 
       protected:
         /**
@@ -175,13 +170,12 @@ namespace internal
          * The input argument @p new_numbers may either have as many entries
          * as there are global degrees of freedom (i.e. dof_handler.n_dofs() )
          * or dof_handler.locally_owned_dofs().n_elements(). Therefore it can
-         * be utilised with renumbering functions implemented for the
+         * be utilized with renumbering functions implemented for the
          * parallel::distributed case.
          */
         virtual
-        void
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       NumberCache &number_cache) const;
+        NumberCache
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
       };
 
 
@@ -212,9 +206,8 @@ namespace internal
 
         // documentation is inherited
         virtual
-        void
-        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers,
-                       NumberCache &number_cache) const;
+        NumberCache
+        renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
 
       private:
         /**

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -40,10 +40,22 @@ namespace internal
       NumberCache ();
 
       /**
+       * Copy constructor. Simply copy all members of the referenced
+       * object to the current object.
+       */
+      NumberCache (const NumberCache &) = default;
+
+      /**
        * Move constructor. Simply move all members of the referenced
        * object to the current object.
        */
       NumberCache (NumberCache &&) = default;
+
+      /**
+       * Copy operator. Simply copy all members of the referenced
+       * object to the current object.
+       */
+      NumberCache &operator= (const NumberCache &) = default;
 
       /**
        * Move assignment operator. Simply move all members of the referenced

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -40,6 +40,18 @@ namespace internal
       NumberCache ();
 
       /**
+       * Move constructor. Simply move all members of the referenced
+       * object to the current object.
+       */
+      NumberCache (NumberCache &&) = default;
+
+      /**
+       * Move assignment operator. Simply move all members of the referenced
+       * object to the current object.
+       */
+      NumberCache &operator= (NumberCache &&) = default;
+
+      /**
        * Determine an estimate for the memory consumption (in bytes) of this
        * object.
        */

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1098,7 +1098,7 @@ void DoFHandler<dim,spacedim>::distribute_dofs (const FiniteElement<dim,spacedim
   internal::DoFHandler::Implementation::reserve_space (*this);
 
   // hand things off to the policy
-  policy->distribute_dofs (number_cache);
+  number_cache = policy->distribute_dofs ();
 
   // initialize the block info object
   // only if this is a sequential

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1126,13 +1126,7 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs (const FiniteElement<dim, spa
   clear_mg_space();
 
   internal::DoFHandler::Implementation::reserve_space_mg (*this);
-  const parallel::distributed::Triangulation<dim,spacedim> *dist_tr = dynamic_cast<const parallel::distributed::Triangulation<dim,spacedim>*>(&*tria);
-  if (!dist_tr)
-    mg_number_cache.resize((*tria).n_levels());
-  else
-    mg_number_cache.resize(dist_tr->n_global_levels());
-
-  policy->distribute_mg_dofs (mg_number_cache);
+  mg_number_cache = policy->distribute_mg_dofs ();
 
   // initialize the block info object
   // only if this is a sequential

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1215,7 +1215,7 @@ DoFHandler<dim,spacedim>::renumber_dofs (const std::vector<types::global_dof_ind
               ExcMessage ("New DoF index is not less than the total number of dofs."));
 #endif
 
-  policy->renumber_dofs (new_numbers, number_cache);
+  number_cache = policy->renumber_dofs (new_numbers);
 }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -908,13 +908,6 @@ namespace internal
 
 
 
-      /* --------------------- class PolicyBase ---------------- */
-
-      template <int dim, int spacedim>
-      PolicyBase<dim,spacedim>::~PolicyBase ()
-      {}
-
-
       /* --------------------- class Sequential ---------------- */
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -922,9 +922,9 @@ namespace internal
 
 
       template <int dim, int spacedim>
-      void
+      NumberCache
       Sequential<dim,spacedim>::
-      distribute_dofs (NumberCache &number_cache_current) const
+      distribute_dofs () const
       {
         const types::global_dof_index n_dofs =
           Implementation::distribute_dofs (0,
@@ -950,7 +950,8 @@ namespace internal
         number_cache.locally_owned_dofs_per_processor
           = std::vector<IndexSet> (1,
                                    number_cache.locally_owned_dofs);
-        number_cache_current = number_cache;
+
+        return number_cache;
       }
 
 
@@ -1011,7 +1012,7 @@ namespace internal
         number_cache.locally_owned_dofs_per_processor
           = std::vector<IndexSet> (1,
                                    number_cache.locally_owned_dofs);
-        number_cache_current = number_cache;
+        number_cache_current = std::move(number_cache);
       }
 
 
@@ -1027,55 +1028,243 @@ namespace internal
 
 
 
+      namespace
+      {
+        /**
+         * This function is a variation of DoFTools::get_dof_subdomain_association()
+         * with the exception that it is (i) specialized for
+         * parallel::shared::Triangulation objects, and (ii) does not assume that the
+         * internal number cache of the DoFHandler has already been set up. In can,
+         * consequently, be called at a point when we are still distributing degrees
+         * of freedom.
+         */
+        template <class DoFHandlerType>
+        std::vector<types::subdomain_id>
+        get_dof_subdomain_association (const DoFHandlerType          &dof_handler,
+                                       const types::global_dof_index  n_dofs,
+                                       const unsigned int             n_procs)
+        {
+          std::vector<types::subdomain_id> subdomain_association (n_dofs,
+                                                                  numbers::invalid_subdomain_id);
+          std::vector<types::global_dof_index> local_dof_indices;
+          local_dof_indices.reserve (DoFTools::max_dofs_per_cell(dof_handler));
+
+          // pseudo-randomly assign variables which lie on the interface between
+          // subdomains to each of the two or more
+          bool coin_flip = true;
+
+          // loop over all cells and record which subdomain a DoF belongs to.
+          // toss a coin in case it is on an interface
+          typename DoFHandlerType::active_cell_iterator
+          cell = dof_handler.begin_active(),
+          endc = dof_handler.end();
+          for (; cell!=endc; ++cell)
+            {
+              // get the owner of the cell; note that we have made sure above that
+              // all cells are either locally owned or ghosts (not artificial), so
+              // this call will always yield the true owner
+              const types::subdomain_id subdomain_id = cell->subdomain_id();
+              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              local_dof_indices.resize (dofs_per_cell);
+              cell->get_dof_indices (local_dof_indices);
+
+              // set subdomain ids. if dofs already have their values set then
+              // they must be on partition interfaces. in that case randomly
+              // assign them to either the previous association or the current
+              // one, where we take "random" to be "once this way once that way"
+              for (unsigned int i=0; i<dofs_per_cell; ++i)
+                if (subdomain_association[local_dof_indices[i]] ==
+                    numbers::invalid_subdomain_id)
+                  subdomain_association[local_dof_indices[i]] = subdomain_id;
+                else
+                  {
+                    if (coin_flip == true)
+                      subdomain_association[local_dof_indices[i]] = subdomain_id;
+                    coin_flip = !coin_flip;
+                  }
+            }
+
+          Assert (std::find (subdomain_association.begin(),
+                             subdomain_association.end(),
+                             numbers::invalid_subdomain_id)
+                  == subdomain_association.end(),
+                  ExcInternalError());
+
+          Assert (*std::max_element (subdomain_association.begin(),
+                                     subdomain_association.end())
+                  < n_procs,
+                  ExcInternalError());
+
+          return subdomain_association;
+        }
+
+      }
 
 
       template <int dim, int spacedim>
-      void
+      NumberCache
       ParallelShared<dim,spacedim>::
-      distribute_dofs (NumberCache &number_cache) const
+      distribute_dofs () const
       {
-        // If the underlying shared::Tria allows artificial cells, we need to do
-        // some tricks here to make Sequential algorithms play nicely.
-        // Namely, we first restore the original partition (without artificial cells)
-        // and then turn artificial cells on at the end of this function.
         const parallel::shared::Triangulation<dim, spacedim> *tr =
           (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&this->dof_handler->get_triangulation()));
         Assert(tr != nullptr, ExcInternalError());
-        typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator
-        cell = this->dof_handler->get_triangulation().begin_active(),
-        endc = this->dof_handler->get_triangulation().end();
-        std::vector<types::subdomain_id> current_subdomain_ids(tr->n_active_cells());
-        const std::vector<types::subdomain_id> &true_subdomain_ids = tr->get_true_subdomain_ids_of_cells();
+
+        const unsigned int n_procs = Utilities::MPI::n_mpi_processes(tr->get_communicator());
+
+        // If the underlying shared::Tria allows artificial cells,
+        // then save the current set of subdomain ids, and set
+        // subdomain ids to the "true" owner of each cell. we later
+        // restore these flags
+        std::vector<types::subdomain_id> saved_subdomain_ids;
         if (tr->with_artificial_cells())
-          for (unsigned int index=0; cell != endc; cell++, index++)
+          {
+            saved_subdomain_ids.resize (tr->n_active_cells());
+
+            typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator
+            cell = this->dof_handler->get_triangulation().begin_active(),
+            endc = this->dof_handler->get_triangulation().end();
+
+            const std::vector<types::subdomain_id> &true_subdomain_ids
+              = tr->get_true_subdomain_ids_of_cells();
+
+            for (unsigned int index=0; cell != endc; ++cell, ++index)
+              {
+                saved_subdomain_ids[index] = cell->subdomain_id();
+                cell->set_subdomain_id(true_subdomain_ids[index]);
+              }
+          }
+
+        // first let the sequential algorithm do its magic. it is going to
+        // enumerate DoFs on all cells, regardless of owner
+        NumberCache number_cache
+          = this->Sequential<dim,spacedim>::distribute_dofs ();
+
+        // then re-enumerate them based on their subdomain association.
+        // for this, we first have to identify for each current DoF
+        // index which subdomain they belong to. ideally, we would
+        // like to call DoFRenumbering::subdomain_wise(), but
+        // because the NumberCache of the current DoFHandler is not
+        // fully set up yet, we can't quite do that. also, that
+        // function has to deal with other kinds of triangulations as
+        // well, whereas we here know what kind of triangulation
+        // we have and can simplify the code accordingly
+        const unsigned int n_dofs = number_cache.n_global_dofs;
+        std::vector<types::global_dof_index> new_dof_indices (n_dofs,
+                                                              numbers::invalid_dof_index);
+        {
+          // first get the association of each dof with a subdomain and
+          // determine the total number of subdomain ids used
+          const std::vector<types::subdomain_id> subdomain_association
+            = get_dof_subdomain_association (*this->dof_handler, n_dofs, n_procs);
+
+          // then renumber the subdomains by first looking at those belonging
+          // to subdomain 0, then those of subdomain 1, etc. note that the
+          // algorithm is stable, i.e. if two dofs i,j have i<j and belong to
+          // the same subdomain, then they will be in this order also after
+          // reordering
+          types::global_dof_index next_free_index = 0;
+          for (types::subdomain_id subdomain=0; subdomain<n_procs; ++subdomain)
+            for (types::global_dof_index i=0; i<n_dofs; ++i)
+              if (subdomain_association[i] == subdomain)
+                {
+                  Assert (new_dof_indices[i] == numbers::invalid_dof_index,
+                          ExcInternalError());
+                  new_dof_indices[i] = next_free_index;
+                  ++next_free_index;
+                }
+
+          // we should have numbered all dofs
+          Assert (next_free_index == n_dofs, ExcInternalError());
+          Assert (std::find (new_dof_indices.begin(), new_dof_indices.end(),
+                             numbers::invalid_dof_index)
+                  == new_dof_indices.end(),
+                  ExcInternalError());
+        }
+        // finally do the renumbering. we can use the sequential
+        // version of the function because we do things on all
+        // cells and all cells have their subdomain ids and DoFs
+        // correctly set
+        this->Sequential<dim, spacedim>::renumber_dofs (new_dof_indices, number_cache);
+
+
+        // update the number cache. for this, we first have to find the subdomain
+        // association for each DoF again following renumbering, from which we
+        // can then compute the IndexSets of locally owned DoFs for all processors.
+        // all other fields then follow from this
+        //
+        // given the way we enumerate degrees of freedom, the locally owned
+        // ranges must all be contiguous and consecutive. this makes filling
+        // the IndexSets cheap. an assertion at the top verifies that this
+        // assumption is true
+        const std::vector<types::subdomain_id> subdomain_association
+          = get_dof_subdomain_association (*this->dof_handler, n_dofs, n_procs);
+
+        for (unsigned int i=1; i<n_dofs; ++i)
+          Assert (subdomain_association[i] >= subdomain_association[i-1],
+                  ExcInternalError());
+
+        {
+          number_cache.locally_owned_dofs_per_processor.clear();
+          number_cache.locally_owned_dofs_per_processor.resize (n_procs,
+                                                                IndexSet(n_dofs));
+
+          // we know that the set of subdomain indices is contiguous from
+          // the assertion above; find the start and end index for each
+          // processor, taking into account that sometimes a processor
+          // may not in fact have any DoFs at all. we do the latter
+          // by just identifying contiguous ranges of subdomain_ids
+          // and filling IndexSets for those subdomains; subdomains
+          // that don't appear will lead to IndexSets that are simply
+          // never touched and remain empty as initialized above.
+          unsigned int start_index = 0;
+          unsigned int end_index   = 0;
+          while (start_index < n_dofs)
             {
-              current_subdomain_ids[index] = cell->subdomain_id();
-              cell->set_subdomain_id(true_subdomain_ids[index]);
+              while ((end_index) < n_dofs &&
+                     (subdomain_association[end_index] == subdomain_association[start_index]))
+                ++end_index;
+
+              // we've now identified a range of same indices. set that
+              // range in the corresponding IndexSet
+              if (end_index > start_index)
+                {
+                  const unsigned int subdomain_owner = subdomain_association[start_index];
+                  number_cache.locally_owned_dofs_per_processor[subdomain_owner]
+                  .add_range (start_index, end_index);
+                }
+
+              // then move on to thinking about the next range
+              start_index = end_index;
             }
+        }
 
-        // let the sequential algorithm do its magic, then sort DoF indices
-        // by subdomain
-        this->Sequential<dim,spacedim>::distribute_dofs (number_cache);
-        DoFRenumbering::subdomain_wise (*this->dof_handler);
+        // from this, calculate all of the other number cache fields
+        number_cache.locally_owned_dofs
+          = number_cache.locally_owned_dofs_per_processor[this->dof_handler->get_triangulation().locally_owned_subdomain()];
+        number_cache.n_locally_owned_dofs_per_processor
+        .resize (number_cache.locally_owned_dofs_per_processor.size());
+        for (unsigned int i=0; i<number_cache.n_locally_owned_dofs_per_processor.size(); ++i)
+          number_cache.n_locally_owned_dofs_per_processor[i]
+            = number_cache.locally_owned_dofs_per_processor[i].n_elements();
+        number_cache.n_locally_owned_dofs
+          = number_cache.n_locally_owned_dofs_per_processor[this->dof_handler->get_triangulation().locally_owned_subdomain()];
 
-        // dofrenumbering will reset subdomains, this is ugly but we need to do it again:
-        cell = tr->begin_active();
+        number_cache.n_global_dofs = n_dofs;
+
+
+        // finally, restore current subdomain ids
         if (tr->with_artificial_cells())
-          for (unsigned int index=0; cell != endc; cell++, index++)
-            cell->set_subdomain_id(true_subdomain_ids[index]);
+          {
+            typename parallel::shared::Triangulation<dim,spacedim>::active_cell_iterator
+            cell = this->dof_handler->get_triangulation().begin_active(),
+            endc = this->dof_handler->get_triangulation().end();
 
-        number_cache.locally_owned_dofs_per_processor = DoFTools::locally_owned_dofs_per_subdomain (*this->dof_handler);
-        number_cache.locally_owned_dofs = number_cache.locally_owned_dofs_per_processor[this->dof_handler->get_triangulation().locally_owned_subdomain()];
-        number_cache.n_locally_owned_dofs_per_processor.resize (number_cache.locally_owned_dofs_per_processor.size());
-        for (unsigned int i = 0; i < number_cache.n_locally_owned_dofs_per_processor.size(); i++)
-          number_cache.n_locally_owned_dofs_per_processor[i] = number_cache.locally_owned_dofs_per_processor[i].n_elements();
-        number_cache.n_locally_owned_dofs = number_cache.n_locally_owned_dofs_per_processor[this->dof_handler->get_triangulation().locally_owned_subdomain()];
+            for (unsigned int index=0; cell != endc; ++cell, ++index)
+              cell->set_subdomain_id(saved_subdomain_ids[index]);
+          }
 
-        // restore current subdomain ids
-        cell = tr->begin_active();
-        if (tr->with_artificial_cells())
-          for (unsigned int index=0; cell != endc; cell++, index++)
-            cell->set_subdomain_id(current_subdomain_ids[index]);
+        return number_cache;
       }
 
 
@@ -2088,9 +2277,9 @@ namespace internal
 
 
       template <int dim, int spacedim>
-      void
+      NumberCache
       ParallelDistributed<dim, spacedim>::
-      distribute_dofs (NumberCache &number_cache_current) const
+      distribute_dofs () const
       {
         NumberCache number_cache;
 
@@ -2289,7 +2478,7 @@ namespace internal
 #endif // DEBUG
 #endif // DEAL_II_WITH_P4EST
 
-        number_cache_current = number_cache;
+        return number_cache;
       }
 
 
@@ -2777,7 +2966,7 @@ namespace internal
         }
 #endif
 
-        number_cache_current = number_cache;
+        number_cache_current = std::move(number_cache);
       }
     }
   }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -434,8 +434,7 @@ namespace internal
         template <int dim, int spacedim>
         static
         unsigned int
-        distribute_dofs_on_level (const unsigned int        offset,
-                                  const types::subdomain_id level_subdomain_id,
+        distribute_dofs_on_level (const types::subdomain_id level_subdomain_id,
                                   DoFHandler<dim,spacedim> &dof_handler,
                                   const unsigned int level)
         {
@@ -457,7 +456,7 @@ namespace internal
           tria.save_user_flags(user_flags);
           const_cast<dealii::Triangulation<dim,spacedim> &>(tria).clear_user_flags ();
 
-          unsigned int next_free_dof = offset;
+          unsigned int next_free_dof = 0;
           typename DoFHandler<dim,spacedim>::level_cell_iterator
           cell = dof_handler.begin(level),
           endc = dof_handler.end(level);
@@ -971,7 +970,7 @@ namespace internal
         for (unsigned int level = 0; level < dof_handler->get_triangulation().n_levels(); ++level)
           {
             const types::global_dof_index next_free_dof
-              = Implementation::distribute_dofs_on_level(0, numbers::invalid_subdomain_id,
+              = Implementation::distribute_dofs_on_level(numbers::invalid_subdomain_id,
                                                          *dof_handler, level);
 
             // set up the number cache of this level
@@ -2537,8 +2536,7 @@ namespace internal
 
             //* 1. distribute on own subdomain
             const unsigned int n_initial_local_dofs =
-              Implementation::distribute_dofs_on_level(0,
-                                                       tr->locally_owned_subdomain(),
+              Implementation::distribute_dofs_on_level(tr->locally_owned_subdomain(),
                                                        *dof_handler,
                                                        level);
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1422,9 +1422,11 @@ namespace DoFTools
            ExcDimensionMismatch(subdomain_association.size(),
                                 dof_handler.n_dofs()));
 
-    Assert(dof_handler.n_dofs() > 0,
-           ExcMessage("Number of DoF is not positive. "
-                      "This could happen when the function is called before NumberCache is written."));
+    // catch an error that happened in some versions of the shared tria
+    // distribute_dofs() function where we were trying to call this
+    // function at a point in time when not all internal DoFHandler
+    // structures were quite set up yet.
+    Assert(dof_handler.n_dofs() > 0, ExcInternalError());
 
     // In case this function is executed with parallel::shared::Triangulation
     // with possibly artifical cells, we need to take "true" subdomain IDs (i.e. without


### PR DESCRIPTION
Again in preparation for #3511. The idea here is that instead of passing the
DoFHandler object as a reference argument to each of the policy functions
(thereby enshrining the DoFHandler type into the interface), rather just
let derived classes store this reference whenever they are constructed.

This way I can share the idea of the policy classes with the hp class,
and should be able to share some code as well.

I ran all multigrid tests, which exercise both the non-mg and mg
parts of the DoFHandler. I see no failures.