### PR TITLE
Remove an unnecessary cast.

### DIFF
--- a/tests/distributed_grids/solution_transfer_02.cc
+++ b/tests/distributed_grids/solution_transfer_02.cc
@@ -84,7 +84,7 @@ void test(std::ostream & /*out*/)
 
   Vector<double> solution(dofh.n_dofs());
   VectorTools::interpolate (mapping,
-                            * static_cast<dealii::DoFHandler<dim>* >(&dofh),
+                            dofh,
                             func,
                             solution);
 

--- a/tests/distributed_grids/solution_transfer_03.cc
+++ b/tests/distributed_grids/solution_transfer_03.cc
@@ -104,7 +104,7 @@ void test(std::ostream & /*out*/)
 
       Vector<double> solution(dofh.n_dofs());
       VectorTools::interpolate (mapping,
-                                * static_cast<dealii::DoFHandler<dim>* >(&dofh),
+                                dofh,
                                 func,
                                 solution);
 


### PR DESCRIPTION
It's not clear what we were thinking here, but the cast is no longer necessary.