### PR TITLE
Check the numeric type to get an upper bound.

### DIFF
--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -345,7 +345,8 @@ namespace VectorTools
 
             // count, how often we have
             // added to this dof
-            Assert (touch_count[local_dof_indices[j]] < numbers::internal_face_boundary_id,
+            Assert (touch_count[local_dof_indices[j]]
+                    < std::numeric_limits<decltype(touch_count)::value_type>::max(),
                     ExcInternalError());
             ++touch_count[local_dof_indices[j]];
           }


### PR DESCRIPTION
According to @bangerth this is a holdover from long ago when 255 was automatically replaced with numbers::internal_face_boundary_id everywhere in the library.