### PR TITLE
Generate vectorized data on 1D faces for MF::shape_info

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -461,7 +461,7 @@ namespace CUDAWrappers
     unsigned int size_shape_values = n_dofs_1d*n_q_points_1d*sizeof(Number);
 
     cudaError_t cuda_error = cudaMemcpyToSymbol(internal::global_shape_values,
-                                                &shape_info.shape_values_number[0],
+                                                &shape_info.shape_values[0],
                                                 size_shape_values,
                                                 0,
                                                 cudaMemcpyHostToDevice);
@@ -470,7 +470,7 @@ namespace CUDAWrappers
     if (update_flags & update_gradients)
       {
         cuda_error = cudaMemcpyToSymbol(internal::global_shape_gradients,
-                                        &shape_info.shape_gradient_number[0],
+                                        &shape_info.shape_gradient[0],
                                         size_shape_values,
                                         0,
                                         cudaMemcpyHostToDevice);

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -100,7 +100,7 @@ namespace internal
   struct FEEvaluationImpl
   {
     static
-    void evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                    VectorizedArray<Number> *values_dofs_actual[],
                    VectorizedArray<Number> *values_quad[],
                    VectorizedArray<Number> *gradients_quad[][dim],
@@ -111,7 +111,7 @@ namespace internal
                    const bool               evaluate_hessians);
 
     static
-    void integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                     VectorizedArray<Number> *values_dofs_actual[],
                     VectorizedArray<Number> *values_quad[],
                     VectorizedArray<Number> *gradients_quad[][dim],
@@ -126,7 +126,7 @@ namespace internal
   inline
   void
   FEEvaluationImpl<type,dim,fe_degree,n_q_points_1d,n_components,Number>
-  ::evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
               VectorizedArray<Number> *values_dofs_actual[],
               VectorizedArray<Number> *values_quad[],
               VectorizedArray<Number> *gradients_quad[][dim],
@@ -351,7 +351,7 @@ namespace internal
   inline
   void
   FEEvaluationImpl<type,dim,fe_degree,n_q_points_1d,n_components,Number>
-  ::integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                VectorizedArray<Number> *values_dofs_actual[],
                VectorizedArray<Number> *values_quad[],
                VectorizedArray<Number> *gradients_quad[][dim],
@@ -554,7 +554,7 @@ namespace internal
   struct FEEvaluationImplTransformToCollocation
   {
     static
-    void evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                    VectorizedArray<Number> *values_dofs[],
                    VectorizedArray<Number> *values_quad[],
                    VectorizedArray<Number> *gradients_quad[][dim],
@@ -565,7 +565,7 @@ namespace internal
                    const bool               evaluate_hessians);
 
     static
-    void integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                     VectorizedArray<Number> *values_dofs[],
                     VectorizedArray<Number> *values_quad[],
                     VectorizedArray<Number> *gradients_quad[][dim],
@@ -578,7 +578,7 @@ namespace internal
   inline
   void
   FEEvaluationImplTransformToCollocation<dim, fe_degree, n_components, Number>
-  ::evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
               VectorizedArray<Number> *values_dofs[],
               VectorizedArray<Number> *values_quad[],
               VectorizedArray<Number> *gradients_quad[][dim],
@@ -662,7 +662,7 @@ namespace internal
   inline
   void
   FEEvaluationImplTransformToCollocation<dim, fe_degree, n_components, Number>
-  ::integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                VectorizedArray<Number> *values_dofs[],
                VectorizedArray<Number> *values_quad[],
                VectorizedArray<Number> *gradients_quad[][dim],
@@ -741,7 +741,7 @@ namespace internal
   struct FEEvaluationImplCollocation
   {
     static
-    void evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                    VectorizedArray<Number> *values_dofs[],
                    VectorizedArray<Number> *values_quad[],
                    VectorizedArray<Number> *gradients_quad[][dim],
@@ -752,7 +752,7 @@ namespace internal
                    const bool               evaluate_hessians);
 
     static
-    void integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+    void integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                     VectorizedArray<Number> *values_dofs[],
                     VectorizedArray<Number> *values_quad[],
                     VectorizedArray<Number> *gradients_quad[][dim],
@@ -765,7 +765,7 @@ namespace internal
   inline
   void
   FEEvaluationImplCollocation<dim, fe_degree, n_components, Number>
-  ::evaluate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::evaluate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
               VectorizedArray<Number> *values_dofs[],
               VectorizedArray<Number> *values_quad[],
               VectorizedArray<Number> *gradients_quad[][dim],
@@ -829,7 +829,7 @@ namespace internal
   inline
   void
   FEEvaluationImplCollocation<dim, fe_degree, n_components, Number>
-  ::integrate (const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
+  ::integrate (const MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &shape_info,
                VectorizedArray<Number> *values_dofs[],
                VectorizedArray<Number> *values_quad[],
                VectorizedArray<Number> *gradients_quad[][dim],

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -153,8 +153,8 @@ public:
   /**
    * Return a reference to the ShapeInfo object currently in use.
    */
-  const internal::MatrixFreeFunctions::ShapeInfo<Number> &
-  get_shape_info() const;
+  const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &
+      get_shape_info() const;
 
   /**
    * Fills the JxW values currently used.
@@ -808,7 +808,7 @@ protected:
    * product. Also contained in matrix_info, but it simplifies code if we
    * store a reference to it.
    */
-  const internal::MatrixFreeFunctions::ShapeInfo<Number> *data;
+  const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> *data;
 
   /**
    * A pointer to the Cartesian Jacobian information of the present cell. Only
@@ -2168,7 +2168,7 @@ FEEvaluationBase<dim,n_components_,Number>
   dof_info           (nullptr),
   mapping_info       (nullptr),
   // select the correct base element from the given FE component
-  data               (new internal::MatrixFreeFunctions::ShapeInfo<Number>(quadrature, fe, fe.component_to_base_index(first_selected_component).first)),
+  data               (new internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>>(quadrature, fe, fe.component_to_base_index(first_selected_component).first)),
   cartesian_data     (nullptr),
   jacobian           (nullptr),
   J_value            (nullptr),
@@ -2230,7 +2230,7 @@ FEEvaluationBase<dim,n_components_,Number>
   dof_info           (other.dof_info),
   mapping_info       (other.mapping_info),
   data               (other.matrix_info == nullptr ?
-                      new internal::MatrixFreeFunctions::ShapeInfo<Number>(*other.data) :
+                      new internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>>(*other.data) :
                       other.data),
   cartesian_data     (nullptr),
   jacobian           (nullptr),
@@ -2301,7 +2301,7 @@ FEEvaluationBase<dim,n_components_,Number>
   mapping_info = other.mapping_info;
   if (other.matrix_info == nullptr)
     {
-      data = new internal::MatrixFreeFunctions::ShapeInfo<Number>(*other.data);
+      data = new internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>>(*other.data);
       scratch_data_array = new AlignedVector<VectorizedArray<Number> >();
     }
   else
@@ -2552,8 +2552,8 @@ FEEvaluationBase<dim,n_components_,Number>::get_cell_type () const
 
 template <int dim, int n_components_, typename Number>
 inline
-const internal::MatrixFreeFunctions::ShapeInfo<Number> &
-FEEvaluationBase<dim,n_components_,Number>::get_shape_info() const
+const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &
+    FEEvaluationBase<dim,n_components_,Number>::get_shape_info() const
 {
   Assert(data != nullptr, ExcInternalError());
   return *data;

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -841,11 +841,11 @@ public:
   /**
    * Return the unit cell information for given hp index.
    */
-  const internal::MatrixFreeFunctions::ShapeInfo<Number> &
-  get_shape_info (const unsigned int fe_component = 0,
-                  const unsigned int quad_index   = 0,
-                  const unsigned int hp_active_fe_index = 0,
-                  const unsigned int hp_active_quad_index = 0) const;
+  const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &
+      get_shape_info (const unsigned int fe_component = 0,
+                      const unsigned int quad_index   = 0,
+                      const unsigned int hp_active_fe_index = 0,
+                      const unsigned int hp_active_quad_index = 0) const;
 
   /**
    * Obtains a scratch data object for internal use. Make sure to release it
@@ -980,7 +980,7 @@ private:
   /**
    * Contains shape value information on the unit cell.
    */
-  Table<4,internal::MatrixFreeFunctions::ShapeInfo<Number> > shape_info;
+  Table<4,internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>>> shape_info;
 
   /**
    * Describes how the cells are gone through. With the cell level (first
@@ -1452,11 +1452,11 @@ MatrixFree<dim,Number>::get_ghost_set(const unsigned int dof_index) const
 
 template <int dim, typename Number>
 inline
-const internal::MatrixFreeFunctions::ShapeInfo<Number> &
-MatrixFree<dim,Number>::get_shape_info (const unsigned int index_fe,
-                                        const unsigned int index_quad,
-                                        const unsigned int active_fe_index,
-                                        const unsigned int active_quad_index) const
+const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<Number>> &
+    MatrixFree<dim,Number>::get_shape_info (const unsigned int index_fe,
+                                            const unsigned int index_quad,
+                                            const unsigned int active_fe_index,
+                                            const unsigned int active_quad_index) const
 {
   AssertIndexRange (index_fe, shape_info.size(0));
   AssertIndexRange (index_quad, shape_info.size(1));

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -780,7 +780,7 @@ namespace MatrixFreeOperators
     FullMatrix<double> shapes_1d(fe_degree+1, fe_degree+1);
     for (unsigned int i=0, c=0; i<shapes_1d.m(); ++i)
       for (unsigned int j=0; j<shapes_1d.n(); ++j, ++c)
-        shapes_1d(i,j) = fe_eval.get_shape_info().shape_values_number[c];
+        shapes_1d(i,j) = fe_eval.get_shape_info().shape_values[c][0];
     shapes_1d.gauss_jordan();
     const unsigned int stride = (fe_degree+2)/2;
     inverse_shape.resize(stride*(fe_degree+1));

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -49,7 +49,8 @@ namespace internal
       n_q_points (0),
       dofs_per_cell (0),
       n_q_points_face (0),
-      dofs_per_face (0)
+      dofs_per_face (0),
+      nodal_at_cell_boundaries (false)
     {}
 
 
@@ -69,8 +70,7 @@ namespace internal
       fe_degree = fe->degree;
       n_q_points_1d = quad.size();
 
-      const unsigned int n_dofs_1d = fe_degree+1,
-                         n_q_points_1d = quad.size();
+      const unsigned int n_dofs_1d = std::min(fe->dofs_per_cell, fe_degree+1);
 
       // renumber (this is necessary for FE_Q, for example, since there the
       // vertex DoFs come first, which is incompatible with the lexicographic
@@ -111,6 +111,10 @@ namespace internal
             scalar_lexicographic = fe_q_dg0->get_poly_space_numbering_inverse();
             element_type = tensor_symmetric_plus_dg0;
           }
+        else if (fe->dofs_per_cell == 0)
+          {
+            // FE_Nothing case -> nothing to do here
+          }
         else
           Assert(false, ExcNotImplemented());
 
@@ -138,7 +142,7 @@ namespace internal
 
             // invert numbering again. Need to do it manually because we might
             // have undefined blocks
-            lexicographic_numbering.resize(fe_in.element_multiplicity(base_element_number)*fe->dofs_per_cell);
+            lexicographic_numbering.resize(fe_in.element_multiplicity(base_element_number)*fe->dofs_per_cell, numbers::invalid_unsigned_int);
             for (unsigned int i=0; i<lexicographic.size(); ++i)
               if (lexicographic[i] != numbers::invalid_unsigned_int)
                 {
@@ -154,29 +158,31 @@ namespace internal
         // by reading the name, as done before r29356)
         if (fe->has_support_points())
           unit_point = fe->get_unit_support_points()[scalar_lexicographic[0]];
-        Assert(std::fabs(fe->shape_value(scalar_lexicographic[0],
+        Assert(fe->dofs_per_cell == 0 ||
+               std::fabs(fe->shape_value(scalar_lexicographic[0],
                                          unit_point)-1) < 1e-13,
-               ExcInternalError());
+               ExcInternalError("Could not decode 1D shape functions for the "
+                                "element " + fe->get_name()));
       }
 
       n_q_points      = Utilities::fixed_power<dim>(n_q_points_1d);
       dofs_per_cell   = fe->dofs_per_cell;
       n_q_points_face = dim>1?Utilities::fixed_power<dim-1>(n_q_points_1d):1;
-      dofs_per_face   = fe->dofs_per_face;
+      dofs_per_face   = dim>1?Utilities::fixed_power<dim-1>(fe_degree+1):1;
 
       const unsigned int array_size = n_dofs_1d*n_q_points_1d;
       this->shape_gradients.resize_fast (array_size);
       this->shape_values.resize_fast (array_size);
       this->shape_hessians.resize_fast (array_size);
 
-      this->face_value[0].resize(n_dofs_1d);
-      this->face_gradient[0].resize(n_dofs_1d);
-      this->subface_value[0].resize(array_size);
-      this->face_value[1].resize(n_dofs_1d);
-      this->face_gradient[1].resize(n_dofs_1d);
-      this->subface_value[1].resize(array_size);
-      this->shape_values_number.resize (array_size);
-      this->shape_gradient_number.resize (array_size);
+      this->shape_data_on_face[0].resize(3*n_dofs_1d);
+      this->shape_data_on_face[1].resize(3*n_dofs_1d);
+      this->values_within_subface[0].resize(array_size);
+      this->values_within_subface[1].resize(array_size);
+      this->gradients_within_subface[0].resize(array_size);
+      this->gradients_within_subface[1].resize(array_size);
+      this->hessians_within_subface[0].resize(array_size);
+      this->hessians_within_subface[1].resize(array_size);
 
       for (unsigned int i=0; i<n_dofs_1d; ++i)
         {
@@ -186,31 +192,72 @@ namespace internal
           for (unsigned int q=0; q<n_q_points_1d; ++q)
             {
               // fill both vectors with
-              // VectorizedArray<Number>::n_array_elements
-              // copies for the shape information and
-              // non-vectorized fields
+              // VectorizedArray<Number>::n_array_elements copies for the
+              // shape information and non-vectorized fields
               Point<dim> q_point = unit_point;
               q_point[0] = quad.get_points()[q][0];
-              shape_values_number[i*n_q_points_1d+q]   = fe->shape_value(my_i,q_point);
-              shape_gradient_number[i*n_q_points_1d+q] = fe->shape_grad (my_i,q_point)[0];
-              shape_values   [i*n_q_points_1d+q] =
-                shape_values_number  [i*n_q_points_1d+q];
-              shape_gradients[i*n_q_points_1d+q] =
-                shape_gradient_number[i*n_q_points_1d+q];
-              shape_hessians[i*n_q_points_1d+q] =
-                fe->shape_grad_grad(my_i,q_point)[0][0];
+
+              shape_values   [i*n_q_points_1d+q] = fe->shape_value(my_i,q_point);
+              shape_gradients[i*n_q_points_1d+q] = fe->shape_grad(my_i,q_point)[0];
+              shape_hessians [i*n_q_points_1d+q] = fe->shape_grad_grad(my_i,q_point)[0][0];
+
+              // evaluate basis functions on the two 1D subfaces (i.e., at the
+              // positions divided by one half and shifted by one half,
+              // respectively)
               q_point[0] *= 0.5;
-              subface_value[0][i*n_q_points_1d+q] = fe->shape_value(my_i,q_point);
+              values_within_subface[0][i*n_q_points_1d+q] = fe->shape_value(my_i,q_point);
+              gradients_within_subface[0][i*n_q_points_1d+q] = fe->shape_grad(my_i,q_point)[0];
+              hessians_within_subface[0][i*n_q_points_1d+q] = fe->shape_grad_grad(my_i,q_point)[0][0];
               q_point[0] += 0.5;
-              subface_value[1][i*n_q_points_1d+q] = fe->shape_value(my_i,q_point);
+              values_within_subface[1][i*n_q_points_1d+q] = fe->shape_value(my_i,q_point);
+              gradients_within_subface[1][i*n_q_points_1d+q] = fe->shape_grad(my_i,q_point)[0];
+              hessians_within_subface[1][i*n_q_points_1d+q] = fe->shape_grad_grad(my_i,q_point)[0][0];
             }
-          Point<dim> q_point;
-          this->face_value[0][i] = fe->shape_value(my_i,q_point);
-          this->face_gradient[0][i] = fe->shape_grad(my_i,q_point)[0];
+
+          // evaluate basis functions on the 1D faces, i.e., in zero and one
+          Point<dim> q_point = unit_point;
+          q_point[0] = 0;
+          this->shape_data_on_face[0][i] = fe->shape_value(my_i,q_point);
+          this->shape_data_on_face[0][i+n_dofs_1d] = fe->shape_grad(my_i,q_point)[0];
+          this->shape_data_on_face[0][i+2*n_dofs_1d] = fe->shape_grad_grad(my_i,q_point)[0][0];
           q_point[0] = 1;
-          this->face_value[1][i] = fe->shape_value(my_i,q_point);
-          this->face_gradient[1][i] = fe->shape_grad(my_i,q_point)[0];
+          this->shape_data_on_face[1][i] = fe->shape_value(my_i,q_point);
+          this->shape_data_on_face[1][i+n_dofs_1d] = fe->shape_grad(my_i,q_point)[0];
+          this->shape_data_on_face[1][i+2*n_dofs_1d] = fe->shape_grad_grad(my_i,q_point)[0][0];
         }
+
+      // get gradient and Hessian transformation matrix for the polynomial
+      // space associated with the quadrature rule (collocation space)
+      {
+        const unsigned int stride = (n_q_points_1d+1)/2;
+        shape_gradients_collocation_eo.resize(n_q_points_1d*stride);
+        shape_hessians_collocation_eo.resize(n_q_points_1d*stride);
+        FE_DGQArbitraryNodes<1> fe(quad.get_points());
+        for (unsigned int i=0; i<n_q_points_1d/2; ++i)
+          for (unsigned int q=0; q<stride; ++q)
+            {
+              shape_gradients_collocation_eo[i*stride+q] =
+                0.5* (fe.shape_grad(i, quad.get_points()[q])[0] +
+                      fe.shape_grad(i, quad.get_points()[n_q_points_1d-1-q])[0]);
+              shape_gradients_collocation_eo[(n_q_points_1d-1-i)*stride+q] =
+                0.5* (fe.shape_grad(i, quad.get_points()[q])[0] -
+                      fe.shape_grad(i, quad.get_points()[n_q_points_1d-1-q])[0]);
+              shape_hessians_collocation_eo[i*stride+q] =
+                0.5* (fe.shape_grad_grad(i, quad.get_points()[q])[0][0] +
+                      fe.shape_grad_grad(i, quad.get_points()[n_q_points_1d-1-q])[0][0]);
+              shape_hessians_collocation_eo[(n_q_points_1d-1-i)*stride+q] =
+                0.5* (fe.shape_grad_grad(i, quad.get_points()[q])[0][0] -
+                      fe.shape_grad_grad(i, quad.get_points()[n_q_points_1d-1-q])[0][0]);
+            }
+        if (n_q_points_1d % 2 == 1)
+          for (unsigned int q=0; q<stride; ++q)
+            {
+              shape_gradients_collocation_eo[n_q_points_1d/2*stride+q] =
+                fe.shape_grad(n_q_points_1d/2, quad.get_points()[q])[0];
+              shape_hessians_collocation_eo[n_q_points_1d/2*stride+q] =
+                fe.shape_grad_grad(n_q_points_1d/2, quad.get_points()[q])[0][0];
+            }
+      }
 
       if (element_type == tensor_general &&
           check_1d_shapes_symmetric(n_q_points_1d))
@@ -218,90 +265,94 @@ namespace internal
           if (check_1d_shapes_collocation())
             element_type = tensor_symmetric_collocation;
           else
+            element_type = tensor_symmetric;
+          if (n_dofs_1d > 3 && element_type == tensor_symmetric)
             {
-              element_type = tensor_symmetric;
-              // get gradient and Hessian transformation matrix for the
-              // polynomial space associated with the quadrature rule
-              // (collocation space)
-              if (fe_degree+1 == n_q_points_1d)
-                {
-                  const unsigned int stride = fe_degree/2+1;
-                  shape_gradients_collocation_eo.resize((fe_degree+1)*stride);
-                  shape_hessians_collocation_eo.resize((fe_degree+1)*stride);
-                  FE_DGQArbitraryNodes<1> fe(quad.get_points());
-                  for (unsigned int i=0; i<(fe_degree+1)/2; ++i)
-                    for (unsigned int q=0; q<stride; ++q)
-                      {
-                        shape_gradients_collocation_eo[i*stride+q] =
-                          0.5* (fe.shape_grad(i, quad.get_points()[q])[0] +
-                                fe.shape_grad(i, quad.get_points()[n_q_points_1d-1-q])[0]);
-                        shape_gradients_collocation_eo[(fe_degree-i)*stride+q] =
-                          0.5* (fe.shape_grad(i, quad.get_points()[q])[0] -
-                                fe.shape_grad(i, quad.get_points()[n_q_points_1d-1-q])[0]);
-                        shape_hessians_collocation_eo[i*stride+q] =
-                          0.5* (fe.shape_grad_grad(i, quad.get_points()[q])[0][0] +
-                                fe.shape_grad_grad(i, quad.get_points()[n_q_points_1d-1-q])[0][0]);
-                        shape_hessians_collocation_eo[(fe_degree-i)*stride+q] =
-                          0.5* (fe.shape_grad_grad(i, quad.get_points()[q])[0][0] -
-                                fe.shape_grad_grad(i, quad.get_points()[n_q_points_1d-1-q])[0][0]);
-                      }
-                  if (fe_degree % 2 == 0)
-                    for (unsigned int q=0; q<stride; ++q)
-                      {
-                        shape_gradients_collocation_eo[fe_degree/2*stride+q] =
-                          fe.shape_grad(fe_degree/2, quad.get_points()[q])[0];
-                        shape_hessians_collocation_eo[fe_degree/2*stride+q] =
-                          fe.shape_grad_grad(fe_degree/2, quad.get_points()[q])[0][0];
-                      }
-                }
+              // check if we are a Hermite type
+              element_type = tensor_symmetric_hermite;
+              for (unsigned int i=1; i<n_dofs_1d; ++i)
+                if (std::abs(this->shape_data_on_face[0][i][0]) > 1e-12)
+                  element_type = tensor_symmetric;
+              for (unsigned int i=2; i<n_dofs_1d; ++i)
+                if (std::abs(this->shape_data_on_face[0][n_dofs_1d+i][0]) > 1e-12)
+                  element_type = tensor_symmetric;
             }
         }
       else if (element_type == tensor_symmetric_plus_dg0)
         check_1d_shapes_symmetric(n_q_points_1d);
 
-      // face information
-      unsigned int n_faces = GeometryInfo<dim>::faces_per_cell;
-      this->face_indices.reinit(n_faces, this->dofs_per_face);
-      switch (dim)
+      nodal_at_cell_boundaries = true;
+      for (unsigned int i=1; i<n_dofs_1d; ++i)
+        if (std::abs(this->shape_data_on_face[0][i][0]) > 1e-13 ||
+            std::abs(this->shape_data_on_face[1][i-1][0]) > 1e-13)
+          nodal_at_cell_boundaries = false;
+
+      if (nodal_at_cell_boundaries == true)
         {
-        case 3:
-        {
-          for (unsigned int i=0; i<this->dofs_per_face; i++)
+          face_to_cell_index_nodal.reinit(GeometryInfo<dim>::faces_per_cell,
+                                          dofs_per_face);
+          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
             {
-              const unsigned int jump_term =
-                this->dofs_per_face*((i*n_dofs_1d)/this->dofs_per_face);
-              this->face_indices(0,i) = i*n_dofs_1d;
-              this->face_indices(1,i) = i*n_dofs_1d + n_dofs_1d-1;
-              this->face_indices(2,i) = i%n_dofs_1d + jump_term;
-              this->face_indices(3,i) = (i%n_dofs_1d + jump_term +
-                                         (n_dofs_1d-1)*n_dofs_1d);
-              this->face_indices(4,i) = i;
-              this->face_indices(5,i) = (n_dofs_1d-1)*this->dofs_per_face+i;
+              const unsigned int direction = f/2;
+              const unsigned int stride = direction < dim-1 ? (fe_degree+1) : 1;
+              int shift = 1;
+              for (unsigned int d=0; d<direction; ++d)
+                shift *= fe_degree+1;
+              const unsigned int offset = (f%2)*fe_degree*shift;
+
+              if (direction == 0 || direction == dim-1)
+                for (unsigned int i=0; i<dofs_per_face; ++i)
+                  face_to_cell_index_nodal(f,i) = offset + i*stride;
+              else
+                // local coordinate system on faces 2 and 3 is zx in
+                // deal.II, not xz as expected for tensor products -> adjust
+                // that here
+                for (unsigned int j=0; j<=fe_degree; ++j)
+                  for (unsigned int i=0; i<=fe_degree; ++i)
+                    {
+                      const unsigned int ind = offset + j*dofs_per_face + i;
+                      AssertIndexRange(ind, dofs_per_cell);
+                      const unsigned int l = i*(fe_degree+1)+j;
+                      face_to_cell_index_nodal(f,l) = ind;
+                    }
             }
-          break;
         }
-        case 2:
+
+      if (element_type == tensor_symmetric_hermite)
         {
-          for (unsigned int i=0; i<this->dofs_per_face; i++)
+          face_to_cell_index_hermite.reinit(GeometryInfo<dim>::faces_per_cell,
+                                            2*dofs_per_face);
+          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
             {
-              this->face_indices(0,i) = n_dofs_1d*i;
-              this->face_indices(1,i) = n_dofs_1d*i + n_dofs_1d-1;
-              this->face_indices(2,i) = i;
-              this->face_indices(3,i) = (n_dofs_1d-1)*n_dofs_1d+i;
+              const unsigned int direction = f/2;
+              const unsigned int stride = direction < dim-1 ? (fe_degree+1) : 1;
+              int shift = 1;
+              for (unsigned int d=0; d<direction; ++d)
+                shift *= fe_degree+1;
+              const unsigned int offset = (f%2)*fe_degree*shift;
+              if (f%2 == 1)
+                shift = -shift;
+
+              if (direction == 0 || direction == dim-1)
+                for (unsigned int i=0; i<dofs_per_face; ++i)
+                  {
+                    face_to_cell_index_hermite(f,2*i) = offset + i*stride;
+                    face_to_cell_index_hermite(f,2*i+1) = offset + i*stride + shift;
+                  }
+              else
+                // local coordinate system on faces 2 and 3 is zx in
+                // deal.II, not xz as expected for tensor products -> adjust
+                // that here
+                for (unsigned int j=0; j<=fe_degree; ++j)
+                  for (unsigned int i=0; i<=fe_degree; ++i)
+                    {
+                      const unsigned int ind = offset + j*dofs_per_face + i;
+                      AssertIndexRange(ind, dofs_per_cell);
+                      const unsigned int l = i*(fe_degree+1)+j;
+                      face_to_cell_index_hermite(f,2*l) = ind;
+                      face_to_cell_index_hermite(f,2*l+1) = ind+shift;
+                    }
             }
-          break;
-        }
-        case 1:
-        {
-          if (this->dofs_per_face>0)
-            {
-              this->face_indices(0,0) = 0;
-              this->face_indices(1,0) = n_dofs_1d-1;
-            }
-          break;
-        }
-        default:
-          Assert (false, ExcNotImplemented());
         }
     }
 
@@ -311,15 +362,20 @@ namespace internal
     bool
     ShapeInfo<Number>::check_1d_shapes_symmetric(const unsigned int n_q_points_1d)
     {
+      if (dofs_per_cell == 0)
+        return false;
+
       const double zero_tol =
-        types_are_equal<Number,double>::value==true?1e-10:1e-7;
+        types_are_equal<Number,double>::value==true?1e-12:1e-7;
       // symmetry for values
       const unsigned int n_dofs_1d = fe_degree + 1;
       for (unsigned int i=0; i<(n_dofs_1d+1)/2; ++i)
         for (unsigned int j=0; j<n_q_points_1d; ++j)
           if (std::fabs(shape_values[i*n_q_points_1d+j][0] -
                         shape_values[(n_dofs_1d-i)*n_q_points_1d
-                                     -j-1][0]) > zero_tol)
+                                     -j-1][0]) >
+              std::max(zero_tol, zero_tol*
+                       std::abs(shape_values[i*n_q_points_1d+j][0])))
             return false;
 
       // shape values should be zero at x=0.5 for all basis functions except
@@ -412,10 +468,8 @@ namespace internal
         return false;
 
       const double zero_tol =
-        types_are_equal<Number,double>::value==true?1e-10:1e-7;
-      // check: - identity operation for shape values
-      //        - zero diagonal at interior points for gradients
-      //        - gradient equal to unity at element boundary
+        types_are_equal<Number,double>::value==true?1e-12:1e-7;
+      // check: identity operation for shape values
       const unsigned int n_points_1d = fe_degree+1;
       for (unsigned int i=0; i<n_points_1d; ++i)
         for (unsigned int j=0; j<n_points_1d; ++j)
@@ -448,14 +502,12 @@ namespace internal
       memory += MemoryConsumption::memory_consumption(shape_hessians_eo);
       memory += MemoryConsumption::memory_consumption(shape_gradients_collocation_eo);
       memory += MemoryConsumption::memory_consumption(shape_hessians_collocation_eo);
-      memory += face_indices.memory_consumption();
       for (unsigned int i=0; i<2; ++i)
         {
-          memory += MemoryConsumption::memory_consumption(face_value[i]);
-          memory += MemoryConsumption::memory_consumption(face_gradient[i]);
+          memory += MemoryConsumption::memory_consumption(shape_data_on_face[i]);
+          memory += MemoryConsumption::memory_consumption(values_within_subface[i]);
+          memory += MemoryConsumption::memory_consumption(gradients_within_subface[i]);
         }
-      memory += MemoryConsumption::memory_consumption(shape_values_number);
-      memory += MemoryConsumption::memory_consumption(shape_gradient_number);
       return memory;
     }
 

--- a/source/matrix_free/matrix_free.cc
+++ b/source/matrix_free/matrix_free.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/matrix_free/matrix_free.templates.h>
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/vectorization.h>
 #include <deal.II/base/conditional_ostream.h>
 
 #include <iostream>
@@ -26,5 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template struct internal::MatrixFreeFunctions::ShapeInfo<double>;
 template struct internal::MatrixFreeFunctions::ShapeInfo<float>;
+template struct internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<double>>;
+template struct internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<float>>;
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This is the first step to enable DG computations in `MatrixFree` that Katharina Kormann and I have written. We plan to commit the code in a series of half a dozen separate PRs. This is the simplest one and simply prepares the data structures that are needed to evaluate shape functions at the faces. There were some old data structures in the class already which are now obsolete: They were not used in the library and sit in an internal namespace, so we are free to change them.