### PR TITLE
Mark conversion constructors of SymmetricTensor and Tensor as 'explicit'

### DIFF
--- a/doc/news/changes/incompatibilities/20170820DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20170820DanielArndt-1
@@ -1,0 +1,4 @@
+Changed: The constructors SymmetricTensor (const Tensor &) and
+Tensor (const array_type &) have been marked as 'explicit'.
+<br>
+(Daniel Arndt, 2017/08/20)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -551,7 +551,7 @@ public:
    * <tt>symmetrize</tt> function first. If you aren't sure, it is good
    * practice to check before calling <tt>symmetrize</tt>.
    */
-  SymmetricTensor (const Tensor<2,dim,Number> &t);
+  explicit SymmetricTensor (const Tensor<2,dim,Number> &t);
 
   /**
    * A constructor that creates a symmetric tensor from an array holding its

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -517,6 +517,8 @@ template <int rank, int dim, typename Number>
 class SymmetricTensor
 {
 public:
+  static_assert(rank%2==0, "A SymmetricTensor must have even rank!");
+
   /**
    * Provide a way to get the dimension of an object without explicit
    * knowledge of it's data type. Implementation is this way instead of

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -378,7 +378,7 @@ public:
   /**
    * Constructor, where the data is copied from a C-style array.
    */
-  Tensor (const array_type &initializer);
+  explicit Tensor (const array_type &initializer);
 
   /**
    * Constructor from tensors with different underlying scalar type. This
@@ -816,7 +816,7 @@ inline
 Tensor<rank_,dim,Number>::Tensor (const array_type &initializer)
 {
   for (unsigned int i=0; i<dim; ++i)
-    values[i] = initializer[i];
+    values[i] = Tensor<rank_-1, dim, Number>(initializer[i]);
 }
 
 
@@ -826,7 +826,7 @@ inline
 Tensor<rank_,dim,Number>::Tensor (const Tensor<rank_,dim,OtherNumber> &initializer)
 {
   for (unsigned int i=0; i!=dim; ++i)
-    values[i] = initializer[i];
+    values[i] = Tensor<rank_-1,dim,Number>(initializer[i]);
 }
 
 

--- a/tests/base/symmetric_tensor_28.cc
+++ b/tests/base/symmetric_tensor_28.cc
@@ -32,7 +32,7 @@ void test ()
       s[i][j] = (i+1) * (j+1);
 
   Tensor<2,dim> t = s;
-  SymmetricTensor<2,dim> u = t;
+  SymmetricTensor<2,dim> u (t);
 
   for (unsigned int i=0; i<dim; ++i)
     for (unsigned int j=0; j<dim; ++j)

--- a/tests/base/tensor_mixing_types_01.cc
+++ b/tests/base/tensor_mixing_types_01.cc
@@ -54,9 +54,9 @@ int main ()
   }
 
   {
-    dealii::Tensor<1,2,float> f = { {1., 2.} };
-    dealii::Tensor<1,2,double> d = { {4., 8.} };
-    dealii::Tensor<1,2,std::complex<double> > c = { {16., 32.} };
+    dealii::Tensor<1,2,float> f ({1., 2.});
+    dealii::Tensor<1,2,double> d ({4., 8.});
+    dealii::Tensor<1,2,std::complex<double> > c ({16., 32.});
 
     deallog << f + d << std::endl;
     deallog << f - d << std::endl;
@@ -82,9 +82,9 @@ int main ()
   }
 
   {
-    dealii::Tensor<1,3,float> f = { {1., 2., 4.} };
-    dealii::Tensor<1,3,double> d = { {4., 8., 16.} };
-    dealii::Tensor<1,3,std::complex<double> > c = { {32., 64., 128.} };
+    dealii::Tensor<1,3,float> f ({1., 2., 4.});
+    dealii::Tensor<1,3,double> d ({4., 8., 16.});
+    dealii::Tensor<1,3,std::complex<double> > c ({32., 64., 128.});
 
     deallog << f + d << std::endl;
     deallog << f - d << std::endl;

--- a/tests/fe/fe_values_view_02.cc
+++ b/tests/fe/fe_values_view_02.cc
@@ -91,8 +91,9 @@ void test (const Triangulation<dim> &tr,
 
                   AssertThrow (fe_values[vec_components].symmetric_gradient (i,q)
                                ==
-                               (fe_values[vec_components].gradient(i,q) +
-                                transpose(fe_values[vec_components].gradient(i,q)))/2,
+                               decltype(fe_values[vec_components].symmetric_gradient (i,q))
+                               ( (fe_values[vec_components].gradient(i,q) +
+                                  transpose(fe_values[vec_components].gradient(i,q)))/2 ),
                                ExcInternalError());
 
                   AssertThrow (fe_values[vec_components].hessian (i,q)[d]

--- a/tests/fe/fe_values_view_04.cc
+++ b/tests/fe/fe_values_view_04.cc
@@ -96,8 +96,9 @@ void test (const Triangulation<dim> &tr,
 
                       AssertThrow (fe_values[vec_components].symmetric_gradient (i,q)
                                    ==
-                                   (fe_values[vec_components].gradient(i,q) +
-                                    transpose(fe_values[vec_components].gradient(i,q)))/2,
+                                   decltype(fe_values[vec_components].symmetric_gradient (i,q))
+                                   ( (fe_values[vec_components].gradient(i,q) +
+                                      transpose(fe_values[vec_components].gradient(i,q)))/2 ),
                                    ExcInternalError());
 
                       AssertThrow (fe_values[vec_components].hessian (i,q)[d]

--- a/tests/serialization/symmetric_tensor.cc
+++ b/tests/serialization/symmetric_tensor.cc
@@ -29,14 +29,14 @@ void test ()
     {2., 5., 6.},
     {3., 6., 9.}
   };
-  SymmetricTensor<rank,dim> t1(a1);
+  SymmetricTensor<rank,dim> t1((Tensor<rank,dim>(a1)));
 
 
   double a2[3][3] = {{10., 11., 12.},
     {11., 14., 15.},
     {12., 15., 18.}
   };
-  SymmetricTensor<rank,dim> t2(a2);
+  SymmetricTensor<rank,dim> t2((Tensor<rank,dim>(a2)));
 
   verify (t1, t2);
 }
@@ -44,9 +44,7 @@ void test ()
 
 int main ()
 {
-  std::ofstream logfile("output");
-  deallog << std::setprecision(3);
-  deallog.attach(logfile);
+  initlog();
 
   test ();
 


### PR DESCRIPTION
Fixes #4894 and improves the error if one tries to construct a `SymmetricTensor` with an odd rank.