### PR TITLE
Disabled a few extra diagnostic warnings for external packages

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -303,6 +303,9 @@ _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")         \
 _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")     \
 _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")      \
 _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")     \
+_Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")       \
+_Pragma("GCC diagnostic ignored \"-Woverflow\"")                 \
+_Pragma("GCC diagnostic ignored \"-Wpedantic\"")                 \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \


### PR DESCRIPTION
- `-Wignored-qualifiers`
- `-Woverflow`
- `-Wpedantic`
