### PR TITLE
Bugfix: Make library compile with -DWITH_NANOFLANN=ON

### DIFF
--- a/include/deal.II/numerics/kdtree.h
+++ b/include/deal.II/numerics/kdtree.h
@@ -22,6 +22,8 @@
 
 #include <deal.II/base/point.h>
 
+#include <memory>
+
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <nanoflann.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
@@ -245,7 +247,7 @@ unsigned int KDTree<dim>::size() const
     return adaptor->points.size();
   else
     return 0;
-};
+}
 
 
 


### PR DESCRIPTION
We were missing a mandatory include in numerics/kdtree.h

In reference to #4704
In reference to #4825