### PR TITLE
Compress the result of complete_index_set().

### DIFF
--- a/doc/news/changes/minor/20170624Bangerth
+++ b/doc/news/changes/minor/20170624Bangerth
@@ -1,0 +1,4 @@
+Changed: The complete_index_set() function now returns a compressed
+version of the IndexSet that contains all indices.
+<br>
+(Wolfgang Bangerth, 2017/06/24)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -887,6 +887,7 @@ IndexSet complete_index_set (const unsigned int N)
 {
   IndexSet is (N);
   is.add_range(0, N);
+  is.compress();
   return is;
 }
 


### PR DESCRIPTION
I was getting different results from the serialization of a DoFHandler after simplifying
some code, and after several hours of debugging found that it is a non-functional difference
in how we store a complete IndexSet -- go figure. The difference is that in the old
code, we added the complete range and then called compress() whereas in the new code,
we just called complete_index_set(). The index set represented is the same, but the
internal representation is different because the latter was not compressed and the
index of the largest range wasn't set.

I opted for a changelog entry because the effect is visible via serialization. There
is already one test that showed the difference this patch makes when applying 
other patches I'm working on.