### PR TITLE
Use appropriate constructor for QGaussChebyshev*

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -100,6 +100,8 @@ public:
   /**
    * Build this quadrature formula as the tensor product of a formula in a
    * dimension one less than the present and a formula in one dimension.
+   * This constructor assumes (and tests) that constant functions are integrated
+   * exactly, i.e. the sum of the quadrature weights is one.
    *
    * <tt>SubQuadrature<dim>::type</tt> expands to <tt>Quadrature<dim-1></tt>.
    */
@@ -117,6 +119,10 @@ public:
    * In order to avoid a conflict with the copy constructor in 1d, we let the
    * argument be a 0d quadrature formula for dim==1, and a 1d quadrature
    * formula for all other space dimensions.
+   *
+   * This constructor does not require that constant functions are integrated
+   * exactly. Therefore, it is appropriate if the one-dimensional formula
+   * is defined with respect to a weighting function.
    */
   explicit Quadrature (const Quadrature<dim != 1 ? 1 : 0> &quadrature_1d);
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -1181,7 +1181,7 @@ QGaussChebyshev<1>::QGaussChebyshev(const unsigned int n)
 template <int dim>
 QGaussChebyshev<dim>::QGaussChebyshev (const unsigned int n)
   :
-  Quadrature<dim> (QGaussChebyshev<dim-1>(n), QGaussChebyshev<1>(n))
+  Quadrature<dim> (QGaussChebyshev<1>(n))
 {}
 
 
@@ -1249,7 +1249,7 @@ QGaussRadauChebyshev<1>::get_quadrature_weights(const unsigned int n,
 
 template <>
 QGaussRadauChebyshev<1>::QGaussRadauChebyshev(const unsigned int n,
-                                              QGaussRadauChebyshev<1>::EndPoint ep)
+                                              EndPoint ep)
   :
   Quadrature<1> (n),
   ep (ep)
@@ -1267,22 +1267,11 @@ QGaussRadauChebyshev<1>::QGaussRadauChebyshev(const unsigned int n,
 }
 
 
-template <>
-QGaussRadauChebyshev<2>::QGaussRadauChebyshev (const unsigned int n,
-                                               EndPoint ep)
-  :
-  Quadrature<2> (QGaussRadauChebyshev<1>(n, static_cast<QGaussRadauChebyshev<1>::EndPoint>(ep)),
-                 QGaussRadauChebyshev<1>(n, static_cast<QGaussRadauChebyshev<1>::EndPoint>(ep))),
-  ep (ep)
-{}
-
-
 template <int dim>
 QGaussRadauChebyshev<dim>::QGaussRadauChebyshev (const unsigned int n,
                                                  EndPoint ep)
   :
-  Quadrature<dim> (QGaussRadauChebyshev<dim-1>(n,static_cast<typename QGaussRadauChebyshev<dim-1>::EndPoint>(ep)),
-                   QGaussRadauChebyshev<1>(n,static_cast<QGaussRadauChebyshev<1>::EndPoint>(ep))),
+  Quadrature<dim> (QGaussRadauChebyshev<1>(n,static_cast<QGaussRadauChebyshev<1>::EndPoint>(ep))),
   ep (ep)
 {}
 
@@ -1346,7 +1335,7 @@ QGaussLobattoChebyshev<1>::QGaussLobattoChebyshev(const unsigned int n)
 template <int dim>
 QGaussLobattoChebyshev<dim>::QGaussLobattoChebyshev (const unsigned int n)
   :
-  Quadrature<dim> (QGaussLobattoChebyshev<dim-1>(n), QGaussLobattoChebyshev<1>(n))
+  Quadrature<dim> (QGaussLobattoChebyshev<1>(n))
 {}
 
 // explicit specialization

--- a/tests/base/quadrature_construct_chebyshev.cc
+++ b/tests/base/quadrature_construct_chebyshev.cc
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that the QGaussChebyshev, QGaussRadauChebyshev and QGaussLobattoChebyshev,
+// can be constructed in all dimensions. Previously, this failed since the base class
+// constructor used required the one-dimensional quadrature formula to integrate
+// constants exactly. This is not true for the classes considered here.
+
+
+#include "../tests.h"
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/quadrature.h>
+
+template <int dim>
+void
+construct_quadrature()
+{
+  QGaussChebyshev<dim> q_1(2);
+  deallog << "QGaussChebyshev<" << dim << ">: OK" << std::endl;
+  QGaussRadauChebyshev<dim> q_2(2);
+  deallog << "QGaussRadauChebyshev<" << dim << ">: OK" << std::endl;
+  QGaussLobattoChebyshev<dim> q_3(2);
+  deallog << "QGaussLobattoChebyshev<" << dim << ">: OK" << std::endl;
+}
+
+int main()
+{
+  initlog();
+
+  construct_quadrature<1>();
+  construct_quadrature<2>();
+  construct_quadrature<3>();
+}
+

--- a/tests/base/quadrature_construct_chebyshev.output
+++ b/tests/base/quadrature_construct_chebyshev.output
@@ -1,0 +1,10 @@
+
+DEAL::QGaussChebyshev<1>: OK
+DEAL::QGaussRadauChebyshev<1>: OK
+DEAL::QGaussLobattoChebyshev<1>: OK
+DEAL::QGaussChebyshev<2>: OK
+DEAL::QGaussRadauChebyshev<2>: OK
+DEAL::QGaussLobattoChebyshev<2>: OK
+DEAL::QGaussChebyshev<3>: OK
+DEAL::QGaussRadauChebyshev<3>: OK
+DEAL::QGaussLobattoChebyshev<3>: OK


### PR DESCRIPTION
Fixes #4625.
The reason why the constructor reported the problem is that these quadrature formulas don't integrate constant functions exactly, but are defined with respect to a weighting function.
There exists a different constructor for `Quadrature` that is applicable and doesn't check this property so use it instead.