### PR TITLE
Remove a TODO.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -14,8 +14,6 @@
 // ---------------------------------------------------------------------
 
 
-//TODO [TH]: renumber DoFs for multigrid is not done yet
-
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/work_stream.h>
 #include <deal.II/base/utilities.h>


### PR DESCRIPTION
The TODO isn't really addressed, but previous to #4560, the functions
in question simply did the wrong thing, whereas since #4560, we at
least get an ExcNotImplemented().

Fixes #4559.