### PR TITLE
Timer mpi fixes

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -80,7 +80,7 @@ public:
   /**
    * Constructor that takes an MPI communicator as input. A timer constructed
    * this way will sum up the CPU times over all processors in the MPI network
-   * when requested by the operator ().
+   * when requested by Timer::cpu_time().
    *
    * Starts the timer at 0 sec.
    *

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -22,10 +22,6 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
-
 #include <string>
 #include <list>
 #include <map>
@@ -81,7 +77,6 @@ public:
    */
   Timer ();
 
-#ifdef DEAL_II_WITH_MPI
   /**
    * Constructor that takes an MPI communicator as input. A timer constructed
    * this way will sum up the CPU times over all processors in the MPI network
@@ -94,8 +89,6 @@ public:
    * only works if you stop() the timer before querying for the wall time. The
    * time for the MPI operations are not included in the timing but may slow
    * down your program.
-   *
-   * This constructor is only available if deal.II is compiled with MPI support.
    */
   Timer (MPI_Comm mpi_communicator,
          const bool sync_wall_time = false);
@@ -127,7 +120,6 @@ public:
   template <class StreamType>
   void print_total_data(StreamType &stream) const;
 
-#endif
 
   /**
    * Re-start the timer at the point where it was stopped. This way a
@@ -242,7 +234,6 @@ private:
    */
   MPI_Comm            mpi_communicator;
 
-#ifdef DEAL_II_WITH_MPI
   /**
    * Store whether the wall time is synchronized between machines.
    */
@@ -263,7 +254,6 @@ private:
    * number of MPI processes in the MPI_Comm for the total run time.
    */
   Utilities::MPI::MinMaxAvg mpi_total_data;
-#endif
 };
 
 
@@ -556,7 +546,6 @@ public:
                const enum OutputFrequency output_frequency,
                const enum OutputType      output_type);
 
-#ifdef DEAL_II_WITH_MPI
   /**
    * Constructor that takes an MPI communicator as input. A timer constructed
    * this way will sum up the CPU times over all processors in the MPI network
@@ -612,11 +601,6 @@ public:
                ConditionalOStream        &stream,
                const enum OutputFrequency output_frequency,
                const enum OutputType      output_type);
-
-
-
-
-#endif
 
   /**
    * Destructor. Calls print_summary() in case the option for writing the
@@ -760,8 +744,6 @@ void Timer::restart ()
 
 
 
-#ifdef DEAL_II_WITH_MPI
-
 inline
 const Utilities::MPI::MinMaxAvg &
 Timer::get_data() const
@@ -803,8 +785,6 @@ Timer::print_total_data(StreamType &stream) const
          << " max @" << statistic.max_index << ", min=" << statistic.min << " @"
          << statistic.min_index << ", avg=" << statistic.avg << std::endl;
 }
-
-#endif
 
 
 

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -96,30 +96,67 @@ public:
   /**
    * Return a reference to the data structure with global timing information
    * for the last lap. Filled after calling stop().
+   *
+   * @deprecated Use Timer::get_last_lap_data() instead, which returns a
+   * reference to the same structure.
    */
-  const Utilities::MPI::MinMaxAvg &get_data() const;
+  const Utilities::MPI::MinMaxAvg &get_data() const DEAL_II_DEPRECATED;
+
+  /**
+   * Return a reference to the data structure containing timing information
+   * across all MPI processes in the given communicator about the last
+   * lap. Filled after calling stop().
+   */
+  const Utilities::MPI::MinMaxAvg &get_last_lap_data() const;
 
   /**
    * Return a reference to the data structure with global timing information
-   * for the total run.
-   * Filled after calling stop().
+   * for the total run. Filled after calling stop().
+   *
+   * @deprecated Use Timer::get_accumulated_wall_time_data() instead, which
+   * returns a reference the same structure.
    */
-  const Utilities::MPI::MinMaxAvg &get_total_data() const;
+  const Utilities::MPI::MinMaxAvg &get_total_data() const DEAL_II_DEPRECATED;
+
+  /**
+   * Return a reference to the data structure with global timing information
+   * for the total run. Filled after calling stop().
+   */
+  const Utilities::MPI::MinMaxAvg &get_accumulated_wall_time_data() const;
 
   /**
    * Prints the data returned by get_data(), i.e. for the last lap,
    * to the given stream.
+   *
+   * @deprecated Use Timer::print_last_lap_data() instead, which prints the
+   * same information.
    */
   template <class StreamType>
-  void print_data(StreamType &stream) const;
+  void print_data(StreamType &stream) const DEAL_II_DEPRECATED;
+
+  /**
+   * Print the data returned by Timer::get_last_lap_data() to the given
+   * stream.
+   */
+  template <class StreamType>
+  void print_last_lap_data(StreamType &stream) const;
 
   /**
    * Prints the data returned by get_total_data(), i.e. for the total run,
    * to the given stream.
+   *
+   * @deprecated Use Timer::print_accumulated_wall_time_data() instead, which
+   * prints the same information.
    */
   template <class StreamType>
-  void print_total_data(StreamType &stream) const;
+  void print_total_data(StreamType &stream) const DEAL_II_DEPRECATED;
 
+  /**
+   * Print the data returned by Timer::get_accumulated_wall_time_data() to the
+   * given stream.
+   */
+  template <class StreamType>
+  void print_accumulated_wall_time_data(StreamType &stream) const;
 
   /**
    * Re-start the timer at the point where it was stopped. This way a
@@ -240,12 +277,11 @@ private:
   bool sync_wall_time;
 
   /**
-   * A structure for parallel wall time measurement that includes the minimum
-   * time recorded among all processes, the maximum time as well as the
-   * average time defined as the sum of all individual times divided by the
-   * number of MPI processes in the MPI_Comm for the last lap.
+   * A structure for parallel wall time measurement that includes the minimum,
+   * maximum, and average over all processors known to the MPI communicator of
+   * the last lap time.
    */
-  Utilities::MPI::MinMaxAvg mpi_data;
+  Utilities::MPI::MinMaxAvg last_lap_data;
 
   /**
    * A structure for parallel wall time measurement that includes the minimum
@@ -253,7 +289,7 @@ private:
    * average time defined as the sum of all individual times divided by the
    * number of MPI processes in the MPI_Comm for the total run time.
    */
-  Utilities::MPI::MinMaxAvg mpi_total_data;
+  Utilities::MPI::MinMaxAvg accumulated_wall_time_data;
 };
 
 
@@ -748,7 +784,16 @@ inline
 const Utilities::MPI::MinMaxAvg &
 Timer::get_data() const
 {
-  return mpi_data;
+  return last_lap_data;
+}
+
+
+
+inline
+const Utilities::MPI::MinMaxAvg &
+Timer::get_last_lap_data() const
+{
+  return last_lap_data;
 }
 
 
@@ -757,7 +802,16 @@ inline
 const Utilities::MPI::MinMaxAvg &
 Timer::get_total_data() const
 {
-  return mpi_total_data;
+  return accumulated_wall_time_data;
+}
+
+
+
+inline
+const Utilities::MPI::MinMaxAvg &
+Timer::get_accumulated_wall_time_data() const
+{
+  return accumulated_wall_time_data;
 }
 
 
@@ -767,7 +821,17 @@ inline
 void
 Timer::print_data(StreamType &stream) const
 {
-  const Utilities::MPI::MinMaxAvg statistic = get_data();
+  print_last_lap_data(stream);
+}
+
+
+
+template <class StreamType>
+inline
+void
+Timer::print_last_lap_data(StreamType &stream) const
+{
+  const Utilities::MPI::MinMaxAvg statistic = get_last_lap_data();
   stream << statistic.max << " wall,"
          << " max @" << statistic.max_index << ", min=" << statistic.min << " @"
          << statistic.min_index << ", avg=" << statistic.avg << std::endl;
@@ -780,7 +844,17 @@ inline
 void
 Timer::print_total_data(StreamType &stream) const
 {
-  const Utilities::MPI::MinMaxAvg statistic = get_total_data();
+  print_accumulated_wall_time_data(stream);
+}
+
+
+
+template <class StreamType>
+inline
+void
+Timer::print_accumulated_wall_time_data(StreamType &stream) const
+{
+  const Utilities::MPI::MinMaxAvg statistic = get_accumulated_wall_time_data();
   stream << statistic.max << " wall,"
          << " max @" << statistic.max_index << ", min=" << statistic.min << " @"
          << statistic.min_index << ", avg=" << statistic.avg << std::endl;

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -126,7 +126,7 @@ void Timer::start ()
   current_lap_starting_wall_time = windows::wall_clock();
   current_lap_starting_cpu_time = windows::cpu_clock();
 #else
-#  error Unsupported platform. Porting not finished.
+#  error "Unsupported platform. Porting not finished."
 #endif
 }
 
@@ -154,7 +154,7 @@ double Timer::stop ()
       last_lap_time = windows::wall_clock() - current_lap_starting_wall_time;
       last_lap_cpu_time = windows::cpu_clock() - current_lap_starting_cpu_time;
 #else
-#  error Unsupported platform. Porting not finished.
+#  error "Unsupported platform. Porting not finished."
 #endif
 
       this->mpi_data = Utilities::MPI::min_max_avg (last_lap_time,
@@ -195,7 +195,7 @@ double Timer::cpu_time() const
       const double running_time = windows::cpu_clock() - current_lap_starting_cpu_time + accumulated_cpu_time;
       return running_time;
 #else
-#  error Unsupported platform. Porting not finished.
+#  error "Unsupported platform. Porting not finished."
 #endif
     }
   else

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -37,33 +37,10 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-// in case we use an MPI compiler, need
-// to create a communicator just for the
-// current process
 Timer::Timer()
   :
-  current_lap_starting_cpu_time (0.),
-  current_lap_starting_wall_time (0.),
-  accumulated_cpu_time (0.),
-  accumulated_wall_time (0.),
-  last_lap_time (numbers::signaling_nan<double>()),
-  last_lap_cpu_time(numbers::signaling_nan<double>()),
-  running (false)
-#ifdef DEAL_II_WITH_MPI
-  ,
-  mpi_communicator (MPI_COMM_SELF),
-  sync_wall_time (false)
-#endif
-{
-#ifdef DEAL_II_WITH_MPI
-  mpi_data.sum = mpi_data.min = mpi_data.max = mpi_data.avg = numbers::signaling_nan<double>();
-  mpi_data.min_index = mpi_data.max_index = numbers::invalid_unsigned_int;
-  mpi_total_data.sum = mpi_total_data.min = mpi_total_data.max = mpi_total_data.avg = 0.;
-  mpi_total_data.min_index = mpi_total_data.max_index = 0;
-#endif
-
-  start();
-}
+  Timer(MPI_COMM_SELF, /*sync_wall_time=*/false)
+{}
 
 
 

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -57,10 +57,10 @@ Timer::Timer(MPI_Comm mpi_communicator,
   mpi_communicator (mpi_communicator),
   sync_wall_time(sync_wall_time_)
 {
-  mpi_data.sum = mpi_data.min = mpi_data.max = mpi_data.avg = numbers::signaling_nan<double>();
-  mpi_data.min_index = mpi_data.max_index = numbers::invalid_unsigned_int;
-  mpi_total_data.sum = mpi_total_data.min = mpi_total_data.max = mpi_total_data.avg = 0.;
-  mpi_total_data.min_index = mpi_total_data.max_index = 0;
+  last_lap_data.sum = last_lap_data.min = last_lap_data.max = last_lap_data.avg = numbers::signaling_nan<double>();
+  last_lap_data.min_index = last_lap_data.max_index = numbers::invalid_unsigned_int;
+  accumulated_wall_time_data.sum = accumulated_wall_time_data.min = accumulated_wall_time_data.max = accumulated_wall_time_data.avg = 0.;
+  accumulated_wall_time_data.min_index = accumulated_wall_time_data.max_index = 0;
 
   start();
 }
@@ -157,18 +157,18 @@ double Timer::stop ()
 #  error "Unsupported platform. Porting not finished."
 #endif
 
-      this->mpi_data = Utilities::MPI::min_max_avg (last_lap_time,
-                                                    mpi_communicator);
-      if (sync_wall_time && Utilities::MPI::job_supports_mpi())
+      last_lap_data = Utilities::MPI::min_max_avg (last_lap_time,
+                                                   mpi_communicator);
+      if (sync_wall_time)
         {
-          last_lap_time = this->mpi_data.max;
+          last_lap_time = last_lap_data.max;
           last_lap_cpu_time = Utilities::MPI::min_max_avg (last_lap_cpu_time,
                                                            mpi_communicator).max;
         }
       accumulated_wall_time += last_lap_time;
       accumulated_cpu_time += last_lap_cpu_time;
-      this->mpi_total_data = Utilities::MPI::min_max_avg (accumulated_wall_time,
-                                                          mpi_communicator);
+      accumulated_wall_time_data = Utilities::MPI::min_max_avg (accumulated_wall_time,
+                                                                mpi_communicator);
     }
   return accumulated_cpu_time;
 }
@@ -263,10 +263,10 @@ void Timer::reset ()
   accumulated_cpu_time = 0.;
   accumulated_wall_time = 0.;
   running         = false;
-  mpi_data.sum = mpi_data.min = mpi_data.max = mpi_data.avg = numbers::signaling_nan<double>();
-  mpi_data.min_index = mpi_data.max_index = numbers::invalid_unsigned_int;
-  mpi_total_data.sum = mpi_total_data.min = mpi_total_data.max = mpi_total_data.avg = 0.;
-  mpi_total_data.min_index = mpi_total_data.max_index = 0;
+  last_lap_data.sum = last_lap_data.min = last_lap_data.max = last_lap_data.avg = numbers::signaling_nan<double>();
+  last_lap_data.min_index = last_lap_data.max_index = numbers::invalid_unsigned_int;
+  accumulated_wall_time_data.sum = accumulated_wall_time_data.min = accumulated_wall_time_data.max = accumulated_wall_time_data.avg = 0.;
+  accumulated_wall_time_data.min_index = accumulated_wall_time_data.max_index = 0;
 }
 
 


### PR DESCRIPTION
Today's progress towards #4867. This PR:
1. improves the documentation
2. deprecates some functions with ambiguous names (including `Timer::get_data()`)
3. always enables the MPI functionality (except an `#ifdef` check around one call to `MPI_Barrier`, of course). Our own dummy implementation in `base/mpi.h` fills in the pieces we need.