### PR TITLE
Fix a problem with old TBBs.

### DIFF
--- a/doc/news/changes/minor/20170726AlbertoSartori
+++ b/doc/news/changes/minor/20170726AlbertoSartori
@@ -1,0 +1,3 @@
+Fixed: FunctionParser uses shared_ptr instead of unique_ptr in order to fix compilation issues with gcc-5.4.
+<br>
+(Alberto Sartori, 2017/07/26)

--- a/doc/news/changes/minor/20170726AlbertoSartori
+++ b/doc/news/changes/minor/20170726AlbertoSartori
@@ -1,3 +1,5 @@
-Fixed: FunctionParser uses shared_ptr instead of unique_ptr in order to fix compilation issues with gcc-5.4.
+Fixed: The FunctionParser class demonstrated an incompatibility with
+(very) old versions of the Threading Building Blocks used in
+deal.II. This is now worked around.
 <br>
-(Alberto Sartori, 2017/07/26)
+(Alberto Sartori, Wolfgang Bangerth, 2017/07/26)

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -328,11 +328,17 @@ private:
 
   /**
    * The muParser objects for each thread (and one for each component). We are
-   * storing shared_ptr so that we don't need to include the definition of
+   * storing a unique_ptr so that we don't need to include the definition of
    * mu::Parser in this header.
    */
-  // std::unique_ptr does not compile with gcc-5.4
+#if TBB_VERSION_MAJOR >= 4
+  mutable Threads::ThreadLocalStorage<std::vector<std::unique_ptr<mu::Parser> > > fp;
+#else
+  // older TBBs have a bug in which they want to return thread-local
+  // objects by value. this doesn't work for std::unique_ptr, so use a
+  // std::shared_ptr
   mutable Threads::ThreadLocalStorage<std::vector<std::shared_ptr<mu::Parser> > > fp;
+#endif
 
   /**
    * An array to keep track of all the constants, required to initialize fp in

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -328,10 +328,11 @@ private:
 
   /**
    * The muParser objects for each thread (and one for each component). We are
-   * storing unique_ptr so that we don't need to include the definition of
+   * storing shared_ptr so that we don't need to include the definition of
    * mu::Parser in this header.
    */
-  mutable Threads::ThreadLocalStorage<std::vector<std::unique_ptr<mu::Parser> > > fp;
+  // std::unique_ptr does not compile with gcc-5.4
+  mutable Threads::ThreadLocalStorage<std::vector<std::shared_ptr<mu::Parser> > > fp;
 
   /**
    * An array to keep track of all the constants, required to initialize fp in


### PR DESCRIPTION
This extends @asartori's patch in #4663 to address the correct underlying
problem: namely, that the TBB used is too old.

Fixes #4661.