### PR TITLE
Avoid warnings related to the deprecation of types_are_equal

### DIFF
--- a/doc/news/changes/minor/20170814DavidWells
+++ b/doc/news/changes/minor/20170814DavidWells
@@ -1,0 +1,2 @@
+Deprecated: types_are_equal has been deprecated in favor of std::is_same.
+<br> (David Wells, 2017/08/14)

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -297,25 +297,9 @@ namespace internal
  * instead of this class.
  */
 template <typename T, typename U>
-struct types_are_equal
-{
-  static const bool value = false;
-} DEAL_II_DEPRECATED;
+struct types_are_equal : std::is_same<T,U>
+{} DEAL_II_DEPRECATED;
 
-
-/**
- * Partial specialization of the general template for the case that both
- * template arguments are equal. See the documentation of the general template
- * for more information.
- *
- * @deprecated Use the standard library type trait <code>std::is_same</code>
- * instead of this class.
- */
-template <typename T>
-struct types_are_equal<T,T>
-{
-  static const bool value = true;
-} DEAL_II_DEPRECATED;
 
 
 /**


### PR DESCRIPTION
Implementing the template specialization already triggers the creation of a deprecation message
if `include/deal.II/base/template_constraints.h` is included ([Example](https://cdash.kyomu.43-1.org/testDetails.php?test=39057577&build=10064)). 
Hence, just replace the implementation of `types_are_equal` by the replacement `std::is_same`.

Relates #4704.