### PR TITLE
Allow the create_* functions to be called with nullptr coefficients

### DIFF
--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -671,7 +671,7 @@ namespace MatrixCreator
                            const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -712,7 +712,7 @@ namespace MatrixCreator
   void create_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof,
@@ -728,7 +728,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -770,7 +770,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping,
@@ -785,7 +785,7 @@ namespace MatrixCreator
                            const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -822,7 +822,7 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim> &dof,
                            const hp::QCollection<dim> &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
@@ -838,7 +838,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -877,7 +877,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const coefficient,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1198,7 +1198,7 @@ namespace MatrixCreator
                                const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                Vector<number>            &rhs_vector,
                                std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                               const Function<spacedim,number> *const coefficient,
+                               const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                                std::vector<unsigned int> component_mapping)
   {
     // what would that be in 1d? the
@@ -1597,7 +1597,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &rhs,
                                     Vector<number>            &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a,
                                     std::vector<unsigned int> component_mapping)
   {
     create_boundary_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof, q,
@@ -1615,7 +1615,7 @@ namespace MatrixCreator
                                const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                Vector<number>            &rhs_vector,
                                std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                               const Function<spacedim,number> *const coefficient,
+                               const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
                                std::vector<unsigned int> component_mapping)
   {
     // what would that be in 1d? the
@@ -1684,7 +1684,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &rhs,
                                     Vector<number>            &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a,
                                     std::vector<unsigned int> component_mapping)
   {
     create_boundary_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1698,7 +1698,7 @@ namespace MatrixCreator
                               const DoFHandler<dim,spacedim>    &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1740,7 +1740,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const DoFHandler<dim,spacedim>    &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(StaticMappingQ1<dim,spacedim>::mapping,
@@ -1756,7 +1756,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1800,7 +1800,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof, q,
@@ -1814,7 +1814,7 @@ namespace MatrixCreator
                               const hp::DoFHandler<dim,spacedim>    &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1853,7 +1853,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1869,7 +1869,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1910,7 +1910,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const coefficient,
+                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -237,7 +237,7 @@ namespace MatrixCreator
                            const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -248,7 +248,7 @@ namespace MatrixCreator
   void create_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -274,7 +274,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -287,7 +287,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -298,7 +298,7 @@ namespace MatrixCreator
                            const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -308,7 +308,7 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -321,7 +321,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = nullptr,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -333,7 +333,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
 
@@ -367,7 +367,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const weight = 0,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const weight = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
 
@@ -382,7 +382,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -396,7 +396,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -409,7 +409,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -433,7 +433,7 @@ namespace MatrixCreator
                               const DoFHandler<dim,spacedim> &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -444,7 +444,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const DoFHandler<dim,spacedim> &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -469,7 +469,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim> &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -482,7 +482,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim> &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -494,7 +494,7 @@ namespace MatrixCreator
                               const hp::DoFHandler<dim,spacedim> &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -505,7 +505,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const hp::DoFHandler<dim,spacedim> &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -519,7 +519,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -532,7 +532,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<spacedim> *const a = nullptr,
+                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**

--- a/tests/numerics/create_laplace_matrix_constraints_01.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_01.cc
@@ -104,9 +104,8 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, dummy, constraints);
+                                      rhs_function, rhs, nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02.cc
@@ -108,9 +108,8 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, dummy, constraints);
+                                      rhs_function, rhs, nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02b.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02b.cc
@@ -104,9 +104,8 @@ check ()
                          quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      dummy, constraints);
+                                      nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_01.cc
+++ b/tests/numerics/create_mass_matrix_constraints_01.cc
@@ -104,9 +104,8 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, dummy, constraints);
+                                   rhs_function, rhs, nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02.cc
@@ -108,9 +108,8 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, dummy, constraints);
+                                   rhs_function, rhs, nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02b.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02b.cc
@@ -104,9 +104,8 @@ check ()
                       quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   dummy, constraints);
+                                   nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values


### PR DESCRIPTION
Calling these functions with a nullptr coefficient didn't work before as the template arguments couldn't be deduced from`Function<spacedim, number>`.