### PR TITLE
Suppress a warning.

### DIFF
--- a/bundled/boost-1.62.0/include/boost/iostreams/filter/gzip.hpp
+++ b/bundled/boost-1.62.0/include/boost/iostreams/filter/gzip.hpp
@@ -670,8 +670,8 @@ basic_gzip_compressor<Alloc>::basic_gzip_compressor
               gzip::extra_flags::best_speed :
               0 );
     header_.reserve(length);
-    header_ += gzip::magic::id1;                         // ID1.
-    header_ += gzip::magic::id2;                         // ID2.
+    header_ += char(gzip::magic::id1);                   // ID1.
+    header_ += char(gzip::magic::id2);                   // ID2.
     header_ += gzip::method::deflate;                    // CM.
     header_ += static_cast<char>(flags);                 // FLG.
     header_ += static_cast<char>(0xFF & p.mtime);        // MTIME.


### PR DESCRIPTION
The compiler warns about the line
  header_ += gzip::magic::id2;                   // ID2.
deep in BOOST when writing the header for a gzip-compressed block of data. This
is because (i) gzip::magic::id2 is declared as an int, and (ii) has a value
greater than what a *signed char* can store, i.e., greater than 127. Furthermore,
std::string::operator+ takes a 'char', which may or may not be unsigned but
apparently on my system is signed. So we get a warning about overflow.

The only reasonable way to deal with this is to do the casting explicitly.

Follow-up to #4528.