### PR TITLE
Fix compilation with unity build.

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -66,7 +66,6 @@ SET(_unity_include_src
   quadrature_lib.cc
   quadrature_selector.cc
   subscriptor.cc
-  symmetric_tensor.cc
   table_handler.cc
   tensor_function.cc
   tensor_product_polynomials.cc
@@ -81,6 +80,7 @@ SET(_unity_include_src
 
 SET(_separate_src
   data_out_base.cc
+  symmetric_tensor.cc
   )
 
 # determined by profiling

--- a/source/lac/tridiagonal_matrix.cc
+++ b/source/lac/tridiagonal_matrix.cc
@@ -240,7 +240,7 @@ TridiagonalMatrix<double>::compute_eigenvalues()
   stev (&N, &nn, &*diagonal.begin(), &*right.begin(), nullptr, &one, nullptr, &info);
   Assert(info == 0, ExcInternalError());
 
-  state = eigenvalues;
+  state = LAPACKSupport::eigenvalues;
 #else
   Assert(false, ExcNeedsLAPACK());
 #endif
@@ -251,7 +251,7 @@ template <typename number>
 number
 TridiagonalMatrix<number>::eigenvalue(const size_type i) const
 {
-  Assert(state == eigenvalues, ExcState(state));
+  Assert(state == LAPACKSupport::eigenvalues, ExcState(state));
   Assert(i<n(), ExcIndexRange(i,0,n()));
   return diagonal[i];
 }


### PR DESCRIPTION
There are two independent things addressed here for the unity build. One is that the new `eigenvalues` method introduced in #4673 that clashes with the state of `LAPACKSupport` if in the same compilation unit. The second issue is a workaround rather than a fix: To use `std::sqrt(Sacado::Fad::DFad<double>)`, the Sacado headers must be included *before* the `symmetric_tensor.h` or `tensor.h` (I didn't check which one it was). There is the respective line in the first inclusions of `symmetric_tensor.cc` that fixes this. However, in the unity build we cannot make sure this and the build rightly fails. I do not see another solution than to exclude `symmetric_tensor.cc` from the unity build. Of course, this is not really a fix, but a person interested in using `Sacado` will have learned this already and know to include it at the top of the file. The alternative would have been to include `Sacado.hpp` in `config.h`, but that pulls in all Sacado headers in all compilation units. And we do not want to forward declare the methods in Sacado.