### PR TITLE
sharedtria/communicate_active_fe_indices_(01|02): add output variants

### DIFF
--- a/tests/sharedtria/communicate_active_fe_indices_01.with_metis=true.mpirun=3.output.2
+++ b/tests/sharedtria/communicate_active_fe_indices_01.with_metis=true.mpirun=3.output.2
@@ -1,0 +1,23 @@
+
+DEAL:0:1d::n_dofs: 9
+DEAL:0:1d::n_locally_owned_dofs: 4
+DEAL:0:2d::n_dofs: 81
+DEAL:0:2d::n_locally_owned_dofs: 28
+DEAL:0:3d::n_dofs: 729
+DEAL:0:3d::n_locally_owned_dofs: 244
+
+DEAL:1:1d::n_dofs: 9
+DEAL:1:1d::n_locally_owned_dofs: 3
+DEAL:1:2d::n_dofs: 81
+DEAL:1:2d::n_locally_owned_dofs: 26
+DEAL:1:3d::n_dofs: 729
+DEAL:1:3d::n_locally_owned_dofs: 240
+
+
+DEAL:2:1d::n_dofs: 9
+DEAL:2:1d::n_locally_owned_dofs: 2
+DEAL:2:2d::n_dofs: 81
+DEAL:2:2d::n_locally_owned_dofs: 27
+DEAL:2:3d::n_dofs: 729
+DEAL:2:3d::n_locally_owned_dofs: 245
+

--- a/tests/sharedtria/communicate_active_fe_indices_02.with_metis=true.mpirun=3.output.2
+++ b/tests/sharedtria/communicate_active_fe_indices_02.with_metis=true.mpirun=3.output.2
@@ -1,0 +1,23 @@
+
+DEAL:0:1d::n_dofs: 9
+DEAL:0:1d::n_locally_owned_dofs: 4
+DEAL:0:2d::n_dofs: 81
+DEAL:0:2d::n_locally_owned_dofs: 28
+DEAL:0:3d::n_dofs: 729
+DEAL:0:3d::n_locally_owned_dofs: 244
+
+DEAL:1:1d::n_dofs: 9
+DEAL:1:1d::n_locally_owned_dofs: 3
+DEAL:1:2d::n_dofs: 81
+DEAL:1:2d::n_locally_owned_dofs: 26
+DEAL:1:3d::n_dofs: 729
+DEAL:1:3d::n_locally_owned_dofs: 240
+
+
+DEAL:2:1d::n_dofs: 9
+DEAL:2:1d::n_locally_owned_dofs: 2
+DEAL:2:2d::n_dofs: 81
+DEAL:2:2d::n_locally_owned_dofs: 27
+DEAL:2:3d::n_dofs: 729
+DEAL:2:3d::n_locally_owned_dofs: 245
+


### PR DESCRIPTION
Add two output variants for different compiler/metis versions. Change of output
is only a different partition of degrees of freedom.

#4704