### PR TITLE
Fix Assert with the correct number type

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1264,7 +1264,7 @@ namespace internal
                 ExcIndexRange (vertex_index, 0,
                                dof_handler.vertex_dof_offsets.size()));
         Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
-                numbers::invalid_dof_index,
+                numbers::invalid_unsigned_int,
                 ExcMessage ("This vertex is unused and has no DoFs associated with it"));
 
         // hop along the list of index

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1175,7 +1175,7 @@ namespace internal
         Assert (fe_index < dof_handler.finite_elements->size(),
                 ExcInternalError());
         Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
-                numbers::invalid_dof_index,
+                numbers::invalid_unsigned_int,
                 ExcMessage ("This vertex is unused and has no DoFs associated with it"));
 
         // hop along the list of index
@@ -1312,7 +1312,7 @@ namespace internal
                             "this DoFHandler"));
 
         // if this vertex is unused, return 0
-        if (dof_handler.vertex_dof_offsets[vertex_index] == numbers::invalid_dof_index)
+        if (dof_handler.vertex_dof_offsets[vertex_index] == numbers::invalid_unsigned_int)
           return 0;
 
         // hop along the list of index
@@ -1364,7 +1364,7 @@ namespace internal
         // make sure we don't ask on
         // unused vertices
         Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
-                numbers::invalid_dof_index,
+                numbers::invalid_unsigned_int,
                 ExcInternalError());
 
         // hop along the list of index
@@ -1424,7 +1424,7 @@ namespace internal
         // make sure we don't ask on
         // unused vertices
         Assert (dof_handler.vertex_dof_offsets[vertex_index] !=
-                numbers::invalid_dof_index,
+                numbers::invalid_unsigned_int,
                 ExcInternalError());
 
         // hop along the list of index

--- a/tests/hp/hp_dof_handler.cc
+++ b/tests/hp/hp_dof_handler.cc
@@ -30,10 +30,7 @@
 
 int main ()
 {
-  std::ofstream logfile("output");
-  logfile.precision(2);
-
-  deallog.attach(logfile);
+  initlog();
 
   const unsigned int dim=2;
   Triangulation<dim> tria;


### PR DESCRIPTION
Updating this particular `Assert` was forgotten in #4778. Detected by Coverity.