### PR TITLE
Prefer numbers::PI to M_PI.

### DIFF
--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -76,6 +76,7 @@ namespace LA
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/grid_refinement.h>
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 
@@ -213,8 +214,10 @@ namespace Step55
     const double R_x = p[0];
     const double R_y = p[1];
 
-    values[0] = -1.0L/2.0L*(-2*sqrt(25.0 + 4*pow(M_PI, 2)) + 10.0)*exp(R_x*(-2*sqrt(25.0 + 4*pow(M_PI, 2)) + 10.0)) - 0.4*pow(M_PI, 2)*exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*cos(2*R_y*M_PI) + 0.1*pow(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0, 2)*exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*cos(2*R_y*M_PI);
-    values[1] = 0.2*M_PI*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0)*exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*sin(2*R_y*M_PI) - 0.05*pow(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0, 3)*exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*sin(2*R_y*M_PI)/M_PI;
+    const double pi = numbers::PI;
+    const double pi2 = pi*pi;
+    values[0] = -1.0L/2.0L*(-2*sqrt(25.0 + 4*pi2) + 10.0)*exp(R_x*(-2*sqrt(25.0 + 4*pi2) + 10.0)) - 0.4*pi2*exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*cos(2*R_y*pi) + 0.1*pow(-sqrt(25.0 + 4*pi2) + 5.0, 2)*exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*cos(2*R_y*pi);
+    values[1] = 0.2*pi*(-sqrt(25.0 + 4*pi2) + 5.0)*exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*sin(2*R_y*pi) - 0.05*pow(-sqrt(25.0 + 4*pi2) + 5.0, 3)*exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*sin(2*R_y*pi)/pi;
     values[2] = 0;
   }
 
@@ -237,9 +240,11 @@ namespace Step55
     const double R_x = p[0];
     const double R_y = p[1];
 
-    values[0] = -exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*cos(2*R_y*M_PI) + 1;
-    values[1] = (1.0L/2.0L)*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0)*exp(R_x*(-sqrt(25.0 + 4*pow(M_PI, 2)) + 5.0))*sin(2*R_y*M_PI)/M_PI;
-    values[2] = -1.0L/2.0L*exp(R_x*(-2*sqrt(25.0 + 4*pow(M_PI, 2)) + 10.0)) - 2.0*(-6538034.74494422 + 0.0134758939981709*exp(4*sqrt(25.0 + 4*pow(M_PI, 2))))/(-80.0*exp(3*sqrt(25.0 + 4*pow(M_PI, 2))) + 16.0*sqrt(25.0 + 4*pow(M_PI, 2))*exp(3*sqrt(25.0 + 4*pow(M_PI, 2)))) - 1634508.68623606*exp(-3.0*sqrt(25.0 + 4*pow(M_PI, 2)))/(-10.0 + 2.0*sqrt(25.0 + 4*pow(M_PI, 2))) + (-0.00673794699908547*exp(sqrt(25.0 + 4*pow(M_PI, 2))) + 3269017.37247211*exp(-3*sqrt(25.0 + 4*pow(M_PI, 2))))/(-8*sqrt(25.0 + 4*pow(M_PI, 2)) + 40.0) + 0.00336897349954273*exp(1.0*sqrt(25.0 + 4*pow(M_PI, 2)))/(-10.0 + 2.0*sqrt(25.0 + 4*pow(M_PI, 2)));
+    const double pi = numbers::PI;
+    const double pi2 = pi*pi;
+    values[0] = -exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*cos(2*R_y*pi) + 1;
+    values[1] = (1.0L/2.0L)*(-sqrt(25.0 + 4*pi2) + 5.0)*exp(R_x*(-sqrt(25.0 + 4*pi2) + 5.0))*sin(2*R_y*pi)/pi;
+    values[2] = -1.0L/2.0L*exp(R_x*(-2*sqrt(25.0 + 4*pi2) + 10.0)) - 2.0*(-6538034.74494422 + 0.0134758939981709*exp(4*sqrt(25.0 + 4*pi2)))/(-80.0*exp(3*sqrt(25.0 + 4*pi2)) + 16.0*sqrt(25.0 + 4*pi2)*exp(3*sqrt(25.0 + 4*pi2))) - 1634508.68623606*exp(-3.0*sqrt(25.0 + 4*pi2))/(-10.0 + 2.0*sqrt(25.0 + 4*pi2)) + (-0.00673794699908547*exp(sqrt(25.0 + 4*pi2)) + 3269017.37247211*exp(-3*sqrt(25.0 + 4*pi2)))/(-8*sqrt(25.0 + 4*pi2) + 40.0) + 0.00336897349954273*exp(1.0*sqrt(25.0 + 4*pi2))/(-10.0 + 2.0*sqrt(25.0 + 4*pi2));
   }
 
 

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -112,7 +112,7 @@ eigenvalues (const SymmetricTensor<2,3,Number> &T)
       // floating point errors might place it slightly outside
       // this range. It is therefore necessary to correct for it
       const Number phi =
-        (tmp_2 <= -1.0 ? Number(M_PI/3.0) :
+        (tmp_2 <= -1.0 ? Number(numbers::PI/3.0) :
          (tmp_2 >= 1.0 ? Number(0.0) :
           std::acos(tmp_2)/3.0));
 
@@ -122,7 +122,7 @@ eigenvalues (const SymmetricTensor<2,3,Number> &T)
       = { {
           static_cast<Number>(q + 2.0*p*std::cos(phi)),
           static_cast<Number>(0.0),
-          static_cast<Number>(q + 2.0*p*std::cos(phi + (2.0/3.0*M_PI)))
+          static_cast<Number>(q + 2.0*p*std::cos(phi + (2.0/3.0*numbers::PI)))
         }
       };
       // Use the identity tr(T) = eig1 + eig2 + eig3

--- a/tests/fail/abf_approximation_01.cc
+++ b/tests/fail/abf_approximation_01.cc
@@ -49,6 +49,7 @@ char buf[1000];
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -475,7 +476,7 @@ int main ()
     MappingQ1Eulerian<2> mapping_euler (deformation, *dof_handler_def);
 
     // Try rotating the elements
-    for (double rotat = 0; rotat < 2 * M_PI; rotat += 0.25 * M_PI)
+    for (double rotat = 0; rotat < 2 * numbers::PI; rotat += 0.25 * numbers::PI)
       {
         // Rotate element
         VectorTools::project (*dof_handler_def, hn_constraints_def,

--- a/tests/fail/rt_distorted_01.cc
+++ b/tests/fail/rt_distorted_01.cc
@@ -44,6 +44,7 @@ std::ofstream logfile ("output");
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -373,7 +374,7 @@ int main (int /*argc*/, char **/*argv*/)
 
   unsigned int test_out = 0;
   // Try rotating the elements
-  for (double rotat = 0; rotat < 2 * M_PI; rotat += 0.25 * M_PI)
+  for (double rotat = 0; rotat < 2 * numbers::PI; rotat += 0.25 * numbers::PI)
     {
       // Rotate element
       VectorTools::project (*dof_handler_def, hn_constraints_def,

--- a/tests/fail/rt_distorted_02.cc
+++ b/tests/fail/rt_distorted_02.cc
@@ -46,6 +46,7 @@ char buf[1000];
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/lac/constraint_matrix.h>
@@ -390,7 +391,7 @@ int main ()
   deallog << buf;
 
   // Try rotating the elements
-  for (double rotat = 0; rotat < 2 * M_PI; rotat += 0.25 * M_PI)
+  for (double rotat = 0; rotat < 2 * numbers::PI; rotat += 0.25 * numbers::PI)
     {
       // Rotate element
       VectorTools::project (dof_handler_def, hn_constraints_def,

--- a/tests/fe/fe_values_function_manifold.cc
+++ b/tests/fe/fe_values_function_manifold.cc
@@ -2,6 +2,7 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
@@ -48,7 +49,7 @@ using namespace dealii;
 static const unsigned int fe_order = 4;
 static const dealii::types::boundary_id boundary_id = 0;
 static const dealii::types::manifold_id cubic_manifold_id = 1;
-static const double pi = M_PI;
+static const double pi = numbers::PI;
 
 // ----------------------------------------------------------------------------
 // Manufactured solution and manufactured forcing

--- a/tests/physics/transformations-rotations_01.cc
+++ b/tests/physics/transformations-rotations_01.cc
@@ -18,6 +18,7 @@
 
 #include "../tests.h"
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>
@@ -97,7 +98,7 @@ int main ()
   deallog << std::setprecision(3);
   deallog.attach(logfile);
 
-  const double deg_to_rad = M_PI/180.0;
+  const double deg_to_rad = numbers::PI/180.0;
 
   // 2-d
   {


### PR DESCRIPTION
Windows does not define M_PI, so we need this for MSVC.

@tjhei I am surprised that you did not include this in your commits :)