### PR TITLE
Fix failing MPI tests

### DIFF
--- a/include/deal.II/distributed/grid_tools.h
+++ b/include/deal.II/distributed/grid_tools.h
@@ -337,12 +337,8 @@ namespace parallel
         {
           internal::CellDataTransferBuffer<dim, DataType> &data = destination_to_data_buffer_map[*it];
 
-          // pack all the data into
-          // the buffer for this
-          // recipient and send
-          // it. keep data around
-          // till we can make sure
-          // that the packet has been
+          // pack all the data into the buffer for this recipient and send it.
+          // keep data around till we can make sure that the packet has been
           // received
           sendbuffers[idx] = data.pack_data ();
           const int ierr = MPI_Isend(sendbuffers[idx].data(), sendbuffers[idx].size(),
@@ -383,6 +379,14 @@ namespace parallel
 
               unpack(cell, *data);
             }
+        }
+
+      // make sure that all communication is finished
+      // when we leave this function.
+      if (requests.size())
+        {
+          const int ierr = MPI_Waitall(requests.size(), &requests[0], MPI_STATUSES_IGNORE);
+          AssertThrowMPI(ierr);
         }
 #endif // DEAL_II_WITH_MPI
     }


### PR DESCRIPTION
Fixes #4890 and hence also part of #4880.

It seems that we were missing to replace the part (dof_handler_policy.cc:3477)
```
       // wait for all Isends to complete, so that we can safely destroy the		
       // buffers.		i
       if (send_requests.size() > 0)		
         {		
           const int ierr = MPI_Waitall(send_requests.size(), &send_requests[0],		
                                        MPI_STATUSES_IGNORE);		
           AssertThrowMPI(ierr);		
         }		

       // check that all messages got sent and received		
       Assert (Utilities::MPI::sum (needs_to_get_cells.size(),		
                                    triangulation->get_communicator())		
                  ==		
                Utilities::MPI::sum (senders.size(),		
                                      triangulation->get_communicator()),		
                 ExcInternalError());		
```

in #4855.

@bangerth Please have a look to confirm that this makes sense to you.