### PR TITLE
Relax tolerance in tensor product matrix test with floats.

### DIFF
--- a/tests/lac/tensor_product_matrix_03.cc
+++ b/tests/lac/tensor_product_matrix_03.cc
@@ -85,7 +85,7 @@ void do_test()
 int main()
 {
   initlog();
-  deallog.threshold_double(1e-3);
+  deallog.threshold_double(5e-3);
 
   do_test<1,1>();
   do_test<1,2>();


### PR DESCRIPTION
The test tolerance of `1e-3` is apparently too strict for some LAPACK implementations with floats.