### PR TITLE
Add a glossary link for material_id.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -126,6 +126,9 @@ namespace types
    *
    * There is a special value, numbers::invalid_material_id that is used to
    * indicate an invalid value of this type.
+   *
+   * @see
+   * @ref GlossMaterialId "Glossary entry on material indicators"
    */
   typedef unsigned char material_id;
 }


### PR DESCRIPTION
This little commit adds a link equivalent to the one for Manifold IDs to the `typedef` of `material_id`.