### PR TITLE
Clean up the Timer CPU time calculations.

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -203,8 +203,11 @@ public:
   double last_wall_time() const;
 
   /**
-   * Access to the current total CPU time without stopping the timer.
-   * The elapsed time is returned in units of seconds.
+   * Access to the current total CPU time without stopping the timer. The
+   * elapsed time is returned in units of seconds.
+   *
+   * If an MPI communicator is provided to the constructor then this value is
+   * summed over all relevant MPI processes.
    */
   double cpu_time() const;
 


### PR DESCRIPTION
More progress towards #4867: this collects all of the (platform-dependent) resource usage code in one place.