### PR TITLE
Update CMake error message in tutorials.

### DIFF
--- a/examples/step-17/CMakeLists.txt
+++ b/examples/step-17/CMakeLists.txt
@@ -43,7 +43,10 @@ IF(NOT DEAL_II_WITH_PETSC OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_PETSC = ${DEAL_II_WITH_PETSC}
+    DEAL_II_PETSC_WITH_COMPLEX = ${DEAL_II_PETSC_WITH_COMPLEX}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-17/CMakeLists.txt
+++ b/examples/step-17/CMakeLists.txt
@@ -40,10 +40,10 @@ ENDIF ()
 #
 IF(NOT DEAL_II_WITH_PETSC OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-18/CMakeLists.txt
+++ b/examples/step-18/CMakeLists.txt
@@ -44,7 +44,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_PETSC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
+    DEAL_II_WITH_PETSC = ${DEAL_II_WITH_PETSC}
+    DEAL_II_PETSC_WITH_COMPLEX = ${DEAL_II_PETSC_WITH_COMPLEX}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-18/CMakeLists.txt
+++ b/examples/step-18/CMakeLists.txt
@@ -40,11 +40,11 @@ ENDIF ()
 #
 IF(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_PETSC OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_PETSC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-22/CMakeLists.txt
+++ b/examples/step-22/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-22/CMakeLists.txt
+++ b/examples/step-22/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-29/CMakeLists.txt
+++ b/examples/step-29/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-29/CMakeLists.txt
+++ b/examples/step-29/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-31/CMakeLists.txt
+++ b/examples/step-31/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-31/CMakeLists.txt
+++ b/examples/step-31/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-32/CMakeLists.txt
+++ b/examples/step-32/CMakeLists.txt
@@ -46,7 +46,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-32/CMakeLists.txt
+++ b/examples/step-32/CMakeLists.txt
@@ -42,11 +42,11 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST OR NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -44,7 +44,9 @@ IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -42,9 +42,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-34/CMakeLists.txt
+++ b/examples/step-34/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MUPARSER = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-34/CMakeLists.txt
+++ b/examples/step-34/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_MUPARSER) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MUPARSER = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-35/CMakeLists.txt
+++ b/examples/step-35/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-35/CMakeLists.txt
+++ b/examples/step-35/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-36/CMakeLists.txt
+++ b/examples/step-36/CMakeLists.txt
@@ -43,7 +43,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_PETSC = ON
     DEAL_II_WITH_SLEPC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_PETSC = ${DEAL_II_WITH_PETSC}
+    DEAL_II_WITH_SLEPC = ${DEAL_II_WITH_SLEPC}
+    DEAL_II_PETSC_WITH_COMPLEX = ${DEAL_II_PETSC_WITH_COMPLEX}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-36/CMakeLists.txt
+++ b/examples/step-36/CMakeLists.txt
@@ -39,11 +39,11 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_PETSC OR NOT DEAL_II_WITH_SLEPC OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
     DEAL_II_WITH_SLEPC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-37/CMakeLists.txt
+++ b/examples/step-37/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_LAPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_LAPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_LAPACK = ${DEAL_II_WITH_LAPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-37/CMakeLists.txt
+++ b/examples/step-37/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_LAPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_LAPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-40/CMakeLists.txt
+++ b/examples/step-40/CMakeLists.txt
@@ -46,7 +46,13 @@ Error! This tutorial requires a deal.II library that was configured with the fol
 or
     DEAL_II_WITH_TRILINOS = ON
     DEAL_II_WITH_P4EST = ON
-One or both of these combinations are OFF in your installation but at least one is required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_PETSC = ${DEAL_II_WITH_PETSC}
+    DEAL_II_PETSC_WITH_COMPLEX = ${DEAL_II_PETSC_WITH_COMPLEX}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements.
+One or both of the aforementioned combinations of prerequisites are not met by your installation, but at least one is required for this tutorial step."
     )
 ENDIF()
 

--- a/examples/step-40/CMakeLists.txt
+++ b/examples/step-40/CMakeLists.txt
@@ -39,7 +39,7 @@ ENDIF()
 #
 IF(NOT (DEAL_II_WITH_PETSC OR DEAL_II_WITH_TRILINOS) OR NOT DEAL_II_WITH_P4EST OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
     DEAL_II_WITH_P4EST = ON

--- a/examples/step-41/CMakeLists.txt
+++ b/examples/step-41/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-41/CMakeLists.txt
+++ b/examples/step-41/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-42/CMakeLists.txt
+++ b/examples/step-42/CMakeLists.txt
@@ -46,7 +46,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-42/CMakeLists.txt
+++ b/examples/step-42/CMakeLists.txt
@@ -42,11 +42,11 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST OR NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-43/CMakeLists.txt
+++ b/examples/step-43/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-43/CMakeLists.txt
+++ b/examples/step-43/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-45/CMakeLists.txt
+++ b/examples/step-45/CMakeLists.txt
@@ -43,7 +43,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-45/CMakeLists.txt
+++ b/examples/step-45/CMakeLists.txt
@@ -39,11 +39,11 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST OR NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-46/CMakeLists.txt
+++ b/examples/step-46/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-46/CMakeLists.txt
+++ b/examples/step-46/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-50/CMakeLists.txt
+++ b/examples/step-50/CMakeLists.txt
@@ -46,7 +46,11 @@ Error! This tutorial requires a deal.II library that was configured with the fol
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-50/CMakeLists.txt
+++ b/examples/step-50/CMakeLists.txt
@@ -42,11 +42,11 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST OR NOT DEAL_II_WITH_TRILINOS) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_WITH_TRILINOS = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-53/CMakeLists.txt
+++ b/examples/step-53/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_ZLIB) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
   DEAL_II_WITH_ZLIB = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+  DEAL_II_WITH_ZLIB = ${DEAL_II_WITH_ZLIB}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-53/CMakeLists.txt
+++ b/examples/step-53/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_ZLIB) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
   DEAL_II_WITH_ZLIB = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-54/CMakeLists.txt
+++ b/examples/step-54/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_OPENCASCADE) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_OPENCASCADE = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-54/CMakeLists.txt
+++ b/examples/step-54/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_OPENCASCADE) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_OPENCASCADE = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_OPENCASCADE = ${DEAL_II_WITH_OPENCASCADE}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-55/CMakeLists.txt
+++ b/examples/step-55/CMakeLists.txt
@@ -41,12 +41,18 @@ IF(NOT (DEAL_II_WITH_PETSC OR DEAL_II_WITH_TRILINOS) OR NOT DEAL_II_WITH_P4EST O
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
-    DEAL_II_WITH_P4EST = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF
+    DEAL_II_WITH_P4EST = ON
 or
     DEAL_II_WITH_TRILINOS = ON
     DEAL_II_WITH_P4EST = ON
-One or both of these combinations are OFF in your installation but at least one is required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_PETSC = ${DEAL_II_WITH_PETSC}
+    DEAL_II_PETSC_WITH_COMPLEX = ${DEAL_II_PETSC_WITH_COMPLEX}
+    DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
+    DEAL_II_WITH_TRILINOS = ${DEAL_II_WITH_TRILINOS}
+which conflict with the requirements.
+One or both of the aforementioned combinations of prerequisites are not met by your installation, but at least one is required for this tutorial step."
     )
 ENDIF()
 

--- a/examples/step-55/CMakeLists.txt
+++ b/examples/step-55/CMakeLists.txt
@@ -39,7 +39,7 @@ ENDIF()
 #
 IF(NOT (DEAL_II_WITH_PETSC OR DEAL_II_WITH_TRILINOS) OR NOT DEAL_II_WITH_P4EST OR DEAL_II_PETSC_WITH_COMPLEX) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_PETSC = ON
     DEAL_II_WITH_P4EST = ON
     DEAL_II_PETSC_WITH_COMPLEX = OFF

--- a/examples/step-56/CMakeLists.txt
+++ b/examples/step-56/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-56/CMakeLists.txt
+++ b/examples/step-56/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 

--- a/examples/step-57/CMakeLists.txt
+++ b/examples/step-57/CMakeLists.txt
@@ -41,7 +41,9 @@ IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
+    DEAL_II_WITH_UMFPACK = ${DEAL_II_WITH_UMFPACK}
+which conflict with the requirements."
     )
 ENDIF()
 

--- a/examples/step-57/CMakeLists.txt
+++ b/examples/step-57/CMakeLists.txt
@@ -39,9 +39,9 @@ ENDIF()
 #
 IF(NOT DEAL_II_WITH_UMFPACK) # keep in one line
   MESSAGE(FATAL_ERROR "
-Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_UMFPACK = ON
-One or all of these are OFF in your installation but are required for this tutorial step."
+However, the deal.II library found at ${DEAL_II_PATH} was configured with options that conflict with these requirements."
     )
 ENDIF()
 


### PR DESCRIPTION
This removes any ambiguity in the outputted message previously caused by
double negation.

Fixes #4600