### PR TITLE
Do not use dim3 for non-CUDA code

### DIFF
--- a/tests/grid/grid_generator_cheese.cc
+++ b/tests/grid/grid_generator_cheese.cc
@@ -23,7 +23,7 @@
 
 
 
-void dim2(std::ostream &os)
+void dim_2(std::ostream &os)
 {
   const unsigned int d=2;
   Triangulation<d> tr;
@@ -37,7 +37,7 @@ void dim2(std::ostream &os)
   gout.write_vtk(tr, os);
 }
 
-void dim3(std::ostream &os)
+void dim_3(std::ostream &os)
 {
   const unsigned int d=3;
   Triangulation<d> tr;
@@ -57,6 +57,6 @@ int main()
 {
   initlog(true);
   std::ostream &logfile = deallog.get_file_stream();
-  dim2(logfile);
-  dim3(logfile);
+  dim_2(logfile);
+  dim_3(logfile);
 }

--- a/tests/grid/grid_generator_general_cell.cc
+++ b/tests/grid/grid_generator_general_cell.cc
@@ -20,7 +20,7 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_out.h>
 
-void dim2(std::ostream &os)
+void dim_2(std::ostream &os)
 {
   std::vector<Point<2> > vertices(4);
   vertices[0](0) = -1.;
@@ -39,7 +39,7 @@ void dim2(std::ostream &os)
   gout.write_vtk(tria, os);
 }
 
-void dim3(std::ostream &os)
+void dim_3(std::ostream &os)
 {
   std::vector<Point<3> > vertices(8);
   vertices[0](0) = -1.;
@@ -79,6 +79,6 @@ int main()
 {
   initlog(true);
   std::ostream &logfile = deallog.get_file_stream();
-  dim2(logfile);
-  dim3(logfile);
+  dim_2(logfile);
+  dim_3(logfile);
 }

--- a/tests/grid/grid_generator_hyper_cross.cc
+++ b/tests/grid/grid_generator_hyper_cross.cc
@@ -23,7 +23,7 @@
 
 
 
-void dim2(std::ostream &os)
+void dim_2(std::ostream &os)
 {
   const unsigned int d=2;
   Triangulation<d> tr;
@@ -39,7 +39,7 @@ void dim2(std::ostream &os)
   gout.write_vtk(tr, os);
 }
 
-void dim3(std::ostream &os)
+void dim_3(std::ostream &os)
 {
   const unsigned int d=3;
   Triangulation<d> tr;
@@ -62,6 +62,6 @@ int main()
 {
   initlog(true);
   std::ostream &logfile = deallog.get_file_stream();
-  dim2(logfile);
-  dim3(logfile);
+  dim_2(logfile);
+  dim_3(logfile);
 }

--- a/tests/grid/grid_generator_simplex.cc
+++ b/tests/grid/grid_generator_simplex.cc
@@ -23,7 +23,7 @@
 
 
 
-void dim2(std::ostream &os)
+void dim_2(std::ostream &os)
 {
   const unsigned int d=2;
   Triangulation<d> tr;
@@ -39,7 +39,7 @@ void dim2(std::ostream &os)
   gout.write_vtk(tr, os);
 }
 
-void dim3(std::ostream &os)
+void dim_3(std::ostream &os)
 {
   const unsigned int d=3;
   Triangulation<d> tr;
@@ -68,6 +68,6 @@ int main()
 {
   initlog(true);
   std::ostream &logfile = deallog.get_file_stream();
-  dim2(logfile);
-  dim3(logfile);
+  dim_2(logfile);
+  dim_3(logfile);
 }

--- a/tests/grid/manifold_ids_on_boundary_01.cc
+++ b/tests/grid/manifold_ids_on_boundary_01.cc
@@ -26,7 +26,7 @@
 #include <iostream>
 
 
-void dim2(std::ostream &os)
+void dim_2(std::ostream &os)
 {
   const unsigned int d=2;
   const Point<d> center(0,0);
@@ -46,7 +46,7 @@ void dim2(std::ostream &os)
   gout.write_vtk(tr, os);
 }
 
-void dim3(std::ostream &os)
+void dim_3(std::ostream &os)
 {
   const unsigned int d=3;
 
@@ -70,6 +70,6 @@ int main()
 {
   initlog(true);
   std::ostream &logfile = deallog.get_file_stream();
-  dim2(logfile);
-  dim3(logfile);
+  dim_2(logfile);
+  dim_3(logfile);
 }


### PR DESCRIPTION
dim3 is an array of size 3 defined by CUDA. Remove non CUDA-related dim3
because it creates an error due to conflicting declaration.