### PR TITLE
Fix a compiler error by explicitly providing template arguments.

### DIFF
--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -245,7 +245,7 @@ namespace internal
       std::array<Number,dim>   w;
       // The off-diagonal elements of the tridiagonal
       std::array<Number,dim-1> ee;
-      tridiagonalize(A, Q, w, ee);
+      tridiagonalize<dim,Number>(A, Q, w, ee);
 
       // Number of iterations
       const unsigned int max_n_it = 30;


### PR DESCRIPTION
I'm getting the following compiler errors here:
```
home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.templates.h: In instantiation of ‘std::array<std::pair<Number, dealii::Tensor<1, dim, Number> >, dim> dealii::internal::SymmetricTensor::ql_implicit_shifts(const dealii::SymmetricTensor<2, dim, Number>&) [with int dim = 1; Number = double]’:
source/base/symmetric_tensor.inst:29:69:   required from here
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.templates.h:248:21: error: no matching function for call to ‘tridiagonalize(const dealii::SymmetricTensor<2, 1, double>&, dealii::Tensor<2, 1, double>&, std::array<double, 1ul>&, std::array<double, 0ul>&)’
       tridiagonalize(A, Q, w, ee);
       ~~~~~~~~~~~~~~^~~~~~~~~~~~~
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.templates.h:148:5: note: candidate: template<int dim, class Number> void dealii::internal::SymmetricTensor::tridiagonalize(const dealii::SymmetricTensor<2, dim, Number>&, dealii::Tensor<2, dim, Number>&, std::array<Number, dim>&, std::array<Number, (dim - 1)>&)
     tridiagonalize (const dealii::SymmetricTensor<2,dim,Number> &A,
     ^~~~~~~~~~~~~~
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.templates.h:148:5: note:   template argument deduction/substitution failed:
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.templates.h:248:21: note:   mismatched types ‘int’ and ‘long unsigned int’
       tridiagonalize(A, Q, w, ee);
       ~~~~~~~~~~~~~~^~~~~~~~~~~~~

[...many times over...]
```
The issue is that the size type that is used as the second template argument of of `std::array<T,N>` is `unsigned long int`. So when we try to call
```
    template <int dim, typename Number>
    void
    tridiagonalize (const dealii::SymmetricTensor<2,dim,Number> &A,
                    dealii::Tensor<2,dim,Number>                &Q,
                    std::array<Number,dim>                      &d,
                    std::array<Number,dim-1>                    &e)
```
it tries to deduce `dim` from all of these places -- but because `dim` has type `int` in the first occurrences but `unsigned long` in the last two, the compiler fails. I suspect that's a bug in the compiler because it should look at values, not types of `dim`, but apparently it fails to do so here.

The problem is quickly worked around by explicitly specifying `dim` at the call site, rather than letting the compiler figure it out.