### PR TITLE
Fix clang warning in grid/grid_in.cc

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2077,7 +2077,7 @@ void GridIn<3>::read_netcdf (const std::string &filename)
   // as it denotes an internal face
   for (unsigned int i=0; i<bmarker.size(); ++i)
     Assert(0<=bmarker[i] &&
-           static_cast<types::boundary_id>(bmarker[i])<numbers::internal_face_boundary_id,
+           static_cast<types::boundary_id>(bmarker[i])!=numbers::internal_face_boundary_id,
            ExcIO());
 
   // finally we setup the boundary

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2076,7 +2076,9 @@ void GridIn<3>::read_netcdf (const std::string &filename)
   // take numbers::internal_face_boundary_id
   // as it denotes an internal face
   for (unsigned int i=0; i<bmarker.size(); ++i)
-    Assert(0<=bmarker[i] && bmarker[i]<numbers::internal_face_boundary_id, ExcIO());
+    Assert(0<=bmarker[i] &&
+           static_cast<types::boundary_id>(bmarker[i])<numbers::internal_face_boundary_id,
+           ExcIO());
 
   // finally we setup the boundary
   // information


### PR DESCRIPTION
Relates #4704. [CDash](https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=9904) reports some warnings about comparing signed and unsigned types.