### PR TITLE
Simplify code that uses variadic templates.

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -455,7 +455,8 @@ namespace hp
   FECollection<dim,spacedim>::FECollection (const FETypes &... fes)
   {
     static_assert(is_base_of_all<FiniteElement<dim, spacedim>, FETypes...>::value,
-                  "Not all of the input parameters are derived from FiniteElement<dim, spacedim>!");
+                  "Not all of the input arguments of this function "
+                  "are derived from FiniteElement<dim,spacedim>!");
 
     // loop over all of the given arguments and add the finite
     // elements to this collection

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -457,16 +457,13 @@ namespace hp
     static_assert(is_base_of_all<FiniteElement<dim, spacedim>, FETypes...>::value,
                   "Not all of the input parameters are derived from FiniteElement<dim, spacedim>!");
 
-    // We want to call 'push_back' for each of the arguments. To do so parameter
-    // pack expansion comes in handy. Unfortunately, we can't just write
-    //   push_back(fes)...;
-    // but have to treat this as arguments to some function which doesn't need
-    // to do anything with it. Now,
-    //   [](...) {}(push_back(fes)...);
-    // doesn't work as well because the ellipsis cannot deal with no parameters
-    // at all. Hence, we extend the return value of each of the return values
-    // by zero using the comma operator.
-    [](...) {}((push_back(fes),0)...);
+    // loop over all of the given arguments and add the finite
+    // elements to this collection
+    for (auto p :
+         {
+           &fes...
+         })
+      push_back (*p);
   }
 
 


### PR DESCRIPTION
It turns out that we can do '&args...' to get the addresses of the objects, and then
'{ &args... }' to get a std::initializer_list that we can iterate over. This makes the
code significantly easier to read. This simplifies what we came up with in #4909 and
#4922.

While there, also update an error message wording.