### PR TITLE
Fix some minor bugs in #4628

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2905,43 +2905,43 @@ private:
   /**
    * Whether this entry is valid and contains data to be written.
    */
-  const bool valid;
+  bool valid;
 
   /**
    * The name of the HDF5 heavy data solution file this entry references.
    */
-  const std::string h5_sol_filename;
+  std::string h5_sol_filename;
 
   /**
    * The name of the HDF5 mesh file this entry references.
    */
-  const std::string h5_mesh_filename;
+  std::string h5_mesh_filename;
 
   /**
    * The simulation time associated with this entry.
    */
-  const double entry_time;
+  double entry_time;
 
   /**
    * The number of data nodes.
    */
-  const unsigned int num_nodes;
+  unsigned int num_nodes;
 
   /**
    * The number of data cells.
    */
-  const unsigned int num_cells;
+  unsigned int num_cells;
 
   /**
    * The dimension associated with the data.
    */
-  const unsigned int dimension;
+  unsigned int dimension;
 
   /**
    * The dimension of the space the data lives in.
    * Note that dimension <= space_dimension.
    */
-  const unsigned int space_dimension;
+  unsigned int space_dimension;
 
   /**
    * The attributes associated with this entry and their dimension.

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -141,7 +141,7 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS; deal_II_space_dimension :  SPACE_DIM
 #endif
 }
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; flag_type : OUTPUT_FLAG_TYPES)
+for (deal_II_dimension : OUTPUT_DIMENSIONS; deal_II_space_dimension :  SPACE_DIMENSIONS; flag_type : OUTPUT_FLAG_TYPES)
 {
     template
     void


### PR DESCRIPTION
Fix two oversights of #4628. Further contributes toward #308.
The `const` members made assignments impossible, and the missing instantiation can lead to linker errors.