### PR TITLE
Deprecate filling TableIndices indices with invalid numbers.

### DIFF
--- a/doc/news/changes/incompatibilities/20170710Bangerth
+++ b/doc/news/changes/incompatibilities/20170710Bangerth
@@ -1,0 +1,10 @@
+Changed: The TableIndices class had a single constructor that just
+took as many indices as one wanted, and padded any unassigned indices
+with numbers::invalid_unsigned_int. This invited mistakes and indeed
+led to difficult to track down errors.
+<br>
+This constructor is therefore now deprecated, and has been replaced by
+a series of constructors with between one and five arguments that can
+be used for objects of type TableIndices<1> to TableIndices<5>.
+<br>
+(Wolfgang Bangerth, 2017/07/10)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -68,7 +68,7 @@ namespace internal
       Assert (position < 2, ExcIndexRange (position, 0, 2));
 
       if (position == 0)
-        return TableIndices<2>(new_index);
+        return TableIndices<2>(new_index, numbers::invalid_unsigned_int);
       else
         return TableIndices<2>(previous_indices[0], new_index);
     }
@@ -91,14 +91,20 @@ namespace internal
       switch (position)
         {
         case 0:
-          return TableIndices<4>(new_index);
+          return TableIndices<4>(new_index,
+                                 numbers::invalid_unsigned_int,
+                                 numbers::invalid_unsigned_int,
+                                 numbers::invalid_unsigned_int);
         case 1:
           return TableIndices<4>(previous_indices[0],
-                                 new_index);
+                                 new_index,
+                                 numbers::invalid_unsigned_int,
+                                 numbers::invalid_unsigned_int);
         case 2:
           return TableIndices<4>(previous_indices[0],
                                  previous_indices[1],
-                                 new_index);
+                                 new_index,
+                                 numbers::invalid_unsigned_int);
         case 3:
           return TableIndices<4>(previous_indices[0],
                                  previous_indices[1],
@@ -1656,13 +1662,45 @@ SymmetricTensor<rank,dim,Number>::operator ()
 
 
 
+namespace internal
+{
+  namespace SymmetricTensor
+  {
+    template <int rank>
+    TableIndices<rank>
+    get_partially_filled_indices (const unsigned int row,
+                                  const internal::int2type<2> &)
+    {
+      return TableIndices<rank> (row,
+                                 numbers::invalid_unsigned_int);
+
+    }
+
+
+    template <int rank>
+    TableIndices<rank>
+    get_partially_filled_indices (const unsigned int row,
+                                  const internal::int2type<4> &)
+    {
+      return TableIndices<rank> (row,
+                                 numbers::invalid_unsigned_int,
+                                 numbers::invalid_unsigned_int,
+                                 numbers::invalid_unsigned_int);
+
+    }
+  }
+}
+
+
 template <int rank, int dim, typename Number>
 internal::SymmetricTensorAccessors::Accessor<rank,dim,true,rank-1,Number>
 SymmetricTensor<rank,dim,Number>::operator [] (const unsigned int row) const
 {
   return
     internal::SymmetricTensorAccessors::
-    Accessor<rank,dim,true,rank-1,Number> (*this, TableIndices<rank> (row));
+    Accessor<rank,dim,true,rank-1,Number> (*this,
+                                           internal::SymmetricTensor::get_partially_filled_indices<rank> (row,
+                                               internal::int2type<rank>()));
 }
 
 
@@ -1673,7 +1711,9 @@ SymmetricTensor<rank,dim,Number>::operator [] (const unsigned int row)
 {
   return
     internal::SymmetricTensorAccessors::
-    Accessor<rank,dim,false,rank-1,Number> (*this, TableIndices<rank> (row));
+    Accessor<rank,dim,false,rank-1,Number> (*this,
+                                            internal::SymmetricTensor::get_partially_filled_indices<rank> (row,
+                                                internal::int2type<rank>()));
 }
 
 

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -34,6 +34,8 @@ DEAL_II_NAMESPACE_OPEN
  * It is used in tensorial objects like the TableBase and SymmetricTensor
  * classes to represent a nested choice of indices.
  *
+ * @tparam N The number of indices stored in each object.
+ *
  * @ingroup data
  * @author Wolfgang Bangerth, Matthias Maier, 2002, 2015
  */
@@ -43,9 +45,69 @@ class TableIndices
 public:
 
   /**
-   * Default constructor. It sets all indices to zero.
+   * Default constructor. This constructor sets all indices to zero.
    */
   TableIndices();
+
+  /**
+   * Constructor. This is the appropriate constructor for an
+   * object of type TableIndices<1> and initializes the single
+   * index with @p index0.
+   *
+   * This constructor will result in a compiler error if
+   * the template argument @p N is different from one.
+   */
+  TableIndices (const unsigned int index0);
+
+  /**
+   * Constructor. This is the appropriate constructor for an
+   * object of type TableIndices<2> and initializes the
+   * indices stored by this object by the given arguments.
+   *
+   * This constructor will result in a compiler error if
+   * the template argument @p N is different from two.
+   */
+  TableIndices (const unsigned int index0,
+                const unsigned int index1);
+
+  /**
+   * Constructor. This is the appropriate constructor for an
+   * object of type TableIndices<3> and initializes the
+   * indices stored by this object by the given arguments.
+   *
+   * This constructor will result in a compiler error if
+   * the template argument @p N is different from three.
+   */
+  TableIndices (const unsigned int index0,
+                const unsigned int index1,
+                const unsigned int index2);
+
+  /**
+   * Constructor. This is the appropriate constructor for an
+   * object of type TableIndices<4> and initializes the
+   * indices stored by this object by the given arguments.
+   *
+   * This constructor will result in a compiler error if
+   * the template argument @p N is different from four.
+   */
+  TableIndices (const unsigned int index0,
+                const unsigned int index1,
+                const unsigned int index2,
+                const unsigned int index3);
+
+  /**
+   * Constructor. This is the appropriate constructor for an
+   * object of type TableIndices<5> and initializes the
+   * indices stored by this object by the given arguments.
+   *
+   * This constructor will result in a compiler error if
+   * the template argument @p N is different from five.
+   */
+  TableIndices (const unsigned int index0,
+                const unsigned int index1,
+                const unsigned int index2,
+                const unsigned int index3,
+                const unsigned int index4);
 
   /**
    * Convenience constructor that takes up to 9 arguments. It can be used to
@@ -58,17 +120,18 @@ public:
    *
    * Note that only the first <tt>N</tt> arguments are actually used.
    *
-   * @tparam N The number of indices stored in each object.
+   * @deprecated Use the constructor with the appropriate number of arguments
+   *   to initialize the @p N indices instead.
    */
   TableIndices (const unsigned int index0,
-                const unsigned int index1 = numbers::invalid_unsigned_int,
-                const unsigned int index2 = numbers::invalid_unsigned_int,
-                const unsigned int index3 = numbers::invalid_unsigned_int,
-                const unsigned int index4 = numbers::invalid_unsigned_int,
-                const unsigned int index5 = numbers::invalid_unsigned_int,
+                const unsigned int index1,
+                const unsigned int index2,
+                const unsigned int index3,
+                const unsigned int index4,
+                const unsigned int index5,
                 const unsigned int index6 = numbers::invalid_unsigned_int,
                 const unsigned int index7 = numbers::invalid_unsigned_int,
-                const unsigned int index8 = numbers::invalid_unsigned_int);
+                const unsigned int index8 = numbers::invalid_unsigned_int) DEAL_II_DEPRECATED;
 
   /**
    * Read-only access the value of the <tt>i</tt>th index.
@@ -123,6 +186,77 @@ TableIndices<N>::TableIndices()
   for (unsigned int i=0; i<N; ++i)
     indices[i] = 0;
 }
+
+
+
+template <int N>
+TableIndices<N>::TableIndices(const unsigned int index0)
+{
+  static_assert (N==1,
+                 "This constructor is only available for TableIndices<1> objects.");
+  indices[0] = index0;
+}
+
+
+
+template <int N>
+TableIndices<N>::TableIndices(const unsigned int index0,
+                              const unsigned int index1)
+{
+  static_assert (N==2,
+                 "This constructor is only available for TableIndices<2> objects.");
+  indices[0] = index0;
+  indices[1] = index1;
+}
+
+
+
+template <int N>
+TableIndices<N>::TableIndices(const unsigned int index0,
+                              const unsigned int index1,
+                              const unsigned int index2)
+{
+  static_assert (N==3,
+                 "This constructor is only available for TableIndices<3> objects.");
+  indices[0] = index0;
+  indices[1] = index1;
+  indices[2] = index2;
+}
+
+
+
+template <int N>
+TableIndices<N>::TableIndices(const unsigned int index0,
+                              const unsigned int index1,
+                              const unsigned int index2,
+                              const unsigned int index3)
+{
+  static_assert (N==4,
+                 "This constructor is only available for TableIndices<4> objects.");
+  indices[0] = index0;
+  indices[1] = index1;
+  indices[2] = index2;
+  indices[3] = index3;
+}
+
+
+
+template <int N>
+TableIndices<N>::TableIndices(const unsigned int index0,
+                              const unsigned int index1,
+                              const unsigned int index2,
+                              const unsigned int index3,
+                              const unsigned int index4)
+{
+  static_assert (N==5,
+                 "This constructor is only available for TableIndices<5> objects.");
+  indices[0] = index0;
+  indices[1] = index1;
+  indices[2] = index2;
+  indices[3] = index3;
+  indices[4] = index4;
+}
+
 
 
 template <int N>

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -57,7 +57,7 @@ public:
    * This constructor will result in a compiler error if
    * the template argument @p N is different from one.
    */
-  TableIndices (const unsigned int index0);
+  explicit TableIndices (const unsigned int index0);
 
   /**
    * Constructor. This is the appropriate constructor for an


### PR DESCRIPTION
The TableIndices constructor would just take however many indices
it was given and padded the rest with invalid unsigned ints. This
is against the spirit we usually apply everywhere else by requiring
code to be explicit about what they want to happen. It also leads
to awkward to track issues such as the one reported in #4565.

Fix this by providing TableIndices with constructors for various
numbers of arguments, and ensuring via static_asserts that the
correct constructor is the only one that can be called.

This also required a bit of working around issues in the
SymmetricTensor accessor machinery, but nothing major.

Fixes #4565.