### PR TITLE
Remove 'enum' qualifications from function calls.

### DIFF
--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -567,9 +567,9 @@ public:
    * @param output_type A variable indicating what kind of timing the output
    * should represent (CPU or wall time).
    */
-  TimerOutput (std::ostream              &stream,
-               const enum OutputFrequency output_frequency,
-               const enum OutputType      output_type);
+  TimerOutput (std::ostream          &stream,
+               const OutputFrequency  output_frequency,
+               const OutputType       output_type);
 
   /**
    * Constructor.
@@ -581,9 +581,9 @@ public:
    * @param output_type A variable indicating what kind of timing the output
    * should represent (CPU or wall time).
    */
-  TimerOutput (ConditionalOStream        &stream,
-               const enum OutputFrequency output_frequency,
-               const enum OutputType      output_type);
+  TimerOutput (ConditionalOStream    &stream,
+               const OutputFrequency  output_frequency,
+               const OutputType       output_type);
 
   /**
    * Constructor that takes an MPI communicator as input. A timer constructed
@@ -608,10 +608,10 @@ public:
    * <code>MPI_Barrier</code> call before starting and stopping the timer for
    * each section.
    */
-  TimerOutput (MPI_Comm                   mpi_comm,
-               std::ostream              &stream,
-               const enum OutputFrequency output_frequency,
-               const enum OutputType      output_type);
+  TimerOutput (MPI_Comm               mpi_comm,
+               std::ostream          &stream,
+               const OutputFrequency  output_frequency,
+               const OutputType       output_type);
 
   /**
    * Constructor that takes an MPI communicator as input. A timer constructed
@@ -636,10 +636,10 @@ public:
    * <code>MPI_Barrier</code> call before starting and stopping the timer for
    * each section.)
    */
-  TimerOutput (MPI_Comm                   mpi_comm,
-               ConditionalOStream        &stream,
-               const enum OutputFrequency output_frequency,
-               const enum OutputType      output_type);
+  TimerOutput (MPI_Comm               mpi_comm,
+               ConditionalOStream    &stream,
+               const OutputFrequency  output_frequency,
+               const OutputType       output_type);
 
   /**
    * Destructor. Calls print_summary() in case the option for writing the

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -329,8 +329,8 @@ void Timer::reset ()
 /* ---------------------------- TimerOutput -------------------------- */
 
 TimerOutput::TimerOutput (std::ostream &stream,
-                          const enum OutputFrequency output_frequency,
-                          const enum OutputType output_type)
+                          const OutputFrequency output_frequency,
+                          const OutputType output_type)
   :
   output_frequency (output_frequency),
   output_type (output_type),
@@ -342,8 +342,8 @@ TimerOutput::TimerOutput (std::ostream &stream,
 
 
 TimerOutput::TimerOutput (ConditionalOStream &stream,
-                          const enum OutputFrequency output_frequency,
-                          const enum OutputType output_type)
+                          const OutputFrequency output_frequency,
+                          const OutputType output_type)
   :
   output_frequency (output_frequency),
   output_type (output_type),
@@ -356,8 +356,8 @@ TimerOutput::TimerOutput (ConditionalOStream &stream,
 
 TimerOutput::TimerOutput (MPI_Comm      mpi_communicator,
                           std::ostream &stream,
-                          const enum OutputFrequency output_frequency,
-                          const enum OutputType output_type)
+                          const OutputFrequency output_frequency,
+                          const OutputType output_type)
   :
   output_frequency (output_frequency),
   output_type (output_type),
@@ -370,8 +370,8 @@ TimerOutput::TimerOutput (MPI_Comm      mpi_communicator,
 
 TimerOutput::TimerOutput (MPI_Comm      mpi_communicator,
                           ConditionalOStream &stream,
-                          const enum OutputFrequency output_frequency,
-                          const enum OutputType output_type)
+                          const OutputFrequency output_frequency,
+                          const OutputType output_type)
   :
   output_frequency (output_frequency),
   output_type (output_type),

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -57,9 +57,9 @@ namespace TrilinosWrappers
 
 
 
-  SolverBase::SolverBase (const enum SolverBase::SolverName  solver_name,
-                          SolverControl                     &cn,
-                          const AdditionalData              &data)
+  SolverBase::SolverBase (const SolverBase::SolverName  solver_name,
+                          SolverControl                &cn,
+                          const AdditionalData         &data)
     :
     solver_name    (solver_name),
     solver_control (cn),


### PR DESCRIPTION
This is not needed in C++ (it is in C) and in most places we do not provide it anyway.

In addition, the enum qualification in symmetric_tensor.h is not correct: `SymmetricTensorEigenvectorMethod` is an enum struct, not an enum, so MSVC (rightfully) complains.

Conflicts with #4970. @tjhei I would prefer to get rid of the `enum` everywhere. Is that okay with you?