### PR TITLE
Improve the storage of MG vertex dofs.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1017,24 +1017,22 @@ private:
     unsigned int finest_level;
 
     /**
+     * The number of degrees of freedom per vertex. We need to store
+     * this because every object of this kind stores the indices on
+     * all relevant levels in one array, and the starting offset for
+     * a particular level is determined by that level's index times
+     * the number of degrees of freedom per vertex.
+     */
+    unsigned int dofs_per_vertex;
+
+    /**
      * A pointer to an array where we store the indices of the DoFs that live
      * on the various levels this vertex exists on.
      *
      * The starting offset of the DoFs that belong to a @p level are given by
-     * <code>indices_offset[level-coarsest_level]</code>.
+     * <code>dofs_per_vertex * (level-coarsest_level)</code>.
      */
     types::global_dof_index *indices;
-
-    /**
-     * This array stores, for each level starting with coarsest_level, the
-     * offset in the <code>indices</code> array where the DoF indices for each
-     * level are stored.
-     *
-     * We need to explicitly store this offset because this class does not
-     * store how many degrees of freedom the finite element has per vertex,
-     * and consequently cannot compute the offset on the fly.
-     */
-    types::global_dof_index *indices_offset;
   };
 
   /**
@@ -1370,7 +1368,7 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::get_index (const unsigned int level,
                                                     const unsigned int dof_number) const
 {
   Assert ((level >= coarsest_level) && (level <= finest_level), ExcInvalidLevel (level));
-  return indices[indices_offset[level - coarsest_level] + dof_number];
+  return indices[dofs_per_vertex * (level - coarsest_level) + dof_number];
 }
 
 
@@ -1383,7 +1381,7 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::set_index (const unsigned int level,
                                                     const types::global_dof_index index)
 {
   Assert ((level >= coarsest_level) && (level <= finest_level), ExcInvalidLevel (level));
-  indices[indices_offset[level - coarsest_level] + dof_number] = index;
+  indices[dofs_per_vertex * (level - coarsest_level) + dof_number] = index;
 }
 
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -966,11 +966,6 @@ private:
     MGVertexDoFs ();
 
     /**
-     * Destructor.
-     */
-    ~MGVertexDoFs ();
-
-    /**
      * A function that is called to allocate the necessary amount of memory to
      * store the indices of the DoFs that live on this vertex for the given
      * (inclusive) range of levels.
@@ -1032,7 +1027,7 @@ private:
      * The starting offset of the DoFs that belong to a @p level are given by
      * <code>dofs_per_vertex * (level-coarsest_level)</code>.
      */
-    types::global_dof_index *indices;
+    std::unique_ptr<types::global_dof_index[]> indices;
   };
 
   /**

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1521,8 +1521,7 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs ()
   :
   coarsest_level (numbers::invalid_unsigned_int),
   finest_level (0),
-  indices (nullptr),
-  indices_offset (nullptr)
+  indices (nullptr)
 {}
 
 
@@ -1531,7 +1530,6 @@ template <int dim, int spacedim>
 DoFHandler<dim, spacedim>::MGVertexDoFs::~MGVertexDoFs ()
 {
   delete[] indices;
-  delete[] indices_offset;
 }
 
 
@@ -1539,7 +1537,7 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::~MGVertexDoFs ()
 template <int dim, int spacedim>
 void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
                                                     const unsigned int fl,
-                                                    const unsigned int dofs_per_vertex)
+                                                    const unsigned int n_dofs_per_vertex)
 {
   if (indices != nullptr)
     {
@@ -1547,14 +1545,9 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
       indices = nullptr;
     }
 
-  if (indices_offset != nullptr)
-    {
-      delete[] indices_offset;
-      indices_offset = nullptr;
-    }
-
-  coarsest_level = cl;
-  finest_level   = fl;
+  coarsest_level  = cl;
+  finest_level    = fl;
+  dofs_per_vertex = n_dofs_per_vertex;
 
   if (coarsest_level <= finest_level)
     {
@@ -1563,10 +1556,6 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
 
       indices = new types::global_dof_index[n_indices];
       std::fill (indices, indices+n_indices, numbers::invalid_dof_index);
-
-      indices_offset = new types::global_dof_index[n_levels];
-      for (unsigned int i = 0; i < n_levels; ++i)
-        indices_offset[i] = i * dofs_per_vertex;
     }
 }
 

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1520,17 +1520,8 @@ template <int dim, int spacedim>
 DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs ()
   :
   coarsest_level (numbers::invalid_unsigned_int),
-  finest_level (0),
-  indices (nullptr)
+  finest_level (0)
 {}
-
-
-
-template <int dim, int spacedim>
-DoFHandler<dim, spacedim>::MGVertexDoFs::~MGVertexDoFs ()
-{
-  delete[] indices;
-}
 
 
 
@@ -1539,12 +1530,6 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
                                                     const unsigned int fl,
                                                     const unsigned int n_dofs_per_vertex)
 {
-  if (indices != nullptr)
-    {
-      delete[] indices;
-      indices = nullptr;
-    }
-
   coarsest_level  = cl;
   finest_level    = fl;
   dofs_per_vertex = n_dofs_per_vertex;
@@ -1554,9 +1539,12 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
       const unsigned int n_levels = finest_level - coarsest_level + 1;
       const unsigned int n_indices = n_levels * dofs_per_vertex;
 
-      indices = new types::global_dof_index[n_indices];
-      std::fill (indices, indices+n_indices, numbers::invalid_dof_index);
+      indices.reset (new types::global_dof_index[n_indices]);
+      std::fill (indices.get(), indices.get()+n_indices,
+                 numbers::invalid_dof_index);
     }
+  else
+    indices.reset ();
 }
 
 


### PR DESCRIPTION
The DoF indices for a vertex are stored in an array where we just
collate the indices for each level. There is currently another
array that stors the offset within this array where the DoFs
for a given level start. This array is dynamically allocated,
but it is altogether unnecessary because the offsets are computable:
they are simply the number of the multigrid level times
dofs_per_vertex.

Consequently, get rid of the array and replace it by storing dofs_per_vertex.
We can then easily compute the starting offset wherever necessary, rather than
having to look it up.