### PR TITLE
Simplify VectorMemory::Pointer.

### DIFF
--- a/include/deal.II/algorithms/newton.templates.h
+++ b/include/deal.II/algorithms/newton.templates.h
@@ -117,12 +117,12 @@ namespace Algorithms
     AnyData src2;
     src1.add<const VectorType *>(&u, "Newton iterate");
     src1.merge(in);
-    src2.add<const VectorType *>(res, "Newton residual");
+    src2.add<const VectorType *>(res.get(), "Newton residual");
     src2.merge(src1);
     AnyData out1;
-    out1.add<VectorType *>(res, "Residual");
+    out1.add<VectorType *>(res.get(), "Residual");
     AnyData out2;
-    out2.add<VectorType *>(Du, "Update");
+    out2.add<VectorType *>(Du.get(), "Update");
 
     unsigned int step = 0;
     // fill res with (f(u), v)
@@ -135,9 +135,9 @@ namespace Algorithms
         AnyData tmp;
         VectorType *p = &u;
         tmp.add<const VectorType *>(p, "solution");
-        p = Du;
+        p = Du.get();
         tmp.add<const VectorType *>(p, "update");
-        p = res;
+        p = res.get();
         tmp.add<const VectorType *>(p, "residual");
         *data_out << step;
         *data_out << tmp;
@@ -166,9 +166,9 @@ namespace Algorithms
             AnyData tmp;
             VectorType *p = &u;
             tmp.add<const VectorType *>(p, "solution");
-            p = Du;
+            p = Du.get();
             tmp.add<const VectorType *>(p, "update");
-            p = res;
+            p = res.get();
             tmp.add<const VectorType *>(p, "residual");
             *data_out << step;
             *data_out << tmp;

--- a/include/deal.II/algorithms/theta_timestepping.templates.h
+++ b/include/deal.II/algorithms/theta_timestepping.templates.h
@@ -105,9 +105,9 @@ namespace Algorithms
     AnyData src2;
 
     AnyData out1;
-    out1.add<VectorType *>(aux, "Solution");
+    out1.add<VectorType *>(aux.get(), "Solution");
     // The data provided to the inner solver
-    src2.add<const VectorType *>(aux, "Previous time");
+    src2.add<const VectorType *>(aux.get(), "Previous time");
     src2.add<const VectorType *>(&solution, "Previous iterate");
     src2.add<const double *>(&d_implicit.time, "Time");
     src2.add<const double *>(&d_implicit.step, "Timestep");


### PR DESCRIPTION
This rarely used class essentially operates like a std::unique_ptr
with a special deallocation object -- namely one that returns the vector
pointed to to a VectorMemory pool, rather than the standard operation of
calling 'delete' on the pointer. This realization allows writing the
class in a simple way by just deriving from 'std::unique_ptr'. The magic
happens in the constructor where we set the special deleter object.

The simplification is almost functionally identical to the original. The
only noteworthy difference is that the old class had an automatic
conversion operator to a regular pointer, which I removed. This now
needs to be written via the '.get()' member function, but I think that's
useful anyway since the automatic conversion encourages poor design
where we keep both plain pointers and VectorMemory::Pointer objects
pointing to the same memory location.

There are numerous other cleanups one can contemplate for the
vector memory classes, but one thing at a time.

Passes the testsuite without new failures.