### PR TITLE
do not allow import from ghosted TrilinosWrappers to ReadWriteVector

### DIFF
--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -291,6 +291,8 @@ namespace LinearAlgebra
      * replace the current elements. The last parameter can be used if the same
      * communication pattern is used multiple times. This can be used to improve
      * performance.
+     *
+     * @note: The @p trilinos_vec is not allowed to have ghost entries.
      */
     void import(const TrilinosWrappers::MPI::Vector &trilinos_vec,
                 VectorOperation::values operation,

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -338,20 +338,32 @@ namespace LinearAlgebra
 
     if (operation==VectorOperation::insert)
       {
-        target_vector.Import(multivector, import, Insert);
-        double *values = target_vector.Values();
+        const int err = target_vector.Import(multivector, import, Insert);
+        AssertThrow(err == 0, ExcMessage("Epetra Import() failed with error code: "
+                                         + Utilities::to_string(err)));
+
+        const double *values = target_vector.Values();
         const int size = target_vector.MyLength();
+        Assert(size==0 || values != nullptr, ExcInternalError("Import failed."));
+
         for (int i=0; i<size; ++i)
           val[i] = values[i];
       }
-    else
+    else if (operation==VectorOperation::add)
       {
-        target_vector.Import(multivector, import, Add);
-        double *values = target_vector.Values();
+        const int err = target_vector.Import(multivector, import, Add);
+        AssertThrow(err == 0, ExcMessage("Epetra Import() failed with error code: "
+                                         + Utilities::to_string(err)));
+
+        const double *values = target_vector.Values();
         const int size = target_vector.MyLength();
+        Assert(size==0 || values != nullptr, ExcInternalError("Import failed."));
+
         for (int i=0; i<size; ++i)
           val[i] += values[i];
       }
+    else
+      AssertThrow(false, ExcNotImplemented());
   }
 
 

--- a/tests/trilinos/readwritevector_02.cc
+++ b/tests/trilinos/readwritevector_02.cc
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2016 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+// test ghosted TrilinosWrappers::MPI::Vector -> RWV
+
+#include "../tests.h"
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <vector>
+
+void test()
+{
+  IndexSet is(8);
+  unsigned int rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  if (rank==0)
+    is.add_range(0,4);
+  if (rank==1)
+    is.add_range(4,8);
+  is.compress();
+
+  deallog << "IS: ";
+  is.print(deallog);
+
+  IndexSet is_ghosted(8);
+  is_ghosted.add_range(2,6);
+  deallog << "IS_ghosted: ";
+  is_ghosted.print(deallog);
+
+  TrilinosWrappers::MPI::Vector tril_vector(is);
+  TrilinosWrappers::MPI::Vector tril_vector_ghosted;
+  tril_vector_ghosted.reinit(is, is_ghosted, MPI_COMM_WORLD);
+  for (unsigned int i=0; i<8; ++i)
+    tril_vector[i] = i;
+
+  tril_vector.compress(VectorOperation::insert);
+  deallog << "trilinos vec:" << std::endl;
+  tril_vector.print(deallog.get_file_stream());
+
+  tril_vector_ghosted = tril_vector;
+
+  deallog << "trilinos vec ghosted:" << std::endl;
+  tril_vector_ghosted.print(deallog.get_file_stream());
+
+
+  IndexSet readwrite_is (tril_vector_ghosted.vector_partitioner());
+  deallog << "ghosted IS: ";
+  readwrite_is.print(deallog);
+
+  deallog << "tril_vector_ghosted.owned_elements() ";
+  tril_vector_ghosted.locally_owned_elements().print(deallog);
+
+  {
+    deallog << "import of ghosted vector should fail:" << std::endl;
+    LinearAlgebra::ReadWriteVector<double> readwrite(readwrite_is);
+    try
+      {
+        readwrite.import(tril_vector_ghosted, VectorOperation::insert);
+        deallog << "RWVector contents:" << std::endl;
+        readwrite.print(deallog.get_file_stream());
+      }
+    catch (ExceptionBase &exc)
+      {
+        deallog << exc.get_exc_name() << std::endl;
+      }
+  }
+  {
+    deallog << "import of distributed vector should work:" << std::endl;
+    LinearAlgebra::ReadWriteVector<double> readwrite(readwrite_is);
+    readwrite.import(tril_vector, VectorOperation::insert);
+    deallog << "RWVector contents:" << std::endl;
+    readwrite.print(deallog.get_file_stream());
+  }
+
+  deallog << "OK" <<std::endl;
+}
+
+int main (int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization (argc, argv, testing_max_num_threads());
+
+  MPILogInitAll log;
+
+  test();
+}

--- a/tests/trilinos/readwritevector_02.mpirun=2.output
+++ b/tests/trilinos/readwritevector_02.mpirun=2.output
@@ -1,0 +1,65 @@
+
+DEAL:0::IS: {[0,3]}
+DEAL:0::IS_ghosted: {[2,5]}
+DEAL:0::trilinos vec:
+size:8 local_size:4 :
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+DEAL:0::trilinos vec ghosted:
+size:8 local_size:6 :
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+DEAL:0::ghosted IS: {[0,5]}
+DEAL:0::tril_vector_ghosted.owned_elements() {[0,3]}
+DEAL:0::import of ghosted vector should fail:
+DEAL:0::ExcMessage("Epetra Import() failed with error code: " + Utilities::to_string(err))
+DEAL:0::import of distributed vector should work:
+DEAL:0::RWVector contents:
+IndexSet: {[0,5]}
+
+0.000e+00
+1.000e+00
+2.000e+00
+3.000e+00
+4.000e+00
+5.000e+00
+DEAL:0::OK
+
+DEAL:1::IS: {[4,7]}
+DEAL:1::IS_ghosted: {[2,5]}
+DEAL:1::trilinos vec:
+size:8 local_size:4 :
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
+DEAL:1::trilinos vec ghosted:
+size:8 local_size:6 :
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
+DEAL:1::ghosted IS: {[2,7]}
+DEAL:1::tril_vector_ghosted.owned_elements() {[4,7]}
+DEAL:1::import of ghosted vector should fail:
+DEAL:1::ExcMessage("Epetra Import() failed with error code: " + Utilities::to_string(err))
+DEAL:1::import of distributed vector should work:
+DEAL:1::RWVector contents:
+IndexSet: {[2,7]}
+
+2.000e+00
+3.000e+00
+4.000e+00
+5.000e+00
+6.000e+00
+7.000e+00
+DEAL:1::OK
+


### PR DESCRIPTION
I would like to import from a ``TrilinosWrappers::MPI::Vector`` with ghost entries to a ``ReadWriteVector``. Attached is a test that shows that the imported values are incorrectly all zero.

Before I spend more time debugging to see what is going on, do we want to support this case at all? So should we just add an assert somewhere?

If we don't want to support it directly, I will use this PR to add a constructor
```
ReadWriteVector(const TrilinosWrappers::MPI::Vector &)
```
That gives a local view of the vector and its ghost elements (without communication), if that is acceptable? (Code for that is already written and works)