### PR TITLE
Grammar: clarify obtain vs. attain.

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -257,7 +257,7 @@ namespace PETScWrappers
 
     /**
      * Initialize a Vector from a PETSc Vec object. Note that we do not copy
-     * the vector and we do not attain ownership, so we do not destroy the
+     * the vector and we do not obtain ownership, so we do not destroy the
      * PETSc object in the destructor.
      */
     explicit VectorBase (const Vec &v);
@@ -711,7 +711,7 @@ namespace PETScWrappers
      * it got created by this class and determines if it gets destructed in
      * the destructor.
      */
-    bool attained_ownership;
+    bool obtained_ownership;
 
     /**
      * Collective set or add operation: This function is invoked by the

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -134,7 +134,7 @@ namespace PETScWrappers
     void
     Vector::clear ()
     {
-      attained_ownership = true;
+      obtained_ownership = true;
       VectorBase::clear ();
 
       create_vector(0, 0);

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -114,7 +114,7 @@ namespace PETScWrappers
     vector (nullptr),
     ghosted(false),
     last_action (::dealii::VectorOperation::unknown),
-    attained_ownership(true)
+    obtained_ownership(true)
   {
     Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
@@ -129,7 +129,7 @@ namespace PETScWrappers
     ghosted(v.ghosted),
     ghost_indices(v.ghost_indices),
     last_action (::dealii::VectorOperation::unknown),
-    attained_ownership(true)
+    obtained_ownership(true)
   {
     Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
@@ -150,7 +150,7 @@ namespace PETScWrappers
     vector(v),
     ghosted(false),
     last_action (::dealii::VectorOperation::unknown),
-    attained_ownership(false)
+    obtained_ownership(false)
   {
     Assert( MultithreadInfo::is_running_single_threaded(),
             ExcMessage("PETSc does not support multi-threaded access, set "
@@ -161,7 +161,7 @@ namespace PETScWrappers
 
   VectorBase::~VectorBase ()
   {
-    if (attained_ownership)
+    if (obtained_ownership)
       {
         const PetscErrorCode ierr = VecDestroy (&vector);
         AssertNothrow (ierr == 0, ExcPETScError(ierr));
@@ -174,7 +174,7 @@ namespace PETScWrappers
   void
   VectorBase::clear ()
   {
-    if (attained_ownership)
+    if (obtained_ownership)
       {
         const PetscErrorCode ierr = VecDestroy (&vector);
         AssertThrow (ierr == 0, ExcPETScError(ierr));
@@ -183,7 +183,7 @@ namespace PETScWrappers
     ghosted = false;
     ghost_indices.clear ();
     last_action = ::dealii::VectorOperation::unknown;
-    attained_ownership = true;
+    obtained_ownership = true;
   }
 
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -156,8 +156,7 @@ build_one_patch (const cell_iterator                                            
             {
               const Point<dimension> v = (*cell)->vertex(vertex);
 
-              // make sure that the radial variable does attain negative
-              // values
+              // make sure that the radial variable is nonnegative
               Assert (v(0) >= 0, ExcRadialVariableHasNegativeValues(v(0)));
 
               // now set the vertices of the patch


### PR DESCRIPTION
Attain and obtain are nearly, but not quite, synonyms: 'attain' implies achievement or accomplishment while 'obtain' just implies ownership. This patch fixes our errant usage of 'attain' (one comment also had a logic error, which I fixed).