### PR TITLE
Further VectorMemory cleanups.

### DIFF
--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -74,10 +74,11 @@ class VectorMemory : public Subscriptor
 public:
 
   /**
-   * Virtual destructor is needed as there are virtual functions in this
+   * Virtual destructor. This destructor is declared @p virtual to allow
+   * destroying objects of derived type through pointers to this base
    * class.
    */
-  virtual ~VectorMemory () {}
+  virtual ~VectorMemory () = default;
 
   /**
    * Return a pointer to a new vector. The number of elements or their

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -260,10 +260,12 @@ public:
 
 private:
   /**
-   * Type to enter into the array. First component will be a flag telling
-   * whether the vector is used, second the vector itself.
+   * A type that describes this entries of an array that represents
+   * the vectors stored by this object. The first component of the pair
+   * is be a flag telling whether the vector is used, the second
+   * a pointer to the vector itself.
    */
-  typedef std::pair<bool, VectorType *> entry_type;
+  typedef std::pair<bool, std::unique_ptr<VectorType> > entry_type;
 
   /**
    * The class providing the actual storage for the memory pool.
@@ -272,7 +274,7 @@ private:
    * Only one of these pools is used for each vector type, thus allocating all
    * vectors from the same storage.
    *
-   * @author Guido Kanschat, 2007
+   * @author Guido Kanschat, 2007, Wolfgang Bangerth 2017.
    */
   struct Pool
   {
@@ -280,14 +282,17 @@ private:
      * Standard constructor creating an empty pool
      */
     Pool();
+
     /**
-     * Destructor. Frees memory and warns about memory leaks
+     * Destructor.
      */
     ~Pool();
+
     /**
      * Create data vector; does nothing after first initialization
      */
     void initialize(const size_type size);
+
     /**
      * Pointer to the storage object
      */
@@ -304,6 +309,7 @@ private:
    * output at the end of an object's lifetime.
    */
   size_type total_alloc;
+
   /**
    * Number of vectors currently allocated in this object; used for detecting
    * memory leaks.

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -158,11 +158,6 @@ class PrimitiveVectorMemory : public VectorMemory<VectorType>
 {
 public:
   /**
-   * Constructor.
-   */
-  PrimitiveVectorMemory () = default;
-
-  /**
    * Return a pointer to a new vector. The number of elements or their
    * subdivision into blocks (if applicable) is unspecified and users of this
    * function should reset vectors to their proper size. The same holds for
@@ -171,10 +166,7 @@ public:
    * For the present class, calling this function will allocate a new vector
    * on the heap and returning a pointer to it.
    */
-  virtual VectorType *alloc ()
-  {
-    return new VectorType();
-  }
+  virtual VectorType *alloc ();
 
   /**
    * Return a vector and indicate that it is not going to be used any further
@@ -184,10 +176,7 @@ public:
    * For the present class, this means that the vector is returned to the
    * global heap.
    */
-  virtual void free (const VectorType *const v)
-  {
-    delete v;
-  }
+  virtual void free (const VectorType *const v);
 };
 
 
@@ -358,6 +347,26 @@ VectorMemory<VectorType>::Pointer::Pointer(VectorMemory<VectorType> &mem)
   mem.free(v);
 })
 {}
+
+
+
+template <typename VectorType>
+VectorType *
+PrimitiveVectorMemory<VectorType>::alloc ()
+{
+  return new VectorType();
+}
+
+
+
+template <typename VectorType>
+void
+PrimitiveVectorMemory<VectorType>::free (const VectorType *const v)
+{
+  delete v;
+}
+
+
 
 
 #endif // DOXYGEN

--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -18,6 +18,7 @@
 
 
 #include <deal.II/lac/vector_memory.h>
+#include <deal.II/base/std_cxx14/memory.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -42,18 +43,12 @@ inline
 GrowingVectorMemory<VectorType>::Pool::~Pool()
 {
   // Nothing to do if memory was unused.
-  if (data == nullptr) return;
+  if (data == nullptr)
+    return;
 
-  // First, delete all remaining
-  // vectors. Actually, there should
-  // be none, if there is no memory
-  // leak
-  for (typename std::vector<entry_type>::iterator i=data->begin();
-       i != data->end();
-       ++i)
-    {
-      delete i->second;
-    }
+  // delete the 'data' object. this also releases all vectors
+  // that are pointed to by the std::unique_ptrs
+  data->clear();
   delete data;
 }
 
@@ -72,7 +67,7 @@ GrowingVectorMemory<VectorType>::Pool::initialize(const size_type size)
            ++i)
         {
           i->first = false;
-          i->second = new VectorType;
+          i->second = std_cxx14::make_unique<VectorType>();
         }
     }
 }
@@ -116,6 +111,7 @@ VectorType *
 GrowingVectorMemory<VectorType>::alloc ()
 {
   Threads::Mutex::ScopedLock lock(mutex);
+
   ++total_alloc;
   ++current_alloc;
   // see if there is a free vector
@@ -126,16 +122,14 @@ GrowingVectorMemory<VectorType>::alloc ()
       if (i->first == false)
         {
           i->first = true;
-          return (i->second);
+          return i->second.get();
         }
     }
 
-  // no free vector found, so let's
-  // just allocate a new one
-  const entry_type t (true, new VectorType);
-  pool.data->push_back(t);
+  // no free vector found, so let's just allocate a new one
+  pool.data->emplace_back(entry_type (true, std_cxx14::make_unique<VectorType>()));
 
-  return t.second;
+  return pool.data->back().second.get();
 }
 
 
@@ -146,10 +140,11 @@ void
 GrowingVectorMemory<VectorType>::free(const VectorType *const v)
 {
   Threads::Mutex::ScopedLock lock(mutex);
+
   for (typename std::vector<entry_type>::iterator i=pool.data->begin();
        i != pool.data->end(); ++i)
     {
-      if (v == (i->second))
+      if (v == i->second.get())
         {
           i->first = false;
           --current_alloc;
@@ -168,21 +163,8 @@ GrowingVectorMemory<VectorType>::release_unused_memory ()
 {
   Threads::Mutex::ScopedLock lock(mutex);
 
-  std::vector<entry_type> new_data;
-
   if (pool.data != nullptr)
-    {
-      const typename std::vector<entry_type>::const_iterator
-      end = pool.data->end();
-      for (typename std::vector<entry_type>::const_iterator
-           i = pool.data->begin(); i != end ; ++i)
-        if (i->first == false)
-          delete i->second;
-        else
-          new_data.push_back (*i);
-
-      *pool.data = new_data;
-    }
+    pool.data->clear();
 }
 
 


### PR DESCRIPTION
While there, also convert SolverCG to a scheme where we use smart pointers
instead of things we have to allocate/deallocate by hand.

Follow-up to #4925.