### PR TITLE
Mark some constructors '=delete'.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -58,6 +58,12 @@ public:
   virtual ~ExceptionBase () noexcept;
 
   /**
+   * Copy operator. This operator is deleted since exception objects
+   * are not copyable.
+   */
+  ExceptionBase operator= (const ExceptionBase &) = delete;
+
+  /**
    * Set the file name and line of where the exception appeared as well as the
    * violated condition and the name of the exception as a char pointer. This
    * function also populates the stacktrace.
@@ -142,11 +148,6 @@ protected:
 #endif
 
 private:
-  /**
-   * Copy operator. Made private since it is not used and not implemented.
-   */
-  ExceptionBase operator= (const ExceptionBase &exc);
-
   /**
    * Internal function that generates the c_string. Called by what().
    */

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -48,6 +48,12 @@ class MultithreadInfo
 {
 public:
   /**
+   * Constructor. This constructor is deleted because no instance of
+   * this class needs to be constructed (all members are static).
+   */
+  MultithreadInfo () = delete;
+
+  /**
    * The number of CPUs in the system. At the moment detection of CPUs is only
    * implemented on Linux, FreeBSD, and Mac computers.  It is one if detection
    * failed or is not implemented on your system.
@@ -96,13 +102,6 @@ public:
   static bool is_running_single_threaded ();
 
 private:
-
-
-  /**
-   * Constructor made private because no instance of this class needs to be
-   * constructed as all members are static.
-   */
-  MultithreadInfo ();
 
   /**
    * Private function to determine the number of CPUs. Implementation for

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -312,9 +312,9 @@ namespace internal
                 const TableIndices<rank> &previous_indices);
 
       /**
-       * Copy constructor. Not needed, and invisible, so private.
+       * Copy constructor.
        */
-      Accessor (const Accessor &a);
+      Accessor (const Accessor &) = default;
 
     public:
 
@@ -395,14 +395,14 @@ namespace internal
                 const TableIndices<rank> &previous_indices);
 
       /**
-       * Default constructor. Not needed, and invisible, so private.
+       * Default constructor. Not needed, so deleted.
        */
-      Accessor ();
+      Accessor () = delete;
 
       /**
-       * Copy constructor. Not needed, and invisible, so private.
+       * Copy constructor.
        */
-      Accessor (const Accessor &a);
+      Accessor (const Accessor &) = default;
 
     public:
 
@@ -852,15 +852,6 @@ namespace internal
     {}
 
 
-    template <int rank, int dim, bool constness, int P, typename Number>
-    Accessor<rank,dim,constness,P,Number>::
-    Accessor (const Accessor &a)
-      :
-      tensor (a.tensor),
-      previous_indices (a.previous_indices)
-    {}
-
-
 
     template <int rank, int dim, bool constness, int P, typename Number>
     Accessor<rank,dim,constness,P-1,Number>
@@ -889,16 +880,6 @@ namespace internal
       :
       tensor (tensor),
       previous_indices (previous_indices)
-    {}
-
-
-
-    template <int rank, int dim, bool constness, typename Number>
-    Accessor<rank,dim,constness,1,Number>::
-    Accessor (const Accessor &a)
-      :
-      tensor (a.tensor),
-      previous_indices (a.previous_indices)
     {}
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -166,9 +166,9 @@ namespace internal
                 const iterator    data);
 
       /**
-       * Default constructor. Not needed, and invisible, so private.
+       * Default constructor. Not needed, and invisible, so deleted.
        */
-      Accessor ();
+      Accessor () = delete;
 
     public:
 
@@ -269,9 +269,9 @@ namespace internal
                 const iterator    data);
 
       /**
-       * Default constructor. Not needed, so private.
+       * Default constructor. Not needed, so deleted.
        */
-      Accessor ();
+      Accessor () = delete;
 
     public:
       /**
@@ -1706,21 +1706,6 @@ namespace internal
 
     template <int N, typename T, bool C, unsigned int P>
     inline
-    Accessor<N,T,C,P>::Accessor ()
-      :
-      table (*static_cast<const TableType *>(0)),
-      data (0)
-    {
-      // accessor objects are only
-      // temporary objects, so should
-      // not need to be copied around
-      Assert (false, ExcInternalError());
-    }
-
-
-
-    template <int N, typename T, bool C, unsigned int P>
-    inline
     Accessor<N,T,C,P-1>
     Accessor<N,T,C,P>::operator [] (const unsigned int i) const
     {
@@ -1755,21 +1740,6 @@ namespace internal
       table (table),
       data (data)
     {}
-
-
-
-    template <int N, typename T, bool C>
-    inline
-    Accessor<N,T,C,1>::Accessor ()
-      :
-      table (*static_cast<const TableType *>(0)),
-      data (0)
-    {
-      // accessor objects are only
-      // temporary objects, so should
-      // not need to be copied around
-      Assert (false, ExcInternalError());
-    }
 
 
 

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -266,13 +266,19 @@ namespace parallel
      * parallel::shared::Triangulation objects throughout the library even if
      * it is disabled.
      *
-     * Since the constructor of this class is private, no such objects can
-     * actually be created if MPI is not available.
+     * Since the constructor of this class is deleted, no such objects
+     * can actually be created as this would be pointless given that
+     * MPI is not available.
      */
     template <int dim, int spacedim = dim>
     class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
     {
     public:
+      /**
+       * Constructor. Deleted to make sure that objects of this type cannot be
+       * constructed (see also the class documentation).
+       */
+      Triangulation () = delete;
 
       /**
        * A dummy function to return empty vector.
@@ -283,12 +289,8 @@ namespace parallel
        * A dummy function which always returns true.
        */
       bool with_artificial_cells() const;
-    private:
-      /**
-       * Constructor.
-       */
-      Triangulation ();
 
+    private:
       /**
        * A dummy vector.
        */

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -1029,18 +1029,19 @@ namespace parallel
      * parallel::distributed::Triangulation objects throughout the library
      * even if it is disabled.
      *
-     * Since the constructor of this class is private, no such objects can
-     * actually be created if we don't have p4est available.
+     * Since the constructor of this class is deleted, no such objects
+     * can actually be created as this would be pointless given that
+     * p4est is not available.
      */
     template <int dim, int spacedim = dim>
     class Triangulation : public dealii::parallel::Triangulation<dim,spacedim>
     {
-    private:
+    public:
       /**
-       * Constructor.
+       * Constructor. Deleted to make sure that objects of this type cannot be
+       * constructed (see also the class documentation).
        */
-      Triangulation ();
-
+      Triangulation () = delete;
     };
   }
 }

--- a/include/deal.II/dofs/dof_faces.h
+++ b/include/deal.II/dofs/dof_faces.h
@@ -67,12 +67,12 @@ namespace internal
     template <int dim>
     class DoFFaces
     {
+    public:
       /**
-       * Make the constructor private to prevent the use of this template,
-       * only the specializations should be used
+       * Constructor. This constructor is deleted to prevent the use of this template,
+       * as only the specializations should be used
        */
-    private:
-      DoFFaces();
+      DoFFaces() = delete;
     };
 
     /**

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1581,8 +1581,8 @@ public:
   /**
    * Copy constructor.
    *
-   * You should really use the @p copy_triangulation function, so we declare
-   * this function but let it throw an internal error. The reason for this is
+   * You should really use the @p copy_triangulation function, so this
+   * constructor is deleted. The reason for this is
    * that we may want to use triangulation objects in collections. However,
    * C++ containers require that the objects stored in them are copyable, so
    * we need to provide a copy constructor. On the other hand, copying
@@ -1593,7 +1593,7 @@ public:
    * Finally, through the exception, one easily finds the places where code
    * has to be changed to avoid copies.
    */
-  Triangulation (const Triangulation<dim, spacedim> &t);
+  Triangulation (const Triangulation<dim, spacedim> &) = delete;
 
   /**
    * Move constructor.

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -48,12 +48,12 @@ namespace internal
     template <int dim>
     class TriaFaces
     {
-    private:
+    public:
       /**
-       * Make the constructor private so no one can use this general template.
-       * Only the specializations should be used.
+       * Constructor. This constructor is deleted to prevent the use of this template,
+       * as only the specializations should be used
        */
-      TriaFaces();
+      TriaFaces() = delete;
     };
 
 

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -401,7 +401,7 @@ public:
    * amounts of computing time. However, copy constructors are needed if one
    * wants to place a SparsityPattern in a container, e.g., to write such
    * statements like <tt>v.push_back (SparsityPattern());</tt>, with
-   * <tt>v</tt> a vector of SparsityPattern objects.
+   * <tt>v</tt> a std::vector of SparsityPattern objects.
    *
    * Usually, it is sufficient to use the explicit keyword to disallow
    * unwanted temporaries, but this does not work for <tt>std::vector</tt>s.

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -189,11 +189,6 @@ bool MultithreadInfo::is_running_single_threaded()
 }
 
 
-MultithreadInfo::MultithreadInfo ()
-{}
-
-
-
 std::size_t
 MultithreadInfo::memory_consumption ()
 {

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -290,16 +290,6 @@ namespace parallel
   namespace shared
   {
     template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::Triangulation ()
-      :
-      dealii::parallel::Triangulation<dim,spacedim>(MPI_COMM_SELF)
-    {
-      Assert (false, ExcNotImplemented());
-    }
-
-
-
-    template <int dim, int spacedim>
     bool
     Triangulation<dim,spacedim>::with_artificial_cells() const
     {

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3932,22 +3932,6 @@ namespace parallel
 }
 
 
-#else // DEAL_II_WITH_P4EST
-
-namespace parallel
-{
-  namespace distributed
-  {
-    template <int dim, int spacedim>
-    Triangulation<dim,spacedim>::Triangulation ()
-      :
-      dealii::parallel::Triangulation<dim,spacedim>(MPI_COMM_SELF)
-    {
-      Assert (false, ExcNotImplemented());
-    }
-  }
-}
-
 #endif // DEAL_II_WITH_P4EST
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -8968,25 +8968,6 @@ Triangulation (const MeshSmoothing smooth_grid,
 }
 
 
-template <int dim, int spacedim>
-Triangulation<dim, spacedim>::
-Triangulation (const Triangulation<dim, spacedim> &other)
-// do not set any subscriptors;
-// anyway, calling this constructor
-// is an error!
-  :
-  Subscriptor(),
-  signals (),
-  anisotropic_refinement(false),
-  check_for_distorted_cells(other.check_for_distorted_cells)
-{
-  Assert (false, ExcMessage ("You are not allowed to call this constructor "
-                             "because copying Triangulation objects is not "
-                             "allowed. Use Triangulation::copy_triangulation() "
-                             "instead."));
-}
-
-
 
 template <int dim, int spacedim>
 Triangulation<dim, spacedim>::


### PR DESCRIPTION
We have had a number of classes for which some constructors were made
private and/or purposefully not implemented to ensure that they can't
be used. With C++11, we can now mark them as =delete. This patch
does so for a number of classes.

While there, I also marked a pair of copy constructors as =default.

Fixes #2940.