### PR TITLE
Disable two gcc 7.1.0 diagnostics for external includes

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -301,6 +301,7 @@ _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")   \
 _Pragma("GCC diagnostic ignored \"-Wundef\"")                    \
 _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")         \
 _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")     \
+_Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")      \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -300,6 +300,7 @@ _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")       \
 _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")   \
 _Pragma("GCC diagnostic ignored \"-Wundef\"")                    \
 _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")         \
+_Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")     \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \


### PR DESCRIPTION
Disable -Wint-in-bool-context and -Wimplicit-fallthrough in our
  DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
pragma

In reference to #4704