### PR TITLE
Generalize GridTools::exchange_cell_data_to_ghosts()

### DIFF
--- a/tests/distributed_grids/grid_tools_exchange_cell_data_04.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_04.cc
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2001 - 2015 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test GridTools::exchange_cell_data_to_ghosts
+//
+// this test works just like the _01 test, but it skips those cells
+// where we have an odd 'counter' value via the boost::optional
+// framework
+
+#include "../tests.h"
+#include <deal.II/base/logstream.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/grid_tools.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/cell_id.h>
+
+#include <algorithm>
+
+template <int dim>
+void test ()
+{
+  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  deallog << "dim = " << dim << std::endl;
+
+  parallel::distributed::Triangulation<dim> tria (mpi_communicator);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  std::set<std::string> output;
+
+  typedef typename parallel::distributed::Triangulation<dim>::active_cell_iterator cell_iterator;
+  typedef double DT;
+  int counter = 0;
+  parallel::GridTools::exchange_cell_data_to_ghosts<
+  DT,
+  parallel::distributed::Triangulation<dim>>
+  (tria,
+   [&](const cell_iterator& cell) -> boost::optional<DT>
+  {
+    ++counter;
+    if (counter % 2 == 0)
+      {
+        DT value = counter;
+
+        deallog << "pack "
+        << cell->id()
+        << " "
+        << value << std::endl;
+        return value;
+      }
+    else
+      {
+        deallog << "skipping "
+        << cell->id()
+        << ' ' << counter
+        << std::endl;
+        return boost::optional<DT>();
+      }
+  },
+  [&](const cell_iterator& cell, const DT& data)
+  {
+    std::ostringstream oss;
+    oss << "unpack "
+        << cell->id()
+        << " "
+        << data
+        << " from "
+        << cell->subdomain_id();
+
+    output.insert(oss.str());
+  });
+
+  // sort the output because it will come in in random order
+  for (auto &it : output)
+    deallog << it << std::endl;
+}
+
+
+int main (int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, 1);
+  MPILogInitAll log;
+
+  test<2> ();
+  test<3> ();
+
+  return 0;
+}

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_04.with_p4est=true.mpirun=2.output
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_04.with_p4est=true.mpirun=2.output
@@ -1,0 +1,67 @@
+
+DEAL:0::dim = 2
+DEAL:0::skipping 0_2:02 1
+DEAL:0::pack 0_2:03 2.00000
+DEAL:0::skipping 0_2:12 3
+DEAL:0::pack 0_2:13 4.00000
+DEAL:0::unpack 0_2:21 2 from 1
+DEAL:0::unpack 0_2:31 4 from 1
+DEAL:0::dim = 3
+DEAL:0::skipping 0_2:04 1
+DEAL:0::pack 0_2:05 2.00000
+DEAL:0::skipping 0_2:06 3
+DEAL:0::pack 0_2:07 4.00000
+DEAL:0::skipping 0_2:14 5
+DEAL:0::pack 0_2:15 6.00000
+DEAL:0::skipping 0_2:16 7
+DEAL:0::pack 0_2:17 8.00000
+DEAL:0::skipping 0_2:24 9
+DEAL:0::pack 0_2:25 10.0000
+DEAL:0::skipping 0_2:26 11
+DEAL:0::pack 0_2:27 12.0000
+DEAL:0::skipping 0_2:34 13
+DEAL:0::pack 0_2:35 14.0000
+DEAL:0::skipping 0_2:36 15
+DEAL:0::pack 0_2:37 16.0000
+DEAL:0::unpack 0_2:41 2 from 1
+DEAL:0::unpack 0_2:43 4 from 1
+DEAL:0::unpack 0_2:51 6 from 1
+DEAL:0::unpack 0_2:53 8 from 1
+DEAL:0::unpack 0_2:61 10 from 1
+DEAL:0::unpack 0_2:63 12 from 1
+DEAL:0::unpack 0_2:71 14 from 1
+DEAL:0::unpack 0_2:73 16 from 1
+
+DEAL:1::dim = 2
+DEAL:1::skipping 0_2:20 1
+DEAL:1::pack 0_2:21 2.00000
+DEAL:1::skipping 0_2:30 3
+DEAL:1::pack 0_2:31 4.00000
+DEAL:1::unpack 0_2:03 2 from 0
+DEAL:1::unpack 0_2:13 4 from 0
+DEAL:1::dim = 3
+DEAL:1::skipping 0_2:40 1
+DEAL:1::pack 0_2:41 2.00000
+DEAL:1::skipping 0_2:42 3
+DEAL:1::pack 0_2:43 4.00000
+DEAL:1::skipping 0_2:50 5
+DEAL:1::pack 0_2:51 6.00000
+DEAL:1::skipping 0_2:52 7
+DEAL:1::pack 0_2:53 8.00000
+DEAL:1::skipping 0_2:60 9
+DEAL:1::pack 0_2:61 10.0000
+DEAL:1::skipping 0_2:62 11
+DEAL:1::pack 0_2:63 12.0000
+DEAL:1::skipping 0_2:70 13
+DEAL:1::pack 0_2:71 14.0000
+DEAL:1::skipping 0_2:72 15
+DEAL:1::pack 0_2:73 16.0000
+DEAL:1::unpack 0_2:05 2 from 0
+DEAL:1::unpack 0_2:07 4 from 0
+DEAL:1::unpack 0_2:15 6 from 0
+DEAL:1::unpack 0_2:17 8 from 0
+DEAL:1::unpack 0_2:25 10 from 0
+DEAL:1::unpack 0_2:27 12 from 0
+DEAL:1::unpack 0_2:35 14 from 0
+DEAL:1::unpack 0_2:37 16 from 0
+

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_04.with_p4est=true.mpirun=3.output
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_04.with_p4est=true.mpirun=3.output
@@ -1,0 +1,111 @@
+
+DEAL:0::dim = 2
+DEAL:0::skipping 0_2:01 1
+DEAL:0::pack 0_2:02 2.00000
+DEAL:0::skipping 0_2:03 3
+DEAL:0::unpack 0_2:12 2 from 1
+DEAL:0::unpack 0_2:20 4 from 1
+DEAL:0::dim = 3
+DEAL:0::skipping 0_2:03 1
+DEAL:0::pack 0_2:04 2.00000
+DEAL:0::skipping 0_2:05 3
+DEAL:0::pack 0_2:06 4.00000
+DEAL:0::skipping 0_2:07 5
+DEAL:0::pack 0_2:12 6.00000
+DEAL:0::skipping 0_2:13 7
+DEAL:0::pack 0_2:14 8.00000
+DEAL:0::skipping 0_2:15 9
+DEAL:0::pack 0_2:16 10.0000
+DEAL:0::skipping 0_2:17 11
+DEAL:0::pack 0_2:21 12.0000
+DEAL:0::skipping 0_2:23 13
+DEAL:0::pack 0_2:24 14.0000
+DEAL:0::skipping 0_2:25 15
+DEAL:0::pack 0_2:26 16.0000
+DEAL:0::skipping 0_2:27 17
+DEAL:0::unpack 0_2:31 2 from 1
+DEAL:0::unpack 0_2:34 4 from 1
+DEAL:0::unpack 0_2:36 6 from 1
+DEAL:0::unpack 0_2:40 8 from 1
+DEAL:0::unpack 0_2:42 10 from 1
+DEAL:0::unpack 0_2:51 2 from 2
+DEAL:0::unpack 0_2:53 4 from 2
+DEAL:0::unpack 0_2:61 8 from 2
+DEAL:0::unpack 0_2:63 10 from 2
+DEAL:0::unpack 0_2:71 14 from 2
+
+DEAL:1::dim = 2
+DEAL:1::skipping 0_2:10 1
+DEAL:1::pack 0_2:12 2.00000
+DEAL:1::skipping 0_2:13 3
+DEAL:1::pack 0_2:20 4.00000
+DEAL:1::skipping 0_2:21 5
+DEAL:1::pack 0_2:23 6.00000
+DEAL:1::unpack 0_2:02 2 from 0
+DEAL:1::unpack 0_2:31 2 from 2
+DEAL:1::dim = 3
+DEAL:1::skipping 0_2:30 1
+DEAL:1::pack 0_2:31 2.00000
+DEAL:1::skipping 0_2:32 3
+DEAL:1::pack 0_2:34 4.00000
+DEAL:1::skipping 0_2:35 5
+DEAL:1::pack 0_2:36 6.00000
+DEAL:1::skipping 0_2:37 7
+DEAL:1::pack 0_2:40 8.00000
+DEAL:1::skipping 0_2:41 9
+DEAL:1::pack 0_2:42 10.0000
+DEAL:1::skipping 0_2:43 11
+DEAL:1::pack 0_2:45 12.0000
+DEAL:1::skipping 0_2:46 13
+DEAL:1::pack 0_2:47 14.0000
+DEAL:1::unpack 0_2:04 2 from 0
+DEAL:1::unpack 0_2:06 4 from 0
+DEAL:1::unpack 0_2:12 6 from 0
+DEAL:1::unpack 0_2:14 8 from 0
+DEAL:1::unpack 0_2:16 10 from 0
+DEAL:1::unpack 0_2:21 12 from 0
+DEAL:1::unpack 0_2:24 14 from 0
+DEAL:1::unpack 0_2:53 4 from 2
+DEAL:1::unpack 0_2:56 6 from 2
+DEAL:1::unpack 0_2:61 8 from 2
+DEAL:1::unpack 0_2:63 10 from 2
+DEAL:1::unpack 0_2:65 12 from 2
+DEAL:1::unpack 0_2:71 14 from 2
+DEAL:1::unpack 0_2:73 16 from 2
+
+
+DEAL:2::dim = 2
+DEAL:2::skipping 0_2:30 1
+DEAL:2::pack 0_2:31 2.00000
+DEAL:2::skipping 0_2:32 3
+DEAL:2::unpack 0_2:12 2 from 1
+DEAL:2::unpack 0_2:23 6 from 1
+DEAL:2::dim = 3
+DEAL:2::skipping 0_2:50 1
+DEAL:2::pack 0_2:51 2.00000
+DEAL:2::skipping 0_2:52 3
+DEAL:2::pack 0_2:53 4.00000
+DEAL:2::skipping 0_2:54 5
+DEAL:2::pack 0_2:56 6.00000
+DEAL:2::skipping 0_2:60 7
+DEAL:2::pack 0_2:61 8.00000
+DEAL:2::skipping 0_2:62 9
+DEAL:2::pack 0_2:63 10.0000
+DEAL:2::skipping 0_2:64 11
+DEAL:2::pack 0_2:65 12.0000
+DEAL:2::skipping 0_2:70 13
+DEAL:2::pack 0_2:71 14.0000
+DEAL:2::skipping 0_2:72 15
+DEAL:2::pack 0_2:73 16.0000
+DEAL:2::skipping 0_2:74 17
+DEAL:2::unpack 0_2:06 4 from 0
+DEAL:2::unpack 0_2:14 8 from 0
+DEAL:2::unpack 0_2:16 10 from 0
+DEAL:2::unpack 0_2:24 14 from 0
+DEAL:2::unpack 0_2:26 16 from 0
+DEAL:2::unpack 0_2:34 4 from 1
+DEAL:2::unpack 0_2:36 6 from 1
+DEAL:2::unpack 0_2:42 10 from 1
+DEAL:2::unpack 0_2:45 12 from 1
+DEAL:2::unpack 0_2:47 14 from 1
+


### PR DESCRIPTION
This PR generalizes `GridTools::exchange_cell_data_to_ghosts()` in that it allows the `pack` function to return an empty `boost::optional`, and in that case no data is actually sent. I also add a test.

Passes all of the MPI tests as well as the `distributed/grid_tools_exchange_cell_data_*` tests that were already there.