### PR TITLE
Add alternative output for pattern_tools_06/07

### DIFF
--- a/tests/base/pattern_tools_06.output.1
+++ b/tests/base/pattern_tools_06.output.1
@@ -1,0 +1,13 @@
+
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3.000000, 5:1.000000
+DEAL::To value : 1:3.000000, 5:1.000000
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3.000000, 5:1.000000
+DEAL::To value : 5:1.000000, 1:3.000000
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3.000000, 5:1.000000, 5:2.000000
+DEAL::To value : 1:3.000000, 5:1.000000, 5:2.000000
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 5:2.000000, 5:1.000000, 1:3.000000
+DEAL::To value : 1:3.000000, 5:1.000000, 5:2.000000

--- a/tests/base/pattern_tools_07.output.1
+++ b/tests/base/pattern_tools_07.output.1
@@ -1,0 +1,22 @@
+
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 0, 1
+DEAL::To value : 0, 1
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1, 2
+DEAL::To value : 1, 2
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 2, 3
+DEAL::To value : 2, 3
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 3, 4
+DEAL::To value : 3, 4
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 4, 5
+DEAL::To value : 4, 5
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 6, 5
+DEAL::To value : 5, 6
+DEAL::Pattern  : [List of <[Integer]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 7, 6
+DEAL::To value : 6, 7


### PR DESCRIPTION
In the tests `pattern_tools_06` and `pattern_tools_06` `unordered_map` and `unordered_multimap` are used for which we can't know the order in which they store elements. Hence, allow some additional valid output whcih differs by the order of elements for these containers.