### PR TITLE
Fix tensor initialiser and function return types

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -397,7 +397,7 @@ namespace internal
   template <typename T>
   struct NumberType
   {
-    static DEAL_II_CUDA_HOST_DEV T value (const T &t)
+    static DEAL_II_CUDA_HOST_DEV const T &value (const T &t)
     {
       return t;
     }
@@ -406,9 +406,23 @@ namespace internal
   template <typename T>
   struct NumberType<std::complex<T> >
   {
+    static const std::complex<T> &value (const std::complex<T> &t)
+    {
+      return t;
+    }
+
     static std::complex<T> value (const T &t)
     {
       return std::complex<T>(t);
+    }
+
+    // Facilitate cast from complex<double> to complex<float>
+    template <typename U>
+    static std::complex<T> value (const std::complex<U> &t)
+    {
+      return std::complex<T>(
+               NumberType<T>::value(t.real()),
+               NumberType<T>::value(t.imag()));
     }
   };
 }

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2562,7 +2562,7 @@ Number determinant (const SymmetricTensor<2,dim,Number> &t)
     }
     default:
       Assert (false, ExcNotImplemented());
-      return 0;
+      return internal::NumberType<Number>::value(0.0);
     }
 }
 
@@ -2636,7 +2636,7 @@ template <typename Number>
 inline
 Number second_invariant (const SymmetricTensor<2,1,Number> &)
 {
-  return 0;
+  return internal::NumberType<Number>::value(0.0);
 }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -999,7 +999,7 @@ SymmetricTensor<rank,dim,Number>::
 SymmetricTensor (const SymmetricTensor<rank,dim,OtherNumber> &initializer)
 {
   for (unsigned int i=0; i<base_tensor_type::dimension; ++i)
-    data[i] = initializer.data[i];
+    data[i] = internal::NumberType<typename base_tensor_type::value_type>::value(initializer.data[i]);
 }
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -601,6 +601,11 @@ namespace internal
   template <int rank, int dim, typename T>
   struct NumberType<Tensor<rank,dim,T> >
   {
+    static const Tensor<rank,dim,T> &value (const Tensor<rank,dim,T> &t)
+    {
+      return t;
+    }
+
     static Tensor<rank,dim,T> value (const T &t)
     {
       Tensor<rank,dim,T> tmp;
@@ -612,6 +617,11 @@ namespace internal
   template <int rank, int dim, typename T>
   struct NumberType<Tensor<rank,dim,VectorizedArray<T> > >
   {
+    static const Tensor<rank,dim,VectorizedArray<T> > &value (const Tensor<rank,dim,VectorizedArray<T> > &t)
+    {
+      return t;
+    }
+
     static Tensor<rank,dim,VectorizedArray<T> > value (const T &t)
     {
       Tensor<rank,dim,VectorizedArray<T> > tmp;

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/tensor_accessors.h>
 #include <deal.II/base/template_constraints.h>
@@ -628,6 +629,13 @@ namespace internal
       tmp=internal::NumberType<VectorizedArray<T> >::value(t);
       return tmp;
     }
+
+    static Tensor<rank,dim,VectorizedArray<T> > value (const VectorizedArray<T> &t)
+    {
+      Tensor<rank,dim,VectorizedArray<T> > tmp;
+      tmp=t;
+      return tmp;
+    }
   };
 }
 
@@ -650,7 +658,7 @@ template <typename OtherNumber>
 inline
 Tensor<0,dim,Number>::Tensor (const OtherNumber &initializer)
 {
-  value = initializer;
+  value = internal::NumberType<Number>::value(initializer);
 }
 
 

--- a/include/deal.II/base/tensor_deprecated.h
+++ b/include/deal.II/base/tensor_deprecated.h
@@ -236,7 +236,7 @@ inline
 Number double_contract (const Tensor<2, dim, Number> &src1,
                         const Tensor<2, dim, Number> &src2)
 {
-  Number res = 0.;
+  Number res = internal::NumberType<Number>::value(0.0);
   for (unsigned int i=0; i<dim; ++i)
     res += src1[i] * src2[i];
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -74,6 +74,11 @@ namespace internal
   template <typename T>
   struct NumberType<VectorizedArray<T> >
   {
+    static const VectorizedArray<T> &value (const VectorizedArray<T> &t)
+    {
+      return t;
+    }
+
     static VectorizedArray<T> value (const T &t)
     {
       VectorizedArray<T> tmp;


### PR DESCRIPTION
Two small patches:
1. In the tensor constructors, use a cast to convert the underlying data in the tensor when the input initialiser has a different `NumberType`. This is effectively what we do [here as well](https://github.com/dealii/dealii/blob/master/include/deal.II/base/tensor.h#L829).
2. Correctly initialise some return values using our nifty internal template struct.