### PR TITLE
Moved Sacado product type header and Sacado tests

### DIFF
--- a/include/deal.II/base/sacado_product_type.h
+++ b/include/deal.II/base/sacado_product_type.h
@@ -1,7 +1,7 @@
 #ifndef dealii_sacado_product_type_h_deprecated
 #define dealii_sacado_product_type_h_deprecated
-#warning This file is deprecated. Use <deal.II/differentiation/sacado_product_types.h> instead.
+#warning This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.
 
-#  include <deal.II/differentiation/sacado_product_types.h>
+#  include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #endif

--- a/include/deal.II/differentiation/ad/sacado_product_types.h
+++ b/include/deal.II/differentiation/ad/sacado_product_types.h
@@ -13,8 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
-#ifndef dealii_differentiation_sacado_product_types_h
-#define dealii_differentiation_sacado_product_types_h
+#ifndef dealii_differentiation_ad_sacado_product_types_h
+#define dealii_differentiation_ad_sacado_product_types_h
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/tensor.h>

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -22,7 +22,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Sacado.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 #endif
 
 #include <deal.II/base/symmetric_tensor.h>

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -39,7 +39,7 @@
 #include <iomanip>
 #include <memory>
 
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/tests/fe/fe_values_view_get_function_from_local_dof_values_02.cc
+++ b/tests/fe/fe_values_view_get_function_from_local_dof_values_02.cc
@@ -25,7 +25,7 @@
 #include "../tests.h"
 
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/grid/grid_generator.h>

--- a/tests/sacado/sacado_product_type_01.cc
+++ b/tests/sacado/sacado_product_type_01.cc
@@ -19,7 +19,7 @@
 #include <typeinfo>
 
 #include <deal.II/base/tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_02.cc
+++ b/tests/sacado/sacado_product_type_02.cc
@@ -19,7 +19,7 @@
 #include <typeinfo>
 
 #include <deal.II/base/tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_03.cc
+++ b/tests/sacado/sacado_product_type_03.cc
@@ -19,7 +19,7 @@
 #include <typeinfo>
 
 #include <deal.II/base/tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_04.cc
+++ b/tests/sacado/sacado_product_type_04.cc
@@ -19,7 +19,7 @@
 #include <typeinfo>
 
 #include <deal.II/base/tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_05.cc
+++ b/tests/sacado/sacado_product_type_05.cc
@@ -19,7 +19,7 @@
 #include <typeinfo>
 
 #include <deal.II/base/tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_06.cc
+++ b/tests/sacado/sacado_product_type_06.cc
@@ -18,7 +18,7 @@
 
 
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_07.cc
+++ b/tests/sacado/sacado_product_type_07.cc
@@ -18,7 +18,7 @@
 
 
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_08.cc
+++ b/tests/sacado/sacado_product_type_08.cc
@@ -18,7 +18,7 @@
 
 
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 

--- a/tests/sacado/sacado_product_type_09.cc
+++ b/tests/sacado/sacado_product_type_09.cc
@@ -18,7 +18,7 @@
 
 
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/differentiation/sacado_product_types.h>
+#include <deal.II/differentiation/ad/sacado_product_types.h>
 
 #include "../tests.h"
 


### PR DESCRIPTION
This relocates the directory in which the Sacado header is found, and restructures Sacado tests (they're now isolated from the rest of the Trilinos tests).

With reference to #4704