### PR TITLE
Use std::chrono types in the Timer class.

### DIFF
--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -20,7 +20,6 @@
 #   DEAL_II_HAVE_GETPID
 #   DEAL_II_HAVE_JN
 #   DEAL_II_HAVE_SYS_RESOURCE_H
-#   DEAL_II_HAVE_SYS_TIME_H
 #   DEAL_II_HAVE_UNISTD_H
 #   DEAL_II_MSVC
 #
@@ -36,8 +35,6 @@
 # Check for various posix (and linux) specific header files and symbols
 #
 CHECK_INCLUDE_FILE_CXX("sys/resource.h" DEAL_II_HAVE_SYS_RESOURCE_H)
-
-CHECK_INCLUDE_FILE_CXX("sys/time.h" DEAL_II_HAVE_SYS_TIME_H)
 
 CHECK_INCLUDE_FILE_CXX("unistd.h" DEAL_II_HAVE_UNISTD_H)
 CHECK_CXX_SYMBOL_EXISTS("gethostname" "unistd.h" DEAL_II_HAVE_GETHOSTNAME)

--- a/doc/news/changes/incompatibilities/20170819DavidWellsMatthiasMaier
+++ b/doc/news/changes/incompatibilities/20170819DavidWellsMatthiasMaier
@@ -13,6 +13,7 @@ are no longer defined:
   <li> <code>DEAL_II_HAVE_SYS_TIMES_H</code>
   <li> <code>DEAL_II_HAVE_TIMES</code>
   <li> <code>DEAL_II_HAVE_SYS_TYPES_H</code>
+  <li> <code>DEAL_II_HAVE_SYS_TIMES_H</code>
 </ul>
 
-<br> (Matthias Maier and David Wells, 2017/08/08 - 2017/08/19)
+<br> (Matthias Maier and David Wells, 2017/08/08 - 2017/08/24)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -123,7 +123,6 @@
  */
 
 #cmakedefine DEAL_II_HAVE_SYS_RESOURCE_H
-#cmakedefine DEAL_II_HAVE_SYS_TIME_H
 #cmakedefine DEAL_II_HAVE_UNISTD_H
 #cmakedefine DEAL_II_HAVE_GETHOSTNAME
 #cmakedefine DEAL_II_HAVE_GETPID


### PR DESCRIPTION
This commit does two things:
1. The CPU time calculating function has been moved to a `std::chrono`-compliant clock class.
2. The various time measurements stored as private members of Timer have been reorganized into two structs of type `ClockMeasurements`. The new, equivalent fields use `std::chrono` types instead of double precision numbers.

Part of #4867.