### PR TITLE
Avoid raw pointers. Use std::unique_ptr instead.

### DIFF
--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -714,8 +714,8 @@ ChunkSparseMatrix<number>::vmult_add (OutVector &dst,
                                            std::cref(*cols),
                                            std::placeholders::_1, std::placeholders::_2,
                                            val.get(),
-                                           cols->sparsity_pattern.rowstart,
-                                           cols->sparsity_pattern.colnums,
+                                           cols->sparsity_pattern.rowstart.get(),
+                                           cols->sparsity_pattern.colnums.get(),
                                            std::cref(src),
                                            std::ref(dst)),
                                 internal::SparseMatrix::minimum_parallel_grain_size/cols->chunk_size+1);
@@ -751,7 +751,7 @@ ChunkSparseMatrix<number>::Tvmult_add (OutVector &dst,
   // like in vmult_add, but don't keep an iterator into dst around since we're
   // not traversing it sequentially this time
   const number    *val_ptr    = val.get();
-  const size_type *colnum_ptr = cols->sparsity_pattern.colnums;
+  const size_type *colnum_ptr = cols->sparsity_pattern.colnums.get();
 
   for (size_type chunk_row=0; chunk_row<n_regular_chunk_rows; ++chunk_row)
     {
@@ -845,7 +845,7 @@ ChunkSparseMatrix<number>::matrix_norm_square (const Vector<somenumber> &v) cons
        n_chunk_rows);
 
   const number    *val_ptr    = val.get();
-  const size_type *colnum_ptr = cols->sparsity_pattern.colnums;
+  const size_type *colnum_ptr = cols->sparsity_pattern.colnums.get();
   typename Vector<somenumber>::const_iterator v_ptr = v.begin();
 
   for (size_type chunk_row=0; chunk_row<n_regular_chunk_rows; ++chunk_row)
@@ -953,7 +953,7 @@ ChunkSparseMatrix<number>::matrix_scalar_product (const Vector<somenumber> &u,
        n_chunk_rows);
 
   const number    *val_ptr    = val.get();
-  const size_type *colnum_ptr = cols->sparsity_pattern.colnums;
+  const size_type *colnum_ptr = cols->sparsity_pattern.colnums.get();
   typename Vector<somenumber>::const_iterator u_ptr = u.begin();
 
   for (size_type chunk_row=0; chunk_row<n_regular_chunk_rows; ++chunk_row)
@@ -1155,7 +1155,7 @@ ChunkSparseMatrix<number>::residual (Vector<somenumber>       &dst,
        n_chunk_rows);
 
   const number    *val_ptr    = val.get();
-  const size_type *colnum_ptr = cols->sparsity_pattern.colnums;
+  const size_type *colnum_ptr = cols->sparsity_pattern.colnums.get();
   typename Vector<somenumber>::iterator dst_ptr = dst.begin();
 
   for (size_type chunk_row=0; chunk_row<n_regular_chunk_rows; ++chunk_row)

--- a/include/deal.II/lac/sparse_decomposition.templates.h
+++ b/include/deal.II/lac/sparse_decomposition.templates.h
@@ -135,9 +135,9 @@ void
 SparseLUDecomposition<number>::prebuild_lower_bound()
 {
   const size_type *const
-  column_numbers = this->get_sparsity_pattern().colnums;
+  column_numbers = this->get_sparsity_pattern().colnums.get();
   const std::size_t *const
-  rowstart_indices = this->get_sparsity_pattern().rowstart;
+  rowstart_indices = this->get_sparsity_pattern().rowstart.get();
   const size_type N = this->m();
 
   prebuilt_lower_bound.resize (N);

--- a/include/deal.II/lac/sparse_ilu.templates.h
+++ b/include/deal.II/lac/sparse_ilu.templates.h
@@ -59,8 +59,8 @@ void SparseILU<number>::initialize (const SparseMatrix<somenumber> &matrix,
   // translating in essence the algorithm given at the end of section 10.3.2,
   // using the names of variables used there
   const SparsityPattern     &sparsity = this->get_sparsity_pattern();
-  const std::size_t *const ia    = sparsity.rowstart;
-  const size_type *const ja      = sparsity.colnums;
+  const std::size_t *const ia    = sparsity.rowstart.get();
+  const size_type *const ja      = sparsity.colnums.get();
 
   number *luval = this->SparseMatrix<number>::val.get();
 
@@ -147,9 +147,9 @@ void SparseILU<number>::vmult (Vector<somenumber>       &dst,
 
   const size_type N=dst.size();
   const std::size_t *const rowstart_indices
-    = this->get_sparsity_pattern().rowstart;
+    = this->get_sparsity_pattern().rowstart.get();
   const size_type *const column_numbers
-    = this->get_sparsity_pattern().colnums;
+    = this->get_sparsity_pattern().colnums.get();
 
   // solve LUx=b in two steps:
   // first Ly = b, then
@@ -221,9 +221,9 @@ void SparseILU<number>::Tvmult (Vector<somenumber>       &dst,
 
   const size_type N=dst.size();
   const std::size_t *const rowstart_indices
-    = this->get_sparsity_pattern().rowstart;
+    = this->get_sparsity_pattern().rowstart.get();
   const size_type *const column_numbers
-    = this->get_sparsity_pattern().colnums;
+    = this->get_sparsity_pattern().colnums.get();
 
   // solve (LU)'x=b in two steps:
   // first U'y = b, then

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -612,7 +612,7 @@ SparseMatrix<number>::add (const size_type  row,
   // unsorted case: first, search all the
   // indices to find out which values we
   // actually need to add.
-  const size_type *const my_cols = cols->colnums;
+  const size_type *const my_cols = cols->colnums.get();
   size_type index = cols->rowstart[row];
   const size_type next_row_index = cols->rowstart[row+1];
 
@@ -671,7 +671,7 @@ SparseMatrix<number>::set (const size_type  row,
   // First, search all the indices to find
   // out which values we actually need to
   // set.
-  const size_type *my_cols = cols->colnums;
+  const size_type *my_cols = cols->colnums.get();
   std::size_t index = cols->rowstart[row], next_index = index;
   const std::size_t next_row_index = cols->rowstart[row+1];
 
@@ -757,8 +757,8 @@ SparseMatrix<number>::vmult (OutVector &dst,
                                            <number,InVector,OutVector>,
                                            std::placeholders::_1, std::placeholders::_2,
                                            val.get(),
-                                           cols->rowstart,
-                                           cols->colnums,
+                                           cols->rowstart.get(),
+                                           cols->colnums.get(),
                                            std::cref(src),
                                            std::ref(dst),
                                            false),
@@ -812,8 +812,8 @@ SparseMatrix<number>::vmult_add (OutVector &dst,
                                            <number,InVector,OutVector>,
                                            std::placeholders::_1, std::placeholders::_2,
                                            val.get(),
-                                           cols->rowstart,
-                                           cols->colnums,
+                                           cols->rowstart.get(),
+                                           cols->colnums.get(),
                                            std::cref(src),
                                            std::ref(dst),
                                            true),
@@ -897,7 +897,9 @@ SparseMatrix<number>::matrix_norm_square (const Vector<somenumber> &v) const
     (std::bind (&internal::SparseMatrix::matrix_norm_sqr_on_subrange
                 <number,Vector<somenumber> >,
                 std::placeholders::_1, std::placeholders::_2,
-                val.get(), cols->rowstart, cols->colnums,
+                val.get(),
+                cols->rowstart.get(),
+                cols->colnums.get(),
                 std::cref(v)),
      0, m(),
      internal::SparseMatrix::minimum_parallel_grain_size);
@@ -960,7 +962,9 @@ SparseMatrix<number>::matrix_scalar_product (const Vector<somenumber> &u,
     (std::bind (&internal::SparseMatrix::matrix_scalar_product_on_subrange
                 <number,Vector<somenumber> >,
                 std::placeholders::_1, std::placeholders::_2,
-                val.get(), cols->rowstart, cols->colnums,
+                val.get(),
+                cols->rowstart.get(),
+                cols->colnums.get(),
                 std::cref(u),
                 std::cref(v)),
      0, m(),
@@ -1347,7 +1351,9 @@ SparseMatrix<number>::residual (Vector<somenumber>       &dst,
                (std::bind (&internal::SparseMatrix::residual_sqr_on_subrange
                            <number,Vector<somenumber>,Vector<somenumber> >,
                            std::placeholders::_1, std::placeholders::_2,
-                           val.get(), cols->rowstart, cols->colnums,
+                           val.get(),
+                           cols->rowstart.get(),
+                           cols->colnums.get(),
                            std::cref(u),
                            std::cref(b),
                            std::ref(dst)),


### PR DESCRIPTION
This patch changes SparsityPattern and classes that use it.

In the same spirit as #4604.