### PR TITLE
Reverse template arguments to parallel::GridTools::exchange_cell_data_to_ghosts()

### DIFF
--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -48,7 +48,11 @@ namespace parallel
      * ghost cell as it was given by @p pack on the owning processor.
      *
      * @tparam DataType The type of the data to be communicated. It is assumed
-     * to be serializable by boost::serialization.
+     *   to be serializable by boost::serialization. In many cases, this
+     *   data type can not be deduced by the compiler, e.g., if you provide
+     *   lambda functions for the second and third argument
+     *   to this function. In this case, you have to explicitly specify
+     *   the @p DataType as a template argument to the function call.
      * @tparam MeshType The type of @p mesh.
      *
      * @param mesh A variable of a type that satisfies the requirements of the
@@ -59,7 +63,7 @@ namespace parallel
      * with the data imported from the other procs.
 
      */
-    template <typename MeshType, typename DataType>
+    template <typename DataType, typename MeshType>
     void
     exchange_cell_data_to_ghosts (const MeshType &mesh,
                                   std::function<DataType (const typename MeshType::active_cell_iterator &)> pack,
@@ -191,7 +195,7 @@ namespace parallel
     }
 
 
-    template <typename MeshType, typename DataType>
+    template <typename DataType, typename MeshType>
     void
     exchange_cell_data_to_ghosts (const MeshType &mesh,
                                   std::function<DataType (const typename MeshType::active_cell_iterator &)> pack,

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_01.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_01.cc
@@ -43,9 +43,10 @@ void test ()
   typedef double DT;
   DT counter = 0.0;
   parallel::GridTools::exchange_cell_data_to_ghosts<
-  parallel::distributed::Triangulation<dim>,
-           DT> (tria,
-                [&](const cell_iterator& cell)
+  DT,
+  parallel::distributed::Triangulation<dim>>
+  (tria,
+   [&](const cell_iterator& cell)
   {
     DT value = ++counter;
 

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_02.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_02.cc
@@ -50,9 +50,10 @@ void test ()
   typedef short DT;
   short counter = 0;
   parallel::GridTools::exchange_cell_data_to_ghosts<
-  DoFHandler<dim>,
-             DT> (dofhandler,
-                  [&](const cell_iterator& cell)
+  DT,
+  DoFHandler<dim> >
+  (dofhandler,
+   [&](const cell_iterator& cell)
   {
     DT value = ++counter;
 

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_03.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_03.cc
@@ -48,9 +48,9 @@ void test ()
   typedef double DT;
   DT counter = 0.0;
   parallel::GridTools::exchange_cell_data_to_ghosts<
-  parallel::shared::Triangulation<dim>,
-           DT> (tria,
-                [&](const cell_iterator& cell)
+  DT, parallel::shared::Triangulation<dim>>
+                                         (tria,
+                                          [&](const cell_iterator& cell)
   {
     DT value = ++counter;
 


### PR DESCRIPTION
This is useful because `MeshType` is deducible from the function argument list, whereas `DataType` is not if you pass a lambda function. Also update the documentation in this regard.

Passes the testsuite.