### PR TITLE
Mark copy operators as explicitly deleted.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -287,6 +287,18 @@ public:
    */
   template <bool level_dof_access2>
   DoFAccessor(const DoFAccessor<structdim, DoFHandlerType, level_dof_access2> &);
+
+  /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on DoF handler objects.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  DoFAccessor<structdim,DoFHandlerType, level_dof_access> &
+  operator = (const DoFAccessor<structdim,DoFHandlerType, level_dof_access> &da) = delete;
+
   /**
    * @}
    */
@@ -670,18 +682,6 @@ protected:
   template <int, class, bool> friend class DoFAccessor;
 
 private:
-  /**
-   * Copy operator. This is normally used in a context like <tt>iterator a,b;
-   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
-   * by @p b to the object pointed to by @p a. However, the result of
-   * dereferencing an iterator is not an object but an accessor; consequently,
-   * this operation is not useful for iterators on triangulations. We declare
-   * this function here private, thus it may not be used from outside.
-   * Furthermore it is not implemented and will give a linker error if used
-   * anyway.
-   */
-  DoFAccessor<structdim,DoFHandlerType, level_dof_access> &
-  operator = (const DoFAccessor<structdim,DoFHandlerType, level_dof_access> &da);
 
   /**
    * Make the DoFHandler class a friend so that it can call the set_xxx()
@@ -802,6 +802,17 @@ public:
   DoFAccessor (const DoFAccessor<dim2, DoFHandlerType2, level_dof_access2> &);
 
   /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on DoF handler objects.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access> &
+  operator = (const DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access> &da) = delete;
+
+  /**
    * @}
    */
 
@@ -810,12 +821,6 @@ public:
    */
   const DoFHandlerType<1,spacedim> &
   get_dof_handler () const;
-
-  /**
-   * Copy operator.
-   */
-  DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access> &
-  operator = (const DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access> &da);
 
   /**
    * Implement the copy operator needed for the iterator classes.
@@ -1227,6 +1232,17 @@ public:
   template <int dim2, class DoFHandlerType2, bool level_dof_access2>
   explicit
   DoFCellAccessor (const DoFAccessor<dim2, DoFHandlerType2, level_dof_access2> &);
+
+  /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on DoF handler objects.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  DoFCellAccessor<DoFHandlerType, level_dof_access> &
+  operator = (const DoFCellAccessor<DoFHandlerType, level_dof_access> &da) = delete;
 
   /**
    * @}
@@ -1716,18 +1732,6 @@ public:
   void update_cell_dof_indices_cache () const;
 
 private:
-  /**
-   * Copy operator. This is normally used in a context like <tt>iterator a,b;
-   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
-   * by @p b to the object pointed to by @p a. However, the result of
-   * dereferencing an iterator is not an object but an accessor; consequently,
-   * this operation is not useful for iterators on triangulations. We declare
-   * this function here private, thus it may not be used from outside.
-   * Furthermore it is not implemented and will give a linker error if used
-   * anyway.
-   */
-  DoFCellAccessor<DoFHandlerType, level_dof_access> &
-  operator = (const DoFCellAccessor<DoFHandlerType, level_dof_access> &da);
 
   /**
    * Make the DoFHandler class a friend so that it can call the

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -294,6 +294,16 @@ protected:
   TriaAccessorBase (const TriaAccessorBase &);
 
   /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on triangulations.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  void operator = (const TriaAccessorBase *) = delete;
+
+  /**
    * Copy operator. Since this is only called from iterators, do not return
    * anything, since the iterator will return itself.
    *
@@ -316,16 +326,6 @@ protected:
   bool operator < (const TriaAccessorBase &other) const;
 
 protected:
-  /**
-   * Copy operator. This is normally used in a context like <tt>iterator a,b;
-   * *a=*b;</tt>. Since the meaning is to copy the object pointed to by @p b
-   * to the object pointed to by @p a and since accessors are not real but
-   * virtual objects, this operation is not useful for iterators on
-   * triangulations. We declare this function here private, thus it may not be
-   * used from outside. Furthermore it is not implemented and will give a
-   * linker error if used anyway.
-   */
-  void operator = (const TriaAccessorBase *);
 
   /**
    * Compare for equality.
@@ -622,6 +622,16 @@ public:
    */
   template <int structdim2, int dim2, int spacedim2>
   TriaAccessor (const TriaAccessor<structdim2,dim2,spacedim2> &);
+
+  /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on triangulations.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  void operator = (const TriaAccessor &) = delete;
 
   /**
    * Test for the element being used or not.  The return value is @p true for
@@ -1517,17 +1527,6 @@ private:
   void clear_children () const;
 
 private:
-  /**
-   * Copy operator. This is normally used in a context like <tt>iterator a,b;
-   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
-   * by @p b to the object pointed to by @p a. However, the result of
-   * dereferencing an iterator is not an object but an accessor; consequently,
-   * this operation is not useful for iterators on triangulations. We declare
-   * this function here private, thus it may not be used from outside.
-   * Furthermore it is not implemented and will give a linker error if used
-   * anyway.
-   */
-  void operator = (const TriaAccessor &);
 
   template <int, int> friend class Triangulation;
 
@@ -2417,6 +2416,16 @@ public:
   CellAccessor (const TriaAccessor<structdim2,dim2,spacedim2> &);
 
   /**
+   * Copy operator. These operators are usually used in a context like <tt>iterator a,b;
+   * *a=*b;</tt>. Presumably, the intent here is to copy the object pointed to
+   * by @p b to the object pointed to by @p a. However, the result of
+   * dereferencing an iterator is not an object but an accessor; consequently,
+   * this operation is not useful for iterators on triangulations.
+   * Consequently, this operator is declared as deleted and can not be used.
+   */
+  void operator = (const CellAccessor<dim, spacedim> &) = delete;
+
+  /**
    * @}
    */
 
@@ -3231,16 +3240,6 @@ private:
    * @ref GlossDirectionFlag.
    */
   void set_direction_flag (const bool new_direction_flag) const;
-  /**
-   * Copy operator. This is normally used in a context like <tt>iterator a,b;
-   * *a=*b;</tt>. Since the meaning is to copy the object pointed to by @p b
-   * to the object pointed to by @p a and since accessors are not real but
-   * virtual objects, this operation is not useful for iterators on
-   * triangulations. We declare this function here private, thus it may not be
-   * used from outside.  Furthermore it is not implemented and will give a
-   * linker error if used anyway.
-   */
-  void operator = (const CellAccessor<dim, spacedim> &);
 
   template <int, int> friend class Triangulation;
 


### PR DESCRIPTION
The operator=() of all accessor classes had previously been hidden
by making them private and not implementing them. C++11 now allows
us to bring them out of the dark and into the light by making
them public, but marking them as '=delete'.