### PR TITLE
Clean up hp::FECollection

### DIFF
--- a/doc/news/changes/minor/20170820DanielArndt
+++ b/doc/news/changes/minor/20170820DanielArndt
@@ -1,0 +1,4 @@
+New: The constructors for hp::FECollection taking a fixed number of
+FiniteElement objects as argument were replaced by a variadic
+template constructor taking an arbitrary number of objects.
+<br> (Daniel Arndt, 2017/08/20)

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -69,38 +69,11 @@ namespace hp
     explicit FECollection (const FiniteElement<dim,spacedim> &fe);
 
     /**
-     * Constructor. This constructor creates a FECollection from two finite
-     * elements.
+     * Constructor. This constructor creates a FECollection from more than
+     * one finite element.
      */
-    FECollection (const FiniteElement<dim,spacedim> &fe1,
-                  const FiniteElement<dim,spacedim> &fe2);
-
-    /**
-     * Constructor. This constructor creates a FECollection from three finite
-     * elements.
-     */
-    FECollection (const FiniteElement<dim,spacedim> &fe1,
-                  const FiniteElement<dim,spacedim> &fe2,
-                  const FiniteElement<dim,spacedim> &fe3);
-
-    /**
-     * Constructor. This constructor creates a FECollection from four finite
-     * elements.
-     */
-    FECollection (const FiniteElement<dim,spacedim> &fe1,
-                  const FiniteElement<dim,spacedim> &fe2,
-                  const FiniteElement<dim,spacedim> &fe3,
-                  const FiniteElement<dim,spacedim> &fe4);
-
-    /**
-     * Constructor. This constructor creates a FECollection from five finite
-     * elements.
-     */
-    FECollection (const FiniteElement<dim,spacedim> &fe1,
-                  const FiniteElement<dim,spacedim> &fe2,
-                  const FiniteElement<dim,spacedim> &fe3,
-                  const FiniteElement<dim,spacedim> &fe4,
-                  const FiniteElement<dim,spacedim> &fe5);
+    template<class... FETypes>
+    explicit FECollection (const FETypes &... fes);
 
     /**
      * Constructor. Same as above but for any number of elements. Pointers to
@@ -114,7 +87,18 @@ namespace hp
     /**
      * Copy constructor.
      */
-    FECollection (const FECollection<dim,spacedim> &fe_collection);
+    FECollection (const FECollection<dim,spacedim> &fe_collection) = default;
+
+    /**
+     * Move constructor.
+     */
+    FECollection (FECollection<dim,spacedim> &&fe_collection) = default;
+
+    /**
+     * Move assignement operator.
+     */
+    FECollection<dim, spacedim> &
+    operator= (FECollection<dim,spacedim> &&fe_collection) = default;
 
     /**
      * Add a finite element. This function generates a copy of the given
@@ -465,6 +449,14 @@ namespace hp
 
 
   /* --------------- inline functions ------------------- */
+
+  template <int dim, int spacedim>
+  template <class... FETypes>
+  FECollection<dim,spacedim>::FECollection (const FETypes &... fes)
+  {
+    [](...) {}((push_back(fes),0)...);
+  }
+
 
   template <int dim, int spacedim>
   inline

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -101,58 +101,6 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
-                                            const FiniteElement<dim,spacedim> &fe2)
-  {
-    push_back(fe1);
-    push_back(fe2);
-  }
-
-
-
-  template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
-                                            const FiniteElement<dim,spacedim> &fe2,
-                                            const FiniteElement<dim,spacedim> &fe3)
-  {
-    push_back(fe1);
-    push_back(fe2);
-    push_back(fe3);
-  }
-
-
-
-  template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
-                                            const FiniteElement<dim,spacedim> &fe2,
-                                            const FiniteElement<dim,spacedim> &fe3,
-                                            const FiniteElement<dim,spacedim> &fe4)
-  {
-    push_back(fe1);
-    push_back(fe2);
-    push_back(fe3);
-    push_back(fe4);
-  }
-
-
-
-  template <int dim, int spacedim>
-  FECollection<dim,spacedim>::FECollection (const FiniteElement<dim,spacedim> &fe1,
-                                            const FiniteElement<dim,spacedim> &fe2,
-                                            const FiniteElement<dim,spacedim> &fe3,
-                                            const FiniteElement<dim,spacedim> &fe4,
-                                            const FiniteElement<dim,spacedim> &fe5)
-  {
-    push_back(fe1);
-    push_back(fe2);
-    push_back(fe3);
-    push_back(fe4);
-    push_back(fe5);
-  }
-
-
-
-  template <int dim, int spacedim>
   FECollection<dim,spacedim>::
   FECollection (const std::vector<const FiniteElement<dim,spacedim>*>  &fes)
   {
@@ -162,27 +110,6 @@ namespace hp
     for (unsigned int i = 0; i < fes.size(); ++i)
       push_back(*fes[i]);
   }
-
-
-
-  template <int dim, int spacedim>
-  FECollection<dim,spacedim>::
-  FECollection (const FECollection<dim,spacedim> &fe_collection)
-    :
-    Subscriptor (),
-    // copy the array
-    // of shared
-    // pointers. nothing
-    // bad should
-    // happen -- they
-    // simply all point
-    // to the same
-    // objects, and the
-    // last one to die
-    // will delete the
-    // mappings
-    finite_elements (fe_collection.finite_elements)
-  {}
 
 
 


### PR DESCRIPTION
This PR replaces all the constructors for hp::FECollection taking a fixed number of FiniteElement objects as argument by a variadic template constructor taking an arbitrary number of objects.
Furthermore, the copy constructor can be defaulted and we make sure that the move constructor and the move assignment operator are implicitly declared (and defaulted).