### PR TITLE
Include correct headers for serialization of std::array

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -36,6 +36,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#include <boost/serialization/array.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <set>

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -30,6 +30,8 @@
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/grid_tools.h>
 
+#include <boost/serialization/array.hpp>
+
 #include <set>
 #include <algorithm>
 #include <functional>


### PR DESCRIPTION
Fixes #4879. Apparently, we were missing to include these header files explicitly. They seem to be included by some other `boost` header file in previous `boost` versions while this is not the case for 1.64.0.