### PR TITLE
Make SynchronousIterators::iterators private.

### DIFF
--- a/doc/news/changes/incompatibilities/20170711Bangerth
+++ b/doc/news/changes/incompatibilities/20170711Bangerth
@@ -1,0 +1,6 @@
+Changed: The SynchronousIteartors::iterators member variable has been
+made private, as mentioned in the changelog of the previous
+release. It can be accessed via SynchronousIterators::operator*(),
+however.
+<br>
+(Wolfgang Bangerth, 2017/07/11)

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -89,7 +89,7 @@ namespace parallel
       {
         for (typename Range::const_iterator p=range.begin();
              p != range.end(); ++p)
-          apply (f, p.iterators);
+          apply (f, *p);
       }
 
     private:

--- a/include/deal.II/base/synchronous_iterator.h
+++ b/include/deal.II/base/synchronous_iterator.h
@@ -72,6 +72,7 @@ struct SynchronousIterators
    */
   Iterators &operator* ();
 
+private:
   /**
    * Storage for the iterators represented by the current class.
    */


### PR DESCRIPTION
This is a member that should have been private all along, but wasn't. It
is now possible to access it via operator*.

Fixes #2712.