### PR TITLE
Restore create_* tests

### DIFF
--- a/tests/numerics/create_laplace_matrix_constraints_01.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_01.cc
@@ -102,8 +102,9 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, nullptr, constraints);
+                                      rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02.cc
@@ -106,8 +106,9 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, nullptr, constraints);
+                                      rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02b.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02b.cc
@@ -102,8 +102,9 @@ check ()
                          quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      nullptr, constraints);
+                                      dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_01.cc
+++ b/tests/numerics/create_mass_matrix_constraints_01.cc
@@ -102,8 +102,9 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, nullptr, constraints);
+                                   rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02.cc
@@ -106,8 +106,9 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, nullptr, constraints);
+                                   rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02b.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02b.cc
@@ -102,8 +102,9 @@ check ()
                       quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   nullptr, constraints);
+                                   dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values


### PR DESCRIPTION
Fixes #4809. Relates #4704.
gcc-4.8.5, icc-13.0.1, icc-16 and icc-17 seem not to be able to convert a `nullptr` to 
`const Function<dim> *const` while this works fine for clang from 3.4.1 and gcc from 4.9.0.

Doing the conversion in the tests explicitly again fixes this.