### PR TITLE
Move an iterator declaration that is now completely generic.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1503,8 +1503,8 @@ public:
   typedef TriaIterator      <TriaAccessor<dim-1, dim, spacedim> > face_iterator;
   typedef TriaActiveIterator<TriaAccessor<dim-1, dim, spacedim> > active_face_iterator;
 
-  typedef typename IteratorSelector::vertex_iterator        vertex_iterator;
-  typedef typename IteratorSelector::active_vertex_iterator active_vertex_iterator;
+  typedef TriaIterator      <dealii::TriaAccessor<0, dim, spacedim> > vertex_iterator;
+  typedef TriaActiveIterator<dealii::TriaAccessor<0, dim, spacedim> > active_vertex_iterator;
 
   typedef typename IteratorSelector::line_iterator        line_iterator;
   typedef typename IteratorSelector::active_line_iterator active_line_iterator;
@@ -3245,12 +3245,12 @@ private:
    * Since users should never have to access these internal properties of how
    * we store data, these iterator types are made private.
    */
-  typedef TriaRawIterator   <CellAccessor<dim,spacedim>         > raw_cell_iterator;
-  typedef TriaRawIterator   <TriaAccessor<dim-1, dim, spacedim> > raw_face_iterator;
-  typedef typename IteratorSelector::raw_vertex_iterator          raw_vertex_iterator;
-  typedef typename IteratorSelector::raw_line_iterator            raw_line_iterator;
-  typedef typename IteratorSelector::raw_quad_iterator            raw_quad_iterator;
-  typedef typename IteratorSelector::raw_hex_iterator             raw_hex_iterator;
+  typedef TriaRawIterator<CellAccessor<dim,spacedim>         >     raw_cell_iterator;
+  typedef TriaRawIterator<TriaAccessor<dim-1, dim, spacedim> >     raw_face_iterator;
+  typedef TriaRawIterator<dealii::TriaAccessor<0, dim, spacedim> > raw_vertex_iterator;
+  typedef typename IteratorSelector::raw_line_iterator             raw_line_iterator;
+  typedef typename IteratorSelector::raw_quad_iterator             raw_quad_iterator;
+  typedef typename IteratorSelector::raw_hex_iterator              raw_hex_iterator;
 
   /**
    * Iterator to the first cell, used or not, on level @p level. If a level

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1503,7 +1503,28 @@ public:
   typedef TriaIterator      <TriaAccessor<dim-1, dim, spacedim> > face_iterator;
   typedef TriaActiveIterator<TriaAccessor<dim-1, dim, spacedim> > active_face_iterator;
 
+  /**
+   * A typedef that defines an iterator type to iterate over
+   * vertices of a mesh.  The concept of iterators is discussed at
+   * length in the
+   * @ref Iterators "iterators documentation module".
+   *
+   * @ingroup Iterators
+   */
   typedef TriaIterator      <dealii::TriaAccessor<0, dim, spacedim> > vertex_iterator;
+
+  /**
+   * A typedef that defines an iterator type to iterate over
+   * vertices of a mesh.  The concept of iterators is discussed at
+   * length in the
+   * @ref Iterators "iterators documentation module".
+   *
+   * This typedef is in fact identical to the @p vertex_iterator typedef
+   * above since all vertices in a mesh are active (i.e., are a vertex of
+   * an active cell).
+   *
+   * @ingroup Iterators
+   */
   typedef TriaActiveIterator<dealii::TriaAccessor<0, dim, spacedim> > active_vertex_iterator;
 
   typedef typename IteratorSelector::line_iterator        line_iterator;

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -655,7 +655,7 @@ public:
    * Pointer to the @p ith vertex bounding this object. Throw an exception if
    * <code>dim=1</code>.
    */
-  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::vertex_iterator
+  TriaIterator<TriaAccessor<0,dim,spacedim> >
   vertex_iterator (const unsigned int i) const;
 
   /**

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1189,11 +1189,10 @@ TriaAccessor<structdim,dim,spacedim>::used () const
 
 template <int structdim, int dim, int spacedim>
 inline
-typename dealii::internal::Triangulation::Iterators<dim,spacedim>::vertex_iterator
+TriaIterator<TriaAccessor<0,dim,spacedim> >
 TriaAccessor<structdim,dim,spacedim>::vertex_iterator (const unsigned int i) const
 {
-  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::vertex_iterator
-         (this->tria, 0, vertex_index (i));
+  return TriaIterator<TriaAccessor<0,dim,spacedim> >(this->tria, 0, vertex_index (i));
 }
 
 

--- a/include/deal.II/grid/tria_iterator_selector.h
+++ b/include/deal.II/grid/tria_iterator_selector.h
@@ -42,9 +42,6 @@ namespace internal
      * @ref Iterators
      * module for more information.
      *
-     * A @p vertex_iterator is typedef'd to an iterator operating on the @p
-     * vertices member variable of a <tt>Triangulation<1></tt> object.
-     *
      * A @p line_iterator is typedef'd to an iterator operating on the @p
      * lines member variable of a <tt>Triangulation<1></tt> object. An @p
      * active_line_iterator only operates on the active lines. @p
@@ -72,10 +69,6 @@ namespace internal
     template <int spacedim>
     struct Iterators<1,spacedim>
     {
-      typedef TriaRawIterator   <dealii::TriaAccessor<0, 1, spacedim> > raw_vertex_iterator;
-      typedef TriaIterator      <dealii::TriaAccessor<0, 1, spacedim> > vertex_iterator;
-      typedef TriaActiveIterator<dealii::TriaAccessor<0, 1, spacedim> > active_vertex_iterator;
-
       typedef TriaRawIterator   <dealii::CellAccessor<1,spacedim> > raw_line_iterator;
       typedef TriaIterator      <dealii::CellAccessor<1,spacedim> > line_iterator;
       typedef TriaActiveIterator<dealii::CellAccessor<1,spacedim> > active_line_iterator;
@@ -98,9 +91,6 @@ namespace internal
      * These are the declarations for the 2D case only. See the
      * @ref Iterators
      * module for more information.
-     *
-     * A @p vertex_iterator is typedef'd to an iterator operating on the @p
-     * vertices member variable of a <tt>Triangulation<2></tt> object.
      *
      * A @p line_iterator is typedef'd to an iterator operating on the @p
      * lines member variable of a <tt>Triangulation<2></tt> object. An @p
@@ -135,10 +125,6 @@ namespace internal
     template <int spacedim>
     struct Iterators<2,spacedim>
     {
-      typedef TriaRawIterator   <dealii::TriaAccessor<0, 2, spacedim> > raw_vertex_iterator;
-      typedef TriaIterator      <dealii::TriaAccessor<0, 2, spacedim> > vertex_iterator;
-      typedef TriaActiveIterator<dealii::TriaAccessor<0, 2, spacedim> > active_vertex_iterator;
-
       typedef TriaRawIterator   <dealii::TriaAccessor<1, 2, spacedim> > raw_line_iterator;
       typedef TriaIterator      <dealii::TriaAccessor<1, 2, spacedim> > line_iterator;
       typedef TriaActiveIterator<dealii::TriaAccessor<1, 2, spacedim> > active_line_iterator;
@@ -179,10 +165,6 @@ namespace internal
     template <int spacedim>
     struct Iterators<3,spacedim>
     {
-      typedef TriaRawIterator   <dealii::TriaAccessor<0, 3, spacedim> > raw_vertex_iterator;
-      typedef TriaIterator      <dealii::TriaAccessor<0, 3, spacedim> > vertex_iterator;
-      typedef TriaActiveIterator<dealii::TriaAccessor<0, 3, spacedim> > active_vertex_iterator;
-
       typedef TriaRawIterator   <dealii::TriaAccessor<1, 3, spacedim> > raw_line_iterator;
       typedef TriaIterator      <dealii::TriaAccessor<1, 3, spacedim> > line_iterator;
       typedef TriaActiveIterator<dealii::TriaAccessor<1, 3, spacedim> > active_line_iterator;


### PR DESCRIPTION
The internal::Triangulation::Iterators class was meant to abstract away things
that look differently between dimensions. But we can now do better because at
least the vertex iterators are completely generic now. So move the typedef from
there to the Triangulation class, where it easier to find for users.

This is in response to #316.