### PR TITLE
Copy the FECollection in hp::DoFHandler for conformity with DoFHandler

### DIFF
--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -781,14 +781,10 @@ namespace hp
     SmartPointer<const Triangulation<dim,spacedim>,DoFHandler<dim,spacedim> > tria;
 
     /**
-     * Store a pointer to the finite element set given latest for the
-     * distribution of dofs. In order to avoid destruction of the object
-     * before the lifetime of the DoF handler, we subscribe to the finite
-     * element object. To unlock the FE before the end of the lifetime of this
-     * DoF handler, use the <tt>clear()</tt> function (this clears all data of
-     * this object as well, though).
+     * Store a pointer to the hp::FECollection object containing the finite element
+     * set this object is initialized with.
      */
-    SmartPointer<const hp::FECollection<dim,spacedim>,hp::DoFHandler<dim,spacedim> > finite_elements;
+    std::unique_ptr<const hp::FECollection<dim,spacedim> > finite_elements;
 
     /**
      * An object that describes how degrees of freedom should be distributed and

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/dof_level.h>
@@ -1277,7 +1278,7 @@ namespace hp
   {
     Assert (tria->n_levels() > 0, ExcInvalidTriangulation());
 
-    finite_elements = &ff;
+    finite_elements = std_cxx14::make_unique<hp::FECollection<dim, spacedim>>(ff);
 
     // at the beginning, make sure every processor knows the
     // active_fe_indices on both its own cells and all ghost cells


### PR DESCRIPTION
In #4908 we decided to copy the `FiniteElement` into a `hp::FECollection` when initializing a `DoFHandler`. This implies that the original `FiniteElement` can be safely detroyed after initialization.
Unfortunately, this breaks conformity with respect to `hp::DoFHandler` where we currently store a `SmartPointer`. This PR resolves (as proposed in#4908) this imbalance.

While this improves the similarity of the `*DoFHandler`classes, we also sacrifize performance since 
reconstructing a lot of `FiniteElement` objects at initialization might be quite expensive. 
That is why I added the 'Discussion' label and I like to hear some opinions.