### PR TITLE
Remove a largely unused iterator typedef.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -783,11 +783,9 @@ namespace internal
         // a problem
         Assert ((dim==structdim
                  ?
-                 typename
-                 internal::Triangulation::Iterators<dim,spacedim>::
-                 raw_cell_iterator (&dof_handler.get_triangulation(),
-                                    obj_level,
-                                    obj_index)->used()
+                 TriaRawIterator<dealii::CellAccessor<dim,spacedim> > (&dof_handler.get_triangulation(),
+                     obj_level,
+                     obj_index)->used()
                  :
                  (structdim==1
                   ?
@@ -835,11 +833,9 @@ namespace internal
         // a problem
         Assert ((dim==structdim
                  ?
-                 typename
-                 internal::Triangulation::Iterators<dim,spacedim>::
-                 raw_cell_iterator (&dof_handler.get_triangulation(),
-                                    obj_level,
-                                    obj_index)->used()
+                 TriaRawIterator<dealii::CellAccessor<dim,spacedim> > (&dof_handler.get_triangulation(),
+                     obj_level,
+                     obj_index)->used()
                  :
                  (structdim==1
                   ?

--- a/include/deal.II/grid/tria_iterator_selector.h
+++ b/include/deal.II/grid/tria_iterator_selector.h
@@ -80,8 +80,6 @@ namespace internal
       typedef TriaRawIterator   <dealii::InvalidAccessor<3,1,spacedim> > raw_hex_iterator;
       typedef TriaIterator      <dealii::InvalidAccessor<3,1,spacedim> > hex_iterator;
       typedef TriaActiveIterator<dealii::InvalidAccessor<3,1,spacedim> > active_hex_iterator;
-
-      typedef raw_line_iterator raw_cell_iterator;
     };
 
 
@@ -136,8 +134,6 @@ namespace internal
       typedef TriaRawIterator   <dealii::InvalidAccessor<3,2,spacedim> > raw_hex_iterator;
       typedef TriaIterator      <dealii::InvalidAccessor<3,2,spacedim> > hex_iterator;
       typedef TriaActiveIterator<dealii::InvalidAccessor<3,2,spacedim> > active_hex_iterator;
-
-      typedef raw_quad_iterator raw_cell_iterator;
     };
 
 
@@ -176,8 +172,6 @@ namespace internal
       typedef TriaRawIterator   <dealii::CellAccessor<3, spacedim> > raw_hex_iterator;
       typedef TriaIterator      <dealii::CellAccessor<3, spacedim> > hex_iterator;
       typedef TriaActiveIterator<dealii::CellAccessor<3, spacedim> > active_hex_iterator;
-
-      typedef raw_hex_iterator raw_cell_iterator;
     };
 
   }


### PR DESCRIPTION
Move further towards the goal of trying to dispatch as small a number
of iterators to make the life of IDEs easier.