### PR TITLE
Don't make GrowingVectorMemory objects 'static'

### DIFF
--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -758,7 +758,7 @@ block_forward_substitution(const BlockLinearOperator<Range, Domain, BlockPayload
     if (m == 0)
       return;
 
-    static GrowingVectorMemory<typename Range::BlockType> vector_memory;
+    GrowingVectorMemory<typename Range::BlockType> vector_memory;
     typename VectorMemory<typename Range::BlockType>::Pointer tmp (vector_memory);
 
     diagonal_inverse.block(0, 0).vmult_add(v.block(0), u.block(0));
@@ -865,7 +865,7 @@ block_back_substitution(const BlockLinearOperator<Range, Domain, BlockPayload> &
            ExcDimensionMismatch(diagonal_inverse.n_block_cols(), m));
     Assert(v.n_blocks() == m, ExcDimensionMismatch(v.n_blocks(), m));
     Assert(u.n_blocks() == m, ExcDimensionMismatch(u.n_blocks(), m));
-    static GrowingVectorMemory<typename Range::BlockType> vector_memory;
+    GrowingVectorMemory<typename Range::BlockType> vector_memory;
     typename VectorMemory<typename Range::BlockType>::Pointer tmp (vector_memory);
 
     if (m == 0)

--- a/include/deal.II/lac/constrained_linear_operator.h
+++ b/include/deal.II/lac/constrained_linear_operator.h
@@ -317,7 +317,7 @@ constrained_right_hand_side(const ConstraintMatrix &constraint_matrix,
       distribute_constraints_linear_operator(constraint_matrix, linop);
     const auto Ct = transpose_operator(C);
 
-    static GrowingVectorMemory<Domain> vector_memory;
+    GrowingVectorMemory<Domain> vector_memory;
     typename VectorMemory<Domain>::Pointer k (vector_memory);
     linop.reinit_domain_vector(*k, /*bool fast=*/ false);
     constraint_matrix.distribute(*k);

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -580,7 +580,7 @@ operator*(const LinearOperator<Range, Intermediate, Payload> &first_op,
 
       return_op.vmult = [first_op, second_op](Range &v, const Domain &u)
       {
-        static GrowingVectorMemory<Intermediate> vector_memory;
+        GrowingVectorMemory<Intermediate> vector_memory;
 
         typename VectorMemory<Intermediate>::Pointer i (vector_memory);
         second_op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -590,7 +590,7 @@ operator*(const LinearOperator<Range, Intermediate, Payload> &first_op,
 
       return_op.vmult_add = [first_op, second_op](Range &v, const Domain &u)
       {
-        static GrowingVectorMemory<Intermediate> vector_memory;
+        GrowingVectorMemory<Intermediate> vector_memory;
 
         typename VectorMemory<Intermediate>::Pointer i (vector_memory);
         second_op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -600,7 +600,7 @@ operator*(const LinearOperator<Range, Intermediate, Payload> &first_op,
 
       return_op.Tvmult = [first_op, second_op](Domain &v, const Range &u)
       {
-        static GrowingVectorMemory<Intermediate> vector_memory;
+        GrowingVectorMemory<Intermediate> vector_memory;
 
         typename VectorMemory<Intermediate>::Pointer i (vector_memory);
         first_op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -610,7 +610,7 @@ operator*(const LinearOperator<Range, Intermediate, Payload> &first_op,
 
       return_op.Tvmult_add = [first_op, second_op](Domain &v, const Range &u)
       {
-        static GrowingVectorMemory<Intermediate> vector_memory;
+        GrowingVectorMemory<Intermediate> vector_memory;
 
         typename VectorMemory<Intermediate>::Pointer i (vector_memory);
         first_op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -695,7 +695,7 @@ inverse_operator(const LinearOperator<Range, Domain, Payload> &op,
   return_op.vmult_add =
     [op, &solver, &preconditioner](Range &v, const Domain &u)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer v2 (vector_memory);
     op.reinit_range_vector(*v2, /*bool omit_zeroing_entries =*/ false);
@@ -712,7 +712,7 @@ inverse_operator(const LinearOperator<Range, Domain, Payload> &op,
   return_op.Tvmult_add =
     [op, &solver, &preconditioner](Range &v, const Domain &u)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer v2 (vector_memory);
     op.reinit_range_vector(*v2, /*bool omit_zeroing_entries =*/ false);
@@ -1033,7 +1033,7 @@ namespace
   void apply_with_intermediate_storage(Function function, Range &v,
                                        const Domain &u, bool add)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer i (vector_memory);
     i->reinit(v, /*bool omit_zeroing_entries =*/true);

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -748,7 +748,7 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
 
   return_comp.apply = [op, comp](Domain &v)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_domain_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -759,7 +759,7 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
 
   return_comp.apply_add = [op, comp](Domain &v)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -794,7 +794,7 @@ operator*(const PackagedOperation<Range> &comp,
 
   return_comp.apply = [op, comp](Domain &v)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);
@@ -805,7 +805,7 @@ operator*(const PackagedOperation<Range> &comp,
 
   return_comp.apply_add = [op, comp](Domain &v)
   {
-    static GrowingVectorMemory<Range> vector_memory;
+    GrowingVectorMemory<Range> vector_memory;
 
     typename VectorMemory<Range>::Pointer i (vector_memory);
     op.reinit_range_vector(*i, /*bool omit_zeroing_entries =*/ true);

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -204,9 +204,10 @@ public:
  *
  * Each time a vector is requested from this class, it checks if it has one
  * available and returns its address, or allocates a new one on the heap. If a
- * vector is returned, through the free() member function, it doesn't return
- * it to the operating system memory subsystem, but keeps it around unused for
- * later use if alloc() is called again, or until the object is destroyed. The
+ * vector is returned from its user, through the GrowingVectorMemory::free()
+ * member function, it doesn't return the allocated memory to the operating
+ * system memory subsystem, but keeps it around unused for later use if
+ * GrowingVectorMemory::alloc() is called again. The
  * class therefore avoid the overhead of repeatedly allocating memory on the
  * heap if temporary vectors are required and released frequently; on the
  * other hand, it doesn't release once-allocated memory at the earliest
@@ -214,13 +215,15 @@ public:
  * consumption.
  *
  * All GrowingVectorMemory objects of the same vector type use the same memory
- * Pool. Therefore, functions can create such a VectorMemory object whenever
- * needed without performance penalty. A drawback of this policy might be that
+ * pool. (In other words: The pool of vectors from which this class draws is
+ * <i>global</i>, rather than a regular member variable of the current class
+ * that is destroyed at the time that the surrounding GrowingVectorMemory
+ * object is destroyed.) Therefore, functions can create such a
+ * GrowingVectorMemory object whenever needed without the performance penalty
+ * of creating a new memory pool every time. A drawback of this policy is that
  * vectors once allocated are only released at the end of the program run.
- * Nevertheless, the since they are reused, this should be of no concern.
- * Additionally, the destructor of the Pool warns about memory leaks.
  *
- * @author Guido Kanschat, 1999, 2007
+ * @author Guido Kanschat, 1999, 2007; Wolfgang Bangerth, 2017.
  */
 template <typename VectorType = dealii::Vector<double> >
 class GrowingVectorMemory : public VectorMemory<VectorType>
@@ -239,11 +242,10 @@ public:
                        const bool log_statistics = false);
 
   /**
-   * Destructor. Release all vectors. This destructor also offers some
-   * statistic on the number of allocated vectors.
-   *
-   * The log file will also contain a warning message, if there are allocated
-   * vectors left.
+   * Destructor. The destructor also checks that all vectors that have been
+   * allocated through the current object have all been released again.
+   * However, as discussed in the class documentation, this does not imply
+   * that their memory is returned to the operating system.
    */
   virtual ~GrowingVectorMemory();
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2972,7 +2972,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // Initialize intermediate vector
@@ -3006,7 +3006,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // These operators may themselves be transposed or not, so we let them
@@ -3051,7 +3051,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // Initialize intermediate vector
@@ -3085,7 +3085,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // These operators may themselves be transposed or not, so we let them
@@ -3149,7 +3149,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // Initialize intermediate vector
@@ -3181,7 +3181,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // These operators may themselves be transposed or not, so we let them
@@ -3223,7 +3223,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // Initialize intermediate vector
@@ -3255,7 +3255,7 @@ namespace TrilinosWrappers
         {
           // Duplicated from LinearOperator::operator*
           // TODO: Template the constructor on GrowingVectorMemory vector type?
-          static GrowingVectorMemory<GVMVectorType> vector_memory;
+          GrowingVectorMemory<GVMVectorType> vector_memory;
           GVMVectorType *i = vector_memory.alloc();
 
           // These operators may themselves be transposed or not, so we let them


### PR DESCRIPTION
While there, also document better that all GrowingVectorMemory objects
use a common, global pool. Fixes #4955. In reference to #4935.