### PR TITLE
Document the default argument for the coefficient in the create_* functions

### DIFF
--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -671,7 +671,7 @@ namespace MatrixCreator
                            const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -712,7 +712,7 @@ namespace MatrixCreator
   void create_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof,
@@ -728,7 +728,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -770,7 +770,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping,
@@ -785,7 +785,7 @@ namespace MatrixCreator
                            const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -822,7 +822,7 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim> &dof,
                            const hp::QCollection<dim> &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection,
@@ -838,7 +838,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number>      &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -877,7 +877,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                           const Function<spacedim,number> *const coefficient,
                            const ConstraintMatrix   &constraints)
   {
     create_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1198,7 +1198,7 @@ namespace MatrixCreator
                                const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                Vector<number>            &rhs_vector,
                                std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                               const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                               const Function<spacedim,number> *const coefficient,
                                std::vector<unsigned int> component_mapping)
   {
     // what would that be in 1d? the
@@ -1597,7 +1597,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &rhs,
                                     Vector<number>            &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a,
+                                    const Function<spacedim,number> *const a,
                                     std::vector<unsigned int> component_mapping)
   {
     create_boundary_mass_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof, q,
@@ -1615,7 +1615,7 @@ namespace MatrixCreator
                                const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                Vector<number>            &rhs_vector,
                                std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                               const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const coefficient,
+                               const Function<spacedim,number> *const coefficient,
                                std::vector<unsigned int> component_mapping)
   {
     // what would that be in 1d? the
@@ -1684,7 +1684,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &rhs,
                                     Vector<number>            &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a,
+                                    const Function<spacedim,number> *const a,
                                     std::vector<unsigned int> component_mapping)
   {
     create_boundary_mass_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1698,7 +1698,7 @@ namespace MatrixCreator
                               const DoFHandler<dim,spacedim>    &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1740,7 +1740,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const DoFHandler<dim,spacedim>    &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(StaticMappingQ1<dim,spacedim>::mapping,
@@ -1756,7 +1756,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1800,7 +1800,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(StaticMappingQ1<dim,spacedim>::mapping, dof, q,
@@ -1814,7 +1814,7 @@ namespace MatrixCreator
                               const hp::DoFHandler<dim,spacedim>    &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1853,7 +1853,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,
@@ -1869,7 +1869,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix   &constraints)
   {
     Assert (matrix.m() == dof.n_dofs(),
@@ -1910,7 +1910,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const coefficient,
+                              const Function<spacedim> *const coefficient,
                               const ConstraintMatrix &constraints)
   {
     create_laplace_matrix(hp::StaticMappingQ1<dim,spacedim>::mapping_collection, dof, q,

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -237,7 +237,7 @@ namespace MatrixCreator
                            const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -248,7 +248,7 @@ namespace MatrixCreator
   void create_mass_matrix (const DoFHandler<dim,spacedim>    &dof,
                            const Quadrature<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -274,7 +274,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -287,7 +287,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = 0,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -298,7 +298,7 @@ namespace MatrixCreator
                            const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -308,7 +308,7 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = 0,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -321,7 +321,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -333,7 +333,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                           const Function<spacedim,number> *const a = 0,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
 
@@ -367,7 +367,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const weight = nullptr,
+                                    const Function<spacedim,number> *const weight = 0,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
 
@@ -382,7 +382,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                                    const Function<spacedim,number> *const a = 0,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -396,7 +396,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                                    const Function<spacedim,number> *const a = 0,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -409,7 +409,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<std::integral_constant<int, spacedim>::value, typename identity<number>::type> *const a = nullptr,
+                                    const Function<spacedim,number> *const a = 0,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -433,7 +433,7 @@ namespace MatrixCreator
                               const DoFHandler<dim,spacedim> &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -444,7 +444,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const DoFHandler<dim,spacedim> &dof,
                               const Quadrature<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -469,7 +469,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim> &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -482,7 +482,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim> &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -494,7 +494,7 @@ namespace MatrixCreator
                               const hp::DoFHandler<dim,spacedim> &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -505,7 +505,7 @@ namespace MatrixCreator
   void create_laplace_matrix (const hp::DoFHandler<dim,spacedim> &dof,
                               const hp::QCollection<dim>    &q,
                               SparseMatrix<double>     &matrix,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -519,7 +519,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -532,7 +532,7 @@ namespace MatrixCreator
                               SparseMatrix<double>     &matrix,
                               const Function<spacedim>      &rhs,
                               Vector<double>           &rhs_vector,
-                              const Function<std::integral_constant<int, spacedim>::value> *const a = nullptr,
+                              const Function<spacedim> *const a = nullptr,
                               const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -220,6 +220,9 @@ namespace MatrixCreator
    * Assemble the mass matrix. If no coefficient is given (i.e., if the
    * pointer to a function object is zero as it is by default), the
    * coefficient is taken as being constant and equal to one.
+   * In case you want to specify @p constraints and use the default argument
+   * for the coefficient you have to specify the (unused) coefficient argument as
+   * <code>(const Function<spacedim,number> *const)nullptr</code>.
    *
    * If the library is configured to use multithreading, this function works
    * in parallel.
@@ -255,6 +258,9 @@ namespace MatrixCreator
    * Assemble the mass matrix and a right hand side vector. If no coefficient
    * is given (i.e., if the pointer to a function object is zero as it is by
    * default), the coefficient is taken as being constant and equal to one.
+   * In case you want to specify @p constraints and use the default argument
+   * for the coefficient you have to specify the (unused) coefficient argument as
+   * <code>(const Function <spacedim,number> *const)nullptr</code>.
    *
    * If the library is configured to use multithreading, this function works
    * in parallel.
@@ -287,7 +293,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -308,7 +314,7 @@ namespace MatrixCreator
   void create_mass_matrix (const hp::DoFHandler<dim,spacedim>    &dof,
                            const hp::QCollection<dim>    &q,
                            SparseMatrix<number>     &matrix,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
   /**
@@ -333,7 +339,7 @@ namespace MatrixCreator
                            SparseMatrix<number>     &matrix,
                            const Function<spacedim,number> &rhs,
                            Vector<number>           &rhs_vector,
-                           const Function<spacedim,number> *const a = 0,
+                           const Function<spacedim,number> *const a = nullptr,
                            const ConstraintMatrix   &constraints = ConstraintMatrix());
 
 
@@ -348,6 +354,9 @@ namespace MatrixCreator
    *
    * @arg @p weight: an optional weight for the computation of the mass
    * matrix. If no weight is given, it is set to one.
+   * In case you want to specify @p component_mapping and use the default argument
+   * for the coefficient you have to specify the (unused) coefficient argument as
+   * <code>(const Function <spacedim,number> *const)nullptr</code>.
    *
    * @arg @p component_mapping: if the components in @p boundary_functions and
    * @p dof do not coincide, this vector allows them to be remapped. If the
@@ -382,7 +391,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<spacedim,number> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -396,7 +405,7 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<spacedim,number> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
@@ -409,13 +418,16 @@ namespace MatrixCreator
                                     const std::map<types::boundary_id, const Function<spacedim,number>*> &boundary_functions,
                                     Vector<number>           &rhs_vector,
                                     std::vector<types::global_dof_index> &dof_to_boundary_mapping,
-                                    const Function<spacedim,number> *const a = 0,
+                                    const Function<spacedim,number> *const a = nullptr,
                                     std::vector<unsigned int> component_mapping = std::vector<unsigned int>());
 
   /**
    * Assemble the Laplace matrix. If no coefficient is given (i.e., if the
    * pointer to a function object is zero as it is by default), the
    * coefficient is taken as being constant and equal to one.
+   * In case you want to specify @p constraints and use the default argument
+   * for the coefficient you have to specify the (unused) coefficient argument as
+   * <code>(const Function<spacedim> *const)nullptr</code>.
    *
    * If the library is configured to use multithreading, this function works
    * in parallel.
@@ -450,6 +462,9 @@ namespace MatrixCreator
   /**
    * Assemble the Laplace matrix and a right hand side vector. If no
    * coefficient is given, it is assumed to be constant one.
+   * In case you want to specify @p constraints and use the default argument
+   * for the coefficient you have to specify the (unused) coefficient argument as
+   * <code>(const Function<spacedim> *const)nullptr</code>.
    *
    * If the library is configured to use multithreading, this function works
    * in parallel.

--- a/tests/numerics/create_laplace_matrix_constraints_01.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_01.cc
@@ -102,8 +102,9 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, nullptr, constraints);
+                                      rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02.cc
@@ -106,8 +106,9 @@ check ()
                          rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      rhs_function, rhs, nullptr, constraints);
+                                      rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_laplace_matrix_constraints_02b.cc
+++ b/tests/numerics/create_laplace_matrix_constraints_02b.cc
@@ -102,8 +102,9 @@ check ()
                          quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_laplace_matrix (mapping, dof, quadrature, matrix,
-                                      nullptr, constraints);
+                                      dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_01.cc
+++ b/tests/numerics/create_mass_matrix_constraints_01.cc
@@ -102,8 +102,9 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, nullptr, constraints);
+                                   rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02.cc
@@ -106,8 +106,9 @@ check ()
                       rhs_function, rhs_ref);
   constraints.condense(matrix_ref, rhs_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   rhs_function, rhs, nullptr, constraints);
+                                   rhs_function, rhs, dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02b.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02b.cc
@@ -102,8 +102,9 @@ check ()
                       quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
+  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   nullptr, constraints);
+                                   dummy, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values

--- a/tests/numerics/create_mass_matrix_constraints_02b.cc
+++ b/tests/numerics/create_mass_matrix_constraints_02b.cc
@@ -102,9 +102,8 @@ check ()
                       quadrature, matrix_ref);
   constraints.condense(matrix_ref);
 
-  const Function<dim> *const dummy = nullptr;
   MatrixTools::create_mass_matrix (mapping, dof, quadrature, matrix,
-                                   dummy, constraints);
+                                   (const Function <dim> *const)nullptr, constraints);
 
   // compute reference: need to cancel constrained entries as these will in
   // general get different values


### PR DESCRIPTION
Fixes #4809. Relates #4704. Supersedes #4811. Reverses #4762.

Some compilers can't implicitly convert a `nullptr` to
`const Function<dim> *const`. As discussed in #4811 this is the reason to go back to the old interface and document how to use the default (`nullptr`) argument.