### PR TITLE
[8.5.1] remove fallthrough warnings.

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -73,6 +73,11 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Woverloaded-virtual")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-long-long")
 
 #
+# Disable fallthrough warnings on GCC7:
+#
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wno-implicit-fallthrough")
+
+#
 # Disable Wplacement-new that will trigger a lot of warnings
 # in the BOOST function classes that we include via the
 # BOOST signals classes:


### PR DESCRIPTION
This is not needed on master (we have `DEAL_II_FALLTHROUGH`), but we get a lot of warnings without this with GCC7.