### PR TITLE
Remove some undefined static members.

### DIFF
--- a/doc/news/changes/incompatibilities/20170827DavidWells
+++ b/doc/news/changes/incompatibilities/20170827DavidWells
@@ -1,0 +1,4 @@
+Changed: The public struct <code>FE_DGP::Matrices</code> has been removed. It
+previously contained two static pointers that were never defined.
+<br>
+(David Wells, 2017/08/27)

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -445,26 +445,6 @@ public:
    */
   virtual std::size_t memory_consumption () const;
 
-
-  /**
-   * Declare a nested class which will hold static definitions of various
-   * matrices such as constraint and embedding matrices. The definition of the
-   * various static fields are in the files <tt>fe_dgp_[123]d.cc</tt> in the
-   * source directory.
-   */
-  struct Matrices
-  {
-    /**
-     * As @p embedding but for projection matrices.
-     */
-    static const double *const projection_matrices[][GeometryInfo<dim>::max_children_per_cell];
-
-    /**
-     * As @p n_embedding_matrices but for projection matrices.
-     */
-    static const unsigned int n_projection_matrices;
-  };
-
   /**
    * Return a list of constant modes of the element. For this element, the
    * first entry is true, all other are false.
@@ -488,42 +468,6 @@ private:
 };
 
 /* @} */
-#ifndef DOXYGEN
-
-
-// declaration of explicit specializations of member variables
-template <>
-const double *const FE_DGP<1>::Matrices::projection_matrices[][GeometryInfo<1>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGP<1>::Matrices::n_projection_matrices;
-
-template <>
-const double *const FE_DGP<2>::Matrices::projection_matrices[][GeometryInfo<2>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGP<2>::Matrices::n_projection_matrices;
-
-template <>
-const double *const FE_DGP<3>::Matrices::projection_matrices[][GeometryInfo<3>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGP<3>::Matrices::n_projection_matrices;
-
-//codimension 1
-template <>
-const double *const FE_DGP<1,2>::Matrices::projection_matrices[][GeometryInfo<1>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGP<1,2>::Matrices::n_projection_matrices;
-
-template <>
-const double *const FE_DGP<2,3>::Matrices::projection_matrices[][GeometryInfo<2>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGP<2,3>::Matrices::n_projection_matrices;
-
-#endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -501,40 +501,6 @@ public:
    */
   virtual std::size_t memory_consumption () const;
 
-
-private:
-  /**
-   * Declare a nested class which will hold static definitions of various
-   * matrices such as constraint and embedding matrices. The definition of the
-   * various static fields are in the files <tt>fe_dgp_[123]d.cc</tt> in the
-   * source directory.
-   */
-  struct Matrices
-  {
-    /**
-     * Pointers to the embedding matrices, one for each polynomial degree
-     * starting from constant elements
-     */
-    static const double *const embedding[][GeometryInfo<dim>::max_children_per_cell];
-
-    /**
-     * Number of elements (first index) the above field has. Equals the
-     * highest polynomial degree plus one for which the embedding matrices
-     * have been computed.
-     */
-    static const unsigned int n_embedding_matrices;
-
-    /**
-     * As @p embedding but for projection matrices.
-     */
-    static const double *const projection_matrices[][GeometryInfo<dim>::max_children_per_cell];
-
-    /**
-     * As @p n_embedding_matrices but for projection matrices.
-     */
-    static const unsigned int n_projection_matrices;
-  };
-
 protected:
 
   /**
@@ -606,47 +572,6 @@ private:
 };
 
 /*@}*/
-
-#ifndef DOXYGEN
-
-// declaration of explicit specializations of member variables
-template <>
-const double *const FE_DGPNonparametric<1,1>::Matrices::embedding[][GeometryInfo<1>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<1,1>::Matrices::n_embedding_matrices;
-
-template <>
-const double *const FE_DGPNonparametric<1,1>::Matrices::projection_matrices[][GeometryInfo<1>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<1,1>::Matrices::n_projection_matrices;
-
-template <>
-const double *const FE_DGPNonparametric<2,2>::Matrices::embedding[][GeometryInfo<2>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<2,2>::Matrices::n_embedding_matrices;
-
-template <>
-const double *const FE_DGPNonparametric<2,2>::Matrices::projection_matrices[][GeometryInfo<2>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<2,2>::Matrices::n_projection_matrices;
-
-template <>
-const double *const FE_DGPNonparametric<3,3>::Matrices::embedding[][GeometryInfo<3>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<3,3>::Matrices::n_embedding_matrices;
-
-template <>
-const double *const FE_DGPNonparametric<3,3>::Matrices::projection_matrices[][GeometryInfo<3>::max_children_per_cell];
-
-template <>
-const unsigned int FE_DGPNonparametric<3,3>::Matrices::n_projection_matrices;
-
-#endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -69,23 +69,10 @@ FE_DGPNonparametric<dim,spacedim>::FE_DGPNonparametric (const unsigned int degre
   // presently not implemented for DGPNonparametric
   // elements.
   //
-  // if it were, then the following
-  // snippet would be the right code
-//    if ((degree < Matrices::n_projection_matrices) &&
-//        (Matrices::projection_matrices[degree] != 0))
-//      {
-//        restriction[0].fill (Matrices::projection_matrices[degree]);
-//      }
-//    else
-//                                   // matrix undefined, set size to zero
-//      for (unsigned int i=0;i<GeometryInfo<dim>::max_children_per_cell;++i)
-//        restriction[i].reinit(0, 0);
   // since not implemented, set to
   // "empty". however, that is done in the
   // default constructor already, so do nothing
-//  for (unsigned int i=0;i<GeometryInfo<dim>::max_children_per_cell;++i)
-//    this->restriction[i].reinit(0, 0);
-
+  //
   // note further, that these
   // elements have neither support
   // nor face-support points, so


### PR DESCRIPTION
These members of FE_DGQ and some of its relatives were introduced in 3fa9183a80e but removed in 4200847f6dc in favor of FETools::compute_embedding_matrices.

7210f53dbd removed a preprocessor guard around this code that was needed by MSVC, but we can do one better by just removing the declarations themselves.

@tjhei I needed this for MSVC.