### PR TITLE
Fix some naming issues: Call it 'preconditioner'.

### DIFF
--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -134,7 +134,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
 protected:
   /**
@@ -257,7 +257,7 @@ private:
   template <typename MatrixType, typename PreconditionerType>
   IterationResult
   iterate(const MatrixType         &A,
-          const PreconditionerType &precondition);
+          const PreconditionerType &preconditioner);
 };
 
 /*@}*/
@@ -367,7 +367,7 @@ template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 typename SolverBicgstab<VectorType>::IterationResult
 SolverBicgstab<VectorType>::iterate(const MatrixType         &A,
-                                    const PreconditionerType &precondition)
+                                    const PreconditionerType &preconditioner)
 {
 //TODO:[GK] Implement "use the length of the computed orthogonal residual" in the BiCGStab method.
   SolverControl::State state = SolverControl::iterate;
@@ -402,7 +402,7 @@ SolverBicgstab<VectorType>::iterate(const MatrixType         &A,
           p.add(-beta*omega, v);
         }
 
-      precondition.vmult(y,p);
+      preconditioner.vmult(y,p);
       A.vmult(v,y);
       rhobar = rbar * v;
 
@@ -428,7 +428,7 @@ SolverBicgstab<VectorType>::iterate(const MatrixType         &A,
           return IterationResult(false, SolverControl::success, step, res);
         }
 
-      precondition.vmult(z,r);
+      preconditioner.vmult(z,r);
       A.vmult(t,z);
       rhobar = t*r;
       omega = rhobar/(t*t);
@@ -456,7 +456,7 @@ void
 SolverBicgstab<VectorType>::solve(const MatrixType         &A,
                                   VectorType               &x,
                                   const VectorType         &b,
-                                  const PreconditionerType &precondition)
+                                  const PreconditionerType &preconditioner)
 {
   deallog.push("Bicgstab");
   Vr    = this->memory.alloc();
@@ -491,7 +491,7 @@ SolverBicgstab<VectorType>::solve(const MatrixType         &A,
           state.state = SolverControl::success;
           break;
         }
-      state = iterate(A, precondition);
+      state = iterate(A, preconditioner);
       ++step;
     }
   while (state.breakdown == true);

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -130,7 +130,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
   /**
    * Connect a slot to retrieve the CG coefficients. The slot will be called
@@ -312,7 +312,7 @@ void
 SolverCG<VectorType>::solve (const MatrixType         &A,
                              VectorType               &x,
                              const VectorType         &b,
-                             const PreconditionerType &precondition)
+                             const PreconditionerType &preconditioner)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -376,7 +376,7 @@ SolverCG<VectorType>::solve (const MatrixType         &A,
 
       if (std::is_same<PreconditionerType,PreconditionIdentity>::value == false)
         {
-          precondition.vmult(h,g);
+          preconditioner.vmult(h,g);
 
           d.equ(-1.,h);
 
@@ -409,7 +409,7 @@ SolverCG<VectorType>::solve (const MatrixType         &A,
           if (std::is_same<PreconditionerType,PreconditionIdentity>::value
               == false)
             {
-              precondition.vmult(h,g);
+              preconditioner.vmult(h,g);
 
               beta = gh;
               Assert(beta != 0., ExcDivideByZero());

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -166,7 +166,7 @@ public:
   void solve (const MatrixType         &A,
               VectorType               &x,
               const VectorType         &b,
-              const PreconditionerType &precondition);
+              const PreconditionerType &preconditioner);
 
 protected:
 
@@ -377,7 +377,7 @@ template <typename MatrixType, typename PreconditionerType>
 void SolverFIRE<VectorType>::solve (const MatrixType         &A,
                                     VectorType               &x,
                                     const VectorType         &b,
-                                    const PreconditionerType &precondition)
+                                    const PreconditionerType &preconditioner)
 {
 
   std::function<double(VectorType &,  const VectorType &)> compute_func =
@@ -394,7 +394,7 @@ void SolverFIRE<VectorType>::solve (const MatrixType         &A,
     return 0.5*A.matrix_norm_square(x) - x*b;
   };
 
-  this->solve (compute_func, x, precondition);
+  this->solve (compute_func, x, preconditioner);
 }
 
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -246,7 +246,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
   /**
    * Connect a slot to retrieve the estimated condition number. Called on each
@@ -477,7 +477,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
 private:
 
@@ -748,7 +748,7 @@ void
 SolverGMRES<VectorType>::solve (const MatrixType         &A,
                                 VectorType               &x,
                                 const VectorType         &b,
-                                const PreconditionerType &precondition)
+                                const PreconditionerType &preconditioner)
 {
   // this code was written a very long time ago by people not associated with
   // deal.II. we don't make any guarantees to its optimality or that it even
@@ -840,7 +840,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
         {
           A.vmult(p,x);
           p.sadd(-1.,1.,b);
-          precondition.vmult(v,p);
+          preconditioner.vmult(v,p);
         }
       else
         {
@@ -871,7 +871,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
               r->sadd(-1.,1.,b);
             }
           else
-            precondition.vmult(*r,v);
+            preconditioner.vmult(*r,v);
 
           double res = r->l2_norm();
           last_res = res;
@@ -901,11 +901,11 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
           if (left_precondition)
             {
               A.vmult(p, tmp_vectors[inner_iteration]);
-              precondition.vmult(vv,p);
+              preconditioner.vmult(vv,p);
             }
           else
             {
-              precondition.vmult(p, tmp_vectors[inner_iteration]);
+              preconditioner.vmult(p, tmp_vectors[inner_iteration]);
               A.vmult(vv,p);
             }
 
@@ -965,7 +965,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
                   p = 0.;
                   for (unsigned int i=0; i<dim; ++i)
                     p.add(h_(i), tmp_vectors[i]);
-                  precondition.vmult(*r,p);
+                  preconditioner.vmult(*r,p);
                   x_->add(1.,*r);
                 };
               A.vmult(*r,*x_);
@@ -980,7 +980,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
                 }
               else
                 {
-                  precondition.vmult(*x_, *r);
+                  preconditioner.vmult(*x_, *r);
                   const double preconditioned_res=x_->l2_norm();
                   last_res = preconditioned_res;
 
@@ -1011,7 +1011,7 @@ SolverGMRES<VectorType>::solve (const MatrixType         &A,
           p = 0.;
           for (unsigned int i=0; i<dim; ++i)
             p.add(h(i), tmp_vectors[i]);
-          precondition.vmult(v,p);
+          preconditioner.vmult(v,p);
           x.add(1.,v);
         };
       // end of outer iteration. restart if no convergence and the number of
@@ -1139,7 +1139,7 @@ void
 SolverFGMRES<VectorType>::solve (const MatrixType         &A,
                                  VectorType               &x,
                                  const VectorType         &b,
-                                 const PreconditionerType &precondition)
+                                 const PreconditionerType &preconditioner)
 {
   deallog.push("FGMRES");
 
@@ -1189,7 +1189,7 @@ SolverFGMRES<VectorType>::solve (const MatrixType         &A,
             v(j,x) = 0.;
 
 
-          precondition.vmult(z(j,x), v[j]);
+          preconditioner.vmult(z(j,x), v[j]);
           A.vmult(*aux, z[j]);
 
           // Gram-Schmidt

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -104,7 +104,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
   /**
    * @addtogroup Exceptions
@@ -210,7 +210,7 @@ void
 SolverMinRes<VectorType>::solve (const MatrixType         &A,
                                  VectorType               &x,
                                  const VectorType         &b,
-                                 const PreconditionerType &precondition)
+                                 const PreconditionerType &preconditioner)
 {
   deallog.push("minres");
 
@@ -263,7 +263,7 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
   // positive definite and symmetric
 
   // M v = u[1]
-  precondition.vmult (v,*u[1]);
+  preconditioner.vmult (v,*u[1]);
 
   delta[1] = v * (*u[1]);
   // Preconditioner positive
@@ -297,7 +297,7 @@ SolverMinRes<VectorType>::solve (const MatrixType         &A,
       // precondition: solve M v = u[2]
       // Preconditioner has to be positive
       // definite and symmetric.
-      precondition.vmult(v,*u[2]);
+      preconditioner.vmult(v,*u[2]);
 
       delta[2] = v * (*u[2]);
 

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -91,8 +91,8 @@ public:
      * 1e-16.
      */
     explicit
-    AdditionalData(bool exact_residual = false,
-                   double breakdown=1.e-16) :
+    AdditionalData(const bool   exact_residual = false,
+                   const double breakdown      = 1.e-16) :
       exact_residual(exact_residual),
       breakdown(breakdown)
     {}
@@ -130,7 +130,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
   /**
    * Interface for derived class. This function gets the current iteration
@@ -201,7 +201,7 @@ private:
   template <typename MatrixType, typename PreconditionerType>
   IterationResult
   iterate (const MatrixType         &A,
-           const PreconditionerType &precondition);
+           const PreconditionerType &preconditioner);
 
   /**
    * Number of the current iteration (accumulated over restarts)
@@ -269,7 +269,7 @@ void
 SolverQMRS<VectorType>::solve (const MatrixType         &A,
                                VectorType               &x,
                                const VectorType         &b,
-                               const PreconditionerType &precondition)
+                               const PreconditionerType &preconditioner)
 {
   deallog.push("QMRS");
 
@@ -298,7 +298,7 @@ SolverQMRS<VectorType>::solve (const MatrixType         &A,
     {
       if (step > 0)
         deallog << "Restart step " << step << std::endl;
-      state = iterate(A, precondition);
+      state = iterate(A, preconditioner);
     }
   while (state.state == SolverControl::iterate);
 
@@ -325,7 +325,7 @@ template <class VectorType>
 template <typename MatrixType, typename PreconditionerType>
 typename SolverQMRS<VectorType>::IterationResult
 SolverQMRS<VectorType>::iterate(const MatrixType         &A,
-                                const PreconditionerType &precondition)
+                                const PreconditionerType &preconditioner)
 {
   /* Remark: the matrix A in the article is the preconditioned matrix.
    * Therefore, we have to precondition x before we compute the first residual.
@@ -352,7 +352,7 @@ SolverQMRS<VectorType>::iterate(const MatrixType         &A,
   d.reinit(x);
 
   // Apply right preconditioning to x
-  precondition.vmult(q,x);
+  preconditioner.vmult(q,x);
   // Preconditioned residual
   A.vmult(v,q);
   v.sadd(-1.,1.,b);
@@ -363,7 +363,7 @@ SolverQMRS<VectorType>::iterate(const MatrixType         &A,
 
   p = v;
 
-  precondition.vmult(q,p);
+  preconditioner.vmult(q,p);
 
   tau = v.norm_sqr();
   rho = q*v;
@@ -412,12 +412,12 @@ SolverQMRS<VectorType>::iterate(const MatrixType         &A,
         return IterationResult(SolverControl::iterate, std::fabs(rho));
       // Step 7
       const double rho_old = rho;
-      precondition.vmult(q,v);
+      preconditioner.vmult(q,v);
       rho = q*v;
 
       const double beta = rho/rho_old;
       p.sadd(beta,v);
-      precondition.vmult(q,p);
+      preconditioner.vmult(q,p);
     }
   return IterationResult(SolverControl::success, std::fabs(rho));
 }

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -113,7 +113,7 @@ public:
   solve (const MatrixType         &A,
          VectorType               &x,
          const VectorType         &b,
-         const PreconditionerType &precondition);
+         const PreconditionerType &preconditioner);
 
   /**
    * Solve $A^Tx=b$ for $x$.
@@ -123,7 +123,7 @@ public:
   Tsolve (const MatrixType         &A,
           VectorType               &x,
           const VectorType         &b,
-          const PreconditionerType &precondition);
+          const PreconditionerType &preconditioner);
 
   /**
    * Set the damping-coefficient. Default is 1., i.e. no damping.
@@ -225,7 +225,7 @@ void
 SolverRichardson<VectorType>::solve (const MatrixType         &A,
                                      VectorType               &x,
                                      const VectorType         &b,
-                                     const PreconditionerType &precondition)
+                                     const PreconditionerType &preconditioner)
 {
   SolverControl::State conv=SolverControl::iterate;
 
@@ -252,7 +252,7 @@ SolverRichardson<VectorType>::solve (const MatrixType         &A,
           // but do it in 2 steps
           A.vmult(r,x);
           r.sadd(-1.,1.,b);
-          precondition.vmult(d,r);
+          preconditioner.vmult(d,r);
 
           // The required norm of the
           // (preconditioned)
@@ -296,7 +296,7 @@ void
 SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
                                       VectorType               &x,
                                       const VectorType         &b,
-                                      const PreconditionerType &precondition)
+                                      const PreconditionerType &preconditioner)
 {
   SolverControl::State conv=SolverControl::iterate;
   double last_criterion = -std::numeric_limits<double>::max();
@@ -322,7 +322,7 @@ SolverRichardson<VectorType>::Tsolve (const MatrixType         &A,
           // but do it in 2 steps
           A.Tvmult(r,x);
           r.sadd(-1.,1.,b);
-          precondition.Tvmult(d,r);
+          preconditioner.Tvmult(d,r);
 
           last_criterion = criterion();
           conv = this->iteration_status (iter, last_criterion, x);


### PR DESCRIPTION
When we talk about preconditioner objects, some of the solvers use the
term 'precondition' for the object, but that's misleading. Name things
properly.