### PR TITLE
suppress MSVC warnings

### DIFF
--- a/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
+++ b/bundled/boost-1.62.0/include/boost/config/compiler/visualc.hpp
@@ -294,9 +294,10 @@
 #endif
 
 //
-// tjhei: taken from boost git repo
+// tjhei: upgrade supported MSVC version to 19.11
+// Boost repo has only 19.10:
 // last known and checked version is 19.10.24629 (VC++ 2017 RC):
-#if (_MSC_VER > 1910)
+#if (_MSC_VER > 1911)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else

--- a/cmake/setup_compiler_flags_msvc.cmake
+++ b/cmake/setup_compiler_flags_msvc.cmake
@@ -73,6 +73,10 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "/wd4789")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "/wd4808")
 
 
+# Bug in MSVC 2017: bogus warning C5037: an out-of-line definition of a member of a class template cannot have default arguments
+# see https://developercommunity.visualstudio.com/content/problem/81223/incorrect-error-c5037-with-permissive.html
+ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "/wd5037")
+
 #############################
 #                           #
 #    For Release target:    #


### PR DESCRIPTION
Those are new warnings introduced with 19.11 (2017 final)

See: https://cdash.kyomu.43-1.org/viewBuildError.php?type=1&buildid=10866