### PR TITLE
Fix all deprecations in examples

### DIFF
--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -357,7 +357,7 @@ namespace Step12
     Vector<double> &local_vector = dinfo.vector(0).block(0);
 
     const std::vector<double> &JxW = fe_v.get_JxW_values ();
-    const std::vector<Tensor<1,dim> > &normals = fe_v.get_all_normal_vectors ();
+    const std::vector<Tensor<1,dim> > &normals = fe_v.get_normal_vectors ();
 
     std::vector<double> g(fe_v.n_quadrature_points);
 
@@ -421,7 +421,7 @@ namespace Step12
     // solution and the right hand side does not receive any contributions.
 
     const std::vector<double> &JxW = fe_v.get_JxW_values ();
-    const std::vector<Tensor<1,dim> > &normals = fe_v.get_all_normal_vectors ();
+    const std::vector<Tensor<1,dim> > &normals = fe_v.get_normal_vectors ();
 
     for (unsigned int point=0; point<fe_v.n_quadrature_points; ++point)
       {

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1721,7 +1721,7 @@ namespace Step28
         std::cout << "   Cycle=" << cycle
                   << ", n_dofs=" << energy_groups[0]->n_dofs() + energy_groups[1]->n_dofs()
                   << ",  k_eff=" << k_eff
-                  << ", time=" << timer()
+                  << ", time=" << timer.cpu_time()
                   << std::endl;
 
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -504,7 +504,7 @@ namespace Step29
     // function:
     timer.stop ();
     deallog << "done ("
-            << timer()
+            << timer.cpu_time()
             << "s)"
             << std::endl;
 
@@ -539,7 +539,7 @@ namespace Step29
 
     timer.stop ();
     deallog << "done ("
-            << timer()
+            << timer.cpu_time()
             << "s)"
             << std::endl;
 
@@ -779,7 +779,7 @@ namespace Step29
 
     timer.stop ();
     deallog << "done ("
-            << timer()
+            << timer.cpu_time()
             << "s)"
             << std::endl;
   }
@@ -823,7 +823,7 @@ namespace Step29
 
     timer.stop ();
     deallog << "done ("
-            << timer ()
+            << timer.cpu_time()
             << "s)"
             << std::endl;
   }
@@ -895,7 +895,7 @@ namespace Step29
 
     timer.stop ();
     deallog << "done ("
-            << timer()
+            << timer.cpu_time()
             << "s)"
             << std::endl;
   }

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -235,7 +235,7 @@ namespace Step30
     Vector<double> &cell_vector) const
   {
     const std::vector<double> &JxW = fe_v.get_JxW_values ();
-    const std::vector<Tensor<1,dim> > &normals = fe_v.get_all_normal_vectors ();
+    const std::vector<Tensor<1,dim> > &normals = fe_v.get_normal_vectors ();
 
     std::vector<Point<dim> > beta (fe_v.n_quadrature_points);
     std::vector<double> g(fe_v.n_quadrature_points);
@@ -273,7 +273,7 @@ namespace Step30
     FullMatrix<double> &ue_ve_matrix) const
   {
     const std::vector<double> &JxW = fe_v.get_JxW_values ();
-    const std::vector<Tensor<1,dim> > &normals = fe_v.get_all_normal_vectors ();
+    const std::vector<Tensor<1,dim> > &normals = fe_v.get_normal_vectors ();
 
     std::vector<Point<dim> > beta (fe_v.n_quadrature_points);
 
@@ -952,7 +952,7 @@ namespace Step30
         Timer assemble_timer;
         assemble_system2 ();
         std::cout << "Time of assemble_system2: "
-                  << assemble_timer()
+                  << assemble_timer.cpu_time()
                   << std::endl;
         solve (solution2);
 

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -607,7 +607,7 @@ namespace Step34
         cell->get_dof_indices(local_dof_indices);
 
         const std::vector<Point<dim> >    &q_points = fe_v.get_quadrature_points();
-        const std::vector<Tensor<1,dim> > &normals  = fe_v.get_all_normal_vectors();
+        const std::vector<Tensor<1,dim> > &normals  = fe_v.get_normal_vectors();
         wind.vector_value_list(q_points, cell_wind);
 
         // We then form the integral over the current cell for all degrees of
@@ -692,7 +692,7 @@ namespace Step34
                 std::vector<Vector<double> > singular_cell_wind( singular_quadrature.size(),
                                                                  Vector<double>(dim) );
 
-                const std::vector<Tensor<1,dim> > &singular_normals  = fe_v_singular.get_all_normal_vectors();
+                const std::vector<Tensor<1,dim> > &singular_normals  = fe_v_singular.get_normal_vectors();
                 const std::vector<Point<dim> >    &singular_q_points = fe_v_singular.get_quadrature_points();
 
                 wind.vector_value_list(singular_q_points, singular_cell_wind);
@@ -964,7 +964,7 @@ namespace Step34
         fe_v.reinit(cell);
 
         const std::vector<Point<dim> >    &q_points = fe_v.get_quadrature_points();
-        const std::vector<Tensor<1,dim> > &normals  = fe_v.get_all_normal_vectors();
+        const std::vector<Tensor<1,dim> > &normals  = fe_v.get_normal_vectors();
 
         cell->get_dof_indices(dofs);
         fe_v.get_function_values(phi, local_phi);

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -832,7 +832,7 @@ namespace Step37
     constraints.close();
     setup_time += time.wall_time();
     time_details << "Distribute DoFs & B.C.     (CPU/wall) "
-                 << time() << "s/" << time.wall_time() << "s" << std::endl;
+                 << time.cpu_time() << "s/" << time.wall_time() << "s" << std::endl;
     time.restart();
 
     {
@@ -855,7 +855,7 @@ namespace Step37
 
     setup_time += time.wall_time();
     time_details << "Setup matrix-free system   (CPU/wall) "
-                 << time() << "s/" << time.wall_time() << "s" << std::endl;
+                 << time.cpu_time() << "s/" << time.wall_time() << "s" << std::endl;
     time.restart();
 
     // Next, initialize the matrices for the multigrid method on all the
@@ -902,7 +902,7 @@ namespace Step37
       }
     setup_time += time.wall_time();
     time_details << "Setup matrix-free levels   (CPU/wall) "
-                 << time() << "s/" << time.wall_time() << "s" << std::endl;
+                 << time.cpu_time() << "s/" << time.wall_time() << "s" << std::endl;
   }
 
 
@@ -936,7 +936,7 @@ namespace Step37
 
     setup_time += time.wall_time();
     time_details << "Assemble right hand side   (CPU/wall) "
-                 << time() << "s/" << time.wall_time() << "s" << std::endl;
+                 << time.cpu_time() << "s/" << time.wall_time() << "s" << std::endl;
   }
 
 
@@ -955,7 +955,7 @@ namespace Step37
     MGTransferMatrixFree<dim,float> mg_transfer(mg_constrained_dofs);
     mg_transfer.build(dof_handler);
     setup_time += time.wall_time();
-    time_details << "MG build transfer time     (CPU/wall) " << time()
+    time_details << "MG build transfer time     (CPU/wall) " << time.cpu_time()
                  << "s/" << time.wall_time() << "s\n";
     time.restart();
 
@@ -1089,7 +1089,7 @@ namespace Step37
     SolverControl solver_control (100, 1e-12*system_rhs.l2_norm());
     SolverCG<LinearAlgebra::distributed::Vector<double> > cg (solver_control);
     setup_time += time.wall_time();
-    time_details << "MG build smoother time     (CPU/wall) " << time()
+    time_details << "MG build smoother time     (CPU/wall) " << time.cpu_time()
                  << "s/" << time.wall_time() << "s\n";
     pcout << "Total setup time               (wall) " << setup_time
           << "s\n";
@@ -1103,7 +1103,7 @@ namespace Step37
 
     pcout << "Time solve ("
           << solver_control.last_step()
-          << " iterations)  (CPU/wall) " << time() << "s/"
+          << " iterations)  (CPU/wall) " << time.cpu_time() << "s/"
           << time.wall_time() << "s\n";
   }
 

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -704,9 +704,8 @@ namespace Step50
     SolverControl coarse_solver_control (1000, 1e-10, false, false);
     SolverCG<vector_t> coarse_solver(coarse_solver_control);
     PreconditionIdentity id;
-    MGCoarseGridLACIteration<SolverCG<vector_t>,vector_t> coarse_grid_solver(coarse_solver,
-        coarse_matrix,
-        id);
+    MGCoarseGridIterativeSolver<vector_t, SolverCG<vector_t>, matrix_t, PreconditionIdentity>
+    coarse_grid_solver(coarse_solver, coarse_matrix, id);
 
     // The next component of a multilevel solver or preconditioner is
     // that we need a smoother on each level. A common choice for this
@@ -765,8 +764,7 @@ namespace Step50
     // Now, we are ready to set up the
     // V-cycle operator and the
     // multilevel preconditioner.
-    Multigrid<vector_t > mg(mg_dof_handler,
-                            mg_matrix,
+    Multigrid<vector_t > mg(mg_matrix,
                             coarse_grid_solver,
                             mg_transfer,
                             mg_smoother,

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -525,7 +525,7 @@ public:
    * beginning. So the number of components of @p f cannot be less than the
    * calling object.
    */
-  virtual void substitute_function_value_with (const ConstantFunction<dim, Number> &f);
+  virtual void substitute_function_value_with (const Functions::ConstantFunction<dim, Number> &f);
 
   /**
    * Return the value of the function at the given point for all components.

--- a/tests/grid/find_active_cell_around_point_01.cc
+++ b/tests/grid/find_active_cell_around_point_01.cc
@@ -35,7 +35,7 @@
 
 
 template <int dim, int spacedim>
-double test(unsigned int n_ref, unsigned int n_points)
+void test(unsigned int n_ref, unsigned int n_points)
 {
   deallog << "Testing " << dim << ", " << spacedim << std::endl;
 


### PR DESCRIPTION
Apparently, we are supressing warnings about deprecated functions when building the examples.
Not sure this is worth an issue but this fixes all the current ones.