### PR TITLE
rewrite p4est::iterate

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -285,11 +285,6 @@ namespace internal
       static
       size_t (&connectivity_memory_used) (types<2>::connectivity *p4est);
 
-      template <int spacedim>
-      static void iterate(dealii::internal::p4est::types<2>::forest *parallel_forest,
-                          dealii::internal::p4est::types<2>::ghost *parallel_ghost,
-                          void *user_data);
-
       static const unsigned int max_level = P4EST_MAXLEVEL;
     };
 
@@ -472,10 +467,6 @@ namespace internal
       static
       size_t (&connectivity_memory_used) (types<3>::connectivity *p4est);
 
-      template <int spacedim>
-      static void iterate(dealii::internal::p4est::types<3>::forest *parallel_forest,
-                          dealii::internal::p4est::types<3>::ghost *parallel_ghost,
-                          void *user_data);
 
       static const unsigned int max_level = P8EST_MAXLEVEL;
     };
@@ -513,6 +504,16 @@ namespace internal
       typedef p8est_iter_face_t      face_iter;
     };
 
+
+    /**
+     * Iterate over the given p4est and call the callback functions
+     */
+    template <int dim>
+    static void iterate(typename dealii::internal::p4est::types<dim>::forest *parallel_forest,
+                        typename dealii::internal::p4est::types<dim>::ghost *parallel_ghost,
+                        std::function<void (typename dealii::internal::p4est::iter<dim>::face_info *info)> face_callback,
+                        std::function<void (typename dealii::internal::p4est::iter<3>::edge_info *info)> edge_callback,
+                        std::function<void (typename dealii::internal::p4est::iter<dim>::corner_info *info)> corner_callback);
 
 
     /**
@@ -565,17 +566,6 @@ namespace internal
                          const typename types<dim>::topidx coarse_grid_cell);
 
 
-    /**
-     * This is the callback data structure used to fill
-     * vertices_with_ghost_neighbors via the p4est_iterate tool
-     */
-    template <int dim, int spacedim>
-    struct FindGhosts
-    {
-      const typename dealii::parallel::distributed::Triangulation<dim,spacedim> *triangulation;
-      sc_array_t                                                                *subids;
-      std::map<unsigned int, std::set<dealii::types::subdomain_id> >            *vertices_with_ghost_neighbors;
-    };
 
 
   }

--- a/source/distributed/p4est_wrappers.inst.in
+++ b/source/distributed/p4est_wrappers.inst.in
@@ -72,10 +72,11 @@ for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
 #if       deal_II_space_dimension >= deal_II_dimension
     template
     void
-    functions<deal_II_dimension>::
-    iterate<deal_II_space_dimension>(dealii::internal::p4est::types<deal_II_dimension>::forest *parallel_forest,
-                                     dealii::internal::p4est::types<deal_II_dimension>::ghost *parallel_ghost,
-                                     void *user_data);
+    iterate<deal_II_space_dimension>(typename dealii::internal::p4est::types<deal_II_space_dimension>::forest *parallel_forest,
+                                     typename dealii::internal::p4est::types<deal_II_space_dimension>::ghost *parallel_ghost,
+                                     std::function<void (typename dealii::internal::p4est::iter<deal_II_space_dimension>::face_info *info)> face_callback,
+                                     std::function<void (typename dealii::internal::p4est::iter<deal_II_space_dimension>::edge_info *info)> edge_callback,
+                                     std::function<void (typename dealii::internal::p4est::iter<deal_II_space_dimension>::corner_info *info)> corner_callback);
 #endif
 #endif
     \}


### PR DESCRIPTION
One suggestion to fix p4est::iterate. Maybe this is overkill, I don't know.
- add a generic function working on std::functions
- move specific code into member functions of ``FindGhosts``

addresses #4796 