### PR TITLE
Fix serialize_hp_dof_handler

### DIFF
--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -66,7 +66,8 @@ namespace internal
   std::string policy_to_string(const dealii::internal::DoFHandler::Policy::PolicyBase<dim,spacedim> &policy)
   {
     std::string policy_name;
-    if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::Sequential<dealii::DoFHandler<dim,spacedim> >*>(&policy))
+    if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::Sequential<dealii::DoFHandler<dim,spacedim> >*>(&policy)
+        || dynamic_cast<const typename dealii::internal::DoFHandler::Policy::Sequential<dealii::hp::DoFHandler<dim,spacedim> >*>(&policy))
       policy_name = "Policy::Sequential<";
     else if (dynamic_cast<const typename dealii::internal::DoFHandler::Policy::ParallelDistributed<dim,spacedim>*>(&policy))
       policy_name = "Policy::ParallelDistributed<";


### PR DESCRIPTION
Due to the change in the template arguments of `internal::DoFHandler::Policy::Sequential` we have to check for both `DoFHandler` and `hp::DoFHandler` here.
[serialize_hp_dof_handler](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=bits%2Fserialize_hp_dof_handler.debug&date=2017-07-06) failed because of this.