### PR TITLE
Last DoFHandlerPolicy updates for now.

### DIFF
--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -135,7 +135,7 @@ namespace internal
        * parallel::shared::Triangulation object.
        */
       template <int dim, int spacedim>
-      class ParallelShared : public Sequential<dim,spacedim>
+      class ParallelShared : public PolicyBase<dim,spacedim>
       {
       public:
         /**
@@ -176,6 +176,12 @@ namespace internal
         virtual
         NumberCache
         renumber_dofs (const std::vector<types::global_dof_index>  &new_numbers) const;
+
+      private:
+        /**
+         * The DoFHandler object on which this policy object works.
+         */
+        SmartPointer<dealii::DoFHandler<dim,spacedim> > dof_handler;
       };
 
 


### PR DESCRIPTION
Still in preparation for #3511. I think I'm done for the moment with this
file and will turn my attention to the hp::DoFHandler class and clean up
there a bit before attempting to parallelize it.

There are places in the DoFHandler Policy classes that I still want to
clean up. Specifically, the parallel distributed functions are still
a bit of a mess -- they probably haven't been touched since 2010 and
could use some TLC. But that can wait till I'm about to use that
code for the hp case. For the moment my next goal is to use the
policy classes for the sequential and parallel shared cases.

I'm grateful for the reviews -- I know that's not exciting work,
but I think/hope that I'm making our code base easier to read
and maintain.