### PR TITLE
Make noexcept for AssertNoThrow more explicit

### DIFF
--- a/tests/base/exception_nothrow.cc
+++ b/tests/base/exception_nothrow.cc
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// test that AssertNothrow is printing what we expect.
+
+#include "../tests.h"
+
+int main ()
+{
+  initlog();
+  deal_II_exceptions::disable_abort_on_exception();
+  AssertNothrow(1==2, ExcInternalError());
+}

--- a/tests/base/exception_nothrow.debug.output
+++ b/tests/base/exception_nothrow.debug.output
@@ -1,0 +1,12 @@
+
+DEAL::Exception: ExcInternalError()
+DEAL::
+--------------------------------------------------------
+An error occurred in file <exception_nothrow.cc> in function
+    int main()
+The violated condition was: 
+    1==2
+Additional information: 
+    (none)
+--------------------------------------------------------
+

--- a/tests/base/reference.debug.output
+++ b/tests/base/reference.debug.output
@@ -11,6 +11,16 @@ DEAL::Construct C
 DEAL::Construct D
 DEAL::Destruct D
 DEAL::Exception: ExcInUse (counter, object_info->name(), infostring)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::check_no_subscribers() const
+The violated condition was: 
+    counter == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+
 DEAL::Destruct C
 DEAL::Destruct B
 DEAL::Destruct A

--- a/tests/lac/vector_memory.debug.output
+++ b/tests/lac/vector_memory.debug.output
@@ -2,4 +2,24 @@
 DEAL::GrowingVectorMemory:Overall allocated vectors: 10
 DEAL::GrowingVectorMemory:Maximum allocated vectors: 6
 DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    dealii::GrowingVectorMemory<VectorType>::~GrowingVectorMemory() [with VectorType = dealii::Vector<double>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+
 DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    dealii::GrowingVectorMemory<VectorType>::~GrowingVectorMemory() [with VectorType = dealii::Vector<float>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    (none)
+--------------------------------------------------------
+


### PR DESCRIPTION
`AssertNoThrow` used to call `issue_error` which may throw. In particular, Coverity complains about this.
Also make sure to not indirectly call `MPIThrow` in `internals::abort` through `Utilities::MPI::n_mpi_processes`