### PR TITLE
Allow copying invalid iterators

### DIFF
--- a/doc/news/changes/minor/20170823Bangerth
+++ b/doc/news/changes/minor/20170823Bangerth
@@ -1,0 +1,11 @@
+Fixed: It turns out that it was not possible to copy an invalid
+operator, i.e., the following code would yield an exception:
+@code
+  typename DoFHandler<dim>::active_cell_iterator invalid_1;
+  typename DoFHandler<dim>::active_cell_iterator invalid_2;
+
+  invalid_1 = invalid_2;  // resulted in an error
+@endcode
+This made no sense, and has now been fixed.
+<br>
+(Wolfgang Bangerth, 2017/08/23)

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -149,7 +149,7 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::copy_from
 (const DoFAccessor<structdim,DoFHandlerType,level_dof_access2> &a)
 {
   BaseClass::copy_from (a);
-  set_dof_handler (a.dof_handler);
+  this->dof_handler = a.dof_handler;
 }
 
 

--- a/tests/dofs/invalid_iterators_01.cc
+++ b/tests/dofs/invalid_iterators_01.cc
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// check that assigning one invalid iterator to another works. this
+// test is for ::DoFHandler
+
+#include "../tests.h"
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+
+template <int dim>
+void check ()
+{
+  typename DoFHandler<dim>::active_cell_iterator invalid_1;
+
+  // try copy constructor
+  typename DoFHandler<dim>::active_cell_iterator invalid_2 = invalid_1;
+
+  // now also try copy operator
+  invalid_1 = invalid_2;
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main()
+{
+  initlog();
+
+  check<1>();
+  check<2>();
+  check<3>();
+}

--- a/tests/dofs/invalid_iterators_01.output
+++ b/tests/dofs/invalid_iterators_01.output
@@ -1,0 +1,4 @@
+
+DEAL::OK
+DEAL::OK
+DEAL::OK

--- a/tests/dofs/invalid_iterators_02.cc
+++ b/tests/dofs/invalid_iterators_02.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// check that assigning one invalid iterator to another works. this
+// test is for hp::DoFHandler
+
+#include "../tests.h"
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+
+template <int dim>
+void check ()
+{
+  typename hp::DoFHandler<dim>::active_cell_iterator invalid_1;
+
+  // try copy constructor
+  typename hp::DoFHandler<dim>::active_cell_iterator invalid_2 = invalid_1;
+
+  // now also try copy operator
+  invalid_1 = invalid_2;
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int main()
+{
+  initlog();
+
+  check<1>();
+  check<2>();
+  check<3>();
+}

--- a/tests/dofs/invalid_iterators_02.output
+++ b/tests/dofs/invalid_iterators_02.output
@@ -1,0 +1,4 @@
+
+DEAL::OK
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
Over at https://github.com/geodynamics/aspect/pull/1904#pullrequestreview-57643369 , @jdannberg figured out that copying invalid DoF iterators yields an exception. This makes no sense, so make sure it is actually possible.