### PR TITLE
Initialize tensor_product_quadrature in constructor

### DIFF
--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -604,7 +604,8 @@ MappingQGeneric<dim,spacedim>::InternalData::InternalData (const unsigned int po
   :
   polynomial_degree (polynomial_degree),
   n_shape_functions (Utilities::fixed_power<dim>(polynomial_degree+1)),
-  line_support_points(QGaussLobatto<1>(polynomial_degree+1))
+  line_support_points(QGaussLobatto<1>(polynomial_degree+1)),
+  tensor_product_quadrature(false)
 {}
 
 


### PR DESCRIPTION
Coverity reported that `tensor_product_quadrature` was not initialized in a constructor.
Relates #4704. Fixes #4802.