### PR TITLE
Fix tensor product matrix test case in float mode.

### DIFF
--- a/tests/lac/tensor_product_matrix_03.cc
+++ b/tests/lac/tensor_product_matrix_03.cc
@@ -51,7 +51,11 @@ void do_test()
   mat.vmult(v2, v1);
   mat.apply_inverse(v3, v2);
   v3 -= v1;
-  deallog << "Verification of vmult and inverse: " << (double)v3.linfty_norm() << std::endl;
+  // add tolerance to account for different BLAS/LAPACK combinations. Float is
+  // too inaccurate so numdiff does not work...
+  double norm = v3.linfty_norm();
+  deallog << "Verification of vmult and inverse: "
+          << (norm < 1e-3 ? 0. : norm)  << std::endl;
 
   FullMatrix<float> full(v1.size(), v1.size());
   for (unsigned int i=0, c=0; i<(dim>2?size:1); ++i)
@@ -69,13 +73,16 @@ void do_test()
                              + laplace(i,ii)*mass(j,jj)*mass(k,kk);
   full.vmult(v3, v1);
   v3 -= v2;
-  deallog << "Verifiction of vmult: " << (double)v3.linfty_norm() << std::endl;
+
+  norm = v3.linfty_norm();
+  deallog << "Verifiction of vmult: " << (norm < 1e-4 ? 0. : norm) << std::endl;
 
   full.gauss_jordan();
   full.vmult(v3, v1);
   mat.apply_inverse(v2, v1);
   v3 -= v2;
-  deallog << "Verification of inverse: " << (double)v3.linfty_norm() << std::endl;
+  norm = v3.linfty_norm();
+  deallog << "Verification of inverse: " << (norm < 5e-3 ? 0. : norm) << std::endl;
 }
 
 

--- a/tests/lac/tensor_product_matrix_03.with_lapack=true.output
+++ b/tests/lac/tensor_product_matrix_03.with_lapack=true.output
@@ -1,45 +1,45 @@
 
 DEAL::Testing dim=1, degree=1
-DEAL::Verification of vmult and inverse: 1.19209e-07
+DEAL::Verification of vmult and inverse: 0.00000
 DEAL::Verifiction of vmult: 0.00000
-DEAL::Verification of inverse: 5.96046e-08
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=1, degree=2
-DEAL::Verification of vmult and inverse: 1.19209e-07
+DEAL::Verification of vmult and inverse: 0.00000
 DEAL::Verifiction of vmult: 0.00000
-DEAL::Verification of inverse: 2.38419e-07
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=1, degree=5
-DEAL::Verification of vmult and inverse: 9.53674e-06
+DEAL::Verification of vmult and inverse: 0.00000
 DEAL::Verifiction of vmult: 0.00000
-DEAL::Verification of inverse: 4.19617e-05
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=2, degree=1
-DEAL::Verification of vmult and inverse: 2.38419e-07
+DEAL::Verification of vmult and inverse: 0.00000
 DEAL::Verifiction of vmult: 0.00000
-DEAL::Verification of inverse: 1.19209e-07
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=2, degree=2
-DEAL::Verification of vmult and inverse: 9.53674e-07
-DEAL::Verifiction of vmult: 1.90735e-06
-DEAL::Verification of inverse: 3.57628e-07
-DEAL::Testing dim=2, degree=5
-DEAL::Verification of vmult and inverse: 2.47955e-05
-DEAL::Verifiction of vmult: 3.81470e-06
-DEAL::Verification of inverse: 5.14984e-05
-DEAL::Testing dim=2, degree=11
-DEAL::Verification of vmult and inverse: 7.67708e-05
-DEAL::Verifiction of vmult: 5.72205e-06
-DEAL::Verification of inverse: 0.000236511
-DEAL::Testing dim=3, degree=1
-DEAL::Verification of vmult and inverse: 2.38419e-07
+DEAL::Verification of vmult and inverse: 0.00000
 DEAL::Verifiction of vmult: 0.00000
-DEAL::Verification of inverse: 8.94070e-08
+DEAL::Verification of inverse: 0.00000
+DEAL::Testing dim=2, degree=5
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000
+DEAL::Testing dim=2, degree=11
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000
+DEAL::Testing dim=3, degree=1
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=3, degree=2
-DEAL::Verification of vmult and inverse: 1.90735e-06
-DEAL::Verifiction of vmult: 3.81470e-06
-DEAL::Verification of inverse: 9.53674e-07
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=3, degree=3
-DEAL::Verification of vmult and inverse: 1.71661e-05
-DEAL::Verifiction of vmult: 1.14441e-05
-DEAL::Verification of inverse: 1.04904e-05
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000
 DEAL::Testing dim=3, degree=7
-DEAL::Verification of vmult and inverse: 0.000104904
-DEAL::Verifiction of vmult: 1.14441e-05
-DEAL::Verification of inverse: 0.000228882
+DEAL::Verification of vmult and inverse: 0.00000
+DEAL::Verifiction of vmult: 0.00000
+DEAL::Verification of inverse: 0.00000


### PR DESCRIPTION
This test was broken by 8fe5f5eeafe73381311acb68d273f06a21593ab4 where the separate output mode was deleted. The problem is that float does not achieve an accuracy sufficient for numdiff, so we need to manually create a stable output.

Relates to #4880 