### PR TITLE
Avoid Assert in destructors.

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -718,9 +718,9 @@ namespace parallel
        */
       ~TBBPartitioner()
       {
-        Assert(in_use == false,
-               ExcInternalError("A vector partitioner goes out of scope, but "
-                                "it appears to be still in use."));
+        AssertNothrow(in_use == false,
+                      ExcInternalError("A vector partitioner goes out of scope, but "
+                                       "it appears to be still in use."));
       }
 
       /**


### PR DESCRIPTION
We need to use AssertNothrow instead to ensure we don't throw
exceptions in assertions, where this is not allowed.

Fixes a recent problem reported by coverity.