### PR TITLE
Put internal FE functions in specific namespaces.

### DIFF
--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -249,48 +249,54 @@ FE_BDM<dim>::get_ria_vector (const unsigned int deg)
 }
 
 
-namespace
+namespace internal
 {
-  // This function sets up the values of the polynomials we want to
-  // take moments with in the quadrature points. In fact, we multiply
-  // thos by the weights, such that the sum of function values and
-  // test_values over quadrature points yields the interpolated degree
-  // of freedom.
-  template <int dim>
-  void
-  initialize_test_values (std::vector<std::vector<double> > &test_values,
-                          const Quadrature<dim> &quadrature,
-                          const unsigned int deg)
+  namespace FE_BDM
   {
-    PolynomialsP<dim> poly(deg);
-    std::vector<Tensor<1,dim> > dummy1;
-    std::vector<Tensor<2,dim> > dummy2;
-    std::vector<Tensor<3,dim> > dummy3;
-    std::vector<Tensor<4,dim> > dummy4;
-
-    test_values.resize(quadrature.size());
-
-    for (unsigned int k=0; k<quadrature.size(); ++k)
+    namespace
+    {
+      // This function sets up the values of the polynomials we want to
+      // take moments with in the quadrature points. In fact, we multiply
+      // thos by the weights, such that the sum of function values and
+      // test_values over quadrature points yields the interpolated degree
+      // of freedom.
+      template <int dim>
+      void
+      initialize_test_values (std::vector<std::vector<double> > &test_values,
+                              const Quadrature<dim> &quadrature,
+                              const unsigned int deg)
       {
-        test_values[k].resize(poly.n());
-        poly.compute(quadrature.point(k), test_values[k], dummy1, dummy2,
-                     dummy3, dummy4);
-        for (unsigned int i=0; i < poly.n(); ++i)
+        PolynomialsP<dim> poly(deg);
+        std::vector<Tensor<1,dim> > dummy1;
+        std::vector<Tensor<2,dim> > dummy2;
+        std::vector<Tensor<3,dim> > dummy3;
+        std::vector<Tensor<4,dim> > dummy4;
+
+        test_values.resize(quadrature.size());
+
+        for (unsigned int k=0; k<quadrature.size(); ++k)
           {
-            test_values[k][i] *= quadrature.weight(k);
+            test_values[k].resize(poly.n());
+            poly.compute(quadrature.point(k), test_values[k], dummy1, dummy2,
+                         dummy3, dummy4);
+            for (unsigned int i=0; i < poly.n(); ++i)
+              {
+                test_values[k][i] *= quadrature.weight(k);
+              }
           }
       }
-  }
 
-  // This specialization only serves to avoid error messages. Nothing
-  // useful can be computed in dimension zero and thus the vector
-  // length stays zero.
-  template <>
-  void
-  initialize_test_values (std::vector<std::vector<double> > &,
-                          const Quadrature<0> &,
-                          const unsigned int)
-  {}
+      // This specialization only serves to avoid error messages. Nothing
+      // useful can be computed in dimension zero and thus the vector
+      // length stays zero.
+      template <>
+      void
+      initialize_test_values (std::vector<std::vector<double> > &,
+                              const Quadrature<0> &,
+                              const unsigned int)
+      {}
+    }
+  }
 }
 
 
@@ -333,7 +339,7 @@ FE_BDM<dim>::initialize_support_points (const unsigned int deg)
   // point values on faces in 2D. In 3D, this is impossible, since the
   // moments are only taken with respect to PolynomialsP.
   if (dim>2)
-    initialize_test_values(test_values_face, face_points, deg);
+    internal::FE_BDM::initialize_test_values(test_values_face, face_points, deg);
 
   if (deg<=1) return;
 
@@ -347,7 +353,7 @@ FE_BDM<dim>::initialize_support_points (const unsigned int deg)
   // the test functions in the
   // interior quadrature points
 
-  initialize_test_values(test_values_cell, cell_points, deg-2);
+  internal::FE_BDM::initialize_test_values(test_values_cell, cell_points, deg-2);
 }
 
 
@@ -356,4 +362,3 @@ FE_BDM<dim>::initialize_support_points (const unsigned int deg)
 #include "fe_bdm.inst"
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -23,88 +23,93 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-// namespace for some functions that are used in this file.
-namespace
+namespace internal
 {
-  // storage of hand-chosen support
-  // points
-  //
-  // For dim=2, dofs_per_cell of
-  // FE_DGPMonomial(k) is given by
-  // 0.5(k+1)(k+2), i.e.
-  //
-  // k    0  1  2  3  4  5  6  7
-  // dofs 1  3  6 10 15 21 28 36
-  //
-  // indirect access of unit points:
-  // the points for degree k are
-  // located at
-  //
-  // points[start_index[k]..start_index[k+1]-1]
-  const unsigned int start_index2d[6]= {0,1,4,10,20,35};
-  const double points2d[35][2]=
+  namespace FE_DGPMonomial
   {
-    {0,0},
-    {0,0},{1,0},{0,1},
-    {0,0},{1,0},{0,1},{1,1},{0.5,0},{0,0.5},
-    {0,0},{1,0},{0,1},{1,1},{1./3.,0},{2./3.,0},{0,1./3.},{0,2./3.},{0.5,1},{1,0.5},
-    {0,0},{1,0},{0,1},{1,1},{0.25,0},{0.5,0},{0.75,0},{0,0.25},{0,0.5},{0,0.75},{1./3.,1},{2./3.,1},{1,1./3.},{1,2./3.},{0.5,0.5}
-  };
-
-  // For dim=3, dofs_per_cell of
-  // FE_DGPMonomial(k) is given by
-  // 1./6.(k+1)(k+2)(k+3), i.e.
-  //
-  // k    0  1  2  3  4  5  6   7
-  // dofs 1  4 10 20 35 56 84 120
-  const unsigned int start_index3d[6]= {0,1,5,15/*,35*/};
-  const double points3d[35][3]=
-  {
-    {0,0,0},
-    {0,0,0},{1,0,0},{0,1,0},{0,0,1},
-    {0,0,0},{1,0,0},{0,1,0},{0,0,1},{0.5,0,0},{0,0.5,0},{0,0,0.5},{1,1,0},{1,0,1},{0,1,1}
-  };
-
-
-  template <int dim>
-  void generate_unit_points (const unsigned int,
-                             std::vector<Point<dim> > &);
-
-  template <>
-  void generate_unit_points (const unsigned int k,
-                             std::vector<Point<1> > &p)
-  {
-    Assert(p.size()==k+1, ExcDimensionMismatch(p.size(), k+1));
-    const double h = 1./k;
-    for (unsigned int i=0; i<p.size(); ++i)
-      p[i](0)=i*h;
-  }
-
-  template <>
-  void generate_unit_points (const unsigned int k,
-                             std::vector<Point<2> > &p)
-  {
-    Assert(k<=4, ExcNotImplemented());
-    Assert(p.size()==start_index2d[k+1]-start_index2d[k], ExcInternalError());
-    for (unsigned int i=0; i<p.size(); ++i)
+    namespace
+    {
+      // storage of hand-chosen support
+      // points
+      //
+      // For dim=2, dofs_per_cell of
+      // FE_DGPMonomial(k) is given by
+      // 0.5(k+1)(k+2), i.e.
+      //
+      // k    0  1  2  3  4  5  6  7
+      // dofs 1  3  6 10 15 21 28 36
+      //
+      // indirect access of unit points:
+      // the points for degree k are
+      // located at
+      //
+      // points[start_index[k]..start_index[k+1]-1]
+      const unsigned int start_index2d[6]= {0,1,4,10,20,35};
+      const double points2d[35][2]=
       {
-        p[i](0)=points2d[start_index2d[k]+i][0];
-        p[i](1)=points2d[start_index2d[k]+i][1];
-      }
-  }
+        {0,0},
+        {0,0},{1,0},{0,1},
+        {0,0},{1,0},{0,1},{1,1},{0.5,0},{0,0.5},
+        {0,0},{1,0},{0,1},{1,1},{1./3.,0},{2./3.,0},{0,1./3.},{0,2./3.},{0.5,1},{1,0.5},
+        {0,0},{1,0},{0,1},{1,1},{0.25,0},{0.5,0},{0.75,0},{0,0.25},{0,0.5},{0,0.75},{1./3.,1},{2./3.,1},{1,1./3.},{1,2./3.},{0.5,0.5}
+      };
 
-  template <>
-  void generate_unit_points (const unsigned int k,
-                             std::vector<Point<3> > &p)
-  {
-    Assert(k<=2, ExcNotImplemented());
-    Assert(p.size()==start_index3d[k+1]-start_index3d[k], ExcInternalError());
-    for (unsigned int i=0; i<p.size(); ++i)
+      // For dim=3, dofs_per_cell of
+      // FE_DGPMonomial(k) is given by
+      // 1./6.(k+1)(k+2)(k+3), i.e.
+      //
+      // k    0  1  2  3  4  5  6   7
+      // dofs 1  4 10 20 35 56 84 120
+      const unsigned int start_index3d[6]= {0,1,5,15/*,35*/};
+      const double points3d[35][3]=
       {
-        p[i](0)=points3d[start_index3d[k]+i][0];
-        p[i](1)=points3d[start_index3d[k]+i][1];
-        p[i](2)=points3d[start_index3d[k]+i][2];
+        {0,0,0},
+        {0,0,0},{1,0,0},{0,1,0},{0,0,1},
+        {0,0,0},{1,0,0},{0,1,0},{0,0,1},{0.5,0,0},{0,0.5,0},{0,0,0.5},{1,1,0},{1,0,1},{0,1,1}
+      };
+
+
+      template <int dim>
+      void generate_unit_points (const unsigned int,
+                                 std::vector<Point<dim> > &);
+
+      template <>
+      void generate_unit_points (const unsigned int k,
+                                 std::vector<Point<1> > &p)
+      {
+        Assert(p.size()==k+1, ExcDimensionMismatch(p.size(), k+1));
+        const double h = 1./k;
+        for (unsigned int i=0; i<p.size(); ++i)
+          p[i](0)=i*h;
       }
+
+      template <>
+      void generate_unit_points (const unsigned int k,
+                                 std::vector<Point<2> > &p)
+      {
+        Assert(k<=4, ExcNotImplemented());
+        Assert(p.size()==start_index2d[k+1]-start_index2d[k], ExcInternalError());
+        for (unsigned int i=0; i<p.size(); ++i)
+          {
+            p[i](0)=points2d[start_index2d[k]+i][0];
+            p[i](1)=points2d[start_index2d[k]+i][1];
+          }
+      }
+
+      template <>
+      void generate_unit_points (const unsigned int k,
+                                 std::vector<Point<3> > &p)
+      {
+        Assert(k<=2, ExcNotImplemented());
+        Assert(p.size()==start_index3d[k+1]-start_index3d[k], ExcInternalError());
+        for (unsigned int i=0; i<p.size(); ++i)
+          {
+            p[i](0)=points3d[start_index3d[k]+i][0];
+            p[i](1)=points3d[start_index3d[k]+i][1];
+            p[i](2)=points3d[start_index3d[k]+i][2];
+          }
+      }
+    }
   }
 }
 
@@ -199,7 +204,7 @@ get_interpolation_matrix (const FiniteElement<dim> &source_fe,
   else
     {
       std::vector<Point<dim> > unit_points(this->dofs_per_cell);
-      generate_unit_points(this->degree, unit_points);
+      internal::FE_DGPMonomial::generate_unit_points(this->degree, unit_points);
 
       FullMatrix<double> source_fe_matrix(unit_points.size(), source_fe.dofs_per_cell);
       for (unsigned int j=0; j<source_fe.dofs_per_cell; ++j)

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -30,15 +30,21 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace
+namespace internal
 {
-  std::vector<Point<1> >
-  get_QGaussLobatto_points (const unsigned int degree)
+  namespace FE_DGQ
   {
-    if (degree > 0)
-      return QGaussLobatto<1>(degree+1).get_points();
-    else
-      return std::vector<Point<1> >(1, Point<1>(0.5));
+    namespace
+    {
+      std::vector<Point<1> >
+      get_QGaussLobatto_points (const unsigned int degree)
+      {
+        if (degree > 0)
+          return QGaussLobatto<1>(degree+1).get_points();
+        else
+          return std::vector<Point<1> >(1, Point<1>(0.5));
+      }
+    }
   }
 }
 
@@ -48,14 +54,15 @@ template <int dim, int spacedim>
 FE_DGQ<dim, spacedim>::FE_DGQ (const unsigned int degree)
   :
   FE_Poly<TensorProductPolynomials<dim>, dim, spacedim>
-  (TensorProductPolynomials<dim>(Polynomials::generate_complete_Lagrange_basis(get_QGaussLobatto_points(degree))),
+  (TensorProductPolynomials<dim>(Polynomials::generate_complete_Lagrange_basis
+                                 (internal::FE_DGQ::get_QGaussLobatto_points(degree))),
    FiniteElementData<dim>(get_dpo_vector(degree), 1, degree, FiniteElementData<dim>::L2),
    std::vector<bool>(FiniteElementData<dim>(get_dpo_vector(degree),1, degree).dofs_per_cell, true),
    std::vector<ComponentMask>(FiniteElementData<dim>(get_dpo_vector(degree),1, degree).dofs_per_cell, std::vector<bool>(1,true)))
 {
   // Compute support points, which are the tensor product of the Lagrange
   // interpolation points in the constructor.
-  Quadrature<dim> support_quadrature(get_QGaussLobatto_points(degree));
+  Quadrature<dim> support_quadrature(internal::FE_DGQ::get_QGaussLobatto_points(degree));
   Assert (support_quadrature.get_points().size() > 0,
           (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints ()));
   this->unit_support_points = support_quadrature.get_points();
@@ -872,7 +879,8 @@ FE_DGQLegendre<dim,spacedim>::clone() const
 template <int dim, int spacedim>
 FE_DGQHermite<dim,spacedim>::FE_DGQHermite (const unsigned int degree)
   : FE_DGQ<dim,spacedim>(degree < 3 ?
-                         Polynomials::generate_complete_Lagrange_basis(get_QGaussLobatto_points(degree))
+                         Polynomials::generate_complete_Lagrange_basis
+                         (internal::FE_DGQ::get_QGaussLobatto_points(degree))
                          :
                          Polynomials::HermiteInterpolation::generate_complete_basis(degree))
 {}

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -22,93 +22,99 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace
+namespace internal
 {
-  /**
-   * Auxiliary function to create multiplicity vector from input enrichment functions.
-   */
-  template <typename T>
-  std::vector<unsigned int>
-  build_multiplicities(const std::vector<std::vector<T > > &functions )
+  namespace FE_Enriched
   {
-    std::vector<unsigned int> multiplicities;
-    multiplicities.push_back(1); // the first one is non-enriched FE
-    for (unsigned int i = 0; i < functions.size(); i++)
-      multiplicities.push_back(functions[i].size());
-
-    return multiplicities;
-  }
-
-
-  /**
-   * Auxiliary function to build FiniteElement's vector
-   */
-  template <int dim, int spacedim>
-  std::vector< const FiniteElement< dim, spacedim > * >
-  build_fes(const FiniteElement<dim,spacedim> *fe_base,
-            const std::vector<const FiniteElement<dim,spacedim> * > &fe_enriched)
-  {
-    std::vector< const FiniteElement< dim, spacedim > * > fes;
-    fes.push_back(fe_base);
-    for (unsigned int i = 0; i < fe_enriched.size(); i++)
-      fes.push_back(fe_enriched[i]);
-
-    return fes;
-  }
-
-
-  /**
-   * Auxiliary function which check consistency of the input parameters.
-   * Returns true if everything is ok.
-   */
-  template <int dim, int spacedim>
-  bool
-  consistency_check (const std::vector< const FiniteElement< dim, spacedim > * > &fes,
-                     const std::vector< unsigned int > &multiplicities,
-                     const std::vector<std::vector<std::function<const Function<spacedim> *(const typename Triangulation<dim, spacedim>::cell_iterator &) > > > &functions)
-  {
-    AssertThrow(fes.size() > 0,
-                ExcMessage("FEs size should be >=1"));
-    AssertThrow(fes.size() == multiplicities.size(),
-                ExcMessage("FEs and multiplicities should have the same size"));
-
-    AssertThrow (functions.size() == fes.size() - 1,
-                 ExcDimensionMismatch(functions.size(), fes.size()-1));
-
-    AssertThrow(multiplicities[0] == 1,
-                ExcMessage("First multiplicity should be 1"));
-
-    const unsigned int n_comp_base = fes[0]->n_components();
-
-    // start from fe=1 as 0th is always non-enriched FE.
-    for (unsigned int fe=1; fe < fes.size(); fe++)
+    namespace
+    {
+      /**
+       * Auxiliary function to create multiplicity vector from input enrichment functions.
+       */
+      template <typename T>
+      std::vector<unsigned int>
+      build_multiplicities(const std::vector<std::vector<T > > &functions )
       {
-        const FE_Nothing<dim> *fe_nothing = dynamic_cast<const FE_Nothing<dim>*>(fes[fe]);
-        if (fe_nothing)
-          AssertThrow (fe_nothing->is_dominating(),
-                       ExcMessage("Only dominating FE_Nothing can be used in FE_Enriched"));
+        std::vector<unsigned int> multiplicities;
+        multiplicities.push_back(1); // the first one is non-enriched FE
+        for (unsigned int i = 0; i < functions.size(); i++)
+          multiplicities.push_back(functions[i].size());
 
-        AssertThrow (fes[fe]->n_components() == n_comp_base,
-                     ExcMessage("All elements must have the same number of components"));
+        return multiplicities;
       }
-    return true;
-  }
 
 
-  /**
-   * Auxiliary function which determines whether the FiniteElement will be enriched.
-   */
-  template <int dim, int spacedim>
-  bool
-  check_if_enriched (const std::vector< const FiniteElement< dim, spacedim > * > &fes)
-  {
-    // start from fe=1 as 0th is always non-enriched FE.
-    for (unsigned int fe=1; fe < fes.size(); fe++)
-      if (dynamic_cast<const FE_Nothing<dim>*>(fes[fe]) == nullptr)
-        // this is not FE_Nothing => there will be enrichment
+      /**
+       * Auxiliary function to build FiniteElement's vector
+       */
+      template <int dim, int spacedim>
+      std::vector< const FiniteElement< dim, spacedim > * >
+      build_fes(const FiniteElement<dim,spacedim> *fe_base,
+                const std::vector<const FiniteElement<dim,spacedim> * > &fe_enriched)
+      {
+        std::vector< const FiniteElement< dim, spacedim > * > fes;
+        fes.push_back(fe_base);
+        for (unsigned int i = 0; i < fe_enriched.size(); i++)
+          fes.push_back(fe_enriched[i]);
+
+        return fes;
+      }
+
+
+      /**
+       * Auxiliary function which check consistency of the input parameters.
+       * Returns true if everything is ok.
+       */
+      template <int dim, int spacedim>
+      bool
+      consistency_check (const std::vector< const FiniteElement< dim, spacedim > * > &fes,
+                         const std::vector< unsigned int > &multiplicities,
+                         const std::vector<std::vector<std::function<const Function<spacedim> *(const typename dealii::Triangulation<dim, spacedim>::cell_iterator &) > > > &functions)
+      {
+        AssertThrow(fes.size() > 0,
+                    ExcMessage("FEs size should be >=1"));
+        AssertThrow(fes.size() == multiplicities.size(),
+                    ExcMessage("FEs and multiplicities should have the same size"));
+
+        AssertThrow (functions.size() == fes.size() - 1,
+                     ExcDimensionMismatch(functions.size(), fes.size()-1));
+
+        AssertThrow(multiplicities[0] == 1,
+                    ExcMessage("First multiplicity should be 1"));
+
+        const unsigned int n_comp_base = fes[0]->n_components();
+
+        // start from fe=1 as 0th is always non-enriched FE.
+        for (unsigned int fe=1; fe < fes.size(); fe++)
+          {
+            const FE_Nothing<dim> *fe_nothing = dynamic_cast<const FE_Nothing<dim>*>(fes[fe]);
+            if (fe_nothing)
+              AssertThrow (fe_nothing->is_dominating(),
+                           ExcMessage("Only dominating FE_Nothing can be used in FE_Enriched"));
+
+            AssertThrow (fes[fe]->n_components() == n_comp_base,
+                         ExcMessage("All elements must have the same number of components"));
+          }
         return true;
+      }
 
-    return false;
+
+      /**
+       * Auxiliary function which determines whether the FiniteElement will be enriched.
+       */
+      template <int dim, int spacedim>
+      bool
+      check_if_enriched (const std::vector< const FiniteElement< dim, spacedim > * > &fes)
+      {
+        // start from fe=1 as 0th is always non-enriched FE.
+        for (unsigned int fe=1; fe < fes.size(); fe++)
+          if (dynamic_cast<const FE_Nothing<dim>*>(fes[fe]) == nullptr)
+            // this is not FE_Nothing => there will be enrichment
+            return true;
+
+        return false;
+      }
+    }
   }
 }
 
@@ -149,8 +155,8 @@ FE_Enriched<dim,spacedim>::FE_Enriched (const FiniteElement<dim,spacedim> *fe_ba
                                         const std::vector<const FiniteElement<dim,spacedim> * > &fe_enriched,
                                         const std::vector<std::vector<std::function<const Function<spacedim> *(const typename Triangulation<dim, spacedim>::cell_iterator &) > > > &functions)
   :
-  FE_Enriched<dim,spacedim> (build_fes(fe_base,fe_enriched),
-                             build_multiplicities(functions),
+  FE_Enriched<dim,spacedim> (internal::FE_Enriched::build_fes(fe_base,fe_enriched),
+                             internal::FE_Enriched::build_multiplicities(functions),
                              functions)
 {}
 
@@ -164,11 +170,11 @@ FE_Enriched<dim,spacedim>::FE_Enriched (const std::vector< const FiniteElement< 
                                FETools::Compositing::compute_restriction_is_additive_flags(fes,multiplicities),
                                FETools::Compositing::compute_nonzero_components(fes,multiplicities,false)),
   enrichments(functions),
-  is_enriched(check_if_enriched(fes)),
+  is_enriched(internal::FE_Enriched::check_if_enriched(fes)),
   fe_system(fes,multiplicities)
 {
   // descriptive error are thrown within the function.
-  Assert(consistency_check(fes,multiplicities,functions),
+  Assert(internal::FE_Enriched::consistency_check(fes,multiplicities,functions),
          ExcInternalError());
 
   initialize(fes, multiplicities);

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -27,25 +27,31 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace
+namespace internal
 {
-  std::vector<Point<1> >
-  get_QGaussLobatto_points (const unsigned int degree)
+  namespace FE_FaceQ
   {
-    if (degree > 0)
-      return QGaussLobatto<1>(degree+1).get_points();
-    else
-      return std::vector<Point<1> >(1, Point<1>(0.5));
+    namespace
+    {
+      std::vector<Point<1> >
+      get_QGaussLobatto_points (const unsigned int degree)
+      {
+        if (degree > 0)
+          return QGaussLobatto<1>(degree+1).get_points();
+        else
+          return std::vector<Point<1> >(1, Point<1>(0.5));
+      }
+    }
   }
 }
 
 template <int dim, int spacedim>
 FE_FaceQ<dim,spacedim>::FE_FaceQ (const unsigned int degree)
   :
-  FE_PolyFace<TensorProductPolynomials<dim-1>, dim, spacedim> (
-    TensorProductPolynomials<dim-1>(Polynomials::generate_complete_Lagrange_basis(get_QGaussLobatto_points(degree))),
-    FiniteElementData<dim>(get_dpo_vector(degree), 1, degree, FiniteElementData<dim>::L2),
-    std::vector<bool>(1,true))
+  FE_PolyFace<TensorProductPolynomials<dim-1>, dim, spacedim>
+  (TensorProductPolynomials<dim-1>(Polynomials::generate_complete_Lagrange_basis(internal::FE_FaceQ::get_QGaussLobatto_points(degree))),
+   FiniteElementData<dim>(get_dpo_vector(degree), 1, degree, FiniteElementData<dim>::L2),
+   std::vector<bool>(1,true))
 {
   // initialize unit face support points
   const unsigned int codim = dim-1;
@@ -56,7 +62,7 @@ FE_FaceQ<dim,spacedim>::FE_FaceQ (const unsigned int degree)
       this->unit_face_support_points[0][d] = 0.5;
   else
     {
-      std::vector<Point<1> > points = get_QGaussLobatto_points(degree);
+      std::vector<Point<1> > points = internal::FE_FaceQ::get_QGaussLobatto_points(degree);
 
       unsigned int k=0;
       for (unsigned int iz=0; iz <= ((codim>2) ? this->degree : 0) ; ++iz)

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -44,17 +44,20 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  namespace
+  namespace FE_Nedelec
   {
-    double
-    get_embedding_computation_tolerance(const unsigned int p)
+    namespace
     {
-      // This heuristic was computed by monitoring the worst residual
-      // resulting from the least squares computation when computing
-      // the face embedding matrices in the FE_Nedelec constructor.
-      // The residual growth is exponential, but is bounded by this
-      // function up to degree 12.
-      return 1.e-15*std::exp(std::pow(p,1.075));
+      double
+      get_embedding_computation_tolerance(const unsigned int p)
+      {
+        // This heuristic was computed by monitoring the worst residual
+        // resulting from the least squares computation when computing
+        // the face embedding matrices in the FE_Nedelec constructor.
+        // The residual growth is exponential, but is bounded by this
+        // function up to degree 12.
+        return 1.e-15*std::exp(std::pow(p,1.075));
+      }
     }
   }
 }
@@ -107,7 +110,7 @@ FE_Nedelec<dim>::FE_Nedelec (const unsigned int order)
 
   FETools::compute_face_embedding_matrices<dim,double>
   (*this, face_embeddings, 0, 0,
-   internal::get_embedding_computation_tolerance(order));
+   internal::FE_Nedelec::get_embedding_computation_tolerance(order));
 
   switch (dim)
     {
@@ -3022,7 +3025,7 @@ FE_Nedelec<dim>
       this_nonconst.reinit_restriction_and_prolongation_matrices ();
       // Fill prolongation matrices with embedding operators
       FETools::compute_embedding_matrices (this_nonconst, this_nonconst.prolongation, true,
-                                           internal::get_embedding_computation_tolerance(this->degree));
+                                           internal::FE_Nedelec::get_embedding_computation_tolerance(this->degree));
 #ifdef DEBUG_NEDELEC
       deallog << "Restriction" << std::endl;
 #endif
@@ -3073,7 +3076,7 @@ FE_Nedelec<dim>
       this_nonconst.reinit_restriction_and_prolongation_matrices ();
       // Fill prolongation matrices with embedding operators
       FETools::compute_embedding_matrices (this_nonconst, this_nonconst.prolongation, true,
-                                           internal::get_embedding_computation_tolerance(this->degree));
+                                           internal::FE_Nedelec::get_embedding_computation_tolerance(this->degree));
 #ifdef DEBUG_NEDELEC
       deallog << "Restriction" << std::endl;
 #endif

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -19,10 +19,16 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace
+namespace internal
 {
-  const char *
-  zero_dof_message = "This element has no shape functions.";
+  namespace FE_Nothing
+  {
+    namespace
+    {
+      const char *
+      zero_dof_message = "This element has no shape functions.";
+    }
+  }
 }
 
 
@@ -85,8 +91,8 @@ double
 FE_Nothing<dim,spacedim>::shape_value (const unsigned int /*i*/,
                                        const Point<dim> & /*p*/) const
 {
-  (void)zero_dof_message;
-  Assert(false,ExcMessage(zero_dof_message));
+  (void)internal::FE_Nothing::zero_dof_message;
+  Assert(false,ExcMessage(internal::FE_Nothing::zero_dof_message));
   return 0;
 }
 
@@ -306,4 +312,3 @@ get_subface_interpolation_matrix (const FiniteElement<dim,spacedim> & /*source_f
 
 
 DEAL_II_NAMESPACE_CLOSE
-

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -25,19 +25,25 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace
+namespace internal
 {
-  std::vector<Point<1> >
-  get_QGaussLobatto_points (const unsigned int degree)
+  namespace FE_Q
   {
-    if (degree > 0)
-      return QGaussLobatto<1>(degree+1).get_points();
-    else
+    namespace
+    {
+      std::vector<Point<1> >
+      get_QGaussLobatto_points (const unsigned int degree)
       {
-        typedef FE_Q_Base<TensorProductPolynomials<1>, 1, 1> FEQ;
-        AssertThrow(false, FEQ::ExcFEQCannotHaveDegree0());
+        if (degree > 0)
+          return QGaussLobatto<1>(degree+1).get_points();
+        else
+          {
+            typedef FE_Q_Base<TensorProductPolynomials<1>, 1, 1> FEQ;
+            AssertThrow(false, FEQ::ExcFEQCannotHaveDegree0());
+          }
+        return std::vector<Point<1> >();
       }
-    return std::vector<Point<1> >();
+    }
   }
 }
 
@@ -47,13 +53,13 @@ template <int dim, int spacedim>
 FE_Q<dim,spacedim>::FE_Q (const unsigned int degree)
   :
   FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>
-  (TensorProductPolynomials<dim>(Polynomials::generate_complete_Lagrange_basis(get_QGaussLobatto_points(degree))),
+  (TensorProductPolynomials<dim>(Polynomials::generate_complete_Lagrange_basis(internal::FE_Q::get_QGaussLobatto_points(degree))),
    FiniteElementData<dim>(this->get_dpo_vector(degree),
                           1, degree,
                           FiniteElementData<dim>::H1),
    std::vector<bool> (1, false))
 {
-  this->initialize(get_QGaussLobatto_points(degree));
+  this->initialize(internal::FE_Q::get_QGaussLobatto_points(degree));
 }
 
 

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -28,23 +28,29 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace
+namespace internal
 {
-  /**
-   * A function which maps  in[i] to i,i.e. output[in[i]] = i;
-   */
-  inline
-  std::vector<unsigned int>
-  invert_numbering (const std::vector<unsigned int> &in)
+  namespace FE_Q_Hierarchical
   {
-    std::vector<unsigned int> out (in.size());
-    for (unsigned int i=0; i<in.size(); ++i)
+    namespace
+    {
+      /**
+       * A function which maps  in[i] to i,i.e. output[in[i]] = i;
+       */
+      inline
+      std::vector<unsigned int>
+      invert_numbering (const std::vector<unsigned int> &in)
       {
-        Assert (in[i] < out.size(),
-                dealii::ExcIndexRange(in[i],0,out.size()));
-        out[in[i]]=i;
+        std::vector<unsigned int> out (in.size());
+        for (unsigned int i=0; i<in.size(); ++i)
+          {
+            Assert (in[i] < out.size(),
+                    dealii::ExcIndexRange(in[i],0,out.size()));
+            out[in[i]]=i;
+          }
+        return out;
       }
-    return out;
+    }
   }
 }
 
@@ -1812,8 +1818,8 @@ FE_Q_Hierarchical<dim>::
 face_fe_q_hierarchical_to_hierarchic_numbering (const unsigned int degree)
 {
   FiniteElementData<dim-1> fe_data(FE_Q_Hierarchical<dim-1>::get_dpo_vector(degree),1,degree);
-  return invert_numbering(FE_Q_Hierarchical<dim-1>::
-                          hierarchic_to_fe_q_hierarchical_numbering (fe_data));
+  return internal::FE_Q_Hierarchical::invert_numbering
+         (FE_Q_Hierarchical<dim-1>::hierarchic_to_fe_q_hierarchical_numbering (fe_data));
 }
 
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -30,18 +30,21 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace
+namespace internal
 {
-  bool IsNonZero (unsigned int i)
+  namespace FESystem
   {
-    return i>0;
+    namespace
+    {
+      unsigned int count_nonzeros(const std::vector<unsigned int> &vec)
+      {
+        return std::count_if(vec.begin(), vec.end(), [](const unsigned int i)
+        {
+          return i > 0;
+        });
+      }
+    }
   }
-
-  unsigned int count_nonzeros(const std::vector<unsigned int> &vec)
-  {
-    return std::count_if(vec.begin(), vec.end(), IsNonZero);
-  }
-
 }
 /* ----------------------- FESystem::InternalData ------------------- */
 
@@ -275,7 +278,7 @@ FESystem<dim,spacedim>::FESystem (
   FiniteElement<dim,spacedim> (FETools::Compositing::multiply_dof_numbers(fes, multiplicities),
                                FETools::Compositing::compute_restriction_is_additive_flags (fes, multiplicities),
                                FETools::Compositing::compute_nonzero_components(fes, multiplicities)),
-  base_elements(count_nonzeros(multiplicities))
+  base_elements(internal::FESystem::count_nonzeros(multiplicities))
 {
   initialize(fes, multiplicities);
 }
@@ -1458,7 +1461,7 @@ void FESystem<dim,spacedim>::initialize (const std::vector<const FiniteElement<d
           ExcDimensionMismatch (fes.size(), multiplicities.size()) );
   Assert (fes.size() > 0,
           ExcMessage ("Need to pass at least one finite element."));
-  Assert (count_nonzeros(multiplicities) > 0,
+  Assert (internal::FESystem::count_nonzeros(multiplicities) > 0,
           ExcMessage("You only passed FiniteElements with multiplicity 0."));
 
   // Note that we need to skip every fe with multiplicity 0 in the following block of code


### PR DESCRIPTION
This is the finite element equivalent to 6310b2dee3e and is also necessary for the (possible) unity build patch.

This PR does nothing but move free functions that only exist in source files into specific namespaces.