### PR TITLE
Limit setting active_fe_indices to locally owned cells

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3781,16 +3781,15 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_active_fe_index (const uns
                       "children because no degrees of freedom will be assigned "
                       "to this cell."));
 
-  if (i != DoFHandlerType::default_fe_index)
-    Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
-             (this->dof_handler) != nullptr)
-            ||
-            this->is_locally_owned(),
-            ExcMessage ("You can only set active_fe_index information on cells "
-                        "that are locally owned. On ghost cells, this information "
-                        "will automatically be propagated from the owning process "
-                        "of that cell, and there is no information at all on "
-                        "artificial cells."));
+  Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
+           (this->dof_handler) != nullptr)
+          ||
+          this->is_locally_owned(),
+          ExcMessage ("You can only set active_fe_index information on cells "
+                      "that are locally owned. On ghost cells, this information "
+                      "will automatically be propagated from the owning process "
+                      "of that cell, and there is no information at all on "
+                      "artificial cells."));
   dealii::internal::DoFCellAccessor::Implementation::set_active_fe_index (*this, i);
 }
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3073,8 +3073,7 @@ namespace internal
       unsigned int
       active_fe_index (const DoFCellAccessor<DoFHandler<dim,spacedim>, level_dof_access> &)
       {
-        // ::DoFHandler only supports a
-        // single active fe with index
+        // ::DoFHandler only supports a single active fe with index
         // zero
         return 0;
       }
@@ -3106,8 +3105,7 @@ namespace internal
                            const unsigned int                                i)
       {
         (void)i;
-        // ::DoFHandler only supports a
-        // single active fe with index
+        // ::DoFHandler only supports a single active fe with index
         // zero
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (i == 0, typename BaseClass::ExcInvalidObject());
@@ -3757,6 +3755,14 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::active_fe_index () const
                       "children because no degrees of freedom are assigned "
                       "to this cell and, consequently, no finite element "
                       "is associated with it."));
+  Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
+           (this->dof_handler) != nullptr)
+          ||
+          (this->is_locally_owned() || this->is_ghost()),
+          ExcMessage ("You can only query active_fe_index information on cells "
+                      "that are either locally owned or (after distributing "
+                      "degrees of freedom) are ghost cells."));
+
   return dealii::internal::DoFCellAccessor::Implementation::active_fe_index (*this);
 }
 
@@ -3774,6 +3780,17 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_active_fe_index (const uns
           ExcMessage ("You can not set the active_fe_index on a cell that has "
                       "children because no degrees of freedom will be assigned "
                       "to this cell."));
+
+  if (i != DoFHandlerType::default_fe_index)
+    Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
+             (this->dof_handler) != nullptr)
+            ||
+            this->is_locally_owned(),
+            ExcMessage ("You can only set active_fe_index information on cells "
+                        "that are locally owned. On ghost cells, this information "
+                        "will automatically be propagated from the owning process "
+                        "of that cell, and there is no information at all on "
+                        "artificial cells."));
   dealii::internal::DoFCellAccessor::Implementation::set_active_fe_index (*this, i);
 }
 

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -132,19 +132,26 @@ namespace hp
    *
    * When this class is used with either a parallel::shared::Triangulation
    * or a parallel::distributed::Triangulation, you can only set active
-   * FE indices on cells that are locally owned or that are ghost cells,
+   * FE indices on cells that are locally owned,
    * using a call such as <code>cell-@>set_active_fe_index(...)</code>.
-   * On the other hand, setting the active FE index on artificial cells
-   * is not allowed.
+   * On the other hand, setting the active FE index on ghost
+   * or artificial cells is not allowed.
    *
-   * However, setting the index on ghost cells has no real effect: whenever
+   * Ghost cells do acquire the information what element
+   * is active on them, however: whenever
    * you call hp::DoFHandler::distribute_dofs(), all processors that
    * participate in the parallel mesh exchange information in such a way
    * that the active FE index on ghost cells equals the active FE index
    * that was set on that processor that owned that particular ghost cell.
-   * In other words, information that may have previously been set on
-   * ghost cells is overwritten so that the active FE index there is
-   * consistent with the value on the processor that owns the cell.
+   * Consequently, one can <i>query</i> the @p active_fe_index on ghost
+   * cells, just not set it by hand.
+   *
+   * On artificial cells, no information is available about the
+   * @p active_fe_index used there. That's because we don't even know
+   * whether these cells exist at all, and even if they did, the
+   * current processor does not know anything specific about them.
+   * See @ref GlossArtificialCell "the glossary entry on artificial cells"
+   * for more information.
    *
    *
    * @ingroup dofs

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1237,7 +1237,8 @@ namespace hp
     active_cell_iterator cell=begin_active(),
                          endc=end();
     for (unsigned int i=0; cell!=endc; ++cell, ++i)
-      cell->set_active_fe_index(active_fe_indices[i]);
+      if (cell->is_locally_owned())
+        cell->set_active_fe_index(active_fe_indices[i]);
   }
 
 
@@ -1253,7 +1254,7 @@ namespace hp
     active_cell_iterator cell=begin_active(),
                          endc=end();
     for (unsigned int i=0; cell!=endc; ++cell, ++i)
-      active_fe_indices[i]=cell->active_fe_index();
+      active_fe_indices[i] = cell->active_fe_index();
   }
 
 
@@ -1603,9 +1604,14 @@ namespace hp
                 // cell->active_fe_index() since that function is not
                 // allowed for inactive cells, but we can access this
                 // information from the DoFLevels directly
+                //
+                // we don't have to set the active_fe_index for ghost
+                // cells -- these will be exchanged automatically
+                // upon distribute_dofs()
                 for (unsigned int i = 0; i < cell->n_children(); ++i)
-                  cell->child (i)->set_active_fe_index
-                  (levels[cell->level()]->active_fe_index (cell->index()));
+                  if (cell->child (i)->is_locally_owned())
+                    cell->child (i)->set_active_fe_index
+                    (levels[cell->level()]->active_fe_index (cell->index()));
               }
           }
       }

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -863,6 +863,65 @@ namespace internal
 
           return std::min(max_couplings,dof_handler.n_dofs());
         }
+
+
+        /**
+         * Given a hp::DoFHandler object, make sure that the active_fe_indices that
+         * a user has set for locally owned cells are communicated to all ghost
+         * cells as well.
+         */
+        template <int dim, int spacedim>
+        static
+        void communicate_active_fe_indices (dealii::hp::DoFHandler<dim,spacedim> &dof_handler)
+        {
+          if (const parallel::shared::Triangulation<dim, spacedim> *tr =
+                dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()))
+            {
+              // we have a shared triangulation. in this case, every processor
+              // knows about all cells, but every processor only has knowledge
+              // about the active_fe_index on the cells it owns.
+              //
+              // we can create a complete set of active_fe_indices by letting
+              // every processor create a vector of indices for all cells,
+              // filling only those on the cells it owns and setting the indices
+              // on the other cells to zero. then we add all of these vectors
+              // up, and because every vector entry has exactly one processor
+              // that owns it, the sum is correct
+              std::vector<unsigned int> active_fe_indices (tr->n_active_cells(),
+                                                           (unsigned int)0);
+              for (const auto &cell : dof_handler.active_cell_iterators())
+                if (cell->is_locally_owned())
+                  active_fe_indices[cell->active_cell_index()] = cell->active_fe_index();
+
+              Utilities::MPI::sum (active_fe_indices,
+                                   tr->get_communicator(),
+                                   active_fe_indices);
+
+              // now go back and fill the active_fe_index on ghost
+              // cells. we would like to call cell->set_active_fe_index(),
+              // but that function does not allow setting these indices on
+              // non-locally_owned cells. so we have to work around the
+              // issue a little bit by accessing the underlying data
+              // structures directly
+              for (auto cell : dof_handler.active_cell_iterators())
+                if (cell->is_ghost())
+                  dof_handler.levels[cell->level()]->
+                  set_active_fe_index(cell->index(),
+                                      active_fe_indices[cell->active_cell_index()]);
+            }
+          else if (const parallel::distributed::Triangulation<dim, spacedim> *tr =
+                     dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()))
+            {
+              Assert (false, ExcNotImplemented());
+            }
+          else
+            {
+              // a sequential triangulation. there is nothing we need to do here
+              Assert ((dynamic_cast<const parallel::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation())
+                       == nullptr),
+                      ExcInternalError());
+            }
+        }
       };
     }
   }
@@ -1199,64 +1258,6 @@ namespace hp
 
 
 
-  namespace
-  {
-    /**
-     * Given a hp::DoFHandler object, make sure that the active_fe_indices that
-     * a user has set for locally owned cells are communicated to all ghost
-     * cells as well.
-     */
-    template <int dim, int spacedim>
-    void communicate_active_fe_indices (hp::DoFHandler<dim,spacedim> &dof_handler)
-    {
-      if (const parallel::shared::Triangulation<dim, spacedim> *tr =
-            dynamic_cast<const parallel::shared::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()))
-        {
-          // we have a shared triangulation. in this case, every processor
-          // knows about all cells, but every processor only has knowledge
-          // about the active_fe_index on the cells it owns.
-          //
-          // we can create a complete set of active_fe_indices by letting
-          // every processor create a vector of indices for all cells,
-          // filling only those on the cells it owns and setting the indices
-          // on the other cells to zero. then we add all of these vectors
-          // up, and because every vector entry has exactly one processor
-          // that owns it, the sum is correct
-          std::vector<unsigned int> active_fe_indices (tr->n_active_cells(),
-                                                       (unsigned int)0);
-          for (const auto &cell : dof_handler.active_cell_iterators())
-            if (cell->is_locally_owned())
-              active_fe_indices[cell->active_cell_index()] = cell->active_fe_index();
-
-          Utilities::MPI::sum (active_fe_indices,
-                               tr->get_communicator(),
-                               active_fe_indices);
-
-          // now go back and fill the active_fe_index on ghost cells
-          for (auto cell : dof_handler.active_cell_iterators())
-            if (cell->is_ghost())
-              cell->set_active_fe_index(active_fe_indices[cell->active_cell_index()]);
-        }
-      else if (const parallel::distributed::Triangulation<dim, spacedim> *tr =
-                 dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation()))
-        {
-          Assert (false, ExcNotImplemented());
-        }
-      else
-        {
-          // a sequential triangulation. there is nothing we need to do here
-          Assert ((dynamic_cast<const parallel::Triangulation<dim, spacedim>*> (&dof_handler.get_triangulation())
-                   == nullptr),
-                  ExcInternalError());
-        }
-    }
-  }
-
-
-
-
-
-
   template <int dim, int spacedim>
   void DoFHandler<dim,spacedim>::distribute_dofs (const hp::FECollection<dim,spacedim> &ff)
   {
@@ -1266,7 +1267,7 @@ namespace hp
 
     // at the beginning, make sure every processor knows the
     // active_fe_indices on both its own cells and all ghost cells
-    communicate_active_fe_indices (*this);
+    dealii::internal::hp::DoFHandler::Implementation::communicate_active_fe_indices (*this);
 
     // If an underlying shared::Tria allows artificial cells,
     // then save the current set of subdomain ids, and set

--- a/tests/vector_tools/integrate_difference_04_hp_02.cc
+++ b/tests/vector_tools/integrate_difference_04_hp_02.cc
@@ -83,8 +83,9 @@ void test(VectorTools::NormType norm, double value, double exp = 2.0)
 
   // assign FEs mostly randomly to each cell
   for (auto cell : dofh.active_cell_iterators())
-    cell->set_active_fe_index (cell->active_cell_index() %
-                               fe.size());
+    if (cell->is_locally_owned())
+      cell->set_active_fe_index (cell->active_cell_index() %
+                                 fe.size());
   dofh.distribute_dofs(fe);
 
   TrilinosWrappers::MPI::Vector interpolated(dofh.locally_owned_dofs(),


### PR DESCRIPTION
This pull request finishes what #4712 started, namely disallow setting the `active_fe_index` on cells that are not locally owned. This requires a bit of adjusting of one place in the code (the first commit) where the primary component of the patch is to move code around -- the actual change is only the line where we used to call `cell->set_active_fe_index()` and now need to access internal data structures.

The first two commits make sure we don't ever call `set_active_fe_index()` on non-locally owned cells. The third commit actually forbids doing this. The fourth commit documents the changed behavior.

In reference to #3511 and #1366. Also #4704.