### PR TITLE
Fix generating doxygen output from changes.h

### DIFF
--- a/doc/news/changes/minor/20170529DenisDavydov
+++ b/doc/news/changes/minor/20170529DenisDavydov
@@ -1,6 +1,6 @@
 New: deal.IIFeatureConfig.cmake will contain detailed information about
 feature configuration and is installed along with other CMake files.
-These variables can be loaded by calling INCLUDE(${DEAL_II_FEATURE_CONFIG}).
+These variables can be loaded by calling INCLUDE(\${DEAL_II_FEATURE_CONFIG}).
 This is useful when users want to link in additional parts of dependencies, not
 required by deal.II (i.e. filesystem library from Boost package).
 <br>


### PR DESCRIPTION
Fixes #4552. The offending changelog entry is from 2017/05/29 so the information that it didn't work after 2017/05/27 was pretty accurate.