### PR TITLE
Deprecate types_are_equal.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -412,7 +412,7 @@ namespace internal
       // completely fill its memory and may lead to false positives in
       // e.g. valgrind
       if (std::is_trivial<T>::value == true &&
-          types_are_equal<T,long double>::value == false)
+          std::is_same<T,long double>::value == false)
         {
           const unsigned char zero [sizeof(T)] = {};
           // cast element to (void*) to silence compiler warning for virtual

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -283,7 +283,7 @@ namespace internal
  * @code
  *   template <typename T>
  *   void Vector<T>::some_operation () {
- *     if (types_are_equal<T,double>::value == true)
+ *     if (std::is_same<T,double>::value == true)
  *       call_some_blas_function_for_doubles;
  *     else
  *       do_it_by_hand;
@@ -292,24 +292,30 @@ namespace internal
  *
  * This construct is made possible through the existence of a partial
  * specialization of the class for template arguments that are equal.
+ *
+ * @deprecated Use the standard library type trait <code>std::is_same</code>
+ * instead of this class.
  */
 template <typename T, typename U>
 struct types_are_equal
 {
   static const bool value = false;
-};
+} DEAL_II_DEPRECATED;
 
 
 /**
  * Partial specialization of the general template for the case that both
  * template arguments are equal. See the documentation of the general template
  * for more information.
+ *
+ * @deprecated Use the standard library type trait <code>std::is_same</code>
+ * instead of this class.
  */
 template <typename T>
 struct types_are_equal<T,T>
 {
   static const bool value = true;
-};
+} DEAL_II_DEPRECATED;
 
 
 /**

--- a/include/deal.II/lac/constraint_matrix.templates.h
+++ b/include/deal.II/lac/constraint_matrix.templates.h
@@ -2241,7 +2241,7 @@ ConstraintMatrix::distribute_local_to_global (
                             global_vector.size() == 0) ? false : true;
   typedef typename MatrixType::value_type number;
   const bool use_dealii_matrix =
-    types_are_equal<MatrixType,SparseMatrix<number> >::value;
+    std::is_same<MatrixType,SparseMatrix<number> >::value;
 
   AssertDimension (local_matrix.n(), local_dof_indices.size());
   AssertDimension (local_matrix.m(), local_dof_indices.size());
@@ -2344,7 +2344,7 @@ ConstraintMatrix::distribute_local_to_global (
   // add must be equal if we have a Trilinos or PETSc vector but do not have to
   // be if we have a deal.II native vector: one could further optimize this for
   // Vector, LinearAlgebra::distributed::vector, etc.
-  if (types_are_equal<typename VectorType::value_type, number>::value)
+  if (std::is_same<typename VectorType::value_type, number>::value)
     {
       global_vector.add(vector_indices,
                         *reinterpret_cast<std::vector<number> *>(&vector_values));
@@ -2382,7 +2382,7 @@ distribute_local_to_global (const FullMatrix<typename MatrixType::value_type>  &
                             global_vector.size() == 0) ? false : true;
   typedef typename MatrixType::value_type number;
   const bool use_dealii_matrix =
-    types_are_equal<MatrixType,BlockSparseMatrix<number> >::value;
+    std::is_same<MatrixType,BlockSparseMatrix<number> >::value;
 
   AssertDimension (local_matrix.n(), local_dof_indices.size());
   AssertDimension (local_matrix.m(), local_dof_indices.size());

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -527,11 +527,11 @@ void FullMatrix<number>::mmult (FullMatrix<number2>       &dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if ((types_are_equal<number,double>::value
+  if ((std::is_same<number,double>::value
        ||
-       types_are_equal<number,float>::value)
+       std::is_same<number,float>::value)
       &&
-      types_are_equal<number,number2>::value)
+      std::is_same<number,number2>::value)
     if (this->n()*this->m()*src.n() > 300)
       {
         // In case we have the BLAS function gemm detected by CMake, we
@@ -597,11 +597,11 @@ void FullMatrix<number>::Tmmult (FullMatrix<number2>       &dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if ((types_are_equal<number,double>::value
+  if ((std::is_same<number,double>::value
        ||
-       types_are_equal<number,float>::value)
+       std::is_same<number,float>::value)
       &&
-      types_are_equal<number,number2>::value)
+      std::is_same<number,number2>::value)
     if (this->n()*this->m()*src.n() > 300)
       {
         // In case we have the BLAS function gemm detected by CMake, we
@@ -687,11 +687,11 @@ void FullMatrix<number>::mTmult (FullMatrix<number2>       &dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if ((types_are_equal<number,double>::value
+  if ((std::is_same<number,double>::value
        ||
-       types_are_equal<number,float>::value)
+       std::is_same<number,float>::value)
       &&
-      types_are_equal<number,number2>::value)
+      std::is_same<number,number2>::value)
     if (this->n()*this->m()*src.m() > 300)
       {
         // In case we have the BLAS function gemm detected by CMake, we
@@ -775,11 +775,11 @@ void FullMatrix<number>::TmTmult (FullMatrix<number2>       &dst,
   // works for us (it is usually not efficient to use BLAS for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if ((types_are_equal<number,double>::value
+  if ((std::is_same<number,double>::value
        ||
-       types_are_equal<number,float>::value)
+       std::is_same<number,float>::value)
       &&
-      types_are_equal<number,number2>::value)
+      std::is_same<number,number2>::value)
     if (this->n()*this->m()*src.m() > 300)
       {
         // In case we have the BLAS function gemm detected by CMake, we
@@ -1762,9 +1762,9 @@ FullMatrix<number>::gauss_jordan ()
   // efficient to use Lapack for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if (types_are_equal<number,double>::value
+  if (std::is_same<number,double>::value
       ||
-      types_are_equal<number,float>::value)
+      std::is_same<number,float>::value)
     if (this->n_cols() > 15)
       {
         // In case we have the LAPACK functions

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2124,10 +2124,10 @@ PreconditionChebyshev<MatrixType,VectorType,PreconditionerType>::estimate_eigenv
 
   // We do not need the third auxiliary vector in case we have a
   // DiagonalMatrix as preconditioner and use deal.II's own vectors
-  if (types_are_equal<PreconditionerType,DiagonalMatrix<VectorType> >::value == false ||
-      (types_are_equal<VectorType,dealii::Vector<typename VectorType::value_type> >::value == false
+  if (std::is_same<PreconditionerType,DiagonalMatrix<VectorType> >::value == false ||
+      (std::is_same<VectorType,dealii::Vector<typename VectorType::value_type> >::value == false
        &&
-       types_are_equal<VectorType,LinearAlgebra::distributed::Vector<typename VectorType::value_type> >::value == false
+       std::is_same<VectorType,LinearAlgebra::distributed::Vector<typename VectorType::value_type> >::value == false
       ))
     update3.reinit (src, true);
 

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -402,7 +402,7 @@ SolverCG<VectorType>::solve (const MatrixType         &A,
           return;
         }
 
-      if (types_are_equal<PreconditionerType,PreconditionIdentity>::value == false)
+      if (std::is_same<PreconditionerType,PreconditionIdentity>::value == false)
         {
           precondition.vmult(h,g);
 
@@ -434,7 +434,7 @@ SolverCG<VectorType>::solve (const MatrixType         &A,
           if (conv != SolverControl::iterate)
             break;
 
-          if (types_are_equal<PreconditionerType,PreconditionIdentity>::value
+          if (std::is_same<PreconditionerType,PreconditionIdentity>::value
               == false)
             {
               precondition.vmult(h,g);

--- a/include/deal.II/lac/sparse_decomposition.templates.h
+++ b/include/deal.II/lac/sparse_decomposition.templates.h
@@ -163,7 +163,7 @@ SparseLUDecomposition<number>::copy_from (const SparseMatrix<somenumber> &matrix
       const somenumber *input_ptr = matrix.val.get();
       number *this_ptr = this->val.get();
       const number *const end_ptr = this_ptr + this->n_nonzero_elements();
-      if (types_are_equal<somenumber, number>::value == true)
+      if (std::is_same<somenumber, number>::value == true)
         std::memcpy (this_ptr, input_ptr, this->n_nonzero_elements()*sizeof(number));
       else
         for ( ; this_ptr != end_ptr; ++input_ptr, ++this_ptr)

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -228,7 +228,7 @@ namespace internal
 
       void operator() (const size_type begin, const size_type end) const
       {
-        if (types_are_equal<Number,OtherNumber>::value)
+        if (std::is_same<Number,OtherNumber>::value)
           std::memcpy(dst+begin, src+begin, (end-begin)*sizeof(Number));
         else
           {
@@ -689,7 +689,7 @@ namespace internal
     template <typename Number, typename Number2>
     struct Dot
     {
-      static const bool vectorizes = types_are_equal<Number,Number2>::value &&
+      static const bool vectorizes = std::is_same<Number,Number2>::value &&
                                      (VectorizedArray<Number>::n_array_elements > 1);
 
       Dot(const Number *X, const Number2 *Y)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3083,7 +3083,7 @@ FEEvaluationBase<dim,n_components_,Number>
                 for (unsigned int comp=0; comp<n_components; ++comp)
                   operation.process_dof_gather(dof_indices+ind,
                                                *src[comp], values_dofs[comp][j],
-                                               std::integral_constant<bool, types_are_equal<typename VectorType::value_type,Number>::value>());
+                                               std::integral_constant<bool, std::is_same<typename VectorType::value_type,Number>::value>());
             }
         }
 
@@ -3226,7 +3226,7 @@ FEEvaluationBase<dim,n_components_,Number>
                 for (unsigned int j=0; j<dofs_per_cell; ++j, ind += VectorizedArray<Number>::n_array_elements)
                   operation.process_dof_gather(dof_indices+ind,
                                                *src[0], values_dofs[comp][j],
-                                               std::integral_constant<bool, types_are_equal<typename VectorType::value_type,Number>::value>());
+                                               std::integral_constant<bool, std::is_same<typename VectorType::value_type,Number>::value>());
             }
         }
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -378,7 +378,7 @@ namespace internal
         return false;
 
       const double zero_tol =
-        types_are_equal<Number,double>::value==true?1e-12:1e-7;
+        std::is_same<Number,double>::value==true?1e-12:1e-7;
       // symmetry for values
       const unsigned int n_dofs_1d = fe_degree + 1;
       for (unsigned int i=0; i<(n_dofs_1d+1)/2; ++i)
@@ -480,7 +480,7 @@ namespace internal
         return false;
 
       const double zero_tol =
-        types_are_equal<Number,double>::value==true?1e-12:1e-7;
+        std::is_same<Number,double>::value==true?1e-12:1e-7;
       // check: identity operation for shape values
       const unsigned int n_points_1d = fe_degree+1;
       for (unsigned int i=0; i<n_points_1d; ++i)

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -132,7 +132,7 @@ struct FE_Q_Base<PolynomialType,xdim,xspacedim>::Implementation
     const unsigned int dim = 2;
 
     unsigned int q_deg = fe.degree;
-    if (types_are_equal<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value)
+    if (std::is_same<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value)
       q_deg = fe.degree-1;
 
     // restricted to each face, the traces of the shape functions is an
@@ -239,7 +239,7 @@ struct FE_Q_Base<PolynomialType,xdim,xspacedim>::Implementation
     const unsigned int dim = 3;
 
     unsigned int q_deg = fe.degree;
-    if (types_are_equal<PolynomialType,TensorProductPolynomialsBubbles<dim> >::value)
+    if (std::is_same<PolynomialType,TensorProductPolynomialsBubbles<dim> >::value)
       q_deg = fe.degree-1;
 
     // For a detailed documentation of the interpolation see the
@@ -422,7 +422,7 @@ FE_Q_Base<PolynomialType,dim,spacedim>::FE_Q_Base
   :
   FE_Poly<PolynomialType,dim,spacedim>(poly_space, fe_data, restriction_is_additive_flags,
                                        std::vector<ComponentMask>(1, std::vector<bool>(1,true))),
-  q_degree (types_are_equal<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value
+  q_degree (std::is_same<PolynomialType, TensorProductPolynomialsBubbles<dim> >::value
             ?this->degree-1
             :this->degree)
 {}

--- a/tests/lac/gmres_eigenvalues.cc
+++ b/tests/lac/gmres_eigenvalues.cc
@@ -67,7 +67,7 @@ void test (unsigned int variant)
       }
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant,1));

--- a/tests/lac/gmres_reorthogonalize_01.cc
+++ b/tests/lac/gmres_reorthogonalize_01.cc
@@ -60,7 +60,7 @@ void test (unsigned int variant)
       matrix(i,i) = 1e30*(i+1)*(i+1)*(i+1)*(i+1);
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant,1));

--- a/tests/lac/gmres_reorthogonalize_03.cc
+++ b/tests/lac/gmres_reorthogonalize_03.cc
@@ -59,7 +59,7 @@ void test (unsigned int variant)
       matrix(i,i) = 1e30*(i+1)*(i+1)*(i+1)*(i+1);
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant,1));

--- a/tests/lac/la_vector_add_and_dot.cc
+++ b/tests/lac/la_vector_add_and_dot.cc
@@ -43,7 +43,7 @@ void check ()
       v1.add(factor, v2);
       const number prod = v1 * v3;
       const number prod_check = check.add_and_dot(factor, v2, v3);
-      if (test == 0 && types_are_equal<number,double>::value)
+      if (test == 0 && std::is_same<number,double>::value)
         {
           deallog << "Vector add reference:   ";
           for (unsigned int i=0; i<size; ++i)

--- a/tests/lac/vector_add_and_dot.cc
+++ b/tests/lac/vector_add_and_dot.cc
@@ -41,7 +41,7 @@ void check ()
       v1.add(factor, v2);
       const number prod = v1 * v3;
       const number prod_check = check.add_and_dot(factor, v2, v3);
-      if (test == 0 && types_are_equal<number,double>::value)
+      if (test == 0 && std::is_same<number,double>::value)
         {
           deallog << "Vector add reference:   ";
           v1.print(deallog);

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -146,7 +146,7 @@ public:
     // for floats for the relative error size
     for (unsigned int i=0; i<2; ++i)
       {
-        if (types_are_equal<Number,double>::value == true)
+        if (std::is_same<Number,double>::value == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i*3+0]/total[i*3+0] << std::endl;
@@ -164,7 +164,7 @@ public:
             const double output2 = total[i*3+2] == 0 ? 0. : errors[i*3+2] / total[i*3+2];
             deallog << "Error function Laplacians FE " << i << ": " << output2 << std::endl;
           }
-        else if (types_are_equal<Number,float>::value == true)
+        else if (std::is_same<Number,float>::value == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i*3+0]/total[i*3+0] << std::endl;

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -185,7 +185,7 @@ public:
     // for floats for the relative error size
     for (unsigned int i=0; i<3; ++i)
       {
-        if (types_are_equal<Number,double>::value == true)
+        if (std::is_same<Number,double>::value == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i*3+0]/total[i*3+0] << std::endl;
@@ -203,7 +203,7 @@ public:
             const double output2 = total[i*3+2] == 0 ? 0. : errors[i*3+2] / total[i*3+2];
             deallog << "Error function Laplacians FE " << i << ": " << output2 << std::endl;
           }
-        else if (types_are_equal<Number,float>::value == true)
+        else if (std::is_same<Number,float>::value == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i*3+0]/total[i*3+0] << std::endl;

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -305,7 +305,7 @@ public:
 template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void do_test (const DoFHandler<dim>  &dof)
 {
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     {
       deallog.push("float");
     }
@@ -383,7 +383,7 @@ void do_test (const DoFHandler<dim>  &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     deallog.pop();
 }
 

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -76,7 +76,7 @@ using namespace dealii::MatrixFreeOperators;
 template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void do_test (const DoFHandler<dim>  &dof)
 {
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     {
       deallog.push("float");
     }
@@ -199,7 +199,7 @@ void do_test (const DoFHandler<dim>  &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -432,7 +432,7 @@ public:
 template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void do_test (const DoFHandler<dim>  &dof)
 {
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     {
       deallog.push("float");
     }
@@ -536,7 +536,7 @@ void do_test (const DoFHandler<dim>  &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     deallog.pop();
 }
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -113,7 +113,7 @@ public:
 template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void do_test (const DoFHandler<dim>  &dof)
 {
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     {
       deallog.push("float");
     }
@@ -259,7 +259,7 @@ void do_test (const DoFHandler<dim>  &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -113,7 +113,7 @@ public:
 template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void do_test (const DoFHandler<dim>  &dof)
 {
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     {
       deallog.push("float");
     }
@@ -259,7 +259,7 @@ void do_test (const DoFHandler<dim>  &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (types_are_equal<number,float>::value == true)
+  if (std::is_same<number,float>::value == true)
     deallog.pop();
 
   fine_matrix.clear();


### PR DESCRIPTION
C++11 provides `std::is_same`, which has the same functionality.