### PR TITLE
Fixes possible error on "Vector<Number>::add(..)".

### DIFF
--- a/doc/news/changes/minor/20170823TulioLigneul
+++ b/doc/news/changes/minor/20170823TulioLigneul
@@ -1,0 +1,5 @@
+Fixed: On Vector::add(..), a pointer to the first element of a std::vector
+is gotten by std::vector::data() instead of using the "&v[0]" idiom, which
+results in an undefined behaviour.
+<br>
+(Tulio Ligneul, 2017/08/23)

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1278,7 +1278,7 @@ Vector<Number>::add (const std::vector<size_type> &indices,
 {
   Assert (indices.size() == values.size(),
           ExcDimensionMismatch(indices.size(), values.size()));
-  add (indices.size(), &indices[0], &values[0]);
+  add (indices.size(), indices.data(), values.data());
 }
 
 
@@ -1292,7 +1292,7 @@ Vector<Number>::add (const std::vector<size_type> &indices,
 {
   Assert (indices.size() == values.size(),
           ExcDimensionMismatch(indices.size(), values.size()));
-  add (indices.size(), &indices[0], values.val);
+  add (indices.size(), indices.data(), values.val);
 }
 
 


### PR DESCRIPTION
In "Vector<Number>::add(..)", a pointer to the first element of the
std::vectors was gotten, for instance, by &indices[0], which implies
that the first element of the vector exists. Therefore, if an empty
vector was used, while this works on gcc, this would result in a crash
when using Visual Studio. In this case, the pointer should be gotten by
std::vector::data(). This fix changes de former by the latter access form.