### PR TITLE
Make some manifold checks in MappingQGeneric dimension independent.

### DIFF
--- a/doc/news/changes/incompatibilities/20170711DavidWells
+++ b/doc/news/changes/incompatibilities/20170711DavidWells
@@ -1,0 +1,3 @@
+Changed: In 1D, MappingQGeneric now considers a cell to have multiple manifolds if the manifold attached to the cell does not match one of the manifolds attached to a face (i.e., vertex).
+<br>
+(David Wells, 2017/07/10)


### PR DESCRIPTION
This is a follow up to #4591 that changes things slightly in 1D. I really doubt that anyone is relying on the current behavior (generalized geometry descriptions in 1D are an obscure topic).

As of db5ea0f52db we support get_manifold on 1D manifolds, so we can remove the overload workaround here for 1D. This changes the behavior of this function slightly: we now correctly calculate `all_manifold_ids_are_equal = false` if the cell manifold, in 1D, does not equal one of the face (vertex) manifolds.

Note that in 2D lines are faces, so we still check all lines.