### PR TITLE
Disable warning for boost-1.65.0

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -302,6 +302,7 @@ _Pragma("GCC diagnostic ignored \"-Wundef\"")                    \
 _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")         \
 _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")     \
 _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")      \
+_Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")     \
 _Pragma("GCC diagnostic warning \"-Wpragmas\"")
 
 #  define DEAL_II_ENABLE_EXTRA_DIAGNOSTICS                       \


### PR DESCRIPTION
Compiling with gcc-7.1.0 and boost-1.65.0 currently triggers
> /mnt/data/darndt/boost-1.65.0/include/boost/archive/detail/iserializer.hpp:69:1: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]

There is not much we can do about this kind of warning so simple disable it.