### PR TITLE
Break the Manifold interface for performance.

### DIFF
--- a/doc/news/changes/incompatibilities/20170910DavidWells
+++ b/doc/news/changes/incompatibilities/20170910DavidWells
@@ -1,0 +1,19 @@
+Changed: The methods
+<ol>
+  <li>Manifold::get_new_point</li>
+  <li>Manifold::project_to_manifold</li>
+</ol>
+have had their declarations changed in an incompatible manner: these three
+methods now take ArrayView arguments instead of <code>std::vector</code>s. This
+change was done for performance reasons: before this change about a third of the
+time spent generating a curved grid (in this particular benchmark, a circle
+described with polar coordinates and a transfinite interpolation) was used in
+allocating and freeing memory used by the <code>std::vector</code> arguments to
+Manifold::get_new_point() even though the sizes of the arrays are usually known
+at compilation time. This change completely eliminates this allocation cost.
+
+The method <code>Manifold::add_new_points()</code> has been removed in favor of
+Manifold::get_new_points(), which also uses ArrayView arguments instead of
+<code>std::vector</code>s.
+<br>
+(David Wells, 2017/09/10)

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -419,7 +419,7 @@ public:
    */
   virtual
   void
-  add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
                   ArrayView<Point<spacedim>>              new_points) const;
 
@@ -738,7 +738,7 @@ public:
    */
   virtual
   void
-  add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
                   ArrayView<Point<spacedim>>              new_points) const override;
 
@@ -964,7 +964,7 @@ public:
    */
   virtual
   void
-  add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
                   ArrayView<Point<spacedim>>              new_points) const override;
   /**

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -740,7 +740,7 @@ public:
   void
   add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
-                  ArrayView<Point<spacedim>>              new_points) const;
+                  ArrayView<Point<spacedim>>              new_points) const override;
 
   /**
    * Project to FlatManifold. This is the identity function for flat,
@@ -752,7 +752,7 @@ public:
   virtual
   Point<spacedim>
   project_to_manifold (const ArrayView<const Point<spacedim>> &points,
-                       const Point<spacedim>                  &candidate) const;
+                       const Point<spacedim>                  &candidate) const override;
 
   /**
    * Return a vector that, at $\mathbf x_1$, is tangential to
@@ -778,7 +778,7 @@ public:
   virtual
   Tensor<1,spacedim>
   get_tangent_vector (const Point<spacedim> &x1,
-                      const Point<spacedim> &x2) const;
+                      const Point<spacedim> &x2) const override;
 
   /**
    * Return the periodicity of this Manifold.
@@ -966,7 +966,7 @@ public:
   void
   add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
-                  ArrayView<Point<spacedim>>              new_points) const;
+                  ArrayView<Point<spacedim>>              new_points) const override;
   /**
    * Pull back the given point in spacedim to the Euclidean chartdim
    * dimensional space.
@@ -1065,7 +1065,7 @@ public:
   virtual
   Tensor<1,spacedim>
   get_tangent_vector (const Point<spacedim> &x1,
-                      const Point<spacedim> &x2) const;
+                      const Point<spacedim> &x2) const override;
 
   /**
    * Return the periodicity associated with the submanifold.

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -619,7 +619,7 @@ private:
  * the case for PolarManifold but not for Spherical manifold, so be careful
  * when using the latter. In case the quality of the manifold is not good
  * enough, upon mesh refinement it may happen that the transformation to a
- * chart inside the get_new_point() or add_new_points() methods produces
+ * chart inside the get_new_point() or get_new_points() methods produces
  * points that are outside the unit cell. Then this class throws an exception
  * of type Mapping::ExcTransformationFailed. In that case, the mesh should be
  * refined before attaching this class, as done in the following example:
@@ -721,7 +721,7 @@ public:
    */
   virtual
   void
-  add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+  get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
                   ArrayView<Point<spacedim>>              new_points) const override;
 

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -218,7 +218,7 @@ public:
   Point<spacedim>
   get_intermediate_point(const Point<spacedim> &p1,
                          const Point<spacedim> &p2,
-                         const double w) const;
+                         const double w) const override;
 
   /**
    * Compute the derivative of the get_intermediate_point() function
@@ -227,7 +227,7 @@ public:
   virtual
   Tensor<1,spacedim>
   get_tangent_vector (const Point<spacedim> &x1,
-                      const Point<spacedim> &x2) const;
+                      const Point<spacedim> &x2) const override;
 
   /**
    * Return a point on the spherical manifold which is intermediate
@@ -723,7 +723,7 @@ public:
   void
   add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                   const Table<2,double>                  &weights,
-                  ArrayView<Point<spacedim>>              new_points) const;
+                  ArrayView<Point<spacedim>>              new_points) const override;
 
 private:
   /**

--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -87,8 +87,8 @@ namespace OpenCASCADE
      * algorithms.
      */
     virtual Point<spacedim>
-    project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                         const Point<spacedim> &candidate) const;
+    project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                         const Point<spacedim>                  &candidate) const;
 
 
   private:
@@ -149,8 +149,8 @@ namespace OpenCASCADE
      * projection algorithms.
      */
     virtual Point<spacedim>
-    project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                         const Point<spacedim> &candidate) const;
+    project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                         const Point<spacedim>                  &candidate) const;
 
   private:
     /**
@@ -236,8 +236,8 @@ namespace OpenCASCADE
      * exception is thrown.
      */
     virtual Point<spacedim>
-    project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                         const Point<spacedim> &candidate) const;
+    project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                         const Point<spacedim>                  &candidate) const;
 
   private:
     /**

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -3821,7 +3821,7 @@ add_line_support_points (const typename Triangulation<dim,spacedim>::cell_iterat
               const std::size_t n_rows = support_point_weights_perimeter_to_interior[0].size(0);
               a.resize(a.size() + n_rows);
               auto a_view = make_array_view(a.end() - n_rows, a.end());
-              manifold.add_new_points(make_array_view(vertices.begin(),
+              manifold.get_new_points(make_array_view(vertices.begin(),
                                                       vertices.end()),
                                       support_point_weights_perimeter_to_interior[0],
                                       a_view);
@@ -3916,7 +3916,7 @@ add_quad_support_points(const Triangulation<3,3>::cell_iterator &cell,
           const std::size_t n_rows = support_point_weights_perimeter_to_interior[1].size(0);
           a.resize(a.size() + n_rows);
           auto a_view = make_array_view(a.end() - n_rows, a.end());
-          face->get_manifold().add_new_points (make_array_view(tmp_points.begin(),
+          face->get_manifold().get_new_points (make_array_view(tmp_points.begin(),
                                                                tmp_points.end()),
                                                support_point_weights_perimeter_to_interior[1],
                                                a_view);
@@ -3959,7 +3959,7 @@ add_quad_support_points(const Triangulation<2,3>::cell_iterator &cell,
       const std::size_t n_rows = weights.size(0);
       a.resize(a.size() + n_rows);
       auto a_view = make_array_view(a.end() - n_rows, a.end());
-      cell->get_manifold().add_new_points(make_array_view(vertices.begin(),
+      cell->get_manifold().get_new_points(make_array_view(vertices.begin(),
                                                           vertices.end()),
                                           weights,
                                           a_view);
@@ -4016,7 +4016,7 @@ compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_
           const std::size_t n_rows = support_point_weights_cell.size(0);
           a.resize(a.size() + n_rows);
           auto a_view = make_array_view(a.end() - n_rows, a.end());
-          cell->get_manifold().add_new_points(make_array_view(a.begin(),
+          cell->get_manifold().get_new_points(make_array_view(a.begin(),
                                                               a.end() - n_rows),
                                               support_point_weights_cell,
                                               a_view);
@@ -4040,7 +4040,7 @@ compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_
                 const std::size_t n_rows = support_point_weights_perimeter_to_interior[1].size(0);
                 a.resize(a.size() + n_rows);
                 auto a_view = make_array_view(a.end() - n_rows, a.end());
-                cell->get_manifold().add_new_points(make_array_view(a.begin(),
+                cell->get_manifold().get_new_points(make_array_view(a.begin(),
                                                                     a.end() - n_rows),
                                                     support_point_weights_perimeter_to_interior[1],
                                                     a_view);
@@ -4057,7 +4057,7 @@ compute_mapping_support_points(const typename Triangulation<dim,spacedim>::cell_
               const std::size_t n_rows = support_point_weights_perimeter_to_interior[2].size(0);
               a.resize(a.size() + n_rows);
               auto a_view = make_array_view(a.end() - n_rows, a.end());
-              cell->get_manifold().add_new_points(make_array_view(a.begin(),
+              cell->get_manifold().get_new_points(make_array_view(a.begin(),
                                                                   a.end() - n_rows),
                                                   support_point_weights_perimeter_to_interior[2],
                                                   a_view);

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -122,18 +122,12 @@ add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
 {
   AssertDimension(surrounding_points.size(), weights.size(1));
 
-  const std::size_t n_points = surrounding_points.size();
-  // TODO find a better dimension-dependent estimate for the size of this
-  // vector
-  boost::container::small_vector<double, 20> local_weights(n_points);
   for (unsigned int row=0; row<weights.size(0); ++row)
     {
-      for (unsigned int i=0; i<n_points; ++i)
-        local_weights[i] = weights(row,i);
       new_points[row] = get_new_point(make_array_view(surrounding_points.begin(),
                                                       surrounding_points.end()),
-                                      make_array_view(local_weights.begin(),
-                                                      local_weights.end()));
+                                      make_array_view(weights,
+                                                      row));
     }
 }
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -116,7 +116,7 @@ get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
 template <int dim, int spacedim>
 void
 Manifold<dim, spacedim>::
-add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                 const Table<2,double>                  &weights,
                 ArrayView<Point<spacedim>>              new_points) const
 {
@@ -573,7 +573,7 @@ get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
 template <int dim, int spacedim>
 void
 FlatManifold<dim, spacedim>::
-add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                 const Table<2,double>                  &weights,
                 ArrayView<Point<spacedim>>              new_points) const
 {
@@ -731,7 +731,7 @@ get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
 template <int dim, int spacedim, int chartdim>
 void
 ChartManifold<dim,spacedim,chartdim>::
-add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                 const Table<2,double>                  &weights,
                 ArrayView<Point<spacedim>>              new_points) const
 {
@@ -745,7 +745,7 @@ add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
     chart_points[i] = pull_back(surrounding_points[i]);
 
   boost::container::small_vector<Point<chartdim>, 200> new_points_on_chart(weights.size(0));
-  sub_manifold.add_new_points(make_array_view(chart_points.begin(),
+  sub_manifold.get_new_points(make_array_view(chart_points.begin(),
                                               chart_points.end()),
                               weights,
                               make_array_view(new_points_on_chart.begin(),

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -29,27 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 
 using namespace Manifolds;
 
-// This structure is used as comparison function for std::sort when sorting
-// points according to their weight.
-struct CompareWeights
-{
-public:
-  CompareWeights(const std::vector<double> &weights)
-    :
-    compare_weights(weights)
-  {}
-
-  bool operator() (unsigned int a, unsigned int b) const
-  {
-    return compare_weights[a] < compare_weights[b];
-  }
-
-private:
-  const std::vector<double> &compare_weights;
-};
-
 /* -------------------------- Manifold --------------------- */
-
 template <int dim, int spacedim>
 Manifold<dim, spacedim>::~Manifold ()
 {}
@@ -59,7 +39,7 @@ Manifold<dim, spacedim>::~Manifold ()
 template <int dim, int spacedim>
 Point<spacedim>
 Manifold<dim, spacedim>::
-project_to_manifold (const std::vector<Point<spacedim> > &,
+project_to_manifold (const ArrayView<const Point<spacedim>> &,
                      const Point<spacedim> &) const
 {
   Assert (false, ExcPureFunctionCalled());
@@ -75,10 +55,9 @@ get_intermediate_point (const Point<spacedim> &p1,
                         const Point<spacedim> &p2,
                         const double w) const
 {
-  std::vector<Point<spacedim> > vertices;
-  vertices.push_back(p1);
-  vertices.push_back(p2);
-  return project_to_manifold(vertices, w * p2 + (1-w)*p1 );
+  const std::array<Point<spacedim>, 2> vertices {{p1, p2}};
+  return project_to_manifold(make_array_view(vertices.begin(), vertices.end()),
+                             w * p2 + (1-w)*p1);
 }
 
 
@@ -86,8 +65,8 @@ get_intermediate_point (const Point<spacedim> &p1,
 template <int dim, int spacedim>
 Point<spacedim>
 Manifold<dim, spacedim>::
-get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
-               const std::vector<double>           &weights) const
+get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
+               const ArrayView<const double>          &weights) const
 {
   const double tol = 1e-10;
   const unsigned int n_points = surrounding_points.size();
@@ -106,7 +85,11 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
   // associative (as for the SphericalManifold).
   boost::container::small_vector<unsigned int, 100> permutation(n_points);
   std::iota(permutation.begin(), permutation.end(), 0u);
-  std::sort(permutation.begin(), permutation.end(), CompareWeights(weights));
+  std::sort(permutation.begin(), permutation.end(),
+            [&weights](const std::size_t a, const std::size_t b)
+  {
+    return weights[a] < weights[b];
+  });
 
   // Now loop over points in the order of their associated weight
   Point<spacedim> p = surrounding_points[permutation[0]];
@@ -133,22 +116,24 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
 template <int dim, int spacedim>
 void
 Manifold<dim, spacedim>::
-add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
-                const Table<2,double>               &weights,
-                std::vector<Point<spacedim> >       &new_points) const
+add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                const Table<2,double>                  &weights,
+                ArrayView<Point<spacedim>>              new_points) const
 {
   AssertDimension(surrounding_points.size(), weights.size(1));
-  Assert(&surrounding_points != &new_points,
-         ExcMessage("surrounding_points and new_points cannot be the same "
-                    "array"));
 
-  const unsigned int n_points = surrounding_points.size();
-  std::vector<double> local_weights(n_points);
+  const std::size_t n_points = surrounding_points.size();
+  // TODO find a better dimension-dependent estimate for the size of this
+  // vector
+  boost::container::small_vector<double, 20> local_weights(n_points);
   for (unsigned int row=0; row<weights.size(0); ++row)
     {
       for (unsigned int i=0; i<n_points; ++i)
         local_weights[i] = weights(row,i);
-      new_points.push_back(get_new_point(surrounding_points, local_weights));
+      new_points[row] = get_new_point(make_array_view(surrounding_points.begin(),
+                                                      surrounding_points.end()),
+                                      make_array_view(local_weights.begin(),
+                                                      local_weights.end()));
     }
 }
 
@@ -353,8 +338,11 @@ Point<spacedim>
 Manifold<dim, spacedim>::
 get_new_point_on_line (const typename Triangulation<dim, spacedim>::line_iterator &line) const
 {
-  const std::pair<std::vector<Point<spacedim> >, std::vector<double> > points_weights(get_default_points_and_weights(line));
-  return get_new_point (points_weights.first,points_weights.second);
+  const auto points_weights = get_default_points_and_weights(line);
+  return get_new_point (make_array_view(points_weights.first.begin(),
+                                        points_weights.first.end()),
+                        make_array_view(points_weights.second.begin(),
+                                        points_weights.second.end()));
 }
 
 
@@ -364,8 +352,11 @@ Point<spacedim>
 Manifold<dim, spacedim>::
 get_new_point_on_quad (const typename Triangulation<dim, spacedim>::quad_iterator &quad) const
 {
-  const std::pair<std::vector<Point<spacedim> >, std::vector<double> > points_weights(get_default_points_and_weights(quad));
-  return get_new_point (points_weights.first,points_weights.second);
+  const auto points_weights = get_default_points_and_weights(quad);
+  return get_new_point (make_array_view(points_weights.first.begin(),
+                                        points_weights.first.end()),
+                        make_array_view(points_weights.second.begin(),
+                                        points_weights.second.end()));
 }
 
 
@@ -492,8 +483,11 @@ Point<3>
 Manifold<3,3>::
 get_new_point_on_hex (const Triangulation<3, 3>::hex_iterator &hex) const
 {
-  const std::pair<std::vector<Point<3> >, std::vector<double> > points_weights(get_default_points_and_weights(hex,true));
-  return get_new_point (points_weights.first,points_weights.second);
+  const auto points_weights = get_default_points_and_weights(hex, true);
+  return get_new_point (make_array_view(points_weights.first.begin(),
+                                        points_weights.first.end()),
+                        make_array_view(points_weights.second.begin(),
+                                        points_weights.second.end()));
 }
 
 
@@ -505,15 +499,12 @@ Manifold<dim,spacedim>::get_tangent_vector(const Point<spacedim> &x1,
 {
   const double epsilon = 1e-8;
 
-  std::vector<Point<spacedim> > q;
-  q.push_back(x1);
-  q.push_back(x2);
-
-  std::vector<double> w;
-  w.push_back(epsilon);
-  w.push_back(1.0-epsilon);
-
-  const Tensor<1,spacedim> neighbor_point = get_new_point (q, w);
+  const std::array<Point<spacedim>, 2> points {{x1, x2}};
+  const std::array<double, 2> weights {{epsilon, 1.0 - epsilon}};
+  const Point<spacedim> neighbor_point = get_new_point (make_array_view(points.begin(),
+                                                        points.end()),
+                                                        make_array_view(weights.begin(),
+                                                            weights.end()));
   return (neighbor_point-x1)/epsilon;
 }
 
@@ -533,8 +524,8 @@ FlatManifold<dim,spacedim>::FlatManifold (const Tensor<1,spacedim> &periodicity,
 template <int dim, int spacedim>
 Point<spacedim>
 FlatManifold<dim, spacedim>::
-get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
-               const std::vector<double>           &weights) const
+get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
+               const ArrayView<const double>          &weights) const
 {
   Assert(std::abs(std::accumulate(weights.begin(), weights.end(), 0.0)-1.0) < 1e-10,
          ExcMessage("The weights for the individual points should sum to 1!"));
@@ -588,15 +579,15 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
 template <int dim, int spacedim>
 void
 FlatManifold<dim, spacedim>::
-add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
-                const Table<2,double>               &weights,
-                std::vector<Point<spacedim> >       &new_points) const
+add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                const Table<2,double>                  &weights,
+                ArrayView<Point<spacedim>>              new_points) const
 {
   AssertDimension(surrounding_points.size(), weights.size(1));
   if (weights.size(0) == 0)
     return;
 
-  const unsigned int n_points = surrounding_points.size();
+  const std::size_t n_points = surrounding_points.size();
 
   Tensor<1,spacedim> minP = periodicity;
   for (unsigned int d=0; d<spacedim; ++d)
@@ -612,7 +603,8 @@ add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
   // check whether periodicity shifts some of the points. Only do this if
   // necessary to avoid memory allocation
   const Point<spacedim> *surrounding_points_start = &surrounding_points[0];
-  std::vector<Point<spacedim> > modified_points;
+
+  boost::container::small_vector<Point<spacedim>, 200> modified_points;
   bool adjust_periodicity = false;
   for (unsigned int d=0; d<spacedim; ++d)
     if (periodicity[d] > 0)
@@ -624,7 +616,9 @@ add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
           }
   if (adjust_periodicity == true)
     {
-      modified_points = surrounding_points;
+      modified_points.resize(surrounding_points.size());
+      std::copy(surrounding_points.begin(), surrounding_points.end(),
+                modified_points.begin());
       for (unsigned int d=0; d<spacedim; ++d)
         if (periodicity[d] > 0)
           for (unsigned int i=0; i<n_points; ++i)
@@ -648,16 +642,20 @@ add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
           if (new_point[d] < 0)
             new_point[d] += periodicity[d];
 
-      new_points.push_back(project_to_manifold(surrounding_points, new_point));
+      // TODO should this use surrounding_points_start or surrounding_points?
+      // The older version used surrounding_points
+      new_points[row] = project_to_manifold(make_array_view(surrounding_points.begin(),
+                                                            surrounding_points.end()),
+                                            new_point);
     }
 }
 
 
-
 template <int dim, int spacedim>
 Point<spacedim>
-FlatManifold<dim, spacedim>::project_to_manifold (const std::vector<Point<spacedim> > &/*vertices*/,
-                                                  const Point<spacedim> &candidate) const
+FlatManifold<dim, spacedim>::project_to_manifold
+(const ArrayView<const Point<spacedim>> &/*vertices*/,
+ const Point<spacedim>                  &candidate) const
 {
   return candidate;
 }
@@ -717,15 +715,19 @@ ChartManifold<dim,spacedim,chartdim>::ChartManifold (const Tensor<1,chartdim> &p
 template <int dim, int spacedim, int chartdim>
 Point<spacedim>
 ChartManifold<dim,spacedim,chartdim>::
-get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
-               const std::vector<double>           &weights) const
+get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
+               const ArrayView<const double>          &weights) const
 {
-  std::vector<Point<chartdim> > chart_points(surrounding_points.size());
+  const std::size_t n_points = surrounding_points.size();
 
-  for (unsigned int i=0; i<surrounding_points.size(); ++i)
+  boost::container::small_vector<Point<chartdim>, 200> chart_points(n_points);
+
+  for (unsigned int i=0; i<n_points; ++i)
     chart_points[i] = pull_back(surrounding_points[i]);
 
-  const Point<chartdim> p_chart = sub_manifold.get_new_point(chart_points,weights);
+  const Point<chartdim> p_chart = sub_manifold.get_new_point
+                                  (make_array_view(chart_points.begin(), chart_points.end()),
+                                   weights);
 
   return push_forward(p_chart);
 }
@@ -735,25 +737,28 @@ get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
 template <int dim, int spacedim, int chartdim>
 void
 ChartManifold<dim,spacedim,chartdim>::
-add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
-                const Table<2,double>               &weights,
-                std::vector<Point<spacedim> >       &new_points) const
+add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                const Table<2,double>                  &weights,
+                ArrayView<Point<spacedim>>              new_points) const
 {
   Assert(weights.size(0) > 0, ExcEmptyObject());
   AssertDimension(surrounding_points.size(), weights.size(1));
 
-  const unsigned int n_points = surrounding_points.size();
+  const std::size_t n_points = surrounding_points.size();
 
-  std::vector<Point<chartdim> > chart_points(n_points);
-  for (unsigned int i=0; i<n_points; ++i)
+  boost::container::small_vector<Point<chartdim>, 200> chart_points(n_points);
+  for (std::size_t i=0; i<n_points; ++i)
     chart_points[i] = pull_back(surrounding_points[i]);
 
-  std::vector<Point<chartdim> > new_points_on_chart;
-  new_points_on_chart.reserve(weights.size(0));
-  sub_manifold.add_new_points(chart_points, weights, new_points_on_chart);
+  boost::container::small_vector<Point<chartdim>, 200> new_points_on_chart(weights.size(0));
+  sub_manifold.add_new_points(make_array_view(chart_points.begin(),
+                                              chart_points.end()),
+                              weights,
+                              make_array_view(new_points_on_chart.begin(),
+                                              new_points_on_chart.end()));
 
-  for (unsigned int row=0; row<weights.size(0); ++row)
-    new_points.push_back(push_forward(new_points_on_chart[row]));
+  for (std::size_t row=0; row<weights.size(0); ++row)
+    new_points[row] = push_forward(new_points_on_chart[row]);
 }
 
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -276,8 +276,8 @@ get_tangent_vector (const Point<spacedim> &p1,
 template <int dim, int spacedim>
 Point<spacedim>
 SphericalManifold<dim,spacedim>::
-get_new_point (const std::vector<Point<spacedim> > &vertices,
-               const std::vector<double> &weights) const
+get_new_point (const ArrayView<const Point<spacedim>> &vertices,
+               const ArrayView<const double>          &weights) const
 {
   const unsigned int n_points = vertices.size();
 
@@ -368,8 +368,8 @@ CylindricalManifold<dim, spacedim>::CylindricalManifold(const Point<spacedim> &d
 template <int dim, int spacedim>
 Point<spacedim>
 CylindricalManifold<dim,spacedim>::
-get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
-               const std::vector<double>           &weights) const
+get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
+               const ArrayView<const double>          &weights) const
 {
   // First check if the average in space lies on the axis.
   Point<spacedim> middle;
@@ -536,11 +536,12 @@ DerivativeForm<1,chartdim, spacedim>
 FunctionManifold<dim,spacedim,chartdim>::push_forward_gradient(const Point<chartdim> &chart_point) const
 {
   DerivativeForm<1, chartdim, spacedim> DF;
-  std::vector<Tensor<1, chartdim> > gradients(spacedim);
-  push_forward_function->vector_gradient(chart_point, gradients);
   for (unsigned int i=0; i<spacedim; ++i)
-    for (unsigned int j=0; j<chartdim; ++j)
-      DF[i][j] = gradients[i][j];
+    {
+      const auto gradient = push_forward_function->gradient(chart_point, i);
+      for (unsigned int j=0; j<chartdim; ++j)
+        DF[i][j] = gradient[j];
+    }
   return DF;
 }
 
@@ -724,8 +725,12 @@ namespace
 
         // add the contribution from the lines around the cell (first line in
         // formula)
-        std::vector<double> weights(GeometryInfo<2>::vertices_per_face);
-        std::vector<Point<spacedim> > points(GeometryInfo<2>::vertices_per_face);
+        std::array<double, GeometryInfo<2>::vertices_per_face> weights;
+        std::array<Point<spacedim>, GeometryInfo<2>::vertices_per_face> points;
+        // note that the views are immutable, but the arrays are not
+        const auto weights_view = make_array_view(weights.begin(), weights.end());
+        const auto points_view = make_array_view(points.begin(), points.end());
+
         for (unsigned int line=0; line<GeometryInfo<2>::lines_per_cell; ++line)
           {
             const double my_weight = line%2 ? chart_point[line/2] : 1-chart_point[line/2];
@@ -748,7 +753,8 @@ namespace
                 weights[0] = 1. - line_point;
                 weights[1] = line_point;
                 new_point += my_weight *
-                             cell.line(line)->get_manifold().get_new_point(points, weights);
+                             cell.line(line)->get_manifold().get_new_point(points_view,
+                                                                           weights_view);
               }
           }
 
@@ -790,8 +796,12 @@ namespace
           weights_lines[line] = 0;
 
         // start with the contributions of the faces
-        std::vector<double> weights;
-        std::vector<Point<spacedim> > points;
+        std::array<double, GeometryInfo<2>::vertices_per_cell> weights;
+        std::array<Point<spacedim>, GeometryInfo<2>::vertices_per_cell> points;
+        // note that the views are immutable, but the arrays are not
+        const auto weights_view = make_array_view(weights.begin(), weights.end());
+        const auto points_view = make_array_view(points.begin(), points.end());
+
         for (unsigned int face=0; face<GeometryInfo<3>::faces_per_cell; ++face)
           {
             Point<2> quad_point(chart_point[(face/2+1)%3], chart_point[(face/2+2)%3]);
@@ -817,15 +827,14 @@ namespace
               }
             else
               {
-                points.resize(GeometryInfo<2>::vertices_per_cell);
-                weights.resize(GeometryInfo<2>::vertices_per_cell);
                 for (unsigned int v=0; v<GeometryInfo<2>::vertices_per_cell; ++v)
                   {
                     points[v] = cell.vertex(GeometryInfo<3>::face_to_cell_vertices(face,v));
                     weights[v] = GeometryInfo<2>::d_linear_shape_function(quad_point, v);
                   }
                 new_point += my_weight *
-                             cell.face(face)->get_manifold().get_new_point(points, weights);
+                             cell.face(face)->get_manifold().get_new_point(points_view,
+                                                                           weights_view);
               }
           }
 
@@ -860,14 +869,13 @@ namespace
               }
             else
               {
-                points.resize(2);
-                weights.resize(2);
                 points[0] = cell.vertex(GeometryInfo<3>::line_to_cell_vertices(line,0));
                 points[1] = cell.vertex(GeometryInfo<3>::line_to_cell_vertices(line,1));
                 weights[0] = 1. - line_point;
                 weights[1] = line_point;
                 new_point -= my_weight *
-                             cell.line(line)->get_manifold().get_new_point(points, weights);
+                             cell.line(line)->get_manifold().get_new_point(points_view,
+                                                                           weights_view);
               }
           }
 
@@ -995,7 +1003,7 @@ TransfiniteInterpolationManifold<dim,spacedim>
 template <int dim, int spacedim>
 std::array<unsigned int, 10>
 TransfiniteInterpolationManifold<dim,spacedim>
-::get_possible_cells_around_points(const std::vector<Point<spacedim> > &points) const
+::get_possible_cells_around_points(const ArrayView<const Point<spacedim>> &points) const
 {
   // The methods to identify cells around points in GridTools are all written
   // for the active cells, but we are here looking at some cells at the coarse
@@ -1012,7 +1020,7 @@ TransfiniteInterpolationManifold<dim,spacedim>
   typename Triangulation<dim,spacedim>::cell_iterator
   cell = triangulation->begin(level_coarse),
   endc = triangulation->end(level_coarse);
-  std::vector<std::pair<double, unsigned int> > distances_and_cells;
+  boost::container::small_vector<std::pair<double, unsigned int>, 200> distances_and_cells;
   for ( ; cell != endc; ++cell)
     {
       // only consider cells where the current manifold is attached
@@ -1069,14 +1077,14 @@ TransfiniteInterpolationManifold<dim,spacedim>
 
 
 template <int dim, int spacedim>
-std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
-    std::vector<Point<dim> > >
-    TransfiniteInterpolationManifold<dim, spacedim>
-    ::compute_chart_points (const std::vector<Point<spacedim> > &surrounding_points) const
+typename Triangulation<dim,spacedim>::cell_iterator
+TransfiniteInterpolationManifold<dim, spacedim>
+::compute_chart_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                        ArrayView<Point<dim>>                   chart_points) const
 {
-  std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
-      std::vector<Point<dim> > > chart_points;
-  chart_points.second.resize(surrounding_points.size());
+  Assert(surrounding_points.size() == chart_points.size(),
+         ExcMessage("The chart points array view must be as large as the "
+                    "surrounding points array view."));
 
   std::array<unsigned int,10> nearby_cells =
     get_possible_cells_around_points(surrounding_points);
@@ -1092,11 +1100,11 @@ std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
       bool inside_unit_cell = true;
       for (unsigned int i=0; i<surrounding_points.size(); ++i)
         {
-          chart_points.second[i] = pull_back(cell, surrounding_points[i]);
+          chart_points[i] = pull_back(cell, surrounding_points[i]);
 
           // Tolerance 1e-6 chosen that the method also works with
           // SphericalManifold
-          if (GeometryInfo<dim>::is_inside_unit_cell(chart_points.second[i],
+          if (GeometryInfo<dim>::is_inside_unit_cell(chart_points[i],
                                                      1e-6) == false)
             {
               inside_unit_cell = false;
@@ -1105,16 +1113,14 @@ std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
         }
       if (inside_unit_cell == true)
         {
-          chart_points.first = cell;
-          return chart_points;
+          return cell;
         }
     }
 
   // a valid inversion should have returned a point above.
   AssertThrow(false,
               (typename Mapping<dim,spacedim>::ExcTransformationFailed()));
-  chart_points.second.clear();
-  return chart_points;
+  return typename Triangulation<dim,spacedim>::cell_iterator();
 }
 
 
@@ -1122,16 +1128,17 @@ std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
 template <int dim, int spacedim>
 Point<spacedim>
 TransfiniteInterpolationManifold<dim, spacedim>
-::get_new_point (const std::vector<Point<spacedim> > &surrounding_points,
-                 const std::vector<double>           &weights) const
+::get_new_point (const ArrayView<const Point<spacedim>> &surrounding_points,
+                 const ArrayView<const double>          &weights) const
 {
-  const std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
-        std::vector<Point<dim> > > chart_points =
-          compute_chart_points(surrounding_points);
+  boost::container::small_vector<Point<dim>, 100> chart_points(surrounding_points.size());
+  ArrayView<Point<dim>> chart_points_view = make_array_view(chart_points.begin(),
+                                                            chart_points.end());
+  const auto cell = compute_chart_points(surrounding_points, chart_points_view);
 
-  const Point<dim> p_chart = chart_manifold.get_new_point(chart_points.second,weights);
+  const Point<dim> p_chart = chart_manifold.get_new_point (chart_points_view, weights);
 
-  return push_forward(chart_points.first, p_chart);
+  return push_forward(cell, p_chart);
 }
 
 
@@ -1139,23 +1146,26 @@ TransfiniteInterpolationManifold<dim, spacedim>
 template <int dim, int spacedim>
 void
 TransfiniteInterpolationManifold<dim,spacedim>::
-add_new_points (const std::vector<Point<spacedim> > &surrounding_points,
-                const Table<2,double>               &weights,
-                std::vector<Point<spacedim> >       &new_points) const
+add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+                const Table<2,double>                  &weights,
+                ArrayView<Point<spacedim> >             new_points) const
 {
   Assert(weights.size(0) > 0, ExcEmptyObject());
   AssertDimension(surrounding_points.size(), weights.size(1));
 
-  const std::pair<typename Triangulation<dim,spacedim>::cell_iterator,
-        std::vector<Point<dim> > > chart_points =
-          compute_chart_points(surrounding_points);
+  boost::container::small_vector<Point<dim>, 100> chart_points(surrounding_points.size());
+  ArrayView<Point<dim>> chart_points_view = make_array_view(chart_points.begin(),
+                                                            chart_points.end());
+  const auto cell = compute_chart_points(surrounding_points, chart_points_view);
 
-  std::vector<Point<dim> > new_points_on_chart;
-  new_points_on_chart.reserve(weights.size(0));
-  chart_manifold.add_new_points(chart_points.second, weights, new_points_on_chart);
+  boost::container::small_vector<Point<dim>, 100> new_points_on_chart(weights.size(0));
+  chart_manifold.add_new_points(chart_points_view,
+                                weights,
+                                make_array_view(new_points_on_chart.begin(),
+                                                new_points_on_chart.end()));
 
   for (unsigned int row=0; row<weights.size(0); ++row)
-    new_points.push_back(push_forward(chart_points.first, new_points_on_chart[row]));
+    new_points[row] = push_forward(cell, new_points_on_chart[row]);
 }
 
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1146,7 +1146,7 @@ TransfiniteInterpolationManifold<dim, spacedim>
 template <int dim, int spacedim>
 void
 TransfiniteInterpolationManifold<dim,spacedim>::
-add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
+get_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
                 const Table<2,double>                  &weights,
                 ArrayView<Point<spacedim> >             new_points) const
 {
@@ -1159,7 +1159,7 @@ add_new_points (const ArrayView<const Point<spacedim>> &surrounding_points,
   const auto cell = compute_chart_points(surrounding_points, chart_points_view);
 
   boost::container::small_vector<Point<dim>, 100> new_points_on_chart(weights.size(0));
-  chart_manifold.add_new_points(chart_points_view,
+  chart_manifold.get_new_points(chart_points_view,
                                 weights,
                                 make_array_view(new_points_on_chart.begin(),
                                                 new_points_on_chart.end()));

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -4044,15 +4044,20 @@ namespace internal
                       // as returned by the underlying manifold
                       // object.
                       {
-                        std::vector<Point<spacedim> > ps(2);
-                        std::vector<double> ws(2, 0.5);
-                        ps[0] = cell->face(boundary_face)
-                                ->child(0)->vertex(1);
-                        ps[1] = cell->face(GeometryInfo<dim>
-                                           ::opposite_face[boundary_face])
-                                ->child(0)->vertex(1);
+                        const std::array<Point<spacedim>, 2> ps
+                        {
+                          {
+                            cell->face(boundary_face)->child(0)->vertex(1),
+                            cell->face(GeometryInfo<dim>::opposite_face[boundary_face])
+                            ->child(0)->vertex(1)
+                          }
+                        };
+                        const std::array<double, 2> ws {{0.5, 0.5}};
                         triangulation.vertices[next_unused_vertex]
-                          = cell->get_manifold().get_new_point(ps,ws);
+                          = cell->get_manifold().get_new_point(make_array_view(ps.begin(),
+                                                                               ps.end()),
+                                                               make_array_view(ws.begin(),
+                                                                               ws.end()));
                       }
                   }
               }

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1051,10 +1051,11 @@ namespace
     else
       {
         TriaRawIterator<TriaAccessor<structdim, dim, spacedim> > it(obj);
-        const std::pair<std::vector<Point<spacedim> >,
-              std::vector<double> > points_and_weights = Manifolds::get_default_points_and_weights(it, use_laplace);
-        return obj.get_manifold().get_new_point(points_and_weights.first,
-                                                points_and_weights.second);
+        const auto points_and_weights = Manifolds::get_default_points_and_weights(it, use_laplace);
+        return obj.get_manifold().get_new_point(make_array_view(points_and_weights.first.begin(),
+                                                                points_and_weights.first.end()),
+                                                make_array_view(points_and_weights.second.begin(),
+                                                                points_and_weights.second.end()));
       }
   }
 }
@@ -1206,8 +1207,8 @@ Point<spacedim>
 TriaAccessor<structdim, dim, spacedim>::intermediate_point (const Point<structdim> &coordinates) const
 {
   // Surrounding points and weights.
-  std::vector<Point<spacedim> > p(GeometryInfo<structdim>::vertices_per_cell);
-  std::vector<double>   w(GeometryInfo<structdim>::vertices_per_cell);
+  std::array<Point<spacedim>, GeometryInfo<structdim>::vertices_per_cell> p;
+  std::array<double, GeometryInfo<structdim>::vertices_per_cell> w;
 
   for (unsigned int i=0; i<GeometryInfo<structdim>::vertices_per_cell; ++i)
     {
@@ -1215,7 +1216,8 @@ TriaAccessor<structdim, dim, spacedim>::intermediate_point (const Point<structdi
       w[i] = GeometryInfo<structdim>::d_linear_shape_function(coordinates, i);
     }
 
-  return this->get_manifold().get_new_point(p, w);
+  return this->get_manifold().get_new_point(make_array_view(p.begin(), p.end()),
+                                            make_array_view(w.begin(), w.end()));
 }
 
 

--- a/source/opencascade/boundary_lib.cc
+++ b/source/opencascade/boundary_lib.cc
@@ -90,8 +90,8 @@ namespace OpenCASCADE
 
   template <int dim, int spacedim>
   Point<spacedim>  NormalProjectionBoundary<dim,spacedim>::
-  project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                       const Point<spacedim> &candidate) const
+  project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                       const Point<spacedim>                  &candidate) const
   {
     (void)surrounding_points;
 #ifdef DEBUG
@@ -120,8 +120,8 @@ namespace OpenCASCADE
 
   template <int dim, int spacedim>
   Point<spacedim>  DirectionalProjectionBoundary<dim,spacedim>::
-  project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                       const Point<spacedim> &candidate) const
+  project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                       const Point<spacedim>                  &candidate) const
   {
     (void)surrounding_points;
 #ifdef DEBUG
@@ -151,8 +151,8 @@ namespace OpenCASCADE
 
   template <int dim, int spacedim>
   Point<spacedim>  NormalToMeshProjectionBoundary<dim,spacedim>::
-  project_to_manifold (const std::vector<Point<spacedim> > &surrounding_points,
-                       const Point<spacedim> &candidate) const
+  project_to_manifold (const ArrayView<const Point<spacedim>> &surrounding_points,
+                       const Point<spacedim>                  &candidate) const
   {
     TopoDS_Shape out_shape;
     Tensor<1,3> average_normal;

--- a/tests/manifold/chart_manifold_03.cc
+++ b/tests/manifold/chart_manifold_03.cc
@@ -117,7 +117,8 @@ void test(unsigned int ref=1)
 
   for (unsigned int i=0; i<ps.size(); ++i)
     {
-      middle = manifold.get_new_point(ps[i],ws);
+      middle = manifold.get_new_point(make_array_view(ps[i]),
+                                      make_array_view(ws));
       deallog << "P0: " << ps[i][0] << " , P1: " << ps[i][1] << " , Middle: " << middle << std::endl;
     }
 
@@ -135,4 +136,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/chart_manifold_03_embedded.cc
+++ b/tests/manifold/chart_manifold_03_embedded.cc
@@ -125,7 +125,8 @@ void test(unsigned int ref=1)
 
   for (unsigned int i=0; i<ps.size(); ++i)
     {
-      middle = manifold.get_new_point(ps[i],ws);
+      middle = manifold.get_new_point(make_array_view(ps[i]),
+                                      make_array_view(ws));
       deallog << "P0: " << ps[i][0] << " , P1: " << ps[i][1] << " , Middle: " << middle << std::endl;
     }
 
@@ -141,4 +142,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/chart_manifold_09.cc
+++ b/tests/manifold/chart_manifold_09.cc
@@ -60,12 +60,11 @@ main()
           weights[0] = (double)i/((double)n_intermediates-1);
           weights[1] = 1.0-weights[0];
 
-          deallog << manifold.get_new_point(points, weights) << std::endl;
+          deallog << manifold.get_new_point(make_array_view(points),
+                                            make_array_view(weights))
+                  << std::endl;
         }
     }
 
   return 0;
 }
-
-
-

--- a/tests/manifold/composition_manifold_01.cc
+++ b/tests/manifold/composition_manifold_01.cc
@@ -57,7 +57,8 @@ int main ()
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(sp, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(sp),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, sp[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, sp[1]);
 
@@ -70,4 +71,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/composition_manifold_02.cc
+++ b/tests/manifold/composition_manifold_02.cc
@@ -68,7 +68,8 @@ int main ()
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(sp, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(sp),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, sp[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, sp[1]);
 
@@ -80,4 +81,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/composition_manifold_03.cc
+++ b/tests/manifold/composition_manifold_03.cc
@@ -72,7 +72,8 @@ int main ()
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(sp, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(sp),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, sp[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, sp[1]);
 
@@ -84,4 +85,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/composition_manifold_04.cc
+++ b/tests/manifold/composition_manifold_04.cc
@@ -73,7 +73,8 @@ int main ()
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(sp, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(sp),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, sp[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, sp[1]);
 
@@ -93,7 +94,8 @@ int main ()
       w[1] = 1.0 - w[0];
 
       Point<spacedim> ip = manifold.
-                           pull_back(manifold.get_new_point(sp, w));
+                           pull_back(manifold.get_new_point(make_array_view(sp),
+                                                            make_array_view(w)));
 
       ip[0] = w[1];
 

--- a/tests/manifold/flat_manifold_03.cc
+++ b/tests/manifold/flat_manifold_03.cc
@@ -76,7 +76,8 @@ void test(unsigned int ref=1)
 
   for (unsigned int i=0; i<ps.size(); ++i)
     {
-      middle = manifold.get_new_point(ps[i],ws);
+      middle = manifold.get_new_point(make_array_view(ps[i]),
+                                      make_array_view(ws));
       deallog << "P0: " << ps[i][0] << " , P1: " << ps[i][1] << " , Middle: " << middle << std::endl;
     }
 
@@ -94,4 +95,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/flat_manifold_07.cc
+++ b/tests/manifold/flat_manifold_07.cc
@@ -60,12 +60,11 @@ main()
           weights[0] = (double)i/((double)n_intermediates-1);
           weights[1] = 1.0-weights[0];
 
-          deallog << manifold.get_new_point(points, weights) << std::endl;
+          deallog << manifold.get_new_point(make_array_view(points),
+                                            make_array_view(weights))
+                  << std::endl;
         }
     }
 
   return 0;
 }
-
-
-

--- a/tests/manifold/function_manifold_03.cc
+++ b/tests/manifold/function_manifold_03.cc
@@ -67,7 +67,8 @@ void test(unsigned int ref=1)
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(p, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(p),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, p[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, p[1]);
 
@@ -89,4 +90,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/polar_manifold_08.cc
+++ b/tests/manifold/polar_manifold_08.cc
@@ -66,12 +66,11 @@ main()
           weights[0] = (double)i/((double)n_intermediates-1);
           weights[1] = 1.0-weights[0];
 
-          deallog << manifold.get_new_point(points, weights) << std::endl;
+          deallog << manifold.get_new_point(make_array_view(points),
+                                            make_array_view(weights))
+                  << std::endl;
         }
     }
 
   return 0;
 }
-
-
-

--- a/tests/manifold/projection_manifold_01.cc
+++ b/tests/manifold/projection_manifold_01.cc
@@ -31,8 +31,8 @@ class MyManifold : public Manifold<dim, spacedim>
 {
 public:
   Point<spacedim>
-  project_to_manifold (const std::vector<Point<spacedim> > &vertices,
-                       const Point<spacedim> &candidate) const
+  project_to_manifold (const ArrayView<const Point<spacedim> > &vertices,
+                       const Point<spacedim> &candidate) const override
   {
     // Shift the y coordinate to 4*x*(1-x)
     Point<spacedim> p = candidate;
@@ -73,4 +73,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/spherical_manifold_01.cc
+++ b/tests/manifold/spherical_manifold_01.cc
@@ -158,9 +158,12 @@ main()
     weights[1] = 1.0/3.0;
     weights[2] = 1.0/3.0;
 
-    Point<3> Q = manifold.get_new_point(points1, weights);
-    Point<3> S = manifold.get_new_point(points2, weights);
-    Point<3> T = manifold.get_new_point(points3, weights);
+    Point<3> Q = manifold.get_new_point(make_array_view(points1),
+                                        make_array_view(weights));
+    Point<3> S = manifold.get_new_point(make_array_view(points2),
+                                        make_array_view(weights));
+    Point<3> T = manifold.get_new_point(make_array_view(points3),
+                                        make_array_view(weights));
 
     Point<3> P5(0.707107, 0.707107, 0.0);
     Point<3> P4(0.0, 0.0, 1.0);
@@ -177,6 +180,3 @@ main()
   // Quadrature (const std::vector< Point< dim > > &points, const std::vector< double > &weights);
   return 0;
 }
-
-
-

--- a/tests/manifold/tensor_product_manifold_01.cc
+++ b/tests/manifold/tensor_product_manifold_01.cc
@@ -61,7 +61,8 @@ void test1()
       w[0] = 1.0-(double)i/((double)n_intermediates);
       w[1] = 1.0 - w[0];
 
-      Point<spacedim> ip = manifold.get_new_point(sp, w);
+      Point<spacedim> ip = manifold.get_new_point(make_array_view(sp),
+                                                  make_array_view(w));
       Tensor<1,spacedim> t1 = manifold.get_tangent_vector(ip, sp[0]);
       Tensor<1,spacedim> t2 = manifold.get_tangent_vector(ip, sp[1]);
 
@@ -83,4 +84,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/transfinite_manifold_01.cc
+++ b/tests/manifold/transfinite_manifold_01.cc
@@ -43,14 +43,18 @@ void do_test(const Triangulation<dim,spacedim> &tria)
             std::vector<double> weights(2);
             weights[0] = 0.1;
             weights[1] = 0.9;
-            Point<spacedim> p = cell->get_manifold().get_new_point(points, weights);
-            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            Point<spacedim> p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                                   make_array_view(weights));
+            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                   make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
             weights[0] = 0.55;
             weights[1] = 0.45;
-            p = cell->get_manifold().get_new_point(points, weights);
-            pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                   make_array_view(weights));
+            pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                                                  make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
           }
@@ -147,4 +151,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/transfinite_manifold_02.cc
+++ b/tests/manifold/transfinite_manifold_02.cc
@@ -43,14 +43,18 @@ void do_test(const Triangulation<dim,spacedim> &tria)
             std::vector<double> weights(2);
             weights[0] = 0.1;
             weights[1] = 0.9;
-            Point<spacedim> p = cell->get_manifold().get_new_point(points, weights);
-            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            Point<spacedim> p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                                   make_array_view(weights));
+            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                   make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
             weights[0] = 0.55;
             weights[1] = 0.45;
-            p = cell->get_manifold().get_new_point(points, weights);
-            pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                   make_array_view(weights));
+            pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                                                  make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
           }
@@ -156,4 +160,3 @@ int main ()
 
   return 0;
 }
-

--- a/tests/manifold/transfinite_manifold_04.cc
+++ b/tests/manifold/transfinite_manifold_04.cc
@@ -43,14 +43,18 @@ void do_test(const Triangulation<dim,spacedim> &tria)
             std::vector<double> weights(2);
             weights[0] = 0.1;
             weights[1] = 0.9;
-            Point<spacedim> p = cell->get_manifold().get_new_point(points, weights);
-            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            Point<spacedim> p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                                   make_array_view(weights));
+            Point<spacedim> pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                   make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
             weights[0] = 0.55;
             weights[1] = 0.45;
-            p = cell->get_manifold().get_new_point(points, weights);
-            pref = cell->face(face)->get_manifold().get_new_point(points, weights);
+            p = cell->get_manifold().get_new_point(make_array_view(points),
+                                                   make_array_view(weights));
+            pref = cell->face(face)->get_manifold().get_new_point(make_array_view(points),
+                                                                  make_array_view(weights));
             deallog << "Distance between cell manifold and face manifold: "
                     << (pref-p) << std::endl;
           }
@@ -118,5 +122,3 @@ int main ()
 
   return 0;
 }
-
-


### PR DESCRIPTION
This is the branch which I have mentioned in passing a few times: we spend nearly a third of our time allocating and freeing memory inside of the Manifold functions called when creating a grid.

I am not sure if we want to proceed with this and there are still a few things that need to be fixed:
- [x] The minimum boost version needs to be increased to ~~1.58~~ 1.59 (update: 1.58 is not compatible with deal.II)
- [x] The dimension-dependent functions for returning the number of default points in each direction are pretty ugly. 
- [x] The `Manifolds::get_default_points_and_weights` function could also be improved.

In addition, I included a commit that adds a new constructor to `ArrayView` which creates an `ArrayView` from a `std::vector`: this allows all tests but one to pass in their current form.

In reference to #4704.