### PR TITLE
Remove int2type and bool2type

### DIFF
--- a/doc/news/changes/minor/20170810DanielArndt
+++ b/doc/news/changes/minor/20170810DanielArndt
@@ -1,0 +1,4 @@
+Deprecated: internal::bool2type and int2type has been depreated
+in favor of std::intergral_constant.
+<br>
+(Daniel Arndt, 2017/08/10)

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -441,7 +441,7 @@ namespace internal
         std::memset ((void *)(destination_+begin), 0, (end-begin)*sizeof(T));
       else
         copy_construct_or_assign(begin, end,
-                                 ::dealii::internal::bool2type<initialize_memory>());
+                                 std::integral_constant<bool, initialize_memory>());
     }
 
   private:
@@ -452,7 +452,7 @@ namespace internal
     // copy assignment operation
     void copy_construct_or_assign(const std::size_t begin,
                                   const std::size_t end,
-                                  ::dealii::internal::bool2type<false>) const
+                                  std::integral_constant<bool, false>) const
     {
       for (std::size_t i=begin; i<end; ++i)
         destination_[i] = element_;
@@ -461,7 +461,7 @@ namespace internal
     // copy constructor (memory initialization)
     void copy_construct_or_assign(const std::size_t begin,
                                   const std::size_t end,
-                                  ::dealii::internal::bool2type<true>) const
+                                  std::integral_constant<bool, true>) const
     {
       for (std::size_t i=begin; i<end; ++i)
         new (&destination_[i]) T(element_);

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1654,7 +1654,7 @@ namespace internal
     template <int rank>
     TableIndices<rank>
     get_partially_filled_indices (const unsigned int row,
-                                  const internal::int2type<2> &)
+                                  const std::integral_constant<int, 2> &)
     {
       return TableIndices<rank> (row,
                                  numbers::invalid_unsigned_int);
@@ -1665,7 +1665,7 @@ namespace internal
     template <int rank>
     TableIndices<rank>
     get_partially_filled_indices (const unsigned int row,
-                                  const internal::int2type<4> &)
+                                  const std::integral_constant<int, 4> &)
     {
       return TableIndices<rank> (row,
                                  numbers::invalid_unsigned_int,
@@ -1685,7 +1685,7 @@ SymmetricTensor<rank,dim,Number>::operator [] (const unsigned int row) const
     internal::SymmetricTensorAccessors::
     Accessor<rank,dim,true,rank-1,Number> (*this,
                                            internal::SymmetricTensor::get_partially_filled_indices<rank> (row,
-                                               internal::int2type<rank>()));
+                                               std::integral_constant<int, rank>()));
 }
 
 
@@ -1698,7 +1698,7 @@ SymmetricTensor<rank,dim,Number>::operator [] (const unsigned int row)
     internal::SymmetricTensorAccessors::
     Accessor<rank,dim,false,rank-1,Number> (*this,
                                             internal::SymmetricTensor::get_partially_filled_indices<rank> (row,
-                                                internal::int2type<rank>()));
+                                                std::integral_constant<int, rank>()));
 }
 
 
@@ -1990,7 +1990,7 @@ namespace internal
       TableIndices<2>
       unrolled_to_component_indices
       (const unsigned int i,
-       const int2type<2> &)
+       const std::integral_constant<int, 2> &)
       {
         Assert ((i < dealii::SymmetricTensor<2,dim,double>::n_independent_components),
                 ExcIndexRange(i, 0, dealii::SymmetricTensor<2,dim,double>::n_independent_components));
@@ -2054,7 +2054,7 @@ namespace internal
       TableIndices<rank>
       unrolled_to_component_indices
       (const unsigned int i,
-       const int2type<rank> &)
+       const std::integral_constant<int, rank> &)
       {
         (void)i;
         Assert ((i < dealii::SymmetricTensor<rank,dim,double>::n_independent_components),
@@ -2075,7 +2075,7 @@ SymmetricTensor<rank,dim,Number>::unrolled_to_component_indices
 {
   return
     internal::SymmetricTensor::unrolled_to_component_indices<dim> (i,
-        internal::int2type<rank>());
+        std::integral_constant<int, rank>());
 }
 
 

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -254,21 +254,25 @@ namespace internal
    * still select which of the different <code>X::f()</code> we want based on
    * the <code>subdim</code> template argument.
    *
+   * @deprecated Use std::integral_constant instead.
+   *
    * @author Wolfgang Bangerth, 2006
    */
   template <int N>
   struct int2type
-  {};
+  {} DEAL_II_DEPRECATED;
 
 
   /**
    * The equivalent of the int2type class for boolean arguments.
    *
+   * @deprecated Use std::integral_constant instead.
+   *
    * @author Wolfgang Bangerth, 2009
    */
   template <bool B>
   struct bool2type
-  {};
+  {} DEAL_II_DEPRECATED;
 }
 
 

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -254,7 +254,7 @@ namespace internal
    * still select which of the different <code>X::f()</code> we want based on
    * the <code>subdim</code> template argument.
    *
-   * @deprecated Use std::integral_constant instead.
+   * @deprecated Use std::integral_constant<int, N> instead.
    *
    * @author Wolfgang Bangerth, 2006
    */
@@ -266,7 +266,7 @@ namespace internal
   /**
    * The equivalent of the int2type class for boolean arguments.
    *
-   * @deprecated Use std::integral_constant instead.
+   * @deprecated Use std::integral_constant<bool, B> instead.
    *
    * @author Wolfgang Bangerth, 2009
    */

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -821,7 +821,7 @@ namespace internal
     ArrayElementType &
     subscript (ArrayElementType *values,
                const unsigned int i,
-               dealii::internal::int2type<dim>)
+               std::integral_constant<int, dim>)
     {
       Assert (i<dim, ExcIndexRange(i, 0, dim));
       return values[i];
@@ -833,7 +833,7 @@ namespace internal
     ArrayElementType &
     subscript (ArrayElementType *,
                const unsigned int,
-               dealii::internal::int2type<0>)
+               std::integral_constant<int, 0>)
     {
       Assert(false, ExcMessage("Cannot access elements of an object of type Tensor<rank,0,Number>."));
       static ArrayElementType t;
@@ -849,7 +849,7 @@ DEAL_II_CUDA_HOST_DEV
 typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i)
 {
-  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
+  return dealii::internal::TensorSubscriptor::subscript(values, i, std::integral_constant<int, dim>());
 }
 
 
@@ -859,7 +859,7 @@ DEAL_II_CUDA_HOST_DEV
 const typename Tensor<rank_,dim,Number>::value_type &
 Tensor<rank_,dim,Number>::operator[] (const unsigned int i) const
 {
-  return dealii::internal::TensorSubscriptor::subscript(values, i, dealii::internal::int2type<dim>());
+  return dealii::internal::TensorSubscriptor::subscript(values, i, std::integral_constant<int, dim>());
 }
 
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -825,8 +825,8 @@ namespace parallel
        *
        * This function exists in 2d and 3d variants.
        */
-      void copy_new_triangulation_to_p4est (dealii::internal::int2type<2>);
-      void copy_new_triangulation_to_p4est (dealii::internal::int2type<3>);
+      void copy_new_triangulation_to_p4est (std::integral_constant<int, 2>);
+      void copy_new_triangulation_to_p4est (std::integral_constant<int, 3>);
 
       /**
        * Copy the local part of the refined forest from p4est into the

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -219,7 +219,7 @@ namespace internal
                      const unsigned int                      obj_index,
                      const unsigned int                      fe_index,
                      const unsigned int                      local_index,
-                     dealii::internal::int2type<1>)
+                     std::integral_constant<int, 1>)
       {
         return dof_handler.levels[obj_level]->dof_object.
                get_dof_index (dof_handler,
@@ -237,7 +237,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<1>,
+                     std::integral_constant<int, 1>,
                      const types::global_dof_index              global_index)
       {
         dof_handler.levels[obj_level]->dof_object.
@@ -257,7 +257,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<1>)
+                     std::integral_constant<int, 1>)
       {
         (void)obj_level;
         // faces have no levels
@@ -278,7 +278,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<1>,
+                     std::integral_constant<int, 1>,
                      const types::global_dof_index              global_index)
       {
         (void)obj_level;
@@ -301,7 +301,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<2>)
+                     std::integral_constant<int, 2>)
       {
         return dof_handler.levels[obj_level]->dof_object.
                get_dof_index (dof_handler,
@@ -319,7 +319,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<2>,
+                     std::integral_constant<int, 2>,
                      const types::global_dof_index              global_index)
       {
         dof_handler.levels[obj_level]->dof_object.
@@ -339,7 +339,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<1>)
+                     std::integral_constant<int, 1>)
       {
         (void)obj_level;
         // faces have no levels
@@ -360,7 +360,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<1>,
+                     std::integral_constant<int, 1>,
                      const types::global_dof_index              global_index)
       {
         (void)obj_level;
@@ -384,7 +384,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<2>)
+                     std::integral_constant<int, 2>)
       {
         (void)obj_level;
         // faces have no levels
@@ -405,7 +405,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<2>,
+                     std::integral_constant<int, 2>,
                      const types::global_dof_index              global_index)
       {
         (void)obj_level;
@@ -429,7 +429,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<3>)
+                     std::integral_constant<int, 3>)
       {
         return dof_handler.levels[obj_level]->dof_object.
                get_dof_index (dof_handler,
@@ -447,7 +447,7 @@ namespace internal
                      const unsigned int              obj_index,
                      const unsigned int              fe_index,
                      const unsigned int              local_index,
-                     dealii::internal::int2type<3>,
+                     std::integral_constant<int, 3>,
                      const types::global_dof_index              global_index)
       {
         dof_handler.levels[obj_level]->dof_object.
@@ -467,7 +467,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &)
+                     const std::integral_constant<int, 1> &)
       {
         return dof_handler.levels[obj_level]->
                get_dof_index (obj_index,
@@ -484,7 +484,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &,
+                     const std::integral_constant<int, 1> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.levels[obj_level]->
@@ -503,7 +503,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &)
+                     const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.
                get_dof_index (dof_handler,
@@ -522,7 +522,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &,
+                     const std::integral_constant<int, 1> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.faces->lines.
@@ -543,7 +543,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<2> &)
+                     const std::integral_constant<int, 2> &)
       {
         return dof_handler.levels[obj_level]->
                get_dof_index (obj_index,
@@ -560,7 +560,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<2> &,
+                     const std::integral_constant<int, 2> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.levels[obj_level]->
@@ -579,7 +579,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &)
+                     const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.
                get_dof_index (dof_handler,
@@ -598,7 +598,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<1> &,
+                     const std::integral_constant<int, 1> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.faces->lines.
@@ -619,7 +619,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<2> &)
+                     const std::integral_constant<int, 2> &)
       {
         return dof_handler.faces->quads.
                get_dof_index (dof_handler,
@@ -638,7 +638,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<2> &,
+                     const std::integral_constant<int, 2> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.faces->quads.
@@ -659,7 +659,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<3> &)
+                     const std::integral_constant<int, 3> &)
       {
         return dof_handler.levels[obj_level]->
                get_dof_index (obj_index,
@@ -676,7 +676,7 @@ namespace internal
                      const unsigned int       obj_index,
                      const unsigned int       fe_index,
                      const unsigned int       local_index,
-                     const dealii::internal::int2type<3> &,
+                     const std::integral_constant<int, 3> &,
                      const types::global_dof_index       global_index)
       {
         dof_handler.levels[obj_level]->
@@ -749,7 +749,7 @@ namespace internal
                           const unsigned int,
                           const unsigned int,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<structdim> &)
+                          const std::integral_constant<int, structdim> &)
       {
         return (fe_index == 0);
       }
@@ -762,7 +762,7 @@ namespace internal
       n_active_fe_indices (const dealii::DoFHandler<dim,spacedim> &dof_handler,
                            const unsigned int obj_level,
                            const unsigned int obj_index,
-                           const dealii::internal::int2type<structdim> &)
+                           const std::integral_constant<int, structdim> &)
       {
         (void)dof_handler;
         (void)obj_level;
@@ -811,7 +811,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<structdim> &)
+                           const std::integral_constant<int, structdim> &)
       {
         (void)dof_handler;
         (void)obj_level;
@@ -862,7 +862,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<1> &)
+                          const std::integral_constant<int, 1> &)
       {
         return dof_handler.levels[obj_level]->fe_index_is_active(obj_index,
                                                                  fe_index);
@@ -875,7 +875,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<1,spacedim> &,
                            const unsigned int /*obj_level*/,
                            const unsigned int /*obj_index*/,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         // on a cell, the number of active elements is one
         return 1;
@@ -890,7 +890,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         (void)n;
         Assert (n==0, ExcMessage("On cells, there can only be one active FE index"));
@@ -905,7 +905,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<1> &)
+                          const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.fe_index_is_active(dof_handler,
                                                            obj_index,
@@ -920,7 +920,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<2,spacedim> &dof_handler,
                            const unsigned int,
                            const unsigned int obj_index,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.n_active_fe_indices (dof_handler,
                                                              obj_index);
@@ -934,7 +934,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.nth_active_fe_index (dof_handler,
                                                              obj_level,
@@ -951,7 +951,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<2> &)
+                          const std::integral_constant<int, 2> &)
       {
         return dof_handler.levels[obj_level]->fe_index_is_active(obj_index,
                                                                  fe_index);
@@ -964,7 +964,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<2,spacedim> &,
                            const unsigned int /*obj_level*/,
                            const unsigned int /*obj_index*/,
-                           const dealii::internal::int2type<2> &)
+                           const std::integral_constant<int, 2> &)
       {
         // on a cell, the number of active elements is one
         return 1;
@@ -979,7 +979,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<2> &)
+                           const std::integral_constant<int, 2> &)
       {
         (void)n;
         Assert (n==0, ExcMessage("On cells, there can only be one active FE index"));
@@ -995,7 +995,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<1> &)
+                          const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.fe_index_is_active(dof_handler,
                                                            obj_index,
@@ -1010,7 +1010,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<3,spacedim> &dof_handler,
                            const unsigned int,
                            const unsigned int obj_index,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.n_active_fe_indices (dof_handler,
                                                              obj_index);
@@ -1025,7 +1025,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<1> &)
+                           const std::integral_constant<int, 1> &)
       {
         return dof_handler.faces->lines.nth_active_fe_index (dof_handler,
                                                              obj_level,
@@ -1042,7 +1042,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<2> &)
+                          const std::integral_constant<int, 2> &)
       {
         return dof_handler.faces->quads.fe_index_is_active(dof_handler,
                                                            obj_index,
@@ -1057,7 +1057,7 @@ namespace internal
                           const unsigned int obj_level,
                           const unsigned int obj_index,
                           const unsigned int fe_index,
-                          const dealii::internal::int2type<3> &)
+                          const std::integral_constant<int, 3> &)
       {
         return dof_handler.levels[obj_level]->fe_index_is_active(obj_index,
                                                                  fe_index);
@@ -1070,7 +1070,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<3,spacedim> &dof_handler,
                            const unsigned int,
                            const unsigned int obj_index,
-                           const dealii::internal::int2type<2> &)
+                           const std::integral_constant<int, 2> &)
       {
         return dof_handler.faces->quads.n_active_fe_indices (dof_handler,
                                                              obj_index);
@@ -1085,7 +1085,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<2> &)
+                           const std::integral_constant<int, 2> &)
       {
         return dof_handler.faces->quads.nth_active_fe_index (dof_handler,
                                                              obj_level,
@@ -1101,7 +1101,7 @@ namespace internal
       n_active_fe_indices (const dealii::hp::DoFHandler<3,spacedim> &,
                            const unsigned int /*obj_level*/,
                            const unsigned int /*obj_index*/,
-                           const dealii::internal::int2type<3> &)
+                           const std::integral_constant<int, 3> &)
       {
         // on a cell, the number of active elements is one
         return 1;
@@ -1116,7 +1116,7 @@ namespace internal
                            const unsigned int obj_level,
                            const unsigned int obj_index,
                            const unsigned int n,
-                           const dealii::internal::int2type<3> &)
+                           const std::integral_constant<int, 3> &)
       {
         (void)n;
         Assert (n==0, ExcMessage("On cells, there can only be one active FE index"));
@@ -1609,7 +1609,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::dof_index (const unsigned int 
          this->present_index,
          fe_index,
          i,
-         dealii::internal::int2type<dim>());
+         std::integral_constant<int, dim>());
 }
 
 
@@ -1636,7 +1636,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::set_dof_index (const unsigned 
       this->present_index,
       fe_index,
       i,
-      dealii::internal::int2type<dim>(),
+      std::integral_constant<int, dim>(),
       index);
 }
 
@@ -1653,7 +1653,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::n_active_fe_indices () const
     n_active_fe_indices (*this->dof_handler,
                          this->level(),
                          this->present_index,
-                         dealii::internal::int2type<dim>());
+                         std::integral_constant<int, dim>());
 }
 
 
@@ -1670,7 +1670,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::nth_active_fe_index (const uns
                          this->level(),
                          this->present_index,
                          n,
-                         dealii::internal::int2type<dim>());
+                         std::integral_constant<int, dim>());
 }
 
 
@@ -1687,7 +1687,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::fe_index_is_active (const unsi
                         this->level(),
                         this->present_index,
                         fe_index,
-                        dealii::internal::int2type<dim>());
+                        std::integral_constant<int, dim>());
 }
 
 
@@ -3512,7 +3512,7 @@ namespace internal
     TriaIterator<dealii::DoFAccessor<DoFHandlerType::dimension-1,DoFHandlerType,level_dof_access> >
     get_face (const dealii::DoFCellAccessor<DoFHandlerType,level_dof_access> &cell,
               const unsigned int i,
-              const dealii::internal::int2type<1>)
+              const std::integral_constant<int, 1>)
     {
       dealii::DoFAccessor<0, DoFHandlerType,level_dof_access>
       a (&cell.get_triangulation(),
@@ -3536,7 +3536,7 @@ namespace internal
     TriaIterator<dealii::DoFAccessor<DoFHandlerType::dimension-1,DoFHandlerType,level_dof_access> >
     get_face (const dealii::DoFCellAccessor<DoFHandlerType,level_dof_access> &cell,
               const unsigned int i,
-              const dealii::internal::int2type<2>)
+              const std::integral_constant<int, 2>)
     {
       return cell.line(i);
     }
@@ -3547,7 +3547,7 @@ namespace internal
     TriaIterator<dealii::DoFAccessor<DoFHandlerType::dimension-1,DoFHandlerType,level_dof_access> >
     get_face (const dealii::DoFCellAccessor<DoFHandlerType,level_dof_access> &cell,
               const unsigned int i,
-              const dealii::internal::int2type<3>)
+              const std::integral_constant<int, 3>)
     {
       return cell.quad(i);
     }
@@ -3563,7 +3563,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::face (const unsigned int i) co
   Assert (i<GeometryInfo<dim>::faces_per_cell, ExcIndexRange (i, 0, GeometryInfo<dim>::faces_per_cell));
 
   const unsigned int dim = DoFHandlerType::dimension;
-  return dealii::internal::DoFCellAccessor::get_face (*this, i, dealii::internal::int2type<dim>());
+  return dealii::internal::DoFCellAccessor::get_face (*this, i, std::integral_constant<int, dim>());
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -290,7 +290,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<1> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<dim> *faces,
-                 const dealii::internal::int2type<1>)
+                 const std::integral_constant<int, 1>)
     {
       return &faces->lines;
     }
@@ -300,7 +300,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<2> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<dim> *faces,
-                 const dealii::internal::int2type<2>)
+                 const std::integral_constant<int, 2>)
     {
       return &faces->quads;
     }
@@ -308,7 +308,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<1> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<1> *,
-                 const dealii::internal::int2type<1>)
+                 const std::integral_constant<int, 1>)
     {
       Assert (false, ExcInternalError());
       return nullptr;
@@ -317,7 +317,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<2> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<2> *,
-                 const dealii::internal::int2type<2>)
+                 const std::integral_constant<int, 2>)
     {
       Assert (false, ExcInternalError());
       return nullptr;
@@ -326,7 +326,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<3> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<3> *,
-                 const dealii::internal::int2type<3>)
+                 const std::integral_constant<int, 3>)
     {
       Assert (false, ExcInternalError());
       return nullptr;
@@ -340,7 +340,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<3> > *
     get_objects (dealii::internal::Triangulation::TriaFaces<dim> *,
-                 const dealii::internal::int2type<3>)
+                 const std::integral_constant<int, 3>)
     {
       Assert (false, ExcInternalError());
       return nullptr;
@@ -353,7 +353,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<structdim> > *
     get_objects (dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *,
-                 const dealii::internal::int2type<structdim>)
+                 const std::integral_constant<int, structdim>)
     {
       Assert (false, ExcInternalError());
       return nullptr;
@@ -363,7 +363,7 @@ namespace internal
     inline
     dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *
     get_objects (dealii::internal::Triangulation::TriaObjects<dealii::internal::Triangulation::TriaObject<dim> > *cells,
-                 const dealii::internal::int2type<dim>)
+                 const std::integral_constant<int, dim>)
     {
       return cells;
     }
@@ -382,10 +382,10 @@ TriaAccessorBase<structdim,dim,spacedim>::objects() const
     // current class is only used for
     // objects that are *not* cells
     return *dealii::internal::TriaAccessorBase::get_objects (this->tria->faces.get(),
-                                                             dealii::internal::int2type<structdim> ());
+                                                             std::integral_constant<int, structdim> ());
   else
     return *dealii::internal::TriaAccessorBase::get_objects (&this->tria->levels[this->present_level]->cells,
-                                                             dealii::internal::int2type<structdim> ());
+                                                             std::integral_constant<int, structdim> ());
 }
 
 

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -1399,7 +1399,7 @@ private:
                               MatrixType                   &global_matrix,
                               VectorType                   &global_vector,
                               bool                          use_inhomogeneities_for_rhs,
-                              internal::bool2type<false>) const;
+                              std::integral_constant<bool, false>) const;
 
   /**
    * This function actually implements the local_to_global function for block
@@ -1413,7 +1413,7 @@ private:
                               MatrixType                   &global_matrix,
                               VectorType                   &global_vector,
                               bool                          use_inhomogeneities_for_rhs,
-                              internal::bool2type<true>) const;
+                              std::integral_constant<bool, true>) const;
 
   /**
    * This function actually implements the local_to_global function for
@@ -1425,7 +1425,7 @@ private:
                                SparsityPatternType          &sparsity_pattern,
                                const bool                    keep_constrained_entries,
                                const Table<2,bool>          &dof_mask,
-                               internal::bool2type<false>) const;
+                               std::integral_constant<bool, false>) const;
 
   /**
    * This function actually implements the local_to_global function for block
@@ -1437,7 +1437,7 @@ private:
                                SparsityPatternType          &sparsity_pattern,
                                const bool                    keep_constrained_entries,
                                const Table<2,bool>          &dof_mask,
-                               internal::bool2type<true>) const;
+                               std::integral_constant<bool, true>) const;
 
   /**
    * Internal helper function for distribute_local_to_global function.
@@ -1888,7 +1888,7 @@ distribute_local_to_global (const FullMatrix<typename MatrixType::value_type>   
   Vector<typename MatrixType::value_type> dummy(0);
   distribute_local_to_global (local_matrix, dummy, local_dof_indices,
                               global_matrix, dummy, false,
-                              dealii::internal::bool2type<IsBlockMatrix<MatrixType>::value>());
+                              std::integral_constant<bool, IsBlockMatrix<MatrixType>::value>());
 }
 
 
@@ -1909,7 +1909,7 @@ distribute_local_to_global (const FullMatrix<typename MatrixType::value_type>   
   // the actual implementation follows in the cm.templates.h file.
   distribute_local_to_global (local_matrix, local_vector, local_dof_indices,
                               global_matrix, global_vector, use_inhomogeneities_for_rhs,
-                              dealii::internal::bool2type<IsBlockMatrix<MatrixType>::value>());
+                              std::integral_constant<bool, IsBlockMatrix<MatrixType>::value>());
 }
 
 
@@ -1928,7 +1928,7 @@ add_entries_local_to_global (const std::vector<size_type> &local_dof_indices,
   // the actual implementation follows in the cm.templates.h file.
   add_entries_local_to_global (local_dof_indices, sparsity_pattern,
                                keep_constrained_entries, dof_mask,
-                               internal::bool2type<IsBlockMatrix<SparsityPatternType>::value>());
+                               std::integral_constant<bool, IsBlockMatrix<SparsityPatternType>::value>());
 }
 
 

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -555,14 +555,14 @@ namespace internal
       }
 
       template <class VEC>
-      void set_zero_in_parallel(const std::vector<size_type> &cm, VEC &vec, internal::bool2type<false>)
+      void set_zero_in_parallel(const std::vector<size_type> &cm, VEC &vec, std::integral_constant<bool, false>)
       {
         set_zero_parallel(cm, vec, 0);
       }
 
       // in parallel for BlockVectors
       template <class VEC>
-      void set_zero_in_parallel(const std::vector<size_type> &cm, VEC &vec, internal::bool2type<true>)
+      void set_zero_in_parallel(const std::vector<size_type> &cm, VEC &vec, std::integral_constant<bool, true>)
       {
         size_type start_shift = 0;
         for (size_type j=0; j<vec.n_blocks(); ++j)
@@ -583,7 +583,7 @@ namespace internal
       template <class VEC>
       void set_zero_all(const std::vector<size_type> &cm, VEC &vec)
       {
-        set_zero_in_parallel<VEC>(cm, vec, internal::bool2type<IsBlockVector<VEC>::value>());
+        set_zero_in_parallel<VEC>(cm, vec, std::integral_constant<bool, IsBlockVector<VEC>::value>());
         vec.compress(VectorOperation::insert);
       }
 
@@ -748,7 +748,7 @@ namespace internal
                                        const IndexSet                      &/*locally_owned_elements*/,
                                        const IndexSet                      &needed_elements,
                                        TrilinosWrappers::MPI::Vector       &output,
-                                       const internal::bool2type<false>     /*is_block_vector*/)
+                                       const std::integral_constant<bool, false>     /*is_block_vector*/)
     {
       Assert(!vec.has_ghost_elements(),
              ExcGhostsPresent());
@@ -771,7 +771,7 @@ namespace internal
                                        const IndexSet                   &locally_owned_elements,
                                        const IndexSet                   &needed_elements,
                                        PETScWrappers::MPI::Vector       &output,
-                                       const internal::bool2type<false>  /*is_block_vector*/)
+                                       const std::integral_constant<bool, false>  /*is_block_vector*/)
     {
       output.reinit (locally_owned_elements, needed_elements, vec.get_mpi_communicator());
       output = vec;
@@ -784,7 +784,7 @@ namespace internal
                                        const IndexSet                              &locally_owned_elements,
                                        const IndexSet                              &needed_elements,
                                        LinearAlgebra::distributed::Vector<number>       &output,
-                                       const internal::bool2type<false>             /*is_block_vector*/)
+                                       const std::integral_constant<bool, false>             /*is_block_vector*/)
     {
       // TODO: the in vector might already have all elements. need to find a
       // way to efficiently avoid the copy then
@@ -803,7 +803,7 @@ namespace internal
                                        const IndexSet                   &/*locally_owned_elements*/,
                                        const IndexSet                   &/*needed_elements*/,
                                        Vector                           &/*output*/,
-                                       const internal::bool2type<false>  /*is_block_vector*/)
+                                       const std::integral_constant<bool, false>  /*is_block_vector*/)
     {
       Assert (false, ExcMessage ("We shouldn't even get here!"));
     }
@@ -816,7 +816,7 @@ namespace internal
                                        const IndexSet                  &locally_owned_elements,
                                        const IndexSet                  &needed_elements,
                                        VectorType                      &output,
-                                       const internal::bool2type<true>  /*is_block_vector*/)
+                                       const std::integral_constant<bool, true>  /*is_block_vector*/)
     {
       output.reinit (vec.n_blocks());
 
@@ -827,7 +827,7 @@ namespace internal
                                              locally_owned_elements.get_view (block_start, block_start+vec.block(b).size()),
                                              needed_elements.get_view (block_start, block_start+vec.block(b).size()),
                                              output.block(b),
-                                             internal::bool2type<false>());
+                                             std::integral_constant<bool, false>());
           block_start += vec.block(b).size();
         }
 
@@ -884,7 +884,7 @@ ConstraintMatrix::distribute (VectorType &vec) const
       internal::import_vector_with_ghost_elements (vec,
                                                    vec_owned_elements, needed_elements,
                                                    ghosted_vector,
-                                                   internal::bool2type<IsBlockVector<VectorType>::value>());
+                                                   std::integral_constant<bool, IsBlockVector<VectorType>::value>());
 
       for (constraint_iterator it = lines.begin();
            it != lines.end(); ++it)
@@ -2233,7 +2233,7 @@ ConstraintMatrix::distribute_local_to_global (
   MatrixType                      &global_matrix,
   VectorType                      &global_vector,
   bool                            use_inhomogeneities_for_rhs,
-  internal::bool2type<false>) const
+  std::integral_constant<bool, false>) const
 {
   // check whether we work on real vectors or we just used a dummy when
   // calling the other function above.
@@ -2376,7 +2376,7 @@ distribute_local_to_global (const FullMatrix<typename MatrixType::value_type>  &
                             MatrixType                   &global_matrix,
                             VectorType                   &global_vector,
                             bool                          use_inhomogeneities_for_rhs,
-                            internal::bool2type<true>) const
+                            std::integral_constant<bool, true>) const
 {
   const bool use_vectors = (local_vector.size() == 0 &&
                             global_vector.size() == 0) ? false : true;
@@ -2563,7 +2563,7 @@ add_entries_local_to_global (const std::vector<size_type> &local_dof_indices,
                              SparsityPatternType          &sparsity_pattern,
                              const bool                    keep_constrained_entries,
                              const Table<2,bool>          &dof_mask,
-                             internal::bool2type<false> ) const
+                             std::integral_constant<bool, false> ) const
 {
   Assert (sparsity_pattern.n_rows() == sparsity_pattern.n_cols(), ExcNotQuadratic());
 
@@ -2716,7 +2716,7 @@ add_entries_local_to_global (const std::vector<size_type> &local_dof_indices,
                              SparsityPatternType          &sparsity_pattern,
                              const bool                    keep_constrained_entries,
                              const Table<2,bool>          &dof_mask,
-                             internal::bool2type<true> ) const
+                             std::integral_constant<bool, true> ) const
 {
   // just as the other add_entries_local_to_global function, but now
   // specialized for block matrices.

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -369,8 +369,8 @@ namespace TrilinosWrappers
     void vmult (VectorType1       &dst,
                 const VectorType2 &src,
                 const bool         transpose,
-                const dealii::internal::bool2type<true>,
-                const dealii::internal::bool2type<true>) const;
+                const std::integral_constant<bool, true>,
+                const std::integral_constant<bool, true>) const;
 
     /**
      * Internal version of (T)vmult where the source vector is a block vector
@@ -380,8 +380,8 @@ namespace TrilinosWrappers
     void vmult (VectorType1       &dst,
                 const VectorType2 &src,
                 const bool         transpose,
-                const dealii::internal::bool2type<false>,
-                const dealii::internal::bool2type<true>) const;
+                const std::integral_constant<bool, false>,
+                const std::integral_constant<bool, true>) const;
 
     /**
      * Internal version of (T)vmult where the source vector is a non-block
@@ -391,8 +391,8 @@ namespace TrilinosWrappers
     void vmult (VectorType1       &dst,
                 const VectorType2 &src,
                 const bool         transpose,
-                const dealii::internal::bool2type<true>,
-                const dealii::internal::bool2type<false>) const;
+                const std::integral_constant<bool, true>,
+                const std::integral_constant<bool, false>) const;
 
     /**
      * Internal version of (T)vmult where both source vector and the
@@ -403,8 +403,8 @@ namespace TrilinosWrappers
     void vmult (VectorType1       &dst,
                 const VectorType2 &src,
                 const bool         transpose,
-                const dealii::internal::bool2type<false>,
-                const dealii::internal::bool2type<false>) const;
+                const std::integral_constant<bool, false>,
+                const std::integral_constant<bool, false>) const;
   };
 
 
@@ -455,8 +455,8 @@ namespace TrilinosWrappers
                             const VectorType2 &src) const
   {
     vmult(dst, src, false,
-          dealii::internal::bool2type<IsBlockVector<VectorType1>::value>(),
-          dealii::internal::bool2type<IsBlockVector<VectorType2>::value>());
+          std::integral_constant<bool, IsBlockVector<VectorType1>::value>(),
+          std::integral_constant<bool, IsBlockVector<VectorType2>::value>());
   }
 
 
@@ -468,8 +468,8 @@ namespace TrilinosWrappers
                              const VectorType2 &src) const
   {
     vmult(dst, src, true,
-          dealii::internal::bool2type<IsBlockVector<VectorType1>::value>(),
-          dealii::internal::bool2type<IsBlockVector<VectorType2>::value>());
+          std::integral_constant<bool, IsBlockVector<VectorType1>::value>(),
+          std::integral_constant<bool, IsBlockVector<VectorType2>::value>());
   }
 
 
@@ -480,8 +480,8 @@ namespace TrilinosWrappers
   BlockSparseMatrix::vmult (VectorType1       &dst,
                             const VectorType2 &src,
                             const bool         transpose,
-                            dealii::internal::bool2type<true>,
-                            dealii::internal::bool2type<true>) const
+                            std::integral_constant<bool, true>,
+                            std::integral_constant<bool, true>) const
   {
     if (transpose == true)
       BaseClass::Tvmult_block_block (dst, src);
@@ -498,8 +498,8 @@ namespace TrilinosWrappers
   BlockSparseMatrix::vmult (VectorType1       &dst,
                             const VectorType2 &src,
                             const bool         transpose,
-                            dealii::internal::bool2type<false>,
-                            dealii::internal::bool2type<true>) const
+                            std::integral_constant<bool, false>,
+                            std::integral_constant<bool, true>) const
   {
     if (transpose == true)
       BaseClass::Tvmult_nonblock_block (dst, src);
@@ -515,8 +515,8 @@ namespace TrilinosWrappers
   BlockSparseMatrix::vmult (VectorType1       &dst,
                             const VectorType2 &src,
                             const bool         transpose,
-                            dealii::internal::bool2type<true>,
-                            dealii::internal::bool2type<false>) const
+                            std::integral_constant<bool, true>,
+                            std::integral_constant<bool, false>) const
   {
     if (transpose == true)
       BaseClass::Tvmult_block_nonblock (dst, src);
@@ -532,8 +532,8 @@ namespace TrilinosWrappers
   BlockSparseMatrix::vmult (VectorType1       &dst,
                             const VectorType2 &src,
                             const bool         transpose,
-                            dealii::internal::bool2type<false>,
-                            dealii::internal::bool2type<false>) const
+                            std::integral_constant<bool, false>,
+                            std::integral_constant<bool, false>) const
   {
     if (transpose == true)
       BaseClass::Tvmult_nonblock_nonblock (dst, src);

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -942,7 +942,7 @@ namespace internal
           // version often enough, we need to have all tasks but the last one
           // to be divisible by the vectorization length
           accumulate_regular(op, n_chunks, index, outer_results,
-                             internal::bool2type<Operation::vectorizes>());
+                             std::integral_constant<bool, Operation::vectorizes>());
 
           // now work on the remainder, i.e., the last up to 32 values. Use
           // switch statement with fall-through to work on these values.
@@ -1039,7 +1039,7 @@ namespace internal
                        size_type       &n_chunks,
                        size_type       &index,
                        ResultType (&outer_results)[vector_accumulation_recursion_threshold],
-                       internal::bool2type<false>)
+                       std::integral_constant<bool, false>)
     {
       // note that each chunk is chosen to have a width of 32, thereby the index
       // is incremented by 4*8 for each @p i.
@@ -1076,7 +1076,7 @@ namespace internal
                        size_type       &n_chunks,
                        size_type       &index,
                        Number (&outer_results)[vector_accumulation_recursion_threshold],
-                       internal::bool2type<true>)
+                       std::integral_constant<bool, true>)
     {
       // we start from @p index and workout @p n_chunks each of size 32.
       // in order employ SIMD and work on @p nvecs at a time, we split this

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2703,7 +2703,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<true>) const
+                             std::integral_constant<bool, true>) const
     {
       res.gather(vec.begin(), indices);
     }
@@ -2714,7 +2714,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<false>) const
+                             std::integral_constant<bool, false>) const
     {
       for (unsigned int v=0; v<VectorizedArray<Number>::n_array_elements; ++v)
         res[v] = vector_access(const_cast<const VectorType &>(vec), indices[v]);
@@ -2773,7 +2773,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<true>) const
+                             std::integral_constant<bool, true>) const
     {
       // TODO: enable scatter path when indices are fixed
       //#if DEAL_II_COMPILER_VECTORIZATION_LEVEL < 3
@@ -2795,7 +2795,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<false>) const
+                             std::integral_constant<bool, false>) const
     {
       for (unsigned int v=0; v<VectorizedArray<Number>::n_array_elements; ++v)
         vector_access(vec, indices[v]) += res[v];
@@ -2851,7 +2851,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<true>) const
+                             std::integral_constant<bool, true>) const
     {
       res.scatter(indices, vec.begin());
     }
@@ -2860,7 +2860,7 @@ namespace internal
     void process_dof_gather (const unsigned int      *indices,
                              VectorType              &vec,
                              VectorizedArray<Number> &res,
-                             internal::bool2type<false>) const
+                             std::integral_constant<bool, false>) const
     {
       for (unsigned int v=0; v<VectorizedArray<Number>::n_array_elements; ++v)
         vector_access(vec, indices[v]) = res[v];
@@ -3083,7 +3083,7 @@ FEEvaluationBase<dim,n_components_,Number>
                 for (unsigned int comp=0; comp<n_components; ++comp)
                   operation.process_dof_gather(dof_indices+ind,
                                                *src[comp], values_dofs[comp][j],
-                                               dealii::internal::bool2type<types_are_equal<typename VectorType::value_type,Number>::value>());
+                                               std::integral_constant<bool, types_are_equal<typename VectorType::value_type,Number>::value>());
             }
         }
 
@@ -3226,7 +3226,7 @@ FEEvaluationBase<dim,n_components_,Number>
                 for (unsigned int j=0; j<dofs_per_cell; ++j, ind += VectorizedArray<Number>::n_array_elements)
                   operation.process_dof_gather(dof_indices+ind,
                                                *src[0], values_dofs[comp][j],
-                                               dealii::internal::bool2type<types_are_equal<typename VectorType::value_type,Number>::value>());
+                                               std::integral_constant<bool, types_are_equal<typename VectorType::value_type,Number>::value>());
             }
         }
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1773,11 +1773,11 @@ namespace internal
   void update_ghost_values_finish_block (const VectorStruct &vec,
                                          std::integral_constant<bool, true>);
   template <typename VectorStruct>
-  void compress_start_block (const VectorStruct &vec,
+  void compress_start_block (VectorStruct       &vec,
                              const unsigned int channel,
                              std::integral_constant<bool, true>);
   template <typename VectorStruct>
-  void compress_finish_block (const VectorStruct &vec,
+  void compress_finish_block (VectorStruct &vec,
                               std::integral_constant<bool, true>);
 
   template <typename VectorStruct>
@@ -1797,12 +1797,12 @@ namespace internal
                                          std::integral_constant<bool, false>)
   {}
   template <typename VectorStruct>
-  void compress_start_block (const VectorStruct &,
+  void compress_start_block (VectorStruct &,
                              const unsigned int,
                              std::integral_constant<bool, false>)
   {}
   template <typename VectorStruct>
-  void compress_finish_block (const VectorStruct &,
+  void compress_finish_block (VectorStruct &,
                               std::integral_constant<bool, false>)
   {}
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1764,46 +1764,46 @@ namespace internal
   template <typename VectorStruct>
   bool update_ghost_values_start_block (const VectorStruct &vec,
                                         const unsigned int channel,
-                                        internal::bool2type<true>);
+                                        std::integral_constant<bool, true>);
   template <typename VectorStruct>
   void reset_ghost_values_block (const VectorStruct &vec,
                                  const bool          zero_out_ghosts,
-                                 internal::bool2type<true>);
+                                 std::integral_constant<bool, true>);
   template <typename VectorStruct>
   void update_ghost_values_finish_block (const VectorStruct &vec,
-                                         internal::bool2type<true>);
+                                         std::integral_constant<bool, true>);
   template <typename VectorStruct>
   void compress_start_block (const VectorStruct &vec,
                              const unsigned int channel,
-                             internal::bool2type<true>);
+                             std::integral_constant<bool, true>);
   template <typename VectorStruct>
   void compress_finish_block (const VectorStruct &vec,
-                              internal::bool2type<true>);
+                              std::integral_constant<bool, true>);
 
   template <typename VectorStruct>
   bool update_ghost_values_start_block (const VectorStruct &,
                                         const unsigned int,
-                                        internal::bool2type<false>)
+                                        std::integral_constant<bool, false>)
   {
     return false;
   }
   template <typename VectorStruct>
   void reset_ghost_values_block (const VectorStruct &,
                                  const bool,
-                                 internal::bool2type<false>)
+                                 std::integral_constant<bool, false>)
   {}
   template <typename VectorStruct>
   void update_ghost_values_finish_block (const VectorStruct &,
-                                         internal::bool2type<false>)
+                                         std::integral_constant<bool, false>)
   {}
   template <typename VectorStruct>
   void compress_start_block (const VectorStruct &,
                              const unsigned int,
-                             internal::bool2type<false>)
+                             std::integral_constant<bool, false>)
   {}
   template <typename VectorStruct>
   void compress_finish_block (const VectorStruct &,
-                              internal::bool2type<false>)
+                              std::integral_constant<bool, false>)
   {}
 
 
@@ -1817,7 +1817,7 @@ namespace internal
   {
     return
       update_ghost_values_start_block(vec, channel,
-                                      internal::bool2type<IsBlockVector<VectorStruct>::value>());
+                                      std::integral_constant<bool, IsBlockVector<VectorStruct>::value>());
   }
 
 
@@ -1862,7 +1862,7 @@ namespace internal
   inline
   bool update_ghost_values_start_block (const VectorStruct &vec,
                                         const unsigned int channel,
-                                        internal::bool2type<true>)
+                                        std::integral_constant<bool, true>)
   {
     bool return_value = false;
     for (unsigned int i=0; i<vec.n_blocks(); ++i)
@@ -1881,7 +1881,7 @@ namespace internal
                            const bool          zero_out_ghosts)
   {
     reset_ghost_values_block(vec, zero_out_ghosts,
-                             internal::bool2type<IsBlockVector<VectorStruct>::value>());
+                             std::integral_constant<bool, IsBlockVector<VectorStruct>::value>());
   }
 
 
@@ -1923,7 +1923,7 @@ namespace internal
   inline
   void reset_ghost_values_block (const VectorStruct &vec,
                                  const bool          zero_out_ghosts,
-                                 internal::bool2type<true>)
+                                 std::integral_constant<bool, true>)
   {
     for (unsigned int i=0; i<vec.n_blocks(); ++i)
       reset_ghost_values(vec.block(i), zero_out_ghosts);
@@ -1936,7 +1936,7 @@ namespace internal
   void update_ghost_values_finish (const VectorStruct &vec)
   {
     update_ghost_values_finish_block(vec,
-                                     internal::bool2type<IsBlockVector<VectorStruct>::value>());
+                                     std::integral_constant<bool, IsBlockVector<VectorStruct>::value>());
   }
 
 
@@ -1973,7 +1973,7 @@ namespace internal
   template <typename VectorStruct>
   inline
   void update_ghost_values_finish_block (const VectorStruct &vec,
-                                         internal::bool2type<true>)
+                                         std::integral_constant<bool, true>)
   {
     for (unsigned int i=0; i<vec.n_blocks(); ++i)
       update_ghost_values_finish(vec.block(i));
@@ -1987,7 +1987,7 @@ namespace internal
                        const unsigned int channel = 0)
   {
     compress_start_block (vec, channel,
-                          internal::bool2type<IsBlockVector<VectorStruct>::value>());
+                          std::integral_constant<bool, IsBlockVector<VectorStruct>::value>());
   }
 
 
@@ -2026,7 +2026,7 @@ namespace internal
   inline
   void compress_start_block (VectorStruct      &vec,
                              const unsigned int channel,
-                             internal::bool2type<true>)
+                             std::integral_constant<bool, true>)
   {
     for (unsigned int i=0; i<vec.n_blocks(); ++i)
       compress_start(vec.block(i), channel + 500*i);
@@ -2039,7 +2039,7 @@ namespace internal
   void compress_finish (VectorStruct &vec)
   {
     compress_finish_block(vec,
-                          internal::bool2type<IsBlockVector<VectorStruct>::value>());
+                          std::integral_constant<bool, IsBlockVector<VectorStruct>::value>());
   }
 
 
@@ -2076,7 +2076,7 @@ namespace internal
   template <typename VectorStruct>
   inline
   void compress_finish_block (VectorStruct &vec,
-                              internal::bool2type<true>)
+                              std::integral_constant<bool, true>)
   {
     for (unsigned int i=0; i<vec.n_blocks(); ++i)
       compress_finish(vec.block(i));

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1343,7 +1343,7 @@ namespace parallel
 
       setup_coarse_cell_to_p4est_tree_permutation ();
 
-      copy_new_triangulation_to_p4est (dealii::internal::int2type<dim>());
+      copy_new_triangulation_to_p4est (std::integral_constant<int, dim>());
 
       try
         {
@@ -1997,7 +1997,7 @@ namespace parallel
 
     template <>
     void
-    Triangulation<2,2>::copy_new_triangulation_to_p4est (dealii::internal::int2type<2>)
+    Triangulation<2,2>::copy_new_triangulation_to_p4est (std::integral_constant<int, 2>)
     {
       const unsigned int dim = 2, spacedim = 2;
       Assert (this->n_cells(0) > 0, ExcInternalError());
@@ -2068,7 +2068,7 @@ namespace parallel
     // specialize the dim template argument, but let spacedim open
     template <>
     void
-    Triangulation<2,3>::copy_new_triangulation_to_p4est (dealii::internal::int2type<2>)
+    Triangulation<2,3>::copy_new_triangulation_to_p4est (std::integral_constant<int, 2>)
     {
       const unsigned int dim = 2, spacedim = 3;
       Assert (this->n_cells(0) > 0, ExcInternalError());
@@ -2137,7 +2137,7 @@ namespace parallel
 
     template <>
     void
-    Triangulation<3,3>::copy_new_triangulation_to_p4est (dealii::internal::int2type<3>)
+    Triangulation<3,3>::copy_new_triangulation_to_p4est (std::integral_constant<int, 3>)
     {
       const int dim = 3, spacedim = 3;
       Assert (this->n_cells(0) > 0, ExcInternalError());
@@ -3693,7 +3693,7 @@ namespace parallel
           setup_coarse_cell_to_p4est_tree_permutation ();
         }
 
-      copy_new_triangulation_to_p4est (dealii::internal::int2type<dim>());
+      copy_new_triangulation_to_p4est (std::integral_constant<int, dim>());
 
       try
         {

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -556,7 +556,7 @@ namespace internal
         const unsigned int obj_index,
         const unsigned int fe_index,
         const unsigned int local_index,
-        const int2type<1>)
+        const std::integral_constant<int, 1>)
       {
         return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -564,7 +564,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const int2type<1>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
         return mg_faces.lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -572,7 +572,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const int2type<2>)
+      get_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
         return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -580,7 +580,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const int2type<1>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 1>)
       {
         return mg_faces.lines.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -588,7 +588,7 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const int2type<2>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 2>)
       {
         return mg_faces.quads.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
@@ -596,49 +596,49 @@ namespace internal
       template <int spacedim>
       static
       types::global_dof_index
-      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const int2type<3>)
+      get_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const std::integral_constant<int, 3>)
       {
         return mg_level.dof_object.get_dof_index (dof_handler, obj_index, fe_index, local_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<1> &mg_level, internal::DoFHandler::DoFFaces<1> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<1>)
+      void set_dof_index (const DoFHandler<1, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<1> &mg_level, internal::DoFHandler::DoFFaces<1> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<1>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &, internal::DoFHandler::DoFFaces<2> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_faces.lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<2>)
+      void set_dof_index (const DoFHandler<2, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<2> &mg_level, internal::DoFHandler::DoFFaces<2> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
         mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<1>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 1>)
       {
         mg_faces.lines.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<2>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &, internal::DoFHandler::DoFFaces<3> &mg_faces, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 2>)
       {
         mg_faces.quads.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
 
       template <int spacedim>
       static
-      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const int2type<3>)
+      void set_dof_index (const DoFHandler<3, spacedim> &dof_handler, internal::DoFHandler::DoFLevel<3> &mg_level, internal::DoFHandler::DoFFaces<3> &, const unsigned int obj_index, const unsigned int fe_index, const unsigned int local_index, const types::global_dof_index global_index, const std::integral_constant<int, 3>)
       {
         mg_level.dof_object.set_dof_index (dof_handler, obj_index, fe_index, local_index, global_index);
       }
@@ -1221,7 +1221,7 @@ DoFHandler<dim, spacedim>::get_dof_index (const unsigned int obj_level,
   return internal::DoFHandler::Implementation::get_dof_index (*this, *this->mg_levels[obj_level],
                                                               *this->mg_faces, obj_index,
                                                               fe_index, local_index,
-                                                              internal::int2type<structdim> ());
+                                                              std::integral_constant<int, structdim> ());
 }
 
 
@@ -1241,7 +1241,7 @@ void DoFHandler<dim, spacedim>::set_dof_index (const unsigned int obj_level,
                                                        fe_index,
                                                        local_index,
                                                        global_index,
-                                                       internal::int2type<structdim> ());
+                                                       std::integral_constant<int, structdim> ());
 }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1166,7 +1166,7 @@ namespace internal
         types::global_dof_index
         distribute_mg_dofs_on_cell (const typename DoFHandler<dim,spacedim>::level_cell_iterator &cell,
                                     types::global_dof_index   next_free_dof,
-                                    const internal::int2type<1> &)
+                                    const std::integral_constant<int, 1> &)
         {
           // distribute dofs of vertices
           if (cell->get_fe().dofs_per_vertex > 0)
@@ -1219,7 +1219,7 @@ namespace internal
         types::global_dof_index
         distribute_mg_dofs_on_cell (const typename DoFHandler<dim,spacedim>::level_cell_iterator &cell,
                                     types::global_dof_index   next_free_dof,
-                                    const internal::int2type<2> &)
+                                    const std::integral_constant<int, 2> &)
         {
           if (cell->get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
@@ -1265,7 +1265,7 @@ namespace internal
         types::global_dof_index
         distribute_mg_dofs_on_cell (const typename DoFHandler<dim,spacedim>::level_cell_iterator &cell,
                                     types::global_dof_index   next_free_dof,
-                                    const internal::int2type<3> &)
+                                    const std::integral_constant<int, 3> &)
         {
           if (cell->get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
@@ -1402,7 +1402,7 @@ namespace internal
                 (cell->level_subdomain_id() == level_subdomain_id))
               next_free_dof
                 = Implementation::distribute_mg_dofs_on_cell<dim,spacedim> (cell, next_free_dof,
-                    internal::int2type<dim>());
+                    std::integral_constant<int, dim>());
 
           // finally restore the user flags
           const_cast<dealii::Triangulation<dim,spacedim> &>(tria).load_user_flags(user_flags);

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1700,7 +1700,7 @@ namespace DoFRenumbering
       {
         // dispatch to
         // dimension-dependent functions
-        return compare (c1, c2, dealii::internal::int2type<dim>());
+        return compare (c1, c2, std::integral_constant<int, dim>());
       }
 
     private:
@@ -1710,7 +1710,7 @@ namespace DoFRenumbering
       template <class DHCellIterator, int xdim>
       bool compare (const DHCellIterator &c1,
                     const DHCellIterator &c2,
-                    dealii::internal::int2type<xdim>) const
+                    std::integral_constant<int, xdim>) const
       {
         const Tensor<1,dim> v1 = c1->center() - center;
         const Tensor<1,dim> v2 = c2->center() - center;
@@ -1727,7 +1727,7 @@ namespace DoFRenumbering
       template <class DHCellIterator>
       bool compare (const DHCellIterator &,
                     const DHCellIterator &,
-                    dealii::internal::int2type<1>) const
+                    std::integral_constant<int, 1>) const
       {
         Assert (dim >= 2,
                 ExcMessage ("This operation only makes sense for dim>=2."));

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -565,7 +565,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const dealii::DoFHandler<1> &,
                                             ConstraintMatrix &,
-                                            dealii::internal::int2type<1>)
+                                            std::integral_constant<int, 1>)
     {
       // nothing to do for regular dof handlers in 1d
     }
@@ -586,7 +586,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const dealii::hp::DoFHandler<1> &/*dof_handler*/,
                                             ConstraintMatrix        &/*constraints*/,
-                                            dealii::internal::int2type<1>)
+                                            std::integral_constant<int, 1>)
     {
       // we may have to compute constraints for vertices. gotta think about
       // that a bit more
@@ -607,7 +607,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const dealii::DoFHandler<1,2> &,
                                             ConstraintMatrix &,
-                                            dealii::internal::int2type<1>)
+                                            std::integral_constant<int, 1>)
     {
       // nothing to do for regular dof handlers in 1d
     }
@@ -623,7 +623,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const dealii::DoFHandler<1,3> &,
                                             ConstraintMatrix &,
-                                            dealii::internal::int2type<1>)
+                                            std::integral_constant<int, 1>)
     {
       // nothing to do for regular dof handlers in 1d
     }
@@ -644,7 +644,7 @@ namespace DoFTools
 //     void
 //     make_oldstyle_hanging_node_constraints (const dealii::DoFHandler<1,2> &,
 //                                          ConstraintMatrix    &,
-//                                          dealii::internal::int2type<1>)
+//                                          std::integral_constant<int, 1>)
 //     {
 //                                     // nothing to do for regular
 //                                     // dof handlers in 1d
@@ -654,7 +654,7 @@ namespace DoFTools
 //     void
 //     make_oldstyle_hanging_node_constraints (const dealii::hp::DoFHandler<1,2> &/*dof_handler*/,
 //                                          ConstraintMatrix        &/*constraints*/,
-//                                          dealii::internal::int2type<1>)
+//                                          std::integral_constant<int, 1>)
 //     {
 //                                     // we may have to compute
 //                                     // constraints for
@@ -671,7 +671,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const DoFHandlerType &dof_handler,
                                             ConstraintMatrix     &constraints,
-                                            dealii::internal::int2type<2>)
+                                            std::integral_constant<int, 2>)
     {
       const unsigned int dim = 2;
 
@@ -809,7 +809,7 @@ namespace DoFTools
     void
     make_oldstyle_hanging_node_constraints (const DoFHandlerType &dof_handler,
                                             ConstraintMatrix     &constraints,
-                                            dealii::internal::int2type<3>)
+                                            std::integral_constant<int, 3>)
     {
       const unsigned int dim = 3;
 
@@ -1742,7 +1742,7 @@ namespace DoFTools
       internal::
       make_oldstyle_hanging_node_constraints (dof_handler,
                                               constraints,
-                                              dealii::internal::int2type<DoFHandlerType::dimension>());
+                                              std::integral_constant<int, DoFHandlerType::dimension>());
   }
 
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2930,7 +2930,7 @@ next_cell:
       Point<Iterator::AccessorType::space_dimension>
       get_face_midpoint (const Iterator &object,
                          const unsigned int f,
-                         dealii::internal::int2type<1>)
+                         std::integral_constant<int, 1>)
       {
         return object->vertex(f);
       }
@@ -2946,7 +2946,7 @@ next_cell:
       Point<Iterator::AccessorType::space_dimension>
       get_face_midpoint (const Iterator &object,
                          const unsigned int f,
-                         dealii::internal::int2type<2>)
+                         std::integral_constant<int, 2>)
       {
         return object->line(f)->center();
       }
@@ -2962,7 +2962,7 @@ next_cell:
       Point<Iterator::AccessorType::space_dimension>
       get_face_midpoint (const Iterator &object,
                          const unsigned int f,
-                         dealii::internal::int2type<3>)
+                         std::integral_constant<int, 3>)
       {
         return object->face(f)->center();
       }
@@ -3009,11 +3009,11 @@ next_cell:
             diameter = std::min (diameter,
                                  get_face_midpoint
                                  (object, f,
-                                  dealii::internal::int2type<structdim>())
+                                  std::integral_constant<int, structdim>())
                                  .distance (get_face_midpoint
                                             (object,
                                              e,
-                                             dealii::internal::int2type<structdim>())));
+                                             std::integral_constant<int, structdim>())));
 
         return diameter;
       }
@@ -3265,8 +3265,8 @@ next_cell:
 
 
       void fix_up_faces (const dealii::Triangulation<1,1>::cell_iterator &,
-                         dealii::internal::int2type<1>,
-                         dealii::internal::int2type<1>)
+                         std::integral_constant<int, 1>,
+                         std::integral_constant<int, 1>)
       {
         // nothing to do for the faces of
         // cells in 1d
@@ -3279,8 +3279,8 @@ next_cell:
       // mid-points
       template <int structdim, int spacedim>
       void fix_up_faces (const typename dealii::Triangulation<structdim,spacedim>::cell_iterator &cell,
-                         dealii::internal::int2type<structdim>,
-                         dealii::internal::int2type<spacedim>)
+                         std::integral_constant<int, structdim>,
+                         std::integral_constant<int, spacedim>)
       {
         // see if we first can fix up
         // some of the faces of this
@@ -3356,8 +3356,8 @@ next_cell:
 
         internal::FixUpDistortedChildCells
         ::fix_up_faces (cell,
-                        dealii::internal::int2type<dim>(),
-                        dealii::internal::int2type<spacedim>());
+                        std::integral_constant<int, dim>(),
+                        std::integral_constant<int, spacedim>());
 
         // fix up the object. we need to
         // respect the manifold if the cell is

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -672,8 +672,8 @@ namespace
   template <int dim>
   bool
   has_distorted_children (const typename Triangulation<dim,dim>::cell_iterator &cell,
-                          internal::int2type<dim>,
-                          internal::int2type<dim>)
+                          std::integral_constant<int, dim>,
+                          std::integral_constant<int, dim>)
   {
     Assert (cell->has_children(), ExcInternalError());
 
@@ -707,8 +707,8 @@ namespace
   template <int dim, int spacedim>
   bool
   has_distorted_children (const typename Triangulation<dim,spacedim>::cell_iterator &,
-                          internal::int2type<dim>,
-                          internal::int2type<spacedim>)
+                          std::integral_constant<int, dim>,
+                          std::integral_constant<int, spacedim>)
   {
     return false;
   }
@@ -4906,8 +4906,8 @@ namespace internal
                   if ((check_for_distorted_cells == true)
                       &&
                       has_distorted_children (cell,
-                                              internal::int2type<dim>(),
-                                              internal::int2type<spacedim>()))
+                                              std::integral_constant<int, dim>(),
+                                              std::integral_constant<int, spacedim>()))
                     cells_with_distorted_children.distorted_cells.push_back (cell);
                   // inform all listeners that cell refinement is done
                   triangulation.signals.post_refinement_on_cell(cell);
@@ -8557,8 +8557,8 @@ namespace internal
                   if ((check_for_distorted_cells == true)
                       &&
                       has_distorted_children (hex,
-                                              internal::int2type<dim>(),
-                                              internal::int2type<spacedim>()))
+                                              std::integral_constant<int, dim>(),
+                                              std::integral_constant<int, spacedim>()))
                     cells_with_distorted_children.distorted_cells.push_back (hex);
 
                   // note that the refinement flag was already cleared

--- a/source/grid/tria_boundary.cc
+++ b/source/grid/tria_boundary.cc
@@ -709,7 +709,7 @@ namespace internal
   Point<spacedim>
   compute_projection (const Iterator        &object,
                       const Point<spacedim> &y,
-                      internal::int2type<dim>)
+                      std::integral_constant<int, dim>)
   {
     // let's look at this for
     // simplicity for a quad (dim==2)
@@ -806,7 +806,7 @@ namespace internal
   Point<1>
   compute_projection (const Iterator &,
                       const Point<1> &y,
-                      /* it's a quad: */internal::int2type<2>)
+                      /* it's a quad: */std::integral_constant<int, 2>)
   {
     return y;
   }
@@ -816,7 +816,7 @@ namespace internal
   Point<2>
   compute_projection (const Iterator &,
                       const Point<2> &y,
-                      /* it's a quad: */internal::int2type<2>)
+                      /* it's a quad: */std::integral_constant<int, 2>)
   {
     return y;
   }
@@ -846,7 +846,7 @@ project_to_surface (const typename Triangulation<dim, spacedim>::quad_iterator &
     return y;
   else
     return internal::compute_projection (quad, y,
-                                         /* it's a quad */internal::int2type<2>());
+                                         /* it's a quad */std::integral_constant<int, 2>());
 }
 
 

--- a/source/lac/constraint_matrix.cc
+++ b/source/lac/constraint_matrix.cc
@@ -1323,7 +1323,7 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
                                                       MatrixType                      &, \
                                                       VectorType                      &, \
                                                       bool                             , \
-                                                      internal::bool2type<false>) const
+                                                      std::integral_constant<bool, false>) const
 #define MATRIX_FUNCTIONS(MatrixType) \
   template void ConstraintMatrix:: \
   distribute_local_to_global<MatrixType,Vector<MatrixType::value_type> > (const FullMatrix<MatrixType::value_type>        &, \
@@ -1332,7 +1332,7 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
       MatrixType                      &, \
       Vector<MatrixType::value_type>                  &, \
       bool                             , \
-      internal::bool2type<false>) const
+      std::integral_constant<bool, false>) const
 #define BLOCK_MATRIX_VECTOR_FUNCTIONS(MatrixType, VectorType)   \
   template void ConstraintMatrix:: \
   distribute_local_to_global<MatrixType,VectorType > (const FullMatrix<MatrixType::value_type>        &, \
@@ -1341,7 +1341,7 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
                                                       MatrixType                      &, \
                                                       VectorType                      &, \
                                                       bool                             , \
-                                                      internal::bool2type<true>) const
+                                                      std::integral_constant<bool, true>) const
 #define BLOCK_MATRIX_FUNCTIONS(MatrixType)      \
   template void ConstraintMatrix:: \
   distribute_local_to_global<MatrixType,Vector<MatrixType::value_type> > (const FullMatrix<MatrixType::value_type>        &, \
@@ -1350,7 +1350,7 @@ PARALLEL_VECTOR_FUNCTIONS(TrilinosWrappers::MPI::BlockVector);
       MatrixType                      &, \
       Vector<MatrixType::value_type>                  &, \
       bool                             , \
-      internal::bool2type<true>) const
+      std::integral_constant<bool, true>) const
 
 MATRIX_FUNCTIONS(SparseMatrix<double>);
 MATRIX_FUNCTIONS(SparseMatrix<float>);
@@ -1395,7 +1395,7 @@ BLOCK_MATRIX_VECTOR_FUNCTIONS(TrilinosWrappers::BlockSparseMatrix, TrilinosWrapp
       SparsityPatternType &,                                                         \
       const bool,                                                                    \
       const Table<2,bool> &,                                                         \
-      internal::bool2type<false>) const;                                             \
+      std::integral_constant<bool, false>) const;                                             \
   template void ConstraintMatrix::add_entries_local_to_global<SparsityPatternType> ( \
       const std::vector<ConstraintMatrix::size_type> &,                              \
       const std::vector<ConstraintMatrix::size_type> &,                              \
@@ -1408,7 +1408,7 @@ BLOCK_MATRIX_VECTOR_FUNCTIONS(TrilinosWrappers::BlockSparseMatrix, TrilinosWrapp
       SparsityPatternType &,                                                         \
       const bool,                                                                    \
       const Table<2,bool> &,                                                         \
-      internal::bool2type<true>) const;                                              \
+      std::integral_constant<bool, true>) const;                                              \
   template void ConstraintMatrix::add_entries_local_to_global<SparsityPatternType> ( \
       const std::vector<ConstraintMatrix::size_type> &,                              \
       const std::vector<ConstraintMatrix::size_type> &,                              \

--- a/source/lac/constraint_matrix.inst.in
+++ b/source/lac/constraint_matrix.inst.in
@@ -39,11 +39,11 @@ for (S: REAL_SCALARS; T : DEAL_II_VEC_TEMPLATES)
     template void ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, LinearAlgebra::distributed::T<S> > (
         const FullMatrix<S> &, const Vector<S>&, const std::vector< size_type > &,
         DiagonalMatrix<LinearAlgebra::distributed::T<S> > &, LinearAlgebra::distributed::T<S>&,
-        bool, dealii::internal::bool2type<false>) const;
+        bool, std::integral_constant<bool, false>) const;
     template void ConstraintMatrix::distribute_local_to_global<DiagonalMatrix<LinearAlgebra::distributed::T<S> >, T<S> > (
         const FullMatrix<S> &, const Vector<S>&, const std::vector< size_type > &,
         DiagonalMatrix<LinearAlgebra::distributed::T<S> > &, T<S>&,
-        bool, dealii::internal::bool2type<false>) const;
+        bool, std::integral_constant<bool, false>) const;
 }
 
 


### PR DESCRIPTION
Using C++11 we can use std::integral_constant instead.