### PR TITLE
Deprecate ParpackSolver::Shift

### DIFF
--- a/doc/news/changes/minor/20170703MatthiasMaier
+++ b/doc/news/changes/minor/20170703MatthiasMaier
@@ -1,0 +1,3 @@
+Deprecated: The ParpackSolver::Shift class has been deprecated.
+<br>
+(Matthias Maier, 2017/07/03)

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -203,6 +203,11 @@ public:
 
   /**
    * Auxiliary class to represent <code>A-sigma*B</code> operator.
+   *
+   * @deprecated: Use LinearOperator to create a shifted operator by hand:
+   * <code>
+   *   const auto shift = linear_operator(A) - sigma * linear_operator(B);
+   * </code>
    */
   template <typename MatrixType>
   class Shift : public dealii::Subscriptor
@@ -245,7 +250,8 @@ public:
     const MatrixType &A;
     const MatrixType &B;
     const double sigma;
-  };
+
+  } DEAL_II_DEPRECATED;
 
   /**
    * Standardized data struct to pipe additional data to the solver, should it


### PR DESCRIPTION
LinearOperator does the job nicely, so no need for a custom shift class :-)