### PR TITLE
Avoid a warning with gcc 4.8.

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -87,7 +87,7 @@ namespace hp
     /**
      * Copy constructor.
      */
-    FECollection (const FECollection<dim,spacedim> &fe_collection) = default;
+    FECollection (const FECollection<dim,spacedim> &) = default;
 
     /**
      * Move constructor.


### PR DESCRIPTION
GCC 4.8 warns about an 'unused argument' for constructors marked '=default'.
This is annoying, but easily worked around.