### PR TITLE
Fix compilation without p4est

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3499,6 +3499,7 @@ namespace internal
       {
 #ifndef DEAL_II_WITH_P4EST
         Assert (false, ExcNotImplemented());
+        return NumberCache();
 #else
         const unsigned int dim      = DoFHandlerType::dimension;
         const unsigned int spacedim = DoFHandlerType::space_dimension;
@@ -3702,9 +3703,8 @@ namespace internal
               }
         }
 #endif // DEBUG
-#endif // DEAL_II_WITH_P4EST
-
         return number_cache;
+#endif // DEAL_II_WITH_P4EST
       }
 
 


### PR DESCRIPTION
[CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?buildid=9385) still shows a problem in `dealii::internal::DoFHandler::Policy::ParallelDistributed<DoFHandlerType>::distribute_dofs()` in case we compile without p4est. We were missing to define a variable of type `NumberCache` to return.