### PR TITLE
make an Assert in LA::distributed::Vector::compress_finish() less rigid

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -676,9 +676,15 @@ namespace LinearAlgebra
             for ( ; my_imports!=part.import_indices().end(); ++my_imports)
               for (unsigned int j=my_imports->first; j<my_imports->second;
                    j++, read_position++)
+                // Below we use relatively large precision in units in the last place (ULP) as
+                // this Assert can be easily triggered in p::d::SolutionTransfer.
+                // The rationale is that during interpolation on two elements sharing
+                // the face, values on this face obtained from each side might
+                // be different due to additions being done in different order.
                 Assert(*read_position == Number() ||
                        std::abs(local_element(j) - *read_position) <=
-                       std::abs(local_element(j)) * 10000. *
+                       std::abs(local_element(j) + *read_position) *
+                       100000. *
                        std::numeric_limits<real_type>::epsilon(),
                        ExcNonMatchingElements(*read_position, local_element(j),
                                               part.this_mpi_process()));


### PR DESCRIPTION
this is a follow-up to https://github.com/dealii/dealii/pull/3727 and the discussion in https://groups.google.com/d/msg/dealii/RHw7hhCM2z8/83dbTgTYDQAJ

I hit this issue again and I don't really know other approach than to relax the tolerance.