### PR TITLE
Fix warning about instantiation of GeometryInfo<0>

### DIFF
--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -1832,7 +1832,6 @@ alternating_form_at_vertices
 }
 
 
-template struct GeometryInfo<0>;
 template struct GeometryInfo<1>;
 template struct GeometryInfo<2>;
 template struct GeometryInfo<3>;


### PR DESCRIPTION
This fixes the warning
> source/base/geometry_info.cc:1835:17: warning: explicit instantiation of 'GeometryInfo<0>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
include/deal.II/base/geometry_info.h:861:8: note: previous template specialization is here
