### PR TITLE
MGLevelGlobalTransfer and MGTransferMatrixFree for LA::d::BlockVector

### DIFF
--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -952,7 +952,7 @@ namespace Step37
   void LaplaceProblem<dim>::solve ()
   {
     Timer time;
-    MGTransferMatrixFree<dim,float> mg_transfer(mg_constrained_dofs);
+    MGTransferMatrixFree<dim,LinearAlgebra::distributed::Vector<float>> mg_transfer(mg_constrained_dofs);
     mg_transfer.build(dof_handler);
     setup_time += time.wall_time();
     time_details << "MG build transfer time     (CPU/wall) " << time()

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -1075,7 +1075,7 @@ namespace Step37
     mg.set_edge_matrices(mg_interface, mg_interface);
 
     PreconditionMG<dim, LinearAlgebra::distributed::Vector<float>,
-                   MGTransferMatrixFree<dim,float> >
+                   MGTransferMatrixFree<dim,LinearAlgebra::distributed::Vector<float>>>
                    preconditioner(dof_handler, mg, mg_transfer);
 
     // The setup of the multigrid routines is quite easy and one cannot see

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -563,7 +563,7 @@ protected:
   /**
    * The MGConstrainedDoFs of the level systems.
    */
-  SmartPointer<const MGConstrainedDoFs, MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> > > mg_constrained_dofs;
+  SmartPointer<const MGConstrainedDoFs, MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<Number> > > mg_constrained_dofs;
 
   /**
    * In the function copy_to_mg, we need to access ghosted entries of the

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -441,6 +441,147 @@ protected:
 
 
 /**
+ * Implementation of transfer between the global vectors and the multigrid
+ * levels for use in the derived class MGTransferBlockMatrixFree.
+ * This class is a specialization for the case of
+ * LinearAlgebra::distributed::BlockVector that requires a few different calling
+ * routines as compared to the %parallel vectors in the PETScWrappers and
+ * TrilinosWrappers namespaces.
+ *
+ * It is assumed that each block in the vector spans the whole index space of the
+ * DoFHandler object. In other words, this class would do exactly the same as
+ * what MGLevelGlobalTransfer does for each block in BlockVector.
+ *
+ * @author Denis Davydov
+ * @date 2017
+ */
+template <typename Number>
+class MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<Number> > : public MGTransferBase<LinearAlgebra::distributed::BlockVector<Number> >
+{
+public:
+
+  /**
+   * Reset the object to the state it had right after the default constructor.
+   */
+  void clear ();
+
+  /**
+   * Transfer from a vector on the global grid to vectors defined on each of
+   * the levels separately, i.a. an @p MGVector.
+   */
+  template <int dim, typename Number2, int spacedim>
+  void
+  copy_to_mg (const DoFHandler<dim,spacedim>                                  &dof,
+              MGLevelObject<LinearAlgebra::distributed::BlockVector<Number> > &dst,
+              const LinearAlgebra::distributed::BlockVector<Number2>          &src) const;
+
+  /**
+   * Transfer from multi-level vector to normal vector.
+   *
+   * Copies data from active portions of an MGVector into the respective
+   * positions of a <tt>Vector<number></tt>. In order to keep the result
+   * consistent, constrained degrees of freedom are set to zero.
+   */
+  template <int dim, typename Number2, int spacedim>
+  void
+  copy_from_mg (const DoFHandler<dim,spacedim>                                        &dof,
+                LinearAlgebra::distributed::BlockVector<Number2>                      &dst,
+                const MGLevelObject<LinearAlgebra::distributed::BlockVector<Number> > &src) const;
+
+  /**
+   * Add a multi-level vector to a normal vector.
+   *
+   * Works as the previous function, but probably not for continuous elements.
+   */
+  template <int dim, typename Number2, int spacedim>
+  void
+  copy_from_mg_add (const DoFHandler<dim,spacedim>                                        &dof,
+                    LinearAlgebra::distributed::BlockVector<Number2>                      &dst,
+                    const MGLevelObject<LinearAlgebra::distributed::BlockVector<Number> > &src) const;
+
+  /**
+   * Memory used by this object.
+   */
+  std::size_t memory_consumption () const;
+
+  /**
+   * Print the copy index fields for debugging purposes.
+   */
+  void print_indices(std::ostream &os) const;
+
+protected:
+
+  /**
+   * Internal function to @p fill copy_indices*. Called by derived classes.
+   */
+  template <int dim, int spacedim>
+  void fill_and_communicate_copy_indices(const DoFHandler<dim,spacedim> &dof);
+
+  /**
+   * Sizes of the multi-level vectors.
+   */
+  std::vector<types::global_dof_index> sizes;
+
+  /**
+   * Mapping for the copy_to_mg() and copy_from_mg() functions. Here only
+   * index pairs locally owned is stored.
+   *
+   * The data is organized as follows: one vector per level. Each element of
+   * these vectors contains first the global index, then the level index.
+   */
+  std::vector<std::vector<std::pair<unsigned int, unsigned int> > >
+  copy_indices;
+
+  /**
+   * Additional degrees of freedom for the copy_to_mg() function. These are
+   * the ones where the global degree of freedom is locally owned and the
+   * level degree of freedom is not.
+   *
+   * Organization of the data is like for @p copy_indices_mine.
+   */
+  std::vector<std::vector<std::pair<unsigned int, unsigned int> > >
+  copy_indices_global_mine;
+
+  /**
+   * Additional degrees of freedom for the copy_from_mg() function. These are
+   * the ones where the level degree of freedom is locally owned and the
+   * global degree of freedom is not.
+   *
+   * Organization of the data is like for @p copy_indices_mine.
+   */
+  std::vector<std::vector<std::pair<unsigned int, unsigned int> > >
+  copy_indices_level_mine;
+
+  /**
+   * Stores whether the copy operation from the global to the level vector is
+   * actually a plain copy to the finest level. This means that the grid has
+   * no adaptive refinement and the numbering on the finest multigrid level is
+   * the same as in the global case.
+   */
+  bool perform_plain_copy;
+
+  /**
+   * The MGConstrainedDoFs of the level systems.
+   */
+  SmartPointer<const MGConstrainedDoFs, MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> > > mg_constrained_dofs;
+
+  /**
+   * In the function copy_to_mg, we need to access ghosted entries of the
+   * global vector for inserting into the level vectors. This vector is
+   * populated with those entries.
+   */
+  mutable LinearAlgebra::distributed::BlockVector<Number> ghosted_global_vector;
+
+  /**
+   * In the function copy_from_mg, we access all level vectors with certain
+   * ghost entries for inserting the result into a global vector.
+   */
+  mutable MGLevelObject<LinearAlgebra::distributed::BlockVector<Number> > ghosted_level_vector;
+};
+
+
+
+/**
  * Implementation of the MGTransferBase interface for which the transfer
  * operations are prebuilt upon construction of the object of this class as
  * matrices. This is the fast way, since it only needs to build the operation

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -456,7 +456,6 @@ namespace internal
     AssertIndexRange(dst.min_level(), dst.max_level()+1);
     reinit_vector(mg_dof_handler, component_to_block_map, dst);
     const unsigned int n_blocks = internal::get_n_blocks(src);
-    AssertDimension(internal::get_n_blocks(ghosted_global_vector), n_blocks);
 
     if (perform_plain_copy)
       {
@@ -473,6 +472,7 @@ namespace internal
         return;
       }
 
+    AssertDimension(internal::get_n_blocks(ghosted_global_vector), n_blocks);
     // the ghosted vector should already have the correct local size (but
     // different parallel layout)
     for (unsigned int b = 0; b < n_blocks; ++b)
@@ -528,8 +528,6 @@ namespace internal
     AssertIndexRange(src.max_level(), mg_dof_handler.get_triangulation().n_global_levels());
     AssertIndexRange(src.min_level(), src.max_level()+1);
     const unsigned int n_blocks = internal::get_n_blocks(dst);
-    for (unsigned int level=src.min_level(); level<=src.max_level(); ++level)
-      AssertDimension(internal::get_n_blocks(ghosted_level_vector[level]), n_blocks);
 
     if (perform_plain_copy)
       {
@@ -554,6 +552,8 @@ namespace internal
     dst = 0;
     for (unsigned int level=src.min_level(); level<=src.max_level(); ++level)
       {
+        AssertDimension(internal::get_n_blocks(ghosted_level_vector[level]), n_blocks);
+
         typedef std::vector<std::pair<unsigned int, unsigned int> >::const_iterator dof_pair_iterator;
 
         // the ghosted vector should already have the correct local size (but
@@ -602,8 +602,6 @@ namespace internal
     typedef typename VectorType2::value_type Number2;
 
     const unsigned int n_blocks = get_n_blocks(dst);
-    for (unsigned int level=src.min_level(); level<=src.max_level(); ++level)
-      AssertDimension(internal::get_n_blocks(ghosted_level_vector[level]), n_blocks);
 
     // For non-DG: degrees of freedom in the refinement face may need special
     // attention, since they belong to the coarse level, but have fine level
@@ -612,6 +610,8 @@ namespace internal
     dst.zero_out_ghosts();
     for (unsigned int level=src.min_level(); level<=src.max_level(); ++level)
       {
+        AssertDimension(internal::get_n_blocks(ghosted_level_vector[level]), n_blocks);
+
         typedef std::vector<std::pair<unsigned int, unsigned int> >::const_iterator dof_pair_iterator;
 
         // the ghosted vector should already have the correct local size (but

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -45,13 +45,18 @@ DEAL_II_NAMESPACE_OPEN
  * of one of these elements. Systems with different elements or other elements
  * are currently not implemented.
  *
- * @author Martin Kronbichler
- * @date 2016
+ * This class only supports LinearAlgebra::distributed::Vector and
+ * LinearAlgebra::distributed::BlockVector. For the latter case, the
+ * same transfer will be done for each block.
+ *
+ * @author Martin Kronbichler, Denis Davydov
+ * @date 2016, 2017
  */
-template <int dim, typename Number>
-class MGTransferMatrixFree : public MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >
+template <int dim, typename VectorType = LinearAlgebra::distributed::Vector<double>>
+class MGTransferMatrixFree : public MGLevelGlobalTransfer<VectorType>
 {
 public:
+  typedef typename VectorType::value_type Number;
   /**
    * Constructor without constraint matrices. Use this constructor only with
    * discontinuous finite elements or with no local refinement.
@@ -98,9 +103,9 @@ public:
    * @param dst has as many elements as there are degrees of freedom on the
    * finer level.
    */
-  virtual void prolongate (const unsigned int                           to_level,
-                           LinearAlgebra::distributed::Vector<Number>       &dst,
-                           const LinearAlgebra::distributed::Vector<Number> &src) const;
+  virtual void prolongate (const unsigned int  to_level,
+                           VectorType         &dst,
+                           const VectorType   &src) const;
 
   /**
    * Restrict a vector from level <tt>from_level</tt> to level
@@ -121,8 +126,8 @@ public:
    * coarser level.
    */
   virtual void restrict_and_add (const unsigned int from_level,
-                                 LinearAlgebra::distributed::Vector<Number>       &dst,
-                                 const LinearAlgebra::distributed::Vector<Number> &src) const;
+                                 VectorType         &dst,
+                                 const VectorType   &src) const;
 
   /**
    * Finite element does not provide prolongation matrices.
@@ -220,17 +225,17 @@ private:
    * Performs templated prolongation operation
    */
   template <int degree>
-  void do_prolongate_add(const unsigned int                           to_level,
-                         LinearAlgebra::distributed::Vector<Number>       &dst,
-                         const LinearAlgebra::distributed::Vector<Number> &src) const;
+  void do_prolongate_add(const unsigned int   to_level,
+                         VectorType           &dst,
+                         const VectorType     &src) const;
 
   /**
    * Performs templated restriction operation
    */
   template <int degree>
-  void do_restrict_add(const unsigned int                           from_level,
-                       LinearAlgebra::distributed::Vector<Number>       &dst,
-                       const LinearAlgebra::distributed::Vector<Number> &src) const;
+  void do_restrict_add(const unsigned int   from_level,
+                       VectorType           &dst,
+                       const VectorType     &src) const;
 };
 
 

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/multigrid/mg_base.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/base/mg_level_object.h>

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -306,6 +306,25 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::fill_and_com
 
 
 template <typename Number>
+template <int dim, int spacedim>
+void
+MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<Number> >::fill_and_communicate_copy_indices
+(const DoFHandler<dim,spacedim> &mg_dof)
+{
+  internal_fill_and_communicate_copy_indices(
+    mg_dof,
+    this->mg_constrained_dofs,
+    this->ghosted_level_vector,
+    this->ghosted_global_vector,
+    this->copy_indices,
+    this->copy_indices_level_mine,
+    this->copy_indices_global_mine,
+    this->perform_plain_copy);
+}
+
+
+
+template <typename Number>
 void
 MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::clear()
 {
@@ -318,6 +337,23 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::clear()
   ghosted_global_vector.reinit(0);
   ghosted_level_vector.resize(0, 0);
 }
+
+
+
+// FIXME: this is exact duplicate...
+template <typename Number>
+void
+MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<Number> >::clear()
+{
+  sizes.resize(0);
+  copy_indices.clear();
+  copy_indices_global_mine.clear();
+  copy_indices_level_mine.clear();
+  mg_constrained_dofs = nullptr;
+  ghosted_global_vector.reinit(0);
+  ghosted_level_vector.resize(0, 0);
+}
+
 
 
 
@@ -366,6 +402,25 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::memory_consu
 }
 
 
+// FIXME: exact copy
+template <typename Number>
+std::size_t
+MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<Number> >::memory_consumption () const
+{
+  std::size_t result = sizeof(*this);
+  result += MemoryConsumption::memory_consumption(sizes);
+  result += MemoryConsumption::memory_consumption(copy_indices);
+  result += MemoryConsumption::memory_consumption(copy_indices_global_mine);
+  result += MemoryConsumption::memory_consumption(copy_indices_level_mine);
+  result += ghosted_global_vector.memory_consumption();
+  for (unsigned int i=ghosted_level_vector.min_level();
+       i<=ghosted_level_vector.max_level(); ++i)
+    result += ghosted_level_vector[i].memory_consumption();
+
+  return result;
+}
+
+
 
 // explicit instantiation
 #include "mg_level_global_transfer.inst"
@@ -373,6 +428,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::memory_consu
 // create an additional instantiation currently not supported by the automatic
 // template instantiation scheme
 template class MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<float> >;
-
+template class MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<float> >;
+template class MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<double> >;
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -141,15 +141,21 @@ MGLevelGlobalTransfer<VectorType>::memory_consumption () const
 
 
 
-/* ------------------ MGLevelGlobalTransfer<VectorType> ----------------- */
+/* ------------------ MGLevelGlobalTransfer<LA::d::Vector> ----------------- */
 
-
-template <typename Number>
-template <int dim, int spacedim>
+template <int dim, int spacedim, typename VectorType>
 void
-MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::fill_and_communicate_copy_indices
-(const DoFHandler<dim,spacedim> &mg_dof)
+internal_fill_and_communicate_copy_indices
+(const DoFHandler<dim,spacedim> &mg_dof,
+ SmartPointer<const MGConstrainedDoFs, MGLevelGlobalTransfer<VectorType>> &mg_constrained_dofs,
+ MGLevelObject<VectorType> &ghosted_level_vector,
+ VectorType &ghosted_global_vector,
+ std::vector<std::vector<std::pair<unsigned int, unsigned int> > > &copy_indices,
+ std::vector<std::vector<std::pair<unsigned int, unsigned int> > > &copy_indices_level_mine,
+ std::vector<std::vector<std::pair<unsigned int, unsigned int> > > &copy_indices_global_mine,
+ bool &perform_plain_copy)
 {
+  typedef typename VectorType::value_type Number;
   // first go to the usual routine...
   std::vector<std::vector<std::pair<types::global_dof_index, types::global_dof_index> > >
   my_copy_indices;
@@ -191,72 +197,75 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::fill_and_com
       level_index_set[l].add_indices(accessed_level_indices.begin(),
                                      accessed_level_indices.end());
       level_index_set[l].compress();
-      ghosted_level_vector[l].reinit(mg_dof.locally_owned_mg_dofs(l),
-                                     level_index_set[l],
-                                     mpi_communicator);
+      for (unsigned int b = 0; b < internal::get_n_blocks(ghosted_level_vector[l]); ++b)
+        internal::get_block(ghosted_level_vector[l],b).reinit(mg_dof.locally_owned_mg_dofs(l),
+                                                              level_index_set[l],
+                                                              mpi_communicator);
     }
   std::sort(accessed_indices.begin(), accessed_indices.end());
   index_set.add_indices(accessed_indices.begin(), accessed_indices.end());
   index_set.compress();
-  ghosted_global_vector.reinit(mg_dof.locally_owned_dofs(),
-                               index_set,
-                               mpi_communicator);
+  for (unsigned int b = 0; b < internal::get_n_blocks(ghosted_global_vector); ++b)
+    internal::get_block(ghosted_global_vector,b).reinit(mg_dof.locally_owned_dofs(),
+                                                        index_set,
+                                                        mpi_communicator);
 
   // localize the copy indices for faster access. Since all access will be
   // through the ghosted vector in 'data', we can use this (much faster)
   // option
-  this->copy_indices.resize(mg_dof.get_triangulation().n_global_levels());
-  this->copy_indices_level_mine.resize(mg_dof.get_triangulation().n_global_levels());
-  this->copy_indices_global_mine.resize(mg_dof.get_triangulation().n_global_levels());
+  copy_indices.resize(mg_dof.get_triangulation().n_global_levels());
+  copy_indices_level_mine.resize(mg_dof.get_triangulation().n_global_levels());
+  copy_indices_global_mine.resize(mg_dof.get_triangulation().n_global_levels());
   for (unsigned int level=0; level<mg_dof.get_triangulation().n_global_levels(); ++level)
     {
+      // FIXME: assume partitioner is the same for each block
       const Utilities::MPI::Partitioner &global_partitioner =
-        *ghosted_global_vector.get_partitioner();
+        *internal::get_block(ghosted_global_vector,0).get_partitioner();
       const Utilities::MPI::Partitioner &level_partitioner =
-        *ghosted_level_vector[level].get_partitioner();
+        *internal::get_block(ghosted_level_vector[level],0).get_partitioner();
       // owned-owned case: the locally owned indices are going to control
       // the local index
-      this->copy_indices[level].resize(my_copy_indices[level].size());
+      copy_indices[level].resize(my_copy_indices[level].size());
       for (unsigned int i=0; i<my_copy_indices[level].size(); ++i)
-        this->copy_indices[level][i] =
+        copy_indices[level][i] =
           std::pair<unsigned int,unsigned int>
           (global_partitioner.global_to_local(my_copy_indices[level][i].first),
            level_partitioner.global_to_local(my_copy_indices[level][i].second));
 
       // remote-owned case: the locally owned indices for the level and the
       // ghost dofs for the global indices set the local index
-      this->copy_indices_level_mine[level].
+      copy_indices_level_mine[level].
       resize(my_copy_indices_level_mine[level].size());
       for (unsigned int i=0; i<my_copy_indices_level_mine[level].size(); ++i)
-        this->copy_indices_level_mine[level][i] =
+        copy_indices_level_mine[level][i] =
           std::pair<unsigned int,unsigned int>
           (global_partitioner.global_to_local(my_copy_indices_level_mine[level][i].first),
            level_partitioner.global_to_local(my_copy_indices_level_mine[level][i].second));
 
       // owned-remote case: the locally owned indices for the global dofs
       // and the ghost dofs for the level indices set the local index
-      this->copy_indices_global_mine[level].
+      copy_indices_global_mine[level].
       resize(my_copy_indices_global_mine[level].size());
       for (unsigned int i=0; i<my_copy_indices_global_mine[level].size(); ++i)
-        this->copy_indices_global_mine[level][i] =
+        copy_indices_global_mine[level][i] =
           std::pair<unsigned int,unsigned int>
           (global_partitioner.global_to_local(my_copy_indices_global_mine[level][i].first),
            level_partitioner.global_to_local(my_copy_indices_global_mine[level][i].second));
     }
 
-  perform_plain_copy = this->copy_indices.back().size()
+  perform_plain_copy = copy_indices.back().size()
                        == mg_dof.locally_owned_dofs().n_elements();
   if (perform_plain_copy)
     {
-      AssertDimension(this->copy_indices_global_mine.back().size(), 0);
-      AssertDimension(this->copy_indices_level_mine.back().size(), 0);
+      AssertDimension(copy_indices_global_mine.back().size(), 0);
+      AssertDimension(copy_indices_level_mine.back().size(), 0);
 
       // check whether there is a renumbering of degrees of freedom on
       // either the finest level or the global dofs, which means that we
       // cannot apply a plain copy
-      for (unsigned int i=0; i<this->copy_indices.back().size(); ++i)
-        if (this->copy_indices.back()[i].first !=
-            this->copy_indices.back()[i].second)
+      for (unsigned int i=0; i<copy_indices.back().size(); ++i)
+        if (copy_indices.back()[i].first !=
+            copy_indices.back()[i].second)
           {
             perform_plain_copy = false;
             break;
@@ -269,9 +278,29 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::fill_and_com
   // if we do a plain copy, no need to hold additional ghosted vectors
   if (perform_plain_copy)
     {
-      ghosted_global_vector.reinit(0);
+      for (unsigned int b = 0; b < internal::get_n_blocks(ghosted_global_vector); ++b)
+        internal::get_block(ghosted_global_vector,b).reinit(0);
       ghosted_level_vector.resize(0, 0);
     }
+}
+
+
+
+template <typename Number>
+template <int dim, int spacedim>
+void
+MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number> >::fill_and_communicate_copy_indices
+(const DoFHandler<dim,spacedim> &mg_dof)
+{
+  internal_fill_and_communicate_copy_indices(
+    mg_dof,
+    this->mg_constrained_dofs,
+    this->ghosted_level_vector,
+    this->ghosted_global_vector,
+    this->copy_indices,
+    this->copy_indices_level_mine,
+    this->copy_indices_global_mine,
+    this->perform_plain_copy);
 }
 
 

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -45,6 +45,13 @@ for (deal_II_dimension : DIMENSIONS)
     template
     void MGLevelGlobalTransfer< LinearAlgebra::distributed::Vector<float> >::fill_and_communicate_copy_indices<deal_II_dimension,deal_II_dimension>(
         const DoFHandler<deal_II_dimension,deal_II_dimension> &mg_dof);
+    template
+    void MGLevelGlobalTransfer< LinearAlgebra::distributed::BlockVector<float> >::fill_and_communicate_copy_indices<deal_II_dimension,deal_II_dimension>(
+        const DoFHandler<deal_II_dimension,deal_II_dimension> &mg_dof);
+    template
+    void MGLevelGlobalTransfer< LinearAlgebra::distributed::BlockVector<double> >::fill_and_communicate_copy_indices<deal_II_dimension,deal_II_dimension>(
+        const DoFHandler<deal_II_dimension,deal_II_dimension> &mg_dof);
+
 }
 
 for (deal_II_dimension : DIMENSIONS; S1, S2 : REAL_SCALARS)
@@ -58,6 +65,17 @@ for (deal_II_dimension : DIMENSIONS; S1, S2 : REAL_SCALARS)
     template void
     MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<S1> >::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, LinearAlgebra::distributed::Vector<S2>&,
             const MGLevelObject<LinearAlgebra::distributed::Vector<S1> >&) const;
+
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<S1> >::copy_to_mg (
+        const DoFHandler<deal_II_dimension>&, MGLevelObject<LinearAlgebra::distributed::BlockVector<S1> >&, const LinearAlgebra::distributed::BlockVector<S2>&) const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<S1> >::copy_from_mg (const DoFHandler<deal_II_dimension>&, LinearAlgebra::distributed::BlockVector<S2>&,
+            const MGLevelObject<LinearAlgebra::distributed::BlockVector<S1> >&) const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::distributed::BlockVector<S1> >::copy_from_mg_add (const DoFHandler<deal_II_dimension>&, LinearAlgebra::distributed::BlockVector<S2>&,
+            const MGLevelObject<LinearAlgebra::distributed::BlockVector<S1> >&) const;
+
 }
 
 for(deal_II_dimension : DIMENSIONS)

--- a/source/multigrid/mg_transfer_matrix_free.inst.in
+++ b/source/multigrid/mg_transfer_matrix_free.inst.in
@@ -18,4 +18,5 @@
 for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
 {
     template class MGTransferMatrixFree< deal_II_dimension, LinearAlgebra::distributed::Vector<S1> >;
+    template class MGTransferMatrixFree< deal_II_dimension, LinearAlgebra::distributed::BlockVector<S1> >;
 }

--- a/source/multigrid/mg_transfer_matrix_free.inst.in
+++ b/source/multigrid/mg_transfer_matrix_free.inst.in
@@ -17,5 +17,5 @@
 
 for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
 {
-    template class MGTransferMatrixFree< deal_II_dimension, S1 >;
+    template class MGTransferMatrixFree< deal_II_dimension, LinearAlgebra::distributed::Vector<S1> >;
 }

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -162,7 +162,7 @@ void do_test (const DoFHandler<dim>  &dof)
       mg_matrices[level].compute_diagonal();
     }
 
-  MGTransferMatrixFree<dim,double> mg_transfer(mg_constrained_dofs);
+  MGTransferMatrixFree<dim> mg_transfer(mg_constrained_dofs);
   mg_transfer.build(dof);
 
   MGCoarseIterative<LevelMatrixType,number> mg_coarse;
@@ -193,7 +193,7 @@ void do_test (const DoFHandler<dim>  &dof)
                                                             mg_smoother,
                                                             mg_smoother);
   PreconditionMG<dim, LinearAlgebra::distributed::Vector<double>,
-                 MGTransferMatrixFree<dim,double> >
+                 MGTransferMatrixFree<dim> >
                  preconditioner(dof, mg, mg_transfer);
 
   {

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -50,14 +50,14 @@ std::ofstream logfile("output");
 using namespace dealii::MatrixFreeOperators;
 
 template <int dim, typename LAPLACEOPERATOR>
-class MGTransferMF : public MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>
+class MGTransferMF : public MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
 {
 public:
   MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace,
                const MGConstrainedDoFs &mg_constrained_dofs)
     :
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>(mg_constrained_dofs),
-    laplace_operator (laplace)
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>(mg_constrained_dofs),
+        laplace_operator (laplace)
   {
   }
 
@@ -75,8 +75,8 @@ public:
     for (unsigned int level=dst.min_level();
          level<=dst.max_level(); ++level)
       laplace_operator[level].initialize_dof_vector(dst[level]);
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>::
-    copy_to_mg(mg_dof_handler, dst, src);
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>::
+        copy_to_mg(mg_dof_handler, dst, src);
   }
 
 private:

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -374,14 +374,14 @@ private:
 
 
 template <int dim, typename LAPLACEOPERATOR>
-class MGTransferMF : public MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>
+class MGTransferMF : public MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
 {
 public:
   MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace,
                const MGConstrainedDoFs &mg_constrained_dofs)
     :
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>(mg_constrained_dofs),
-    laplace_operator (laplace)
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>(mg_constrained_dofs),
+        laplace_operator (laplace)
   {
   }
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -50,14 +50,14 @@ std::ofstream logfile("output");
 using namespace dealii::MatrixFreeOperators;
 
 template <int dim, typename LAPLACEOPERATOR>
-class MGTransferMF : public MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>
+class MGTransferMF : public MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
 {
 public:
   MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace,
                const MGConstrainedDoFs &mg_constrained_dofs)
     :
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>(mg_constrained_dofs),
-    laplace_operator (laplace)
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>(mg_constrained_dofs),
+        laplace_operator (laplace)
   {
   }
 
@@ -75,8 +75,8 @@ public:
     for (unsigned int level=dst.min_level();
          level<=dst.max_level(); ++level)
       laplace_operator[level].initialize_dof_vector(dst[level]);
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>::
-    copy_to_mg(mg_dof_handler, dst, src);
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>::
+        copy_to_mg(mg_dof_handler, dst, src);
   }
 
 private:

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -371,14 +371,14 @@ private:
 
 
 template <int dim, typename LAPLACEOPERATOR>
-class MGTransferMF : public MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>
+class MGTransferMF : public MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>
 {
 public:
   MGTransferMF(const MGLevelObject<LAPLACEOPERATOR> &laplace,
                const MGConstrainedDoFs &mg_constrained_dofs)
     :
-    MGTransferMatrixFree<dim, typename LAPLACEOPERATOR::value_type>(mg_constrained_dofs),
-    laplace_operator (laplace)
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename LAPLACEOPERATOR::value_type>>(mg_constrained_dofs),
+        laplace_operator (laplace)
   {
   }
 

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -246,14 +246,14 @@ private:
 
 
 template <int dim, typename MatrixType>
-class MGTransferPrebuiltMF : public MGTransferMatrixFree<dim, typename MatrixType::value_type>
+class MGTransferPrebuiltMF : public MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename MatrixType::value_type>>
 {
 public:
   MGTransferPrebuiltMF(const MGLevelObject<MatrixType> &laplace,
                        const MGConstrainedDoFs &mg_constrained_dofs)
     :
-    MGTransferMatrixFree<dim, typename MatrixType::value_type>(mg_constrained_dofs),
-    laplace_operator (laplace)
+    MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<typename MatrixType::value_type>>(mg_constrained_dofs),
+        laplace_operator (laplace)
   {};
 
   /**

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -74,7 +74,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -94,7 +94,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -71,7 +71,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -68,7 +68,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer;
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer;
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_05.cc
+++ b/tests/multigrid/transfer_matrix_free_05.cc
@@ -87,7 +87,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer;
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer;
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -96,7 +96,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_07.cc
+++ b/tests/multigrid/transfer_matrix_free_07.cc
@@ -87,7 +87,7 @@ void check(const unsigned int fe_degree)
       transfer_ref.build_matrices(mgdof);
 
       // build matrix-free transfer
-      MGTransferMatrixFree<dim, Number> transfer;
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer;
       transfer.build(mgdof);
 
       // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_08.cc
+++ b/tests/multigrid/transfer_matrix_free_08.cc
@@ -63,7 +63,7 @@ void check(const FiniteElement<dim> &fe)
   mgdof.distribute_mg_dofs(fe);
 
   // build matrix-free transfer
-  MGTransferMatrixFree<dim, Number> transfer;
+  MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer;
   transfer.build(mgdof);
 
   LinearAlgebra::distributed::Vector<double> vrefdouble;

--- a/tests/multigrid/transfer_matrix_free_09.cc
+++ b/tests/multigrid/transfer_matrix_free_09.cc
@@ -37,7 +37,7 @@ void check(const FiniteElement<dim> &fe)
   deallog << "FE: " << fe.get_name() << std::endl;
 
   MGConstrainedDoFs mg_constrained_dofs;
-  MGTransferMatrixFree<dim,Number> transfer;
+  MGTransferMatrixFree<dim,LinearAlgebra::distributed::Vector<Number>> transfer;
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(6-dim);
@@ -76,7 +76,7 @@ void check(const FiniteElement<dim> &fe)
       transfer.clear();
       transfer.initialize_constraints(mg_constrained_dofs);
       transfer.build(mgdof);
-      MGTransferMatrixFree<dim, Number> transfer_ref(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer_ref(mg_constrained_dofs);
       transfer_ref.build(mgdof);
       MGLevelObject<LinearAlgebra::distributed::Vector<Number> > vectors(0, tr.n_global_levels()-1);
       transfer_ref.copy_to_mg(mgdof, vectors, vref);

--- a/tests/multigrid/transfer_matrix_free_10.cc
+++ b/tests/multigrid/transfer_matrix_free_10.cc
@@ -37,7 +37,7 @@ void check(const FiniteElement<dim> &fe)
   deallog << "FE: " << fe.get_name() << std::endl;
 
   MGConstrainedDoFs mg_constrained_dofs;
-  MGTransferMatrixFree<dim,Number> transfer(mg_constrained_dofs);
+  MGTransferMatrixFree<dim,LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr);
   tr.refine_global(6-dim);
@@ -74,7 +74,7 @@ void check(const FiniteElement<dim> &fe)
 
       // build matrix-free transfer
       transfer.build(mgdof);
-      MGTransferMatrixFree<dim, Number> transfer_ref(mg_constrained_dofs);
+      MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer_ref(mg_constrained_dofs);
       transfer_ref.build(mgdof);
       MGLevelObject<LinearAlgebra::distributed::Vector<Number> > vectors(0, tr.n_global_levels()-1);
       transfer_ref.copy_to_mg(mgdof, vectors, vref);

--- a/tests/multigrid/transfer_matrix_free_11.cc
+++ b/tests/multigrid/transfer_matrix_free_11.cc
@@ -67,7 +67,7 @@ void check(const unsigned int fe_degree)
   deallog << std::endl;
 
   // build matrix-free transfer
-  MGTransferMatrixFree<dim, Number> transfer(mg_constrained_dofs);
+  MGTransferMatrixFree<dim, LinearAlgebra::distributed::Vector<Number>> transfer(mg_constrained_dofs);
   transfer.build(mgdof);
 
   // check prolongation for all levels using random vector

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -88,7 +88,7 @@ void check()
 #endif
       {
         // but the matrix free transfer will work without Trilinos
-        MGTransferMatrixFree<dim, double>
+        MGTransferMatrixFree<dim>
         transfer_ref(mg_constrained_dofs);
         transfer_ref.build(mgdof);
       }


### PR DESCRIPTION
This is WIP. The classes should eventually do exactly the same for each block in a block vector as `MGLevelGlobalTransfer<LA::d::Vector>` and `MGTransferMatrixFree`.

I create the PR early in order to (i) indicate that i am looking at this problem (ii) get feedback/correction of the direction early.

TODO:

- [ ] add tests
- [x] switch `MGTransferMatrixFree` from `Number` to `Vector` template
- [ ] extend to block vectors (extra loops)
- [ ] backwards compatability (keep `MGTransferMatrixFree` with `Number` and point to the new class with `LA::d::Vector<Number>`)

For anyone reviewing it, it's better to look **without** whitespaces, i.e. use https://github.com/dealii/dealii/pull/4667/files?w=1

fixes https://github.com/dealii/dealii/issues/4574

