### PR TITLE
Fix test output for two tests

### DIFF
--- a/tests/lac/precondition_chebyshev_03.with_lapack=true.output
+++ b/tests/lac/precondition_chebyshev_03.with_lapack=true.output
@@ -1,13 +1,13 @@
 
 DEAL::Size 4 Unknowns 9
-DEAL::Residual step i=0:   ilu=0.3321, cheby=0.0826
-DEAL::Residual step i=1:   ilu=0.3592, cheby=0.0825
-DEAL::Residual step i=2:   ilu=0.1717, cheby=0.0523
+DEAL::Residual step i=0:   ilu=0.3321, cheby=0.0789
+DEAL::Residual step i=1:   ilu=0.3592, cheby=0.0789
+DEAL::Residual step i=2:   ilu=0.1717, cheby=0.0507
 DEAL::Size 8 Unknowns 49
-DEAL::Residual step i=0:   ilu=1.9436, cheby=0.1554
-DEAL::Residual step i=1:   ilu=2.1487, cheby=0.1587
-DEAL::Residual step i=2:   ilu=1.7563, cheby=0.1575
+DEAL::Residual step i=0:   ilu=1.9436, cheby=0.1549
+DEAL::Residual step i=1:   ilu=2.1487, cheby=0.1583
+DEAL::Residual step i=2:   ilu=1.7563, cheby=0.1571
 DEAL::Size 16 Unknowns 225
-DEAL::Residual step i=0:   ilu=6.1463, cheby=0.3718
-DEAL::Residual step i=1:   ilu=6.2524, cheby=0.3873
-DEAL::Residual step i=2:   ilu=5.6540, cheby=0.3595
+DEAL::Residual step i=0:   ilu=6.1463, cheby=0.3688
+DEAL::Residual step i=1:   ilu=6.2524, cheby=0.3843
+DEAL::Residual step i=2:   ilu=5.6540, cheby=0.3568

--- a/tests/trilinos/solver_control_06.mpirun=1.output.2
+++ b/tests/trilinos/solver_control_06.mpirun=1.output.2
@@ -1,0 +1,14 @@
+
+DEAL::Convergence step 1 value 2.94702e-13
+DEAL::Convergence step 1 value 2.94702e-13
+DEAL::Convergence step 1 value 2.44586e-16
+DEAL::Convergence step 1 value 2.37953e-13
+DEAL::Convergence step 1 value 1.29101e-16
+DEAL::Convergence step 1 value 2.41628e-16
+DEAL::Convergence step 13 value 1.68944e-13
+DEAL::Convergence step 13 value 1.68944e-13
+DEAL::Convergence step 7 value 4.71695e-14
+DEAL::Convergence step 13 value 1.67245e-13
+DEAL::Convergence step 7 value 7.94998e-13
+DEAL::Convergence step 7 value 5.00750e-14
+DEAL::OK

--- a/tests/trilinos/solver_control_06.mpirun=2.output.2
+++ b/tests/trilinos/solver_control_06.mpirun=2.output.2
@@ -1,0 +1,14 @@
+
+DEAL::Convergence step 1 value 2.94697e-13
+DEAL::Convergence step 1 value 2.94697e-13
+DEAL::Convergence step 1 value 2.39450e-16
+DEAL::Convergence step 1 value 2.37952e-13
+DEAL::Convergence step 1 value 1.26614e-16
+DEAL::Convergence step 1 value 2.34406e-16
+DEAL::Convergence step 12 value 8.50037e-13
+DEAL::Convergence step 12 value 8.50037e-13
+DEAL::Convergence step 7 value 1.94775e-14
+DEAL::Convergence step 12 value 8.42721e-13
+DEAL::Convergence step 7 value 5.55662e-13
+DEAL::Convergence step 7 value 2.07742e-14
+DEAL::OK


### PR DESCRIPTION
This fixes two (unrelated) test failures:
- The first commit addresses a test that was overlooked in #4458.
- The second commit adds a second output file to the commit from #4515. Trilinos has apparently changed the output between different versions.

Observed by the test failures here:
https://cdash.kyomu.43-1.org/viewTest.php?onlyfailed&buildid=8363