### PR TITLE
cmake: fix intel compiler detection

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -264,7 +264,7 @@ CHECK_CXX_SOURCE_COMPILES(
 
   // Check the version language macro, but skip MSVC because
   // MSVC reports 199711 even in MSVC 2017.
-  #if __cplusplus < 201103L && !defined(_MSC_VER)
+  #if __cplusplus < 201103L && !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
   #  error \"insufficient support for C++11\"
   #endif
 

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -20,10 +20,10 @@
 # editing this file.
 #
 
-IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0" )
+IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15.0" )
   MESSAGE(WARNING "\n"
     "You're using an old version of the Intel C++ Compiler (icc/icpc)!\n"
-    "It is strongly recommended to use at least version 10.\n"
+    "It is strongly recommended to use at least version 15.\n"
     )
 ENDIF()
 


### PR DESCRIPTION
It turns out intel defines __cplusplus as "1" instead of "201103", see https://software.intel.com/en-us/node/524490