### PR TITLE
Replace get_finite_element() by get_fe() again

### DIFF
--- a/doc/news/changes/minor/20170825DanielArndt
+++ b/doc/news/changes/minor/20170825DanielArndt
@@ -1,0 +1,6 @@
+Changed: DoFHandler::get_finite_element(unsigned int) has been removed again in
+favor of equipping DoFHandler::get_fe() with a (defaulted) unsigned int
+parameter. hp::DoFHandler::get_finite_element(unsigned int)  has been renamed to
+hp::DoFHandler::get_fe(unsigned int).
+<br>
+(Daniel Arndt, 2017/08/25)

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -257,7 +257,7 @@ namespace Step12
     // formula with number of points one higher than the polynomial degree
     // used. Since the quadratures for cells, boundary and interior faces can
     // be selected independently, we have to hand over this value three times.
-    const unsigned int n_gauss_points = dof_handler.get_finite_element().degree+1;
+    const unsigned int n_gauss_points = dof_handler.get_fe().degree+1;
     info_box.initialize_gauss_quadrature(n_gauss_points,
                                          n_gauss_points,
                                          n_gauss_points);

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -257,7 +257,7 @@ namespace Step13
               //
               // Ideally, we would check this at the beginning of the
               // function, for example by a statement like <code>Assert
-              // (dof_handler.get_finite_element().dofs_per_vertex @> 0,
+              // (dof_handler.get_fe().dofs_per_vertex @> 0,
               // ExcNotImplemented())</code>, which should make it quite clear
               // what is going wrong when the exception is triggered. In this
               // case, we omit it (which is indeed bad style), but knowing

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -219,7 +219,7 @@ namespace Step14
       // ...then have some objects of which the meaning will become clear
       // below...
       QTrapez<dim>  vertex_quadrature;
-      FEValues<dim> fe_values (dof_handler.get_finite_element(),
+      FEValues<dim> fe_values (dof_handler.get_fe(),
                                vertex_quadrature,
                                update_gradients | update_quadrature_points);
       std::vector<Tensor<1,dim> >
@@ -1654,12 +1654,12 @@ namespace Step14
       // have abbreviations for the number of quadrature points and shape
       // functions...
       QGauss<dim> quadrature(4);
-      FEValues<dim>  fe_values (dof_handler.get_finite_element(), quadrature,
+      FEValues<dim>  fe_values (dof_handler.get_fe(), quadrature,
                                 update_gradients |
                                 update_quadrature_points  |
                                 update_JxW_values);
       const unsigned int n_q_points = fe_values.n_quadrature_points;
-      const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+      const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
 
       // ...and have two objects that are used to store the global indices of
       // the degrees of freedom on a cell, and the values of the gradients of

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -434,7 +434,7 @@ namespace Step30
   template <int dim>
   void DGMethod<dim>::assemble_system2 ()
   {
-    const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> dofs (dofs_per_cell);
     std::vector<types::global_dof_index> dofs_neighbor (dofs_per_cell);
 

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -469,12 +469,12 @@ namespace Step33
                                    const Vector<double>  &solution,
                                    Vector<double>        &refinement_indicators)
     {
-      const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+      const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
       std::vector<unsigned int> dofs (dofs_per_cell);
 
       const QMidpoint<dim>  quadrature_formula;
       const UpdateFlags update_flags = update_gradients;
-      FEValues<dim> fe_v (mapping, dof_handler.get_finite_element(),
+      FEValues<dim> fe_v (mapping, dof_handler.get_fe(),
                           quadrature_formula, update_flags);
 
       std::vector<std::vector<Tensor<1,dim> > >
@@ -1431,7 +1431,7 @@ namespace Step33
   template <int dim>
   void ConservationLaw<dim>::assemble_system ()
   {
-    const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
 
     std::vector<types::global_dof_index> dof_indices (dofs_per_cell);
     std::vector<types::global_dof_index> dof_indices_neighbor (dofs_per_cell);

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -759,7 +759,7 @@ namespace Step39
 
     // This starts like before,
     MeshWorker::IntegrationInfoBox<dim> info_box;
-    const unsigned int n_gauss_points = dof_handler.get_finite_element().tensor_degree()+1;
+    const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;
     info_box.initialize_gauss_quadrature(n_gauss_points, n_gauss_points+1, n_gauss_points);
 
     // but now we need to notify the info box of the finite element function we
@@ -827,7 +827,7 @@ namespace Step39
       cell->set_user_index(i);
 
     MeshWorker::IntegrationInfoBox<dim> info_box;
-    const unsigned int n_gauss_points = dof_handler.get_finite_element().tensor_degree()+1;
+    const unsigned int n_gauss_points = dof_handler.get_fe().tensor_degree()+1;
     info_box.initialize_gauss_quadrature(n_gauss_points, n_gauss_points+1, n_gauss_points);
 
     AnyData solution_data;

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -482,7 +482,7 @@ namespace Step41
     for (; cell!=endc; ++cell)
       for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
         {
-          Assert (dof_handler.get_finite_element().dofs_per_cell ==
+          Assert (dof_handler.get_fe().dofs_per_cell ==
                   GeometryInfo<dim>::vertices_per_cell,
                   ExcNotImplemented());
 

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -1314,7 +1314,7 @@ namespace Step43
     FEFaceValues<dim> saturation_fe_face_values_neighbor (saturation_fe, face_quadrature_formula,
                                                           update_values);
 
-    const unsigned int dofs_per_cell = saturation_dof_handler.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = saturation_dof_handler.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
 
     const double                   global_max_u_F_prime = get_max_u_F_prime ();

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1037,7 +1037,7 @@ namespace Step9
                      end_sync_it,
                      &GradientEstimation::template estimate_cell<dim>,
                      std::function<void (const EstimateCopyData &)> (),
-                     EstimateScratchData<dim> (dof_handler.get_finite_element(),
+                     EstimateScratchData<dim> (dof_handler.get_fe(),
                                                solution),
                      EstimateCopyData ());
   }

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -696,7 +696,7 @@ namespace internal
                            const unsigned int              i)
       {
         return dof_handler.mg_vertex_dofs[vertex_index].get_index (level, i,
-                                                                   dof_handler.get_finite_element().dofs_per_vertex);
+                                                                   dof_handler.get_fe().dofs_per_vertex);
       }
 
 
@@ -723,7 +723,7 @@ namespace internal
                                types::global_dof_index         index)
       {
         return dof_handler.mg_vertex_dofs[vertex_index].set_index (level, i,
-                                                                   dof_handler.get_finite_element().dofs_per_vertex,
+                                                                   dof_handler.get_fe().dofs_per_vertex,
                                                                    index);
       }
 
@@ -1140,12 +1140,12 @@ namespace internal
         (void)fe_index;
         Assert ((fe_index == dealii::DoFHandler<dim,spacedim>::default_fe_index),
                 ExcMessage ("Only the default FE index is allowed for non-hp DoFHandler objects"));
-        Assert (local_index < dof_handler.get_finite_element().dofs_per_vertex,
+        Assert (local_index < dof_handler.get_fe().dofs_per_vertex,
                 ExcIndexRange(local_index, 0,
-                              dof_handler.get_finite_element().dofs_per_vertex));
+                              dof_handler.get_fe().dofs_per_vertex));
 
         dof_handler.vertex_dofs[vertex_index *
-                                dof_handler.get_finite_element().dofs_per_vertex
+                                dof_handler.get_fe().dofs_per_vertex
                                 + local_index]
           = global_index;
       }
@@ -1226,13 +1226,13 @@ namespace internal
         (void)fe_index;
         Assert ((fe_index == dealii::DoFHandler<dim,spacedim>::default_fe_index),
                 ExcMessage ("Only the default FE index is allowed for non-hp DoFHandler objects"));
-        Assert (local_index < dof_handler.get_finite_element().dofs_per_vertex,
+        Assert (local_index < dof_handler.get_fe().dofs_per_vertex,
                 ExcIndexRange(local_index, 0,
-                              dof_handler.get_finite_element().dofs_per_vertex));
+                              dof_handler.get_fe().dofs_per_vertex));
 
         return
           dof_handler.vertex_dofs[vertex_index *
-                                  dof_handler.get_finite_element().dofs_per_vertex
+                                  dof_handler.get_fe().dofs_per_vertex
                                   + local_index];
       }
 
@@ -1469,7 +1469,7 @@ namespace internal
                                const unsigned int fe_index)
       {
         const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-          = accessor.get_dof_handler ().get_finite_element(fe_index);
+          = accessor.get_dof_handler ().get_fe(fe_index);
         std::vector<types::global_dof_index>::const_iterator next = dof_indices.begin ();
 
         for (unsigned int vertex = 0; vertex < GeometryInfo<2>::vertices_per_cell; ++vertex)
@@ -1497,7 +1497,7 @@ namespace internal
        const unsigned int                          fe_index)
       {
         const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-          = accessor.get_dof_handler ().get_finite_element(fe_index);
+          = accessor.get_dof_handler ().get_fe(fe_index);
         std::vector<types::global_dof_index>::const_iterator next = dof_indices.begin ();
 
         for (unsigned int vertex = 0; vertex < GeometryInfo<3>::vertices_per_cell; ++vertex)
@@ -1715,8 +1715,8 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::mg_vertex_dof_index (co
   Assert (this->dof_handler != nullptr, ExcInvalidObject ());
   Assert (vertex < GeometryInfo<structdim>::vertices_per_cell,
           ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert (i < this->dof_handler->get_finite_element (fe_index).dofs_per_vertex,
-          ExcIndexRange (i, 0, this->dof_handler->get_finite_element (fe_index).dofs_per_vertex));
+  Assert (i < this->dof_handler->get_fe (fe_index).dofs_per_vertex,
+          ExcIndexRange (i, 0, this->dof_handler->get_fe (fe_index).dofs_per_vertex));
 
   return
     dealii::internal::DoFAccessor::Implementation::mg_vertex_dof_index
@@ -1758,8 +1758,8 @@ DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_vertex_dof_index
   Assert (this->dof_handler != nullptr, ExcInvalidObject ());
   Assert (vertex < GeometryInfo<structdim>::vertices_per_cell,
           ExcIndexRange (vertex, 0, GeometryInfo<structdim>::vertices_per_cell));
-  Assert (i < this->dof_handler->get_finite_element (fe_index).dofs_per_vertex,
-          ExcIndexRange (i, 0, this->dof_handler->get_finite_element (fe_index).dofs_per_vertex));
+  Assert (i < this->dof_handler->get_fe (fe_index).dofs_per_vertex,
+          ExcIndexRange (i, 0, this->dof_handler->get_fe (fe_index).dofs_per_vertex));
 
   return
     dealii::internal::DoFAccessor::Implementation::set_mg_vertex_dof_index
@@ -1792,7 +1792,7 @@ DoFAccessor<dim,DoFHandlerType,level_dof_access>::get_fe (const unsigned int fe_
   Assert (fe_index_is_active (fe_index) == true,
           ExcMessage ("This function can only be called for active fe indices"));
 
-  return this->dof_handler->get_finite_element(fe_index);
+  return this->dof_handler->get_fe(fe_index);
 }
 
 
@@ -1919,7 +1919,7 @@ namespace internal
       const DoFHandlerType &handler = accessor.get_dof_handler();
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-        = handler.get_finite_element (fe_index);
+        = handler.get_fe (fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin ();
 
       for (unsigned int vertex = 0; vertex < GeometryInfo<1>::vertices_per_cell; ++vertex)
@@ -1943,7 +1943,7 @@ namespace internal
       const DoFHandlerType &handler = accessor.get_dof_handler();
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-        = handler.get_finite_element (fe_index);
+        = handler.get_fe (fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin ();
 
       for (unsigned int vertex = 0; vertex < GeometryInfo<2>::vertices_per_cell; ++vertex)
@@ -1972,7 +1972,7 @@ namespace internal
       const DoFHandlerType &handler = accessor.get_dof_handler();
 
       const FiniteElement<DoFHandlerType::dimension, DoFHandlerType::space_dimension> &fe
-        = handler.get_finite_element (fe_index);
+        = handler.get_fe (fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin ();
 
       for (unsigned int vertex = 0; vertex < GeometryInfo<3>::vertices_per_cell; ++vertex)
@@ -2023,23 +2023,23 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::get_dof_indices
     {
     case 1:
       Assert (dof_indices.size() ==
-              (2*this->dof_handler->get_finite_element(fe_index).dofs_per_vertex +
-               this->dof_handler->get_finite_element(fe_index).dofs_per_line),
+              (2*this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+               this->dof_handler->get_fe(fe_index).dofs_per_line),
               ExcVectorDoesNotMatch());
       break;
     case 2:
       Assert (dof_indices.size() ==
-              (4*this->dof_handler->get_finite_element(fe_index).dofs_per_vertex +
-               4*this->dof_handler->get_finite_element(fe_index).dofs_per_line +
-               this->dof_handler->get_finite_element(fe_index).dofs_per_quad),
+              (4*this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+               4*this->dof_handler->get_fe(fe_index).dofs_per_line +
+               this->dof_handler->get_fe(fe_index).dofs_per_quad),
               ExcVectorDoesNotMatch());
       break;
     case 3:
       Assert (dof_indices.size() ==
-              (8*this->dof_handler->get_finite_element(fe_index).dofs_per_vertex +
-               12*this->dof_handler->get_finite_element(fe_index).dofs_per_line +
-               6*this->dof_handler->get_finite_element(fe_index).dofs_per_quad +
-               this->dof_handler->get_finite_element(fe_index).dofs_per_hex),
+              (8*this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+               12*this->dof_handler->get_fe(fe_index).dofs_per_line +
+               6*this->dof_handler->get_fe(fe_index).dofs_per_quad +
+               this->dof_handler->get_fe(fe_index).dofs_per_hex),
               ExcVectorDoesNotMatch());
       break;
     default:
@@ -2060,9 +2060,9 @@ DoFAccessor<structdim,DoFHandlerType,level_dof_access>::get_dof_indices
   // non-active thing
   Assert (this->fe_index_is_active (fe_index)
           ||
-          (this->dof_handler->get_finite_element(fe_index).dofs_per_cell ==
+          (this->dof_handler->get_fe(fe_index).dofs_per_cell ==
            GeometryInfo<structdim>::vertices_per_cell *
-           this->dof_handler->get_finite_element(fe_index).dofs_per_vertex),
+           this->dof_handler->get_fe(fe_index).dofs_per_vertex),
           ExcInternalError());
 
   // now do the actual work
@@ -2085,8 +2085,8 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::get_mg_dof_indices
     case 1:
     {
       Assert (dof_indices.size () ==
-              2 * this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_line,
+              2 * this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+              this->dof_handler->get_fe (fe_index).dofs_per_line,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2094,9 +2094,9 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::get_mg_dof_indices
     case 2:
     {
       Assert (dof_indices.size () ==
-              4 * (this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-                   this->dof_handler->get_finite_element (fe_index).dofs_per_line) +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_quad,
+              4 * (this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+                   this->dof_handler->get_fe (fe_index).dofs_per_line) +
+              this->dof_handler->get_fe (fe_index).dofs_per_quad,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2104,10 +2104,10 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::get_mg_dof_indices
     case 3:
     {
       Assert (dof_indices.size () ==
-              8 * this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-              12 * this->dof_handler->get_finite_element (fe_index).dofs_per_line +
-              6 * this->dof_handler->get_finite_element (fe_index).dofs_per_quad +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_hex,
+              8 * this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+              12 * this->dof_handler->get_fe (fe_index).dofs_per_line +
+              6 * this->dof_handler->get_fe (fe_index).dofs_per_quad +
+              this->dof_handler->get_fe (fe_index).dofs_per_hex,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2137,8 +2137,8 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_dof_indices
     case 1:
     {
       Assert (dof_indices.size () ==
-              2 * this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_line,
+              2 * this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+              this->dof_handler->get_fe (fe_index).dofs_per_line,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2146,9 +2146,9 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_dof_indices
     case 2:
     {
       Assert (dof_indices.size () ==
-              4 * (this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-                   this->dof_handler->get_finite_element (fe_index).dofs_per_line) +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_quad,
+              4 * (this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+                   this->dof_handler->get_fe (fe_index).dofs_per_line) +
+              this->dof_handler->get_fe (fe_index).dofs_per_quad,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2156,10 +2156,10 @@ void DoFAccessor<structdim, DoFHandlerType,level_dof_access>::set_mg_dof_indices
     case 3:
     {
       Assert (dof_indices.size () ==
-              8 * this->dof_handler->get_finite_element (fe_index).dofs_per_vertex +
-              12 * this->dof_handler->get_finite_element (fe_index).dofs_per_line +
-              6 * this->dof_handler->get_finite_element (fe_index).dofs_per_quad +
-              this->dof_handler->get_finite_element (fe_index).dofs_per_hex,
+              8 * this->dof_handler->get_fe (fe_index).dofs_per_vertex +
+              12 * this->dof_handler->get_fe (fe_index).dofs_per_line +
+              6 * this->dof_handler->get_fe (fe_index).dofs_per_quad +
+              this->dof_handler->get_fe (fe_index).dofs_per_hex,
               ExcVectorDoesNotMatch ());
       break;
     }
@@ -2447,7 +2447,7 @@ get_mg_dof_indices (const int,
   (void) fe_index;
   Assert (this->dof_handler != nullptr, ExcInvalidObject ());
   Assert (dof_indices.size () ==
-          this->dof_handler->get_finite_element (fe_index).dofs_per_vertex,
+          this->dof_handler->get_fe (fe_index).dofs_per_vertex,
           ExcVectorDoesNotMatch ());
 
   Assert (false, ExcNotImplemented());
@@ -2533,7 +2533,7 @@ DoFAccessor<0,DoFHandlerType<1,spacedim>, level_dof_access>::
 get_fe (const unsigned int fe_index) const
 {
   Assert (this->dof_handler != nullptr, ExcInvalidObject());
-  return dof_handler->get_finite_element(fe_index);
+  return dof_handler->get_fe(fe_index);
 }
 
 
@@ -2798,7 +2798,7 @@ namespace internal
         // (cell-local) ordering.
         for (unsigned int line=0; line<12; ++line)
           for (unsigned int d=0; d<dofs_per_line; ++d)
-            *next++ = accessor.line(line)->dof_index(accessor.dof_handler->get_finite_element().
+            *next++ = accessor.line(line)->dof_index(accessor.dof_handler->get_fe().
                                                      adjust_line_dof_index_for_line_orientation(d,
                                                          accessor.line_orientation(line)));
         // now copy dof numbers from the face. for
@@ -2816,7 +2816,7 @@ namespace internal
         // face_orientation is non-standard
         for (unsigned int quad=0; quad<6; ++quad)
           for (unsigned int d=0; d<dofs_per_quad; ++d)
-            *next++ = accessor.quad(quad)->dof_index(accessor.dof_handler->get_finite_element().
+            *next++ = accessor.quad(quad)->dof_index(accessor.dof_handler->get_fe().
                                                      adjust_quad_dof_index_for_face_orientation(d,
                                                          accessor.face_orientation(quad),
                                                          accessor.face_flip(quad),
@@ -2984,7 +2984,7 @@ namespace internal
         // (cell-local) ordering.
         for (unsigned int line=0; line<12; ++line)
           for (unsigned int d=0; d<dofs_per_line; ++d, ++index)
-            accessor.line(line)->set_dof_index(accessor.dof_handler->get_finite_element().
+            accessor.line(line)->set_dof_index(accessor.dof_handler->get_fe().
                                                adjust_line_dof_index_for_line_orientation(d,
                                                    accessor.line_orientation(line)),
                                                local_dof_indices[index]);
@@ -3003,7 +3003,7 @@ namespace internal
         // face_orientation is non-standard
         for (unsigned int quad=0; quad<6; ++quad)
           for (unsigned int d=0; d<dofs_per_quad; ++d, ++index)
-            accessor.quad(quad)->set_dof_index(accessor.dof_handler->get_finite_element().
+            accessor.quad(quad)->set_dof_index(accessor.dof_handler->get_fe().
                                                adjust_quad_dof_index_for_face_orientation(d,
                                                    accessor.face_orientation(quad),
                                                    accessor.face_flip(quad),
@@ -3705,7 +3705,7 @@ DoFCellAccessor<DoFHandlerType,level_dof_access>::get_fe () const
           ExcMessage ("In hp::DoFHandler objects, finite elements are only associated "
                       "with active cells. Consequently, you can not ask for the "
                       "active finite element on cells with children."));
-  return this->dof_handler->get_finite_element(active_fe_index());
+  return this->dof_handler->get_fe(active_fe_index());
 }
 
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -832,18 +832,11 @@ public:
 
   /**
    * Return a constant reference to the selected finite element object.
-   *
-   * @deprecated Use get_finite_element() instead.
-   */
-  const FiniteElement<dim,spacedim> &get_fe () const DEAL_II_DEPRECATED;
-
-  /**
-   * Return a constant reference to the selected finite element object.
    * Since there is only one FiniteElement @index must be equal to zero
    * which is also the default value.
    */
   const FiniteElement<dim,spacedim> &
-  get_finite_element (const unsigned int index=0) const;
+  get_fe (const unsigned int index=0) const;
 
   /**
     * Return a constant reference to the set of finite element objects that
@@ -1231,17 +1224,7 @@ DoFHandler<dim, spacedim>::locally_owned_mg_dofs_per_processor (const unsigned i
 template <int dim, int spacedim>
 inline
 const FiniteElement<dim,spacedim> &
-DoFHandler<dim,spacedim>::get_fe () const
-{
-  return this->get_finite_element();
-}
-
-
-
-template <int dim, int spacedim>
-inline
-const FiniteElement<dim,spacedim> &
-DoFHandler<dim,spacedim>::get_finite_element
+DoFHandler<dim,spacedim>::get_fe
 (const unsigned int index) const
 {
   (void) index;
@@ -1342,7 +1325,7 @@ void DoFHandler<dim,spacedim>::save (Archive &ar,
   // loading that this number is indeed correct; same with something that
   // identifies the FE and the policy
   unsigned int n_cells = tria->n_cells();
-  std::string  fe_name = this->get_finite_element().get_name();
+  std::string  fe_name = this->get_fe(0).get_name();
   std::string  policy_name = internal::policy_to_string(*policy);
 
   ar &n_cells &fe_name &policy_name;
@@ -1392,7 +1375,7 @@ void DoFHandler<dim,spacedim>::load (Archive &ar,
   AssertThrow (n_cells == tria->n_cells(),
                ExcMessage ("The object being loaded into does not match the triangulation "
                            "that has been stored previously."));
-  AssertThrow (fe_name == this->get_finite_element().get_name(),
+  AssertThrow (fe_name == this->get_fe(0).get_name(),
                ExcMessage ("The finite element associated with this DoFHandler does not match "
                            "the one that was associated with the DoFHandler previously stored."));
   AssertThrow (policy_name == internal::policy_to_string(*policy),

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -194,14 +194,14 @@ namespace internal
       (void)fe_index;
       Assert ((fe_index == dealii::DoFHandler<dh_dim,spacedim>::default_fe_index),
               ExcMessage ("Only the default FE index is allowed for non-hp DoFHandler objects"));
-      Assert (local_index<dof_handler.get_finite_element().template n_dofs_per_object<dim>(),
-              ExcIndexRange (local_index, 0, dof_handler.get_finite_element().template n_dofs_per_object<dim>()));
-      Assert (obj_index * dof_handler.get_finite_element().template n_dofs_per_object<dim>()+local_index
+      Assert (local_index<dof_handler.get_fe().template n_dofs_per_object<dim>(),
+              ExcIndexRange (local_index, 0, dof_handler.get_fe().template n_dofs_per_object<dim>()));
+      Assert (obj_index * dof_handler.get_fe().template n_dofs_per_object<dim>()+local_index
               <
               dofs.size(),
               ExcInternalError());
 
-      return dofs[obj_index * dof_handler.get_finite_element()
+      return dofs[obj_index * dof_handler.get_fe()
                   .template n_dofs_per_object<dim>() + local_index];
     }
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -385,7 +385,7 @@ namespace DoFTools
    * This function exists for both non-hp and hp DoFHandlers, to allow for a
    * uniform interface to query this property.
    *
-   * @deprecated Use <code>dh.get_finite_element(0).is_primitive()</code>.
+   * @deprecated Use <code>dh.get_fe(0).is_primitive()</code>.
    *
    * @relates DoFHandler
    */
@@ -400,7 +400,7 @@ namespace DoFTools
    * This function exists for both non-hp and hp DoFHandlers, to allow for a
    * uniform interface to query this property.
    *
-   * @deprecated Use <code>dh.get_finite_element(0).is_primitive()</code>.
+   * @deprecated Use <code>dh.get_fe(0).is_primitive()</code>.
    *
    * @relates hp::DoFHandler
    */
@@ -2512,7 +2512,7 @@ namespace DoFTools
   unsigned int
   max_dofs_per_cell (const DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element().dofs_per_cell;
+    return dh.get_fe().dofs_per_cell;
   }
 
 
@@ -2521,7 +2521,7 @@ namespace DoFTools
   unsigned int
   max_dofs_per_face (const DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element().dofs_per_face;
+    return dh.get_fe().dofs_per_face;
   }
 
 
@@ -2530,7 +2530,7 @@ namespace DoFTools
   unsigned int
   max_dofs_per_vertex (const DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element().dofs_per_vertex;
+    return dh.get_fe().dofs_per_vertex;
   }
 
 
@@ -2539,7 +2539,7 @@ namespace DoFTools
   unsigned int
   n_components (const DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element().n_components();
+    return dh.get_fe().n_components();
   }
 
 
@@ -2549,7 +2549,7 @@ namespace DoFTools
   bool
   fe_is_primitive (const DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element().is_primitive();
+    return dh.get_fe().is_primitive();
   }
 
 
@@ -2585,7 +2585,7 @@ namespace DoFTools
   unsigned int
   n_components (const hp::DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element(0).n_components();
+    return dh.get_fe(0).n_components();
   }
 
 
@@ -2594,7 +2594,7 @@ namespace DoFTools
   bool
   fe_is_primitive (const hp::DoFHandler<dim,spacedim> &dh)
   {
-    return dh.get_finite_element(0).is_primitive();
+    return dh.get_fe(0).is_primitive();
   }
 
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -733,7 +733,7 @@ public:
    * version hp::DoFHandler, since one can then write code like this:
    * @code
    *   dofs_per_cell
-   *     = dof_handler->get_finite_element()[cell->active_fe_index()].dofs_per_cell;
+   *     = dof_handler->get_fe()[cell->active_fe_index()].dofs_per_cell;
    * @endcode
    *
    * This code doesn't work in both situations without the present operator

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -495,7 +495,7 @@ namespace FETools
 
       if (locally_owned_children)
         {
-          const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_finite_element();
+          const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_fe();
           const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
           Vector<typename OutVector::value_type> interpolated_values(dofs_per_cell);
@@ -560,7 +560,7 @@ namespace FETools
         }
       else
         {
-          const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_finite_element();
+          const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_fe();
           const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
           Assert (interpolated_values.size() == dofs_per_cell,
@@ -668,7 +668,7 @@ namespace FETools
                                      const Vector<value_type>                                      &local_values,
                                      OutVector                                                     &u)
     {
-      const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_finite_element();
+      const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_fe();
       const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
       if (!dealii_cell->has_children ())
@@ -1135,7 +1135,7 @@ namespace FETools
                   const typename dealii::internal::p4est::types<dim>::quadrant  &p4est_cell,
                   std::vector<CellData>                                         &new_needs)
     {
-      const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_finite_element();
+      const FiniteElement<dim,spacedim> &fe            = dealii_cell->get_dof_handler().get_fe();
       const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
       CellData  cell_data (dofs_per_cell);
@@ -1305,7 +1305,7 @@ namespace FETools
       compute_all_non_local_data (dof2, u2_relevant);
 
       // exclude dofs on more refined ghosted cells
-      const FiniteElement<dim,spacedim> &fe  = dof2.get_finite_element();
+      const FiniteElement<dim,spacedim> &fe  = dof2.get_fe();
       const unsigned int dofs_per_face = fe.dofs_per_face;
       if (dofs_per_face > 0)
         {
@@ -1542,7 +1542,7 @@ namespace FETools
                               const DoFHandler<dim,spacedim> &dof2,
                               OutVector &u2)
       {
-        const unsigned int dofs_per_cell  = dof2.get_finite_element().dofs_per_cell;
+        const unsigned int dofs_per_cell  = dof2.get_fe().dofs_per_cell;
         Vector<typename OutVector::value_type> dof_values(dofs_per_cell);
 
         // then traverse grid bottom up
@@ -1603,8 +1603,8 @@ namespace FETools
                    const ConstraintMatrix &constraints,
                    OutVector &u2)
   {
-    Assert(dof1.get_finite_element(0).n_components() == dof2.get_finite_element(0).n_components(),
-           ExcDimensionMismatch(dof1.get_finite_element(0).n_components(), dof2.get_finite_element(0).n_components()));
+    Assert(dof1.get_fe(0).n_components() == dof2.get_fe(0).n_components(),
+           ExcDimensionMismatch(dof1.get_fe(0).n_components(), dof2.get_fe(0).n_components()));
     Assert(&dof1.get_triangulation()==&dof2.get_triangulation(), ExcTriangulationMismatch());
     Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
     Assert(u2.size()==dof2.n_dofs(), ExcDimensionMismatch(u2.size(), dof2.n_dofs()));

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -259,8 +259,8 @@ namespace FETools
                    const FiniteElement<dim,spacedim>   &fe2,
                    OutVector                           &u1_interpolated)
   {
-    Assert(dof1.get_finite_element(0).n_components() == fe2.n_components(),
-           ExcDimensionMismatch(dof1.get_finite_element(0).n_components(), fe2.n_components()));
+    Assert(dof1.get_fe(0).n_components() == fe2.n_components(),
+           ExcDimensionMismatch(dof1.get_fe(0).n_components(), fe2.n_components()));
     Assert(u1.size() == dof1.n_dofs(),
            ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
     Assert(u1_interpolated.size() == dof1.n_dofs(),
@@ -454,13 +454,13 @@ namespace FETools
   {
     // For discontinuous elements without constraints take the simpler version
     // of the back_interpolate function.
-    if (dof1.get_finite_element().dofs_per_vertex==0 && dof2.get_finite_element().dofs_per_vertex==0
+    if (dof1.get_fe().dofs_per_vertex==0 && dof2.get_fe().dofs_per_vertex==0
         && constraints1.n_constraints()==0 && constraints2.n_constraints()==0)
-      back_interpolate(dof1, u1, dof2.get_finite_element(), u1_interpolated);
+      back_interpolate(dof1, u1, dof2.get_fe(), u1_interpolated);
     else
       {
-        Assert(dof1.get_finite_element(0).n_components() == dof2.get_finite_element(0).n_components(),
-               ExcDimensionMismatch(dof1.get_finite_element(0).n_components(), dof2.get_finite_element(0).n_components()));
+        Assert(dof1.get_fe(0).n_components() == dof2.get_fe(0).n_components(),
+               ExcDimensionMismatch(dof1.get_fe(0).n_components(), dof2.get_fe(0).n_components()));
         Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
         Assert(u1_interpolated.size()==dof1.n_dofs(),
                ExcDimensionMismatch(u1_interpolated.size(), dof1.n_dofs()));
@@ -481,8 +481,8 @@ namespace FETools
                                  const FiniteElement<dim,spacedim> &fe2,
                                  OutVector &u1_difference)
   {
-    Assert(dof1.get_finite_element(0).n_components() == fe2.n_components(),
-           ExcDimensionMismatch(dof1.get_finite_element(0).n_components(), fe2.n_components()));
+    Assert(dof1.get_fe(0).n_components() == fe2.n_components(),
+           ExcDimensionMismatch(dof1.get_fe(0).n_components(), fe2.n_components()));
     Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
     Assert(u1_difference.size()==dof1.n_dofs(),
            ExcDimensionMismatch(u1_difference.size(), dof1.n_dofs()));
@@ -507,9 +507,9 @@ namespace FETools
     // hanging node constraints are
     // allowed.
     const bool hanging_nodes_not_allowed=
-      (dof1.get_finite_element().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
+      (dof1.get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
 
-    const unsigned int dofs_per_cell=dof1.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell=dof1.get_fe().dofs_per_cell;
 
     Vector<typename OutVector::value_type> u1_local(dofs_per_cell);
     Vector<typename OutVector::value_type> u1_diff_local(dofs_per_cell);
@@ -518,7 +518,7 @@ namespace FETools
       dof1.get_triangulation().locally_owned_subdomain();
 
     FullMatrix<double> difference_matrix(dofs_per_cell, dofs_per_cell);
-    get_interpolation_difference_matrix(dof1.get_finite_element(), fe2,
+    get_interpolation_difference_matrix(dof1.get_fe(), fe2,
                                         difference_matrix);
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator cell = dof1.begin_active(),
@@ -604,9 +604,9 @@ namespace FETools
     // without constraints take the
     // cheaper version of the
     // interpolation_difference function.
-    if (dof1.get_finite_element().dofs_per_vertex==0 && dof2.get_finite_element().dofs_per_vertex==0
+    if (dof1.get_fe().dofs_per_vertex==0 && dof2.get_fe().dofs_per_vertex==0
         && constraints1.n_constraints()==0 && constraints2.n_constraints()==0)
-      interpolation_difference(dof1, u1, dof2.get_finite_element(), u1_difference);
+      interpolation_difference(dof1, u1, dof2.get_fe(), u1_difference);
     else
       {
         internal::interpolation_difference(dof1, constraints1, u1, dof2, constraints2, u1_difference);
@@ -622,8 +622,8 @@ namespace FETools
                   OutVector &u2)
   {
     Assert(&dof1.get_triangulation()==&dof2.get_triangulation(), ExcTriangulationMismatch());
-    Assert(dof1.get_finite_element(0).n_components() == dof2.get_finite_element(0).n_components(),
-           ExcDimensionMismatch(dof1.get_finite_element(0).n_components(), dof2.get_finite_element(0).n_components()));
+    Assert(dof1.get_fe(0).n_components() == dof2.get_fe(0).n_components(),
+           ExcDimensionMismatch(dof1.get_fe(0).n_components(), dof2.get_fe(0).n_components()));
     Assert(u1.size()==dof1.n_dofs(), ExcDimensionMismatch(u1.size(), dof1.n_dofs()));
     Assert(u2.size()==dof2.n_dofs(), ExcDimensionMismatch(u2.size(), dof2.n_dofs()));
 
@@ -631,15 +631,15 @@ namespace FETools
     typename DoFHandler<dim,spacedim>::active_cell_iterator cell2 = dof2.begin_active();
     typename DoFHandler<dim,spacedim>::active_cell_iterator end = dof2.end();
 
-    const unsigned int n1 = dof1.get_finite_element().dofs_per_cell;
-    const unsigned int n2 = dof2.get_finite_element().dofs_per_cell;
+    const unsigned int n1 = dof1.get_fe().dofs_per_cell;
+    const unsigned int n2 = dof2.get_fe().dofs_per_cell;
 
     Vector<typename OutVector::value_type> u1_local(n1);
     Vector<typename OutVector::value_type> u2_local(n2);
     std::vector<types::global_dof_index> dofs(n2);
 
     FullMatrix<double> matrix(n2,n1);
-    get_projection_matrix(dof1.get_finite_element(), dof2.get_finite_element(), matrix);
+    get_projection_matrix(dof1.get_fe(), dof2.get_fe(), matrix);
 
     u2 = 0;
     while (cell2 != end)

--- a/include/deal.II/hp/dof_faces.h
+++ b/include/deal.II/hp/dof_faces.h
@@ -54,7 +54,7 @@ namespace internal
      * documentation of the internal::DoFHandler::DoFLevel class, we can
      * compute the location of the first line DoF, for example, by calculating
      * the offset as <code>line_index *
-     * dof_handler.get_finite_element().dofs_per_line</code>. This of course doesn't work
+     * dof_handler.get_fe().dofs_per_line</code>. This of course doesn't work
      * any more if different lines may have different numbers of degrees of
      * freedom associated with them. Consequently, rather than using this
      * simple multiplication, the dofs array has an associated array
@@ -374,9 +374,9 @@ namespace internal
       Assert (fe_index < dof_handler.get_fe_collection().size(),
               ExcIndexRange (fe_index, 0, dof_handler.get_fe_collection().size()));
       Assert (local_index <
-              dof_handler.get_finite_element(fe_index).template n_dofs_per_object<structdim>(),
+              dof_handler.get_fe(fe_index).template n_dofs_per_object<structdim>(),
               ExcIndexRange(local_index, 0,
-                            dof_handler.get_finite_element(fe_index)
+                            dof_handler.get_fe(fe_index)
                             .template n_dofs_per_object<structdim>()));
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, dof_offsets.size()));
@@ -406,7 +406,7 @@ namespace internal
             return *(pointer + 1 + local_index);
           else
             pointer += static_cast<types::global_dof_index>(
-                         dof_handler.get_finite_element(*pointer)
+                         dof_handler.get_fe(*pointer)
                          .template n_dofs_per_object<structdim>() + 1);
         }
     }
@@ -431,9 +431,9 @@ namespace internal
       Assert (fe_index < dof_handler.get_fe_collection().size(),
               ExcIndexRange (fe_index, 0, dof_handler.get_fe_collection().size()));
       Assert (local_index <
-              dof_handler.get_finite_element(fe_index).template n_dofs_per_object<structdim>(),
+              dof_handler.get_fe(fe_index).template n_dofs_per_object<structdim>(),
               ExcIndexRange(local_index, 0,
-                            dof_handler.get_finite_element(fe_index)
+                            dof_handler.get_fe(fe_index)
                             .template n_dofs_per_object<structdim>()));
       Assert (obj_index < dof_offsets.size(),
               ExcIndexRange (obj_index, 0, dof_offsets.size()));
@@ -465,7 +465,7 @@ namespace internal
               return;
             }
           else
-            pointer += dof_handler.get_finite_element(*pointer)
+            pointer += dof_handler.get_fe(*pointer)
                        .template n_dofs_per_object<structdim>() + 1;
         }
     }
@@ -507,7 +507,7 @@ namespace internal
           else
             {
               ++counter;
-              pointer += dof_handler.get_finite_element(*pointer)
+              pointer += dof_handler.get_fe(*pointer)
                          .template n_dofs_per_object<structdim>() + 1;
             }
         }
@@ -564,7 +564,7 @@ namespace internal
             return fe_index;
 
           ++counter;
-          pointer += dof_handler.get_finite_element(fe_index)
+          pointer += dof_handler.get_fe(fe_index)
                      .template n_dofs_per_object<structdim>() + 1;
         }
     }
@@ -615,7 +615,7 @@ namespace internal
             return true;
           else
             pointer += static_cast<types::global_dof_index>(
-                         dof_handler.get_finite_element(*pointer)
+                         dof_handler.get_fe(*pointer)
                          .template n_dofs_per_object<structdim>()+1);
         }
     }

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -669,7 +669,7 @@ namespace hp
      * used by this @p DoFHandler.
      */
     const FiniteElement<dim,spacedim> &
-    get_finite_element (const unsigned int index) const;
+    get_fe (const unsigned int index) const;
 
     /**
      * Return a constant reference to the set of finite element objects that
@@ -1089,7 +1089,7 @@ namespace hp
   template <int dim, int spacedim>
   inline
   const FiniteElement<dim,spacedim> &
-  DoFHandler<dim,spacedim>::get_finite_element
+  DoFHandler<dim,spacedim>::get_fe
   (const unsigned int number) const
   {
     Assert (finite_elements != nullptr,

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.cuh
@@ -439,7 +439,7 @@ namespace CUDAWrappers
     //TODO: only free if we actually need arrays of different length
     free();
 
-    const FiniteElement<dim> &fe = dof_handler.get_finite_element();
+    const FiniteElement<dim> &fe = dof_handler.get_fe();
 
     fe_degree = fe.degree;
     //TODO this should be a templated parameter

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -104,7 +104,7 @@ internal_reinit(const Mapping<dim>                          &mapping,
       for (unsigned int nq =0; nq<n_quad; nq++)
         {
           AssertDimension (quad[nq].size(), 1);
-          shape_info(no,nq,0,0).reinit(quad[nq][0], dof_handler[no]->get_finite_element());
+          shape_info(no,nq,0,0).reinit(quad[nq][0], dof_handler[no]->get_fe());
         }
   }
 
@@ -177,8 +177,8 @@ internal_reinit(const Mapping<dim>                          &mapping,
       for (unsigned int i=0; i<dof_info.size(); ++i)
         {
           dof_info[i].dimension    = dim;
-          dof_info[i].n_components = dof_handler[i]->get_finite_element().element_multiplicity(0);
-          dof_info[i].dofs_per_cell.push_back(dof_handler[i]->get_finite_element().dofs_per_cell);
+          dof_info[i].n_components = dof_handler[i]->get_fe().element_multiplicity(0);
+          dof_info[i].dofs_per_cell.push_back(dof_handler[i]->get_fe().dofs_per_cell);
           dof_info[i].row_starts.resize(size_info.n_macro_cells+1);
           dof_info[i].row_starts.back()[2] =
             cell_level_index.size() % VectorizedArray<Number>::n_array_elements;
@@ -239,7 +239,7 @@ internal_reinit(const Mapping<dim>                            &mapping,
         for (unsigned int nq =0; nq<n_quad; nq++)
           for (unsigned int q_no=0; q_no<quad[nq].size(); ++q_no)
             shape_info(no,nq,fe_no,q_no).reinit (quad[nq][q_no],
-                                                 dof_handler[no]->get_finite_element(fe_no));
+                                                 dof_handler[no]->get_fe(fe_no));
   }
 
   if (additional_data.initialize_indices == true)
@@ -312,8 +312,8 @@ internal_reinit(const Mapping<dim>                            &mapping,
         {
           Assert(dof_handler[i]->get_fe_collection().size() == 1, ExcNotImplemented());
           dof_info[i].dimension    = dim;
-          dof_info[i].n_components = dof_handler[i]->get_finite_element(0).element_multiplicity(0);
-          dof_info[i].dofs_per_cell.push_back(dof_handler[i]->get_finite_element(0).dofs_per_cell);
+          dof_info[i].n_components = dof_handler[i]->get_fe(0).element_multiplicity(0);
+          dof_info[i].dofs_per_cell.push_back(dof_handler[i]->get_fe(0).dofs_per_cell);
           dof_info[i].row_starts.resize(size_info.n_macro_cells+1);
           dof_info[i].row_starts.back()[2] =
             cell_level_index.size() % VectorizedArray<Number>::n_array_elements;
@@ -537,7 +537,7 @@ void MatrixFree<dim,Number>::initialize_indices
       else
         {
           const DoFHandler<dim> *dofh =&*dof_handlers.dof_handler[no];
-          fes.push_back (&dofh->get_finite_element());
+          fes.push_back (&dofh->get_fe());
           dof_info[no].max_fe_index = 1;
           dof_info[no].fe_index_conversion.resize (1);
           dof_info[no].fe_index_conversion[0] =

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -290,7 +290,7 @@ namespace MeshWorker
     level_cell (false)
   {
     std::vector<types::global_dof_index> aux(1);
-    aux[0] = dof_handler.get_finite_element().dofs_per_cell;
+    aux[0] = dof_handler.get_fe().dofs_per_cell;
     aux_local_indices.reinit(aux);
   }
 

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -72,7 +72,7 @@ namespace
                  std::vector<unsigned int> target_component,
                  MGLevelObject<BlockVector<number> > &v)
   {
-    const unsigned int n_blocks = mg_dof.get_finite_element().n_blocks();
+    const unsigned int n_blocks = mg_dof.get_fe().n_blocks();
     if (target_component.size()==0)
       {
         target_component.resize(n_blocks);

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -856,7 +856,7 @@ protected:
    * dummy object of FE_DGQ<dim>(0) in case only the triangulation is used.
    */
   std::vector<std::shared_ptr<dealii::hp::FECollection<DoFHandlerType::dimension,DoFHandlerType::space_dimension> > >
-  get_finite_elements() const;
+  get_fes() const;
 
   /**
    * Overload of the respective DataOutInterface::get_vector_data_ranges()

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -980,7 +980,7 @@ add_data_vector_internal
                         "does not have any degrees of freedom, so it is not "
                         "possible to output DoF data in this context."));
       const std::string name = names[0];
-      const unsigned int n_components = dof_handler->get_finite_element(0).n_components();
+      const unsigned int n_components = dof_handler->get_fe(0).n_components();
       deduced_names.resize (n_components);
       if (n_components > 1)
         {
@@ -1016,9 +1016,9 @@ add_data_vector_internal
               Exceptions::DataOut::ExcInvalidVectorSize (data_vector.size(),
                                                          dof_handler->n_dofs(),
                                                          triangulation->n_active_cells()));
-      Assert (deduced_names.size() == dof_handler->get_finite_element(0).n_components(),
+      Assert (deduced_names.size() == dof_handler->get_fe(0).n_components(),
               Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(),
-                                                            dof_handler->get_finite_element(0).n_components()));
+                                                            dof_handler->get_fe(0).n_components()));
       break;
     default:
       Assert (false, ExcInternalError());
@@ -1230,7 +1230,7 @@ template <typename DoFHandlerType,
           int patch_dim, int patch_space_dim>
 std::vector<std::shared_ptr<dealii::hp::FECollection<DoFHandlerType::dimension,
     DoFHandlerType::space_dimension> > >
-    DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::get_finite_elements() const
+    DataOut_DoFData<DoFHandlerType,patch_dim,patch_space_dim>::get_fes() const
 {
   const unsigned int dhdim = DoFHandlerType::dimension;
   const unsigned int dhspacedim = DoFHandlerType::space_dimension;

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1104,7 +1104,7 @@ estimate (const Mapping<dim, spacedim>               &mapping,
     = subdomain_id_;
 #endif
 
-  const unsigned int n_components = dof_handler.get_finite_element(0).n_components();
+  const unsigned int n_components = dof_handler.get_fe(0).n_components();
   (void)n_components;
 
   // sanity checks

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -40,7 +40,7 @@ namespace Functions
    const VectorType     &myv,
    const Mapping<dim>   &mymapping)
     :
-    Function<dim,typename VectorType::value_type>(mydh.get_finite_element(0).n_components()),
+    Function<dim,typename VectorType::value_type>(mydh.get_fe(0).n_components()),
     dh(&mydh, "FEFieldFunction"),
     data_vector(myv),
     mapping(mymapping),

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -679,7 +679,7 @@ namespace MatrixCreator
     Assert (matrix.n() == dof.n_dofs(),
             ExcDimensionMismatch (matrix.n(), dof.n_dofs()));
 
-    hp::FECollection<dim,spacedim>      fe_collection (dof.get_finite_element());
+    hp::FECollection<dim,spacedim>      fe_collection (dof.get_fe());
     hp::QCollection<dim>                q_collection (q);
     hp::MappingCollection<dim,spacedim> mapping_collection (mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim,number>
@@ -736,7 +736,7 @@ namespace MatrixCreator
     Assert (matrix.n() == dof.n_dofs(),
             ExcDimensionMismatch (matrix.n(), dof.n_dofs()));
 
-    hp::FECollection<dim,spacedim>      fe_collection (dof.get_finite_element());
+    hp::FECollection<dim,spacedim>      fe_collection (dof.get_fe());
     hp::QCollection<dim>                q_collection (q);
     hp::MappingCollection<dim,spacedim> mapping_collection (mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim,number>
@@ -1210,7 +1210,7 @@ namespace MatrixCreator
         return;
       }
 
-    const FiniteElement<dim,spacedim> &fe = dof.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe = dof.get_fe();
     const unsigned int n_components  = fe.n_components();
 
     Assert (matrix.n() == dof.n_boundary_dofs (boundary_functions),
@@ -1706,7 +1706,7 @@ namespace MatrixCreator
     Assert (matrix.n() == dof.n_dofs(),
             ExcDimensionMismatch (matrix.n(), dof.n_dofs()));
 
-    hp::FECollection<dim,spacedim>      fe_collection (dof.get_finite_element());
+    hp::FECollection<dim,spacedim>      fe_collection (dof.get_fe());
     hp::QCollection<dim>                q_collection (q);
     hp::MappingCollection<dim,spacedim> mapping_collection (mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim,double>
@@ -1764,7 +1764,7 @@ namespace MatrixCreator
     Assert (matrix.n() == dof.n_dofs(),
             ExcDimensionMismatch (matrix.n(), dof.n_dofs()));
 
-    hp::FECollection<dim,spacedim>      fe_collection (dof.get_finite_element());
+    hp::FECollection<dim,spacedim>      fe_collection (dof.get_fe());
     hp::QCollection<dim>                q_collection (q);
     hp::MappingCollection<dim,spacedim> mapping_collection (mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim,double>

--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -925,7 +925,7 @@ namespace VectorTools
                 VectorType &vec_result);
 
   /**
-   * Same as above but for <code>n_q_points_1d = matrix_free.get_dof_handler().get_finite_element().degree+1</code>.
+   * Same as above but for <code>n_q_points_1d = matrix_free.get_dof_handler().get_fe().degree+1</code>.
    */
   template <int dim, typename VectorType>
   void project (std::shared_ptr<const MatrixFree<dim,typename VectorType::value_type> > data,

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -94,17 +94,17 @@ namespace VectorTools
                     const ComponentMask                                       &component_mask)
   {
     typedef typename VectorType::value_type number;
-    Assert (component_mask.represents_n_components(dof.get_finite_element(0).n_components()),
+    Assert (component_mask.represents_n_components(dof.get_fe(0).n_components()),
             ExcMessage("The number of components in the mask has to be either "
                        "zero or equal to the number of components in the finite "
                        "element.") );
 
     Assert (vec.size() == dof.n_dofs(),
             ExcDimensionMismatch (vec.size(), dof.n_dofs()));
-    Assert (dof.get_finite_element(0).n_components() == function.n_components,
-            ExcDimensionMismatch(dof.get_finite_element(0).n_components(),
+    Assert (dof.get_fe(0).n_components() == function.n_components,
+            ExcDimensionMismatch(dof.get_fe(0).n_components(),
                                  function.n_components));
-    Assert (component_mask.n_selected_components(dof.get_finite_element(0).n_components()) > 0,
+    Assert (component_mask.n_selected_components(dof.get_fe(0).n_components()) > 0,
             ComponentMask::ExcNoComponentSelected());
 
     const hp::FECollection<dim,spacedim> &fe = dof.get_fe_collection();
@@ -320,11 +320,11 @@ namespace VectorTools
                OutVector                      &data_2)
   {
     typedef typename OutVector::value_type number;
-    Vector<number> cell_data_1(dof_1.get_finite_element().dofs_per_cell);
-    Vector<number> cell_data_2(dof_2.get_finite_element().dofs_per_cell);
+    Vector<number> cell_data_1(dof_1.get_fe().dofs_per_cell);
+    Vector<number> cell_data_2(dof_2.get_fe().dofs_per_cell);
 
     std::vector<short unsigned int> touch_count (dof_2.n_dofs(), 0); //TODO: check on datatype... kinda strange (UK)
-    std::vector<types::global_dof_index>       local_dof_indices (dof_2.get_finite_element().dofs_per_cell);
+    std::vector<types::global_dof_index>       local_dof_indices (dof_2.get_fe().dofs_per_cell);
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator h = dof_1.begin_active();
     typename DoFHandler<dim,spacedim>::active_cell_iterator l = dof_2.begin_active();
@@ -338,7 +338,7 @@ namespace VectorTools
         l->get_dof_indices (local_dof_indices);
 
         // distribute cell vector
-        for (unsigned int j=0; j<dof_2.get_finite_element().dofs_per_cell; ++j)
+        for (unsigned int j=0; j<dof_2.get_fe().dofs_per_cell; ++j)
           {
             ::dealii::internal::ElementAccess<OutVector>::add(cell_data_2(j),
                                                               local_dof_indices[j], data_2);
@@ -381,7 +381,7 @@ namespace VectorTools
   {
     typedef typename VectorType::value_type number;
 
-    Assert( component_mask.represents_n_components(dof.get_finite_element(0).n_components()),
+    Assert( component_mask.represents_n_components(dof.get_fe(0).n_components()),
             ExcMessage("The number of components in the mask has to be either "
                        "zero or equal to the number of components in the finite "
                        "element.") );
@@ -399,8 +399,8 @@ namespace VectorTools
          iter != function_map.end();
          ++iter )
       {
-        Assert( dof.get_finite_element(0).n_components() == iter->second->n_components,
-                ExcDimensionMismatch(dof.get_finite_element(0).n_components(), iter->second->n_components) );
+        Assert( dof.get_fe(0).n_components() == iter->second->n_components,
+                ExcDimensionMismatch(dof.get_fe(0).n_components(), iter->second->n_components) );
       }
 
     const hp::FECollection<dim, spacedim> &fe = dof.get_fe_collection();
@@ -839,8 +839,8 @@ namespace VectorTools
                      const bool                          project_to_boundary_first)
     {
       typedef typename VectorType::value_type number;
-      Assert (dof.get_finite_element(0).n_components() == function.n_components,
-              ExcDimensionMismatch(dof.get_finite_element(0).n_components(),
+      Assert (dof.get_fe(0).n_components() == function.n_components,
+              ExcDimensionMismatch(dof.get_fe(0).n_components(),
                                    function.n_components));
       Assert (vec_result.size() == dof.n_dofs(),
               ExcDimensionMismatch (vec_result.size(), dof.n_dofs()));
@@ -929,14 +929,14 @@ namespace VectorTools
       (void) project_to_boundary_first;
       (void) q_boundary;
 
-      Assert (dof.get_finite_element(0).n_components() == function.n_components,
-              ExcDimensionMismatch(dof.get_finite_element(0).n_components(),
+      Assert (dof.get_fe(0).n_components() == function.n_components,
+              ExcDimensionMismatch(dof.get_fe(0).n_components(),
                                    function.n_components));
       Assert (fe_degree == -1 ||
-              dof.get_finite_element().degree == static_cast<unsigned int>(fe_degree),
-              ExcDimensionMismatch(fe_degree, dof.get_finite_element().degree));
-      Assert (dof.get_finite_element(0).n_components() == components,
-              ExcDimensionMismatch(components, dof.get_finite_element(0).n_components()));
+              dof.get_fe().degree == static_cast<unsigned int>(fe_degree),
+              ExcDimensionMismatch(fe_degree, dof.get_fe().degree));
+      Assert (dof.get_fe(0).n_components() == components,
+              ExcDimensionMismatch(components, dof.get_fe(0).n_components()));
 
       // set up mass matrix and right hand side
       typename MatrixFree<dim,Number>::AdditionalData additional_data;
@@ -946,7 +946,7 @@ namespace VectorTools
       std::shared_ptr<MatrixFree<dim, Number> > matrix_free(
         new MatrixFree<dim, Number> ());
       matrix_free->reinit (mapping, dof, constraints,
-                           QGauss<1>(dof.get_finite_element().degree+2), additional_data);
+                           QGauss<1>(dof.get_fe().degree+2), additional_data);
       typedef MatrixFreeOperators::MassOperator<dim, fe_degree, fe_degree+2, components, LinearAlgebra::distributed::Vector<Number> > MatrixType;
       MatrixType mass_matrix;
       mass_matrix.initialize(matrix_free);
@@ -997,7 +997,7 @@ namespace VectorTools
      const Quadrature<dim-1>                    &q_boundary,
      const bool                                  project_to_boundary_first)
     {
-      switch (dof.get_finite_element().degree)
+      switch (dof.get_fe().degree)
         {
         case 1:
           project_matrix_free<components, 1>
@@ -1040,7 +1040,7 @@ namespace VectorTools
      const Quadrature<dim-1>                    &q_boundary,
      const bool                                  project_to_boundary_first)
     {
-      switch (dof.get_finite_element(0).n_components())
+      switch (dof.get_fe(0).n_components())
         {
         case 1:
           project_matrix_free_degree<1>
@@ -1126,14 +1126,14 @@ namespace VectorTools
                   const bool                    project_to_boundary_first)
     {
       // If we can, use the matrix-free implementation
-      bool use_matrix_free = MatrixFree<dim, typename VectorType::value_type>::is_supported(dof.get_finite_element());
+      bool use_matrix_free = MatrixFree<dim, typename VectorType::value_type>::is_supported(dof.get_fe());
 
       // enforce_zero_boundary and project_to_boundary_first
       // are not yet supported.
       // We have explicit instantiations only if
       // the number of components is not too high.
       if (enforce_zero_boundary || project_to_boundary_first
-          || dof.get_finite_element(0).n_components()>4)
+          || dof.get_fe(0).n_components()>4)
         use_matrix_free = false;
 
       if (use_matrix_free)
@@ -1163,14 +1163,14 @@ namespace VectorTools
                            VectorType                     &vec_result)
     {
       typedef typename VectorType::value_type Number;
-      Assert (dof.get_finite_element(0).n_components() == 1,
-              ExcDimensionMismatch(dof.get_finite_element(0).n_components(),
+      Assert (dof.get_fe(0).n_components() == 1,
+              ExcDimensionMismatch(dof.get_fe(0).n_components(),
                                    1));
       Assert (vec_result.size() == dof.n_dofs(),
               ExcDimensionMismatch (vec_result.size(), dof.n_dofs()));
       Assert (fe_degree == -1 ||
-              dof.get_finite_element().degree == static_cast<unsigned int>(fe_degree),
-              ExcDimensionMismatch(fe_degree, dof.get_finite_element().degree));
+              dof.get_fe().degree == static_cast<unsigned int>(fe_degree),
+              ExcDimensionMismatch(fe_degree, dof.get_fe().degree));
 
       // set up mass matrix and right hand side
       typename MatrixFree<dim,Number>::AdditionalData additional_data;
@@ -1180,7 +1180,7 @@ namespace VectorTools
       std::shared_ptr<MatrixFree<dim, Number> > matrix_free(
         new MatrixFree<dim, Number>());
       matrix_free->reinit (mapping, dof, constraints,
-                           QGauss<1>(dof.get_finite_element().degree+2), additional_data);
+                           QGauss<1>(dof.get_fe().degree+2), additional_data);
       typedef MatrixFreeOperators::MassOperator<dim, fe_degree, fe_degree+2, 1, LinearAlgebra::distributed::Vector<Number> > MatrixType;
       MatrixType mass_matrix;
       mass_matrix.initialize(matrix_free);
@@ -1196,10 +1196,10 @@ namespace VectorTools
 
       // assemble right hand side:
       {
-        FEValues<dim> fe_values (mapping, dof.get_finite_element(), quadrature,
+        FEValues<dim> fe_values (mapping, dof.get_fe(), quadrature,
                                  update_values | update_JxW_values);
 
-        const unsigned int   dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+        const unsigned int   dofs_per_cell = dof.get_fe().dofs_per_cell;
         const unsigned int   n_q_points    = quadrature.size();
         Vector<Number>       cell_rhs (dofs_per_cell);
         std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
@@ -1263,14 +1263,14 @@ namespace VectorTools
       const DoFHandler<dim,spacedim> &dof = matrix_free->get_dof_handler();
 
       typedef typename VectorType::value_type Number;
-      Assert (dof.get_finite_element(0).n_components() == 1,
-              ExcDimensionMismatch(dof.get_finite_element(0).n_components(),
+      Assert (dof.get_fe(0).n_components() == 1,
+              ExcDimensionMismatch(dof.get_fe(0).n_components(),
                                    1));
       Assert (vec_result.size() == dof.n_dofs(),
               ExcDimensionMismatch (vec_result.size(), dof.n_dofs()));
       Assert (fe_degree == -1 ||
-              dof.get_finite_element().degree == static_cast<unsigned int>(fe_degree),
-              ExcDimensionMismatch(fe_degree, dof.get_finite_element().degree));
+              dof.get_fe().degree == static_cast<unsigned int>(fe_degree),
+              ExcDimensionMismatch(fe_degree, dof.get_fe().degree));
 
       typedef MatrixFreeOperators::MassOperator<dim, fe_degree, n_q_points_1d, 1, LinearAlgebra::distributed::Vector<Number> > MatrixType;
       MatrixType mass_matrix;
@@ -1338,7 +1338,7 @@ namespace VectorTools
                 const std::function< typename VectorType::value_type (const typename DoFHandler<dim, spacedim>::active_cell_iterator &, const unsigned int)> func,
                 VectorType                     &vec_result)
   {
-    switch (dof.get_finite_element().degree)
+    switch (dof.get_fe().degree)
       {
       case 1:
         project_parallel<dim,VectorType,spacedim,1> (mapping,dof,constraints,quadrature,func,vec_result);
@@ -1364,7 +1364,7 @@ namespace VectorTools
                 VectorType &vec_result)
   {
     (void) n_q_points_1d;
-    const unsigned int fe_degree = matrix_free->get_dof_handler().get_finite_element().degree;
+    const unsigned int fe_degree = matrix_free->get_dof_handler().get_fe().degree;
 
     Assert (fe_degree+1 == n_q_points_1d,
             ExcNotImplemented());
@@ -1395,7 +1395,7 @@ namespace VectorTools
   {
     project (matrix_free,
              constraints,
-             matrix_free->get_dof_handler().get_finite_element().degree+1,
+             matrix_free->get_dof_handler().get_fe().degree+1,
              func,
              vec_result);
   }
@@ -1502,7 +1502,7 @@ namespace VectorTools
   {
     typedef typename VectorType::value_type Number;
 
-    const FiniteElement<dim,spacedim> &fe  = dof_handler.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe  = dof_handler.get_fe();
     Assert (fe.n_components() == rhs_function.n_components,
             ExcDimensionMismatch(fe.n_components(), rhs_function.n_components));
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
@@ -1768,7 +1768,7 @@ namespace VectorTools
   {
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
             ExcDimensionMismatch(rhs_vector.size(), dof_handler.n_dofs()));
-    Assert (dof_handler.get_finite_element(0).n_components() == 1,
+    Assert (dof_handler.get_fe(0).n_components() == 1,
             ExcMessage ("This function only works for scalar finite elements"));
 
     rhs_vector = 0;
@@ -1779,11 +1779,11 @@ namespace VectorTools
 
     Quadrature<dim> q(GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
 
-    FEValues<dim,spacedim> fe_values(mapping, dof_handler.get_finite_element(),
+    FEValues<dim,spacedim> fe_values(mapping, dof_handler.get_fe(),
                                      q, UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
     cell_point.first->get_dof_indices (local_dof_indices);
@@ -1812,7 +1812,7 @@ namespace VectorTools
   {
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
             ExcDimensionMismatch(rhs_vector.size(), dof_handler.n_dofs()));
-    Assert (dof_handler.get_finite_element(0).n_components() == 1,
+    Assert (dof_handler.get_fe(0).n_components() == 1,
             ExcMessage ("This function only works for scalar finite elements"));
 
     rhs_vector = 0;
@@ -1860,7 +1860,7 @@ namespace VectorTools
   {
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
             ExcDimensionMismatch(rhs_vector.size(), dof_handler.n_dofs()));
-    Assert (dof_handler.get_finite_element(0).n_components() == dim,
+    Assert (dof_handler.get_fe(0).n_components() == dim,
             ExcMessage ("This function only works for vector-valued finite elements."));
 
     rhs_vector = 0;
@@ -1872,11 +1872,11 @@ namespace VectorTools
     const Quadrature<dim> q(GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
 
     const FEValuesExtractors::Vector vec (0);
-    FEValues<dim,spacedim> fe_values(mapping, dof_handler.get_finite_element(),
+    FEValues<dim,spacedim> fe_values(mapping, dof_handler.get_fe(),
                                      q, UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = dof_handler.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
 
     std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
     cell_point.first->get_dof_indices (local_dof_indices);
@@ -1907,7 +1907,7 @@ namespace VectorTools
   {
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
             ExcDimensionMismatch(rhs_vector.size(), dof_handler.n_dofs()));
-    Assert (dof_handler.get_finite_element(0).n_components() == dim,
+    Assert (dof_handler.get_fe(0).n_components() == dim,
             ExcMessage ("This function only works for vector-valued finite elements."));
 
     rhs_vector = 0;
@@ -1956,7 +1956,7 @@ namespace VectorTools
                                    VectorType                         &rhs_vector,
                                    const std::set<types::boundary_id> &boundary_ids)
   {
-    const FiniteElement<dim> &fe  = dof_handler.get_finite_element();
+    const FiniteElement<dim> &fe  = dof_handler.get_fe();
     Assert (fe.n_components() == rhs_function.n_components,
             ExcDimensionMismatch(fe.n_components(), rhs_function.n_components));
     Assert (rhs_vector.size() == dof_handler.n_dofs(),
@@ -2253,7 +2253,7 @@ namespace VectorTools
      std::map<types::global_dof_index,number>                             &boundary_values,
      const ComponentMask                                                  &component_mask)
     {
-      Assert (component_mask.represents_n_components(dof.get_finite_element(0).n_components()),
+      Assert (component_mask.represents_n_components(dof.get_fe(0).n_components()),
               ExcMessage ("The number of components in the mask has to be either "
                           "zero or equal to the number of components in the finite "
                           "element."));
@@ -2818,16 +2818,16 @@ namespace VectorTools
 
       if (component_mapping.size() == 0)
         {
-          AssertDimension (dof.get_finite_element(0).n_components(), boundary_functions.begin()->second->n_components);
+          AssertDimension (dof.get_fe(0).n_components(), boundary_functions.begin()->second->n_components);
           // I still do not see why i
           // should create another copy
           // here
-          component_mapping.resize(dof.get_finite_element(0).n_components());
+          component_mapping.resize(dof.get_fe(0).n_components());
           for (unsigned int i= 0 ; i < component_mapping.size() ; ++i)
             component_mapping[i] = i;
         }
       else
-        AssertDimension (dof.get_finite_element(0).n_components(), component_mapping.size());
+        AssertDimension (dof.get_fe(0).n_components(), component_mapping.size());
 
       std::vector<types::global_dof_index> dof_to_boundary_mapping;
       std::set<types::boundary_id> selected_boundary_components;
@@ -4108,9 +4108,9 @@ namespace VectorTools
     // ones. Thus we have to solve two linear systems of equations of size
     // <tt>degree * (degree + 1)<tt> to obtain the values for the
     // corresponding degrees of freedom.
-    const unsigned int superdegree = dof_handler.get_finite_element ().degree;
+    const unsigned int superdegree = dof_handler.get_fe ().degree;
     const QGauss<dim - 1> reference_face_quadrature (2 * superdegree);
-    const unsigned int dofs_per_face = dof_handler.get_finite_element ().dofs_per_face;
+    const unsigned int dofs_per_face = dof_handler.get_fe ().dofs_per_face;
     hp::FECollection<dim> fe_collection (dof_handler.get_fe_collection ());
     hp::MappingCollection<dim> mapping_collection (mapping);
     hp::QCollection<dim> face_quadrature_collection;
@@ -5602,7 +5602,7 @@ namespace VectorTools
     // normal components of the shape
     // functions supported on the
     // boundary.
-    const FiniteElement<dim> &fe = dof_handler.get_finite_element ();
+    const FiniteElement<dim> &fe = dof_handler.get_fe ();
     QGauss<dim - 1> face_quadrature (fe.degree + 1);
     FEFaceValues<dim> fe_face_values (mapping, fe, face_quadrature, update_JxW_values |
                                       update_normal_vectors |
@@ -7078,7 +7078,7 @@ namespace VectorTools
       // on, if necessary, so have a read-write version of it:
       double exponent = exponent_1;
 
-      const unsigned int        n_components = dof.get_finite_element(0).n_components();
+      const unsigned int        n_components = dof.get_fe(0).n_components();
 
       if (weight!=nullptr)
         {
@@ -7366,7 +7366,7 @@ namespace VectorTools
                     const Point<spacedim>                                     &point)
   {
     typedef typename VectorType::value_type Number;
-    const FiniteElement<dim> &fe = dof.get_finite_element();
+    const FiniteElement<dim> &fe = dof.get_fe();
 
     Assert(difference.size() == fe.n_components(),
            ExcDimensionMismatch(difference.size(), fe.n_components()));
@@ -7468,7 +7468,7 @@ namespace VectorTools
                Vector<typename VectorType::value_type> &value)
   {
     typedef typename VectorType::value_type Number;
-    const FiniteElement<dim> &fe = dof.get_finite_element();
+    const FiniteElement<dim> &fe = dof.get_fe();
 
     Assert(value.size() == fe.n_components(),
            ExcDimensionMismatch(value.size(), fe.n_components()));
@@ -7550,7 +7550,7 @@ namespace VectorTools
                const VectorType               &fe_function,
                const Point<spacedim>          &point)
   {
-    Assert(dof.get_finite_element(0).n_components() == 1,
+    Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
     Vector<typename VectorType::value_type> value(1);
@@ -7567,7 +7567,7 @@ namespace VectorTools
                const VectorType                           &fe_function,
                const Point<spacedim>                      &point)
   {
-    Assert(dof.get_finite_element(0).n_components() == 1,
+    Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
     Vector<typename VectorType::value_type> value(1);
@@ -7643,7 +7643,7 @@ namespace VectorTools
                   const Point<spacedim>          &point,
                   std::vector<Tensor<1, spacedim, typename VectorType::value_type> > &gradient)
   {
-    const FiniteElement<dim> &fe = dof.get_finite_element();
+    const FiniteElement<dim> &fe = dof.get_fe();
 
     Assert(gradient.size() == fe.n_components(),
            ExcDimensionMismatch(gradient.size(), fe.n_components()));
@@ -7726,7 +7726,7 @@ namespace VectorTools
                   const VectorType               &fe_function,
                   const Point<spacedim>          &point)
   {
-    Assert(dof.get_finite_element(0).n_components() == 1,
+    Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
     std::vector<Tensor<1, dim, typename VectorType::value_type> > gradient(1);
@@ -7744,7 +7744,7 @@ namespace VectorTools
                   const VectorType                           &fe_function,
                   const Point<spacedim>                      &point)
   {
-    Assert(dof.get_finite_element(0).n_components() == 1,
+    Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage ("Finite element is not scalar as is necessary for this function"));
 
     std::vector<Tensor<1, dim, typename VectorType::value_type> > gradient(1);
@@ -7849,16 +7849,16 @@ namespace VectorTools
     typedef typename VectorType::value_type Number;
     Assert (v.size() == dof.n_dofs(),
             ExcDimensionMismatch (v.size(), dof.n_dofs()));
-    Assert (component < dof.get_finite_element(0).n_components(),
-            ExcIndexRange(component, 0, dof.get_finite_element(0).n_components()));
+    Assert (component < dof.get_fe(0).n_components(),
+            ExcIndexRange(component, 0, dof.get_fe(0).n_components()));
 
-    FEValues<dim,spacedim> fe(mapping, dof.get_finite_element(), quadrature,
+    FEValues<dim,spacedim> fe(mapping, dof.get_fe(), quadrature,
                               UpdateFlags(update_JxW_values
                                           | update_values));
 
     typename DoFHandler<dim,spacedim>::active_cell_iterator cell;
     std::vector<Vector<Number> > values(quadrature.size(),
-                                        Vector<Number> (dof.get_finite_element(0).n_components()));
+                                        Vector<Number> (dof.get_fe(0).n_components()));
 
     Number mean = Number();
     double area = 0.;
@@ -7925,7 +7925,7 @@ namespace VectorTools
                            const ComponentMask                &mask)
   {
     AssertDimension(vector.size(), dh.n_dofs());
-    const FiniteElement<dim, spacedim> &fe = dh.get_finite_element();
+    const FiniteElement<dim, spacedim> &fe = dh.get_fe();
 
     // Construct default fe_mask;
     const ComponentMask fe_mask(mask.size() ? mask :

--- a/source/dofs/block_info.cc
+++ b/source/dofs/block_info.cc
@@ -29,7 +29,7 @@ BlockInfo::initialize(const DoFHandler<dim, spacedim> &dof, bool levels_only, bo
 {
   if (!levels_only && dof.has_active_dofs())
     {
-      const FiniteElement<dim, spacedim> &fe = dof.get_finite_element();
+      const FiniteElement<dim, spacedim> &fe = dof.get_fe();
       std::vector<types::global_dof_index> sizes(fe.n_blocks());
       DoFTools::count_dofs_per_block(dof, sizes);
       bi_global.reinit(sizes);
@@ -40,7 +40,7 @@ BlockInfo::initialize(const DoFHandler<dim, spacedim> &dof, bool levels_only, bo
       std::vector<std::vector<types::global_dof_index> > sizes (dof.get_triangulation().n_levels ());
 
       for (unsigned int i = 0; i < sizes.size (); ++i)
-        sizes[i].resize (dof.get_finite_element ().n_blocks ());
+        sizes[i].resize (dof.get_fe ().n_blocks ());
 
       MGTools::count_dofs_per_block (dof, sizes);
       levels.resize (sizes.size ());
@@ -55,7 +55,7 @@ template <int dim, int spacedim>
 void
 BlockInfo::initialize_local(const DoFHandler<dim, spacedim> &dof)
 {
-  const FiniteElement<dim, spacedim> &fe = dof.get_finite_element();
+  const FiniteElement<dim, spacedim> &fe = dof.get_fe();
   std::vector<types::global_dof_index> sizes(fe.n_blocks());
 
   base_elements.resize(fe.n_blocks());

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -70,9 +70,9 @@ get_interpolated_dof_values (const InputVector &values,
           Vector<number> tmp (this->get_fe().dofs_per_cell);
           this->get_dof_values (values, tmp);
 
-          FullMatrix<double> interpolation (this->dof_handler->get_finite_element(fe_index).dofs_per_cell,
+          FullMatrix<double> interpolation (this->dof_handler->get_fe(fe_index).dofs_per_cell,
                                             this->get_fe().dofs_per_cell);
-          this->dof_handler->get_finite_element(fe_index).get_interpolation_matrix (this->get_fe(),
+          this->dof_handler->get_fe(fe_index).get_interpolation_matrix (this->get_fe(),
               interpolation);
           interpolation.vmult (interpolated_values, tmp);
         }
@@ -99,7 +99,7 @@ get_interpolated_dof_values (const InputVector &values,
                           "of freedom are only distributed on active cells for which "
                           "the active_fe_index has been set."));
 
-      const FiniteElement<dim,spacedim> &fe            = this->get_dof_handler().get_finite_element(fe_index);
+      const FiniteElement<dim,spacedim> &fe            = this->get_dof_handler().get_fe(fe_index);
       const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
       Assert (this->dof_handler != nullptr,

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -62,12 +62,12 @@ set_dof_values_by_interpolation (const Vector<number> &local_values,
         this->set_dof_values (local_values, values);
       else
         {
-          Assert (local_values.size() == this->dof_handler->get_finite_element(fe_index).dofs_per_cell,
+          Assert (local_values.size() == this->dof_handler->get_fe(fe_index).dofs_per_cell,
                   ExcMessage ("Incorrect size of local_values vector.") );
 
-          FullMatrix<double> interpolation (this->get_fe().dofs_per_cell, this->dof_handler->get_finite_element(fe_index).dofs_per_cell);
+          FullMatrix<double> interpolation (this->get_fe().dofs_per_cell, this->dof_handler->get_fe(fe_index).dofs_per_cell);
 
-          this->get_fe().get_interpolation_matrix (this->dof_handler->get_finite_element(fe_index),
+          this->get_fe().get_interpolation_matrix (this->dof_handler->get_fe(fe_index),
                                                    interpolation);
 
           // do the interpolation to the target space. for historical
@@ -96,7 +96,7 @@ set_dof_values_by_interpolation (const Vector<number> &local_values,
                           "of freedom are only distributed on active cells for which "
                           "the active_fe_index has been set."));
 
-      const FiniteElement<dim,spacedim> &fe            = this->get_dof_handler().get_finite_element(fe_index);
+      const FiniteElement<dim,spacedim> &fe            = this->get_dof_handler().get_fe(fe_index);
       const unsigned int                 dofs_per_cell = fe.dofs_per_cell;
 
       Assert (this->dof_handler != nullptr,

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -107,8 +107,8 @@ namespace internal
       unsigned int
       max_couplings_between_dofs (const DoFHandler<1,spacedim> &dof_handler)
       {
-        return std::min(static_cast<types::global_dof_index>(3*dof_handler.get_finite_element().dofs_per_vertex +
-                                                             2*dof_handler.get_finite_element().dofs_per_line),
+        return std::min(static_cast<types::global_dof_index>(3*dof_handler.get_fe().dofs_per_vertex +
+                                                             2*dof_handler.get_fe().dofs_per_line),
                         dof_handler.n_dofs());
       }
 
@@ -145,29 +145,29 @@ namespace internal
         switch (dof_handler.tria->max_adjacent_cells())
           {
           case 4:
-            max_couplings=19*dof_handler.get_finite_element().dofs_per_vertex +
-                          28*dof_handler.get_finite_element().dofs_per_line +
-                          8*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=19*dof_handler.get_fe().dofs_per_vertex +
+                          28*dof_handler.get_fe().dofs_per_line +
+                          8*dof_handler.get_fe().dofs_per_quad;
             break;
           case 5:
-            max_couplings=21*dof_handler.get_finite_element().dofs_per_vertex +
-                          31*dof_handler.get_finite_element().dofs_per_line +
-                          9*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=21*dof_handler.get_fe().dofs_per_vertex +
+                          31*dof_handler.get_fe().dofs_per_line +
+                          9*dof_handler.get_fe().dofs_per_quad;
             break;
           case 6:
-            max_couplings=28*dof_handler.get_finite_element().dofs_per_vertex +
-                          42*dof_handler.get_finite_element().dofs_per_line +
-                          12*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=28*dof_handler.get_fe().dofs_per_vertex +
+                          42*dof_handler.get_fe().dofs_per_line +
+                          12*dof_handler.get_fe().dofs_per_quad;
             break;
           case 7:
-            max_couplings=30*dof_handler.get_finite_element().dofs_per_vertex +
-                          45*dof_handler.get_finite_element().dofs_per_line +
-                          13*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=30*dof_handler.get_fe().dofs_per_vertex +
+                          45*dof_handler.get_fe().dofs_per_line +
+                          13*dof_handler.get_fe().dofs_per_quad;
             break;
           case 8:
-            max_couplings=37*dof_handler.get_finite_element().dofs_per_vertex +
-                          56*dof_handler.get_finite_element().dofs_per_line +
-                          16*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=37*dof_handler.get_fe().dofs_per_vertex +
+                          56*dof_handler.get_fe().dofs_per_line +
+                          16*dof_handler.get_fe().dofs_per_quad;
             break;
 
           // the following numbers are not based on actual counting but by
@@ -175,44 +175,44 @@ namespace internal
           // example, for dofs_per_vertex, the sequence above is 19, 21, 28,
           // 30, 37, and is continued as follows):
           case 9:
-            max_couplings=39*dof_handler.get_finite_element().dofs_per_vertex +
-                          59*dof_handler.get_finite_element().dofs_per_line +
-                          17*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=39*dof_handler.get_fe().dofs_per_vertex +
+                          59*dof_handler.get_fe().dofs_per_line +
+                          17*dof_handler.get_fe().dofs_per_quad;
             break;
           case 10:
-            max_couplings=46*dof_handler.get_finite_element().dofs_per_vertex +
-                          70*dof_handler.get_finite_element().dofs_per_line +
-                          20*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=46*dof_handler.get_fe().dofs_per_vertex +
+                          70*dof_handler.get_fe().dofs_per_line +
+                          20*dof_handler.get_fe().dofs_per_quad;
             break;
           case 11:
-            max_couplings=48*dof_handler.get_finite_element().dofs_per_vertex +
-                          73*dof_handler.get_finite_element().dofs_per_line +
-                          21*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=48*dof_handler.get_fe().dofs_per_vertex +
+                          73*dof_handler.get_fe().dofs_per_line +
+                          21*dof_handler.get_fe().dofs_per_quad;
             break;
           case 12:
-            max_couplings=55*dof_handler.get_finite_element().dofs_per_vertex +
-                          84*dof_handler.get_finite_element().dofs_per_line +
-                          24*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=55*dof_handler.get_fe().dofs_per_vertex +
+                          84*dof_handler.get_fe().dofs_per_line +
+                          24*dof_handler.get_fe().dofs_per_quad;
             break;
           case 13:
-            max_couplings=57*dof_handler.get_finite_element().dofs_per_vertex +
-                          87*dof_handler.get_finite_element().dofs_per_line +
-                          25*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=57*dof_handler.get_fe().dofs_per_vertex +
+                          87*dof_handler.get_fe().dofs_per_line +
+                          25*dof_handler.get_fe().dofs_per_quad;
             break;
           case 14:
-            max_couplings=63*dof_handler.get_finite_element().dofs_per_vertex +
-                          98*dof_handler.get_finite_element().dofs_per_line +
-                          28*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=63*dof_handler.get_fe().dofs_per_vertex +
+                          98*dof_handler.get_fe().dofs_per_line +
+                          28*dof_handler.get_fe().dofs_per_quad;
             break;
           case 15:
-            max_couplings=65*dof_handler.get_finite_element().dofs_per_vertex +
-                          103*dof_handler.get_finite_element().dofs_per_line +
-                          29*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=65*dof_handler.get_fe().dofs_per_vertex +
+                          103*dof_handler.get_fe().dofs_per_line +
+                          29*dof_handler.get_fe().dofs_per_quad;
             break;
           case 16:
-            max_couplings=72*dof_handler.get_finite_element().dofs_per_vertex +
-                          114*dof_handler.get_finite_element().dofs_per_line +
-                          32*dof_handler.get_finite_element().dofs_per_quad;
+            max_couplings=72*dof_handler.get_fe().dofs_per_vertex +
+                          114*dof_handler.get_fe().dofs_per_line +
+                          32*dof_handler.get_fe().dofs_per_quad;
             break;
 
           default:
@@ -246,10 +246,10 @@ namespace internal
 
         types::global_dof_index max_couplings;
         if (max_adjacent_cells <= 8)
-          max_couplings=7*7*7*dof_handler.get_finite_element().dofs_per_vertex +
-                        7*6*7*3*dof_handler.get_finite_element().dofs_per_line +
-                        9*4*7*3*dof_handler.get_finite_element().dofs_per_quad +
-                        27*dof_handler.get_finite_element().dofs_per_hex;
+          max_couplings=7*7*7*dof_handler.get_fe().dofs_per_vertex +
+                        7*6*7*3*dof_handler.get_fe().dofs_per_line +
+                        9*4*7*3*dof_handler.get_fe().dofs_per_quad +
+                        27*dof_handler.get_fe().dofs_per_hex;
         else
           {
             Assert (false, ExcNotImplemented());
@@ -275,7 +275,7 @@ namespace internal
       {
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
-                dof_handler.get_finite_element().dofs_per_vertex,
+                dof_handler.get_fe().dofs_per_vertex,
                 numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
@@ -284,12 +284,12 @@ namespace internal
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_line,
+                     dof_handler.get_fe().dofs_per_line,
                      numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_cell,
+                     dof_handler.get_fe().dofs_per_cell,
                      numbers::invalid_dof_index);
           }
       }
@@ -301,7 +301,7 @@ namespace internal
       {
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
-                dof_handler.get_finite_element().dofs_per_vertex,
+                dof_handler.get_fe().dofs_per_vertex,
                 numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
@@ -310,12 +310,12 @@ namespace internal
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_quad,
+                     dof_handler.get_fe().dofs_per_quad,
                      numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_cell,
+                     dof_handler.get_fe().dofs_per_cell,
                      numbers::invalid_dof_index);
           }
 
@@ -325,7 +325,7 @@ namespace internal
           {
             dof_handler.faces->lines.dofs
             .resize (dof_handler.tria->n_raw_lines() *
-                     dof_handler.get_finite_element().dofs_per_line,
+                     dof_handler.get_fe().dofs_per_line,
                      numbers::invalid_dof_index);
           }
       }
@@ -337,7 +337,7 @@ namespace internal
       {
         dof_handler.vertex_dofs
         .resize(dof_handler.tria->n_vertices() *
-                dof_handler.get_finite_element().dofs_per_vertex,
+                dof_handler.get_fe().dofs_per_vertex,
                 numbers::invalid_dof_index);
 
         for (unsigned int i=0; i<dof_handler.tria->n_levels(); ++i)
@@ -346,12 +346,12 @@ namespace internal
 
             dof_handler.levels.back()->dof_object.dofs
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_hex,
+                     dof_handler.get_fe().dofs_per_hex,
                      numbers::invalid_dof_index);
 
             dof_handler.levels.back()->cell_dof_indices_cache
             .resize (dof_handler.tria->n_raw_cells(i) *
-                     dof_handler.get_finite_element().dofs_per_cell,
+                     dof_handler.get_fe().dofs_per_cell,
                      numbers::invalid_dof_index);
           }
         dof_handler.faces.reset (new internal::DoFHandler::DoFFaces<3>);
@@ -361,11 +361,11 @@ namespace internal
           {
             dof_handler.faces->lines.dofs
             .resize (dof_handler.tria->n_raw_lines() *
-                     dof_handler.get_finite_element().dofs_per_line,
+                     dof_handler.get_fe().dofs_per_line,
                      numbers::invalid_dof_index);
             dof_handler.faces->quads.dofs
             .resize (dof_handler.tria->n_raw_quads() *
-                     dof_handler.get_finite_element().dofs_per_quad,
+                     dof_handler.get_fe().dofs_per_quad,
                      numbers::invalid_dof_index);
           }
       }
@@ -378,7 +378,7 @@ namespace internal
         dof_handler.clear_mg_space ();
 
         const dealii::Triangulation<1, spacedim> &tria = dof_handler.get_triangulation();
-        const unsigned int &dofs_per_line = dof_handler.get_finite_element ().dofs_per_line;
+        const unsigned int &dofs_per_line = dof_handler.get_fe ().dofs_per_line;
         const unsigned int &n_levels = tria.n_levels ();
 
         for (unsigned int i = 0; i < n_levels; ++i)
@@ -415,7 +415,7 @@ namespace internal
             {
               Assert (min_level[vertex] < n_levels, ExcInternalError ());
               Assert (max_level[vertex] >= min_level[vertex], ExcInternalError ());
-              dof_handler.mg_vertex_dofs[vertex].init (min_level[vertex], max_level[vertex], dof_handler.get_finite_element ().dofs_per_vertex);
+              dof_handler.mg_vertex_dofs[vertex].init (min_level[vertex], max_level[vertex], dof_handler.get_fe ().dofs_per_vertex);
             }
 
           else
@@ -433,7 +433,7 @@ namespace internal
         Assert (dof_handler.get_triangulation().n_levels () > 0, ExcMessage ("Invalid triangulation"));
         dof_handler.clear_mg_space ();
 
-        const dealii::FiniteElement<2, spacedim> &fe = dof_handler.get_finite_element ();
+        const dealii::FiniteElement<2, spacedim> &fe = dof_handler.get_fe ();
         const dealii::Triangulation<2, spacedim> &tria = dof_handler.get_triangulation();
         const unsigned int &n_levels = tria.n_levels ();
 
@@ -492,7 +492,7 @@ namespace internal
         Assert (dof_handler.get_triangulation().n_levels () > 0, ExcMessage ("Invalid triangulation"));
         dof_handler.clear_mg_space ();
 
-        const dealii::FiniteElement<3, spacedim> &fe = dof_handler.get_finite_element ();
+        const dealii::FiniteElement<3, spacedim> &fe = dof_handler.get_fe ();
         const dealii::Triangulation<3, spacedim> &tria = dof_handler.get_triangulation();
         const unsigned int &n_levels = tria.n_levels ();
 
@@ -889,7 +889,7 @@ types::global_dof_index DoFHandler<dim,spacedim>::n_boundary_dofs () const
 {
   std::set<int> boundary_dofs;
 
-  const unsigned int dofs_per_face = get_finite_element().dofs_per_face;
+  const unsigned int dofs_per_face = get_fe().dofs_per_face;
   std::vector<types::global_dof_index> dofs_on_face(dofs_per_face);
 
   // loop over all faces of all cells
@@ -931,7 +931,7 @@ DoFHandler<dim,spacedim>::n_boundary_dofs (const std::set<types::boundary_id> &b
 
   std::set<types::global_dof_index> boundary_dofs;
 
-  const unsigned int dofs_per_face = get_finite_element().dofs_per_face;
+  const unsigned int dofs_per_face = get_fe().dofs_per_face;
   std::vector<types::global_dof_index> dofs_on_face(dofs_per_face);
 
   // same as in the previous
@@ -1169,10 +1169,10 @@ DoFHandler<dim,spacedim>::max_couplings_between_boundary_dofs () const
   switch (dim)
     {
     case 1:
-      return get_finite_element().dofs_per_vertex;
+      return get_fe().dofs_per_vertex;
     case 2:
-      return (3*get_finite_element().dofs_per_vertex +
-              2*get_finite_element().dofs_per_line);
+      return (3*get_fe().dofs_per_vertex +
+              2*get_fe().dofs_per_line);
     case 3:
       // we need to take refinement of
       // one boundary face into
@@ -1190,9 +1190,9 @@ DoFHandler<dim,spacedim>::max_couplings_between_boundary_dofs () const
       // harm since the matrix will cry
       // foul if its requirements are
       // not satisfied
-      return (19*get_finite_element().dofs_per_vertex +
-              28*get_finite_element().dofs_per_line +
-              8*get_finite_element().dofs_per_quad);
+      return (19*get_fe().dofs_per_vertex +
+              28*get_fe().dofs_per_line +
+              8*get_fe().dofs_per_quad);
     default:
       Assert (false, ExcNotImplemented());
       return numbers::invalid_unsigned_int;

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -287,11 +287,11 @@ namespace internal
         {
 
           // distribute dofs of vertices
-          if (dof_handler.get_finite_element().dofs_per_vertex > 0)
+          if (dof_handler.get_fe().dofs_per_vertex > 0)
             for (unsigned int v=0; v<GeometryInfo<1>::vertices_per_cell; ++v)
               {
                 if (cell->vertex_dof_index (v,0) == numbers::invalid_dof_index)
-                  for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_vertex; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                     {
                       Assert ((cell->vertex_dof_index (v,d) ==
                                numbers::invalid_dof_index),
@@ -299,14 +299,14 @@ namespace internal
                       cell->set_vertex_dof_index (v, d, next_free_dof++);
                     }
                 else
-                  for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_vertex; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                     Assert ((cell->vertex_dof_index (v,d) !=
                              numbers::invalid_dof_index),
                             ExcInternalError());
               }
 
           // dofs of line
-          for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_line; ++d)
+          for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
             cell->set_dof_index (d, next_free_dof++);
 
           return next_free_dof;
@@ -321,17 +321,17 @@ namespace internal
                                  const typename DoFHandler<2,spacedim>::active_cell_iterator &cell,
                                  types::global_dof_index                                      next_free_dof)
         {
-          if (dof_handler.get_finite_element().dofs_per_vertex > 0)
+          if (dof_handler.get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
             for (unsigned int vertex=0; vertex<GeometryInfo<2>::vertices_per_cell; ++vertex)
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
               if (cell->vertex_dof_index(vertex, 0) == numbers::invalid_dof_index)
-                for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_vertex; ++d)
+                for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof++);
 
           // for the four sides
-          if (dof_handler.get_finite_element().dofs_per_line > 0)
+          if (dof_handler.get_fe().dofs_per_line > 0)
             for (unsigned int side=0; side<GeometryInfo<2>::faces_per_cell; ++side)
               {
                 const typename DoFHandler<2,spacedim>::line_iterator
@@ -341,14 +341,14 @@ namespace internal
                 // numbered (checking the first dof should be good enough)
                 if (line->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_line; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                     line->set_dof_index (d, next_free_dof++);
               }
 
 
           // dofs of quad
-          if (dof_handler.get_finite_element().dofs_per_quad > 0)
-            for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_quad; ++d)
+          if (dof_handler.get_fe().dofs_per_quad > 0)
+            for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_quad; ++d)
               cell->set_dof_index (d, next_free_dof++);
 
           return next_free_dof;
@@ -363,17 +363,17 @@ namespace internal
                                  const typename DoFHandler<3,spacedim>::active_cell_iterator &cell,
                                  types::global_dof_index                                      next_free_dof)
         {
-          if (dof_handler.get_finite_element().dofs_per_vertex > 0)
+          if (dof_handler.get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
             for (unsigned int vertex=0; vertex<GeometryInfo<3>::vertices_per_cell; ++vertex)
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
               if (cell->vertex_dof_index(vertex, 0) == numbers::invalid_dof_index)
-                for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_vertex; ++d)
+                for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                   cell->set_vertex_dof_index (vertex, d, next_free_dof++);
 
           // for the lines
-          if (dof_handler.get_finite_element().dofs_per_line > 0)
+          if (dof_handler.get_fe().dofs_per_line > 0)
             for (unsigned int l=0; l<GeometryInfo<3>::lines_per_cell; ++l)
               {
                 const typename DoFHandler<3,spacedim>::line_iterator
@@ -383,12 +383,12 @@ namespace internal
                 // numbered (checking the first dof should be good enough)
                 if (line->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_line; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                     line->set_dof_index (d, next_free_dof++);
               }
 
           // for the quads
-          if (dof_handler.get_finite_element().dofs_per_quad > 0)
+          if (dof_handler.get_fe().dofs_per_quad > 0)
             for (unsigned int q=0; q<GeometryInfo<3>::quads_per_cell; ++q)
               {
                 const typename DoFHandler<3,spacedim>::quad_iterator
@@ -398,14 +398,14 @@ namespace internal
                 // numbered (checking the first dof should be good enough)
                 if (quad->dof_index(0) == numbers::invalid_dof_index)
                   // if not: distribute dofs
-                  for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_quad; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_quad; ++d)
                     quad->set_dof_index (d, next_free_dof++);
               }
 
 
           // dofs of hex
-          if (dof_handler.get_finite_element().dofs_per_hex > 0)
-            for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_hex; ++d)
+          if (dof_handler.get_fe().dofs_per_hex > 0)
+            for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_hex; ++d)
               cell->set_dof_index (d, next_free_dof++);
 
           return next_free_dof;
@@ -634,8 +634,8 @@ namespace internal
                         // make sure the entry in the equivalence
                         // table exists
                         ensure_existence_of_dof_identities<0>
-                        (dof_handler.get_finite_element(first_fe_index),
-                         dof_handler.get_finite_element(other_fe_index),
+                        (dof_handler.get_fe(first_fe_index),
+                         dof_handler.get_fe(other_fe_index),
                          vertex_dof_identities[first_fe_index][other_fe_index]);
 
                         // then loop through the identities we
@@ -1452,7 +1452,7 @@ namespace internal
               // really is unused
               Assert (dof_handler.get_triangulation()
                       .vertex_used((i-dof_handler.vertex_dofs.begin()) /
-                                   dof_handler.get_finite_element().dofs_per_vertex)
+                                   dof_handler.get_fe().dofs_per_vertex)
                       == false,
                       ExcInternalError ());
         }
@@ -1572,7 +1572,7 @@ namespace internal
                     = dealii::internal::DoFAccessor::Implementation::
                       nth_active_vertex_fe_index (dof_handler, vertex_index, f);
 
-                  for (unsigned int d=0; d<dof_handler.get_finite_element(fe_index).dofs_per_vertex; ++d)
+                  for (unsigned int d=0; d<dof_handler.get_fe(fe_index).dofs_per_vertex; ++d)
                     {
                       const types::global_dof_index old_dof_index
                         = dealii::internal::DoFAccessor::Implementation::
@@ -1616,7 +1616,7 @@ namespace internal
             {
               const unsigned int fe_index = cell->active_fe_index ();
 
-              for (unsigned int d=0; d<dof_handler.get_finite_element(fe_index).template n_dofs_per_object<dim>(); ++d)
+              for (unsigned int d=0; d<dof_handler.get_fe(fe_index).template n_dofs_per_object<dim>(); ++d)
                 {
                   const types::global_dof_index old_dof_index = cell->dof_index(d,fe_index);
                   if (old_dof_index != numbers::invalid_dof_index)
@@ -1679,7 +1679,7 @@ namespace internal
                         const unsigned int fe_index
                           = line->nth_active_fe_index (f);
 
-                        for (unsigned int d=0; d<dof_handler.get_finite_element(fe_index).dofs_per_line; ++d)
+                        for (unsigned int d=0; d<dof_handler.get_fe(fe_index).dofs_per_line; ++d)
                           {
                             const types::global_dof_index old_dof_index = line->dof_index(d,fe_index);
                             if (old_dof_index != numbers::invalid_dof_index)
@@ -1736,7 +1736,7 @@ namespace internal
                         const unsigned int fe_index
                           = line->nth_active_fe_index (f);
 
-                        for (unsigned int d=0; d<dof_handler.get_finite_element(fe_index).dofs_per_line; ++d)
+                        for (unsigned int d=0; d<dof_handler.get_fe(fe_index).dofs_per_line; ++d)
                           {
                             const types::global_dof_index old_dof_index = line->dof_index(d,fe_index);
                             if (old_dof_index != numbers::invalid_dof_index)
@@ -1779,7 +1779,7 @@ namespace internal
                         const unsigned int fe_index
                           = quad->nth_active_fe_index (f);
 
-                        for (unsigned int d=0; d<dof_handler.get_finite_element(fe_index).dofs_per_quad; ++d)
+                        for (unsigned int d=0; d<dof_handler.get_fe(fe_index).dofs_per_quad; ++d)
                           {
                             const types::global_dof_index old_dof_index = quad->dof_index(d,fe_index);
                             if (old_dof_index != numbers::invalid_dof_index)
@@ -1875,17 +1875,17 @@ namespace internal
             // if the present vertex lives on the current level
             if ((i->get_coarsest_level() <= level) &&
                 (i->get_finest_level() >= level))
-              for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_vertex; ++d)
+              for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_vertex; ++d)
                 {
                   const dealii::types::global_dof_index idx
-                    = i->get_index (level, d, dof_handler.get_finite_element().dofs_per_vertex);
+                    = i->get_index (level, d, dof_handler.get_fe().dofs_per_vertex);
 
                   if (check_validity)
                     Assert(idx != numbers::invalid_dof_index, ExcInternalError ());
 
                   if (idx != numbers::invalid_dof_index)
                     i->set_index (level, d,
-                                  dof_handler.get_finite_element().dofs_per_vertex,
+                                  dof_handler.get_fe().dofs_per_vertex,
                                   (indices.size() == 0)?
                                   (new_numbers[idx]) :
                                   (new_numbers[indices.index_within_set(idx)]));
@@ -1956,7 +1956,7 @@ namespace internal
                                const unsigned int                                  level,
                                const bool                                          check_validity)
         {
-          if (dof_handler.get_finite_element().dofs_per_line > 0)
+          if (dof_handler.get_fe().dofs_per_line > 0)
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
@@ -1978,7 +1978,7 @@ namespace internal
                 for (unsigned int l=0; l<GeometryInfo<2>::lines_per_cell; ++l)
                   if (cell->line(l)->user_flag_set())
                     {
-                      for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_line; ++d)
+                      for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                         {
                           const dealii::types::global_dof_index idx = cell->line(l)->mg_dof_index(level, d);
                           if (check_validity)
@@ -2007,8 +2007,8 @@ namespace internal
                                const unsigned int                                  level,
                                const bool                                          check_validity)
         {
-          if (dof_handler.get_finite_element().dofs_per_line > 0 ||
-              dof_handler.get_finite_element().dofs_per_quad > 0)
+          if (dof_handler.get_fe().dofs_per_line > 0 ||
+              dof_handler.get_fe().dofs_per_quad > 0)
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
@@ -2029,7 +2029,7 @@ namespace internal
                 for (unsigned int l=0; l<GeometryInfo<3>::lines_per_cell; ++l)
                   if (cell->line(l)->user_flag_set())
                     {
-                      for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_line; ++d)
+                      for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_line; ++d)
                         {
                           const dealii::types::global_dof_index idx = cell->line(l)->mg_dof_index(level, d);
                           if (check_validity)
@@ -2055,7 +2055,7 @@ namespace internal
                 for (unsigned int l=0; l<GeometryInfo<3>::quads_per_cell; ++l)
                   if (cell->quad(l)->user_flag_set())
                     {
-                      for (unsigned int d=0; d<dof_handler.get_finite_element().dofs_per_quad; ++d)
+                      for (unsigned int d=0; d<dof_handler.get_fe().dofs_per_quad; ++d)
                         {
                           const dealii::types::global_dof_index idx = cell->quad(l)->mg_dof_index(level, d);
                           if (check_validity)

--- a/source/dofs/dof_objects.cc
+++ b/source/dofs/dof_objects.cc
@@ -47,14 +47,14 @@ namespace internal
       (void)fe_index;
       Assert ((fe_index == dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
               ExcMessage ("Only the default FE index is allowed for non-hp DoFHandler objects"));
-      Assert (local_index<dof_handler.get_finite_element().template n_dofs_per_object<dim>(),
-              ExcIndexRange (local_index, 0, dof_handler.get_finite_element().template n_dofs_per_object<dim>()));
-      Assert (obj_index * dof_handler.get_finite_element().template n_dofs_per_object<dim>()+local_index
+      Assert (local_index<dof_handler.get_fe().template n_dofs_per_object<dim>(),
+              ExcIndexRange (local_index, 0, dof_handler.get_fe().template n_dofs_per_object<dim>()));
+      Assert (obj_index * dof_handler.get_fe().template n_dofs_per_object<dim>()+local_index
               <
               dofs.size(),
               ExcInternalError());
 
-      dofs[obj_index * dof_handler.get_finite_element()
+      dofs[obj_index * dof_handler.get_fe()
            .template n_dofs_per_object<dim>() + local_index] = global_index;
     }
   }

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1447,7 +1447,7 @@ namespace DoFRenumbering
             ExcDimensionMismatch(reverse.size(), dof.n_dofs(level)));
 
     unsigned int n_global_dofs = dof.n_dofs(level);
-    unsigned int n_cell_dofs = dof.get_finite_element().n_dofs_per_cell();
+    unsigned int n_cell_dofs = dof.get_fe().n_dofs_per_cell();
 
     std::vector<bool> already_sorted(n_global_dofs, false);
     std::vector<types::global_dof_index> cell_dofs(n_cell_dofs);
@@ -1622,19 +1622,19 @@ namespace DoFRenumbering
       }
     else
       {
-        Assert (dof.get_finite_element().has_support_points(),
+        Assert (dof.get_fe().has_support_points(),
                 typename FiniteElement<DoFHandlerType::dimension>::ExcFEHasNoSupportPoints());
         const unsigned int n_dofs = dof.n_dofs(level);
         std::vector<std::pair<Point<DoFHandlerType::space_dimension>,unsigned int> > support_point_list
         (n_dofs);
 
-        Quadrature<DoFHandlerType::dimension>   q_dummy(dof.get_finite_element().get_unit_support_points());
-        FEValues<DoFHandlerType::dimension,DoFHandlerType::space_dimension> fe_values (dof.get_finite_element(), q_dummy,
+        Quadrature<DoFHandlerType::dimension>   q_dummy(dof.get_fe().get_unit_support_points());
+        FEValues<DoFHandlerType::dimension,DoFHandlerType::space_dimension> fe_values (dof.get_fe(), q_dummy,
             update_quadrature_points);
 
         std::vector<bool> already_touched (dof.n_dofs(), false);
 
-        const unsigned int dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+        const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
         std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
         typename DoFHandlerType::level_cell_iterator begin = dof.begin(level);
         typename DoFHandlerType::level_cell_iterator end = dof.end(level);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -373,7 +373,7 @@ namespace DoFTools
                 const ComponentMask            &component_mask,
                 std::vector<bool>              &selected_dofs)
   {
-    const FiniteElement<dim,spacedim> &fe = dof.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe = dof.get_fe();
     (void)fe;
 
     Assert(component_mask.represents_n_components(fe.n_components()),
@@ -491,7 +491,7 @@ namespace DoFTools
                       const ComponentMask  &component_mask,
                       std::vector<bool>    &selected_dofs)
   {
-    const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe = dof.get_finite_element();
+    const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe = dof.get_fe();
 
     Assert(component_mask.represents_n_components(n_components(dof)),
            ExcMessage ("The given component mask is not sized correctly to represent the "
@@ -544,7 +544,7 @@ namespace DoFTools
                       std::vector<bool>    &selected_dofs)
   {
     // simply defer to the other extract_level_dofs() function
-    extract_level_dofs (level, dof, dof.get_finite_element().component_mask(block_mask),
+    extract_level_dofs (level, dof, dof.get_fe().component_mask(block_mask),
                         selected_dofs);
   }
 
@@ -894,7 +894,7 @@ namespace DoFTools
         // preset all values by false
         std::fill_n (selected_dofs.begin(), dof_handler.n_dofs(), false);
 
-        const FiniteElement<dim,spacedim> &fe = dof_handler.get_finite_element();
+        const FiniteElement<dim,spacedim> &fe = dof_handler.get_fe();
 
         // this function is similar to the make_sparsity_pattern function,
         // see there for more information
@@ -929,7 +929,7 @@ namespace DoFTools
         // preset all values by false
         std::fill_n (selected_dofs.begin(), dof_handler.n_dofs(), false);
 
-        const FiniteElement<dim,spacedim> &fe = dof_handler.get_finite_element();
+        const FiniteElement<dim,spacedim> &fe = dof_handler.get_fe();
 
         // this function is similar to the make_sparsity_pattern function,
         // see there for more information
@@ -1166,7 +1166,7 @@ namespace DoFTools
                           const ComponentMask             &component_mask,
                           std::vector<std::vector<bool> > &constant_modes)
   {
-    const unsigned int n_components = dof_handler.get_finite_element(0).n_components();
+    const unsigned int n_components = dof_handler.get_fe(0).n_components();
     Assert (component_mask.represents_n_components(n_components),
             ExcDimensionMismatch(n_components,
                                  component_mask.size()));
@@ -1576,9 +1576,9 @@ namespace DoFTools
                                          const types::subdomain_id  subdomain,
                                          std::vector<unsigned int> &n_dofs_on_subdomain)
   {
-    Assert (n_dofs_on_subdomain.size() == dof_handler.get_finite_element(0).n_components(),
+    Assert (n_dofs_on_subdomain.size() == dof_handler.get_fe(0).n_components(),
             ExcDimensionMismatch (n_dofs_on_subdomain.size(),
-                                  dof_handler.get_finite_element(0).n_components()));
+                                  dof_handler.get_fe(0).n_components()));
     std::fill (n_dofs_on_subdomain.begin(), n_dofs_on_subdomain.end(), 0);
 
     // in debug mode, make sure that there are some cells at least with
@@ -1607,7 +1607,7 @@ namespace DoFTools
     internal::get_component_association (dof_handler, std::vector<bool>(),
                                          component_association);
 
-    for (unsigned int c=0; c<dof_handler.get_finite_element(0).n_components(); ++c)
+    for (unsigned int c=0; c<dof_handler.get_fe(0).n_components(); ++c)
       {
         for (types::global_dof_index i=0; i<dof_handler.n_dofs(); ++i)
           if ((subdomain_association[i] == subdomain) &&
@@ -1736,7 +1736,7 @@ namespace DoFTools
                             bool                                  only_once,
                             std::vector<unsigned int>             target_component)
   {
-    const unsigned int n_components = dof_handler.get_finite_element(0).n_components();
+    const unsigned int n_components = dof_handler.get_fe(0).n_components();
 
     std::fill (dofs_per_component.begin(), dofs_per_component.end(),
                types::global_dof_index(0));
@@ -2188,7 +2188,7 @@ namespace DoFTools
    const Table<2, Coupling>        &table,
    std::vector<Table<2,Coupling> > &tables_by_block)
   {
-    const FiniteElement<dim,spacedim> &fe = dof_handler.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe = dof_handler.get_fe();
     const unsigned int nb = fe.n_blocks();
 
     tables_by_block.resize(1);
@@ -2253,7 +2253,7 @@ namespace DoFTools
     for (cell=dof_handler.begin(level); cell != endc; ++cell)
       if (cell->is_locally_owned_on_level())
         ++i;
-    block_list.reinit(i, dof_handler.n_dofs(), dof_handler.get_finite_element().dofs_per_cell);
+    block_list.reinit(i, dof_handler.n_dofs(), dof_handler.get_fe().dofs_per_cell);
     i=0;
     for (cell=dof_handler.begin(level); cell != endc; ++cell)
       if (cell->is_locally_owned_on_level())
@@ -2285,7 +2285,7 @@ namespace DoFTools
                          const unsigned int    level,
                          const bool            interior_only)
   {
-    const FiniteElement<DoFHandlerType::dimension> &fe = dof_handler.get_finite_element();
+    const FiniteElement<DoFHandlerType::dimension> &fe = dof_handler.get_fe();
     block_list.reinit(1, dof_handler.n_dofs(level), dof_handler.n_dofs(level));
     typename DoFHandlerType::level_cell_iterator cell;
     typename DoFHandlerType::level_cell_iterator endc = dof_handler.end(level);
@@ -2348,7 +2348,7 @@ namespace DoFTools
             const typename DoFHandlerType::level_cell_iterator cell = pcell->child(child);
 
             // For hp, only this line here would have to be replaced.
-            const FiniteElement<DoFHandlerType::dimension> &fe = dof_handler.get_finite_element();
+            const FiniteElement<DoFHandlerType::dimension> &fe = dof_handler.get_fe();
             const unsigned int n_dofs = fe.dofs_per_cell;
             indices.resize(n_dofs);
             exclude.resize(n_dofs);
@@ -2396,7 +2396,7 @@ namespace DoFTools
                        const bool            single_cell_patches,
                        const bool            invert_vertex_mapping)
   {
-    const unsigned int n_blocks = dof_handler.get_finite_element().n_blocks();
+    const unsigned int n_blocks = dof_handler.get_fe().n_blocks();
     BlockMask exclude_boundary_dofs = BlockMask(n_blocks,interior_only);
     return make_vertex_patches(block_list,
                                dof_handler,

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -450,7 +450,7 @@ namespace DoFTools
       /**
        * A function that returns how many different finite elements a dof
        * handler uses. This is one for non-hp DoFHandlers and
-       * dof_handler.get_finite_element().size() for the hp-versions.
+       * dof_handler.get_fe().size() for the hp-versions.
        */
       template <int dim, int spacedim>
       unsigned int
@@ -1286,7 +1286,7 @@ namespace DoFTools
                                 ExcMessage("Could not find a least face dominating FE."));
 
                     const FiniteElement<dim,spacedim> &dominating_fe
-                      = dof_handler.get_finite_element(dominating_fe_index);
+                      = dof_handler.get_fe(dominating_fe_index);
 
                     // first get the interpolation matrix from the mother
                     // to the virtual dofs
@@ -1385,7 +1385,7 @@ namespace DoFTools
                         const unsigned int subface_fe_index
                           = cell->face(face)->child(sf)->nth_active_fe_index(0);
                         const FiniteElement<dim,spacedim> &subface_fe
-                          = dof_handler.get_finite_element(subface_fe_index);
+                          = dof_handler.get_fe(subface_fe_index);
 
                         // first get the interpolation matrix from the
                         // subface to the virtual dofs
@@ -2676,8 +2676,8 @@ namespace DoFTools
         Assembler::CopyData<dim,spacedim> copy_data;
 
         unsigned int n_interesting_dofs = 0;
-        for (unsigned int local_dof=0; local_dof<coarse_grid.get_finite_element().dofs_per_cell; ++local_dof)
-          if (coarse_grid.get_finite_element().system_to_component_index(local_dof).first
+        for (unsigned int local_dof=0; local_dof<coarse_grid.get_fe().dofs_per_cell; ++local_dof)
+          if (coarse_grid.get_fe().system_to_component_index(local_dof).first
               ==
               coarse_component)
             ++n_interesting_dofs;
@@ -2723,13 +2723,13 @@ namespace DoFTools
                                   std::placeholders::_2,
                                   std::placeholders::_3,
                                   coarse_component,
-                                  std::cref(coarse_grid.get_finite_element()),
+                                  std::cref(coarse_grid.get_fe()),
                                   std::cref(coarse_to_fine_grid_map),
                                   std::cref(parameter_dofs)),
                         std::bind(&copy_intergrid_weights_3<dim,spacedim>,
                                   std::placeholders::_1,
                                   coarse_component,
-                                  std::cref(coarse_grid.get_finite_element()),
+                                  std::cref(coarse_grid.get_fe()),
                                   std::cref(weight_mapping),
                                   is_called_in_parallel,
                                   std::ref(weights)),
@@ -2761,8 +2761,8 @@ namespace DoFTools
         std::vector<types::global_dof_index>                   &weight_mapping)
       {
         // aliases to the finite elements used by the dof handlers:
-        const FiniteElement<dim,spacedim> &coarse_fe = coarse_grid.get_finite_element(),
-                                           &fine_fe = fine_grid.get_finite_element();
+        const FiniteElement<dim,spacedim> &coarse_fe = coarse_grid.get_fe(),
+                                           &fine_fe = fine_grid.get_fe();
 
         // global numbers of dofs
         const types::global_dof_index n_coarse_dofs = coarse_grid.n_dofs(),
@@ -3016,7 +3016,7 @@ namespace DoFTools
     std::vector<bool> coarse_dof_is_parameter (coarse_grid.n_dofs());
     if (true)
       {
-        std::vector<bool> mask (coarse_grid.get_finite_element(0).n_components(),
+        std::vector<bool> mask (coarse_grid.get_fe(0).n_components(),
                                 false);
         mask[coarse_component] = true;
         extract_dofs (coarse_grid, ComponentMask(mask), coarse_dof_is_parameter);
@@ -3226,7 +3226,7 @@ namespace DoFTools
                                   ConstraintMatrix                    &zero_boundary_constraints,
                                   const ComponentMask                 &component_mask)
   {
-    Assert (component_mask.represents_n_components(dof.get_finite_element(0).n_components()),
+    Assert (component_mask.represents_n_components(dof.get_fe(0).n_components()),
             ExcMessage ("The number of components in the mask has to be either "
                         "zero or equal to the number of components in the finite "
                         "element."));

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -125,10 +125,10 @@ namespace DoFTools
             ExcDimensionMismatch (sparsity.n_rows(), n_dofs));
     Assert (sparsity.n_cols() == n_dofs,
             ExcDimensionMismatch (sparsity.n_cols(), n_dofs));
-    Assert (couplings.n_rows() == dof.get_finite_element(0).n_components(),
-            ExcDimensionMismatch(couplings.n_rows(), dof.get_finite_element(0).n_components()));
-    Assert (couplings.n_cols() == dof.get_finite_element(0).n_components(),
-            ExcDimensionMismatch(couplings.n_cols(), dof.get_finite_element(0).n_components()));
+    Assert (couplings.n_rows() == dof.get_fe(0).n_components(),
+            ExcDimensionMismatch(couplings.n_rows(), dof.get_fe(0).n_components()));
+    Assert (couplings.n_cols() == dof.get_fe(0).n_components(),
+            ExcDimensionMismatch(couplings.n_cols(), dof.get_fe(0).n_components()));
 
     // If we have a distributed::Triangulation only allow locally_owned
     // subdomain. Not setting a subdomain is also okay, because we skip
@@ -697,7 +697,7 @@ namespace DoFTools
                                   const types::subdomain_id  subdomain_id)
       {
         const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension>
-        &fe = dof.get_finite_element();
+        &fe = dof.get_fe();
 
         std::vector<types::global_dof_index> dofs_on_this_cell (fe.dofs_per_cell);
         std::vector<types::global_dof_index> dofs_on_other_cell (fe.dofs_per_cell);
@@ -1225,7 +1225,7 @@ namespace DoFTools
     // specialized functions in the internal namespace
     const types::global_dof_index n_dofs = dof.n_dofs();
     (void)n_dofs;
-    const unsigned int n_comp = dof.get_finite_element(0).n_components();
+    const unsigned int n_comp = dof.get_fe(0).n_components();
     (void)n_comp;
 
     Assert (sparsity.n_rows() == n_dofs,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4293,7 +4293,7 @@ FEFaceValues<dim,spacedim>::reinit
   // this cell, are the same
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
           static_cast<const FiniteElementData<dim>&>(
-            cell->get_dof_handler().get_finite_element(cell->active_fe_index ())),
+            cell->get_dof_handler().get_fe(cell->active_fe_index ())),
           (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
 
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
@@ -4460,7 +4460,7 @@ void FESubfaceValues<dim,spacedim>::reinit
   // this cell, are the same
   Assert (static_cast<const FiniteElementData<dim>&>(*this->fe) ==
           static_cast<const FiniteElementData<dim>&>(
-            cell->get_dof_handler().get_finite_element(cell->active_fe_index ())),
+            cell->get_dof_handler().get_fe(cell->active_fe_index ())),
           (typename FEValuesBase<dim,spacedim>::ExcFEDontMatch()));
   Assert (face_no < GeometryInfo<dim>::faces_per_cell,
           ExcIndexRange (face_no, 0, GeometryInfo<dim>::faces_per_cell));

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -207,7 +207,7 @@ MappingFEField<dim,spacedim,VectorType,DoFHandlerType>::MappingFEField
  const ComponentMask  mask)
   :
   euler_vector(&euler_vector),
-  fe(&euler_dof_handler.get_finite_element()),
+  fe(&euler_dof_handler.get_fe()),
   euler_dof_handler(&euler_dof_handler),
   fe_mask(mask.size() ? mask :
           ComponentMask(fe->get_nonzero_components(0).size(), true)),

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -59,8 +59,8 @@ get_vertices
   // object is constructed, which is not necessarily what we want.
 
   //TODO: Only one of these two assertions should be relevant
-  AssertDimension (spacedim, shiftmap_dof_handler->get_finite_element().n_dofs_per_vertex());
-  AssertDimension (shiftmap_dof_handler->get_finite_element(0).n_components(), spacedim);
+  AssertDimension (spacedim, shiftmap_dof_handler->get_fe().n_dofs_per_vertex());
+  AssertDimension (shiftmap_dof_handler->get_fe(0).n_components(), spacedim);
 
   AssertDimension (shiftmap_dof_handler->n_dofs(), euler_transform_vectors->size());
 
@@ -74,7 +74,7 @@ get_vertices
   Assert (dof_cell->active() == true, ExcInactiveCell());
 
   // now get the values of the shift vectors at the vertices
-  Vector<double> mapping_values (shiftmap_dof_handler->get_finite_element().dofs_per_cell);
+  Vector<double> mapping_values (shiftmap_dof_handler->get_fe().dofs_per_cell);
   dof_cell->get_dof_values (*euler_transform_vectors, mapping_values);
 
   for (unsigned int i=0; i<GeometryInfo<dim>::vertices_per_cell; ++i)

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -47,7 +47,7 @@ MappingQEulerianGeneric (const unsigned int                                 degr
   MappingQGeneric<dim,spacedim>(degree),
   mapping_q_eulerian (mapping_q_eulerian),
   support_quadrature(degree),
-  fe_values(mapping_q_eulerian.euler_dof_handler->get_finite_element(),
+  fe_values(mapping_q_eulerian.euler_dof_handler->get_fe(),
             support_quadrature,
             update_values | update_quadrature_points)
 {}
@@ -197,7 +197,7 @@ compute_mapping_support_points (const typename Triangulation<dim,spacedim>::cell
   // or create a separate dof handler for the displacements.
 
   const unsigned int n_support_pts = support_quadrature.size();
-  const unsigned int n_components  = mapping_q_eulerian.euler_dof_handler->get_finite_element(0).n_components();
+  const unsigned int n_components  = mapping_q_eulerian.euler_dof_handler->get_fe(0).n_components();
 
   Assert (n_components >= spacedim, ExcDimensionMismatch(n_components, spacedim) );
 

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -548,7 +548,7 @@ namespace MGTools
     Assert (sparsity.n_cols() == n_dofs,
             ExcDimensionMismatch (sparsity.n_cols(), n_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     typename DoFHandlerType::cell_iterator cell = dof.begin(level),
                                            endc = dof.end(level);
@@ -581,7 +581,7 @@ namespace MGTools
     Assert (sparsity.n_cols() == n_dofs,
             ExcDimensionMismatch (sparsity.n_cols(), n_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     typename DoFHandler<dim,spacedim>::cell_iterator cell = dof.begin(level),
@@ -663,7 +663,7 @@ namespace MGTools
     Assert (sparsity.n_cols() == fine_dofs,
             ExcDimensionMismatch (sparsity.n_cols(), fine_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     typename DoFHandler<dim,spacedim>::cell_iterator cell = dof.begin(level),
@@ -718,7 +718,7 @@ namespace MGTools
                               const Table<2,DoFTools::Coupling> &int_mask,
                               const Table<2,DoFTools::Coupling> &flux_mask)
   {
-    const FiniteElement<dim> &fe = dof.get_finite_element();
+    const FiniteElement<dim> &fe = dof.get_fe();
     const types::global_dof_index n_dofs = dof.n_dofs(level);
     const unsigned int n_comp = fe.n_components();
     (void)n_dofs;
@@ -899,7 +899,7 @@ namespace MGTools
                                    const unsigned int                 level,
                                    const Table<2,DoFTools::Coupling> &flux_mask)
   {
-    const FiniteElement<dim> &fe = dof.get_finite_element();
+    const FiniteElement<dim> &fe = dof.get_fe();
     const unsigned int n_comp = fe.n_components();
     (void)n_comp;
 
@@ -922,7 +922,7 @@ namespace MGTools
     Assert (flux_mask.n_cols() == n_comp,
             ExcDimensionMismatch (flux_mask.n_cols(), n_comp));
 
-    const unsigned int dofs_per_cell = dof.get_finite_element().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     Table<2,bool> support_on_face(dofs_per_cell, GeometryInfo<dim>::faces_per_cell);
@@ -989,7 +989,7 @@ namespace MGTools
                             bool                              only_once,
                             std::vector<unsigned int>         target_component)
   {
-    const FiniteElement<dim> &fe = dof_handler.get_finite_element();
+    const FiniteElement<dim> &fe = dof_handler.get_fe();
     const unsigned int n_components = fe.n_components();
     const unsigned int nlevels = dof_handler.get_triangulation().n_global_levels();
 
@@ -1071,7 +1071,7 @@ namespace MGTools
                   }
               }
             // finally sanity check
-            Assert (!dof_handler.get_finite_element().is_primitive()
+            Assert (!dof_handler.get_fe().is_primitive()
                     ||
                     std::accumulate (result[l].begin(),
                                      result[l].end(), 0U)
@@ -1091,7 +1091,7 @@ namespace MGTools
    std::vector<std::vector<types::global_dof_index> > &dofs_per_block,
    std::vector<unsigned int>                           target_block)
   {
-    const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe = dof_handler.get_finite_element();
+    const FiniteElement<DoFHandlerType::dimension,DoFHandlerType::space_dimension> &fe = dof_handler.get_fe();
     const unsigned int n_blocks = fe.n_blocks();
     const unsigned int n_levels = dof_handler.get_triangulation().n_global_levels();
 
@@ -1366,7 +1366,7 @@ namespace MGTools
             ExcDimensionMismatch (non_interface_dofs.size(),
                                   mg_dof_handler.get_triangulation().n_global_levels()));
 
-    const FiniteElement<dim,spacedim> &fe = mg_dof_handler.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe = mg_dof_handler.get_fe();
 
     const unsigned int   dofs_per_cell   = fe.dofs_per_cell;
     const unsigned int   dofs_per_face   = fe.dofs_per_face;
@@ -1438,7 +1438,7 @@ namespace MGTools
     std::vector<std::vector<types::global_dof_index> >
     tmp_interface_dofs(interface_dofs.size());
 
-    const FiniteElement<dim,spacedim> &fe = mg_dof_handler.get_finite_element();
+    const FiniteElement<dim,spacedim> &fe = mg_dof_handler.get_fe();
 
     const unsigned int   dofs_per_cell   = fe.dofs_per_cell;
     const unsigned int   dofs_per_face   = fe.dofs_per_face;

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -100,7 +100,7 @@ namespace
     const unsigned int selected_block,
     std::vector<std::vector<types::global_dof_index> > &ndofs)
   {
-    const unsigned int n_blocks = mg_dof.get_finite_element().n_blocks();
+    const unsigned int n_blocks = mg_dof.get_fe().n_blocks();
     Assert(selected_block < n_blocks, ExcIndexRange(selected_block, 0, n_blocks));
 
     std::vector<bool> selected(n_blocks, false);
@@ -198,7 +198,7 @@ void MGTransferBlockBase::build_matrices (
   const DoFHandler<dim,spacedim> &,
   const DoFHandler<dim,spacedim> &mg_dof)
 {
-  const FiniteElement<dim> &fe = mg_dof.get_finite_element();
+  const FiniteElement<dim> &fe = mg_dof.get_fe();
   const unsigned int n_blocks  = fe.n_blocks();
   const unsigned int dofs_per_cell = fe.dofs_per_cell;
   const unsigned int n_levels      = mg_dof.get_triangulation().n_levels();
@@ -336,7 +336,7 @@ void MGTransferBlockBase::build_matrices (
                 // prolongation matrix for
                 // this child
                 const FullMatrix<double> &prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child, cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child, cell->refinement_case());
 
                 cell->child(child)->get_mg_dof_indices (dof_indices_child);
 
@@ -375,7 +375,7 @@ void MGTransferBlockBase::build_matrices (
                 // prolongation matrix for
                 // this child
                 const FullMatrix<double> &prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child, cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child, cell->refinement_case());
 
                 cell->child(child)->get_mg_dof_indices (dof_indices_child);
 
@@ -454,8 +454,8 @@ void MGTransferBlockSelect<number>::build_matrices (
   const DoFHandler<dim,spacedim> &mg_dof,
   unsigned int select)
 {
-  const FiniteElement<dim> &fe = mg_dof.get_finite_element();
-  unsigned int n_blocks = mg_dof.get_finite_element().n_blocks();
+  const FiniteElement<dim> &fe = mg_dof.get_fe();
+  unsigned int n_blocks = mg_dof.get_fe().n_blocks();
 
   selected_block = select;
   selected.resize(n_blocks, false);
@@ -538,8 +538,8 @@ void MGTransferBlock<number>::build_matrices (
   const DoFHandler<dim,spacedim> &mg_dof,
   const std::vector<bool> &sel)
 {
-  const FiniteElement<dim> &fe = mg_dof.get_finite_element();
-  unsigned int n_blocks = mg_dof.get_finite_element().n_blocks();
+  const FiniteElement<dim> &fe = mg_dof.get_fe();
+  unsigned int n_blocks = mg_dof.get_fe().n_blocks();
 
   if (sel.size() != 0)
     {

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -85,7 +85,7 @@ namespace
   {
     std::vector<bool> selected=sel;
     std::vector<unsigned int> target_component=target_comp;
-    const unsigned int ncomp = mg_dof.get_finite_element(0).n_components();
+    const unsigned int ncomp = mg_dof.get_fe(0).n_components();
 
     // If the selected and
     // target_component have size 0,
@@ -260,16 +260,16 @@ void MGTransferComponentBase::build_matrices (
   // is empty
   if (target_component.size() == 0)
     {
-      target_component.resize(mg_dof.get_finite_element(0).n_components());
+      target_component.resize(mg_dof.get_fe(0).n_components());
       for (unsigned int i=0; i<target_component.size(); ++i)
         target_component[i] = i;
     }
   else
     {
       // otherwise, check it for consistency
-      Assert (target_component.size() == mg_dof.get_finite_element(0).n_components(),
+      Assert (target_component.size() == mg_dof.get_fe(0).n_components(),
               ExcDimensionMismatch(target_component.size(),
-                                   mg_dof.get_finite_element(0).n_components()));
+                                   mg_dof.get_fe(0).n_components()));
 
       for (unsigned int i=0; i<target_component.size(); ++i)
         {
@@ -282,15 +282,15 @@ void MGTransferComponentBase::build_matrices (
   // different.
   if (mg_target_component.size() == 0)
     {
-      mg_target_component.resize(mg_dof.get_finite_element(0).n_components());
+      mg_target_component.resize(mg_dof.get_fe(0).n_components());
       for (unsigned int i=0; i<mg_target_component.size(); ++i)
         mg_target_component[i] = target_component[i];
     }
   else
     {
-      Assert (mg_target_component.size() == mg_dof.get_finite_element(0).n_components(),
+      Assert (mg_target_component.size() == mg_dof.get_fe(0).n_components(),
               ExcDimensionMismatch(mg_target_component.size(),
-                                   mg_dof.get_finite_element(0).n_components()));
+                                   mg_dof.get_fe(0).n_components()));
 
       for (unsigned int i=0; i<mg_target_component.size(); ++i)
         {
@@ -299,7 +299,7 @@ void MGTransferComponentBase::build_matrices (
         }
     }
 
-  const FiniteElement<dim> &fe = mg_dof.get_finite_element();
+  const FiniteElement<dim> &fe = mg_dof.get_fe();
 
   // Effective number of components
   // is the maximum entry in
@@ -432,7 +432,7 @@ void MGTransferComponentBase::build_matrices (
                 // prolongation matrix for
                 // this child
                 const FullMatrix<double> &prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child, cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child, cell->refinement_case());
 
                 cell->child(child)->get_mg_dof_indices (dof_indices_child);
 
@@ -469,7 +469,7 @@ void MGTransferComponentBase::build_matrices (
                 // prolongation matrix for
                 // this child
                 const FullMatrix<double> &prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child, cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child, cell->refinement_case());
 
                 cell->child(child)->get_mg_dof_indices (dof_indices_child);
 
@@ -553,8 +553,8 @@ void MGTransferSelect<number>::build_matrices (
   const std::vector<unsigned int> &mg_t_component,
   const std::vector<std::set<types::global_dof_index> > &bdry_indices)
 {
-  const FiniteElement<dim> &fe = mg_dof.get_finite_element();
-  unsigned int ncomp = mg_dof.get_finite_element(0).n_components();
+  const FiniteElement<dim> &fe = mg_dof.get_fe();
+  unsigned int ncomp = mg_dof.get_fe(0).n_components();
 
   target_component = t_component;
   mg_target_component = mg_t_component;

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -82,7 +82,7 @@ namespace internal
       IndexSet globally_relevant;
       DoFTools::extract_locally_relevant_dofs(mg_dof, globally_relevant);
 
-      const unsigned int dofs_per_cell = mg_dof.get_finite_element().dofs_per_cell;
+      const unsigned int dofs_per_cell = mg_dof.get_fe().dofs_per_cell;
       std::vector<types::global_dof_index> global_dof_indices (dofs_per_cell);
       std::vector<types::global_dof_index> level_dof_indices  (dofs_per_cell);
 
@@ -395,10 +395,10 @@ namespace internal
                             const dealii::DoFHandler<dim> &mg_dof)
     {
       // currently, we have only FE_Q and FE_DGQ type elements implemented
-      elem_info.n_components = mg_dof.get_finite_element().element_multiplicity(0);
+      elem_info.n_components = mg_dof.get_fe().element_multiplicity(0);
       AssertDimension(Utilities::fixed_power<dim>(fe.dofs_per_cell)*elem_info.n_components,
-                      mg_dof.get_finite_element().dofs_per_cell);
-      AssertDimension(fe.degree, mg_dof.get_finite_element().degree);
+                      mg_dof.get_fe().dofs_per_cell);
+      AssertDimension(fe.degree, mg_dof.get_fe().degree);
       elem_info.fe_degree = fe.degree;
       elem_info.element_is_continuous = fe.dofs_per_vertex > 0;
       Assert(fe.dofs_per_vertex < 2, ExcNotImplemented());
@@ -430,7 +430,7 @@ namespace internal
       elem_info.n_child_cell_dofs = elem_info.n_components*Utilities::fixed_power<dim>(n_child_dofs_1d);
       const Quadrature<1> dummy_quadrature(std::vector<Point<1> >(1, Point<1>()));
       internal::MatrixFreeFunctions::ShapeInfo<Number> shape_info;
-      shape_info.reinit(dummy_quadrature, mg_dof.get_finite_element(), 0);
+      shape_info.reinit(dummy_quadrature, mg_dof.get_fe(), 0);
       elem_info.lexicographic_numbering = shape_info.lexicographic_numbering;
 
       // step 1.4: get the 1d prolongation matrix and combine from both children
@@ -494,8 +494,8 @@ namespace internal
       // ---------------------------- 1. Extract 1D info about the finite element
       // step 1.1: create a 1D copy of the finite element from FETools where we
       // substitute the template argument
-      AssertDimension(mg_dof.get_finite_element().n_base_elements(), 1);
-      std::string fe_name = mg_dof.get_finite_element().base_element(0).get_name();
+      AssertDimension(mg_dof.get_fe().n_base_elements(), 1);
+      std::string fe_name = mg_dof.get_fe().base_element(0).get_name();
       {
         const std::size_t template_starts = fe_name.find_first_of('<');
         Assert (fe_name[template_starts+1] == (dim==1?'1':(dim==2?'2':'3')),
@@ -518,7 +518,7 @@ namespace internal
       for (unsigned int level=0; level<std::min(tria.n_levels(),n_levels-1); ++level)
         coarse_level_indices[level].resize(tria.n_raw_cells(level),
                                            numbers::invalid_unsigned_int);
-      std::vector<types::global_dof_index> local_dof_indices(mg_dof.get_finite_element().dofs_per_cell);
+      std::vector<types::global_dof_index> local_dof_indices(mg_dof.get_fe().dofs_per_cell);
       dirichlet_indices.resize(n_levels-1);
 
       // We use the vectors stored ghosted_level_vector in the base class for
@@ -616,13 +616,13 @@ namespace internal
                         parent_index = start_index/elem_info.n_child_cell_dofs + tria.n_cells(level);
                       parent_child_connect[level][child_index] =
                         std::make_pair(parent_index, c);
-                      AssertIndexRange(mg_dof.get_finite_element().dofs_per_cell,
+                      AssertIndexRange(mg_dof.get_fe().dofs_per_cell,
                                        static_cast<unsigned short>(-1));
 
                       // set Dirichlet boundary conditions (as a list of
                       // constrained DoFs) for the child
                       if (mg_constrained_dofs != nullptr)
-                        for (unsigned int i=0; i<mg_dof.get_finite_element().dofs_per_cell; ++i)
+                        for (unsigned int i=0; i<mg_dof.get_fe().dofs_per_cell; ++i)
                           if (mg_constrained_dofs->is_boundary_index(level,
                                                                      local_dof_indices[elem_info.lexicographic_numbering[i]]))
                             dirichlet_indices[level][child_index].push_back(i);
@@ -660,7 +660,7 @@ namespace internal
 
                   dirichlet_indices[0].emplace_back();
                   if (mg_constrained_dofs != nullptr)
-                    for (unsigned int i=0; i<mg_dof.get_finite_element().dofs_per_cell; ++i)
+                    for (unsigned int i=0; i<mg_dof.get_fe().dofs_per_cell; ++i)
                       if (mg_constrained_dofs->is_boundary_index(0, local_dof_indices[elem_info.lexicographic_numbering[i]]))
                         dirichlet_indices[0].back().push_back(i);
                 }

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -151,7 +151,7 @@ void MGTransferPrebuilt<VectorType>::build_matrices
 (const DoFHandler<dim,spacedim>  &mg_dof)
 {
   const unsigned int n_levels      = mg_dof.get_triangulation().n_global_levels();
-  const unsigned int dofs_per_cell = mg_dof.get_finite_element().dofs_per_cell;
+  const unsigned int dofs_per_cell = mg_dof.get_fe().dofs_per_cell;
 
   this->sizes.resize(n_levels);
   for (unsigned int l=0; l<n_levels; ++l)
@@ -224,8 +224,8 @@ void MGTransferPrebuilt<VectorType>::build_matrices
               {
                 // set an alias to the prolongation matrix for this child
                 const FullMatrix<double> &prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child,
-                                                                         cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child,
+                                                             cell->refinement_case());
 
                 Assert (prolongation.n() != 0, ExcNoProlongation());
 
@@ -274,8 +274,8 @@ void MGTransferPrebuilt<VectorType>::build_matrices
               {
                 // set an alias to the prolongation matrix for this child
                 prolongation
-                  = mg_dof.get_finite_element().get_prolongation_matrix (child,
-                                                                         cell->refinement_case());
+                  = mg_dof.get_fe().get_prolongation_matrix (child,
+                                                             cell->refinement_case());
 
                 if (this->mg_constrained_dofs != nullptr &&
                     this->mg_constrained_dofs->have_boundary_indices())

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -445,7 +445,7 @@ void DataOut<dim,DoFHandlerType>::build_patches
   thread_data (n_datasets, n_subdivisions,
                n_postprocessor_outputs,
                mapping,
-               this->get_finite_elements(),
+               this->get_fes(),
                update_flags,
                cell_to_patch_index_map);
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -335,7 +335,7 @@ void DataOutFaces<dim,DoFHandlerType>::build_patches (const Mapping<dimension> &
                n_subdivisions,
                n_postprocessor_outputs,
                mapping,
-               this->get_finite_elements(),
+               this->get_fes(),
                update_flags);
   DataOutBase::Patch<dimension-1,space_dimension> sample_patch;
   sample_patch.n_subdivisions = n_subdivisions;

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -461,7 +461,7 @@ void DataOutRotation<dim,DoFHandlerType>::build_patches (const unsigned int n_pa
                n_subdivisions, n_patches_per_circle,
                n_postprocessor_outputs,
                StaticMappingQ1<dimension,space_dimension>::mapping,
-               this->get_finite_elements(),
+               this->get_fes(),
                update_flags);
   std::vector<DataOutBase::Patch<dimension+1,space_dimension+1> >
   new_patches (n_patches_per_circle);

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -135,7 +135,7 @@ template <typename number>
 void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<number> &vec,
     const std::string    &name)
 {
-  const unsigned int n_components = dof_handler->get_finite_element(0).n_components ();
+  const unsigned int n_components = dof_handler->get_fe(0).n_components ();
 
   std::vector<std::string> names;
   // if only one component or vector
@@ -176,9 +176,9 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::add_data_vector (const Vector<nu
            (names.size() == 1))
           ||
           ((vec.size() == dof_handler->n_dofs()) &&
-           (names.size() == dof_handler->get_finite_element(0).n_components())),
+           (names.size() == dof_handler->get_fe(0).n_components())),
           Exceptions::DataOut::ExcInvalidNumberOfNames (names.size(),
-                                                        dof_handler->get_finite_element(0).n_components()));
+                                                        dof_handler->get_fe(0).n_components()));
   for (unsigned int i=0; i<names.size(); ++i)
     Assert (names[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
                                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -248,7 +248,7 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::build_patches (const unsigned in
 
   this->validate_dataset_names();
 
-  const unsigned int n_components   = dof_handler->get_finite_element(0).n_components();
+  const unsigned int n_components   = dof_handler->get_fe(0).n_components();
   const unsigned int n_datasets     = dof_data.size() * n_components +
                                       cell_data.size();
 
@@ -275,7 +275,7 @@ void DataOutStack<dim,spacedim,DoFHandlerType>::build_patches (const unsigned in
   // single quadratures,
   // and finite elements. if we have
   // an hp DoFHandler,
-  // dof_handler.get_finite_element() returns a
+  // dof_handler.get_fe() returns a
   // collection of which we do a
   // shallow copy instead
   const hp::QCollection<dim>       q_collection (patch_points);

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -774,7 +774,7 @@ namespace DerivativeApproximation
       // single quadratures, mappings,
       // and finite elements. if we have
       // an hp DoFHandler,
-      // dof_handler.get_finite_element() returns a
+      // dof_handler.get_fe() returns a
       // collection of which we do a
       // shallow copy instead
       const hp::QCollection<dim>       q_collection (midpoint_rule);
@@ -977,8 +977,8 @@ namespace DerivativeApproximation
       Assert (derivative_norm.size() == dof_handler.get_triangulation().n_active_cells(),
               ExcVectorLengthVsNActiveCells (derivative_norm.size(),
                                              dof_handler.get_triangulation().n_active_cells()));
-      Assert (component < dof_handler.get_finite_element(0).n_components(),
-              ExcIndexRange (component, 0, dof_handler.get_finite_element(0).n_components()));
+      Assert (component < dof_handler.get_fe(0).n_components(),
+              ExcIndexRange (component, 0, dof_handler.get_fe(0).n_components()));
 
       typedef std::tuple<TriaActiveIterator<dealii::DoFCellAccessor
       <DoFHandlerType<dim, spacedim>, false> >,

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -248,7 +248,7 @@ estimate (const Mapping<1,spacedim>                  &mapping,
     = subdomain_id_;
 #endif
 
-  const unsigned int n_components       = dof_handler.get_finite_element(0).n_components();
+  const unsigned int n_components       = dof_handler.get_fe(0).n_components();
   const unsigned int n_solution_vectors = solutions.size();
 
   // sanity checks

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -191,7 +191,7 @@ void PointValueHistory<dim>
 
   // Implementation assumes that support
   // points locations are dofs locations
-  AssertThrow (dof_handler->get_finite_element().has_support_points (), ExcNotImplemented ());
+  AssertThrow (dof_handler->get_fe().has_support_points (), ExcNotImplemented ());
 
   // While in general quadrature points seems
   // to refer to Gauss quadrature points, in
@@ -199,14 +199,14 @@ void PointValueHistory<dim>
   // forced to be the support points of the
   // FE.
   Quadrature<dim>
-  support_point_quadrature (dof_handler->get_finite_element().get_unit_support_points ());
-  FEValues<dim> fe_values (dof_handler->get_finite_element(),
+  support_point_quadrature (dof_handler->get_fe().get_unit_support_points ());
+  FEValues<dim> fe_values (dof_handler->get_fe(),
                            support_point_quadrature,
                            update_quadrature_points);
   unsigned int n_support_points
-    = dof_handler->get_finite_element().get_unit_support_points ().size ();
+    = dof_handler->get_fe().get_unit_support_points ().size ();
   unsigned int n_components
-    = dof_handler->get_finite_element(0).n_components ();
+    = dof_handler->get_fe(0).n_components ();
 
   // set up a loop over all the cells in the
   // DoFHandler
@@ -229,7 +229,7 @@ void PointValueHistory<dim>
       // setup valid data in the empty
       // vectors
       unsigned int component
-        = dof_handler->get_finite_element().system_to_component_index (support_point).first;
+        = dof_handler->get_fe().system_to_component_index (support_point).first;
       current_points [component] = fe_values.quadrature_point (support_point);
       current_fe_index [component] = support_point;
     }
@@ -252,7 +252,7 @@ void PointValueHistory<dim>
            support_point < n_support_points; support_point++)
         {
           unsigned int component
-            = dof_handler->get_finite_element().system_to_component_index (support_point).first;
+            = dof_handler->get_fe().system_to_component_index (support_point).first;
           Point<dim> test_point
             = fe_values.quadrature_point (support_point);
 
@@ -269,7 +269,7 @@ void PointValueHistory<dim>
 
 
   std::vector<types::global_dof_index>
-  local_dof_indices (dof_handler->get_finite_element().dofs_per_cell);
+  local_dof_indices (dof_handler->get_fe().dofs_per_cell);
   std::vector <types::global_dof_index> new_solution_indices;
   current_cell->get_dof_indices (local_dof_indices);
   // there is an implicit assumption here
@@ -292,7 +292,7 @@ void PointValueHistory<dim>
   // a vector of points, and does not seem to
   // be intrinsicly faster than this method.
   for (unsigned int component = 0;
-       component < dof_handler->get_finite_element(0).n_components (); component++)
+       component < dof_handler->get_fe(0).n_components (); component++)
     {
       new_solution_indices
       .push_back (local_dof_indices[current_fe_index [component]]);
@@ -334,17 +334,17 @@ void PointValueHistory<dim>
 
   // Implementation assumes that support
   // points locations are dofs locations
-  AssertThrow (dof_handler->get_finite_element().has_support_points (), ExcNotImplemented ());
+  AssertThrow (dof_handler->get_fe().has_support_points (), ExcNotImplemented ());
 
   // While in general quadrature points seems
   // to refer to Gauss quadrature points, in
   // this case the quadrature points are
   // forced to be the support points of the
   // FE.
-  Quadrature<dim> support_point_quadrature (dof_handler->get_finite_element().get_unit_support_points ());
-  FEValues<dim> fe_values (dof_handler->get_finite_element(), support_point_quadrature, update_quadrature_points);
-  unsigned int n_support_points = dof_handler->get_finite_element().get_unit_support_points ().size ();
-  unsigned int n_components = dof_handler->get_finite_element(0).n_components ();
+  Quadrature<dim> support_point_quadrature (dof_handler->get_fe().get_unit_support_points ());
+  FEValues<dim> fe_values (dof_handler->get_fe(), support_point_quadrature, update_quadrature_points);
+  unsigned int n_support_points = dof_handler->get_fe().get_unit_support_points ().size ();
+  unsigned int n_components = dof_handler->get_fe(0).n_components ();
 
   // set up a loop over all the cells in the
   // DoFHandler
@@ -367,7 +367,7 @@ void PointValueHistory<dim>
     {
       // setup valid data in the empty
       // vectors
-      unsigned int component = dof_handler->get_finite_element().system_to_component_index (support_point).first;
+      unsigned int component = dof_handler->get_fe().system_to_component_index (support_point).first;
       temp_points [component] = fe_values.quadrature_point (support_point);
       temp_fe_index [component] = support_point;
     }
@@ -388,7 +388,7 @@ void PointValueHistory<dim>
       fe_values.reinit (cell);
       for (unsigned int support_point = 0; support_point < n_support_points; support_point++)
         {
-          unsigned int component = dof_handler->get_finite_element().system_to_component_index (support_point).first;
+          unsigned int component = dof_handler->get_fe().system_to_component_index (support_point).first;
           Point<dim> test_point = fe_values.quadrature_point (support_point);
 
           for (unsigned int point = 0; point < locations.size (); point++)
@@ -404,13 +404,13 @@ void PointValueHistory<dim>
         }
     }
 
-  std::vector<types::global_dof_index> local_dof_indices (dof_handler->get_finite_element().dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices (dof_handler->get_fe().dofs_per_cell);
   for (unsigned int point = 0; point < locations.size (); point++)
     {
       current_cell[point]->get_dof_indices (local_dof_indices);
       std::vector<types::global_dof_index> new_solution_indices;
 
-      for (unsigned int component = 0; component < dof_handler->get_finite_element(0).n_components (); component++)
+      for (unsigned int component = 0; component < dof_handler->get_fe(0).n_components (); component++)
         {
           new_solution_indices.push_back (local_dof_indices[current_fe_index[point][component]]);
         }
@@ -454,7 +454,7 @@ void PointValueHistory<dim>
     component_mask.insert (std::make_pair (vector_name, mask));
   else
     component_mask.insert (std::make_pair (vector_name,
-                                           ComponentMask(std::vector<bool>(dof_handler->get_finite_element(0).n_components(), true))));
+                                           ComponentMask(std::vector<bool>(dof_handler->get_fe(0).n_components(), true))));
 
   // insert an empty vector of strings
   // to ensure each field has an entry
@@ -471,7 +471,7 @@ void PointValueHistory<dim>
                                  ?
                                  mask.n_selected_components()
                                  :
-                                 dof_handler->get_finite_element(0).n_components());
+                                 dof_handler->get_fe(0).n_components());
 
   int n_datastreams = point_geometry_data.size () * n_stored; // each point has n_stored sub parts
   std::vector < std::vector <double> > vector_size (n_datastreams,
@@ -576,7 +576,7 @@ PointValueHistory<dim>::evaluate_field (const std::string &vector_name,
   typename std::map <std::string, ComponentMask>::iterator mask = component_mask.find(vector_name);
   Assert (mask != component_mask.end(), ExcMessage("vector_name not in class"));
 
-  unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_finite_element(0).n_components ());
+  unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_fe(0).n_components ());
 
   typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
@@ -586,7 +586,7 @@ PointValueHistory<dim>::evaluate_field (const std::string &vector_name,
       // access the data associated with
       // those components
 
-      for (unsigned int store_index = 0, comp = 0; comp < dof_handler->get_finite_element(0).n_components (); comp++)
+      for (unsigned int store_index = 0, comp = 0; comp < dof_handler->get_fe(0).n_components (); comp++)
         {
           if (mask->second[comp])
             {
@@ -626,8 +626,8 @@ PointValueHistory<dim>::evaluate_field (const std::vector <std::string> &vector_
   Assert (!(update_flags & update_normal_vectors),
           ExcMessage("The update of normal vectors may not be requested for evaluation of "
                      "data on cells via DataPostprocessor."));
-  FEValues<dim> fe_values (dof_handler->get_finite_element(), quadrature, update_flags);
-  unsigned int n_components = dof_handler->get_finite_element(0).n_components ();
+  FEValues<dim> fe_values (dof_handler->get_fe(), quadrature, update_flags);
+  unsigned int n_components = dof_handler->get_fe(0).n_components ();
   unsigned int n_quadrature_points = quadrature.size();
 
   unsigned int n_output_variables = data_postprocessor.get_names().size();
@@ -837,10 +837,10 @@ void PointValueHistory<dim>
   typename std::map <std::string, ComponentMask>::iterator mask = component_mask.find(vector_name);
   Assert (mask != component_mask.end(), ExcMessage("vector_name not in class"));
 
-  unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_finite_element(0).n_components ());
+  unsigned int n_stored = mask->second.n_selected_components(dof_handler->get_fe(0).n_components ());
 
   typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
-  Vector <number> value (dof_handler->get_finite_element(0).n_components());
+  Vector <number> value (dof_handler->get_fe(0).n_components());
   for (unsigned int data_store_index = 0; point != point_geometry_data.end (); ++point, ++data_store_index)
     {
       // Make a Vector <double> for the value
@@ -984,7 +984,7 @@ void PointValueHistory<dim>
           // comments
           to_gnuplot << "# Requested location: " << point->requested_location << "\n";
           to_gnuplot << "# DoF_index : Support location (for each component)\n";
-          for (unsigned int component = 0; component < dof_handler->get_finite_element(0).n_components (); component++)
+          for (unsigned int component = 0; component < dof_handler->get_fe(0).n_components (); component++)
             {
               to_gnuplot << "# " << point->solution_indices[component] << " : " << point->support_point_locations [component] << "\n";
             }
@@ -1090,7 +1090,7 @@ Vector<double> PointValueHistory<dim>
   typename std::vector <internal::PointValueHistory::PointGeometryData <dim> >::iterator point = point_geometry_data.begin ();
   for (; point != point_geometry_data.end (); ++point)
     {
-      for (unsigned int component = 0; component < dof_handler->get_finite_element(0).n_components (); component++)
+      for (unsigned int component = 0; component < dof_handler->get_fe(0).n_components (); component++)
         {
           dof_vector (point->solution_indices[component]) = 1;
         }
@@ -1135,7 +1135,7 @@ void PointValueHistory<dim>
 
   locations = std::vector<Point <dim> > ();
 
-  FEValues<dim> fe_values (dof_handler->get_finite_element(), quadrature, update_quadrature_points);
+  FEValues<dim> fe_values (dof_handler->get_fe(), quadrature, update_quadrature_points);
   unsigned int n_quadrature_points = quadrature.size();
   std::vector<Point<dim> > evaluation_points;
 
@@ -1191,7 +1191,7 @@ void PointValueHistory<dim>
             {
               out << "# Requested location: " << point->requested_location << "\n";
               out << "# DoF_index : Support location (for each component)\n";
-              for (unsigned int component = 0; component < dof_handler->get_finite_element(0).n_components (); component++)
+              for (unsigned int component = 0; component < dof_handler->get_fe(0).n_components (); component++)
                 {
                   out << point->solution_indices[component] << " : " << point->support_point_locations [component] << "\n";
                 }

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -148,7 +148,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::refine_interpolate
         // function
         {
           const unsigned int this_fe_index = pointerstruct->second.active_fe_index;
-          const unsigned int dofs_per_cell=cell->get_dof_handler().get_finite_element(this_fe_index).dofs_per_cell;
+          const unsigned int dofs_per_cell=cell->get_dof_handler().get_fe(this_fe_index).dofs_per_cell;
           local_values.reinit(dofs_per_cell, true);
 
           // make sure that the size of the stored indices is the same as
@@ -362,9 +362,9 @@ prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
               if (cell->child(child)->get_fe().dofs_per_cell >
                   cell->child(most_general_child)->get_fe().dofs_per_cell)
                 most_general_child = child;
-          const unsigned int target_finite_element_index = cell->child(most_general_child)->active_fe_index();
+          const unsigned int target_fe_index = cell->child(most_general_child)->active_fe_index();
 
-          const unsigned int dofs_per_cell=cell->get_dof_handler().get_finite_element(target_finite_element_index).dofs_per_cell;
+          const unsigned int dofs_per_cell=cell->get_dof_handler().get_fe(target_fe_index).dofs_per_cell;
 
           std::vector<Vector<typename VectorType::value_type> >(in_size,
                                                                 Vector<typename VectorType::value_type>(dofs_per_cell))
@@ -378,9 +378,9 @@ prepare_for_coarsening_and_refinement(const std::vector<VectorType> &all_in)
           for (unsigned int j=0; j<in_size; ++j)
             cell->get_interpolated_dof_values(all_in[j],
                                               dof_values_on_cell[n_cf][j],
-                                              target_finite_element_index);
+                                              target_fe_index);
           cell_map[std::make_pair(cell->level(), cell->index())]
-            = Pointerstruct(&dof_values_on_cell[n_cf], target_finite_element_index);
+            = Pointerstruct(&dof_values_on_cell[n_cf], target_fe_index);
           ++n_cf;
         }
     }

--- a/tests/numerics/data_out_11.debug.output
+++ b/tests/numerics/data_out_11.debug.output
@@ -1,4 +1,4 @@
 
-DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_finite_element(0).n_components())
-DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_finite_element(0).n_components())
+DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
+DEAL::Exceptions::DataOut::ExcInvalidNumberOfNames (deduced_names.size(), dof_handler->get_fe(0).n_components())
 DEAL::OK


### PR DESCRIPTION
Fixes #4929. This PR partly reverses #4908. As discussed in #4939 people want to keep the name `get_fe` instead of `get_finite_element`. Luckily, this just means to replace `get_finite_element` by `get_fe` everywhere and fixing `DoFHandler`.