### PR TITLE
trilinos/solver_control_06: Add output variants

### DIFF
--- a/tests/trilinos/solver_control_06.mpirun=1.output.3
+++ b/tests/trilinos/solver_control_06.mpirun=1.output.3
@@ -1,0 +1,86 @@
+
+DEAL::Convergence step 1 value 2.94714e-13
+DEAL::Convergence step 1 value 2.94714e-13
+DEAL::Convergence step 1 value 2.41781e-16
+DEAL::Convergence step 1 value 2.37969e-13
+DEAL::Convergence step 1 value 1.34238e-16
+DEAL::Convergence step 1 value 2.50659e-16
+DEAL::Convergence step 13 value 1.68952e-13
+DEAL::Convergence step 13 value 1.68952e-13
+DEAL::Convergence step 7 value 4.71693e-14
+DEAL::Convergence step 13 value 1.67239e-13
+DEAL::Convergence step 7 value 7.94994e-13
+DEAL::Convergence step 7 value 5.00664e-14
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CGS solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned GMRES solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned BICGSTAB solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned TFQMR solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CGS solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned GMRES solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned BICGSTAB solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned TFQMR solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::OK

--- a/tests/trilinos/solver_control_06.mpirun=2.output.3
+++ b/tests/trilinos/solver_control_06.mpirun=2.output.3
@@ -1,0 +1,86 @@
+
+DEAL::Convergence step 1 value 2.94718e-13
+DEAL::Convergence step 1 value 2.94718e-13
+DEAL::Convergence step 1 value 2.42797e-16
+DEAL::Convergence step 1 value 2.37967e-13
+DEAL::Convergence step 1 value 1.29943e-16
+DEAL::Convergence step 1 value 2.69281e-16
+DEAL::Convergence step 12 value 8.50032e-13
+DEAL::Convergence step 12 value 8.50032e-13
+DEAL::Convergence step 7 value 1.94823e-14
+DEAL::Convergence step 12 value 8.42698e-13
+DEAL::Convergence step 7 value 5.55661e-13
+DEAL::Convergence step 7 value 2.07636e-14
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CGS solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned GMRES solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned BICGSTAB solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned TFQMR solution
+DEAL::		***** ML (L=1, /Amesos_KLU_0, )
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CG solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned CGS solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned GMRES solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned BICGSTAB solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::		*******************************************************
+DEAL::		***** Problem: Epetra::CrsMatrix
+DEAL::		***** Preconditioned TFQMR solution
+DEAL::		***** ML (L=2, /Cheby_post0, /Amesos_KLU_1)
+DEAL::		***** No scaling
+DEAL::		*******************************************************
+DEAL::OK


### PR DESCRIPTION
Newer trilinios print the warning string (that we sometimes get and that
is already present in the original .output files) without a leading ~/.

Thus add another output variant.

In reference to #4704