### PR TITLE
Fix unity build with clang-3.5.

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -25,7 +25,6 @@ SET(_unity_include_src
   conditional_ostream.cc
   config.cc
   convergence_table.cc
-  data_out_base.cc
   event.cc
   exceptions.cc
   flow_function.cc
@@ -81,6 +80,7 @@ SET(_unity_include_src
   )
 
 SET(_separate_src
+  data_out_base.cc
   )
 
 # determined by profiling

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -21,7 +21,6 @@ SET(_unity_include_src
   grid_in.cc
   grid_out.cc
   grid_refinement.cc
-  grid_reordering.cc
   intergrid_map.cc
   manifold.cc
   manifold_lib.cc
@@ -35,6 +34,7 @@ SET(_unity_include_src
   )
 
 SET(_separate_src
+  grid_reordering.cc
   grid_tools.cc
   tria.cc
   )


### PR DESCRIPTION
clang-3.5 complained about the new unity build from #4442 due to two problems:
```
In file included from /data/kronbichler/deal/serial_build/source/grid/unity_0.cc:10:
/home/kronbichler/deal/deal.II/source/grid/grid_reordering.cc:1105:20: error: explicit specialization of
      'invert_all_cells_of_negative_grid' after instantiation
GridReordering<1>::invert_all_cells_of_negative_grid(const std::vector<Point<1> > &,
                   ^
/home/kronbichler/deal/deal.II/source/grid/grid_in.cc:367:40: note: implicit instantiation first required here
        GridReordering<dim, spacedim>::invert_all_cells_of_negative_grid(vertices,
                                       ^
```
(two more errors in lines `1115` and `1125` in `grid_reordering.cc`) and
```
In file included from /data/kronbichler/deal/serial_build/source/base/unity_0.cc:21:
/home/kronbichler/deal/deal.II/source/base/geometry_info.cc:113:37: error: explicit specialization of 'ucd_to_deal' after
      instantiation
const unsigned int GeometryInfo<1>::ucd_to_deal[GeometryInfo<1>::vertices_per_cell]
                                    ^
/home/kronbichler/deal/deal.II/source/base/data_out_base.cc:7729:48: note: implicit instantiation first required here
      out << patch.vertices[GeometryInfo<dim>::ucd_to_deal[i]] << ' ';
                                               ^
```
(and a few more errors of the same kind). In order to work around this issue, the two alternatives I see is to add the declarations of the explicit specializations in the header files - which I do not really like - or to exclude these files from the unity build, since it's only two files. And at least `data_out_base` is a pretty large compilation unit already anyway.