### PR TITLE
Add a changelog entry for hp::DoFHandler vs. p::s::Triangulation.

### DIFF
--- a/doc/news/changes/major/20170717Bangerth
+++ b/doc/news/changes/major/20170717Bangerth
@@ -1,0 +1,4 @@
+New: The hp::DoFHandler class can now work with shared triangulations
+of type parallel::shared::Triangulation.
+<br>
+(Wolfgang Bangerth, 2017/07/17)


### PR DESCRIPTION
Since #4593, these two actually work together. Since that patch also
accumulated a number of tests, I will declare that work done
for now -- so closes #1366.