### PR TITLE
Make DoFAccessor::set_active_fe_index() a 'const' function.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1710,7 +1710,7 @@ public:
    * associated with them without having any degrees of freedom. Consequently,
    * this function will produce an exception when called on non-active cells.
    */
-  void set_active_fe_index (const unsigned int i);
+  void set_active_fe_index (const unsigned int i) const;
   /**
    * @}
    */

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -3116,7 +3116,7 @@ namespace internal
       template <int dim, int spacedim, bool level_dof_access>
       static
       void
-      set_active_fe_index (DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &accessor,
+      set_active_fe_index (const DoFCellAccessor<dealii::hp::DoFHandler<dim,spacedim>, level_dof_access> &accessor,
                            const unsigned int                                      i)
       {
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
@@ -3771,7 +3771,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::active_fe_index () const
 template <typename DoFHandlerType, bool level_dof_access>
 inline
 void
-DoFCellAccessor<DoFHandlerType,level_dof_access>::set_active_fe_index (const unsigned int i)
+DoFCellAccessor<DoFHandlerType,level_dof_access>::set_active_fe_index (const unsigned int i) const
 {
   Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
            (this->dof_handler) != nullptr)


### PR DESCRIPTION
We are not being very consistent in marking which DoFAccessor functions are 'const'
because it's difficult to actually define what 'const' would mean: does it change
the accessor, or does it change the DoFHandler it points to. As a consequence,
the TriaAccessor member functions are *all* const, but the DoFAccessor functions
are more or less random.

Rather than attacking this problem altogether, I'm making the minimal change that
solves the problem I currently have. The patch compiles and passes the relevant
tests.