### PR TITLE
Fix a data type

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1174,7 +1174,7 @@ namespace internal
                               (*dof_handler.finite_elements)[fe_index].dofs_per_vertex));
         Assert (fe_index < dof_handler.finite_elements->size(),
                 ExcInternalError());
-        Assert (dof_handler.vertex_dofs_offsets[vertex_index] !=
+        Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
                 numbers::invalid_dof_index,
                 ExcMessage ("This vertex is unused and has no DoFs associated with it"));
 
@@ -1185,7 +1185,7 @@ namespace internal
         // part. trigger an exception if
         // we can't find a set for this
         // particular fe_index
-        const types::global_dof_index starting_offset = dof_handler.vertex_dofs_offsets[vertex_index];
+        const unsigned int starting_offset = dof_handler.vertex_dof_offsets[vertex_index];
         types::global_dof_index *pointer = &dof_handler.vertex_dofs[starting_offset];
         while (true)
           {
@@ -1260,10 +1260,10 @@ namespace internal
         Assert (local_index < (*dof_handler.finite_elements)[fe_index].dofs_per_vertex,
                 ExcIndexRange(local_index, 0,
                               (*dof_handler.finite_elements)[fe_index].dofs_per_vertex));
-        Assert (vertex_index < dof_handler.vertex_dofs_offsets.size(),
+        Assert (vertex_index < dof_handler.vertex_dof_offsets.size(),
                 ExcIndexRange (vertex_index, 0,
-                               dof_handler.vertex_dofs_offsets.size()));
-        Assert (dof_handler.vertex_dofs_offsets[vertex_index] !=
+                               dof_handler.vertex_dof_offsets.size()));
+        Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
                 numbers::invalid_dof_index,
                 ExcMessage ("This vertex is unused and has no DoFs associated with it"));
 
@@ -1274,7 +1274,7 @@ namespace internal
         // part. trigger an exception if
         // we can't find a set for this
         // particular fe_index
-        const types::global_dof_index starting_offset = dof_handler.vertex_dofs_offsets[vertex_index];
+        const unsigned int starting_offset = dof_handler.vertex_dof_offsets[vertex_index];
         const types::global_dof_index *pointer = &dof_handler.vertex_dofs[starting_offset];
         while (true)
           {
@@ -1312,13 +1312,13 @@ namespace internal
                             "this DoFHandler"));
 
         // if this vertex is unused, return 0
-        if (dof_handler.vertex_dofs_offsets[vertex_index] == numbers::invalid_dof_index)
+        if (dof_handler.vertex_dof_offsets[vertex_index] == numbers::invalid_dof_index)
           return 0;
 
         // hop along the list of index
         // sets and count the number of
         // hops
-        const types::global_dof_index starting_offset = dof_handler.vertex_dofs_offsets[vertex_index];
+        const unsigned int starting_offset = dof_handler.vertex_dof_offsets[vertex_index];
         const types::global_dof_index *pointer = &dof_handler.vertex_dofs[starting_offset];
 
         Assert (*pointer != numbers::invalid_dof_index,
@@ -1363,14 +1363,14 @@ namespace internal
                                                                 vertex_index)));
         // make sure we don't ask on
         // unused vertices
-        Assert (dof_handler.vertex_dofs_offsets[vertex_index] !=
+        Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
                 numbers::invalid_dof_index,
                 ExcInternalError());
 
         // hop along the list of index
         // sets and count the number of
         // hops
-        const types::global_dof_index starting_offset = dof_handler.vertex_dofs_offsets[vertex_index];
+        const unsigned int starting_offset = dof_handler.vertex_dof_offsets[vertex_index];
         const types::global_dof_index *pointer = &dof_handler.vertex_dofs[starting_offset];
 
         Assert (*pointer != numbers::invalid_dof_index,
@@ -1423,14 +1423,14 @@ namespace internal
 
         // make sure we don't ask on
         // unused vertices
-        Assert (dof_handler.vertex_dofs_offsets[vertex_index] !=
+        Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
                 numbers::invalid_dof_index,
                 ExcInternalError());
 
         // hop along the list of index
         // sets and see whether we find
         // the given index
-        const types::global_dof_index starting_offset = dof_handler.vertex_dofs_offsets[vertex_index];
+        const unsigned int starting_offset = dof_handler.vertex_dof_offsets[vertex_index];
         const types::global_dof_index *pointer = &dof_handler.vertex_dofs[starting_offset];
 
         Assert (*pointer != numbers::invalid_dof_index,

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -838,7 +838,7 @@ namespace hp
      *
      * The format used here, in the form of a linked list, is the same as used
      * for the arrays used in the internal::hp::DoFLevel hierarchy. Starting
-     * indices into this array are provided by the vertex_dofs_offsets field.
+     * indices into this array are provided by the vertex_dof_offsets field.
      *
      * Access to this field is generally through the
      * DoFAccessor::get_vertex_dof_index() and
@@ -859,7 +859,7 @@ namespace hp
      * functions, encapsulating the actual data format used to the present
      * class.
      */
-    std::vector<types::global_dof_index>      vertex_dofs_offsets;
+    std::vector<unsigned int>      vertex_dof_offsets;
 
     /**
      * Array to store the information if a cell on some level has children or
@@ -939,7 +939,7 @@ namespace hp
   void DoFHandler<dim, spacedim>::save(Archive &ar, unsigned int) const
   {
     ar &vertex_dofs;
-    ar &vertex_dofs_offsets;
+    ar &vertex_dof_offsets;
     ar &number_cache;
     ar &levels;
     ar &faces;
@@ -961,7 +961,7 @@ namespace hp
   void DoFHandler<dim, spacedim>::load(Archive &ar, unsigned int)
   {
     ar &vertex_dofs;
-    ar &vertex_dofs_offsets;
+    ar &vertex_dof_offsets;
     ar &number_cache;
 
     // boost::serialization can restore pointers just fine, but if the

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -169,16 +169,16 @@ namespace internal
           // vertex, we need one slot per fe to store the fe_index,
           // plus dofs_per_vertex for this fe. in addition, we need
           // one slot as the end marker for the fe_indices. at the
-          // same time already fill the vertex_dofs_offsets field
-          dof_handler.vertex_dofs_offsets.resize (dof_handler.tria->n_vertices(),
-                                                  numbers::invalid_dof_index);
+          // same time already fill the vertex_dof_offsets field
+          dof_handler.vertex_dof_offsets.resize (dof_handler.tria->n_vertices(),
+                                                 numbers::invalid_dof_index);
 
           unsigned int vertex_slots_needed = 0;
           for (unsigned int v=0; v<dof_handler.tria->n_vertices(); ++v)
             if (dof_handler.tria->vertex_used(v) == true)
               if (locally_used_vertices[v] == true)
                 {
-                  dof_handler.vertex_dofs_offsets[v] = vertex_slots_needed;
+                  dof_handler.vertex_dof_offsets[v] = vertex_slots_needed;
 
                   for (unsigned int fe=0; fe<dof_handler.finite_elements->size(); ++fe)
                     if (vertex_fe_association[fe][v] == true)
@@ -196,7 +196,7 @@ namespace internal
             if (dof_handler.tria->vertex_used(v) == true)
               if (locally_used_vertices[v] == true)
                 {
-                  unsigned int current_index = dof_handler.vertex_dofs_offsets[v];
+                  unsigned int current_index = dof_handler.vertex_dof_offsets[v];
                   for (unsigned int fe=0; fe<dof_handler.finite_elements->size(); ++fe)
                     if (vertex_fe_association[fe][v] == true)
                       {
@@ -1150,7 +1150,7 @@ namespace hp
                        MemoryConsumption::memory_consumption (*faces) +
                        MemoryConsumption::memory_consumption (number_cache) +
                        MemoryConsumption::memory_consumption (vertex_dofs) +
-                       MemoryConsumption::memory_consumption (vertex_dofs_offsets) +
+                       MemoryConsumption::memory_consumption (vertex_dof_offsets) +
                        MemoryConsumption::memory_consumption (has_children));
     for (unsigned int i=0; i<levels.size(); ++i)
       mem += MemoryConsumption::memory_consumption (*levels[i]);
@@ -1647,7 +1647,7 @@ namespace hp
     faces.reset ();
 
     vertex_dofs = std::move(std::vector<types::global_dof_index>());
-    vertex_dofs_offsets = std::move (std::vector<types::global_dof_index>());
+    vertex_dof_offsets = std::move (std::vector<types::global_dof_index>());
   }
 }
 


### PR DESCRIPTION
This patch is on top of #4773. Only the last commit is relevant, and I will rebase but I want to submit this one last commit for review already given that we're going to be gone for the next 24 hours.

That last commit fixes #4737: We use a `types::global_dof_index` as an offset into an array. But that's not really necessary, a regular `unsigned int` is entirely sufficient.

While there, also rename the variable to get singular/plural right.

In reference to #3511. Also #4704.