### PR TITLE
Use a clearer initialization syntax.

### DIFF
--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -279,7 +279,7 @@ void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::step
  const VectorType &src) const
 {
   GrowingVectorMemory<VectorType> mem;
-  typename VectorMemory<VectorType>::Pointer aux = mem;
+  typename VectorMemory<VectorType>::Pointer aux(mem);
   aux->reinit(dst, false);
   *aux = dst;
   this->do_step(dst, *aux, src, false);
@@ -292,7 +292,7 @@ void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::Tstep
  const VectorType &src) const
 {
   GrowingVectorMemory<VectorType> mem;
-  typename VectorMemory<VectorType>::Pointer aux = mem;
+  typename VectorMemory<VectorType>::Pointer aux(mem);
   aux->reinit(dst, false);
   *aux = dst;
   this->do_step(dst, *aux, src, true);
@@ -305,7 +305,7 @@ void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::vmult
  const VectorType &src) const
 {
   GrowingVectorMemory<VectorType> mem;
-  typename VectorMemory<VectorType>::Pointer aux = mem;
+  typename VectorMemory<VectorType>::Pointer aux(mem);
   dst = 0;
   aux->reinit(dst);
   this->do_step(dst, *aux, src, false);
@@ -318,7 +318,7 @@ void RelaxationBlockJacobi<MatrixType, InverseNumberType, VectorType>::Tvmult
  const VectorType &src) const
 {
   GrowingVectorMemory<VectorType> mem;
-  typename VectorMemory<VectorType>::Pointer aux = mem;
+  typename VectorMemory<VectorType>::Pointer aux(mem);
   dst = 0;
   aux->reinit(dst);
   this->do_step(dst, *aux, src, true);


### PR DESCRIPTION
Specifically, we used the syntax
  Type object = initializer;
in contexts where the initializer is of a different type and the
compiler automatically converted this into 
  Type object(initializer);
where the constructor called was just a regular constructor
that did something with the initializer, but specifically did not
copy the object. This is confusing. Use the latter syntax instead.