### PR TITLE
No longer store dofs_per_vertex for each MG vertex.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -695,7 +695,8 @@ namespace internal
                            const unsigned int              vertex_index,
                            const unsigned int              i)
       {
-        return dof_handler.mg_vertex_dofs[vertex_index].get_index (level, i);
+        return dof_handler.mg_vertex_dofs[vertex_index].get_index (level, i,
+                                                                   dof_handler.get_fe().dofs_per_vertex);
       }
 
 
@@ -721,7 +722,9 @@ namespace internal
                                const unsigned int              i,
                                types::global_dof_index         index)
       {
-        return dof_handler.mg_vertex_dofs[vertex_index].set_index (level, i, index);
+        return dof_handler.mg_vertex_dofs[vertex_index].set_index (level, i,
+                                                                   dof_handler.get_fe().dofs_per_vertex,
+                                                                   index);
       }
 
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -990,14 +990,16 @@ private:
      */
     types::global_dof_index
     get_index (const unsigned int level,
-               const unsigned int dof_number) const;
+               const unsigned int dof_number,
+               const unsigned int dofs_per_vertex) const;
 
     /**
      * Set the index of the <code>dof_number</code>th degree of freedom for
      * the given level stored for the current vertex to <code>index</code>.
      */
-    void set_index (const unsigned int level,
-                    const unsigned int dof_number,
+    void set_index (const unsigned int            level,
+                    const unsigned int            dof_number,
+                    const unsigned int            dofs_per_vertex,
                     const types::global_dof_index index);
 
   private:
@@ -1012,20 +1014,13 @@ private:
     unsigned int finest_level;
 
     /**
-     * The number of degrees of freedom per vertex. We need to store
-     * this because every object of this kind stores the indices on
-     * all relevant levels in one array, and the starting offset for
-     * a particular level is determined by that level's index times
-     * the number of degrees of freedom per vertex.
-     */
-    unsigned int dofs_per_vertex;
-
-    /**
      * A pointer to an array where we store the indices of the DoFs that live
      * on the various levels this vertex exists on.
      *
      * The starting offset of the DoFs that belong to a @p level are given by
-     * <code>dofs_per_vertex * (level-coarsest_level)</code>.
+     * <code>dofs_per_vertex * (level-coarsest_level)</code>. @p dofs_per_vertex
+     * must therefore be passed as an argument to the functions that set or
+     * read an index.
      */
     std::unique_ptr<types::global_dof_index[]> indices;
   };
@@ -1356,7 +1351,8 @@ template <int dim, int spacedim>
 inline
 types::global_dof_index
 DoFHandler<dim, spacedim>::MGVertexDoFs::get_index (const unsigned int level,
-                                                    const unsigned int dof_number) const
+                                                    const unsigned int dof_number,
+                                                    const unsigned int dofs_per_vertex) const
 {
   Assert ((level >= coarsest_level) && (level <= finest_level), ExcInvalidLevel (level));
   return indices[dofs_per_vertex * (level - coarsest_level) + dof_number];
@@ -1367,8 +1363,9 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::get_index (const unsigned int level,
 template <int dim, int spacedim>
 inline
 void
-DoFHandler<dim, spacedim>::MGVertexDoFs::set_index (const unsigned int level,
-                                                    const unsigned int dof_number,
+DoFHandler<dim, spacedim>::MGVertexDoFs::set_index (const unsigned int            level,
+                                                    const unsigned int            dof_number,
+                                                    const unsigned int            dofs_per_vertex,
                                                     const types::global_dof_index index)
 {
   Assert ((level >= coarsest_level) && (level <= finest_level), ExcInvalidLevel (level));

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1343,11 +1343,10 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs ()
 template <int dim, int spacedim>
 void DoFHandler<dim, spacedim>::MGVertexDoFs::init (const unsigned int cl,
                                                     const unsigned int fl,
-                                                    const unsigned int n_dofs_per_vertex)
+                                                    const unsigned int dofs_per_vertex)
 {
   coarsest_level  = cl;
   finest_level    = fl;
-  dofs_per_vertex = n_dofs_per_vertex;
 
   if (coarsest_level <= finest_level)
     {

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1895,12 +1895,15 @@ namespace internal
                 (i->get_finest_level() >= level))
               for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                 {
-                  const dealii::types::global_dof_index idx = i->get_index (level, d);
+                  const dealii::types::global_dof_index idx
+                    = i->get_index (level, d, dof_handler.get_fe().dofs_per_vertex);
+
                   if (check_validity)
                     Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
                   if (idx != numbers::invalid_dof_index)
                     i->set_index (level, d,
+                                  dof_handler.get_fe().dofs_per_vertex,
                                   (indices.size() == 0)?
                                   (new_numbers[idx]) :
                                   (new_numbers[indices.index_within_set(idx)]));


### PR DESCRIPTION
In #4564, I already noted that the way we store vertex DoF indices in the MG
case was not particularly efficient because we kept around a dynamically
sized 'offset' array for each vertex whose entries were computable: they were
successive multiples of dofs_per_cell. So #4564 replaces that by just storing
dofs_per_cell itself for each vertex.

But that, of course, is also wasteful: why store it once per vertex when that
will be the same number for every vertex. Rather, what this patch does is
to pass that number to the functions that access these DoF indices, so that
we can use the global fe.dofs_per_vertex instead. This saves 4 bytes per
vertex, and maybe a few cycles of CPU time on top of it.