### PR TITLE
Remove unused parameter warning

### DIFF
--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1199,7 +1199,7 @@ namespace internal
         return lp_A.determinant();
       }
 #else
-      static number value (const FullMatrix<number> &A)
+      static number value (const FullMatrix<number> &)
       {
         AssertThrow(false, ExcNeedsLAPACK());
         return 0.0;


### PR DESCRIPTION
Remove a warning in case deal.II is set up without LAPACK.