### PR TITLE
Clean up CUDA related files

### DIFF
--- a/include/deal.II/matrix_free/cuda_fe_evaluation.cuh
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.cuh
@@ -20,7 +20,7 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/lac/cuda_vector.h>
 #include <deal.II/matrix_free/cuda_matrix_free.h>
-#include <deal.II/matrix_free/cuda_matrix_free.templates.h>
+#include <deal.II/matrix_free/cuda_matrix_free.templates.cuh>
 #include <deal.II/matrix_free/cuda_tensor_product_kernels.cuh>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
@@ -14,8 +14,8 @@
 // ---------------------------------------------------------------------
 
 
-#ifndef dealii_cuda_matrix_free_templates_h
-#define dealii_cuda_matrix_free_templates_h
+#ifndef dealii__cuda_matrix_free_templates_cuh
+#define dealii__cuda_matrix_free_templates_cuh
 
 #include <deal.II/matrix_free/cuda_matrix_free.h>
 

--- a/source/matrix_free/cuda_matrix_free.cu
+++ b/source/matrix_free/cuda_matrix_free.cu
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/matrix_free/cuda_matrix_free.templates.h>
+#include <deal.II/matrix_free/cuda_matrix_free.templates.cuh>
 
 #ifdef DEAL_II_WITH_CUDA
 

--- a/tests/cuda/matrix_vector_common.cuh
+++ b/tests/cuda/matrix_vector_common.cuh
@@ -156,7 +156,6 @@ int main()
   deallog << std::setprecision (3);
 
   {
-    deallog.threshold_double(5.e-11);
     deallog.push("2d");
     test<2,1>();
     test<2,2>();


### PR DESCRIPTION
-  `threshold_double` doesn't exist anymore
- `cuda_matrix_free.templates.h` can only be compiled using a CUDA compiler, so rename.

Relates #4704.