### PR TITLE
Introduce FEValuesBase::get finite element()

### DIFF
--- a/doc/news/changes/minor/20170823DanielArndt
+++ b/doc/news/changes/minor/20170823DanielArndt
@@ -1,0 +1,5 @@
+New: DoFAccessor::get_fe() has been deprecated in favor of
+DoFAccessor::get_finite_element() to restore similarity to
+the DoFHandler and hp::DoFHandler class.
+<br>
+(Daniel Arndt, 2017/08/23)

--- a/doc/news/changes/minor/20170823DanielArndt-1
+++ b/doc/news/changes/minor/20170823DanielArndt-1
@@ -1,0 +1,5 @@
+New: FEValuesBase::get_fe() has been deprecated in favor of
+FEValuesBase::get_finite_element() to restore similarity to
+the DoFHandler and hp::DoFHandler class.
+<br>
+(Daniel Arndt, 2017/08/23)

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -946,7 +946,7 @@ namespace Step13
     Solver<dim>::AssemblyScratchData::
     AssemblyScratchData (const AssemblyScratchData &scratch_data)
       :
-      fe_values (scratch_data.fe_values.get_fe(),
+      fe_values (scratch_data.fe_values.get_finite_element(),
                  scratch_data.fe_values.get_quadrature(),
                  update_gradients | update_JxW_values)
     {}

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -613,7 +613,7 @@ namespace Step14
     Solver<dim>::AssemblyScratchData::
     AssemblyScratchData (const AssemblyScratchData &scratch_data)
       :
-      fe_values (scratch_data.fe_values.get_fe(),
+      fe_values (scratch_data.fe_values.get_finite_element(),
                  scratch_data.fe_values.get_quadrature(),
                  update_gradients | update_JxW_values)
     {}
@@ -2022,7 +2022,7 @@ namespace Step14
     WeightedResidual<dim>::CellData::
     CellData (const CellData &cell_data)
       :
-      fe_values (cell_data.fe_values.get_fe(),
+      fe_values (cell_data.fe_values.get_finite_element(),
                  cell_data.fe_values.get_quadrature(),
                  update_values   |
                  update_hessians |
@@ -2070,19 +2070,19 @@ namespace Step14
     WeightedResidual<dim>::FaceData::
     FaceData (const FaceData &face_data)
       :
-      fe_face_values_cell (face_data.fe_face_values_cell.get_fe(),
+      fe_face_values_cell (face_data.fe_face_values_cell.get_finite_element(),
                            face_data.fe_face_values_cell.get_quadrature(),
                            update_values        |
                            update_gradients     |
                            update_JxW_values    |
                            update_normal_vectors),
-      fe_face_values_neighbor (face_data.fe_face_values_neighbor.get_fe(),
+      fe_face_values_neighbor (face_data.fe_face_values_neighbor.get_finite_element(),
                                face_data.fe_face_values_neighbor.get_quadrature(),
                                update_values     |
                                update_gradients  |
                                update_JxW_values |
                                update_normal_vectors),
-      fe_subface_values_cell (face_data.fe_subface_values_cell.get_fe(),
+      fe_subface_values_cell (face_data.fe_subface_values_cell.get_finite_element(),
                               face_data.fe_subface_values_cell.get_quadrature(),
                               update_gradients),
       jump_residual (face_data.jump_residual),

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -335,7 +335,7 @@ namespace Step27
     endc = dof_handler.end();
     for (; cell!=endc; ++cell)
       {
-        const unsigned int   dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int   dofs_per_cell = cell->get_finite_element().dofs_per_cell;
 
         cell_matrix.reinit (dofs_per_cell, dofs_per_cell);
         cell_matrix = 0;
@@ -739,7 +739,7 @@ namespace Step27
         // element. This is done by calling FESeries::Fourier::calculate(),
         // that has to be provided with the <code>local_dof_values</code>,
         // <code>cell->active_fe_index()</code> and a Table to store coefficients.
-        local_dof_values.reinit (cell->get_fe().dofs_per_cell);
+        local_dof_values.reinit (cell->get_finite_element().dofs_per_cell);
         cell->get_dof_values (solution, local_dof_values);
 
         fourier->calculate(local_dof_values,

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -377,7 +377,7 @@ namespace Step32
       StokesPreconditioner (const StokesPreconditioner &scratch)
         :
         stokes_fe_values (scratch.stokes_fe_values.get_mapping(),
-                          scratch.stokes_fe_values.get_fe(),
+                          scratch.stokes_fe_values.get_finite_element(),
                           scratch.stokes_fe_values.get_quadrature(),
                           scratch.stokes_fe_values.get_update_flags()),
         grad_phi_u (scratch.grad_phi_u),
@@ -446,7 +446,7 @@ namespace Step32
         :
         StokesPreconditioner<dim> (scratch),
         temperature_fe_values (scratch.temperature_fe_values.get_mapping(),
-                               scratch.temperature_fe_values.get_fe(),
+                               scratch.temperature_fe_values.get_finite_element(),
                                scratch.temperature_fe_values.get_quadrature(),
                                scratch.temperature_fe_values.get_update_flags()),
         phi_u (scratch.phi_u),
@@ -496,7 +496,7 @@ namespace Step32
       TemperatureMatrix (const TemperatureMatrix &scratch)
         :
         temperature_fe_values (scratch.temperature_fe_values.get_mapping(),
-                               scratch.temperature_fe_values.get_fe(),
+                               scratch.temperature_fe_values.get_finite_element(),
                                scratch.temperature_fe_values.get_quadrature(),
                                scratch.temperature_fe_values.get_update_flags()),
         phi_T (scratch.phi_T),
@@ -585,11 +585,11 @@ namespace Step32
       TemperatureRHS (const TemperatureRHS &scratch)
         :
         temperature_fe_values (scratch.temperature_fe_values.get_mapping(),
-                               scratch.temperature_fe_values.get_fe(),
+                               scratch.temperature_fe_values.get_finite_element(),
                                scratch.temperature_fe_values.get_quadrature(),
                                scratch.temperature_fe_values.get_update_flags()),
         stokes_fe_values (scratch.stokes_fe_values.get_mapping(),
-                          scratch.stokes_fe_values.get_fe(),
+                          scratch.stokes_fe_values.get_finite_element(),
                           scratch.stokes_fe_values.get_quadrature(),
                           scratch.stokes_fe_values.get_update_flags()),
         phi_T (scratch.phi_T),
@@ -2368,7 +2368,7 @@ namespace Step32
                                 Assembly::Scratch::StokesSystem<dim> &scratch,
                                 Assembly::CopyData::StokesSystem<dim> &data)
   {
-    const unsigned int dofs_per_cell = scratch.stokes_fe_values.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = scratch.stokes_fe_values.get_finite_element().dofs_per_cell;
     const unsigned int n_q_points    = scratch.stokes_fe_values.n_quadrature_points;
 
     const FEValuesExtractors::Vector velocities (0);
@@ -2524,7 +2524,7 @@ namespace Step32
                                      Assembly::Scratch::TemperatureMatrix<dim> &scratch,
                                      Assembly::CopyData::TemperatureMatrix<dim> &data)
   {
-    const unsigned int dofs_per_cell = scratch.temperature_fe_values.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = scratch.temperature_fe_values.get_finite_element().dofs_per_cell;
     const unsigned int n_q_points    = scratch.temperature_fe_values.n_quadrature_points;
 
     scratch.temperature_fe_values.reinit (cell);
@@ -2644,7 +2644,7 @@ namespace Step32
   {
     const bool use_bdf2_scheme = (timestep_number != 0);
 
-    const unsigned int dofs_per_cell = scratch.temperature_fe_values.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = scratch.temperature_fe_values.get_finite_element().dofs_per_cell;
     const unsigned int n_q_points    = scratch.temperature_fe_values.n_quadrature_points;
 
     const FEValuesExtractors::Vector velocities (0);

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1737,7 +1737,7 @@ namespace Step33
     for (unsigned int q=0; q<n_q_points; ++q)
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         {
-          const unsigned int c = fe_v.get_fe().system_to_component_index(i).first;
+          const unsigned int c = fe_v.get_finite_element().system_to_component_index(i).first;
 
           W[q][c] += independent_local_dof_values[i] *
                      fe_v.shape_value_component(i, q, c);
@@ -1824,7 +1824,7 @@ namespace Step33
         Sacado::Fad::DFad<double> R_i = 0;
 
         const unsigned int
-        component_i = fe_v.get_fe().system_to_component_index(i).first;
+        component_i = fe_v.get_finite_element().system_to_component_index(i).first;
 
         // The residual for each row (i) will be accumulating into this fad
         // variable.  At the end of the assembly for this row, we will query
@@ -1939,7 +1939,7 @@ namespace Step33
     for (unsigned int q=0; q<n_q_points; ++q)
       for (unsigned int i=0; i<dofs_per_cell; ++i)
         {
-          const unsigned int component_i = fe_v.get_fe().system_to_component_index(i).first;
+          const unsigned int component_i = fe_v.get_finite_element().system_to_component_index(i).first;
           Wplus[q][component_i] +=  independent_local_dof_values[i] *
                                     fe_v.shape_value_component(i, q, component_i);
           Wplus_old[q][component_i] +=  old_solution(dof_indices[i]) *
@@ -1954,7 +1954,7 @@ namespace Step33
         for (unsigned int q=0; q<n_q_points; ++q)
           for (unsigned int i=0; i<dofs_per_cell; ++i)
             {
-              const unsigned int component_i = fe_v_neighbor.get_fe().
+              const unsigned int component_i = fe_v_neighbor.get_finite_element().
                                                system_to_component_index(i).first;
               Wminus[q][component_i] += independent_neighbor_dof_values[i] *
                                         fe_v_neighbor.shape_value_component(i, q, component_i);
@@ -2048,14 +2048,14 @@ namespace Step33
     // the neighboring cell:
     std::vector<double> residual_derivatives (dofs_per_cell);
     for (unsigned int i=0; i<fe_v.dofs_per_cell; ++i)
-      if (fe_v.get_fe().has_support_on_face(i, face_no) == true)
+      if (fe_v.get_finite_element().has_support_on_face(i, face_no) == true)
         {
           Sacado::Fad::DFad<double> R_i = 0;
 
           for (unsigned int point=0; point<n_q_points; ++point)
             {
               const unsigned int
-              component_i = fe_v.get_fe().system_to_component_index(i).first;
+              component_i = fe_v.get_finite_element().system_to_component_index(i).first;
 
               R_i += ( parameters.theta * normal_fluxes[point][component_i] +
                        (1.0 - parameters.theta) * normal_fluxes_old[point][component_i] ) *

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -569,10 +569,10 @@ namespace Step35
       InitGradScratchData (const InitGradScratchData &data)
         :
         nqp (data.nqp),
-        fe_val_vel (data.fe_val_vel.get_fe(),
+        fe_val_vel (data.fe_val_vel.get_finite_element(),
                     data.fe_val_vel.get_quadrature(),
                     data.fe_val_vel.get_update_flags()),
-        fe_val_pres (data.fe_val_pres.get_fe(),
+        fe_val_pres (data.fe_val_pres.get_finite_element(),
                      data.fe_val_pres.get_quadrature(),
                      data.fe_val_pres.get_update_flags())
       {}
@@ -626,7 +626,7 @@ namespace Step35
         u_star_local (nqp),
         grad_u_star (nqp),
         u_star_tmp (nqp),
-        fe_val (data.fe_val.get_fe(),
+        fe_val (data.fe_val.get_finite_element(),
                 data.fe_val.get_quadrature(),
                 data.fe_val.get_update_flags())
       {}

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -129,7 +129,7 @@ namespace Step39
     MeshWorker::DoFInfo<dim> &dinfo,
     typename MeshWorker::IntegrationInfo<dim> &info) const
   {
-    const unsigned int deg = info.fe_values(0).get_fe().tensor_degree();
+    const unsigned int deg = info.fe_values(0).get_finite_element().tensor_degree();
     LocalIntegrators::Laplace::nitsche_matrix(
       dinfo.matrix(0,false).matrix, info.fe_values(0),
       LocalIntegrators::Laplace::compute_penalty(dinfo, dinfo, deg, deg));
@@ -143,7 +143,7 @@ namespace Step39
     typename MeshWorker::IntegrationInfo<dim> &info1,
     typename MeshWorker::IntegrationInfo<dim> &info2) const
   {
-    const unsigned int deg = info1.fe_values(0).get_fe().tensor_degree();
+    const unsigned int deg = info1.fe_values(0).get_finite_element().tensor_degree();
     LocalIntegrators::Laplace::ip_matrix(
       dinfo1.matrix(0,false).matrix, dinfo1.matrix(0,true).matrix,
       dinfo2.matrix(0,true).matrix, dinfo2.matrix(0,false).matrix,
@@ -181,7 +181,7 @@ namespace Step39
     std::vector<double> boundary_values(fe.n_quadrature_points);
     exact_solution.value_list(fe.get_quadrature_points(), boundary_values);
 
-    const unsigned int deg = fe.get_fe().tensor_degree();
+    const unsigned int deg = fe.get_finite_element().tensor_degree();
     const double penalty = 2. * deg * (deg+1) * dinfo.face->measure() / dinfo.cell->measure();
 
     for (unsigned k=0; k<fe.n_quadrature_points; ++k)
@@ -245,7 +245,7 @@ namespace Step39
 
     const std::vector<double> &uh = info.values[0][0];
 
-    const unsigned int deg = fe.get_fe().tensor_degree();
+    const unsigned int deg = fe.get_finite_element().tensor_degree();
     const double penalty = 2. * deg * (deg+1) * dinfo.face->measure() / dinfo.cell->measure();
 
     for (unsigned k=0; k<fe.n_quadrature_points; ++k)
@@ -269,7 +269,7 @@ namespace Step39
     const std::vector<Tensor<1,dim> > &Duh1 = info1.gradients[0][0];
     const std::vector<Tensor<1,dim> > &Duh2 = info2.gradients[0][0];
 
-    const unsigned int deg = fe.get_fe().tensor_degree();
+    const unsigned int deg = fe.get_finite_element().tensor_degree();
     const double penalty1 = deg * (deg+1) * dinfo1.face->measure() / dinfo1.cell->measure();
     const double penalty2 = deg * (deg+1) * dinfo2.face->measure() / dinfo2.cell->measure();
     const double penalty = penalty1 + penalty2;
@@ -367,7 +367,7 @@ namespace Step39
 
     const std::vector<double> &uh = info.values[0][0];
 
-    const unsigned int deg = fe.get_fe().tensor_degree();
+    const unsigned int deg = fe.get_finite_element().tensor_degree();
     const double penalty = 2. * deg * (deg+1) * dinfo.face->measure() / dinfo.cell->measure();
 
     for (unsigned k=0; k<fe.n_quadrature_points; ++k)
@@ -390,7 +390,7 @@ namespace Step39
     const std::vector<double> &uh1 = info1.values[0][0];
     const std::vector<double> &uh2 = info2.values[0][0];
 
-    const unsigned int deg = fe.get_fe().tensor_degree();
+    const unsigned int deg = fe.get_finite_element().tensor_degree();
     const double penalty1 = deg * (deg+1) * dinfo1.face->measure() / dinfo1.cell->measure();
     const double penalty2 = deg * (deg+1) * dinfo2.face->measure() / dinfo2.cell->measure();
     const double penalty = penalty1 + penalty2;

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1252,7 +1252,7 @@ namespace Step44
 
     ScratchData_K(const ScratchData_K &rhs)
       :
-      fe_values_ref(rhs.fe_values_ref.get_fe(),
+      fe_values_ref(rhs.fe_values_ref.get_finite_element(),
                     rhs.fe_values_ref.get_quadrature(),
                     rhs.fe_values_ref.get_update_flags()),
       Nx(rhs.Nx),
@@ -1328,10 +1328,10 @@ namespace Step44
 
     ScratchData_RHS(const ScratchData_RHS &rhs)
       :
-      fe_values_ref(rhs.fe_values_ref.get_fe(),
+      fe_values_ref(rhs.fe_values_ref.get_finite_element(),
                     rhs.fe_values_ref.get_quadrature(),
                     rhs.fe_values_ref.get_update_flags()),
-      fe_face_values_ref(rhs.fe_face_values_ref.get_fe(),
+      fe_face_values_ref(rhs.fe_face_values_ref.get_finite_element(),
                          rhs.fe_face_values_ref.get_quadrature(),
                          rhs.fe_face_values_ref.get_update_flags()),
       Nx(rhs.Nx),
@@ -1474,7 +1474,7 @@ namespace Step44
       solution_grads_u_total(rhs.solution_grads_u_total),
       solution_values_p_total(rhs.solution_values_p_total),
       solution_values_J_total(rhs.solution_values_J_total),
-      fe_values_ref(rhs.fe_values_ref.get_fe(),
+      fe_values_ref(rhs.fe_values_ref.get_finite_element(),
                     rhs.fe_values_ref.get_quadrature(),
                     rhs.fe_values_ref.get_update_flags())
     {}

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -586,9 +586,9 @@ namespace Step46
 
         const FEValues<dim> &fe_values = hp_fe_values.get_present_fe_values();
 
-        local_matrix.reinit (cell->get_fe().dofs_per_cell,
-                             cell->get_fe().dofs_per_cell);
-        local_rhs.reinit (cell->get_fe().dofs_per_cell);
+        local_matrix.reinit (cell->get_finite_element().dofs_per_cell,
+                             cell->get_finite_element().dofs_per_cell);
+        local_rhs.reinit (cell->get_finite_element().dofs_per_cell);
 
         // With all of this done, we continue to assemble the cell terms for
         // cells that are part of the Stokes and elastic regions. While we
@@ -606,7 +606,7 @@ namespace Step46
         // documentation module for the elasticity equations:
         if (cell_is_in_fluid_domain (cell))
           {
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
             Assert (dofs_per_cell == stokes_dofs_per_cell,
                     ExcInternalError());
 
@@ -629,7 +629,7 @@ namespace Step46
           }
         else
           {
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
             Assert (dofs_per_cell == elasticity_dofs_per_cell,
                     ExcInternalError());
 
@@ -668,7 +668,7 @@ namespace Step46
         // along since the elimination of nonzero boundary values requires the
         // modification of local and consequently also global right hand side
         // values:
-        local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
         cell->get_dof_indices (local_dof_indices);
         constraints.distribute_local_to_global (local_matrix, local_rhs,
                                                 local_dof_indices,

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -296,7 +296,7 @@ namespace Step47
 
     for (; cell!=endc; ++cell)
       {
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
         cell_matrix.reinit (dofs_per_cell, dofs_per_cell);
         cell_rhs.reinit (dofs_per_cell);
 
@@ -351,10 +351,10 @@ namespace Step47
 
             for (unsigned int q_point=0; q_point<this_fe_values.n_quadrature_points; ++q_point)
               for (unsigned int i=0; i<dofs_per_cell; ++i)
-                if (cell->get_fe().system_to_component_index(i).first == 0)
+                if (cell->get_finite_element().system_to_component_index(i).first == 0)
                   {
                     for (unsigned int j=0; j<dofs_per_cell; ++j)
-                      if (cell->get_fe().system_to_component_index(j).first == 0)
+                      if (cell->get_finite_element().system_to_component_index(j).first == 0)
                         cell_matrix(i,j) += (coefficient_values[q_point] *
                                              this_fe_values.shape_grad(i,q_point) *
                                              this_fe_values.shape_grad(j,q_point) *
@@ -365,7 +365,7 @@ namespace Step47
                                              *
                                              ((std::fabs(level_set(this_fe_values.quadrature_point(q_point)))
                                                -
-                                               std::fabs(level_set(cell->vertex(cell->get_fe().system_to_component_index(j).second))))*
+                                               std::fabs(level_set(cell->vertex(cell->get_finite_element().system_to_component_index(j).second))))*
                                               this_fe_values.shape_grad(j,q_point)
                                               +
                                               grad_level_set(this_fe_values.quadrature_point(q_point)) *
@@ -380,11 +380,11 @@ namespace Step47
                 else
                   {
                     for (unsigned int j=0; j<dofs_per_cell; ++j)
-                      if (cell->get_fe().system_to_component_index(j).first == 0)
+                      if (cell->get_finite_element().system_to_component_index(j).first == 0)
                         cell_matrix(i,j) += (coefficient_values[q_point] *
                                              ((std::fabs(level_set(this_fe_values.quadrature_point(q_point)))
                                                -
-                                               std::fabs(level_set(cell->vertex(cell->get_fe().system_to_component_index(i).second))))*
+                                               std::fabs(level_set(cell->vertex(cell->get_finite_element().system_to_component_index(i).second))))*
                                               this_fe_values.shape_grad(i,q_point)
                                               +
                                               grad_level_set(this_fe_values.quadrature_point(q_point)) *
@@ -396,7 +396,7 @@ namespace Step47
                         cell_matrix(i,j) += (coefficient_values[q_point] *
                                              ((std::fabs(level_set(this_fe_values.quadrature_point(q_point)))
                                                -
-                                               std::fabs(level_set(cell->vertex(cell->get_fe().system_to_component_index(i).second))))*
+                                               std::fabs(level_set(cell->vertex(cell->get_finite_element().system_to_component_index(i).second))))*
                                               this_fe_values.shape_grad(i,q_point)
                                               +
                                               grad_level_set(this_fe_values.quadrature_point(q_point)) *
@@ -404,7 +404,7 @@ namespace Step47
                                               this_fe_values.shape_value(i,q_point)) *
                                              ((std::fabs(level_set(this_fe_values.quadrature_point(q_point)))
                                                -
-                                               std::fabs(level_set(cell->vertex(cell->get_fe().system_to_component_index(j).second))))*
+                                               std::fabs(level_set(cell->vertex(cell->get_finite_element().system_to_component_index(j).second))))*
                                               this_fe_values.shape_grad(j,q_point)
                                               +
                                               grad_level_set(this_fe_values.quadrature_point(q_point)) *
@@ -414,7 +414,7 @@ namespace Step47
 
                     cell_rhs(i) += ((std::fabs(level_set(this_fe_values.quadrature_point(q_point)))
                                      -
-                                     std::fabs(level_set(cell->vertex(cell->get_fe().system_to_component_index(i).second))))*
+                                     std::fabs(level_set(cell->vertex(cell->get_finite_element().system_to_component_index(i).second))))*
                                     this_fe_values.shape_value(i,q_point) *
                                     1.0 *
                                     this_fe_values.JxW(q_point));

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -599,13 +599,13 @@ namespace Step51
 
     ScratchData(const ScratchData &sd)
       :
-      fe_values_local (sd.fe_values_local.get_fe(),
+      fe_values_local (sd.fe_values_local.get_finite_element(),
                        sd.fe_values_local.get_quadrature(),
                        sd.fe_values_local.get_update_flags()),
-      fe_face_values_local (sd.fe_face_values_local.get_fe(),
+      fe_face_values_local (sd.fe_face_values_local.get_finite_element(),
                             sd.fe_face_values_local.get_quadrature(),
                             sd.fe_face_values_local.get_update_flags()),
-      fe_face_values (sd.fe_face_values.get_fe(),
+      fe_face_values (sd.fe_face_values.get_finite_element(),
                       sd.fe_face_values.get_quadrature(),
                       sd.fe_face_values.get_update_flags()),
       ll_matrix (sd.ll_matrix),
@@ -661,10 +661,10 @@ namespace Step51
 
     PostProcessScratchData(const PostProcessScratchData &sd)
       :
-      fe_values_local (sd.fe_values_local.get_fe(),
+      fe_values_local (sd.fe_values_local.get_finite_element(),
                        sd.fe_values_local.get_quadrature(),
                        sd.fe_values_local.get_update_flags()),
-      fe_values (sd.fe_values.get_fe(),
+      fe_values (sd.fe_values.get_finite_element(),
                  sd.fe_values.get_quadrature(),
                  sd.fe_values.get_update_flags()),
       u_values (sd.u_values),
@@ -740,7 +740,7 @@ namespace Step51
     const unsigned int n_q_points    = scratch.fe_values_local.get_quadrature().size();
     const unsigned int n_face_q_points = scratch.fe_face_values_local.get_quadrature().size();
 
-    const unsigned int loc_dofs_per_cell = scratch.fe_values_local.get_fe().dofs_per_cell;
+    const unsigned int loc_dofs_per_cell = scratch.fe_values_local.get_finite_element().dofs_per_cell;
 
     const FEValuesExtractors::Vector fluxes (0);
     const FEValuesExtractors::Scalar scalar (dim);

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -643,11 +643,11 @@ namespace Step9
   AdvectionProblem<dim>::AssemblyScratchData::
   AssemblyScratchData (const AssemblyScratchData &scratch_data)
     :
-    fe_values (scratch_data.fe_values.get_fe(),
+    fe_values (scratch_data.fe_values.get_finite_element(),
                scratch_data.fe_values.get_quadrature(),
                update_values   | update_gradients |
                update_quadrature_points | update_JxW_values),
-    fe_face_values (scratch_data.fe_face_values.get_fe(),
+    fe_face_values (scratch_data.fe_face_values.get_finite_element(),
                     scratch_data.fe_face_values.get_quadrature(),
                     update_values     | update_quadrature_points   |
                     update_JxW_values | update_normal_vectors)
@@ -986,7 +986,7 @@ namespace Step9
   GradientEstimation::EstimateScratchData<dim>::
   EstimateScratchData(const EstimateScratchData &scratch_data)
     :
-    fe_midpoint_value(scratch_data.fe_midpoint_value.get_fe(),
+    fe_midpoint_value(scratch_data.fe_midpoint_value.get_finite_element(),
                       scratch_data.fe_midpoint_value.get_quadrature(),
                       update_values | update_quadrature_points),
     solution(scratch_data.solution)

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -539,9 +539,19 @@ public:
    * Return a reference to the finite element used on this object with the
    * given @p fe_index. @p fe_index must be used on this object, i.e.
    * <code>fe_index_is_active(fe_index)</code> must return true.
+   *
+   * @deprecated Use get_finite_element() instead.
    */
   const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
-  get_fe (const unsigned int fe_index) const;
+  get_fe (const unsigned int fe_index) const  DEAL_II_DEPRECATED;
+
+  /**
+   * Return a reference to the finite element used on this object with the
+   * given @p fe_index. @p fe_index must be used on this object, i.e.
+   * <code>fe_index_is_active(fe_index)</code> must return true.
+   */
+  const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
+  get_finite_element (const unsigned int fe_index) const;
 
   /**
    * @}
@@ -1006,9 +1016,19 @@ public:
    * Return a reference to the finite element used on this object with the
    * given @p fe_index. @p fe_index must be used on this object, i.e.
    * <code>fe_index_is_active(fe_index)</code> must return true.
+   *
+   * @deprecated Use get_finite_element() instead.
    */
   const FiniteElement<DoFHandlerType<1,spacedim>::dimension,DoFHandlerType<1,spacedim>::space_dimension> &
-  get_fe (const unsigned int fe_index) const;
+  get_fe (const unsigned int fe_index) const DEAL_II_DEPRECATED;
+
+  /**
+   * Return a reference to the finite element used on this object with the
+   * given @p fe_index. @p fe_index must be used on this object, i.e.
+   * <code>fe_index_is_active(fe_index)</code> must return true.
+   */
+  const FiniteElement<DoFHandlerType<1,spacedim>::dimension,DoFHandlerType<1,spacedim>::space_dimension> &
+  get_finite_element (const unsigned int fe_index) const;
 
   /**
    * @}
@@ -1679,9 +1699,27 @@ public:
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,
    * this function will produce an exception when called on non-active cells.
+   *
+   * @deprecated Use get_finite_element() instead.
    */
   const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
-  get_fe () const;
+  get_fe () const DEAL_II_DEPRECATED;
+
+  /**
+   * Return the finite element that is used on the cell pointed to by this
+   * iterator. For non-hp DoF handlers, this is of course always the same
+   * element, independent of the cell we are presently on, but for hp DoF
+   * handlers, this may change from cell to cell.
+   *
+   * @note Since degrees of freedoms only exist on active cells for
+   * hp::DoFHandler (i.e., there is currently no implementation of multilevel
+   * hp::DoFHandler objects), it does not make sense to query the finite
+   * element on non-active cells since they do not have finite element spaces
+   * associated with them without having any degrees of freedom. Consequently,
+   * this function will produce an exception when called on non-active cells.
+   */
+  const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
+  get_finite_element () const;
 
   /**
    * Return the index inside the hp::FECollection of the FiniteElement used

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1789,6 +1789,16 @@ inline
 const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
 DoFAccessor<dim,DoFHandlerType,level_dof_access>::get_fe (const unsigned int fe_index) const
 {
+  return get_finite_element(fe_index);
+}
+
+
+
+template <int dim, typename DoFHandlerType, bool level_dof_access>
+inline
+const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
+DoFAccessor<dim,DoFHandlerType,level_dof_access>::get_finite_element (const unsigned int fe_index) const
+{
   Assert (fe_index_is_active (fe_index) == true,
           ExcMessage ("This function can only be called for active fe indices"));
 
@@ -1806,8 +1816,8 @@ namespace internal
                           std::vector<types::global_dof_index>                         &dof_indices,
                           const unsigned int                                            fe_index)
     {
-      const unsigned int dofs_per_vertex = accessor.get_fe(fe_index).dofs_per_vertex,
-                         dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line;
+      const unsigned int dofs_per_vertex = accessor.get_finite_element(fe_index).dofs_per_vertex,
+                         dofs_per_line   = accessor.get_finite_element(fe_index).dofs_per_line;
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
       for (unsigned int vertex=0; vertex<2; ++vertex)
         for (unsigned int d=0; d<dofs_per_vertex; ++d)
@@ -1823,9 +1833,9 @@ namespace internal
                           std::vector<types::global_dof_index>                         &dof_indices,
                           const unsigned int                                            fe_index)
     {
-      const unsigned int dofs_per_vertex = accessor.get_fe(fe_index).dofs_per_vertex,
-                         dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line,
-                         dofs_per_quad   = accessor.get_fe(fe_index).dofs_per_quad;
+      const unsigned int dofs_per_vertex = accessor.get_finite_element(fe_index).dofs_per_vertex,
+                         dofs_per_line   = accessor.get_finite_element(fe_index).dofs_per_line,
+                         dofs_per_quad   = accessor.get_finite_element(fe_index).dofs_per_quad;
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
       for (unsigned int vertex=0; vertex<4; ++vertex)
         for (unsigned int d=0; d<dofs_per_vertex; ++d)
@@ -1843,7 +1853,7 @@ namespace internal
       // (face-local) ordering.
       for (unsigned int line=0; line<4; ++line)
         for (unsigned int d=0; d<dofs_per_line; ++d)
-          *next++ = accessor.line(line)->dof_index(accessor.get_fe(fe_index).
+          *next++ = accessor.line(line)->dof_index(accessor.get_finite_element(fe_index).
                                                    adjust_line_dof_index_for_line_orientation(d,
                                                        accessor.line_orientation(line)),
                                                    fe_index);
@@ -1858,10 +1868,10 @@ namespace internal
                           std::vector<types::global_dof_index>                         &dof_indices,
                           const unsigned int                                            fe_index)
     {
-      const unsigned int dofs_per_vertex = accessor.get_fe(fe_index).dofs_per_vertex,
-                         dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line,
-                         dofs_per_quad   = accessor.get_fe(fe_index).dofs_per_quad,
-                         dofs_per_hex    = accessor.get_fe(fe_index).dofs_per_hex;
+      const unsigned int dofs_per_vertex = accessor.get_finite_element(fe_index).dofs_per_vertex,
+                         dofs_per_line   = accessor.get_finite_element(fe_index).dofs_per_line,
+                         dofs_per_quad   = accessor.get_finite_element(fe_index).dofs_per_quad,
+                         dofs_per_hex    = accessor.get_finite_element(fe_index).dofs_per_hex;
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
       for (unsigned int vertex=0; vertex<8; ++vertex)
         for (unsigned int d=0; d<dofs_per_vertex; ++d)
@@ -1879,7 +1889,7 @@ namespace internal
       // (cell-local) ordering.
       for (unsigned int line=0; line<12; ++line)
         for (unsigned int d=0; d<dofs_per_line; ++d)
-          *next++ = accessor.line(line)->dof_index(accessor.get_fe(fe_index).
+          *next++ = accessor.line(line)->dof_index(accessor.get_finite_element(fe_index).
                                                    adjust_line_dof_index_for_line_orientation(d,
                                                        accessor.line_orientation(line)),fe_index);
       // now copy dof numbers from the face. for
@@ -1897,7 +1907,7 @@ namespace internal
       // face_orientation is non-standard
       for (unsigned int quad=0; quad<6; ++quad)
         for (unsigned int d=0; d<dofs_per_quad; ++d)
-          *next++ = accessor.quad(quad)->dof_index(accessor.get_fe(fe_index).
+          *next++ = accessor.quad(quad)->dof_index(accessor.get_finite_element(fe_index).
                                                    adjust_quad_dof_index_for_face_orientation(d,
                                                        accessor.face_orientation(quad),
                                                        accessor.face_flip(quad),
@@ -1982,12 +1992,12 @@ namespace internal
       for (unsigned int line = 0; line < GeometryInfo<3>::lines_per_cell; ++line)
         for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
           *next++ = accessor.line (line)->mg_dof_index
-                    (level, accessor.get_fe(fe_index).adjust_line_dof_index_for_line_orientation(dof,accessor.line_orientation(line)));
+                    (level, accessor.get_finite_element(fe_index).adjust_line_dof_index_for_line_orientation(dof,accessor.line_orientation(line)));
 
       for (unsigned int quad = 0; quad < GeometryInfo<3>::quads_per_cell; ++quad)
         for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
           *next++ = accessor.quad (quad)->mg_dof_index
-                    (level, accessor.get_fe(fe_index).adjust_quad_dof_index_for_face_orientation
+                    (level, accessor.get_finite_element(fe_index).adjust_quad_dof_index_for_face_orientation
                      (dof,
                       accessor.face_orientation(quad),
                       accessor.face_flip(quad),
@@ -2532,6 +2542,17 @@ const FiniteElement<DoFHandlerType<1,spacedim>::dimension,DoFHandlerType<1,space
 DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
 get_fe (const unsigned int fe_index) const
 {
+  return get_finite_element(fe_index);
+}
+
+
+
+template <template <int, int> class DoFHandlerType, int spacedim, bool level_dof_access>
+inline
+const FiniteElement<DoFHandlerType<1,spacedim>::dimension,DoFHandlerType<1,spacedim>::space_dimension> &
+DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
+get_finite_element (const unsigned int fe_index) const
+{
   Assert (this->dof_handler != nullptr, ExcInvalidObject());
   return dof_handler->get_finite_element(fe_index);
 }
@@ -2665,13 +2686,13 @@ namespace internal
         // don't access the invalid data
         if (accessor.has_children()
             &&
-            (accessor.get_fe().dofs_per_cell !=
-             accessor.get_fe().dofs_per_vertex * GeometryInfo<1>::vertices_per_cell))
+            (accessor.get_finite_element().dofs_per_cell !=
+             accessor.get_finite_element().dofs_per_vertex * GeometryInfo<1>::vertices_per_cell))
           return;
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
 
         // make sure the cache is at least
         // as big as we need it when
@@ -2710,14 +2731,14 @@ namespace internal
         // don't access the invalid data
         if (accessor.has_children()
             &&
-            (accessor.get_fe().dofs_per_cell !=
-             accessor.get_fe().dofs_per_vertex * GeometryInfo<2>::vertices_per_cell))
+            (accessor.get_finite_element().dofs_per_cell !=
+             accessor.get_finite_element().dofs_per_vertex * GeometryInfo<2>::vertices_per_cell))
           return;
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_quad   = accessor.get_finite_element().dofs_per_quad,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
 
         // make sure the cache is at least
         // as big as we need it when
@@ -2758,15 +2779,15 @@ namespace internal
         // don't access the invalid data
         if (accessor.has_children()
             &&
-            (accessor.get_fe().dofs_per_cell !=
-             accessor.get_fe().dofs_per_vertex * GeometryInfo<3>::vertices_per_cell))
+            (accessor.get_finite_element().dofs_per_cell !=
+             accessor.get_finite_element().dofs_per_vertex * GeometryInfo<3>::vertices_per_cell))
           return;
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
-                           dofs_per_hex    = accessor.get_fe().dofs_per_hex,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_quad   = accessor.get_finite_element().dofs_per_quad,
+                           dofs_per_hex    = accessor.get_finite_element().dofs_per_hex,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
 
         // make sure the cache is at least
         // as big as we need it when
@@ -2837,7 +2858,7 @@ namespace internal
         if (accessor.has_children())
           return;
 
-        const unsigned int dofs_per_cell = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = accessor.get_finite_element().dofs_per_cell;
 
         // make sure the cache is at least
         // as big as we need it when
@@ -2885,9 +2906,9 @@ namespace internal
         Assert (accessor.has_children() == false,
                 ExcInternalError());
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
         (void)dofs_per_cell;
 
         Assert (local_dof_indices.size() == dofs_per_cell,
@@ -2918,10 +2939,10 @@ namespace internal
         Assert (accessor.has_children() == false,
                 ExcInternalError());
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_quad   = accessor.get_finite_element().dofs_per_quad,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
         (void)dofs_per_cell;
 
         Assert (local_dof_indices.size() == dofs_per_cell,
@@ -2955,11 +2976,11 @@ namespace internal
         Assert (accessor.has_children() == false,
                 ExcInternalError());
 
-        const unsigned int dofs_per_vertex = accessor.get_fe().dofs_per_vertex,
-                           dofs_per_line   = accessor.get_fe().dofs_per_line,
-                           dofs_per_quad   = accessor.get_fe().dofs_per_quad,
-                           dofs_per_hex    = accessor.get_fe().dofs_per_hex,
-                           dofs_per_cell   = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_vertex = accessor.get_finite_element().dofs_per_vertex,
+                           dofs_per_line   = accessor.get_finite_element().dofs_per_line,
+                           dofs_per_quad   = accessor.get_finite_element().dofs_per_quad,
+                           dofs_per_hex    = accessor.get_finite_element().dofs_per_hex,
+                           dofs_per_cell   = accessor.get_finite_element().dofs_per_cell;
         (void)dofs_per_cell;
 
         Assert (local_dof_indices.size() == dofs_per_cell,
@@ -3113,7 +3134,7 @@ namespace internal
                 typename BaseClass::ExcInvalidObject());
         Assert (static_cast<unsigned int>(local_source_end-local_source_begin)
                 ==
-                accessor.get_fe().dofs_per_cell,
+                accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3143,7 +3164,7 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
+        Assert (local_source_end-local_source_begin == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3174,7 +3195,7 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
+        Assert (local_source_end-local_source_begin == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3206,7 +3227,7 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_source_end-local_source_begin == accessor.get_fe().dofs_per_cell,
+        Assert (local_source_end-local_source_begin == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3236,9 +3257,9 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != nullptr,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_source.m() == accessor.get_fe().dofs_per_cell,
+        Assert (local_source.m() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_source.n() == accessor.get_fe().dofs_per_cell,
+        Assert (local_source.n() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcMatrixDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.m(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
@@ -3271,9 +3292,9 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_source.m() == accessor.get_fe().dofs_per_cell,
+        Assert (local_source.m() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_source.n() == accessor.get_fe().dofs_per_cell,
+        Assert (local_source.n() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_destination.m(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
@@ -3307,15 +3328,15 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_matrix.m() == accessor.get_fe().dofs_per_cell,
+        Assert (local_matrix.m() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_matrix.n() == accessor.get_fe().dofs_per_cell,
+        Assert (local_matrix.n() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_matrix.m(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_matrix.n(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_vector.size() == accessor.get_fe().dofs_per_cell,
+        Assert (local_vector.size() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_vector.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3323,7 +3344,7 @@ namespace internal
         Assert (!accessor.has_children(),
                 ExcMessage ("Cell must be active."));
 
-        const unsigned int n_dofs = accessor.get_fe().dofs_per_cell;
+        const unsigned int n_dofs = accessor.get_finite_element().dofs_per_cell;
         types::global_dof_index *dofs = &accessor.dof_handler->levels[accessor.level()]
                                         ->cell_dof_indices_cache[accessor.present_index *n_dofs];
 
@@ -3350,15 +3371,15 @@ namespace internal
         typedef dealii::DoFAccessor<dim,DoFHandler<dim,spacedim>, level_dof_access> BaseClass;
         Assert (accessor.dof_handler != 0,
                 typename BaseClass::ExcInvalidObject());
-        Assert (local_matrix.m() == accessor.get_fe().dofs_per_cell,
+        Assert (local_matrix.m() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_matrix.n() == accessor.get_fe().dofs_per_cell,
+        Assert (local_matrix.n() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_matrix.m(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_matrix.n(),
                 typename BaseClass::ExcMatrixDoesNotMatch());
-        Assert (local_vector.size() == accessor.get_fe().dofs_per_cell,
+        Assert (local_vector.size() == accessor.get_finite_element().dofs_per_cell,
                 typename BaseClass::ExcVectorDoesNotMatch());
         Assert (accessor.dof_handler->n_dofs() == global_vector.size(),
                 typename BaseClass::ExcVectorDoesNotMatch());
@@ -3543,12 +3564,12 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_indices
   Assert (this->active(), ExcMessage ("get_dof_indices() only works on active cells."));
   Assert (this->is_artificial() == false,
           ExcMessage ("Can't ask for DoF indices on artificial cells."));
-  AssertDimension (dof_indices.size(), this->get_fe().dofs_per_cell);
+  AssertDimension (dof_indices.size(), this->get_finite_element().dofs_per_cell);
 
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
-      ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
-  for (unsigned int i=0; i<this->get_fe().dofs_per_cell; ++i, ++cache)
+      ->get_cell_cache_start (this->present_index, this->get_finite_element().dofs_per_cell);
+  for (unsigned int i=0; i<this->get_finite_element().dofs_per_cell; ++i, ++cache)
     dof_indices[i] = *cache;
 }
 
@@ -3616,16 +3637,16 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_values
           ExcMessage ("Cell must be active."));
 
   Assert (static_cast<unsigned int>(local_values_end-local_values_begin)
-          == this->get_fe().dofs_per_cell,
+          == this->get_finite_element().dofs_per_cell,
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert (values.size() == this->get_dof_handler().n_dofs(),
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
 
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
-      ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
+      ->get_cell_cache_start (this->present_index, this->get_finite_element().dofs_per_cell);
   dealii::internal::DoFAccessor::Implementation::extract_subvector_to(
-    values, cache, cache + this->get_fe().dofs_per_cell, local_values_begin);
+    values, cache, cache + this->get_finite_element().dofs_per_cell, local_values_begin);
 }
 
 
@@ -3646,7 +3667,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_values
           ExcMessage ("Cell must be active."));
 
   Assert (static_cast<unsigned int>(local_values_end-local_values_begin)
-          == this->get_fe().dofs_per_cell,
+          == this->get_finite_element().dofs_per_cell,
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert (values.size() == this->get_dof_handler().n_dofs(),
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
@@ -3654,7 +3675,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_dof_values
 
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
-      ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
+      ->get_cell_cache_start (this->present_index, this->get_finite_element().dofs_per_cell);
 
   constraints.get_dof_values(values, *cache, local_values_begin,
                              local_values_end);
@@ -3676,7 +3697,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_dof_values
           ExcMessage ("Cell must be active."));
 
   Assert (static_cast<unsigned int>(local_values.size())
-          == this->get_fe().dofs_per_cell,
+          == this->get_finite_element().dofs_per_cell,
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert (values.size() == this->get_dof_handler().n_dofs(),
           typename DoFCellAccessor::ExcVectorDoesNotMatch());
@@ -3684,9 +3705,9 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::set_dof_values
 
   const types::global_dof_index *cache
     = this->dof_handler->levels[this->present_level]
-      ->get_cell_cache_start (this->present_index, this->get_fe().dofs_per_cell);
+      ->get_cell_cache_start (this->present_index, this->get_finite_element().dofs_per_cell);
 
-  for (unsigned int i=0; i<this->get_fe().dofs_per_cell; ++i, ++cache)
+  for (unsigned int i=0; i<this->get_finite_element().dofs_per_cell; ++i, ++cache)
     internal::ElementAccess<OutputVector>::set(local_values(i),
                                                *cache, values);
 }
@@ -3697,6 +3718,23 @@ template <typename DoFHandlerType, bool level_dof_access>
 inline
 const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
 DoFCellAccessor<DoFHandlerType,level_dof_access>::get_fe () const
+{
+  Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
+           (this->dof_handler) != nullptr)
+          ||
+          (this->has_children() == false),
+          ExcMessage ("In hp::DoFHandler objects, finite elements are only associated "
+                      "with active cells. Consequently, you can not ask for the "
+                      "active finite element on cells with children."));
+  return this->dof_handler->get_finite_element(active_fe_index());
+}
+
+
+
+template <typename DoFHandlerType, bool level_dof_access>
+inline
+const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &
+DoFCellAccessor<DoFHandlerType,level_dof_access>::get_finite_element () const
 {
   Assert ((dynamic_cast<const dealii::DoFHandler<DoFHandlerType::dimension,DoFHandlerType::space_dimension>*>
            (this->dof_handler) != nullptr)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -737,8 +737,8 @@ public:
    * @endcode
    *
    * This code doesn't work in both situations without the present operator
-   * because DoFHandler::get_fe() returns a finite element, whereas
-   * hp::DoFHandler::get_fe() returns a collection of finite elements that
+   * because DoFHandler::get_finite_element() returns a finite element, whereas
+   * hp::DoFHandler::get_finite_element() returns a collection of finite elements that
    * doesn't offer a <code>dofs_per_cell</code> member variable: one first has
    * to select which finite element to work on, which is done using the
    * operator[]. Fortunately, <code>cell-@>active_fe_index()</code> also works

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -143,9 +143,9 @@ namespace FETools
           ||
           (subdomain_id == numbers::invalid_subdomain_id))
         {
-          Assert(cell1->get_fe().n_components() == cell2->get_fe().n_components(),
-                 ExcDimensionMismatch (cell1->get_fe().n_components(),
-                                       cell2->get_fe().n_components()));
+          Assert(cell1->get_finite_element().n_components() == cell2->get_finite_element().n_components(),
+                 ExcDimensionMismatch (cell1->get_finite_element().n_components(),
+                                       cell2->get_finite_element().n_components()));
 
           // for continuous elements on
           // grids with hanging nodes we
@@ -155,7 +155,7 @@ namespace FETools
           // then hanging nodes are not
           // allowed.
           const bool hanging_nodes_not_allowed
-            = ((cell2->get_fe().dofs_per_vertex != 0) &&
+            = ((cell2->get_finite_element().dofs_per_vertex != 0) &&
                (constraints.n_constraints() == 0));
 
           if (hanging_nodes_not_allowed)
@@ -165,8 +165,8 @@ namespace FETools
                       ExcHangingNodesNotAllowed(0));
 
 
-          const unsigned int dofs_per_cell1 = cell1->get_fe().dofs_per_cell;
-          const unsigned int dofs_per_cell2 = cell2->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell1 = cell1->get_finite_element().dofs_per_cell;
+          const unsigned int dofs_per_cell2 = cell2->get_finite_element().dofs_per_cell;
           u1_local.reinit (dofs_per_cell1);
           u2_local.reinit (dofs_per_cell2);
 
@@ -174,21 +174,21 @@ namespace FETools
           // matrix for this particular
           // pair of elements is already
           // there
-          if (interpolation_matrices[&cell1->get_fe()][&cell2->get_fe()].get() == nullptr)
+          if (interpolation_matrices[&cell1->get_finite_element()][&cell2->get_finite_element()].get() == nullptr)
             {
               std::shared_ptr<FullMatrix<double> >
               interpolation_matrix (new FullMatrix<double> (dofs_per_cell2,
                                                             dofs_per_cell1));
-              interpolation_matrices[&cell1->get_fe()][&cell2->get_fe()]
+              interpolation_matrices[&cell1->get_finite_element()][&cell2->get_finite_element()]
                 = interpolation_matrix;
 
-              get_interpolation_matrix(cell1->get_fe(),
-                                       cell2->get_fe(),
+              get_interpolation_matrix(cell1->get_finite_element(),
+                                       cell2->get_finite_element(),
                                        *interpolation_matrix);
             }
 
           cell1->get_dof_values(u1, u1_local);
-          interpolation_matrices[&cell1->get_fe()][&cell2->get_fe()]
+          interpolation_matrices[&cell1->get_finite_element()][&cell2->get_finite_element()]
           ->vmult(u2_local, u1_local);
 
           dofs.resize (dofs_per_cell2);
@@ -306,7 +306,7 @@ namespace FETools
           // continuous no hanging node
           // constraints are allowed.
           const bool hanging_nodes_not_allowed=
-            (cell->get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
+            (cell->get_finite_element().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
 
           if (hanging_nodes_not_allowed)
             for (unsigned int face=0; face<GeometryInfo<dim>::faces_per_cell; ++face)
@@ -314,24 +314,24 @@ namespace FETools
                       cell->neighbor(face)->level() == cell->level(),
                       ExcHangingNodesNotAllowed(0));
 
-          const unsigned int dofs_per_cell1 = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell1 = cell->get_finite_element().dofs_per_cell;
 
           // make sure back_interpolation
           // matrix is available
-          if (interpolation_matrices[&cell->get_fe()] == nullptr)
+          if (interpolation_matrices[&cell->get_finite_element()] == nullptr)
             {
-              interpolation_matrices[&cell->get_fe()] =
+              interpolation_matrices[&cell->get_finite_element()] =
                 std::shared_ptr<FullMatrix<double> >
                 (new FullMatrix<double>(dofs_per_cell1, dofs_per_cell1));
-              get_back_interpolation_matrix(cell->get_fe(), fe2,
-                                            *interpolation_matrices[&cell->get_fe()]);
+              get_back_interpolation_matrix(cell->get_finite_element(), fe2,
+                                            *interpolation_matrices[&cell->get_finite_element()]);
             }
 
           u1_local.reinit (dofs_per_cell1);
           u1_int_local.reinit (dofs_per_cell1);
 
           cell->get_dof_values(u1, u1_local);
-          interpolation_matrices[&cell->get_fe()]->vmult(u1_int_local, u1_local);
+          interpolation_matrices[&cell->get_finite_element()]->vmult(u1_int_local, u1_local);
           cell->set_dof_values(u1_int_local, u1_interpolated);
         };
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -340,12 +340,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values.begin(), local_dof_values.end());
      * @endcode
      */
@@ -853,12 +853,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values.begin(), local_dof_values.end());
      * @endcode
      */
@@ -1297,12 +1297,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values.begin(), local_dof_values.end());
      * @endcode
      */
@@ -1553,12 +1553,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_finite_element().dofs_per_cell);
      * cell->get_dof_values(solution, local_dof_values.begin(), local_dof_values.end());
      * @endcode
      */

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2810,8 +2810,15 @@ public:
 
   /**
    * Constant reference to the selected finite element object.
+   *
+   * @deprecated Use get_finite_element() instead.
    */
-  const FiniteElement<dim,spacedim> &get_fe () const;
+  const FiniteElement<dim,spacedim> &get_fe () const DEAL_II_DEPRECATED;
+
+  /**
+   * Constant reference to the selected finite element object.
+   */
+  const FiniteElement<dim,spacedim> &get_finite_element () const;
 
   /**
    * Return the update flags set for this object.
@@ -4623,6 +4630,17 @@ FEValuesBase<dim,spacedim>::get_fe () const
 {
   return *fe;
 }
+
+
+
+template <int dim, int spacedim>
+inline
+const FiniteElement<dim,spacedim> &
+FEValuesBase<dim,spacedim>::get_finite_element () const
+{
+  return *fe;
+}
+
 
 
 template <int dim, int spacedim>

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -239,7 +239,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the DoFHandler::get_fe() function.
+     * the DoFHandler::get_finite_element() function.
      */
     FEValues (const dealii::hp::MappingCollection<dim,spacedim> &mapping_collection,
               const dealii::hp::FECollection<dim,spacedim>  &fe_collection,
@@ -256,7 +256,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the DoFHandler::get_fe() function.
+     * the DoFHandler::get_finite_element() function.
      */
     FEValues (const hp::FECollection<dim,spacedim> &fe_collection,
               const hp::QCollection<dim>      &q_collection,
@@ -375,7 +375,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the <tt>DoFHandler::get_fe()</tt> function.
+     * the <tt>DoFHandler::get_finite_element()</tt> function.
      */
     FEFaceValues (const hp::MappingCollection<dim,spacedim> &mapping_collection,
                   const hp::FECollection<dim,spacedim>  &fe_collection,
@@ -392,7 +392,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the <tt>DoFHandler::get_fe()</tt> function.
+     * the <tt>DoFHandler::get_finite_element()</tt> function.
      */
     FEFaceValues (const hp::FECollection<dim,spacedim>  &fe_collection,
                   const hp::QCollection<dim-1> &q_collection,
@@ -493,7 +493,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the <tt>DoFHandler::get_fe()</tt> function.
+     * the <tt>DoFHandler::get_finite_element()</tt> function.
      */
     FESubfaceValues (const hp::MappingCollection<dim,spacedim> &mapping_collection,
                      const hp::FECollection<dim,spacedim>  &fe_collection,
@@ -510,7 +510,7 @@ namespace hp
      * the signature of this function to make it compatible with the signature
      * of the respective constructor of the usual FEValues object, with the
      * respective parameter in that function also being the return value of
-     * the <tt>DoFHandler::get_fe()</tt> function.
+     * the <tt>DoFHandler::get_finite_element()</tt> function.
      */
     FESubfaceValues (const hp::FECollection<dim,spacedim> &fe_collection,
                      const hp::QCollection<dim-1>    &q_collection,

--- a/include/deal.II/integrators/advection.h
+++ b/include/deal.II/integrators/advection.h
@@ -81,7 +81,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
-      const unsigned int n_components = fe.get_fe().n_components();
+      const unsigned int n_components = fe.get_finite_element().n_components();
 
       AssertDimension(velocity.size(), dim);
       // If the size of the
@@ -181,7 +181,7 @@ namespace LocalIntegrators
     {
       const unsigned int nq = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
 
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       Assert(result.size() == n_dofs, ExcDimensionMismatch(result.size(), n_dofs));
@@ -262,7 +262,7 @@ namespace LocalIntegrators
     {
       const unsigned int nq = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
 
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       Assert(result.size() == n_dofs, ExcDimensionMismatch(result.size(), n_dofs));
@@ -314,7 +314,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
-      unsigned int n_components = fe.get_fe().n_components();
+      unsigned int n_components = fe.get_finite_element().n_components();
       AssertDimension (M.m(), n_dofs);
       AssertDimension (M.n(), n_dofs);
 
@@ -338,7 +338,7 @@ namespace LocalIntegrators
               for (unsigned i=0; i<t_dofs; ++i)
                 for (unsigned j=0; j<n_dofs; ++j)
                   {
-                    if (fe.get_fe().is_primitive())
+                    if (fe.get_finite_element().is_primitive())
                       M(i,j) += dx * nv * fe.shape_value(i,k) * fe.shape_value(j,k);
                     else
                       for (unsigned int c=0; c<n_components; ++c)
@@ -454,7 +454,7 @@ namespace LocalIntegrators
       double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
 
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       AssertVectorVectorDimension(data, n_comp, fe.n_quadrature_points);
@@ -550,14 +550,14 @@ namespace LocalIntegrators
           for (unsigned i=0; i<n1; ++i)
             for (unsigned j=0; j<n1; ++j)
               {
-                if (fe1.get_fe().is_primitive())
+                if (fe1.get_finite_element().is_primitive())
                   {
                     M1(i,j) += dx_nbeta*fe.shape_value(j,k)*fetest.shape_value(i,k);
                     M2(i,j) -= dx_nbeta*fe.shape_value(j,k)*fetestn.shape_value(i,k);
                   }
                 else
                   {
-                    for (unsigned int d=0; d<fe1.get_fe().n_components(); ++d)
+                    for (unsigned int d=0; d<fe1.get_finite_element().n_components(); ++d)
                       {
                         M1(i,j) += dx_nbeta*fe.shape_value_component(j,k,d)*fetest.shape_value_component(i,k,d);
                         M2(i,j) -= dx_nbeta*fe.shape_value_component(j,k,d)*fetestn.shape_value_component(i,k,d);
@@ -600,10 +600,10 @@ namespace LocalIntegrators
       const VectorSlice<const std::vector<std::vector<double> > > &velocity,
       const double factor = 1.)
     {
-      Assert(fe1.get_fe().n_components() == 1,
-             ExcDimensionMismatch(fe1.get_fe().n_components(), 1));
-      Assert(fe2.get_fe().n_components() == 1,
-             ExcDimensionMismatch(fe2.get_fe().n_components(), 1));
+      Assert(fe1.get_finite_element().n_components() == 1,
+             ExcDimensionMismatch(fe1.get_finite_element().n_components(), 1));
+      Assert(fe2.get_finite_element().n_components() == 1,
+             ExcDimensionMismatch(fe2.get_finite_element().n_components(), 1));
 
       const unsigned int n1 = fe1.dofs_per_cell;
       // Multiply the quadrature point
@@ -678,7 +678,7 @@ namespace LocalIntegrators
       const VectorSlice<const std::vector<std::vector<double> > > &velocity,
       const double factor = 1.)
     {
-      const unsigned int n_comp = fe1.get_fe().n_components();
+      const unsigned int n_comp = fe1.get_finite_element().n_components();
       const unsigned int n1 = fe1.dofs_per_cell;
       AssertVectorVectorDimension(input1, n_comp, fe1.n_quadrature_points);
       AssertVectorVectorDimension(input2, n_comp, fe2.n_quadrature_points);

--- a/include/deal.II/integrators/divergence.h
+++ b/include/deal.II/integrators/divergence.h
@@ -58,8 +58,8 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
-      AssertDimension(fe.get_fe().n_components(), dim);
-      AssertDimension(fetest.get_fe().n_components(), 1);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), 1);
       AssertDimension(M.m(), t_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -98,7 +98,7 @@ namespace LocalIntegrators
       const VectorSlice<const std::vector<std::vector<Tensor<1,dim> > > > &input,
       const double factor = 1.)
     {
-      AssertDimension(fetest.get_fe().n_components(), 1);
+      AssertDimension(fetest.get_finite_element().n_components(), 1);
       AssertVectorVectorDimension(input, dim, fetest.n_quadrature_points);
       const unsigned int t_dofs = fetest.dofs_per_cell;
       Assert (result.size() == t_dofs, ExcDimensionMismatch(result.size(), t_dofs));
@@ -133,7 +133,7 @@ namespace LocalIntegrators
       const VectorSlice<const std::vector<std::vector<double> > > &input,
       const double factor = 1.)
     {
-      AssertDimension(fetest.get_fe().n_components(), 1);
+      AssertDimension(fetest.get_finite_element().n_components(), 1);
       AssertVectorVectorDimension(input, dim, fetest.n_quadrature_points);
       const unsigned int t_dofs = fetest.dofs_per_cell;
       Assert (result.size() == t_dofs, ExcDimensionMismatch(result.size(), t_dofs));
@@ -169,8 +169,8 @@ namespace LocalIntegrators
       const unsigned int t_dofs = fetest.dofs_per_cell;
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fetest.get_fe().n_components(), dim);
-      AssertDimension(fe.get_fe().n_components(), 1);
+      AssertDimension(fetest.get_finite_element().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), 1);
       AssertDimension(M.m(), t_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -209,7 +209,7 @@ namespace LocalIntegrators
       const std::vector<Tensor<1,dim> > &input,
       const double factor = 1.)
     {
-      AssertDimension(fetest.get_fe().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), dim);
       AssertDimension(input.size(), fetest.n_quadrature_points);
       const unsigned int t_dofs = fetest.dofs_per_cell;
       Assert (result.size() == t_dofs, ExcDimensionMismatch(result.size(), t_dofs));
@@ -243,7 +243,7 @@ namespace LocalIntegrators
       const std::vector<double> &input,
       const double factor = 1.)
     {
-      AssertDimension(fetest.get_fe().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), dim);
       AssertDimension(input.size(), fetest.n_quadrature_points);
       const unsigned int t_dofs = fetest.dofs_per_cell;
       Assert (result.size() == t_dofs, ExcDimensionMismatch(result.size(), t_dofs));
@@ -277,8 +277,8 @@ namespace LocalIntegrators
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
-      AssertDimension(fetest.get_fe().n_components(), 1);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), 1);
       AssertDimension(M.m(), t_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -314,8 +314,8 @@ namespace LocalIntegrators
     {
       const unsigned int t_dofs = fetest.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
-      AssertDimension(fetest.get_fe().n_components(), 1);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), 1);
       AssertDimension(result.size(), t_dofs);
       AssertVectorVectorDimension (data, dim, fe.n_quadrature_points);
 
@@ -349,7 +349,7 @@ namespace LocalIntegrators
     {
       const unsigned int t_dofs = fetest.dofs_per_cell;
 
-      AssertDimension(fetest.get_fe().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), dim);
       AssertDimension(result.size(), t_dofs);
       AssertDimension(data.size(), fetest.n_quadrature_points);
 
@@ -390,10 +390,10 @@ namespace LocalIntegrators
       const unsigned int n_dofs = fe1.dofs_per_cell;
       const unsigned int t_dofs = fetest1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
-      AssertDimension(fetest1.get_fe().n_components(), 1);
-      AssertDimension(fetest2.get_fe().n_components(), 1);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
+      AssertDimension(fetest1.get_finite_element().n_components(), 1);
+      AssertDimension(fetest2.get_finite_element().n_components(), 1);
       AssertDimension(M11.m(), t_dofs);
       AssertDimension(M11.n(), n_dofs);
       AssertDimension(M12.m(), t_dofs);
@@ -486,8 +486,8 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
       AssertDimension(M11.m(), n_dofs);
       AssertDimension(M11.n(), n_dofs);
       AssertDimension(M12.m(), n_dofs);
@@ -532,7 +532,7 @@ namespace LocalIntegrators
     double norm(const FEValuesBase<dim> &fe,
                 const VectorSlice<const std::vector<std::vector<Tensor<1,dim> > > > &Du)
     {
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertVectorVectorDimension (Du, dim, fe.n_quadrature_points);
 
       double result = 0;

--- a/include/deal.II/integrators/elasticity.h
+++ b/include/deal.II/integrators/elasticity.h
@@ -52,7 +52,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -85,7 +85,7 @@ namespace LocalIntegrators
     {
       const unsigned int nq = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
 
       AssertVectorVectorDimension(input, dim, fe.n_quadrature_points);
       Assert(result.size() == n_dofs, ExcDimensionMismatch(result.size(), n_dofs));
@@ -120,7 +120,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -165,7 +165,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -406,8 +406,8 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
       AssertDimension(M11.m(), n_dofs);
       AssertDimension(M11.n(), n_dofs);
       AssertDimension(M12.m(), n_dofs);
@@ -488,8 +488,8 @@ namespace LocalIntegrators
     {
       const unsigned int n1 = fe1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
       AssertVectorVectorDimension(input1, dim, fe1.n_quadrature_points);
       AssertVectorVectorDimension(Dinput1, dim, fe1.n_quadrature_points);
       AssertVectorVectorDimension(input2, dim, fe2.n_quadrature_points);

--- a/include/deal.II/integrators/grad_div.h
+++ b/include/deal.II/integrators/grad_div.h
@@ -56,7 +56,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -92,7 +92,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fetest.dofs_per_cell;
 
-      AssertDimension(fetest.get_fe().n_components(), dim);
+      AssertDimension(fetest.get_finite_element().n_components(), dim);
       AssertVectorVectorDimension(input, dim, fetest.n_quadrature_points);
 
       for (unsigned int k=0; k<fetest.n_quadrature_points; ++k)
@@ -126,7 +126,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -181,7 +181,7 @@ namespace LocalIntegrators
       double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      AssertDimension(fe.get_fe().n_components(), dim)
+      AssertDimension(fe.get_finite_element().n_components(), dim)
       AssertVectorVectorDimension(input, dim, fe.n_quadrature_points);
       AssertVectorVectorDimension(Dinput, dim, fe.n_quadrature_points);
       AssertVectorVectorDimension(data, dim, fe.n_quadrature_points);
@@ -307,7 +307,7 @@ namespace LocalIntegrators
     {
       const unsigned int n1 = fe1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
       AssertVectorVectorDimension(input1, dim, fe1.n_quadrature_points);
       AssertVectorVectorDimension(Dinput1, dim, fe1.n_quadrature_points);
       AssertVectorVectorDimension(input2, dim, fe2.n_quadrature_points);

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -56,7 +56,7 @@ namespace LocalIntegrators
       const double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_components = fe.get_fe().n_components();
+      const unsigned int n_components = fe.get_finite_element().n_components();
 
       for (unsigned int k=0; k<fe.n_quadrature_points; ++k)
         {
@@ -108,7 +108,7 @@ namespace LocalIntegrators
       const std::vector<double> &weights)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_components = fe.get_fe().n_components();
+      const unsigned int n_components = fe.get_finite_element().n_components();
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
       AssertDimension(weights.size(), fe.n_quadrature_points);
@@ -158,7 +158,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       AssertDimension(result.size(), n_dofs);
-      AssertDimension(fe.get_fe().n_components(), 1);
+      AssertDimension(fe.get_finite_element().n_components(), 1);
       AssertDimension(input.size(), fe.n_quadrature_points);
 
       for (unsigned int k=0; k<fe.n_quadrature_points; ++k)
@@ -185,7 +185,7 @@ namespace LocalIntegrators
       const unsigned int n_components = input.size();
 
       AssertDimension(result.size(), n_dofs);
-      AssertDimension(input.size(), fe.get_fe().n_components());
+      AssertDimension(input.size(), fe.get_finite_element().n_components());
 
       for (unsigned int k=0; k<fe.n_quadrature_points; ++k)
         for (unsigned int i=0; i<n_dofs; ++i)
@@ -218,11 +218,11 @@ namespace LocalIntegrators
     {
       const unsigned int n1_dofs = fe1.dofs_per_cell;
       const unsigned int n2_dofs = fe2.dofs_per_cell;
-      const unsigned int n_components = fe1.get_fe().n_components();
+      const unsigned int n_components = fe1.get_finite_element().n_components();
 
       Assert(n1_dofs == n2_dofs, ExcNotImplemented());
       (void) n2_dofs;
-      AssertDimension(n_components, fe2.get_fe().n_components());
+      AssertDimension(n_components, fe2.get_finite_element().n_components());
       AssertDimension(M11.m(), n1_dofs);
       AssertDimension(M12.m(), n1_dofs);
       AssertDimension(M21.m(), n2_dofs);

--- a/include/deal.II/integrators/laplace.h
+++ b/include/deal.II/integrators/laplace.h
@@ -55,7 +55,7 @@ namespace LocalIntegrators
       const double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_components = fe.get_fe().n_components();
+      const unsigned int n_components = fe.get_finite_element().n_components();
 
       for (unsigned int k=0; k<fe.n_quadrature_points; ++k)
         {
@@ -126,7 +126,7 @@ namespace LocalIntegrators
     {
       const unsigned int nq = fe.n_quadrature_points;
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
 
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       Assert(result.size() == n_dofs, ExcDimensionMismatch(result.size(), n_dofs));
@@ -165,7 +165,7 @@ namespace LocalIntegrators
       double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
 
       Assert (M.m() == n_dofs, ExcDimensionMismatch(M.m(), n_dofs));
       Assert (M.n() == n_dofs, ExcDimensionMismatch(M.n(), n_dofs));
@@ -206,7 +206,7 @@ namespace LocalIntegrators
       double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       Assert (M.m() == n_dofs, ExcDimensionMismatch(M.m(), n_dofs));
       Assert (M.n() == n_dofs, ExcDimensionMismatch(M.n(), n_dofs));
 
@@ -318,7 +318,7 @@ namespace LocalIntegrators
       double factor = 1.)
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       AssertVectorVectorDimension(Dinput, n_comp, fe.n_quadrature_points);
       AssertVectorVectorDimension(data, n_comp, fe.n_quadrature_points);
@@ -390,7 +390,7 @@ namespace LocalIntegrators
         {
           const double dx = fe1.JxW(k);
           const Tensor<1,dim> n = fe1.normal_vector(k);
-          for (unsigned int d=0; d<fe1.get_fe().n_components(); ++d)
+          for (unsigned int d=0; d<fe1.get_finite_element().n_components(); ++d)
             {
               for (unsigned int i=0; i<n_dofs; ++i)
                 {
@@ -441,8 +441,8 @@ namespace LocalIntegrators
       double factor2 = -1.)
     {
       const unsigned int n_dofs = fe1.dofs_per_cell;
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
       AssertDimension(M11.n(), n_dofs);
       AssertDimension(M11.m(), n_dofs);
       AssertDimension(M12.n(), n_dofs);
@@ -542,10 +542,10 @@ namespace LocalIntegrators
       double int_factor = 1.,
       double ext_factor = -1.)
     {
-      Assert(fe1.get_fe().n_components() == 1,
-             ExcDimensionMismatch(fe1.get_fe().n_components(), 1));
-      Assert(fe2.get_fe().n_components() == 1,
-             ExcDimensionMismatch(fe2.get_fe().n_components(), 1));
+      Assert(fe1.get_finite_element().n_components() == 1,
+             ExcDimensionMismatch(fe1.get_finite_element().n_components(), 1));
+      Assert(fe2.get_finite_element().n_components() == 1,
+             ExcDimensionMismatch(fe2.get_finite_element().n_components(), 1));
 
       const double nui = int_factor;
       const double nue = (ext_factor < 0) ? int_factor : ext_factor;
@@ -609,7 +609,7 @@ namespace LocalIntegrators
       double int_factor = 1.,
       double ext_factor = -1.)
     {
-      const unsigned int n_comp = fe1.get_fe().n_components();
+      const unsigned int n_comp = fe1.get_finite_element().n_components();
       const unsigned int n1 = fe1.dofs_per_cell;
 
       AssertVectorVectorDimension(input1, n_comp, fe1.n_quadrature_points);

--- a/include/deal.II/integrators/maxwell.h
+++ b/include/deal.II/integrators/maxwell.h
@@ -172,7 +172,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -227,10 +227,10 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
       const unsigned int t_dofs = fetest.dofs_per_cell;
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       // There should be the right number of components (3 in 3D, otherwise 1)
       // for the curl.
-      AssertDimension(fetest.get_fe().n_components(), (dim == 3) ? dim : 1);
+      AssertDimension(fetest.get_finite_element().n_components(), (dim == 3) ? dim : 1);
       AssertDimension(M.m(), t_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -279,7 +279,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -301,7 +301,7 @@ namespace LocalIntegrators
           const Tensor<1,dim> n = fe.normal_vector(k);
           for (unsigned int i=0; i<n_dofs; ++i)
             for (unsigned int j=0; j<n_dofs; ++j)
-              if (fe.get_fe().has_support_on_face(i, face_no) && fe.get_fe().has_support_on_face(j, face_no))
+              if (fe.get_finite_element().has_support_on_face(i, face_no) && fe.get_finite_element().has_support_on_face(j, face_no))
                 {
                   for (unsigned int d=0; d<d_max; ++d)
                     {
@@ -336,7 +336,7 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe.dofs_per_cell;
 
-      AssertDimension(fe.get_fe().n_components(), dim);
+      AssertDimension(fe.get_finite_element().n_components(), dim);
       AssertDimension(M.m(), n_dofs);
       AssertDimension(M.n(), n_dofs);
 
@@ -400,8 +400,8 @@ namespace LocalIntegrators
     {
       const unsigned int n_dofs = fe1.dofs_per_cell;
 
-      AssertDimension(fe1.get_fe().n_components(), dim);
-      AssertDimension(fe2.get_fe().n_components(), dim);
+      AssertDimension(fe1.get_finite_element().n_components(), dim);
+      AssertDimension(fe2.get_finite_element().n_components(), dim);
       AssertDimension(M11.m(), n_dofs);
       AssertDimension(M11.n(), n_dofs);
       AssertDimension(M12.m(), n_dofs);

--- a/include/deal.II/integrators/patches.h
+++ b/include/deal.II/integrators/patches.h
@@ -44,7 +44,7 @@ namespace LocalIntegrators
       const FEValuesBase<dim> &fe,
       const VectorSlice<const std::vector<std::vector<double> > > &input)
     {
-      const unsigned int n_comp = fe.get_fe().n_components();
+      const unsigned int n_comp = fe.get_finite_element().n_components();
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);
       AssertDimension(result.n_rows(), fe.n_quadrature_points);
       AssertDimension(result.n_cols(), n_comp+dim);

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
@@ -339,7 +339,7 @@ namespace CUDAWrappers
       const ConstraintMatrix &constraints)
     {
       std::vector<types::global_dof_index> local_dof_indices(
-        cell->get_fe().dofs_per_cell);
+        cell->get_finite_element().dofs_per_cell);
       cell->get_dof_indices(local_dof_indices);
       constraints.resolve_indices(local_dof_indices);
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2501,7 +2501,7 @@ FEEvaluationBase<dim,n_components_,Number>
                     "instead"));
   Assert(mapped_geometry.get() != nullptr, ExcNotInitialized());
   mapped_geometry->reinit(static_cast<typename Triangulation<dim>::cell_iterator>(cell));
-  local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+  local_dof_indices.resize(cell->get_finite_element().dofs_per_cell);
   if (level_dof_access)
     cell->get_mg_dof_indices(local_dof_indices);
   else

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -644,7 +644,7 @@ void MatrixFree<dim,Number>::initialize_indices
               if (dofh->get_fe_collection().size() > 1)
                 dof_info[no].cell_active_fe_index[counter] =
                   cell_it->active_fe_index();
-              local_dof_indices.resize (cell_it->get_fe().dofs_per_cell);
+              local_dof_indices.resize (cell_it->get_finite_element().dofs_per_cell);
               cell_it->get_dof_indices(local_dof_indices);
               dof_info[no].read_dof_indices (local_dof_indices,
                                              shape_info(no,0,cell_it->active_fe_index(),0).lexicographic_numbering,

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -300,12 +300,12 @@ namespace MeshWorker
   inline void
   DoFInfo<dim,spacedim,number>::get_indices(const DHCellIterator &c)
   {
-    indices.resize(c->get_fe().dofs_per_cell);
+    indices.resize(c->get_finite_element().dofs_per_cell);
     if (block_info == nullptr || block_info->local().size() == 0)
       c->get_active_or_mg_dof_indices(indices);
     else
       {
-        indices_org.resize(c->get_fe().dofs_per_cell);
+        indices_org.resize(c->get_finite_element().dofs_per_cell);
         c->get_active_or_mg_dof_indices(indices_org);
         set_block_indices();
       }

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -584,14 +584,14 @@ namespace MeshWorker
 
         if (pc != nullptr)
           fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FEValues<dim,sdim> (pc->get_mapping(), pc->get_fe(),
+                        new FEValues<dim,sdim> (pc->get_mapping(), pc->get_finite_element(),
                                                 pc->get_quadrature(), pc->get_update_flags()));
         else if (pf != nullptr)
           fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FEFaceValues<dim,sdim> (pf->get_mapping(), pf->get_fe(), pf->get_quadrature(), pf->get_update_flags()));
+                        new FEFaceValues<dim,sdim> (pf->get_mapping(), pf->get_finite_element(), pf->get_quadrature(), pf->get_update_flags()));
         else if (ps != nullptr)
           fevalv[i] = std::shared_ptr<FEValuesBase<dim,sdim> > (
-                        new FESubfaceValues<dim,sdim> (ps->get_mapping(), ps->get_fe(), ps->get_quadrature(), ps->get_update_flags()));
+                        new FESubfaceValues<dim,sdim> (ps->get_mapping(), ps->get_finite_element(), ps->get_quadrature(), ps->get_update_flags()));
         else
           Assert(false, ExcInternalError());
       }

--- a/include/deal.II/meshworker/integration_info.templates.h
+++ b/include/deal.II/meshworker/integration_info.templates.h
@@ -97,7 +97,7 @@ namespace MeshWorker
           {
             const unsigned int fe_no = info.block_info->base_element(b);
             const FEValuesBase<dim,sdim> &fe = this->fe_values(fe_no);
-            const unsigned int n_comp = fe.get_fe().n_components();
+            const unsigned int n_comp = fe.get_finite_element().n_components();
             const unsigned int block_start = info.block_info->local().block_start(b);
             const unsigned int block_size = info.block_info->local().block_size(b);
 
@@ -113,7 +113,7 @@ namespace MeshWorker
     else
       {
         const FEValuesBase<dim,sdim> &fe = this->fe_values(0);
-        const unsigned int n_comp = fe.get_fe().n_components();
+        const unsigned int n_comp = fe.get_finite_element().n_components();
         if (info.level_cell)
           this->global_data->mg_fill(values, gradients, hessians, fe, info.cell->level(), info.indices,
                                      0, n_comp, 0, info.indices.size());

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -207,7 +207,7 @@ MGConstrainedDoFs::initialize(const DoFHandler<dim,spacedim> &dof)
                       continue;
                     }
 
-                  const unsigned int dofs_per_face = cell->face(f)->get_fe(0).dofs_per_face;
+                  const unsigned int dofs_per_face = cell->face(f)->get_finite_element(0).dofs_per_face;
                   std::vector<types::global_dof_index> dofs_1(dofs_per_face);
                   std::vector<types::global_dof_index> dofs_2(dofs_per_face);
 

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -91,7 +91,7 @@ namespace Functions
 
     // Now we can find out about the point
     Quadrature<dim> quad(qp.get());
-    FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
+    FEValues<dim> fe_v(mapping, cell->get_finite_element(), quad,
                        update_values);
     fe_v.reinit(cell);
     std::vector< Vector<typename VectorType::value_type> >
@@ -148,7 +148,7 @@ namespace Functions
 
     // Now we can find out about the point
     Quadrature<dim> quad(qp.get());
-    FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
+    FEValues<dim> fe_v(mapping, cell->get_finite_element(), quad,
                        update_gradients);
     fe_v.reinit(cell);
 
@@ -220,7 +220,7 @@ namespace Functions
 
     // Now we can find out about the point
     Quadrature<dim> quad(qp.get());
-    FEValues<dim> fe_v(mapping, cell->get_fe(), quad,
+    FEValues<dim> fe_v(mapping, cell->get_finite_element(), quad,
                        update_hessians);
     fe_v.reinit(cell);
     std::vector< Vector<typename VectorType::value_type> >

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -234,7 +234,7 @@ namespace MatrixCreator
 
       const unsigned int dofs_per_cell = fe_values.dofs_per_cell,
                          n_q_points    = fe_values.n_quadrature_points;
-      const FiniteElement<dim,spacedim> &fe  = fe_values.get_fe();
+      const FiniteElement<dim,spacedim> &fe  = fe_values.get_finite_element();
       const unsigned int n_components  = fe.n_components();
 
       Assert(data.rhs_function == nullptr ||
@@ -417,7 +417,7 @@ namespace MatrixCreator
 
       const unsigned int dofs_per_cell = fe_values.dofs_per_cell,
                          n_q_points    = fe_values.n_quadrature_points;
-      const FiniteElement<dim,spacedim>    &fe  = fe_values.get_fe();
+      const FiniteElement<dim,spacedim>    &fe  = fe_values.get_finite_element();
       const unsigned int n_components  = fe.n_components();
 
       Assert(data.rhs_function == nullptr ||

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -1279,7 +1279,7 @@ namespace MatrixCreator
       const unsigned int n_components  = fe_collection.n_components();
       const unsigned int n_function_components = boundary_functions.begin()->second->n_components;
       const bool         fe_is_system  = (n_components != 1);
-      const FiniteElement<dim,spacedim> &fe = cell->get_fe();
+      const FiniteElement<dim,spacedim> &fe = cell->get_finite_element();
       const unsigned int dofs_per_face = fe.dofs_per_face;
 
       copy_data.cell = cell;

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -571,10 +571,10 @@ namespace VectorTools
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->at_boundary(f))
             {
-              face_dof_indices.resize (cell->get_fe().dofs_per_face);
+              face_dof_indices.resize (cell->get_finite_element().dofs_per_face);
               cell->face(f)->get_dof_indices (face_dof_indices,
                                               cell->active_fe_index());
-              for (unsigned int i=0; i<cell->get_fe().dofs_per_face; ++i)
+              for (unsigned int i=0; i<cell->get_finite_element().dofs_per_face; ++i)
                 // enter zero boundary values
                 // for all boundary nodes
                 //
@@ -703,11 +703,11 @@ namespace VectorTools
         if (cell2->active() && !cell2->is_locally_owned())
           continue;
 
-        Assert(cell1->get_fe().get_name() ==
-               cell2->get_fe().get_name(),
+        Assert(cell1->get_finite_element().get_name() ==
+               cell2->get_finite_element().get_name(),
                ExcMessage ("Source and destination cells need to use the same finite element"));
 
-        cache.reinit(cell1->get_fe().dofs_per_cell);
+        cache.reinit(cell1->get_finite_element().dofs_per_cell);
 
         // Get and set the corresponding
         // dof_values by interpolation.
@@ -1709,13 +1709,13 @@ namespace VectorTools
 
               // Use the faster code if the
               // FiniteElement is primitive
-              if (cell->get_fe().is_primitive ())
+              if (cell->get_finite_element().is_primitive ())
                 {
                   for (unsigned int point=0; point<n_q_points; ++point)
                     for (unsigned int i=0; i<dofs_per_cell; ++i)
                       {
                         const unsigned int component
-                          = cell->get_fe().system_to_component_index(i).first;
+                          = cell->get_finite_element().system_to_component_index(i).first;
 
                         cell_vector(i) += rhs_values[point](component) *
                                           fe_values.shape_value(i,point) *
@@ -1729,7 +1729,7 @@ namespace VectorTools
                   for (unsigned int point=0; point<n_q_points; ++point)
                     for (unsigned int i=0; i<dofs_per_cell; ++i)
                       for (unsigned int comp_i = 0; comp_i < n_components; ++comp_i)
-                        if (cell->get_fe().get_nonzero_components(i)[comp_i])
+                        if (cell->get_finite_element().get_nonzero_components(i)[comp_i])
                           {
                             cell_vector(i) += rhs_values[point](comp_i) *
                                               fe_values.shape_value_component(i,point,comp_i) *
@@ -1824,10 +1824,10 @@ namespace VectorTools
     Quadrature<dim> q(GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
 
     FEValues<dim> fe_values(mapping[cell_point.first->active_fe_index()],
-                            cell_point.first->get_fe(), q, UpdateFlags(update_values));
+                            cell_point.first->get_finite_element(), q, UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = cell_point.first->get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = cell_point.first->get_finite_element().dofs_per_cell;
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
     cell_point.first->get_dof_indices (local_dof_indices);
@@ -1920,10 +1920,10 @@ namespace VectorTools
 
     const FEValuesExtractors::Vector vec (0);
     FEValues<dim> fe_values(mapping[cell_point.first->active_fe_index()],
-                            cell_point.first->get_fe(), q, UpdateFlags(update_values));
+                            cell_point.first->get_finite_element(), q, UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = cell_point.first->get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = cell_point.first->get_finite_element().dofs_per_cell;
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
     cell_point.first->get_dof_indices (local_dof_indices);
@@ -2181,13 +2181,13 @@ namespace VectorTools
 
                 // Use the faster code if the
                 // FiniteElement is primitive
-                if (cell->get_fe().is_primitive ())
+                if (cell->get_finite_element().is_primitive ())
                   {
                     for (unsigned int point=0; point<n_q_points; ++point)
                       for (unsigned int i=0; i<dofs_per_cell; ++i)
                         {
                           const unsigned int component
-                            = cell->get_fe().system_to_component_index(i).first;
+                            = cell->get_finite_element().system_to_component_index(i).first;
 
                           cell_vector(i) += rhs_values[point](component) *
                                             fe_values.shape_value(i,point) *
@@ -2202,7 +2202,7 @@ namespace VectorTools
                     for (unsigned int point=0; point<n_q_points; ++point)
                       for (unsigned int i=0; i<dofs_per_cell; ++i)
                         for (unsigned int comp_i = 0; comp_i < n_components; ++comp_i)
-                          if (cell->get_fe().get_nonzero_components(i)[comp_i])
+                          if (cell->get_finite_element().get_nonzero_components(i)[comp_i])
                             {
                               cell_vector(i)
                               += rhs_values[point](comp_i) *
@@ -2295,7 +2295,7 @@ namespace VectorTools
                     = *function_map.find(cell->face(direction)->boundary_id())->second;
 
                   // get the FE corresponding to this cell
-                  const FiniteElement<dim,spacedim> &fe = cell->get_fe();
+                  const FiniteElement<dim,spacedim> &fe = cell->get_finite_element();
                   Assert (fe.n_components() == boundary_function.n_components,
                           ExcDimensionMismatch(fe.n_components(),
                                                boundary_function.n_components));
@@ -2407,7 +2407,7 @@ namespace VectorTools
               for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
                    ++face_no)
                 {
-                  const FiniteElement<dim,spacedim> &fe = cell->get_fe();
+                  const FiniteElement<dim,spacedim> &fe = cell->get_finite_element();
 
                   // we can presently deal only with primitive elements for
                   // boundary values. this does not preclude us using
@@ -2415,15 +2415,15 @@ namespace VectorTools
                   // interested in, however. make sure that all shape functions
                   // that are non-zero for the components we are interested in,
                   // are in fact primitive
-                  for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                  for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                     {
                       const ComponentMask &nonzero_component_array
-                        = cell->get_fe().get_nonzero_components (i);
+                        = cell->get_finite_element().get_nonzero_components (i);
                       for (unsigned int c=0; c<n_components; ++c)
                         if ((nonzero_component_array[c] == true)
                             &&
                             (component_mask[c] == true))
-                          Assert (cell->get_fe().is_primitive (i),
+                          Assert (cell->get_finite_element().is_primitive (i),
                                   ExcMessage ("This function can only deal with requested boundary "
                                               "values that correspond to primitive (scalar) base "
                                               "elements"));
@@ -2438,7 +2438,7 @@ namespace VectorTools
                   // in use here has DoFs on the face at all
                   if ((function_map.find(boundary_component) != function_map.end())
                       &&
-                      (cell->get_fe().dofs_per_face > 0))
+                      (cell->get_finite_element().dofs_per_face > 0))
                     {
                       // face is of the right component
                       x_fe_values.reinit(cell, face_no);
@@ -3551,7 +3551,7 @@ namespace VectorTools
                              std::vector<bool>   &dofs_processed)
     {
       const double tol = 0.5 * cell->face (face)->line (line)->diameter ()
-                         / cell->get_fe ().degree;
+                         / cell->get_finite_element().degree;
       const unsigned int dim = 3;
       const unsigned int spacedim = 3;
 
@@ -3564,7 +3564,7 @@ namespace VectorTools
       // objects.
       const FEValues<dim> &
       fe_values = hp_fe_values.get_present_fe_values ();
-      const FiniteElement<dim> &fe = cell->get_fe ();
+      const FiniteElement<dim> &fe = cell->get_finite_element();
       const std::vector< DerivativeForm<1,dim,spacedim> > &
       jacobians = fe_values.get_jacobians ();
       const std::vector<Point<dim> > &
@@ -3582,7 +3582,7 @@ namespace VectorTools
       reference_quadrature_points = fe_values.get_quadrature ().get_points ();
       std::pair<unsigned int, unsigned int> base_indices (0, 0);
 
-      if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) != nullptr)
+      if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) != nullptr)
         {
           unsigned int fe_index = 0;
           unsigned int fe_index_old = 0;
@@ -3720,7 +3720,7 @@ namespace VectorTools
       // objects.
       const FEValues<dim> &
       fe_values = hp_fe_values.get_present_fe_values ();
-      const FiniteElement<dim> &fe = cell->get_fe ();
+      const FiniteElement<dim> &fe = cell->get_finite_element();
       const std::vector< DerivativeForm<1,dim,spacedim> > &
       jacobians = fe_values.get_jacobians ();
       const std::vector<Point<dim> > &
@@ -3728,7 +3728,7 @@ namespace VectorTools
       const unsigned int degree = fe.degree - 1;
       std::pair<unsigned int, unsigned int> base_indices (0, 0);
 
-      if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) != nullptr)
+      if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) != nullptr)
         {
           unsigned int fe_index = 0;
           unsigned int fe_index_old = 0;
@@ -3760,7 +3760,7 @@ namespace VectorTools
         {
         case 2:
         {
-          const double tol = 0.5 * cell->face (face)->diameter () / cell->get_fe ().degree;
+          const double tol = 0.5 * cell->face (face)->diameter () / cell->get_finite_element().degree;
           std::vector<Tensor<1,dim> > tangentials (fe_values.n_quadrature_points);
 
           const std::vector<Point<dim> > &
@@ -4144,7 +4144,7 @@ namespace VectorTools
                   // FE_Nothing object
                   // there is no work to
                   // do
-                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                     return;
 
                   // This is only
@@ -4153,10 +4153,10 @@ namespace VectorTools
                   // element. If the FE
                   // is a FESystem, we
                   // cannot check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
-                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
 
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
@@ -4228,7 +4228,7 @@ namespace VectorTools
                   // FE_Nothing object
                   // there is no work to
                   // do
-                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                     return;
 
                   // This is only
@@ -4237,11 +4237,11 @@ namespace VectorTools
                   // element. If the FE is
                   // a FESystem we cannot
                   // check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
@@ -4347,20 +4347,20 @@ namespace VectorTools
               if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a FE_Nothing object there is no work to do
-                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                     return;
 
                   // This is only implemented, if the FE is a Nedelec
                   // element. If the FE is a FESystem we cannot check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
-                  const unsigned int dofs_per_face = cell->get_fe ().dofs_per_face;
+                  const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
 
                   dofs_processed.resize (dofs_per_face);
                   dof_values.resize (dofs_per_face);
@@ -4424,22 +4424,22 @@ namespace VectorTools
               if (cell->face (face)->boundary_id () == boundary_component)
                 {
                   // if the FE is a FE_Nothing object there is no work to do
-                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                     return;
 
                   // This is only implemented, if the FE is a Nedelec
                   // element. If the FE is a FESystem we cannot check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
-                  const unsigned int superdegree = cell->get_fe ().degree;
+                  const unsigned int superdegree = cell->get_finite_element().degree;
                   const unsigned int degree = superdegree - 1;
-                  const unsigned int dofs_per_face = cell->get_fe ().dofs_per_face;
+                  const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
 
                   dofs_processed.resize (dofs_per_face);
                   dof_values.resize (dofs_per_face);
@@ -4513,7 +4513,7 @@ namespace VectorTools
       // the DoFs corresponding to the group of components making up the vector
       // with first component first_vector_component (length dim).
       const unsigned int dim = 3;
-      const FiniteElement<dim> &fe = cell->get_fe ();
+      const FiniteElement<dim> &fe = cell->get_finite_element();
 
       // reinit for this cell, face and line.
       hp_fe_values.reinit
@@ -4543,7 +4543,7 @@ namespace VectorTools
       // If not using FESystem then must be using FE_Nedelec,
       // which has one base element and one copy of it (with 3 components).
       std::pair<unsigned int, unsigned int> base_indices (0, 0);
-      if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) != nullptr)
+      if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) != nullptr)
         {
           unsigned int fe_index = 0;
           unsigned int fe_index_old = 0;
@@ -4763,7 +4763,7 @@ namespace VectorTools
       const FEFaceValues<dim> &fe_face_values = hp_fe_face_values.get_present_fe_values();
 
       // Initialize the required objects.
-      const FiniteElement<dim> &fe = cell->get_fe ();
+      const FiniteElement<dim> &fe = cell->get_finite_element();
       const std::vector<Point<dim> > &
       quadrature_points = fe_face_values.get_quadrature_points ();
       const unsigned int degree = fe.degree - 1;
@@ -4780,7 +4780,7 @@ namespace VectorTools
       // If not using FESystem then must be using FE_Nedelec,
       // which has one base element and one copy of it (with 3 components).
       std::pair<unsigned int, unsigned int> base_indices (0, 0);
-      if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) != nullptr)
+      if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) != nullptr)
         {
           unsigned int fe_index = 0;
           unsigned int fe_index_old = 0;
@@ -5173,22 +5173,22 @@ namespace VectorTools
                       if (cell->face (face)->boundary_id () == boundary_component)
                         {
                           // If the FE is an FE_Nothing object there is no work to do
-                          if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                          if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                             {
                               return;
                             }
 
                           // This is only implemented for FE_Nedelec elements.
                           // If the FE is a FESystem we cannot check this.
-                          if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                          if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                             {
                               typedef FiniteElement<dim> FEL;
-                              AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                              AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
                                            typename FEL::ExcInterpolationNotImplemented ());
 
                             }
 
-                          const unsigned int dofs_per_face = cell->get_fe ().dofs_per_face;
+                          const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
 
                           dofs_processed.resize (dofs_per_face);
                           dof_values.resize (dofs_per_face);
@@ -5270,24 +5270,24 @@ namespace VectorTools
                       if (cell->face (face)->boundary_id () == boundary_component)
                         {
                           // If the FE is an FE_Nothing object there is no work to do
-                          if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                          if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                             {
                               return;
                             }
 
                           // This is only implemented for FE_Nedelec elements.
                           // If the FE is a FESystem we cannot check this.
-                          if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                          if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                             {
                               typedef FiniteElement<dim> FEL;
 
-                              AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_fe ()) != nullptr,
+                              AssertThrow (dynamic_cast<const FE_Nedelec<dim>*> (&cell->get_finite_element()) != nullptr,
                                            typename FEL::ExcInterpolationNotImplemented ());
                             }
 
-                          const unsigned int superdegree = cell->get_fe ().degree;
+                          const unsigned int superdegree = cell->get_finite_element().degree;
                           const unsigned int degree = superdegree - 1;
-                          const unsigned int dofs_per_face = cell->get_fe ().dofs_per_face;
+                          const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
 
                           dofs_processed.resize (dofs_per_face);
                           dof_values.resize (dofs_per_face);
@@ -5419,7 +5419,7 @@ namespace VectorTools
       // the boundary function times the normal components of the shape
       // functions supported on the boundary.
       const FEValuesExtractors::Vector vec (first_vector_component);
-      const FiniteElement<2> &fe = cell->get_fe ();
+      const FiniteElement<2> &fe = cell->get_finite_element();
       const std::vector<Tensor<1,2> > &normals = fe_values.get_all_normal_vectors ();
       const unsigned int
       face_coordinate_direction[GeometryInfo<2>::faces_per_cell] = {1, 1, 0, 0};
@@ -5502,7 +5502,7 @@ namespace VectorTools
       // the boundary function times the normal components of the shape
       // functions supported on the boundary.
       const FEValuesExtractors::Vector vec (first_vector_component);
-      const FiniteElement<3> &fe = cell->get_fe ();
+      const FiniteElement<3> &fe = cell->get_finite_element();
       const std::vector<Tensor<1,3> > &normals = fe_values.get_all_normal_vectors ();
       const unsigned int
       face_coordinate_directions[GeometryInfo<3>::faces_per_cell][2] = {{1, 2},
@@ -5633,7 +5633,7 @@ namespace VectorTools
                   // FE_Nothing object
                   // there is no work to
                   // do
-                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_fe ()) != nullptr)
+                  if (dynamic_cast<const FE_Nothing<dim>*> (&cell->get_finite_element()) != nullptr)
                     return;
 
                   // This is only
@@ -5642,11 +5642,11 @@ namespace VectorTools
                   // element. If the FE is
                   // a FESystem we cannot
                   // check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
@@ -5706,11 +5706,11 @@ namespace VectorTools
                   // element. If the FE is
                   // a FESystem we cannot
                   // check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
@@ -5797,11 +5797,11 @@ namespace VectorTools
                   // element. If the FE is
                   // a FESystem we cannot
                   // check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
@@ -5844,11 +5844,11 @@ namespace VectorTools
                   // element. If the FE is
                   // a FESystem we cannot
                   // check this.
-                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_fe ()) == nullptr)
+                  if (dynamic_cast<const FESystem<dim>*> (&cell->get_finite_element()) == nullptr)
                     {
                       typedef FiniteElement<dim> FEL;
 
-                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_fe ()) != nullptr,
+                      AssertThrow (dynamic_cast<const FE_RaviartThomas<dim>*> (&cell->get_finite_element()) != nullptr,
                                    typename FEL::ExcInterpolationNotImplemented ());
                     }
 
@@ -5986,7 +5986,7 @@ namespace VectorTools
           if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_id()))
               != boundary_ids.end())
             {
-              const FiniteElement<dim> &fe = cell->get_fe ();
+              const FiniteElement<dim> &fe = cell->get_finite_element();
               typename DoFHandlerType<dim,spacedim>::face_iterator face = cell->face(face_no);
 
               // get the indices of the dofs on this cell...
@@ -6559,7 +6559,7 @@ namespace VectorTools
           if ((b_id=boundary_ids.find(cell->face(face_no)->boundary_id()))
               != boundary_ids.end())
             {
-              const FiniteElement<dim> &fe = cell->get_fe();
+              const FiniteElement<dim> &fe = cell->get_finite_element();
               typename DoFHandlerType<dim,spacedim>::face_iterator face=cell->face(face_no);
 
               // get the indices of the dofs on this cell...

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -216,7 +216,7 @@ namespace parallel
 
       typename DoFHandlerType::cell_iterator cell(*cell_, dof_handler);
 
-      const unsigned int dofs_per_cell=cell->get_fe().dofs_per_cell;
+      const unsigned int dofs_per_cell=cell->get_finite_element().dofs_per_cell;
       ::dealii::Vector<typename VectorType::value_type> dofvalues(dofs_per_cell);
       for (typename std::vector<const VectorType *>::iterator it=input_vectors.begin();
            it !=input_vectors.end();
@@ -240,7 +240,7 @@ namespace parallel
       typename DoFHandlerType::cell_iterator
       cell(*cell_, dof_handler);
 
-      const unsigned int dofs_per_cell=cell->get_fe().dofs_per_cell;
+      const unsigned int dofs_per_cell=cell->get_finite_element().dofs_per_cell;
       ::dealii::Vector<typename VectorType::value_type> dofvalues(dofs_per_cell);
       const typename VectorType::value_type *data_store = reinterpret_cast<const typename VectorType::value_type *>(data);
 

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -67,12 +67,12 @@ get_interpolated_dof_values (const InputVector &values,
           // well, here we need to first get the values from the current
           // cell and then interpolate it to the element requested. this
           // can clearly only happen for hp::DoFHandler objects
-          Vector<number> tmp (this->get_fe().dofs_per_cell);
+          Vector<number> tmp (this->get_finite_element().dofs_per_cell);
           this->get_dof_values (values, tmp);
 
           FullMatrix<double> interpolation (this->dof_handler->get_finite_element(fe_index).dofs_per_cell,
-                                            this->get_fe().dofs_per_cell);
-          this->dof_handler->get_finite_element(fe_index).get_interpolation_matrix (this->get_fe(),
+                                            this->get_finite_element().dofs_per_cell);
+          this->dof_handler->get_finite_element(fe_index).get_interpolation_matrix (this->get_finite_element(),
               interpolation);
           interpolation.vmult (interpolated_values, tmp);
         }

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -65,15 +65,15 @@ set_dof_values_by_interpolation (const Vector<number> &local_values,
           Assert (local_values.size() == this->dof_handler->get_finite_element(fe_index).dofs_per_cell,
                   ExcMessage ("Incorrect size of local_values vector.") );
 
-          FullMatrix<double> interpolation (this->get_fe().dofs_per_cell, this->dof_handler->get_finite_element(fe_index).dofs_per_cell);
+          FullMatrix<double> interpolation (this->get_finite_element().dofs_per_cell, this->dof_handler->get_finite_element(fe_index).dofs_per_cell);
 
-          this->get_fe().get_interpolation_matrix (this->dof_handler->get_finite_element(fe_index),
-                                                   interpolation);
+          this->get_finite_element().get_interpolation_matrix (this->dof_handler->get_finite_element(fe_index),
+                                                               interpolation);
 
           // do the interpolation to the target space. for historical
           // reasons, matrices are set to size 0x0 internally even
           // we reinit as 4x0, so we have to treat this case specially
-          Vector<number> tmp (this->get_fe().dofs_per_cell);
+          Vector<number> tmp (this->get_finite_element().dofs_per_cell);
           if ((tmp.size() > 0) && (local_values.size() > 0))
             interpolation.vmult (tmp, local_values);
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -222,7 +222,7 @@ namespace internal
                ++dominating_fe_index)
             {
               const FiniteElement<dim, spacedim> &this_fe
-                = object->get_fe (object->nth_active_fe_index(dominating_fe_index));
+                = object->get_finite_element (object->nth_active_fe_index(dominating_fe_index));
 
               FiniteElementDomination::Domination
               domination = FiniteElementDomination::either_element_can_dominate;
@@ -233,7 +233,7 @@ namespace internal
                   {
                     const FiniteElement<dim, spacedim>
                     &that_fe
-                      = object->get_fe (object->nth_active_fe_index(other_fe_index));
+                      = object->get_finite_element (object->nth_active_fe_index(other_fe_index));
 
                     domination = domination &
                                  this_fe.compare_for_face_domination(that_fe);
@@ -423,7 +423,7 @@ namespace internal
         {
           const unsigned int dim = 1;
 
-          const FiniteElement<dim,spacedim> &fe       = cell->get_fe();
+          const FiniteElement<dim,spacedim> &fe       = cell->get_finite_element();
           const unsigned int                 fe_index = cell->active_fe_index ();
 
           // number dofs on vertices. to do so, check whether dofs for
@@ -465,7 +465,7 @@ namespace internal
         {
           const unsigned int dim = 2;
 
-          const FiniteElement<dim,spacedim> &fe       = cell->get_fe();
+          const FiniteElement<dim,spacedim> &fe       = cell->get_finite_element();
           const unsigned int                 fe_index = cell->active_fe_index ();
 
           // number dofs on vertices. to do so, check whether dofs for
@@ -523,7 +523,7 @@ namespace internal
         {
           const unsigned int dim = 3;
 
-          const FiniteElement<dim,spacedim> &fe       = cell->get_fe();
+          const FiniteElement<dim,spacedim> &fe       = cell->get_finite_element();
           const unsigned int                 fe_index = cell->active_fe_index ();
 
           // number dofs on vertices. to do so, check whether dofs for
@@ -1173,7 +1173,7 @@ namespace internal
                                     const std::integral_constant<int, 1> &)
         {
           // distribute dofs of vertices
-          if (cell->get_fe().dofs_per_vertex > 0)
+          if (cell->get_finite_element().dofs_per_vertex > 0)
             for (unsigned int v=0; v<GeometryInfo<1>::vertices_per_cell; ++v)
               {
                 typename DoFHandler<dim,spacedim>::level_cell_iterator neighbor = cell->neighbor(v);
@@ -1187,11 +1187,11 @@ namespace internal
                       // mg dofs the same)
                       {
                         if (v==0)
-                          for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
+                          for (unsigned int d=0; d<cell->get_finite_element().dofs_per_vertex; ++d)
                             cell->set_mg_vertex_dof_index (cell->level(), 0, d,
                                                            neighbor->mg_vertex_dof_index (cell->level(), 1, d));
                         else
-                          for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
+                          for (unsigned int d=0; d<cell->get_finite_element().dofs_per_vertex; ++d)
                             cell->set_mg_vertex_dof_index (cell->level(), 1, d,
                                                            neighbor->mg_vertex_dof_index (cell->level(), 0, d));
 
@@ -1201,13 +1201,13 @@ namespace internal
                   }
 
                 // otherwise: create dofs newly
-                for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
+                for (unsigned int d=0; d<cell->get_finite_element().dofs_per_vertex; ++d)
                   cell->set_mg_vertex_dof_index (cell->level(), v, d, next_free_dof++);
               }
 
           // dofs of line
-          if (cell->get_fe().dofs_per_line > 0)
-            for (unsigned int d=0; d<cell->get_fe().dofs_per_line; ++d)
+          if (cell->get_finite_element().dofs_per_line > 0)
+            for (unsigned int d=0; d<cell->get_finite_element().dofs_per_line; ++d)
               cell->set_mg_dof_index (cell->level(), d, next_free_dof++);
 
           // note that this cell has been processed
@@ -1225,18 +1225,18 @@ namespace internal
                                     types::global_dof_index   next_free_dof,
                                     const std::integral_constant<int, 2> &)
         {
-          if (cell->get_fe().dofs_per_vertex > 0)
+          if (cell->get_finite_element().dofs_per_vertex > 0)
             // number dofs on vertices
             for (unsigned int vertex=0; vertex<GeometryInfo<2>::vertices_per_cell; ++vertex)
               // check whether dofs for this
               // vertex have been distributed
               // (only check the first dof)
               if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == numbers::invalid_dof_index)
-                for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
+                for (unsigned int d=0; d<cell->get_finite_element().dofs_per_vertex; ++d)
                   cell->set_mg_vertex_dof_index (cell->level(), vertex, d, next_free_dof++);
 
           // for the four sides
-          if (cell->get_fe().dofs_per_line > 0)
+          if (cell->get_finite_element().dofs_per_line > 0)
             for (unsigned int side=0; side<GeometryInfo<2>::faces_per_cell; ++side)
               {
                 typename DoFHandler<dim,spacedim>::line_iterator line = cell->line(side);
@@ -1245,14 +1245,14 @@ namespace internal
                 // numbered (check only first dof)
                 if (line->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<cell->get_fe().dofs_per_line; ++d)
+                  for (unsigned int d=0; d<cell->get_finite_element().dofs_per_line; ++d)
                     line->set_mg_dof_index (cell->level(), d, next_free_dof++);
               }
 
 
           // dofs of quad
-          if (cell->get_fe().dofs_per_quad > 0)
-            for (unsigned int d=0; d<cell->get_fe().dofs_per_quad; ++d)
+          if (cell->get_finite_element().dofs_per_quad > 0)
+            for (unsigned int d=0; d<cell->get_finite_element().dofs_per_quad; ++d)
               cell->set_mg_dof_index (cell->level(), d, next_free_dof++);
 
 
@@ -1271,17 +1271,17 @@ namespace internal
                                     types::global_dof_index   next_free_dof,
                                     const std::integral_constant<int, 3> &)
         {
-          if (cell->get_fe().dofs_per_vertex > 0)
+          if (cell->get_finite_element().dofs_per_vertex > 0)
             // number dofs on vertices
             for (unsigned int vertex=0; vertex<GeometryInfo<3>::vertices_per_cell; ++vertex)
               // check whether dofs for this vertex have been distributed
               // (only check the first dof)
               if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) == numbers::invalid_dof_index)
-                for (unsigned int d=0; d<cell->get_fe().dofs_per_vertex; ++d)
+                for (unsigned int d=0; d<cell->get_finite_element().dofs_per_vertex; ++d)
                   cell->set_mg_vertex_dof_index (cell->level(), vertex, d, next_free_dof++);
 
           // for the lines
-          if (cell->get_fe().dofs_per_line > 0)
+          if (cell->get_finite_element().dofs_per_line > 0)
             for (unsigned int l=0; l<GeometryInfo<3>::lines_per_cell; ++l)
               {
                 typename DoFHandler<dim,spacedim>::line_iterator line = cell->line(l);
@@ -1291,12 +1291,12 @@ namespace internal
                 // numbered (check only first dof)
                 if (line->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<cell->get_fe().dofs_per_line; ++d)
+                  for (unsigned int d=0; d<cell->get_finite_element().dofs_per_line; ++d)
                     line->set_mg_dof_index (cell->level(), d, next_free_dof++);
               }
 
           // for the quads
-          if (cell->get_fe().dofs_per_quad > 0)
+          if (cell->get_finite_element().dofs_per_quad > 0)
             for (unsigned int q=0; q<GeometryInfo<3>::quads_per_cell; ++q)
               {
                 typename DoFHandler<dim,spacedim>::quad_iterator quad = cell->quad(q);
@@ -1306,14 +1306,14 @@ namespace internal
                 // numbered (check only first dof)
                 if (quad->mg_dof_index(cell->level(), 0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<cell->get_fe().dofs_per_quad; ++d)
+                  for (unsigned int d=0; d<cell->get_finite_element().dofs_per_quad; ++d)
                     quad->set_mg_dof_index (cell->level(), d, next_free_dof++);
               }
 
 
           // dofs of cell
-          if (cell->get_fe().dofs_per_hex > 0)
-            for (unsigned int d=0; d<cell->get_fe().dofs_per_hex; ++d)
+          if (cell->get_finite_element().dofs_per_hex > 0)
+            for (unsigned int d=0; d<cell->get_finite_element().dofs_per_hex; ++d)
               cell->set_mg_dof_index (cell->level(), d, next_free_dof++);
 
 
@@ -2270,7 +2270,7 @@ namespace internal
               // all cells are either locally owned or ghosts (not artificial), so
               // this call will always yield the true owner
               const types::subdomain_id subdomain_id = cell->subdomain_id();
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
               local_dof_indices.resize (dofs_per_cell);
               cell->get_dof_indices (local_dof_indices);
 
@@ -2784,10 +2784,10 @@ namespace internal
 
 
               std::vector<dealii::types::global_dof_index>
-              local_dof_indices (dealii_cell->get_fe().dofs_per_cell);
+              local_dof_indices (dealii_cell->get_finite_element().dofs_per_cell);
               dealii_cell->get_mg_dof_indices (local_dof_indices);
 
-              cell_data_transfer_buffer.dof_numbers_and_indices.push_back(dealii_cell->get_fe().dofs_per_cell);
+              cell_data_transfer_buffer.dof_numbers_and_indices.push_back(dealii_cell->get_finite_element().dofs_per_cell);
               cell_data_transfer_buffer.dof_numbers_and_indices.insert(cell_data_transfer_buffer.dof_numbers_and_indices.end(),
                                                                        local_dof_indices.begin(),
                                                                        local_dof_indices.end());
@@ -2858,7 +2858,7 @@ namespace internal
 
               // update dof indices of cell
               std::vector<dealii::types::global_dof_index>
-              dof_indices (dealii_cell->get_fe().dofs_per_cell);
+              dof_indices (dealii_cell->get_finite_element().dofs_per_cell);
               dealii_cell->get_mg_dof_indices(dof_indices);
 
               bool complete = true;
@@ -3048,7 +3048,7 @@ namespace internal
                   typename dealii::internal::p4est::types<dim>::quadrant p4est_coarse_cell;
                   internal::p4est::init_coarse_quadrant<dim>(p4est_coarse_cell);
 
-                  Assert(cell->get_fe().dofs_per_cell==dofs[0], ExcInternalError());
+                  Assert(cell->get_finite_element().dofs_per_cell==dofs[0], ExcInternalError());
 
                   set_mg_dofindices_recursively<dim,spacedim> (tria,
                                                                p4est_coarse_cell,
@@ -3173,7 +3173,7 @@ namespace internal
             if (cell->user_flag_set())
               {
                 // get dof indices for the current cell
-                std::vector<types::global_dof_index> local_dof_indices (cell->get_fe().dofs_per_cell);
+                std::vector<types::global_dof_index> local_dof_indices (cell->get_finite_element().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
 
                 // now see if there are dof indices that were previously
@@ -3203,7 +3203,7 @@ namespace internal
                 // so return an empty array, but also verify that indeed
                 // the cell is complete
 #ifdef DEBUG
-                std::vector<types::global_dof_index> local_dof_indices (cell->get_fe().dofs_per_cell);
+                std::vector<types::global_dof_index> local_dof_indices (cell->get_finite_element().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
 
                 const bool is_complete
@@ -3251,7 +3251,7 @@ namespace internal
             // cell dof indices cache because we may have set dof indices
             // on a neighboring ghost cell before this one, which may have
             // affected the dof indices we know about the current cell
-            std::vector<types::global_dof_index> local_dof_indices (cell->get_fe().dofs_per_cell);
+            std::vector<types::global_dof_index> local_dof_indices (cell->get_finite_element().dofs_per_cell);
             cell->update_cell_dof_indices_cache();
             cell->get_dof_indices (local_dof_indices);
 
@@ -3388,7 +3388,7 @@ namespace internal
                 // delete all dofs that live there and that we have
                 // previously assigned a number to (i.e. the ones on
                 // the interface)
-                local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
                 for (auto &local_dof_index : local_dof_indices)
                   if (local_dof_index != numbers::invalid_dof_index)
@@ -3536,7 +3536,7 @@ namespace internal
           for (auto cell : dof_handler->active_cell_iterators())
             if (!cell->is_artificial())
               {
-                local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
                 if (local_dof_indices.end() !=
                     std::find (local_dof_indices.begin(),
@@ -3638,9 +3638,9 @@ namespace internal
                       // delete all dofs that live there and that we
                       // have previously assigned a number to
                       // (i.e. the ones on the interface)
-                      local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+                      local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
                       cell->get_mg_dof_indices (local_dof_indices);
-                      for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                      for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                         if (local_dof_indices[i] != numbers::invalid_dof_index)
                           renumbering[local_dof_indices[i]]
                             = numbers::invalid_dof_index;
@@ -3804,7 +3804,7 @@ namespace internal
           for (cell = dof_handler->begin(); cell != endc; ++cell)
             if (cell->level_subdomain_id() != dealii::numbers::artificial_subdomain_id)
               {
-                local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
                 cell->get_mg_dof_indices (local_dof_indices);
                 if (local_dof_indices.end() !=
                     std::find (local_dof_indices.begin(),
@@ -3886,10 +3886,10 @@ namespace internal
           for (auto cell : dof_handler->active_cell_iterators())
             if (cell->is_ghost())
               {
-                local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
                 cell->get_dof_indices (local_dof_indices);
 
-                for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                   // delete a DoF index if it has not already been deleted
                   // (e.g., by visiting a neighboring cell, if it is on the
                   // boundary), and if we don't own it

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -280,7 +280,7 @@ namespace DoFRenumbering
       for (; cell!=endc; ++cell)
         {
 
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
 
           dofs_on_this_cell.resize (dofs_per_cell);
 
@@ -1118,7 +1118,7 @@ namespace DoFRenumbering
         {
           if (cell->is_locally_owned())
             {
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
               std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
               cell->get_dof_indices (local_dof_indices);
 
@@ -1384,7 +1384,7 @@ namespace DoFRenumbering
         // on this cell and reinit the
         // vector storing these
         // numbers.
-        unsigned int n_cell_dofs = (*cell)->get_fe().n_dofs_per_cell();
+        unsigned int n_cell_dofs = (*cell)->get_finite_element().n_dofs_per_cell();
         cell_dofs.resize(n_cell_dofs);
 
         (*cell)->get_active_or_mg_dof_indices(cell_dofs);
@@ -1547,7 +1547,7 @@ namespace DoFRenumbering
         typename DoFHandlerType::active_cell_iterator end = dof.end();
         for ( ; begin != end; ++begin)
           {
-            const unsigned int dofs_per_cell = begin->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = begin->get_finite_element().dofs_per_cell;
             local_dof_indices.resize (dofs_per_cell);
             hp_fe_values.reinit (begin);
             const FEValues<DoFHandlerType::dimension> &fe_values =

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -209,7 +209,7 @@ namespace DoFTools
         if (c->is_locally_owned())
           {
             const unsigned int fe_index = c->active_fe_index();
-            const unsigned int dofs_per_cell = c->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = c->get_finite_element().dofs_per_cell;
             indices.resize(dofs_per_cell);
             c->get_dof_indices(indices);
             for (unsigned int i=0; i<dofs_per_cell; ++i)
@@ -273,7 +273,7 @@ namespace DoFTools
         if (c->is_locally_owned())
           {
             const unsigned int fe_index = c->active_fe_index();
-            const unsigned int dofs_per_cell = c->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = c->get_finite_element().dofs_per_cell;
             indices.resize(dofs_per_cell);
             c->get_dof_indices(indices);
             for (unsigned int i=0; i<dofs_per_cell; ++i)
@@ -334,7 +334,7 @@ namespace DoFTools
 
     for (unsigned int present_cell = 0; cell!=endc; ++cell, ++present_cell)
       {
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
         dof_indices.resize (dofs_per_cell);
         cell->get_dof_indices (dof_indices);
 
@@ -342,7 +342,7 @@ namespace DoFTools
           // consider this dof only if it is the right component. if there
           // is only one component, short cut the test
           if (!consider_components ||
-              (cell->get_fe().system_to_component_index(i).first == component))
+              (cell->get_finite_element().system_to_component_index(i).first == component))
             {
               // sum up contribution of the present_cell to this dof
               dof_data(dof_indices[i]) += cell_data(present_cell);
@@ -419,7 +419,7 @@ namespace DoFTools
                 const ComponentMask                &component_mask,
                 std::vector<bool>                  &selected_dofs)
   {
-    const FiniteElement<dim,spacedim> &fe = dof.begin_active()->get_fe();
+    const FiniteElement<dim,spacedim> &fe = dof.begin_active()->get_finite_element();
     (void)fe;
 
     Assert(component_mask.represents_n_components(fe.n_components()),
@@ -465,7 +465,7 @@ namespace DoFTools
                 std::vector<bool>       &selected_dofs)
   {
     // simply forward to the function that works based on a component mask
-    extract_dofs (dof, dof.get_fe().component_mask (block_mask),
+    extract_dofs (dof, dof.get_finite_element().component_mask (block_mask),
                   selected_dofs);
   }
 
@@ -478,7 +478,7 @@ namespace DoFTools
                 std::vector<bool>       &selected_dofs)
   {
     // simply forward to the function that works based on a component mask
-    extract_dofs (dof, dof.get_fe().component_mask (block_mask),
+    extract_dofs (dof, dof.get_finite_element(0).component_mask (block_mask),
                   selected_dofs);
   }
 
@@ -628,7 +628,7 @@ namespace DoFTools
                  != boundary_ids.end()))
               {
                 const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension>
-                &fe = cell->get_fe();
+                &fe = cell->get_finite_element();
 
                 const unsigned int dofs_per_face = fe.dofs_per_face;
                 face_dof_indices.resize (dofs_per_face);
@@ -727,7 +727,7 @@ namespace DoFTools
                != boundary_ids.end()))
             {
               const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-                = cell->get_fe();
+                = cell->get_finite_element();
 
               const unsigned int dofs_per_cell = fe.dofs_per_cell;
               cell_dof_indices.resize (dofs_per_cell);
@@ -789,7 +789,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       if (!cell->is_artificial() && predicate(cell))
         {
-          local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+          local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
           cell->get_dof_indices (local_dof_indices);
           predicate_dofs.insert(local_dof_indices.begin(),
                                 local_dof_indices.end());
@@ -813,7 +813,7 @@ namespace DoFTools
             continue;
           }
 
-        const unsigned int dofs_per_cell = (*it)->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = (*it)->get_finite_element().dofs_per_cell;
         local_dof_indices.resize (dofs_per_cell);
         (*it)->get_dof_indices (local_dof_indices);
         dofs_with_support_on_halo_cells.insert(local_dof_indices.begin(),
@@ -1017,7 +1017,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       if (cell->subdomain_id() == subdomain_id)
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
           local_dof_indices.resize (dofs_per_cell);
           cell->get_dof_indices (local_dof_indices);
           for (unsigned int i=0; i<dofs_per_cell; ++i)
@@ -1058,7 +1058,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       if (cell->is_locally_owned())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_finite_element().dofs_per_cell);
           cell->get_dof_indices(dof_indices);
 
           for (std::vector<types::global_dof_index>::iterator it=dof_indices.begin();
@@ -1099,7 +1099,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       if (cell->is_ghost())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_finite_element().dofs_per_cell);
           cell->get_dof_indices(dof_indices);
           for (unsigned int i=0; i<dof_indices.size(); ++i)
             if (!dof_set.is_element(dof_indices[i]))
@@ -1145,7 +1145,7 @@ namespace DoFTools
             || id == numbers::artificial_subdomain_id)
           continue;
 
-        dof_indices.resize(cell->get_fe().dofs_per_cell);
+        dof_indices.resize(cell->get_finite_element().dofs_per_cell);
         cell->get_mg_dof_indices(dof_indices);
         for (unsigned int i=0; i<dof_indices.size(); ++i)
           if (!dof_set.is_element(dof_indices[i]))
@@ -1226,7 +1226,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       if (cell->is_locally_owned())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_finite_element().dofs_per_cell);
           cell->get_dof_indices(dof_indices);
 
           for (unsigned int i=0; i<dof_indices.size(); ++i)
@@ -1386,7 +1386,7 @@ namespace DoFTools
             Assert(cell->subdomain_id() != subdomain_id,
                    ExcMessage("The subdomain ID of the halo cell should not match that of the vector entry."));
 
-            local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+            local_dof_indices.resize(cell->get_finite_element().dofs_per_cell);
             cell->get_dof_indices(local_dof_indices);
 
             for (std::vector<types::global_dof_index>::iterator it=local_dof_indices.begin();
@@ -1468,7 +1468,7 @@ namespace DoFTools
     for (; cell!=endc; ++cell)
       {
         const types::subdomain_id subdomain_id = cell_owners[cell->active_cell_index()];
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
         local_dof_indices.resize (dofs_per_cell);
         cell->get_dof_indices (local_dof_indices);
 
@@ -1548,7 +1548,7 @@ namespace DoFTools
           &&
           (cell->subdomain_id() == subdomain))
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
           local_dof_indices.resize (dofs_per_cell);
           cell->get_dof_indices (local_dof_indices);
           subdomain_indices.insert(subdomain_indices.end(),
@@ -1921,7 +1921,7 @@ namespace DoFTools
       for (unsigned int f=0; f<GeometryInfo<DoFHandlerType::dimension>::faces_per_cell; ++f)
         if (cell->at_boundary(f))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
             cell->face(f)->get_dof_indices (dofs_on_face,
                                             cell->active_fe_index());
@@ -1963,7 +1963,7 @@ namespace DoFTools
         if (boundary_ids.find (cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
             cell->face(f)->get_dof_indices (dofs_on_face, cell->active_fe_index());
             for (unsigned int i=0; i<dofs_per_face; ++i)
@@ -2022,12 +2022,12 @@ namespace DoFTools
               hp_fe_values.reinit(cell);
               const FEValues<dim, spacedim> &fe_values = hp_fe_values.get_present_fe_values();
 
-              local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+              local_dof_indices.resize(cell->get_finite_element().dofs_per_cell);
               cell->get_dof_indices(local_dof_indices);
 
               const std::vector<Point<spacedim> > &points =
                 fe_values.get_quadrature_points();
-              for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell; ++i)
+              for (unsigned int i = 0; i < cell->get_finite_element().dofs_per_cell; ++i)
                 // insert the values into the map
                 support_points[local_dof_indices[i]] = points[i];
             }
@@ -2258,7 +2258,7 @@ namespace DoFTools
     for (cell=dof_handler.begin(level); cell != endc; ++cell)
       if (cell->is_locally_owned_on_level())
         {
-          indices.resize(cell->get_fe().dofs_per_cell);
+          indices.resize(cell->get_finite_element().dofs_per_cell);
           cell->get_mg_dof_indices(indices);
 
           if (selected_dofs.size()!=0)
@@ -2295,7 +2295,7 @@ namespace DoFTools
 
     for (cell=dof_handler.begin(level); cell != endc; ++cell)
       {
-        indices.resize(cell->get_fe().dofs_per_cell);
+        indices.resize(cell->get_finite_element().dofs_per_cell);
         cell->get_mg_dof_indices(indices);
 
         if (interior_only)
@@ -2441,7 +2441,7 @@ namespace DoFTools
       for (unsigned int v=0; v<GeometryInfo<DoFHandlerType::dimension>::vertices_per_cell; ++v)
         {
           const unsigned int vg = cell->vertex_index(v);
-          vertex_dof_count[vg] += cell->get_fe().dofs_per_cell;
+          vertex_dof_count[vg] += cell->get_finite_element().dofs_per_cell;
           ++vertex_cell_count[vg];
           for (unsigned int d=0; d<DoFHandlerType::dimension; ++d)
             {
@@ -2486,7 +2486,7 @@ namespace DoFTools
 
     for (cell=dof_handler.begin(level); cell != endc; ++cell)
       {
-        const FiniteElement<DoFHandlerType::dimension> &fe = cell->get_fe();
+        const FiniteElement<DoFHandlerType::dimension> &fe = cell->get_finite_element();
         indices.resize(fe.dofs_per_cell);
         cell->get_mg_dof_indices(indices);
 
@@ -2562,7 +2562,7 @@ namespace DoFTools
         Assert (cell->is_artificial() == false,
                 ExcMessage("This function can not be called with cells that are "
                            "not either locally owned or ghost cells."));
-        local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
         cell->get_dof_indices (local_dof_indices);
         dofs_on_patch.insert (local_dof_indices.begin(),
                               local_dof_indices.end());
@@ -2590,7 +2590,7 @@ namespace DoFTools
         Assert (cell->is_artificial() == false,
                 ExcMessage("This function can not be called with cells that are "
                            "not either locally owned or ghost cells."));
-        local_dof_indices.resize (cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize (cell->get_finite_element().dofs_per_cell);
         cell->get_dof_indices (local_dof_indices);
         dofs_on_patch.insert (local_dof_indices.begin(),
                               local_dof_indices.end());

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -724,7 +724,7 @@ namespace DoFTools
                             ExcNotImplemented());
 
                 // ok, start up the work
-                const FiniteElement<dim,spacedim> &fe       = cell->get_fe();
+                const FiniteElement<dim,spacedim> &fe       = cell->get_finite_element();
                 const unsigned int        fe_index = cell->active_fe_index();
 
                 const unsigned int
@@ -840,7 +840,7 @@ namespace DoFTools
                 // first of all, make sure that we treat a case which is
                 // possible, i.e. either no dofs on the face at all or no
                 // anisotropic refinement
-                if (cell->get_fe().dofs_per_face == 0)
+                if (cell->get_finite_element().dofs_per_face == 0)
                   continue;
 
                 Assert(cell->face(face)->refinement_case()==RefinementCase<dim-1>::isotropic_refinement,
@@ -888,7 +888,7 @@ namespace DoFTools
                   }
 
                 // ok, start up the work
-                const FiniteElement<dim> &fe       = cell->get_fe();
+                const FiniteElement<dim> &fe       = cell->get_finite_element();
                 const unsigned int        fe_index = cell->active_fe_index();
 
                 const unsigned int n_dofs_on_mother = fe.dofs_per_face;
@@ -1098,7 +1098,7 @@ namespace DoFTools
                 // first of all, make sure that we treat a case which is
                 // possible, i.e. either no dofs on the face at all or no
                 // anisotropic refinement
-                if (cell->get_fe().dofs_per_face == 0)
+                if (cell->get_finite_element().dofs_per_face == 0)
                   continue;
 
                 Assert(cell->face(face)->refinement_case()==RefinementCase<dim-1>::isotropic_refinement,
@@ -1142,8 +1142,8 @@ namespace DoFTools
                     if (!cell->neighbor_child_on_subface (face, c)->is_artificial())
                       {
                         mother_face_dominates = mother_face_dominates &
-                                                (cell->get_fe().compare_for_face_domination
-                                                 (cell->neighbor_child_on_subface (face, c)->get_fe()));
+                                                (cell->get_finite_element().compare_for_face_domination
+                                                 (cell->neighbor_child_on_subface (face, c)->get_finite_element()));
                         fe_ind_face_subface.insert(cell->neighbor_child_on_subface (face, c)->active_fe_index());
                       }
 
@@ -1159,7 +1159,7 @@ namespace DoFTools
                     //
                     // so we are going to constrain the DoFs on the face
                     // children against the DoFs on the face itself
-                    master_dofs.resize (cell->get_fe().dofs_per_face);
+                    master_dofs.resize (cell->get_finite_element().dofs_per_face);
 
                     cell->face(face)->get_dof_indices (master_dofs,
                                                        cell->active_fe_index ());
@@ -1191,15 +1191,15 @@ namespace DoFTools
                         // subface between FE_Q(1) and FE_Nothing, there
                         // are no constraints that we need to take care of.
                         // in that case, just continue
-                        if (cell->get_fe().compare_for_face_domination
-                            (subface->get_fe(subface_fe_index))
+                        if (cell->get_finite_element().compare_for_face_domination
+                            (subface->get_finite_element(subface_fe_index))
                             ==
                             FiniteElementDomination::no_requirements)
                           continue;
 
                         // Same procedure as for the mother cell. Extract
                         // the face DoFs from the cell DoFs.
-                        slave_dofs.resize (subface->get_fe(subface_fe_index)
+                        slave_dofs.resize (subface->get_finite_element(subface_fe_index)
                                            .dofs_per_face);
                         subface->get_dof_indices (slave_dofs, subface_fe_index);
 
@@ -1230,8 +1230,8 @@ namespace DoFTools
                         // result of projection verifies the approximation
                         // properties of a finite element onto that mesh
                         ensure_existence_of_subface_matrix
-                        (cell->get_fe(),
-                         subface->get_fe(subface_fe_index),
+                        (cell->get_finite_element(),
+                         subface->get_finite_element(subface_fe_index),
                          c,
                          subface_interpolation_matrices
                          [cell->active_fe_index()][subface_fe_index][c]);
@@ -1291,19 +1291,19 @@ namespace DoFTools
                     // first get the interpolation matrix from the mother
                     // to the virtual dofs
                     Assert (dominating_fe.dofs_per_face <=
-                            cell->get_fe().dofs_per_face,
+                            cell->get_finite_element().dofs_per_face,
                             ExcInternalError());
 
                     ensure_existence_of_face_matrix
                     (dominating_fe,
-                     cell->get_fe(),
+                     cell->get_finite_element(),
                      face_interpolation_matrices
                      [dominating_fe_index][cell->active_fe_index()]);
 
                     // split this matrix into master and slave components.
                     // invert the master component
                     ensure_existence_of_master_dof_mask
-                    (cell->get_fe(),
+                    (cell->get_finite_element(),
                      dominating_fe,
                      (*face_interpolation_matrices
                       [dominating_fe_index]
@@ -1330,7 +1330,7 @@ namespace DoFTools
 
                     // now compute the constraint matrix as the product
                     // between the inverse matrix and the slave part
-                    constraint_matrix.reinit (cell->get_fe().dofs_per_face -
+                    constraint_matrix.reinit (cell->get_finite_element().dofs_per_face -
                                               dominating_fe.dofs_per_face,
                                               dominating_fe.dofs_per_face);
                     restrict_mother_to_virtual_slave
@@ -1339,14 +1339,14 @@ namespace DoFTools
 
                     // then figure out the global numbers of master and
                     // slave dofs and apply constraints
-                    scratch_dofs.resize (cell->get_fe().dofs_per_face);
+                    scratch_dofs.resize (cell->get_finite_element().dofs_per_face);
                     cell->face(face)->get_dof_indices (scratch_dofs,
                                                        cell->active_fe_index ());
 
                     // split dofs into master and slave components
                     master_dofs.clear ();
                     slave_dofs.clear ();
-                    for (unsigned int i=0; i<cell->get_fe().dofs_per_face; ++i)
+                    for (unsigned int i=0; i<cell->get_finite_element().dofs_per_face; ++i)
                       if ((*master_dof_masks
                            [dominating_fe_index][cell->active_fe_index()])[i] == true)
                         master_dofs.push_back (scratch_dofs[i]);
@@ -1355,7 +1355,7 @@ namespace DoFTools
 
                     AssertDimension (master_dofs.size(), dominating_fe.dofs_per_face);
                     AssertDimension (slave_dofs.size(),
-                                     cell->get_fe().dofs_per_face - dominating_fe.dofs_per_face);
+                                     cell->get_finite_element().dofs_per_face - dominating_fe.dofs_per_face);
 
                     filter_constraints (master_dofs,
                                         slave_dofs,
@@ -1466,17 +1466,17 @@ namespace DoFTools
                     const typename DoFHandlerType::level_cell_iterator neighbor = cell->neighbor (face);
 
                     // see which side of the face we have to constrain
-                    switch (cell->get_fe().compare_for_face_domination (neighbor->get_fe ()))
+                    switch (cell->get_finite_element().compare_for_face_domination (neighbor->get_finite_element ()))
                       {
                       case FiniteElementDomination::this_element_dominates:
                       {
                         // Get DoFs on dominating and dominated side of the
                         // face
-                        master_dofs.resize (cell->get_fe().dofs_per_face);
+                        master_dofs.resize (cell->get_finite_element().dofs_per_face);
                         cell->face(face)->get_dof_indices (master_dofs,
                                                            cell->active_fe_index ());
 
-                        slave_dofs.resize (neighbor->get_fe().dofs_per_face);
+                        slave_dofs.resize (neighbor->get_finite_element().dofs_per_face);
                         cell->face(face)->get_dof_indices (slave_dofs,
                                                            neighbor->active_fe_index ());
 
@@ -1488,8 +1488,8 @@ namespace DoFTools
                         // make sure the element constraints for this face
                         // are available
                         ensure_existence_of_face_matrix
-                        (cell->get_fe(),
-                         neighbor->get_fe(),
+                        (cell->get_finite_element(),
+                         neighbor->get_finite_element(),
                          face_interpolation_matrices
                          [cell->active_fe_index()][neighbor->active_fe_index()]);
 
@@ -1566,9 +1566,9 @@ namespace DoFTools
 
                         AssertThrow(dominating_fe_index != numbers::invalid_unsigned_int,
                                     ExcMessage("Could not find the dominating FE for "
-                                               +cell->get_fe().get_name()
+                                               +cell->get_finite_element().get_name()
                                                +" and "
-                                               +neighbor->get_fe().get_name()
+                                               +neighbor->get_finite_element().get_name()
                                                +" inside FECollection."));
 
                         const FiniteElement<dim,spacedim> &dominating_fe = fe_collection[dominating_fe_index];
@@ -1579,19 +1579,19 @@ namespace DoFTools
                         // first get the interpolation matrix from main FE
                         // to the virtual dofs
                         Assert (dominating_fe.dofs_per_face <=
-                                cell->get_fe().dofs_per_face,
+                                cell->get_finite_element().dofs_per_face,
                                 ExcInternalError());
 
                         ensure_existence_of_face_matrix
                         (dominating_fe,
-                         cell->get_fe(),
+                         cell->get_finite_element(),
                          face_interpolation_matrices
                          [dominating_fe_index][cell->active_fe_index()]);
 
                         // split this matrix into master and slave components.
                         // invert the master component
                         ensure_existence_of_master_dof_mask
-                        (cell->get_fe(),
+                        (cell->get_finite_element(),
                          dominating_fe,
                          (*face_interpolation_matrices
                           [dominating_fe_index]
@@ -1618,7 +1618,7 @@ namespace DoFTools
 
                         // now compute the constraint matrix as the product
                         // between the inverse matrix and the slave part
-                        constraint_matrix.reinit (cell->get_fe().dofs_per_face -
+                        constraint_matrix.reinit (cell->get_finite_element().dofs_per_face -
                                                   dominating_fe.dofs_per_face,
                                                   dominating_fe.dofs_per_face);
                         restrict_mother_to_virtual_slave
@@ -1627,14 +1627,14 @@ namespace DoFTools
 
                         // then figure out the global numbers of master and
                         // slave dofs and apply constraints
-                        scratch_dofs.resize (cell->get_fe().dofs_per_face);
+                        scratch_dofs.resize (cell->get_finite_element().dofs_per_face);
                         cell->face(face)->get_dof_indices (scratch_dofs,
                                                            cell->active_fe_index ());
 
                         // split dofs into master and slave components
                         master_dofs.clear ();
                         slave_dofs.clear ();
-                        for (unsigned int i=0; i<cell->get_fe().dofs_per_face; ++i)
+                        for (unsigned int i=0; i<cell->get_finite_element().dofs_per_face; ++i)
                           if ((*master_dof_masks
                                [dominating_fe_index][cell->active_fe_index()])[i] == true)
                             master_dofs.push_back (scratch_dofs[i]);
@@ -1643,7 +1643,7 @@ namespace DoFTools
 
                         AssertDimension (master_dofs.size(), dominating_fe.dofs_per_face);
                         AssertDimension (slave_dofs.size(),
-                                         cell->get_fe().dofs_per_face - dominating_fe.dofs_per_face);
+                                         cell->get_finite_element().dofs_per_face - dominating_fe.dofs_per_face);
 
                         filter_constraints (master_dofs,
                                             slave_dofs,
@@ -1654,12 +1654,12 @@ namespace DoFTools
                         // this is pretty much the same we do above to
                         // resolve h-refinement constraints
                         Assert (dominating_fe.dofs_per_face <=
-                                neighbor->get_fe().dofs_per_face,
+                                neighbor->get_finite_element().dofs_per_face,
                                 ExcInternalError());
 
                         ensure_existence_of_face_matrix
                         (dominating_fe,
-                         neighbor->get_fe(),
+                         neighbor->get_finite_element(),
                          face_interpolation_matrices
                          [dominating_fe_index][neighbor->active_fe_index()]);
 
@@ -1667,14 +1667,14 @@ namespace DoFTools
                           = *(face_interpolation_matrices
                               [dominating_fe_index][neighbor->active_fe_index()]);
 
-                        constraint_matrix.reinit (neighbor->get_fe().dofs_per_face,
+                        constraint_matrix.reinit (neighbor->get_finite_element().dofs_per_face,
                                                   dominating_fe.dofs_per_face);
 
                         restrict_secondface_to_virtual
                         .mmult (constraint_matrix,
                                 restrict_mother_to_virtual_master_inv);
 
-                        slave_dofs.resize (neighbor->get_fe().dofs_per_face);
+                        slave_dofs.resize (neighbor->get_finite_element().dofs_per_face);
                         cell->face(face)->get_dof_indices (slave_dofs,
                                                            neighbor->active_fe_index ());
 
@@ -1779,7 +1779,7 @@ namespace DoFTools
           Assert (face_2->n_children() == GeometryInfo<dim>::max_children_per_face,
                   ExcNotImplemented());
           const unsigned int dofs_per_face
-            = face_1->get_fe(face_1->nth_active_fe_index(0)).dofs_per_face;
+            = face_1->get_finite_element(face_1->nth_active_fe_index(0)).dofs_per_face;
           FullMatrix<double> child_transformation (dofs_per_face, dofs_per_face);
           FullMatrix<double> subface_interpolation (dofs_per_face, dofs_per_face);
           for (unsigned int c=0; c<face_2->n_children(); ++c)
@@ -1788,8 +1788,8 @@ namespace DoFTools
               // interpolated from face_1 to face_2 by multiplying from the
               // left with the one that interpolates from face_2 to
               // its child
-              face_1->get_fe(face_1->nth_active_fe_index(0))
-              .get_subface_interpolation_matrix (face_1->get_fe(face_1->nth_active_fe_index(0)),
+              face_1->get_finite_element(face_1->nth_active_fe_index(0))
+              .get_subface_interpolation_matrix (face_1->get_finite_element(face_1->nth_active_fe_index(0)),
                                                  c,
                                                  subface_interpolation);
               subface_interpolation.mmult (child_transformation, transformation);
@@ -1804,10 +1804,10 @@ namespace DoFTools
         {
           const unsigned int face_1_index = face_1->nth_active_fe_index(0);
           const unsigned int face_2_index = face_2->nth_active_fe_index(0);
-          Assert(face_1->get_fe(face_1_index) == face_2->get_fe(face_2_index),
+          Assert(face_1->get_finite_element(face_1_index) == face_2->get_finite_element(face_2_index),
                  ExcMessage ("Matching periodic cells need to use the same finite element"));
 
-          const FiniteElement<dim, spacedim> &fe = face_1->get_fe(face_1_index);
+          const FiniteElement<dim, spacedim> &fe = face_1->get_finite_element(face_1_index);
 
           Assert(component_mask.represents_n_components(fe.n_components()),
                  ExcMessage ("The number of components in the mask has to be either "
@@ -2189,7 +2189,7 @@ namespace DoFTools
       {
         Assert(face_1->n_active_fe_indices() == 1, ExcInternalError());
         const unsigned int n_dofs_per_face =
-          face_1->get_fe(face_1->nth_active_fe_index(0)).dofs_per_face;
+          face_1->get_finite_element(face_1->nth_active_fe_index(0)).dofs_per_face;
 
         Assert(matrix.m() == 0
                || (first_vector_components.empty() && matrix.m() == n_dofs_per_face)
@@ -2204,7 +2204,7 @@ namespace DoFTools
       {
         Assert(face_2->n_active_fe_indices() == 1, ExcInternalError());
         const unsigned int n_dofs_per_face =
-          face_2->get_fe(face_2->nth_active_fe_index(0)).dofs_per_face;
+          face_2->get_finite_element(face_2->nth_active_fe_index(0)).dofs_per_face;
 
         Assert(matrix.m() == 0
                || (first_vector_components.empty() && matrix.m() == n_dofs_per_face)
@@ -2291,8 +2291,8 @@ namespace DoFTools
         // The finite element that matters is the one on the active face:
         const FiniteElement<dim,spacedim> &fe =
           face_1->has_children()
-          ? face_2->get_fe(face_2->nth_active_fe_index(0))
-          : face_1->get_fe(face_1->nth_active_fe_index(0));
+          ? face_2->get_finite_element(face_2->nth_active_fe_index(0))
+          : face_1->get_finite_element(face_1->nth_active_fe_index(0));
 
         const unsigned int n_dofs_per_face = fe.dofs_per_face;
 
@@ -3251,7 +3251,7 @@ namespace DoFTools
           &&
           cell->at_boundary ())
         {
-          const FiniteElement<dim,spacedim> &fe = cell->get_fe();
+          const FiniteElement<dim,spacedim> &fe = cell->get_finite_element();
 
           // get global indices of dofs on the cell
           cell_dofs.resize (fe.dofs_per_cell);
@@ -3286,7 +3286,7 @@ namespace DoFTools
                       const unsigned int index_on_cell = std::distance(cell_dofs.begin(),
                                                                        it_index_on_cell);
                       const ComponentMask &nonzero_component_array
-                        = cell->get_fe().get_nonzero_components (index_on_cell);
+                        = cell->get_finite_element().get_nonzero_components (index_on_cell);
                       bool nonzero = false;
                       for (unsigned int c=0; c<n_components; ++c)
                         if (nonzero_component_array[c] && component_mask[c])

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -94,7 +94,7 @@ namespace DoFTools
           &&
           cell->is_locally_owned())
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
           dofs_on_this_cell.resize (dofs_per_cell);
           cell->get_dof_indices (dofs_on_this_cell);
 
@@ -231,9 +231,9 @@ namespace DoFTools
         if (!cell_row->has_children() && !cell_col->has_children())
           {
             const unsigned int dofs_per_cell_row =
-              cell_row->get_fe().dofs_per_cell;
+              cell_row->get_finite_element().dofs_per_cell;
             const unsigned int dofs_per_cell_col =
-              cell_col->get_fe().dofs_per_cell;
+              cell_col->get_finite_element().dofs_per_cell;
             std::vector<types::global_dof_index>
             local_dof_indices_row(dofs_per_cell_row);
             std::vector<types::global_dof_index>
@@ -254,9 +254,9 @@ namespace DoFTools
                 const typename DoFHandlerType::cell_iterator
                 cell_row_child = child_cells[i];
                 const unsigned int dofs_per_cell_row =
-                  cell_row_child->get_fe().dofs_per_cell;
+                  cell_row_child->get_finite_element().dofs_per_cell;
                 const unsigned int dofs_per_cell_col =
-                  cell_col->get_fe().dofs_per_cell;
+                  cell_col->get_finite_element().dofs_per_cell;
                 std::vector<types::global_dof_index>
                 local_dof_indices_row(dofs_per_cell_row);
                 std::vector<types::global_dof_index>
@@ -278,9 +278,9 @@ namespace DoFTools
                 const typename DoFHandlerType::active_cell_iterator
                 cell_col_child = child_cells[i];
                 const unsigned int dofs_per_cell_row =
-                  cell_row->get_fe().dofs_per_cell;
+                  cell_row->get_finite_element().dofs_per_cell;
                 const unsigned int dofs_per_cell_col =
-                  cell_col_child->get_fe().dofs_per_cell;
+                  cell_col_child->get_finite_element().dofs_per_cell;
                 std::vector<types::global_dof_index>
                 local_dof_indices_row(dofs_per_cell_row);
                 std::vector<types::global_dof_index>
@@ -353,7 +353,7 @@ namespace DoFTools
       for (unsigned int f=0; f<GeometryInfo<DoFHandlerType::dimension>::faces_per_cell; ++f)
         if (cell->at_boundary(f))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_this_face.resize (dofs_per_face);
             cell->face(f)->get_dof_indices (dofs_on_this_face,
                                             cell->active_fe_index());
@@ -393,7 +393,7 @@ namespace DoFTools
             while (!cell->active())
               cell = cell->child(direction);
 
-            const unsigned int dofs_per_vertex = cell->get_fe().dofs_per_vertex;
+            const unsigned int dofs_per_vertex = cell->get_finite_element().dofs_per_vertex;
             std::vector<types::global_dof_index> boundary_dof_boundary_indices (dofs_per_vertex);
 
             // next get boundary mapped dof indices of boundary dofs
@@ -441,7 +441,7 @@ namespace DoFTools
         if (boundary_ids.find(cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_this_face.resize (dofs_per_face);
             cell->face(f)->get_dof_indices (dofs_on_this_face,
                                             cell->active_fe_index());
@@ -508,7 +508,7 @@ namespace DoFTools
           &&
           cell->is_locally_owned())
         {
-          const unsigned int n_dofs_on_this_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int n_dofs_on_this_cell = cell->get_finite_element().dofs_per_cell;
           dofs_on_this_cell.resize (n_dofs_on_this_cell);
           cell->get_dof_indices (dofs_on_this_cell);
 
@@ -550,7 +550,7 @@ namespace DoFTools
                               cell->neighbor_child_on_subface (face, sub_nr);
 
                           const unsigned int n_dofs_on_neighbor
-                            = sub_neighbor->get_fe().dofs_per_cell;
+                            = sub_neighbor->get_finite_element().dofs_per_cell;
                           dofs_on_other_cell.resize (n_dofs_on_neighbor);
                           sub_neighbor->get_dof_indices (dofs_on_other_cell);
 
@@ -578,7 +578,7 @@ namespace DoFTools
                           continue;
 
                       const unsigned int n_dofs_on_neighbor
-                        = neighbor->get_fe().dofs_per_cell;
+                        = neighbor->get_finite_element().dofs_per_cell;
                       dofs_on_other_cell.resize (n_dofs_on_neighbor);
 
                       neighbor->get_dof_indices (dofs_on_other_cell);
@@ -1011,7 +1011,7 @@ namespace DoFTools
               &&
               cell->is_locally_owned())
             {
-              dofs_on_this_cell.resize (cell->get_fe().dofs_per_cell);
+              dofs_on_this_cell.resize (cell->get_finite_element().dofs_per_cell);
               cell->get_dof_indices (dofs_on_this_cell);
 
               // make sparsity pattern for this cell
@@ -1031,14 +1031,14 @@ namespace DoFTools
 
                   if (cell->at_boundary (face) && (!periodic_neighbor))
                     {
-                      for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
-                        for (unsigned int j=0; j<cell->get_fe().dofs_per_cell; ++j)
-                          if ((flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                         cell->get_fe().system_to_component_index(j).first)
+                      for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
+                        for (unsigned int j=0; j<cell->get_finite_element().dofs_per_cell; ++j)
+                          if ((flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                         cell->get_finite_element().system_to_component_index(j).first)
                                == always)
                               ||
-                              (flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                         cell->get_fe().system_to_component_index(j).first)
+                              (flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                         cell->get_finite_element().system_to_component_index(j).first)
                                == nonzero))
                             sparsity.add (dofs_on_this_cell[i],
                                           dofs_on_this_cell[j]);
@@ -1092,19 +1092,19 @@ namespace DoFTools
                                   cell->periodic_neighbor_child_on_subface (face, sub_nr):
                                   cell->neighbor_child_on_subface (face, sub_nr);
 
-                              dofs_on_other_cell.resize (sub_neighbor->get_fe().dofs_per_cell);
+                              dofs_on_other_cell.resize (sub_neighbor->get_finite_element().dofs_per_cell);
                               sub_neighbor->get_dof_indices (dofs_on_other_cell);
-                              for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                              for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                                 {
-                                  for (unsigned int j=0; j<sub_neighbor->get_fe().dofs_per_cell;
+                                  for (unsigned int j=0; j<sub_neighbor->get_finite_element().dofs_per_cell;
                                        ++j)
                                     {
-                                      if ((flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                                     sub_neighbor->get_fe().system_to_component_index(j).first)
+                                      if ((flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                                     sub_neighbor->get_finite_element().system_to_component_index(j).first)
                                            == always)
                                           ||
-                                          (flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                                     sub_neighbor->get_fe().system_to_component_index(j).first)
+                                          (flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                                     sub_neighbor->get_finite_element().system_to_component_index(j).first)
                                            == nonzero))
                                         {
                                           sparsity.add (dofs_on_this_cell[i],
@@ -1117,12 +1117,12 @@ namespace DoFTools
                                                         dofs_on_other_cell[j]);
                                         }
 
-                                      if ((flux_mask(sub_neighbor->get_fe().system_to_component_index(j).first,
-                                                     cell->get_fe().system_to_component_index(i).first)
+                                      if ((flux_mask(sub_neighbor->get_finite_element().system_to_component_index(j).first,
+                                                     cell->get_finite_element().system_to_component_index(i).first)
                                            == always)
                                           ||
-                                          (flux_mask(sub_neighbor->get_fe().system_to_component_index(j).first,
-                                                     cell->get_fe().system_to_component_index(i).first)
+                                          (flux_mask(sub_neighbor->get_finite_element().system_to_component_index(j).first,
+                                                     cell->get_finite_element().system_to_component_index(i).first)
                                            == nonzero))
                                         {
                                           sparsity.add (dofs_on_this_cell[j],
@@ -1140,18 +1140,18 @@ namespace DoFTools
                         }
                       else
                         {
-                          dofs_on_other_cell.resize (neighbor->get_fe().dofs_per_cell);
+                          dofs_on_other_cell.resize (neighbor->get_finite_element().dofs_per_cell);
                           neighbor->get_dof_indices (dofs_on_other_cell);
-                          for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                          for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                             {
-                              for (unsigned int j=0; j<neighbor->get_fe().dofs_per_cell; ++j)
+                              for (unsigned int j=0; j<neighbor->get_finite_element().dofs_per_cell; ++j)
                                 {
-                                  if ((flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                                 neighbor->get_fe().system_to_component_index(j).first)
+                                  if ((flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                                 neighbor->get_finite_element().system_to_component_index(j).first)
                                        == always)
                                       ||
-                                      (flux_mask(cell->get_fe().system_to_component_index(i).first,
-                                                 neighbor->get_fe().system_to_component_index(j).first)
+                                      (flux_mask(cell->get_finite_element().system_to_component_index(i).first,
+                                                 neighbor->get_finite_element().system_to_component_index(j).first)
                                        == nonzero))
                                     {
                                       sparsity.add (dofs_on_this_cell[i],
@@ -1164,12 +1164,12 @@ namespace DoFTools
                                                     dofs_on_other_cell[j]);
                                     }
 
-                                  if ((flux_mask(neighbor->get_fe().system_to_component_index(j).first,
-                                                 cell->get_fe().system_to_component_index(i).first)
+                                  if ((flux_mask(neighbor->get_finite_element().system_to_component_index(j).first,
+                                                 cell->get_finite_element().system_to_component_index(i).first)
                                        == always)
                                       ||
-                                      (flux_mask(neighbor->get_fe().system_to_component_index(j).first,
-                                                 cell->get_fe().system_to_component_index(i).first)
+                                      (flux_mask(neighbor->get_finite_element().system_to_component_index(j).first,
+                                                 cell->get_finite_element().system_to_component_index(i).first)
                                        == nonzero))
                                     {
                                       sparsity.add (dofs_on_this_cell[j],

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2402,10 +2402,10 @@ get_interpolated_dof_values (const IndexSet &in,
 {
   Assert (cell->has_children() == false, ExcNotImplemented());
 
-  std::vector<types::global_dof_index> dof_indices (cell->get_fe().dofs_per_cell);
+  std::vector<types::global_dof_index> dof_indices (cell->get_finite_element().dofs_per_cell);
   cell->get_dof_indices (dof_indices);
 
-  for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+  for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
     out[i] = (in.is_element (dof_indices[i]) ? 1 : 0);
 }
 
@@ -4087,7 +4087,7 @@ FEValues<dim,spacedim>::reinit
   // used by the DoFHandler used by
   // this cell, are the same
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
-          static_cast<const FiniteElementData<dim>&>(cell->get_fe()),
+          static_cast<const FiniteElementData<dim>&>(cell->get_finite_element()),
           (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
 
   this->maybe_invalidate_previous_present_cell (cell);

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2031,7 +2031,7 @@ namespace internal
     template <int dim, int spacedim>
     Cache<dim,spacedim>::Cache (const FEValuesBase<dim,spacedim> &fe_values)
     {
-      const FiniteElement<dim,spacedim> &fe = fe_values.get_fe();
+      const FiniteElement<dim,spacedim> &fe = fe_values.get_finite_element();
 
       // create the views objects: Allocate a bunch of default-constructed ones
       // then destroy them again and do in-place construction of those we
@@ -4129,14 +4129,14 @@ void FEValues<dim,spacedim>::do_reinit ()
   // already filled by the mapping, let it compute the
   // data for the mapped shape function values, gradients,
   // etc.
-  this->get_fe().fill_fe_values(*this->present_cell,
-                                this->cell_similarity,
-                                this->quadrature,
-                                this->get_mapping(),
-                                *this->mapping_data,
-                                this->mapping_output,
-                                *this->fe_data,
-                                this->finite_element_output);
+  this->get_finite_element().fill_fe_values(*this->present_cell,
+                                            this->cell_similarity,
+                                            this->quadrature,
+                                            this->get_mapping(),
+                                            *this->mapping_data,
+                                            this->mapping_output,
+                                            *this->fe_data,
+                                            this->finite_element_output);
 }
 
 
@@ -4346,14 +4346,14 @@ void FEFaceValues<dim,spacedim>::do_reinit (const unsigned int face_no)
                                               this->mapping_output);
     }
 
-  this->get_fe().fill_fe_face_values(*this->present_cell,
-                                     face_no,
-                                     this->quadrature,
-                                     this->get_mapping(),
-                                     *this->mapping_data,
-                                     this->mapping_output,
-                                     *this->fe_data,
-                                     this->finite_element_output);
+  this->get_finite_element().fill_fe_face_values(*this->present_cell,
+                                                 face_no,
+                                                 this->quadrature,
+                                                 this->get_mapping(),
+                                                 *this->mapping_data,
+                                                 this->mapping_output,
+                                                 *this->fe_data,
+                                                 this->finite_element_output);
 }
 
 
@@ -4599,15 +4599,15 @@ void FESubfaceValues<dim,spacedim>::do_reinit (const unsigned int face_no,
                                                  this->mapping_output);
     }
 
-  this->get_fe().fill_fe_subface_values(*this->present_cell,
-                                        face_no,
-                                        subface_no,
-                                        this->quadrature,
-                                        this->get_mapping(),
-                                        *this->mapping_data,
-                                        this->mapping_output,
-                                        *this->fe_data,
-                                        this->finite_element_output);
+  this->get_finite_element().fill_fe_subface_values(*this->present_cell,
+                                                    face_no,
+                                                    subface_no,
+                                                    this->quadrature,
+                                                    this->get_mapping(),
+                                                    *this->mapping_data,
+                                                    this->mapping_output,
+                                                    *this->fe_data,
+                                                    this->finite_element_output);
 }
 
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3882,7 +3882,7 @@ next_cell:
         // cells including ghost cells
         if (cell->is_artificial() == false)
           {
-            const unsigned int n_dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int n_dofs_per_cell = cell->get_finite_element().dofs_per_cell;
             local_dof_indices.resize(n_dofs_per_cell);
 
             // Take care of adding cell pointer to each
@@ -3919,7 +3919,7 @@ next_cell:
                         //
                         Assert (cell->face(f)->child(c)->has_children() == false, ExcInternalError());
 
-                        const unsigned int n_dofs_per_face = cell->get_fe().dofs_per_face;
+                        const unsigned int n_dofs_per_face = cell->get_finite_element().dofs_per_face;
                         local_face_dof_indices.resize(n_dofs_per_face);
 
                         cell->face(f)->child(c)->get_dof_indices(local_face_dof_indices);
@@ -3949,7 +3949,7 @@ next_cell:
                     unsigned int face_no = neighbor_face_no_subface_no.first;
                     unsigned int subface = neighbor_face_no_subface_no.second;
 
-                    const unsigned int n_dofs_per_face = cell->get_fe().dofs_per_face;
+                    const unsigned int n_dofs_per_face = cell->get_finite_element().dofs_per_face;
                     local_face_dof_indices.resize(n_dofs_per_face);
 
                     cell->neighbor(f)->face(face_no)->get_dof_indices(local_face_dof_indices);
@@ -3962,7 +3962,7 @@ next_cell:
                       {
                         if (c != subface) // don't repeat work on dofs of original cell
                           {
-                            const unsigned int n_dofs_per_face = cell->get_fe().dofs_per_face;
+                            const unsigned int n_dofs_per_face = cell->get_finite_element().dofs_per_face;
                             local_face_dof_indices.resize(n_dofs_per_face);
 
                             Assert (cell->neighbor(f)->face(face_no)->child(c)->has_children() == false, ExcInternalError());
@@ -3994,8 +3994,8 @@ next_cell:
 
                             // dofs_per_line returns number of dofs
                             // on line not including the vertices of the line.
-                            const unsigned int n_dofs_per_line = 2*cell->get_fe().dofs_per_vertex
-                                                                 + cell->get_fe().dofs_per_line;
+                            const unsigned int n_dofs_per_line = 2*cell->get_finite_element().dofs_per_vertex
+                                                                 + cell->get_finite_element().dofs_per_line;
                             local_line_dof_indices.resize(n_dofs_per_line);
 
                             cell->line(l)->child(c)->get_dof_indices(local_line_dof_indices);
@@ -4014,8 +4014,8 @@ next_cell:
 
                         // dofs_per_line returns number of dofs
                         // on line not including the vertices of the line.
-                        const unsigned int n_dofs_per_line = 2*cell->get_fe().dofs_per_vertex
-                                                             + cell->get_fe().dofs_per_line;
+                        const unsigned int n_dofs_per_line = 2*cell->get_finite_element().dofs_per_vertex
+                                                             + cell->get_finite_element().dofs_per_line;
                         local_line_dof_indices.resize(n_dofs_per_line);
 
                         parent_line->get_dof_indices(local_line_dof_indices);
@@ -4026,8 +4026,8 @@ next_cell:
                           {
                             Assert (parent_line->child(c)->has_children() == false, ExcInternalError());
 
-                            const unsigned int n_dofs_per_line = 2*cell->get_fe().dofs_per_vertex
-                                                                 + cell->get_fe().dofs_per_line;
+                            const unsigned int n_dofs_per_line = 2*cell->get_finite_element().dofs_per_vertex
+                                                                 + cell->get_finite_element().dofs_per_line;
                             local_line_dof_indices.resize(n_dofs_per_line);
 
                             parent_line->child(c)->get_dof_indices(local_line_dof_indices);

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -251,10 +251,10 @@ namespace internal
                     !cell->is_artificial())
                   {
                     dof_handler.levels[level]->dof_offsets[cell->index()] = next_free_dof;
-                    next_free_dof += cell->get_fe().template n_dofs_per_object<dim>();
+                    next_free_dof += cell->get_finite_element().template n_dofs_per_object<dim>();
 
                     dof_handler.levels[level]->cell_cache_offsets[cell->index()] = cache_size;
-                    cache_size += cell->get_fe().dofs_per_cell;
+                    cache_size += cell->get_finite_element().dofs_per_cell;
                   }
 
               dof_handler.levels[level]->dof_indices
@@ -280,7 +280,7 @@ namespace internal
                 if (!cell->has_children()
                     &&
                     !cell->is_artificial())
-                  counter += cell->get_fe().template n_dofs_per_object<dim>();
+                  counter += cell->get_finite_element().template n_dofs_per_object<dim>();
 
               Assert (dof_handler.levels[level]->dof_indices.size() == counter,
                       ExcInternalError());
@@ -1135,7 +1135,7 @@ namespace hp
       for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
         if (cell->at_boundary(f))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
 
             cell->face(f)->get_dof_indices (dofs_on_face,
@@ -1170,7 +1170,7 @@ namespace hp
             (boundary_ids.find(cell->face(f)->boundary_id()) !=
              boundary_ids.end()))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_finite_element().dofs_per_face;
             dofs_on_face.resize (dofs_per_face);
 
             cell->face(f)->get_dof_indices (dofs_on_face,

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -141,7 +141,7 @@ namespace MGTools
     // smaller than dim-1.
     for (cell = dofs.begin(level); cell != end; ++cell)
       {
-        const FiniteElement<dim> &fe = cell->get_fe();
+        const FiniteElement<dim> &fe = cell->get_finite_element();
         cell_indices.resize(fe.dofs_per_cell);
         cell->get_mg_dof_indices(cell_indices);
         unsigned int i = 0;
@@ -226,7 +226,7 @@ namespace MGTools
                 continue;
               }
 
-            const FiniteElement<dim> &nfe = neighbor->get_fe();
+            const FiniteElement<dim> &nfe = neighbor->get_finite_element();
             typename DoFHandler<dim,spacedim>::face_iterator face = cell->face(iface);
 
             // Flux couplings are
@@ -324,7 +324,7 @@ namespace MGTools
     // smaller than dim-1.
     for (cell = dofs.begin_active(); cell != end; ++cell)
       {
-        const FiniteElement<dim> &fe = cell->get_fe();
+        const FiniteElement<dim> &fe = cell->get_finite_element();
         const unsigned int fe_index = cell->active_fe_index();
 
         Assert (couplings.n_rows()==fe.n_components(),
@@ -464,7 +464,7 @@ namespace MGTools
                 continue;
               }
 
-            const FiniteElement<dim> &nfe = neighbor->get_fe();
+            const FiniteElement<dim> &nfe = neighbor->get_finite_element();
             typename DoFHandler<dim,spacedim>::face_iterator face = cell->face(iface);
 
             // Flux couplings are
@@ -1252,7 +1252,7 @@ namespace MGTools
             if (dof.get_triangulation().locally_owned_subdomain()!=numbers::invalid_subdomain_id
                 && cell->level_subdomain_id()==numbers::artificial_subdomain_id)
               continue;
-            const FiniteElement<dim> &fe = cell->get_fe();
+            const FiniteElement<dim> &fe = cell->get_finite_element();
             const unsigned int level = cell->level();
             local_dofs.resize(fe.dofs_per_face);
 
@@ -1289,7 +1289,7 @@ namespace MGTools
                 if (cell->at_boundary(face_no) == false)
                   continue;
 
-                const FiniteElement<dim> &fe = cell->get_fe();
+                const FiniteElement<dim> &fe = cell->get_finite_element();
                 const unsigned int level = cell->level();
 
                 typename DoFHandler<dim,spacedim>::face_iterator face = cell->face(face_no);
@@ -1298,10 +1298,10 @@ namespace MGTools
                   // we want to constrain this boundary
                   {
 
-                    for (unsigned int i=0; i<cell->get_fe().dofs_per_cell; ++i)
+                    for (unsigned int i=0; i<cell->get_finite_element().dofs_per_cell; ++i)
                       {
                         const ComponentMask &nonzero_component_array
-                          = cell->get_fe().get_nonzero_components (i);
+                          = cell->get_finite_element().get_nonzero_components (i);
                         // if we want to constrain one of the nonzero components,
                         // we have to constrain all of them
 
@@ -1336,7 +1336,7 @@ namespace MGTools
                                 // We already know that either all or none
                                 // of the components are selected
                                 const ComponentMask &nonzero_component_array
-                                  = cell->get_fe().get_nonzero_components (i);
+                                  = cell->get_finite_element().get_nonzero_components (i);
                                 for (unsigned int c=0; c<n_components; ++c)
                                   if (nonzero_component_array[c] == true)
                                     {

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -140,7 +140,7 @@ build_one_patch
           const FEValuesBase<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &this_fe_patch_values
             = scratch_data.get_present_fe_values (dataset);
           const unsigned int n_components =
-            this_fe_patch_values.get_fe().n_components();
+            this_fe_patch_values.get_finite_element().n_components();
 
           const DataPostprocessor<DoFHandlerType::space_dimension> *postprocessor
             = this->dof_data[dataset]->postprocessor;

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -141,7 +141,7 @@ build_one_patch (const FaceDescriptor *cell_and_face,
           const FEValuesBase<dimension> &this_fe_patch_values
             = data.get_present_fe_values (dataset);
           const unsigned int n_components
-            = this_fe_patch_values.get_fe().n_components();
+            = this_fe_patch_values.get_finite_element().n_components();
           const DataPostprocessor<dim> *postprocessor=this->dof_data[dataset]->postprocessor;
           if (postprocessor != nullptr)
             {

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -188,7 +188,7 @@ build_one_patch (const cell_iterator                                            
               const FEValuesBase<dimension> &fe_patch_values
                 = data.get_present_fe_values(dataset);
               const unsigned int n_components
-                = fe_patch_values.get_fe().n_components();
+                = fe_patch_values.get_finite_element().n_components();
               const DataPostprocessor<dim> *postprocessor=this->dof_data[dataset]->postprocessor;
               if (postprocessor != nullptr)
                 {

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -132,7 +132,7 @@ namespace DerivativeApproximation
                               const InputVector    &solution,
                               const unsigned int    component)
     {
-      if (fe_values.get_fe().n_components() == 1)
+      if (fe_values.get_finite_element().n_components() == 1)
         {
           std::vector<typename InputVector::value_type> values (1);
           fe_values.get_function_values (solution, values);
@@ -141,7 +141,7 @@ namespace DerivativeApproximation
       else
         {
           std::vector<Vector<typename InputVector::value_type> > values
-          (1, Vector<typename InputVector::value_type>(fe_values.get_fe().n_components()));
+          (1, Vector<typename InputVector::value_type>(fe_values.get_finite_element().n_components()));
           fe_values.get_function_values (solution, values);
           return values[0](component);
         }
@@ -248,7 +248,7 @@ namespace DerivativeApproximation
                               const InputVector    &solution,
                               const unsigned int    component)
     {
-      if (fe_values.get_fe().n_components() == 1)
+      if (fe_values.get_finite_element().n_components() == 1)
         {
           std::vector<Tensor<1,dim,typename InputVector::value_type> > values (1);
           fe_values.get_function_gradients (solution, values);
@@ -257,7 +257,7 @@ namespace DerivativeApproximation
       else
         {
           std::vector<std::vector<Tensor<1,dim,typename InputVector::value_type> > > values
-          (1, std::vector<Tensor<1,dim,typename InputVector::value_type> >(fe_values.get_fe().n_components()));
+          (1, std::vector<Tensor<1,dim,typename InputVector::value_type> >(fe_values.get_finite_element().n_components()));
           fe_values.get_function_gradients (solution, values);
           return ProjectedDerivative(values[0][component]);
         };
@@ -591,7 +591,7 @@ namespace DerivativeApproximation
                               const InputVector    &solution,
                               const unsigned int    component)
     {
-      if (fe_values.get_fe().n_components() == 1)
+      if (fe_values.get_finite_element().n_components() == 1)
         {
           std::vector<Tensor<2,dim,typename InputVector::value_type> > values (1);
           fe_values.get_function_hessians (solution, values);
@@ -600,7 +600,7 @@ namespace DerivativeApproximation
       else
         {
           std::vector<std::vector<Tensor<2,dim,typename InputVector::value_type> > > values
-          (1, std::vector<Tensor<2,dim,typename InputVector::value_type> >(fe_values.get_fe().n_components()));
+          (1, std::vector<Tensor<2,dim,typename InputVector::value_type> >(fe_values.get_finite_element().n_components()));
           fe_values.get_function_hessians (solution, values);
           return ProjectedDerivative(values[0][component]);
         };

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -96,7 +96,7 @@ void SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_for_pure_refinem
 
   for (unsigned int i=0; cell!=endc; ++cell, ++i)
     {
-      indices_on_cell[i].resize(cell->get_fe().dofs_per_cell);
+      indices_on_cell[i].resize(cell->get_finite_element().dofs_per_cell);
       // on each cell store the indices of the
       // dofs. after refining we get the values
       // on the children by taking these
@@ -315,7 +315,7 @@ prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
       // CASE 1: active cell that remains as it is
       if (cell->active() && !cell->coarsen_flag_set())
         {
-          const unsigned int dofs_per_cell=cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell=cell->get_finite_element().dofs_per_cell;
           indices_on_cell[n_sr].resize(dofs_per_cell);
           // cell will not be coarsened,
           // so we get away by storing the
@@ -359,8 +359,8 @@ prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
           unsigned int most_general_child = 0;
           if (different_fe_on_children == true)
             for (unsigned int child=1; child<cell->n_children(); ++child)
-              if (cell->child(child)->get_fe().dofs_per_cell >
-                  cell->child(most_general_child)->get_fe().dofs_per_cell)
+              if (cell->child(child)->get_finite_element().dofs_per_cell >
+                  cell->child(most_general_child)->get_finite_element().dofs_per_cell)
                 most_general_child = child;
           const unsigned int target_finite_element_index = cell->child(most_general_child)->active_fe_index();
 
@@ -482,7 +482,7 @@ interpolate (const std::vector<VectorType> &all_in,
               Assert (indexptr == nullptr,
                       ExcInternalError());
 
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell = cell->get_finite_element().dofs_per_cell;
               dofs.resize(dofs_per_cell);
               // get the local
               // indices


### PR DESCRIPTION
Based on #4939. 

`FEValuesBase` is the last class implementing `get_fe()`. As in the previous PRs we deprecate this method in favor of `get_finite_element()` for conformity with the new naming in the other (`DoFHandler`, `hp::DoFHandler`, `DoFAccessor`) classes.