### PR TITLE
Add additional functions to InvalidAccessor.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -563,6 +563,23 @@ public:
    * Dummy function that always returns numbers::invalid_manifold_id.
    */
   types::manifold_id manifold_id () const;
+
+  /**
+   * Dummy function to extract vertices. Returns the origin.
+   */
+  Point<spacedim> &vertex (const unsigned int i) const;
+
+  /**
+   * Dummy function to extract lines. Returns a default-constructed line iterator.
+   */
+  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+  line (const unsigned int i) const;
+
+  /**
+   * Dummy function to extract quads. Returns a default-constructed quad iterator.
+   */
+  typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+  quad (const unsigned int i) const;
 };
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -519,6 +519,40 @@ InvalidAccessor<structdim, dim, spacedim>::manifold_id () const
 }
 
 
+template <int structdim, int dim, int spacedim>
+inline
+Point<spacedim> &
+InvalidAccessor<structdim, dim, spacedim>::vertex (const unsigned int) const
+{
+  // nothing to do here. we could throw an exception but we can't get here
+  // without first creating an object which would have already thrown
+  static Point<spacedim> invalid_vertex;
+  return invalid_vertex;
+}
+
+
+template <int structdim, int dim, int spacedim>
+inline
+typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator
+InvalidAccessor<structdim, dim, spacedim>::line (const unsigned int) const
+{
+  // nothing to do here. we could throw an exception but we can't get here
+  // without first creating an object which would have already thrown
+  return typename dealii::internal::Triangulation::Iterators<dim,spacedim>::line_iterator();
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+inline
+typename dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator
+InvalidAccessor<structdim, dim, spacedim>::quad (const unsigned int) const
+{
+  // nothing to do here. we could throw an exception but we can't get here
+  // without first creating an object which would have already thrown
+  return dealii::internal::Triangulation::Iterators<dim,spacedim>::quad_iterator();
+}
+
 
 /*------------------------ Functions: TriaAccessor ---------------------------*/
 


### PR DESCRIPTION
This was originally written by Luca Heltai and is necessary for the patch removing the Boundary classes.

In reference to #4704.

This is required by #2418: I am in the process of cleaning up the history of that branch and this can be approved independently.