### PR TITLE
Remove a function that is now no longer used.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2662,16 +2662,6 @@ namespace internal
           std::vector<dealii::types::global_dof_index>                        dof_numbers_and_indices;
 
 
-          unsigned int bytes_for_buffer () const
-          {
-            return (sizeof(unsigned int)*2 +
-                    tree_indices.size() * sizeof(unsigned int) +
-                    quadrants.size() * sizeof(typename dealii::internal::p4est
-                                              ::types<dim>::quadrant) +
-                    dof_numbers_and_indices.size() * sizeof(dealii::types::global_dof_index));
-          }
-
-
           /**
            * Write the data of this object to a stream for the purpose of
            * serialization.


### PR DESCRIPTION
We use boost serialization, rather than setting up a fixed-sized buffer
into which we memcpy things.

I verified that this compiles. Because it's an internal class, that's
all that matters. Related to #3511.