### PR TITLE
Use inheritance for TrilinosWrappers iterative solver AdditionalData.

### DIFF
--- a/doc/news/changes/incompatibilities/20170626Jean-PaulPelteret
+++ b/doc/news/changes/incompatibilities/20170626Jean-PaulPelteret
@@ -1,0 +1,6 @@
+Changed: The restart_parameter member variable of
+TrilinosWrappers::SolverGMRES::AdditionalData has been removed.
+This value is now stored as gmres_restart_parameter in the base class
+TrilinosWrappers::SolverBase::AdditionalData.
+<br>
+(Jean-Paul Pelteret, 2017/06/26)

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -370,19 +370,13 @@ namespace TrilinosWrappers
      * Standardized data struct to pipe additional data to the solver.
      */
 
-    struct AdditionalData
+    struct AdditionalData : public SolverBase::AdditionalData
     {
       /**
        * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
     };
 
     /**
@@ -416,19 +410,13 @@ namespace TrilinosWrappers
     /**
      * Standardized data struct to pipe additional data to the solver.
      */
-    struct AdditionalData
+    struct AdditionalData : public SolverBase::AdditionalData
     {
       /**
        * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
     };
 
     /**
@@ -462,7 +450,7 @@ namespace TrilinosWrappers
     /**
      * Standardized data struct to pipe additional data to the solver.
      */
-    struct AdditionalData
+    struct AdditionalData : public SolverBase::AdditionalData
     {
       /**
        * Constructor. By default, set the number of temporary vectors to 30,
@@ -471,17 +459,6 @@ namespace TrilinosWrappers
       explicit
       AdditionalData (const bool         output_solver_details = false,
                       const unsigned int restart_parameter = 30);
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
-
-      /**
-       * Maximum number of tmp vectors.
-       */
-      unsigned int restart_parameter;
     };
 
     /**
@@ -516,19 +493,13 @@ namespace TrilinosWrappers
     /**
      * Standardized data struct to pipe additional data to the solver.
      */
-    struct AdditionalData
+    struct AdditionalData : public SolverBase::AdditionalData
     {
       /**
        * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
     };
 
     /**
@@ -563,19 +534,13 @@ namespace TrilinosWrappers
     /**
      * Standardized data struct to pipe additional data to the solver.
      */
-    struct AdditionalData
+    struct AdditionalData : public SolverBase::AdditionalData
     {
       /**
        * Set the additional data field to the desired output format.
        */
       explicit
       AdditionalData (const bool output_solver_details = false);
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
     };
 
     /**

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -601,7 +601,7 @@ namespace TrilinosWrappers
   SolverCG::AdditionalData::
   AdditionalData (const bool output_solver_details)
     :
-    output_solver_details (output_solver_details)
+    SolverBase::AdditionalData (output_solver_details)
   {}
 
 
@@ -609,9 +609,8 @@ namespace TrilinosWrappers
   SolverCG::SolverCG (SolverControl        &cn,
                       const AdditionalData &data)
     :
-    SolverBase (cn,
-                SolverBase::AdditionalData(data.output_solver_details)),
-    additional_data (data.output_solver_details)
+    SolverBase (cn, data),
+    additional_data (data)
   {
     solver_name = cg;
   }
@@ -623,8 +622,8 @@ namespace TrilinosWrappers
   AdditionalData (const bool output_solver_details,
                   const unsigned int restart_parameter)
     :
-    output_solver_details (output_solver_details),
-    restart_parameter (restart_parameter)
+    SolverBase::AdditionalData (output_solver_details,
+                                restart_parameter)
   {}
 
 
@@ -632,11 +631,8 @@ namespace TrilinosWrappers
   SolverGMRES::SolverGMRES (SolverControl        &cn,
                             const AdditionalData &data)
     :
-    SolverBase (cn,
-                SolverBase::AdditionalData(data.output_solver_details,
-                                           data.restart_parameter)),
-    additional_data (data.output_solver_details,
-                     data.restart_parameter)
+    SolverBase (cn, data),
+    additional_data (data)
   {
     solver_name = gmres;
   }
@@ -647,7 +643,7 @@ namespace TrilinosWrappers
   SolverBicgstab::AdditionalData::
   AdditionalData (const bool output_solver_details)
     :
-    output_solver_details (output_solver_details)
+    SolverBase::AdditionalData (output_solver_details)
   {}
 
 
@@ -656,9 +652,8 @@ namespace TrilinosWrappers
   SolverBicgstab::SolverBicgstab (SolverControl        &cn,
                                   const AdditionalData &data)
     :
-    SolverBase (cn,
-                SolverBase::AdditionalData(data.output_solver_details)),
-    additional_data (data.output_solver_details)
+    SolverBase (cn, data),
+    additional_data (data)
   {
     solver_name = bicgstab;
   }
@@ -669,18 +664,16 @@ namespace TrilinosWrappers
   SolverCGS::AdditionalData::
   AdditionalData (const bool output_solver_details)
     :
-    output_solver_details (output_solver_details)
+    SolverBase::AdditionalData (output_solver_details)
   {}
-
 
 
 
   SolverCGS::SolverCGS (SolverControl        &cn,
                         const AdditionalData &data)
     :
-    SolverBase (cn,
-                SolverBase::AdditionalData(data.output_solver_details)),
-    additional_data (data.output_solver_details)
+    SolverBase (cn, data),
+    additional_data (data)
   {
     solver_name = cgs;
   }
@@ -691,7 +684,7 @@ namespace TrilinosWrappers
   SolverTFQMR::AdditionalData::
   AdditionalData (const bool output_solver_details)
     :
-    output_solver_details (output_solver_details)
+    SolverBase::AdditionalData (output_solver_details)
   {}
 
 
@@ -699,9 +692,8 @@ namespace TrilinosWrappers
   SolverTFQMR::SolverTFQMR (SolverControl        &cn,
                             const AdditionalData &data)
     :
-    SolverBase (cn,
-                SolverBase::AdditionalData(data.output_solver_details)),
-    additional_data (data.output_solver_details)
+    SolverBase (cn, data),
+    additional_data (data)
   {
     solver_name = tfqmr;
   }


### PR DESCRIPTION
The AdditionalData structures for the various TrilinosWrappers solver
classes are now derived from that of SolverBase.