### PR TITLE
Fix test output for base/array_view_09 in release mode

### DIFF
--- a/tests/base/array_view_09.cc
+++ b/tests/base/array_view_09.cc
@@ -118,6 +118,15 @@ void test ()
       {
         deallog << exc.get_exc_name() << std::endl;
       }
+    // we only trigger the exception in debug mode
+    // just output the expected error message in release mode
+    // to make CTest happy
+#ifndef DEBUG
+    deallog <<  "ExcMessage(\"The beginning of the array view should be before the end.\")"
+            << std::endl;
+    deallog <<  "ExcMessage(\"The beginning of the array view should be before the end.\")"
+            << std::endl;
+#endif
   }
 
   deallog << "OK" << std::endl;


### PR DESCRIPTION
The exception which prints an error message we test for in `base/array_view_09` is not triggered in release mode. Hence, the test was [failing](https://cdash.kyomu.43-1.org/testSummary.php?project=1&name=base%2Farray_view_09.release&date=2017-08-01) in release mode.