### PR TITLE
More uses of the VectorMemory::Pointer class.

### DIFF
--- a/include/deal.II/lac/constrained_linear_operator.h
+++ b/include/deal.II/lac/constrained_linear_operator.h
@@ -318,13 +318,11 @@ constrained_right_hand_side(const ConstraintMatrix &constraint_matrix,
     const auto Ct = transpose_operator(C);
 
     static GrowingVectorMemory<Domain> vector_memory;
-    Domain *k = vector_memory.alloc();
+    typename VectorMemory<Domain>::Pointer k (vector_memory);
     linop.reinit_domain_vector(*k, /*bool fast=*/ false);
     constraint_matrix.distribute(*k);
 
     v += Ct * (right_hand_side - linop **k);
-
-    vector_memory.free(k);
   };
 
   // lambda capture expressions are a C++14 feature...

--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -239,10 +239,10 @@ EigenPower<VectorType>::solve (double           &value,
 
   deallog.push("Power method");
 
-  VectorType *Vy = this->memory.alloc ();
+  typename VectorMemory<VectorType>::Pointer Vy (this->memory);
   VectorType &y = *Vy;
   y.reinit (x);
-  VectorType *Vr = this->memory.alloc ();
+  typename VectorMemory<VectorType>::Pointer Vr (this->memory);
   VectorType &r = *Vr;
   r.reinit (x);
 
@@ -290,9 +290,6 @@ EigenPower<VectorType>::solve (double           &value,
       // Brrr, this is not really a good criterion
       conv = this->iteration_status (iter, std::fabs(1./length-1./old_length), x);
     }
-
-  this->memory.free(Vy);
-  this->memory.free(Vr);
 
   deallog.pop();
 

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -750,26 +750,22 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
   {
     static GrowingVectorMemory<Range> vector_memory;
 
-    Range *i = vector_memory.alloc();
+    typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.vmult(v, *i);
-
-    vector_memory.free(i);
   };
 
   return_comp.apply_add = [op, comp](Domain &v)
   {
     static GrowingVectorMemory<Range> vector_memory;
 
-    Range *i = vector_memory.alloc();
+    typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.vmult_add(v, *i);
-
-    vector_memory.free(i);
   };
 
   return return_comp;
@@ -800,26 +796,22 @@ operator*(const PackagedOperation<Range> &comp,
   {
     static GrowingVectorMemory<Range> vector_memory;
 
-    Range *i = vector_memory.alloc();
+    typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.Tvmult(v, *i);
-
-    vector_memory.free(i);
   };
 
   return_comp.apply_add = [op, comp](Domain &v)
   {
     static GrowingVectorMemory<Range> vector_memory;
 
-    Range *i = vector_memory.alloc();
+    typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
 
     comp.apply(*i);
     op.Tvmult_add(v, *i);
-
-    vector_memory.free(i);
   };
 
   return return_comp;


### PR DESCRIPTION
Again see #4935.