### PR TITLE
added missing header

### DIFF
--- a/tests/quick_tests/lapack.cc
+++ b/tests/quick_tests/lapack.cc
@@ -21,6 +21,7 @@
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/vector.h>
 
+#include <fstream>
 #include <iostream>
 
 /*


### PR DESCRIPTION
quick test `lapack.cc` was failing with this error

```
/home/alberto/opt/src/dealii/tests/quick_tests/lapack.cc:100:25: error: variable ‘std::ofstream logfile’ has initializer but incomplete type
   std::ofstream logfile(logname.c_str());
```