### PR TITLE
Fix mapping q1

### DIFF
--- a/doc/news/changes/minor/20170725DiIlioEtAl
+++ b/doc/news/changes/minor/20170725DiIlioEtAl
@@ -1,0 +1,4 @@
+Fixed: MappingQGeneric::transform_real_to_unit_cell had a bug where, for certain
+parallelograms, a problem with subtracting nearly equal floating point numbers
+ruined most of the digits of accuracy in the coordinate transformation.
+<br> (Giovanni Di Ilio, David Wells, Jean-Paul Pelteret, 2017/07/25)

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -91,8 +91,8 @@ namespace internal
        const Point<spacedim> &p)
       {
         Assert(spacedim == 2, ExcInternalError());
-        const double x = p(0);
-        const double y = p(1);
+        const long double x = p(0);
+        const long double y = p(1);
 
         const double x0 = vertices[0](0);
         const double x1 = vertices[1](0);
@@ -104,19 +104,19 @@ namespace internal
         const double y2 = vertices[2](1);
         const double y3 = vertices[3](1);
 
-        const double a = (x1 - x3)*(y0 - y2) - (x0 - x2)*(y1 - y3);
-        const double b = -(x0 - x1 - x2 + x3)*y + (x - 2*x1 + x3)*y0 - (x - 2*x0 + x2)*y1
-                         - (x - x1)*y2 + (x - x0)*y3;
-        const double c = (x0 - x1)*y - (x - x1)*y0 + (x - x0)*y1;
+        const long double a = (x1 - x3)*(y0 - y2) - (x0 - x2)*(y1 - y3);
+        const long double b = -(x0 - x1 - x2 + x3)*y + (x - 2*x1 + x3)*y0 - (x - 2*x0 + x2)*y1
+                              - (x - x1)*y2 + (x - x0)*y3;
+        const long double c = (x0 - x1)*y - (x - x1)*y0 + (x - x0)*y1;
 
-        const double discriminant = b*b - 4*a*c;
+        const long double discriminant = b*b - 4*a*c;
         // exit if the point is not in the cell (this is the only case where the
         // discriminant is negative)
         AssertThrow (discriminant > 0.0,
                      (typename Mapping<spacedim,spacedim>::ExcTransformationFailed()));
 
-        double eta1;
-        double eta2;
+        long double eta1;
+        long double eta2;
         // special case #1: if a is zero, then use the linear formula
         if (a == 0.0 && b != 0.0)
           {
@@ -139,31 +139,31 @@ namespace internal
             eta2 = (-b + std::sqrt(discriminant)) / (2*a);
           }
         // pick the one closer to the center of the cell.
-        const double eta = (std::abs(eta1 - 0.5) < std::abs(eta2 - 0.5)) ? eta1 : eta2;
+        const long double eta = (std::abs(eta1 - 0.5) < std::abs(eta2 - 0.5)) ? eta1 : eta2;
 
         /*
          * There are two ways to compute xi from eta, but either one may have a
          * zero denominator.
          */
-        const double subexpr0 = -eta*x2 + x0*(eta - 1);
-        const double xi_denominator0 = eta*x3 - x1*(eta - 1) + subexpr0;
+        const long double subexpr0 = -eta*x2 + x0*(eta - 1);
+        const long double xi_denominator0 = eta*x3 - x1*(eta - 1) + subexpr0;
         const double max_x = std::max(std::max(std::abs(x0), std::abs(x1)),
                                       std::max(std::abs(x2), std::abs(x3)));
 
         if (std::abs(xi_denominator0) > 1e-10*max_x)
           {
-            const double xi = (x + subexpr0)/xi_denominator0;
+            const long double xi = (x + subexpr0)/xi_denominator0;
             return Point<2>(xi, eta);
           }
         else
           {
             const double max_y = std::max(std::max(std::abs(y0), std::abs(y1)),
                                           std::max(std::abs(y2), std::abs(y3)));
-            const double subexpr1 = -eta*y2 + y0*(eta - 1);
-            const double xi_denominator1 = eta*y3 - y1*(eta - 1) + subexpr1;
+            const long double subexpr1 = -eta*y2 + y0*(eta - 1);
+            const long double xi_denominator1 = eta*y3 - y1*(eta - 1) + subexpr1;
             if (std::abs(xi_denominator1) > 1e-10*max_y)
               {
-                const double xi = (subexpr1 + y)/xi_denominator1;
+                const long double xi = (subexpr1 + y)/xi_denominator1;
                 return Point<2>(xi, eta);
               }
             else // give up and try Newton iteration

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -123,19 +123,20 @@ namespace internal
             eta1 = -c/b;
             eta2 = -c/b;
           }
-        // special case #2: if c is very small or the square root of the
-        // discriminant is nearly b.
-        else if (std::abs(c) < 1e-12*std::abs(b)
-                 || std::abs(std::sqrt(discriminant) - b) <= 1e-14*std::abs(b))
+        // special case #2: a is zero for parallelograms and very small for
+        // near-parallelograms:
+        else if (std::abs(a) < 1e-8*std::abs(b))
+          {
+            // if both a and c are very small then the root should be near
+            // zero: this first case will capture that
+            eta1 = 2*c / (-b - std::sqrt(discriminant));
+            eta2 = 2*c / (-b + std::sqrt(discriminant));
+          }
+        // finally, use the plain version:
+        else
           {
             eta1 = (-b - std::sqrt(discriminant)) / (2*a);
             eta2 = (-b + std::sqrt(discriminant)) / (2*a);
-          }
-        // finally, use the numerically stable version of the quadratic formula:
-        else
-          {
-            eta1 = 2*c / (-b - std::sqrt(discriminant));
-            eta2 = 2*c / (-b + std::sqrt(discriminant));
           }
         // pick the one closer to the center of the cell.
         const double eta = (std::abs(eta1 - 0.5) < std::abs(eta2 - 0.5)) ? eta1 : eta2;

--- a/tests/mappings/mapping_q1_cartesian_grid.cc
+++ b/tests/mappings/mapping_q1_cartesian_grid.cc
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+#include "../tests.h"
+
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/mapping_cartesian.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <fstream>
+#include <iostream>
+
+// Test that MappingQ1 works on Cartesian grids. This is a regression test for
+// a bug where, due to the quadratic equation solver in
+// transform_unit_to_real_cell, we lost nearly all digits of precision due to
+// roundoff.
+
+using namespace dealii;
+
+class RefineTest
+{
+
+public:
+  static constexpr int dim  = 2 ;
+
+public:
+
+  RefineTest(const unsigned int refine_case)
+    :
+    triangulation(),
+    dof_handler(triangulation),
+    refine_case(refine_case)
+  {
+    make_grid();
+    test_mapping();
+  }
+
+private:
+  void make_grid()
+  {
+    if (refine_case == 1)
+      {
+        std::vector< unsigned  int > repetitions(dim);
+        repetitions[0] = repetitions[1] = 5; // Non-unity number of initial partitions
+        const std::array<double,dim> L = {{1.0, 1.0}};
+        GridGenerator::subdivided_hyper_rectangle (triangulation, repetitions, Point<dim>(0.0,0.0), Point<dim>(L[0],L[1]), true);
+        triangulation.refine_global(1); // With refinement
+      }
+    else if (refine_case == 2)
+      {
+        std::vector< unsigned  int > repetitions(dim);
+        repetitions[0] = repetitions[1] = 5; // Non-unity number of initial partitions
+        const std::array<double,dim> L = {{1.0, 1.0}};
+        GridGenerator::subdivided_hyper_rectangle (triangulation, repetitions, Point<dim>(0.0,0.0), Point<dim>(L[0],L[1]), true);
+        triangulation.refine_global(0); // With no refinement
+      }
+    else if (refine_case == 3)
+      {
+        std::vector< unsigned  int > repetitions(dim);
+        repetitions[0] = repetitions[1] = 10; // Finer initial mesh
+        const std::array<double,dim> L = {{1.0, 1.0}};
+        GridGenerator::subdivided_hyper_rectangle (triangulation, repetitions, Point<dim>(0.0,0.0), Point<dim>(L[0],L[1]), true);
+        triangulation.refine_global(0); // With no refinement
+      }
+    else if (refine_case == 4)
+      {
+        std::vector< unsigned  int > repetitions(dim);
+        repetitions[0] = repetitions[1] = 1; // Single cell
+        const std::array<double,dim> L = {{1.0, 1.0}};
+        GridGenerator::subdivided_hyper_rectangle (triangulation, repetitions, Point<dim>(0.0,0.0), Point<dim>(L[0],L[1]), true);
+        triangulation.refine_global(4); // With pure global refinement
+      }
+    else
+      {
+        AssertThrow(false, ExcNotImplemented());
+      }
+  }
+
+  void test_mapping()
+  {
+    const double tol = 1e-8;
+    const MappingQGeneric<dim> mapping(1);
+
+    deallog << "Number of active cells: " << triangulation.n_active_cells() << std::endl;
+
+    auto cell = dof_handler.begin_active();
+    const auto endc = dof_handler.end();
+    for (unsigned int index=0; cell!=endc; ++cell, ++index)
+      {
+        const auto P1 = cell->vertex(0);
+        const auto P2 = cell->vertex(1);
+        const auto P3 = cell->vertex(2);
+
+        // Find the mid-point of the cell
+        Point<dim> test;
+        test[0] = (P1[0]+P2[0])/2.0;
+        test[1] = (P2[1]+P3[1])/2.0;
+
+        // Map to and from the unit cell
+        const Point<dim> dp = mapping.transform_real_to_unit_cell(cell,test);
+        const Point<dim> dp_real = mapping.transform_unit_to_real_cell(cell,dp);
+
+        // Now we start off at the mid-point of the unit cell
+        Point<dim> test_unit_mid;
+        test_unit_mid[0] = 0.5;
+        test_unit_mid[1] = 0.5;
+
+        // And map to and from the real cell
+        const Point<dim> dp_real_mid = mapping.transform_unit_to_real_cell(cell,test_unit_mid);
+        const Point<dim> dp_test_mid = mapping.transform_real_to_unit_cell(cell,dp_real_mid);
+
+        if ((test-dp_real).norm() > tol)
+          {
+            deallog << " " << std::endl;
+            deallog << "ERROR" << std::endl;
+            deallog << "cell = " << index << std::endl;
+            deallog << "cell vertex(0): " << cell->vertex(0) << std::endl;
+            deallog << "cell vertex(1): " << cell->vertex(1) << std::endl;
+            deallog << "cell vertex(2): " << cell->vertex(2) << std::endl;
+            deallog << "cell vertex(3): " << cell->vertex(3) << std::endl;
+            deallog << " " << std::endl;
+            deallog << "test point =   " << test << "  mapped point =   " << dp << "  back-mapping =   " << dp_real << std::endl;
+            deallog << "test point (unit mid) =   " << test_unit_mid << "  mapped point =   " << dp_real_mid << "  forward-mapping =   " << dp_test_mid << std::endl;
+            deallog << "=======================================================================================" << std::endl;
+          }
+      }
+  }
+
+private:
+  Triangulation<dim>      triangulation;
+  DoFHandler<dim>         dof_handler;
+  const unsigned int      refine_case;
+};
+
+int main(/*int argc, char *argv[]*/)
+{
+  initlog();
+
+  {
+    deallog << "Refine case = 1" << std::endl;
+    RefineTest refineglobal(1);
+  }
+  {
+    deallog << "Refine case = 2" << std::endl;
+    RefineTest refineglobal(2);
+  }
+  {
+    deallog << "Refine case = 3" << std::endl;
+    RefineTest refineglobal(3);
+  }
+  {
+    deallog << "Refine case = 4" << std::endl;
+    RefineTest refineglobal(4);
+  }
+  return 0;
+}

--- a/tests/mappings/mapping_q1_cartesian_grid.output
+++ b/tests/mappings/mapping_q1_cartesian_grid.output
@@ -1,0 +1,9 @@
+
+DEAL::Refine case = 1
+DEAL::Number of active cells: 100
+DEAL::Refine case = 2
+DEAL::Number of active cells: 25
+DEAL::Refine case = 3
+DEAL::Number of active cells: 100
+DEAL::Refine case = 4
+DEAL::Number of active cells: 256


### PR DESCRIPTION
This implements the fix discussed in #4654 and also converts a few things to `long double`. This should fix the problem with parallelograms, and the code is now a bit more accurate in the general case too.