### PR TITLE
[WIP] Declare all grid reordering specializations in the header.

### DIFF
--- a/include/deal.II/grid/grid_reordering.h
+++ b/include/deal.II/grid/grid_reordering.h
@@ -670,6 +670,22 @@ public:
     std::vector<CellData<dim> > &original_cells);
 };
 
+#ifndef DOXYGEN
+// specialize the 1D versions to do nothing
+template <int spacedim>
+class GridReordering<1, spacedim>
+{
+public:
+  static void reorder_cells (std::vector<CellData<1> > &/*original_cells*/,
+                             const bool                 /*use_new_style_ordering*/ = false)
+  {}
+
+  static void invert_all_cells_of_negative_grid
+  (const std::vector<Point<spacedim> > &/*all_vertices*/,
+   std::vector<CellData<1> >           &/*cells*/)
+  {}
+};
+
 
 // declaration of explicit specializations
 template <>
@@ -686,6 +702,7 @@ template <>
 void
 GridReordering<3>::invert_all_cells_of_negative_grid(const std::vector<Point<3> > &all_vertices,
                                                      std::vector<CellData<3> >    &cells);
+#endif // ifndef DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -980,12 +980,6 @@ namespace
     for (unsigned int c=0; c<cells.size(); ++c)
       rotate_cell (cell_list, edge_list, c, cells);
   }
-
-
-  // overload of the function above for 1d -- there is nothing
-  // to orient in that case
-  void reorient (std::vector<CellData<1> > &)
-  {}
 }
 
 
@@ -1001,11 +995,6 @@ namespace
    * do the reordering of their
    * arguments in-place.
    */
-  void
-  reorder_new_to_old_style (std::vector<CellData<1> > &)
-  {}
-
-
   void
   reorder_new_to_old_style (std::vector<CellData<2> > &cells)
   {
@@ -1031,11 +1020,6 @@ namespace
   /**
    * And now also in the opposite direction.
    */
-  void
-  reorder_old_to_new_style (std::vector<CellData<1> > &)
-  {}
-
-
   void
   reorder_old_to_new_style (std::vector<CellData<2> > &cells)
   {
@@ -1069,9 +1053,13 @@ GridReordering<dim,spacedim>::reorder_cells (std::vector<CellData<dim> > &cells,
   Assert (cells.size() != 0,
           ExcMessage("List of elements to orient must have at least one cell"));
 
-  // there is nothing for us to do in 1d
+  // There is nothing for us to do in 1d. This should be covered by the
+  // explicit instantiation in the header file.
   if (dim == 1)
-    return;
+    {
+      Assert(false, ExcInternalError());
+      return;
+    }
 
   // if necessary, convert to new-style format
   if (use_new_style_ordering == false)
@@ -1098,35 +1086,6 @@ GridReordering<dim,spacedim>::reorder_cells (std::vector<CellData<dim> > &cells,
     reorder_new_to_old_style(cells);
 }
 
-
-
-template <>
-void
-GridReordering<1>::invert_all_cells_of_negative_grid(const std::vector<Point<1> > &,
-                                                     std::vector<CellData<1> > &)
-{
-  // nothing to be done in 1d
-}
-
-
-
-template <>
-void
-GridReordering<1,2>::invert_all_cells_of_negative_grid(const std::vector<Point<2> > &,
-                                                       std::vector<CellData<1> > &)
-{
-  // nothing to be done in 1d
-}
-
-
-
-template <>
-void
-GridReordering<1,3>::invert_all_cells_of_negative_grid(const std::vector<Point<3> > &,
-                                                       std::vector<CellData<1> > &)
-{
-  // nothing to be done in 1d
-}
 
 
 template <>


### PR DESCRIPTION
What we have now is a bit odd: we specialize the functions in the source files for all meaningful combinations of `dim` and `spacedim`, but we do not declare the 1D functions as specialized. This commit gets around this by putting the 1D specializations, which are no-ops, in the header in a partially specialized template class.

@kronbichler I know you did not want to add specializations to the header, but this way we can delete more code than we add.