### PR TITLE
Change MappingManifold<1, spacedim> to use face manifolds.

### DIFF
--- a/doc/news/changes/incompatibilities/20170708DavidWells
+++ b/doc/news/changes/incompatibilities/20170708DavidWells
@@ -1,0 +1,3 @@
+Changed: In 1D, the face values calculated by <code>MappingManifold</code> now use the manifold attached to the relevant vertex instead of the manifold on the current face.
+<br>
+(David Wells, 2017/07/08)

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -352,37 +352,6 @@ namespace internal
   namespace
   {
     /**
-     * Some specialization for face Manifolds. In one dimension, there
-     * are no Manifolds associated to faces. The mapping argument is
-     * only used to help the compiler infer dim and spacedim.
-     */
-    template <int spacedim>
-    const dealii::Manifold<1, spacedim> &
-    get_face_manifold(const MappingManifold<1,spacedim> &,
-                      const typename dealii::Triangulation<1,spacedim>::cell_iterator &cell,
-                      const unsigned int &)
-    {
-      return cell->get_manifold();
-    }
-
-
-
-    /**
-     * Some specialization for face Manifolds. The mapping argument is
-     * only used to help the compiler infer dim and spacedim.
-     */
-    template <int dim, int spacedim>
-    const dealii::Manifold<dim,spacedim> &
-    get_face_manifold(const MappingManifold<dim,spacedim> &,
-                      const typename dealii::Triangulation<dim,spacedim>::cell_iterator &cell,
-                      const unsigned int face_no)
-    {
-      return cell->face(face_no)->get_manifold();
-    }
-
-
-
-    /**
      * Compute the locations of quadrature points on the object described by
      * the first argument (and the cell for which the mapping support points
      * have already been set), but only if the update_flags of the @p data
@@ -822,7 +791,7 @@ namespace internal
     {
       data.store_vertices(cell);
 
-      data.manifold = &get_face_manifold(mapping, cell, face_no);
+      data.manifold = &cell->face(face_no)->get_manifold();
 
       maybe_compute_q_points<dim,spacedim> (data_set,
                                             data,


### PR DESCRIPTION
As of db5ea0f52db we support get_manifold on 1D manifolds, so we can look up the manifold on a 1D face in a dimension-independent way. This is a slight change from the current behavior, but using Manifolds in 1D is a very obscure use case.

Clarification: the current behavior is to use the manifold defined on the cell on the faces. The change here is to properly use the manifold defined on the faces for the face calculations.

I noticed this while moving around some code related to #4442.