### PR TITLE
Exchange active_fe_index between processors.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3513,6 +3513,7 @@ namespace internal
         const unsigned int
         n_cpus = Utilities::MPI::n_mpi_processes (triangulation->get_communicator());
 
+
         /*
            The following algorithm has a number of stages that are all documented
            in the paper that describes the parallel::distributed functionality:

--- a/tests/sharedtria/communicate_active_fe_indices_01.cc
+++ b/tests/sharedtria/communicate_active_fe_indices_01.cc
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that processors correctly communicate active_fe_index
+// information from their own locally owned cells to the ghosts on
+// other processors
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+
+#include <fstream>
+#include <cstdlib>
+#include <numeric>
+
+
+template <int dim>
+void test()
+{
+  parallel::shared::Triangulation<dim>
+  triangulation (MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global (3);
+
+  hp::FECollection<dim> fe;
+  for (unsigned int i=0; i<Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD); ++i)
+    fe.push_back(FE_Q<dim>(1));
+
+  hp::DoFHandler<dim> dof_handler (triangulation);
+
+  // set the active_fe_index on all locally active cells equal to the
+  // subdomain_id. we can later verify this equality also on ghost
+  // cells
+  for (auto cell : dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cell->set_active_fe_index (cell->subdomain_id());
+
+  dof_handler.distribute_dofs (fe);
+
+  deallog << "n_dofs: " << dof_handler.n_dofs() << std::endl;
+  deallog << "n_locally_owned_dofs: " << dof_handler.n_locally_owned_dofs() << std::endl;
+
+  // verify that the information has been communicated between processors
+  for (auto cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        Assert (cell->active_fe_index ()
+                ==
+                cell->subdomain_id(),
+                ExcInternalError());
+      if (cell->is_ghost())
+        Assert (cell->active_fe_index ()
+                ==
+                cell->subdomain_id(),
+                ExcInternalError());
+
+      // in the current mode for p::s::Tria, every cell is either
+      // locally owned or a ghost
+      Assert (cell->is_locally_owned() || cell->is_ghost(),
+              ExcInternalError());
+    }
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/communicate_active_fe_indices_01.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/communicate_active_fe_indices_01.with_metis=true.mpirun=3.output
@@ -1,0 +1,23 @@
+
+DEAL:0:1d::n_dofs: 9
+DEAL:0:1d::n_locally_owned_dofs: 3
+DEAL:0:2d::n_dofs: 81
+DEAL:0:2d::n_locally_owned_dofs: 26
+DEAL:0:3d::n_dofs: 729
+DEAL:0:3d::n_locally_owned_dofs: 239
+
+DEAL:1:1d::n_dofs: 9
+DEAL:1:1d::n_locally_owned_dofs: 4
+DEAL:1:2d::n_dofs: 81
+DEAL:1:2d::n_locally_owned_dofs: 28
+DEAL:1:3d::n_dofs: 729
+DEAL:1:3d::n_locally_owned_dofs: 241
+
+
+DEAL:2:1d::n_dofs: 9
+DEAL:2:1d::n_locally_owned_dofs: 2
+DEAL:2:2d::n_dofs: 81
+DEAL:2:2d::n_locally_owned_dofs: 27
+DEAL:2:3d::n_dofs: 729
+DEAL:2:3d::n_locally_owned_dofs: 249
+

--- a/tests/sharedtria/communicate_active_fe_indices_02.cc
+++ b/tests/sharedtria/communicate_active_fe_indices_02.cc
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// like _01, but allow for artificial cells
+
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_dgq.h>
+
+#include <fstream>
+#include <cstdlib>
+#include <numeric>
+
+
+template <int dim>
+void test()
+{
+  parallel::shared::Triangulation<dim>
+  triangulation (MPI_COMM_WORLD, dealii::Triangulation<dim>::none, true);
+
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global (3);
+
+  hp::FECollection<dim> fe;
+  for (unsigned int i=0; i<Utilities::MPI::n_mpi_processes (MPI_COMM_WORLD); ++i)
+    fe.push_back(FE_Q<dim>(1));
+
+  hp::DoFHandler<dim> dof_handler (triangulation);
+
+  // set the active_fe_index on all locally active cells equal to the
+  // subdomain_id. we can later verify this equality also on ghost
+  // cells
+  for (auto cell : dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cell->set_active_fe_index (cell->subdomain_id());
+
+  dof_handler.distribute_dofs (fe);
+
+  deallog << "n_dofs: " << dof_handler.n_dofs() << std::endl;
+  deallog << "n_locally_owned_dofs: " << dof_handler.n_locally_owned_dofs() << std::endl;
+
+  // verify that the information has been communicated between processors
+  for (auto cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        Assert (cell->active_fe_index ()
+                ==
+                cell->subdomain_id(),
+                ExcInternalError());
+      if (cell->is_ghost())
+        Assert (cell->active_fe_index ()
+                ==
+                cell->subdomain_id(),
+                ExcInternalError());
+    }
+}
+
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/communicate_active_fe_indices_02.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/communicate_active_fe_indices_02.with_metis=true.mpirun=3.output
@@ -1,0 +1,23 @@
+
+DEAL:0:1d::n_dofs: 9
+DEAL:0:1d::n_locally_owned_dofs: 3
+DEAL:0:2d::n_dofs: 81
+DEAL:0:2d::n_locally_owned_dofs: 26
+DEAL:0:3d::n_dofs: 729
+DEAL:0:3d::n_locally_owned_dofs: 239
+
+DEAL:1:1d::n_dofs: 9
+DEAL:1:1d::n_locally_owned_dofs: 4
+DEAL:1:2d::n_dofs: 81
+DEAL:1:2d::n_locally_owned_dofs: 28
+DEAL:1:3d::n_dofs: 729
+DEAL:1:3d::n_locally_owned_dofs: 241
+
+
+DEAL:2:1d::n_dofs: 9
+DEAL:2:1d::n_locally_owned_dofs: 2
+DEAL:2:2d::n_dofs: 81
+DEAL:2:2d::n_locally_owned_dofs: 27
+DEAL:2:3d::n_dofs: 729
+DEAL:2:3d::n_locally_owned_dofs: 249
+


### PR DESCRIPTION
Every processor should only set active_fe_index on their locally owned
cells, and then get those on ghost cells through parallel exchange.